### PR TITLE
[cesium] - fixed a deadlock with garbage collection on cesium closing

### DIFF
--- a/cesium/delete.go
+++ b/cesium/delete.go
@@ -19,7 +19,6 @@ import (
 	"io/fs"
 	"math/rand"
 	"strconv"
-	"sync"
 	"time"
 )
 
@@ -272,14 +271,12 @@ func (db *DB) garbageCollect(ctx context.Context, maxGoRoutine int64) error {
 	var (
 		sem     = semaphore.NewWeighted(maxGoRoutine)
 		sCtx, _ = signal.Isolated()
-		wg      = &sync.WaitGroup{}
 	)
 	for _, udb := range db.unaryDBs {
 		if err := sem.Acquire(ctx, 1); err != nil {
 			db.mu.RUnlock()
 			return err
 		}
-		wg.Add(1)
 		udb := udb
 		sCtx.Go(func(_ctx context.Context) error {
 			defer sem.Release(1)


### PR DESCRIPTION
# Fix Pull Request Template

## Key Information

- [Linear Issue](https://linear.app/synnaxlabs/issue/SY-840/deadlock-in-delete)

## Description

Cause was on close, mutex is locked on the database while existing already-scheduled garbage collection routines also need to lock the mutex. Fixed by first running DB shutdown then locking mutex for db close.

## Basic Readiness Checklist

- [x] I have performed a self-review of my code.
- [x] I have added sufficient regression tests to cover the changes. – **NONE ADDED**

## Manual QA Additions

- [x] I have updated the [Release Candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template
  with necessary manual QA steps to test my change. - **NONE ADDED**
