### PR TITLE
Update brew.publish.yaml

### DIFF
--- a/.github/workflows/brew.publish.yaml
+++ b/.github/workflows/brew.publish.yaml
@@ -3,7 +3,7 @@ on:
     push:
         tags:
             - "*"
-            
+    workflow_dispatch:
 jobs:
     publish:
         runs-on: ubuntu-latest


### PR DESCRIPTION
This PR allows for manual trigger of the homebrew tap action