### PR TITLE
better exception handling for customLogger

### DIFF
--- a/driver/opc/util.cpp
+++ b/driver/opc/util.cpp
@@ -58,7 +58,31 @@ void customLogger(
     const char *msg,
     va_list args
 ) {
-    std::string prefix = *static_cast<std::string *>(logContext);
+    std::string prefix;
+    try {
+        if (!logContext) {
+            throw std::runtime_error("logContext is nullptr");
+        }
+
+        std::string* prefixPtr = static_cast<std::string*>(logContext);
+        if (!prefixPtr) {
+            throw std::runtime_error("logContext is not a valid std::string pointer");
+        }
+
+        prefix = *prefixPtr;
+        if (prefix.empty()) {
+            prefix = "";
+        }
+    } catch (const std::bad_cast& e) {
+        // Handle bad cast exception
+        std::cerr << "Bad cast: " << e.what() << std::endl;
+    } catch (const std::exception& e) {
+        // Handle other standard exceptions
+        std::cerr << "Exception: " << e.what() << std::endl;
+    } catch (...) {
+        // Handle any other exceptions
+        std::cerr << "Unknown exception occurred" << std::endl;
+    }
     char buffer[1024];
     vsnprintf(buffer, sizeof(buffer), msg, args);
     switch (level) {


### PR DESCRIPTION
PR to fix bad alloc issue occuring in opc/reader.cpp on  UA_Client_Service_read().
- Lack of type/null checking on longContext pointer caused unbounded memory allocation when casting to string
- fix: better null and type checking in the log adapter from the driver to the open62541 interface