### PR TITLE
Leo/sy 834 python client parse numeric strings

### DIFF
--- a/client/py/synnax/channel/payload.py
+++ b/client/py/synnax/channel/payload.py
@@ -68,11 +68,19 @@ def normalize_channel_params(
         return NormalizedChannelKeyResult(single=False, variant="keys", params=[])
     single = isinstance(params, (ChannelKey, ChannelName))
     if isinstance(normalized[0], str):
-        return NormalizedChannelNameResult(
-            single=single,
-            variant="names",
-            params=cast(ChannelNames, normalized),
-        )
+        try:
+            numeric_strings = [ChannelKey(s) for s in normalized]
+            return NormalizedChannelKeyResult(
+                single=single,
+                variant="keys",
+                params=cast(ChannelKeys, numeric_strings)
+            )
+        except ValueError:
+            return NormalizedChannelNameResult(
+                single=single,
+                variant="names",
+                params=cast(ChannelNames, normalized),
+            )
     if isinstance(normalized[0], ChannelPayload):
         return NormalizedChannelNameResult(
             single=single,

--- a/client/py/tests/test_channel.py
+++ b/client/py/tests/test_channel.py
@@ -110,6 +110,28 @@ class TestChannelClient:
         with pytest.raises(sy.NotFoundError):
             client.channels.retrieve(fake_keys)
 
+    def test_retrieve_numeric_string(self, client: sy.Synnax, two_channels: list[sy.channel]):
+        channels = client.channels.retrieve([str(two_channels[0].key), str(two_channels[1].key)])
+        for channel in channels:
+            assert channel.name in ["test", "test2"]
+
+    def test_retrieve_bad_numeric_string(self, client: sy.Synnax):
+        ch1 = client.channels.create(
+            data_type=sy.DataType.FLOAT32,
+            name="test1",
+            rate=1*sy.Rate.HZ
+        )
+        ch2 = client.channels.create(
+            data_type=sy.DataType.FLOAT32,
+            name=str(ch1.key),
+            rate=1*sy.Rate.HZ
+        )
+        
+        # Should get first channel since the numeric string gets converted to a key 
+        result_channel = client.channels.retrieve(ch2.name)
+        assert result_channel.name == "test1"
+        
+
     def test_retrieve_single_multiple_found(
         self,
         client: sy.Synnax,


### PR DESCRIPTION
# Fix Pull Request Template

## Key Information

- [Linear Issue](https://linear.app/synnaxlabs/issue/SY-834/python-client-parse-numeric-strings)

## Description

[client] - python client now parses numeric strings as keys when retrieving instead of using the string as a name.

## Basic Readiness Checklist

- [x] I have performed a self-review of my code.
- [x] I have added sufficient regression tests to cover the changes.

## Manual QA Additions

- [x] I have updated the [Release Candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template
  with necessary manual QA steps to test my change.
