### PR TITLE
[cesium] - fixed a deadlock with relay on db closing

### DIFF
--- a/cesium/gc_test.go
+++ b/cesium/gc_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Garbage collection", Ordered, func() {
 					Expect(db.Close()).To(Succeed())
 					Expect(cleanUp()).To(Succeed())
 				})
-				It("Should recycle properly for a deletion on a rate channel", func() {
+				It("Should recycle properly for deletion on a rate channel", func() {
 					By("Creating a channel")
 					Expect(db.CreateChannel(
 						ctx,

--- a/cesium/internal/unary/delete.go
+++ b/cesium/internal/unary/delete.go
@@ -20,12 +20,18 @@ import (
 // Delete deletes the specified time range from the database. Note that the start of the
 // time range is inclusive whereas the end is note.
 func (db *DB) Delete(ctx context.Context, tr telem.TimeRange) error {
+	if db.closed.Load() {
+		return errDBClosed
+	}
 	return db.wrapError(db.delete(ctx, tr))
 }
 
 // GarbageCollect removes unused telemetry data in the unaryDB. It is NOT safe to call
 // concurrently with other GarbageCollect methods.
 func (db *DB) GarbageCollect(ctx context.Context) error {
+	if db.closed.Load() {
+		return errDBClosed
+	}
 	db.entityCount.add(1)
 	defer db.entityCount.add(-1)
 	return db.wrapError(db.Domain.GarbageCollect(ctx))


### PR DESCRIPTION
# Fix Pull Request Template

## Key Information

- [SY-847](https://linear.app/synnaxlabs/issue/SY-847/[cesium]-relay-closing-race-condition)

## Description

We were shutting down the database signal context before closing the control digests – this deadlocked writes in the control digests which attempt to send to relay – which is already closed after the signal context is closed. This PR fixes this by closing the control digest before shutting down the signal context.

## Basic Readiness Checklist

- [x] I have performed a self-review of my code.
- [x] I have added sufficient regression tests to cover the changes. - **None added** (hard to reproduce locally, test in CI runs)

## Manual QA Additions

- [x] I have updated the [Release Candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template
  with necessary manual QA steps to test my change.
