### PR TITLE
[ops] - typo in test aspen mistaken for test cesium

### DIFF
--- a/.github/workflows/test.aspen.yaml
+++ b/.github/workflows/test.aspen.yaml
@@ -1,4 +1,4 @@
-name: "Test - Cesium"
+name: "Test - Aspen"
 on:
   pull_request:
     branches:


### PR DESCRIPTION
# Fix Pull Request Template

## Key Information

- [SY-892](https://linear.app/synnaxlabs/issue/SY-892/[ops]-wrong-name-for-aspen-test-workflow)
- **To be merged into main!!**

## Description

Our test Aspen was called Test Cesium and this PR fixes that

## Basic Readiness Checklist

- [x] I have performed a self-review of my code.
- [x] I have added sufficient regression tests to cover the changes. - **N/A**

## Manual QA Additions

- [x] I have updated the [Release Candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template
  with necessary manual QA steps to test my change. - **N/A**
