### PR TITLE
[client/ts] - implemented channel retrieve cache invalidation

### DIFF
--- a/client/ts/src/channel/channel.spec.ts
+++ b/client/ts/src/channel/channel.spec.ts
@@ -246,6 +246,12 @@ describe("Channel", () => {
           dataType: DataType.FLOAT32,
         },
       ]);
+      const initial = await client.channels.retrieve([
+        channels[0].key,
+        channels[1].key,
+      ]);
+      expect(initial[0].name).toEqual("test1");
+      expect(initial[1].name).toEqual("test2");
       await client.channels.rename(
         [channels[0].key, channels[1].key],
         ["test3", "test4"],

--- a/client/ts/src/channel/channel.spec.ts
+++ b/client/ts/src/channel/channel.spec.ts
@@ -246,20 +246,15 @@ describe("Channel", () => {
           dataType: DataType.FLOAT32,
         },
       ]);
-      const initial = await client.channels.retrieve([
-        channels[0].key,
-        channels[1].key,
-      ]);
+      // Retrieve channels here to ensure we check for cache invalidation
+      const initial = await client.channels.retrieve(channels.map((c) => c.key));
       expect(initial[0].name).toEqual("test1");
       expect(initial[1].name).toEqual("test2");
       await client.channels.rename(
-        [channels[0].key, channels[1].key],
+        channels.map((c) => c.key),
         ["test3", "test4"],
       );
-      const renamed = await client.channels.retrieve([
-        channels[0].key,
-        channels[1].key,
-      ]);
+      const renamed = await client.channels.retrieve(channels.map((c) => c.key));
       expect(renamed[0].name).toEqual("test3");
       expect(renamed[1].name).toEqual("test4");
     });

--- a/client/ts/src/channel/retriever.ts
+++ b/client/ts/src/channel/retriever.ts
@@ -138,8 +138,8 @@ export class CacheRetriever implements Retriever {
     return results.concat(fetched);
   }
 
-  delete(keys: Params): void {
-    const { variant, normalized } = analyzeChannelParams(keys);
+  delete(channels: Params): void {
+    const { variant, normalized } = analyzeChannelParams(channels);
     if (variant === "names")
       (normalized as string[]).forEach((name) => {
         const keys = this.namesToKeys.get(name);
@@ -163,7 +163,10 @@ export class CacheRetriever implements Retriever {
       if (ch == null) return;
       this.cache.delete(key);
       const keys = this.namesToKeys.get(ch.name);
-      if (keys != null) keys.delete(key);
+      if (keys != null) {
+        keys.delete(key);
+        if (keys.size === 0) this.namesToKeys.delete(ch.name);
+      }
       ch.name = name;
       this.cache.set(key, ch);
       const newKeys = this.namesToKeys.get(name);

--- a/client/ts/src/channel/retriever.ts
+++ b/client/ts/src/channel/retriever.ts
@@ -103,7 +103,7 @@ export class ClusterRetriever implements Retriever {
 
 export class CacheRetriever implements Retriever {
   private readonly cache: Map<number, Payload>;
-  private readonly namesToKeys: Map<string, number>;
+  private readonly namesToKeys: Map<string, Set<number>>;
   private readonly wrapped: Retriever;
 
   constructor(wrapped: Retriever) {
@@ -128,27 +128,74 @@ export class CacheRetriever implements Retriever {
     const results: Payload[] = [];
     const toFetch: KeysOrNames = [];
     normalized.forEach((keyOrName) => {
-      const c = this.getFromCache(keyOrName);
-      if (c != null) results.push(c);
+      const c = this.get(keyOrName);
+      if (c != null) results.push(...c);
       else toFetch.push(keyOrName as never);
     });
     if (toFetch.length === 0) return results;
     const fetched = await this.wrapped.retrieve(toFetch, options);
-    this.updateCache(fetched);
+    this.set(fetched);
     return results.concat(fetched);
   }
 
-  private updateCache(channels: Payload[]): void {
-    channels.forEach((channel) => {
-      this.cache.set(channel.key, channel);
-      this.namesToKeys.set(channel.name, channel.key);
+  delete(keys: Params): void {
+    const { variant, normalized } = analyzeChannelParams(keys);
+    if (variant === "names")
+      (normalized as string[]).forEach((name) => {
+        const keys = this.namesToKeys.get(name);
+        if (keys == null) return;
+        keys.forEach((k) => this.cache.delete(k));
+        this.namesToKeys.delete(name);
+      });
+    else
+      (normalized as number[]).forEach((key) => {
+        const channel = this.cache.get(key);
+        if (channel == null) return;
+        this.cache.delete(key);
+        this.namesToKeys.delete(channel.name);
+      });
+  }
+
+  rename(keys: Key[], names: string[]): void {
+    keys.forEach((key, i) => {
+      const name = names[i];
+      const ch = this.cache.get(key);
+      if (ch == null) return;
+      this.cache.delete(key);
+      const keys = this.namesToKeys.get(ch.name);
+      if (keys != null) keys.delete(key);
+      ch.name = name;
+      this.cache.set(key, ch);
+      const newKeys = this.namesToKeys.get(name);
+      if (newKeys == null) this.namesToKeys.set(name, new Set([key]));
+      else newKeys.add(key);
     });
   }
 
-  private getFromCache(channel: KeyOrName): Payload | undefined {
-    const key = typeof channel === "number" ? channel : this.namesToKeys.get(channel);
-    if (key == null) return undefined;
-    return this.cache.get(key);
+  set(channels: Payload[]): void {
+    channels.forEach((channel) => {
+      this.cache.set(channel.key, channel);
+      const keys = this.namesToKeys.get(channel.name);
+      if (keys == null) this.namesToKeys.set(channel.name, new Set([channel.key]));
+      else keys.add(channel.key);
+    });
+  }
+
+  private get(channel: KeyOrName): Payload[] | undefined {
+    if (typeof channel === "number") {
+      const ch = this.cache.get(channel);
+      if (ch == null) return undefined;
+      return [ch];
+    }
+    const keys = this.namesToKeys.get(channel);
+    if (keys == null) return undefined;
+    const channels: Payload[] = [];
+    keys.forEach((key) => {
+      const ch = this.cache.get(key);
+      if (ch != null) channels.push(ch);
+    });
+    if (channels.length === 0) return undefined;
+    return channels;
   }
 }
 

--- a/client/ts/src/client.ts
+++ b/client/ts/src/client.ts
@@ -106,7 +106,7 @@ export default class Synnax extends framer.Client {
     const chRetriever = new channel.CacheRetriever(
       new channel.ClusterRetriever(transport.unary),
     );
-    const chCreator = new channel.Writer(transport.unary);
+    const chCreator = new channel.Writer(transport.unary, chRetriever);
     super(transport.stream, transport.unary, chRetriever);
     this.createdAt = TimeStamp.now();
     this.props = props;


### PR DESCRIPTION
# Fix Pull Request Template

## Key Information

- [Linear Issue](ebonilla/sy-833-ts-delete-invalidation-on-channel-retrieve-cache)

## Description

We cache channels after retrieving them. If we deleted a retrieved channel, the cache entry would not be removed. This fix addresses that, along with updating the cache on renames.

## Basic Readiness Checklist

- [x] I have performed a self-review of my code.
- [x] I have added sufficient regression tests to cover the changes.

## Manual QA Additions

- [x] I have updated the [Release Candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template
  with necessary manual QA steps to test my change.
