### PR TITLE
Ebonilla/sy 889 pluto make modals not render on document element

### DIFF
--- a/pluto/src/dropdown/Dropdown.tsx
+++ b/pluto/src/dropdown/Dropdown.tsx
@@ -1,3 +1,12 @@
+// Copyright 2024 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
 import {
   box,
   invert,
@@ -23,6 +32,7 @@ import { Dialog as CoreDialog } from "@/dialog";
 import { useClickOutside, useCombinedRefs, useResize, useSyncedRef } from "@/hooks";
 import { Triggers } from "@/triggers";
 import { ComponentSize } from "@/util/component";
+import { getRootElement } from "@/util/rootElement";
 
 export type UseProps = CoreDialog.UseProps;
 export type UseReturn = CoreDialog.UseReturn;
@@ -141,7 +151,7 @@ export const Dialog = ({
       {(keepMounted || visible) && children[1]}
     </Align.Space>
   );
-  if (variant === "floating") child = createPortal(child, document.body);
+  if (variant === "floating") child = createPortal(child, getRootElement());
   else if (variant === "modal") {
     child = createPortal(
       <Align.Space
@@ -152,7 +162,7 @@ export const Dialog = ({
       >
         {child}
       </Align.Space>,
-      document.getElementById("root") ?? document.body,
+      getRootElement(),
     );
   }
 

--- a/pluto/src/dropdown/Dropdown.tsx
+++ b/pluto/src/dropdown/Dropdown.tsx
@@ -152,7 +152,7 @@ export const Dialog = ({
       >
         {child}
       </Align.Space>,
-      document.body,
+      document.getElementById("root") ?? document.body,
     );
   }
 

--- a/pluto/src/modal/Modal.tsx
+++ b/pluto/src/modal/Modal.tsx
@@ -41,6 +41,6 @@ export const Modal = ({ visible, close, ...props }: ModalProps): ReactElement =>
         {...props}
       />
     </Align.Space>,
-    document.body,
+    document.getElementById("root") ?? document.body,
   );
 };

--- a/pluto/src/modal/Modal.tsx
+++ b/pluto/src/modal/Modal.tsx
@@ -17,6 +17,7 @@ import { CSS } from "@/css";
 import { Dialog } from "@/dialog";
 import { useClickOutside } from "@/hooks";
 import { Triggers } from "@/triggers";
+import { getRootElement } from "@/util/rootElement";
 
 export interface ModalProps
   extends Pick<Dialog.UseReturn, "visible" | "close">,
@@ -41,6 +42,6 @@ export const Modal = ({ visible, close, ...props }: ModalProps): ReactElement =>
         {...props}
       />
     </Align.Space>,
-    document.getElementById("root") ?? document.body,
+    getRootElement(),
   );
 };

--- a/pluto/src/modal/Modal.tsx
+++ b/pluto/src/modal/Modal.tsx
@@ -41,6 +41,6 @@ export const Modal = ({ visible, close, ...props }: ModalProps): ReactElement =>
         {...props}
       />
     </Align.Space>,
-    document.documentElement,
+    document.body,
   );
 };

--- a/pluto/src/util/rootElement.ts
+++ b/pluto/src/util/rootElement.ts
@@ -1,0 +1,11 @@
+// Copyright 2024 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+export const getRootElement = (): HTMLElement =>
+  document.getElementById("root") ?? document.body;


### PR DESCRIPTION
# Fix Pull Request Template

## Key Information

- Linear Issue: [SY-889](https://linear.app/synnaxlabs/issue/SY-889/[pluto]-make-modals-not-render-on-document-element)

## Description

Fixes issue where we render modals and dropdowns on the HTML document element instead of the body. This fixes that.

## Basic Readiness Checklist

- [x] I have performed a self-review of my code.
- [x] I have added sufficient regression tests to cover the changes.

## Manual QA Additions

- [x] I have updated the [Release Candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template
  with necessary manual QA steps to test my change.
