### PR TITLE
implement support for boolean expressions

### DIFF
--- a/x/go/calc/calc.go
+++ b/x/go/calc/calc.go
@@ -22,20 +22,37 @@ import (
 
 // A dictionary mapping operators to their token
 var operatorTokens map[string]token.Token = map[string]token.Token{
-	"+": token.ADD,
-	"-": token.SUB,
-	"*": token.MUL,
-	"/": token.QUO,
-	"^": token.XOR,
+	"+":  token.ADD,
+	"-":  token.SUB,
+	"*":  token.MUL,
+	"/":  token.QUO,
+	"^":  token.XOR,
+	"==": token.EQL,
+	"!=": token.NEQ,
+	">":  token.GTR,
+	"<":  token.LSS,
+	">=": token.GEQ,
+	"<=": token.LEQ,
+	"&&": token.LAND,
+	"||": token.LOR,
 }
 
 var precedence map[string]int = map[string]int{
-	"+": 1,
-	"-": 1,
-	"*": 2,
-	"/": 2,
-	"(": 0,
-	"^": 3,
+	"+":  1,
+	"-":  1,
+	"*":  2,
+	"/":  2,
+	"(":  -3,
+	"^":  3,
+	"==": -1,
+	"!=": -1,
+	">":  -1,
+	"<":  -1,
+	">=": -1,
+	"<=": -1,
+	"&&": -2,
+	"||": -2,
+	"!":  0,
 }
 
 var InvalidExpressionError = errors.New("Invalid expression")
@@ -51,12 +68,20 @@ type Resolver interface {
 }
 
 func findTokens(s string) (tokens []string, err error) {
-	re, err := regexp.Compile("[0-9]+(\\.[0-9]*)?|[\\w]+|[+\\-*\\/^()]|[><!=]=|[<>]")
+	re, err := regexp.Compile("[0-9]+(\\.[0-9]*)?|[\\w]+|[+\\-*\\/^()]|[><!=]=|[<>]|&&|\\|\\||!")
 	return re.FindAllString(s, -1), err
 }
 
-func makeBinaryExpr(output *stack.Stack[interface{}], operators *stack.Stack[string]) error {
+func popOperators(output *stack.Stack[interface{}], operators *stack.Stack[string]) error {
 	op, _ := operators.Pop()
+	if op == "!" {
+		X, err := output.Pop()
+		if err != nil {
+			return errors.Wrap(InvalidExpressionError, "Invalid expression: unary operator used with no operand")
+		}
+		output.Push(&ast.UnaryExpr{Op: token.NOT, X: X.(ast.Expr)})
+		return nil
+	}
 	Y, err1 := output.Pop()
 	X, err2 := output.Pop()
 	if err1 != nil || err2 != nil {
@@ -88,34 +113,31 @@ func (e *Expression) Build(s string) error {
 				operators.Push("*")
 			} else {
 				for operators.Len() > 0 && precedence[*operators.Peek()] >= precedence[t] {
-					if err := makeBinaryExpr(&output, &operators); err != nil {
+					if err := popOperators(&output, &operators); err != nil {
 						return err
 					}
 				}
 				operators.Push(t)
 			}
-		case "+", "*", "/":
+		case "+", "*", "/", "==", "!=", ">", "<", ">=", "<=", "&&", "||":
 			for operators.Len() > 0 && precedence[*operators.Peek()] >= precedence[t] {
-				err := makeBinaryExpr(&output, &operators)
-				if err != nil {
+				if err := popOperators(&output, &operators); err != nil {
 					return err
 				}
 			}
 			operators.Push(t)
 		case "^":
 			for operators.Len() > 0 && precedence[*operators.Peek()] > precedence[t] {
-				err := makeBinaryExpr(&output, &operators)
-				if err != nil {
+				if err := popOperators(&output, &operators); err != nil {
 					return err
 				}
 			}
 			operators.Push(t)
-		case "(":
+		case "(", "!":
 			operators.Push(t)
 		case ")":
 			for operators.Len() > 0 && *operators.Peek() != "(" {
-				err := makeBinaryExpr(&output, &operators)
-				if err != nil {
+				if err := popOperators(&output, &operators); err != nil {
 					return err
 				}
 			}
@@ -134,7 +156,7 @@ func (e *Expression) Build(s string) error {
 		}
 	}
 	for operators.Len() > 0 {
-		err := makeBinaryExpr(&output, &operators)
+		err := popOperators(&output, &operators)
 		if err != nil {
 			return err
 		}
@@ -170,9 +192,21 @@ func eval(exp ast.Expr, r Resolver) float64 {
 	case *ast.Ident:
 		i, _ := r.Resolve(exp.Name)
 		return i
+	case *ast.UnaryExpr:
+		switch exp.Op {
+		case token.NOT:
+			return boolToFloat(eval(exp.X, r) == 0)
+		}
 	}
 
 	return 0
+}
+
+func boolToFloat(b bool) float64 {
+	if b {
+		return 1.0
+	}
+	return 0.0
 }
 
 func evalBinaryExpr(exp *ast.BinaryExpr, r Resolver) float64 {
@@ -190,6 +224,22 @@ func evalBinaryExpr(exp *ast.BinaryExpr, r Resolver) float64 {
 		return left / right
 	case token.XOR:
 		return math.Pow(left, right)
+	case token.EQL:
+		return boolToFloat(left == right)
+	case token.NEQ:
+		return boolToFloat(left != right)
+	case token.GTR:
+		return boolToFloat(left > right)
+	case token.LSS:
+		return boolToFloat(left < right)
+	case token.GEQ:
+		return boolToFloat(left >= right)
+	case token.LEQ:
+		return boolToFloat(left <= right)
+	case token.LAND:
+		return boolToFloat(left == 1 && right == 1)
+	case token.LOR:
+		return boolToFloat(left == 1 || right == 1)
 	}
 
 	return 0

--- a/x/go/calc/calc_test.go
+++ b/x/go/calc/calc_test.go
@@ -417,6 +417,11 @@ var _ = Describe("Calc", func() {
 				err := e.Build("5 ==")
 				Expect(err).To(HaveOccurred())
 			})
+			It("Should return an error for an unbalanced unary expression", func() {
+				e := calc.Expression{}
+				err := e.Build("!")
+				Expect(err).To(HaveOccurred())
+			})
 		})
 	})
 	Describe("Evaluate", func() {

--- a/x/go/calc/calc_test.go
+++ b/x/go/calc/calc_test.go
@@ -585,5 +585,61 @@ var _ = Describe("Calc", func() {
 				Expect(e.Evaluate(r4)).To(Equal(float64(1)))
 			})
 		})
+		Describe("Comparator Tests", func() {
+			It("==", func() {
+				e := calc.Expression{}
+				err := e.Build("p == 1")
+				Expect(err).ToNot(HaveOccurred())
+				r1 := &mockResolver{vals: map[string]float64{"p": 1}}
+				r2 := &mockResolver{vals: map[string]float64{"p": 0}}
+				Expect(e.Evaluate(r1)).To(Equal(float64(1)))
+				Expect(e.Evaluate(r2)).To(Equal(float64(0)))
+			})
+			It("!=", func() {
+				e := calc.Expression{}
+				err := e.Build("p != 1")
+				Expect(err).ToNot(HaveOccurred())
+				r1 := &mockResolver{vals: map[string]float64{"p": 1}}
+				r2 := &mockResolver{vals: map[string]float64{"p": 0}}
+				Expect(e.Evaluate(r1)).To(Equal(float64(0)))
+				Expect(e.Evaluate(r2)).To(Equal(float64(1)))
+			})
+			It(">", func() {
+				e := calc.Expression{}
+				err := e.Build("p > 1")
+				Expect(err).ToNot(HaveOccurred())
+				r1 := &mockResolver{vals: map[string]float64{"p": 1}}
+				r2 := &mockResolver{vals: map[string]float64{"p": 0}}
+				Expect(e.Evaluate(r1)).To(Equal(float64(0)))
+				Expect(e.Evaluate(r2)).To(Equal(float64(0)))
+			})
+			It(">=", func() {
+				e := calc.Expression{}
+				err := e.Build("p >= 1")
+				Expect(err).ToNot(HaveOccurred())
+				r1 := &mockResolver{vals: map[string]float64{"p": 1}}
+				r2 := &mockResolver{vals: map[string]float64{"p": 0}}
+				Expect(e.Evaluate(r1)).To(Equal(float64(1)))
+				Expect(e.Evaluate(r2)).To(Equal(float64(0)))
+			})
+			It("<", func() {
+				e := calc.Expression{}
+				err := e.Build("p < 1")
+				Expect(err).ToNot(HaveOccurred())
+				r1 := &mockResolver{vals: map[string]float64{"p": 1}}
+				r2 := &mockResolver{vals: map[string]float64{"p": 0}}
+				Expect(e.Evaluate(r1)).To(Equal(float64(0)))
+				Expect(e.Evaluate(r2)).To(Equal(float64(1)))
+			})
+			It("<=", func() {
+				e := calc.Expression{}
+				err := e.Build("p <= 1")
+				Expect(err).ToNot(HaveOccurred())
+				r1 := &mockResolver{vals: map[string]float64{"p": 1}}
+				r2 := &mockResolver{vals: map[string]float64{"p": 0}}
+				Expect(e.Evaluate(r1)).To(Equal(float64(1)))
+				Expect(e.Evaluate(r2)).To(Equal(float64(1)))
+			})
+		})
 	})
 })


### PR DESCRIPTION
Operations supported:
- &&
- ||
- ==
- !=
- <
- <=
- \>
- \>=
- !

&& and || have a lower precedence than the other operators. For example,
- a == b && c == d would evaluate to (a == b) && (c == d), not ((a == b) && c) == d
- a && b == c && d would evaluate to (a && (b == c)) && d, not (a && b) == (c && d)