### PR TITLE
[synnax] - Homebrew tap version bumping workflow

### DIFF
--- a/.github/workflows/brew.publish.yaml
+++ b/.github/workflows/brew.publish.yaml
@@ -1,0 +1,17 @@
+name: "Bump Homebrew Tap"
+on:
+    push:
+        tags:
+            - "synnax/v*.*.*"
+
+jobs:
+    publish:
+        runs-on: ubuntu-latest
+        steps:
+            - name: Update Homebrew formula
+              uses: dawidd6/action-homebrew-bump-formula@v3
+              with:
+                  token: ${{ secrets.HOMEBREW_BUMP_TOKEN }} ## GitHub token (not the default one)
+                  tap: synnaxlabs/homebrew-synnax
+                  no_fork: true
+                  formula: synnax


### PR DESCRIPTION
This commit addresses issue #229 by introducing a GitHub Action workflow file that automatically bumps the version of synnax in the homebrew tap. It uses a wrapper for the
`brew bump-formula-pr` cli command and requires a
**non-default** GitHub access token to access the separate homebrew tap repository.
The action secret `HOMEBREW_BUMP_TOKEN` needs to be added in order for this workflow to work.