### PR TITLE
Sy 375 server register global zap logger

### DIFF
--- a/.github/workflows/test.aspen.yaml
+++ b/.github/workflows/test.aspen.yaml
@@ -1,4 +1,4 @@
-name: "Test - Cesium"
+name: "Test - Aspen"
 on:
   pull_request:
     branches:

--- a/.github/workflows/test.cesium.yaml
+++ b/.github/workflows/test.cesium.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Test
         if: steps.filter.outputs.changed == 'true'
-        run: go test -v ./... -tags development --covermode=atomic --coverprofile=coverage.txt --ginkgo.label-filter="!integration && !performance"
+        run: go test -v ./... --covermode=atomic --coverprofile=coverage.txt --ginkgo.label-filter="!integration && !performance"
         working-directory: ./cesium
 
       - name: Upload Coverage

--- a/.github/workflows/test.cesium.yaml
+++ b/.github/workflows/test.cesium.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Test
         if: steps.filter.outputs.changed == 'true'
-        run: go test -v ./... --covermode=atomic --coverprofile=coverage.txt --ginkgo.label-filter="!integration && !performance"
+        run: go test -v ./... -tags development --covermode=atomic --coverprofile=coverage.txt --ginkgo.label-filter="!integration && !performance"
         working-directory: ./cesium
 
       - name: Upload Coverage

--- a/.github/workflows/test.synnax.yaml
+++ b/.github/workflows/test.synnax.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Test
         if: steps.filter.outputs.changed == 'true'
-        run: go test -tags noui -v ./... --covermode=atomic --coverprofile=coverage.txt --ginkgo.label-filter="!integration && !performance"
+        run: go test -tags noui development -v ./... --covermode=atomic --coverprofile=coverage.txt --ginkgo.label-filter="!integration && !performance"
         working-directory: ./synnax
 
       - name: Upload Coverage

--- a/.github/workflows/test.synnax.yaml
+++ b/.github/workflows/test.synnax.yaml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Test
         if: steps.filter.outputs.changed == 'true'
-        run: go test -tags noui development -v ./... --covermode=atomic --coverprofile=coverage.txt --ginkgo.label-filter="!integration && !performance"
+        run: go test -tags="noui development" -v ./... --covermode=atomic --coverprofile=coverage.txt --ginkgo.label-filter="!integration && !performance"
         working-directory: ./synnax
 
       - name: Upload Coverage

--- a/alamos/go/log.go
+++ b/alamos/go/log.go
@@ -55,6 +55,11 @@ func NewLogger(configs ...LoggerConfig) (*Logger, error) {
 	return &Logger{Config: cfg, zap: z.WithOptions(zap.AddCallerSkip(1))}, nil
 }
 
+// Zap returns the underlying zap Logger
+func (l *Logger) Zap() *zap.Logger {
+	return l.zap
+}
+
 func (l *Logger) child(meta InstrumentationMeta) (nl *Logger) {
 	if l != nil {
 		nl = &Logger{zap: l.zap.Named(meta.Key), Config: l.Config}

--- a/aspen/internal/cluster/gossip/gossip_test.go
+++ b/aspen/internal/cluster/gossip/gossip_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/synnaxlabs/freighter/fmock"
 	"github.com/synnaxlabs/x/errors"
 	"github.com/synnaxlabs/x/signal"
+	. "github.com/synnaxlabs/x/testutil"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -51,6 +52,7 @@ var _ = Describe("OperationSender", func() {
 			gossipCtx, cancel = signal.WithCancel(ctx)
 			var err error
 			g1, err = gossip.New(gossip.Config{
+				Instrumentation: PanicLogger(),
 				Store:           sOne,
 				TransportClient: net.UnaryClient(),
 				TransportServer: t1,
@@ -58,6 +60,7 @@ var _ = Describe("OperationSender", func() {
 			})
 			Expect(err).ToNot(HaveOccurred())
 			_, err = gossip.New(gossip.Config{
+				Instrumentation: PanicLogger(),
 				Store:           sTwo,
 				TransportClient: net.UnaryClient(),
 				TransportServer: t2,

--- a/aspen/internal/cluster/gossip/gossip_test.go
+++ b/aspen/internal/cluster/gossip/gossip_test.go
@@ -89,9 +89,10 @@ var _ = Describe("OperationSender", func() {
 				g.Expect(sOne.CopyState().Nodes[2].Heartbeat.Version).To(Equal(uint32(0)))
 			}).Should(Succeed())
 		})
-		It("Should return an error when an invalid message is received", func() {
-			_, err := net.UnaryClient().Send(context.Background(), t2.Address, gossip.Message{})
-			Expect(err).To(HaveOccurred())
+		It("Should DPanic when an invalid message is received", func() {
+			Expect(func() {
+				net.UnaryClient().Send(context.Background(), t2.Address, gossip.Message{})
+			}).To(Panic())
 		})
 	})
 })

--- a/cesium/cesium_suite_test.go
+++ b/cesium/cesium_suite_test.go
@@ -30,6 +30,7 @@ func openDBOnFS(fs xfs.FS) *cesium.DB {
 	return MustSucceed(cesium.Open(
 		"",
 		cesium.WithFS(fs),
+		cesium.WithInstrumentation(PanicLogger()),
 	))
 }
 

--- a/cesium/gc_test.go
+++ b/cesium/gc_test.go
@@ -34,7 +34,8 @@ var _ = Describe("Garbage collection", Ordered, func() {
 							GCThreshold:   math.SmallestNonzeroFloat32,
 						}),
 						cesium.WithFS(fs),
-						cesium.WithFileSize(899*telem.ByteSize)))
+						cesium.WithFileSize(899*telem.ByteSize),
+						cesium.WithInstrumentation(PanicLogger())))
 				})
 				AfterAll(func() {
 					Expect(db.Close()).To(Succeed())
@@ -147,7 +148,8 @@ var _ = Describe("Garbage collection", Ordered, func() {
 							GCThreshold:   float32(250) / 719,
 						}),
 						cesium.WithFS(fs),
-						cesium.WithFileSize(899*telem.ByteSize)))
+						cesium.WithFileSize(899*telem.ByteSize),
+						cesium.WithInstrumentation(PanicLogger())))
 				})
 				AfterAll(func() {
 					Expect(db.Close()).To(Succeed())
@@ -221,7 +223,10 @@ var _ = Describe("Garbage collection", Ordered, func() {
 							GCTryInterval: 10 * telem.Millisecond.Duration(),
 							GCThreshold:   1,
 						}),
-						cesium.WithFS(fs), cesium.WithFileSize(49*telem.ByteSize)))
+						cesium.WithFS(fs),
+						cesium.WithFileSize(49*telem.ByteSize),
+						cesium.WithInstrumentation(PanicLogger()),
+					))
 				})
 				AfterAll(func() {
 					Expect(db.Close()).To(Succeed())

--- a/cesium/internal/domain/delete_test.go
+++ b/cesium/internal/domain/delete_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Delete", Ordered, func() {
 			)
 			BeforeEach(func() {
 				fs, cleanUp = makeFS()
-				db = MustSucceed(domain.Open(domain.Config{FS: fs}))
+				db = MustSucceed(domain.Open(domain.Config{FS: fs, Instrumentation: PanicLogger()}))
 				Expect(domain.Write(ctx, db, (10 * telem.SecondTS).SpanRange(10*telem.Second), []byte{10, 11, 12, 13, 14, 15, 16, 17, 18, 19})).To(Succeed())
 				Expect(domain.Write(ctx, db, (20 * telem.SecondTS).SpanRange(10*telem.Second), []byte{20, 21, 22, 23, 24, 25, 26, 27, 28, 29})).To(Succeed())
 				Expect(domain.Write(ctx, db, (30 * telem.SecondTS).SpanRange(10*telem.Second), []byte{30, 31, 32, 33, 34, 35, 36, 37, 38, 39})).To(Succeed())
@@ -200,7 +200,7 @@ var _ = Describe("Delete", Ordered, func() {
 				})
 
 				It("Should return an error when the db is closed", func() {
-					db2 := MustSucceed(domain.Open(domain.Config{FS: fs}))
+					db2 := MustSucceed(domain.Open(domain.Config{FS: fs, Instrumentation: PanicLogger()}))
 					Expect(db2.Close()).To(Succeed())
 					Expect(db2.Delete(ctx, createCalcOffset(0), createCalcOffset(0), telem.TimeRangeMin, telem.Density(1))).To(HaveOccurredAs(core.EntityClosed("domain.db")))
 				})

--- a/cesium/internal/domain/file_controller_test.go
+++ b/cesium/internal/domain/file_controller_test.go
@@ -37,7 +37,11 @@ var _ = Describe("File Controller", Ordered, func() {
 			Describe("Writers", func() {
 				It("Should allow one writing to a file at all times", func() {
 					By("Initializing a file controller")
-					db = MustSucceed(domain.Open(domain.Config{FS: fs, FileSize: 1 * telem.Megabyte}))
+					db = MustSucceed(domain.Open(domain.Config{
+						FS:              fs,
+						FileSize:        1 * telem.Megabyte,
+						Instrumentation: PanicLogger(),
+					}))
 					By("Acquiring one writer on the file 1.domain")
 					w1 := MustSucceed(db.NewWriter(ctx, domain.WriterConfig{
 						Start: 10 * telem.SecondTS,
@@ -74,7 +78,11 @@ var _ = Describe("File Controller", Ordered, func() {
 
 				It("Should obey the file size limit", func() {
 					By("Initializing a file controller")
-					db = MustSucceed(domain.Open(domain.Config{FS: fs, FileSize: 10 * telem.ByteSize}))
+					db = MustSucceed(domain.Open(domain.Config{
+						FS:              fs,
+						FileSize:        10 * telem.ByteSize,
+						Instrumentation: PanicLogger(),
+					}))
 					By("Acquiring one writer on the file 1.domain")
 					w1 := MustSucceed(db.NewWriter(ctx, domain.WriterConfig{
 						Start: 10 * telem.SecondTS,
@@ -98,7 +106,10 @@ var _ = Describe("File Controller", Ordered, func() {
 
 				It("Should persist obey the file size limit", func() {
 					By("Initializing a file controller")
-					db = MustSucceed(domain.Open(domain.Config{FS: fs, FileSize: 10 * telem.ByteSize}))
+					db = MustSucceed(domain.Open(domain.Config{
+						FS: fs, FileSize: 10 * telem.ByteSize,
+						Instrumentation: PanicLogger(),
+					}))
 					By("Acquiring one writer on the file 1.domain")
 					w1 := MustSucceed(db.NewWriter(ctx, domain.WriterConfig{
 						Start: 10 * telem.SecondTS,
@@ -114,7 +125,11 @@ var _ = Describe("File Controller", Ordered, func() {
 					Expect(db.Close()).To(Succeed())
 
 					By("Reopening the db and fc")
-					db = MustSucceed(domain.Open(domain.Config{FS: fs, FileSize: 10 * telem.ByteSize}))
+					db = MustSucceed(domain.Open(domain.Config{
+						FS:              fs,
+						FileSize:        10 * telem.ByteSize,
+						Instrumentation: PanicLogger(),
+					}))
 
 					By("Acquiring a second writer, this would create a new file 2.domain since 1.domain is full")
 					w2, err := db.NewWriter(ctx, domain.WriterConfig{
@@ -129,7 +144,11 @@ var _ = Describe("File Controller", Ordered, func() {
 
 				It("Should open a file if it is below threshold", func() {
 					By("Initializing a file controller")
-					db = MustSucceed(domain.Open(domain.Config{FS: fs, FileSize: 10 * telem.ByteSize}))
+					db = MustSucceed(domain.Open(domain.Config{
+						FS:              fs,
+						FileSize:        10 * telem.ByteSize,
+						Instrumentation: PanicLogger(),
+					}))
 					By("Acquiring one writer on the file 1.domain")
 					w1 := MustSucceed(db.NewWriter(ctx, domain.WriterConfig{
 						Start: 10 * telem.SecondTS,
@@ -154,7 +173,11 @@ var _ = Describe("File Controller", Ordered, func() {
 
 				It("Should persist and open a file if it is below threshold", func() {
 					By("Initializing a file controller")
-					db = MustSucceed(domain.Open(domain.Config{FS: fs, FileSize: 10 * telem.ByteSize}))
+					db = MustSucceed(domain.Open(domain.Config{
+						FS:              fs,
+						FileSize:        10 * telem.ByteSize,
+						Instrumentation: PanicLogger(),
+					}))
 					By("Acquiring one writer on the file 1.domain")
 					w1 := MustSucceed(db.NewWriter(ctx, domain.WriterConfig{
 						Start: 10 * telem.SecondTS,
@@ -170,7 +193,11 @@ var _ = Describe("File Controller", Ordered, func() {
 					Expect(db.Close()).To(Succeed())
 
 					By("Reopening the db and fc")
-					db = MustSucceed(domain.Open(domain.Config{FS: fs, FileSize: 10 * telem.ByteSize}))
+					db = MustSucceed(domain.Open(domain.Config{
+						FS:              fs,
+						FileSize:        10 * telem.ByteSize,
+						Instrumentation: PanicLogger(),
+					}))
 
 					By("Acquiring a second writer, this would not create a new file 2.domain since 1.domain is not full")
 					w2, err := db.NewWriter(ctx, domain.WriterConfig{
@@ -185,7 +212,11 @@ var _ = Describe("File Controller", Ordered, func() {
 
 				It("Should obey the file descriptor limit", func() {
 					By("Initializing a file controller")
-					db = MustSucceed(domain.Open(domain.Config{FS: fs, MaxDescriptors: 2}))
+					db = MustSucceed(domain.Open(domain.Config{
+						FS:              fs,
+						MaxDescriptors:  2,
+						Instrumentation: PanicLogger(),
+					}))
 					By("Acquiring one writer on the file 1.domain")
 					w1 := MustSucceed(db.NewWriter(ctx, domain.WriterConfig{
 						Start: 10 * telem.SecondTS,
@@ -228,7 +259,11 @@ var _ = Describe("File Controller", Ordered, func() {
 
 				It("Should persist the counter file across open/close", func() {
 					By("Initializing a file controller")
-					db = MustSucceed(domain.Open(domain.Config{FS: fs, FileSize: 10 * telem.ByteSize}))
+					db = MustSucceed(domain.Open(domain.Config{
+						FS:              fs,
+						FileSize:        10 * telem.ByteSize,
+						Instrumentation: PanicLogger(),
+					}))
 
 					By("Filling up 1.domain")
 					w1 := MustSucceed(db.NewWriter(ctx, domain.WriterConfig{
@@ -244,7 +279,11 @@ var _ = Describe("File Controller", Ordered, func() {
 					Expect(db.Close()).To(Succeed())
 
 					By("Reopening the db on the same FS")
-					db = MustSucceed(domain.Open(domain.Config{FS: fs, FileSize: 10 * telem.ByteSize}))
+					db = MustSucceed(domain.Open(domain.Config{
+						FS:              fs,
+						FileSize:        10 * telem.ByteSize,
+						Instrumentation: PanicLogger(),
+					}))
 
 					By("Acquiring a new writer: this should go to file 2 instead of 1")
 					w2 := MustSucceed(db.NewWriter(ctx, domain.WriterConfig{
@@ -272,7 +311,11 @@ var _ = Describe("File Controller", Ordered, func() {
 
 				It("Should open writers on partially full files after reopening the file controller", func() {
 					By("Initializing a file controller")
-					db = MustSucceed(domain.Open(domain.Config{FS: fs, FileSize: 10 * telem.ByteSize}))
+					db = MustSucceed(domain.Open(domain.Config{
+						FS:              fs,
+						FileSize:        10 * telem.ByteSize,
+						Instrumentation: PanicLogger(),
+					}))
 
 					By("Filling up 1.domain")
 					w1 := MustSucceed(db.NewWriter(ctx, domain.WriterConfig{
@@ -297,7 +340,11 @@ var _ = Describe("File Controller", Ordered, func() {
 					Expect(db.Close()).To(Succeed())
 
 					By("Reopening the db on the same FS")
-					db = MustSucceed(domain.Open(domain.Config{FS: fs, FileSize: 10 * telem.ByteSize}))
+					db = MustSucceed(domain.Open(domain.Config{
+						FS:              fs,
+						FileSize:        10 * telem.ByteSize,
+						Instrumentation: PanicLogger(),
+					}))
 
 					By("Acquiring a new writer: this should go to file 2")
 					w3 := MustSucceed(db.NewWriter(ctx, domain.WriterConfig{
@@ -408,7 +455,11 @@ var _ = Describe("File Controller", Ordered, func() {
 
 				It("Should work with file auto cutoff generated files", func() {
 					By("Initializing a file controller")
-					db = MustSucceed(domain.Open(domain.Config{FS: fs, FileSize: 10 * telem.ByteSize}))
+					db = MustSucceed(domain.Open(domain.Config{
+						FS:              fs,
+						FileSize:        10 * telem.ByteSize,
+						Instrumentation: PanicLogger(),
+					}))
 
 					By("Filling up 1.domain")
 					w1 := MustSucceed(db.NewWriter(ctx, domain.WriterConfig{
@@ -423,7 +474,11 @@ var _ = Describe("File Controller", Ordered, func() {
 
 					By("Reopening the db")
 					Expect(db.Close()).To(Succeed())
-					db = MustSucceed(domain.Open(domain.Config{FS: fs, FileSize: 10 * telem.ByteSize}))
+					db = MustSucceed(domain.Open(domain.Config{
+						FS:              fs,
+						FileSize:        10 * telem.ByteSize,
+						Instrumentation: PanicLogger(),
+					}))
 
 					By("Acquiring a new writer")
 					w2 := MustSucceed(db.NewWriter(ctx, domain.WriterConfig{

--- a/cesium/internal/domain/gc_test.go
+++ b/cesium/internal/domain/gc_test.go
@@ -38,7 +38,12 @@ var _ = Describe("Garbage Collection", Ordered, func() {
 
 			Context("Happy path - one file", func() {
 				It("Should garbage collect one tombstone", func() {
-					db = MustSucceed(domain.Open(domain.Config{FS: fs, FileSize: 9 * telem.ByteSize, GCThreshold: math.SmallestNonzeroFloat32}))
+					db = MustSucceed(domain.Open(domain.Config{
+						FS:              fs,
+						FileSize:        9 * telem.ByteSize,
+						GCThreshold:     math.SmallestNonzeroFloat32,
+						Instrumentation: PanicLogger(),
+					}))
 					Expect(domain.Write(ctx, db, (10 * telem.SecondTS).Range(19*telem.SecondTS+1), []byte{10, 11, 12, 13, 14, 15, 16, 17, 18, 19})).To(Succeed())
 					Expect(db.Delete(ctx, createCalcOffset(3), createCalcOffset(7), telem.TimeRange{Start: 12*telem.SecondTS + 1, End: 16*telem.SecondTS + 1}, telem.Density(1))).To(Succeed())
 
@@ -81,7 +86,12 @@ var _ = Describe("Garbage Collection", Ordered, func() {
 					})
 				})
 				It("Should garbage collect multiple tombstones", func() {
-					db = MustSucceed(domain.Open(domain.Config{FS: fs, FileSize: 20 * telem.ByteSize, GCThreshold: math.SmallestNonzeroFloat32}))
+					db = MustSucceed(domain.Open(domain.Config{
+						FS:              fs,
+						FileSize:        20 * telem.ByteSize,
+						GCThreshold:     math.SmallestNonzeroFloat32,
+						Instrumentation: PanicLogger(),
+					}))
 					Expect(domain.Write(ctx, db, (10 * telem.SecondTS).Range(19*telem.SecondTS+1), []byte{10, 11, 12, 13, 14, 15, 16, 17, 18, 19})).To(Succeed())
 					Expect(domain.Write(ctx, db, (20 * telem.SecondTS).Range(23*telem.SecondTS+1), []byte{20, 21, 22, 23})).To(Succeed())
 					Expect(domain.Write(ctx, db, (30 * telem.SecondTS).Range(36*telem.SecondTS+1), []byte{30, 31, 32, 33, 34, 35, 36})).To(Succeed())
@@ -139,7 +149,12 @@ var _ = Describe("Garbage Collection", Ordered, func() {
 				})
 
 				It("Should garbage collect multiple tombstones based on the threshold", func() {
-					db = MustSucceed(domain.Open(domain.Config{FS: fs, FileSize: (1.25 * 20) * telem.ByteSize, GCThreshold: float32(16) / 20}))
+					db = MustSucceed(domain.Open(domain.Config{
+						FS:              fs,
+						FileSize:        (1.25 * 20) * telem.ByteSize,
+						GCThreshold:     float32(16) / 20,
+						Instrumentation: PanicLogger(),
+					}))
 					Expect(domain.Write(ctx, db, (10 * telem.SecondTS).Range(19*telem.SecondTS+1), []byte{10, 11, 12, 13, 14, 15, 16, 17, 18, 19})).To(Succeed())
 					Expect(domain.Write(ctx, db, (20 * telem.SecondTS).Range(23*telem.SecondTS+1), []byte{20, 21, 22, 23})).To(Succeed())
 					Expect(domain.Write(ctx, db, (30 * telem.SecondTS).Range(36*telem.SecondTS+1), []byte{30, 31, 32, 33, 34, 35, 36})).To(Succeed())
@@ -178,7 +193,12 @@ var _ = Describe("Garbage Collection", Ordered, func() {
 					})
 				})
 				It("Should not garbage collect a file that is oversize but not still being written to", func() {
-					db = MustSucceed(domain.Open(domain.Config{FS: fs, FileSize: 13 * telem.ByteSize, GCThreshold: math.SmallestNonzeroFloat32}))
+					db = MustSucceed(domain.Open(domain.Config{
+						FS:              fs,
+						FileSize:        13 * telem.ByteSize,
+						GCThreshold:     math.SmallestNonzeroFloat32,
+						Instrumentation: PanicLogger(),
+					}))
 					Expect(domain.Write(ctx, db, (1 * telem.SecondTS).Range(7*telem.SecondTS+1), []byte{1, 2, 3, 4, 5, 6, 7})).To(Succeed())
 					Expect(db.Delete(ctx, createCalcOffset(0), createCalcOffset(2), (1 * telem.SecondTS).Range(3*telem.SecondTS), telem.Density(1)))
 					w := MustSucceed(db.NewWriter(ctx, domain.WriterConfig{Start: 10 * telem.SecondTS}))
@@ -224,7 +244,13 @@ var _ = Describe("Garbage Collection", Ordered, func() {
 			})
 			Context("Happy path - multiple files", func() {
 				It("Should garbage collect multiple tombstones", func() {
-					db = MustSucceed(domain.Open(domain.Config{FS: fs, MaxDescriptors: 4, FileSize: 2 * telem.ByteSize, GCThreshold: math.SmallestNonzeroFloat32}))
+					db = MustSucceed(domain.Open(domain.Config{
+						FS:              fs,
+						MaxDescriptors:  4,
+						FileSize:        2 * telem.ByteSize,
+						GCThreshold:     math.SmallestNonzeroFloat32,
+						Instrumentation: PanicLogger(),
+					}))
 					Expect(domain.Write(ctx, db, (10 * telem.SecondTS).Range(19*telem.SecondTS+1), []byte{10, 11, 12, 13, 14, 15, 16, 17, 18, 19})).To(Succeed())
 					Expect(domain.Write(ctx, db, (20 * telem.SecondTS).Range(23*telem.SecondTS+1), []byte{20, 21, 22, 23})).To(Succeed())
 					Expect(domain.Write(ctx, db, (30 * telem.SecondTS).Range(36*telem.SecondTS+1), []byte{30, 31, 32, 33, 34, 35, 36})).To(Succeed())
@@ -283,7 +309,12 @@ var _ = Describe("Garbage Collection", Ordered, func() {
 				})
 
 				It("Should garbage collect multiple tombstones across many files", func() {
-					db = MustSucceed(domain.Open(domain.Config{FS: fs, FileSize: 7 * telem.ByteSize, GCThreshold: math.SmallestNonzeroFloat32}))
+					db = MustSucceed(domain.Open(domain.Config{
+						FS:              fs,
+						FileSize:        7 * telem.ByteSize,
+						GCThreshold:     math.SmallestNonzeroFloat32,
+						Instrumentation: PanicLogger(),
+					}))
 					Expect(domain.Write(ctx, db, (10 * telem.SecondTS).Range(19*telem.SecondTS+1), []byte{10, 11, 12, 13})).To(Succeed())             // file 1
 					Expect(domain.Write(ctx, db, (20 * telem.SecondTS).Range(25*telem.SecondTS+1), []byte{20, 21, 22, 23, 24, 25})).To(Succeed())     // file 1
 					Expect(domain.Write(ctx, db, (30 * telem.SecondTS).Range(36*telem.SecondTS+1), []byte{30, 31, 32, 33, 34, 35, 36})).To(Succeed()) // file 2
@@ -338,7 +369,12 @@ var _ = Describe("Garbage Collection", Ordered, func() {
 				})
 
 				It("Should garbage collect tombstones based on the threshold", func() {
-					db = MustSucceed(domain.Open(domain.Config{FS: fs, FileSize: 7 * telem.ByteSize, GCThreshold: 0.4}))
+					db = MustSucceed(domain.Open(domain.Config{
+						FS:              fs,
+						FileSize:        7 * telem.ByteSize,
+						GCThreshold:     0.4,
+						Instrumentation: PanicLogger(),
+					}))
 					Expect(domain.Write(ctx, db, (10 * telem.SecondTS).Range(19*telem.SecondTS+1), []byte{10, 11, 12, 13})).To(Succeed())             // file 1
 					Expect(domain.Write(ctx, db, (20 * telem.SecondTS).Range(25*telem.SecondTS+1), []byte{20, 21, 22, 23, 24, 25})).To(Succeed())     // file 1
 					Expect(domain.Write(ctx, db, (30 * telem.SecondTS).Range(36*telem.SecondTS+1), []byte{30, 31, 32, 33, 34, 35, 36})).To(Succeed()) // file 2
@@ -384,7 +420,12 @@ var _ = Describe("Garbage Collection", Ordered, func() {
 			})
 			Context("Tombstone persist", func() {
 				It("Should preserve the tombstones after database closure", func() {
-					db = MustSucceed(domain.Open(domain.Config{FS: fs, FileSize: 7 * telem.ByteSize, GCThreshold: 0.4}))
+					db = MustSucceed(domain.Open(domain.Config{
+						FS:              fs,
+						FileSize:        7 * telem.ByteSize,
+						GCThreshold:     0.4,
+						Instrumentation: PanicLogger(),
+					}))
 					Expect(domain.Write(ctx, db, (10 * telem.SecondTS).Range(19*telem.SecondTS+1), []byte{10, 11, 12, 13})).To(Succeed())             // file 1
 					Expect(domain.Write(ctx, db, (20 * telem.SecondTS).Range(25*telem.SecondTS+1), []byte{20, 21, 22, 23, 24, 25})).To(Succeed())     // file 1
 					Expect(domain.Write(ctx, db, (30 * telem.SecondTS).Range(36*telem.SecondTS+1), []byte{30, 31, 32, 33, 34, 35, 36})).To(Succeed()) // file 2
@@ -393,7 +434,12 @@ var _ = Describe("Garbage Collection", Ordered, func() {
 
 					By("Reopening the DB")
 					Expect(db.Close()).To(Succeed())
-					db = MustSucceed(domain.Open(domain.Config{FS: fs, FileSize: 7 * telem.ByteSize, GCThreshold: 0.4}))
+					db = MustSucceed(domain.Open(domain.Config{
+						FS:              fs,
+						FileSize:        7 * telem.ByteSize,
+						GCThreshold:     0.4,
+						Instrumentation: PanicLogger(),
+					}))
 
 					By("Garbage collecting and asserting the file got smaller")
 					Expect(MustSucceed(db.FS.Stat("1.domain")).Size()).To(Equal(int64(10)))
@@ -448,7 +494,12 @@ var _ = Describe("Garbage Collection", Ordered, func() {
 			})
 			Context("Close", func() {
 				It("Should not allow GC on a closed DB", func() {
-					db = MustSucceed(domain.Open(domain.Config{FS: fs, FileSize: 20 * telem.ByteSize, GCThreshold: math.SmallestNonzeroFloat32}))
+					db = MustSucceed(domain.Open(domain.Config{
+						FS:              fs,
+						FileSize:        20 * telem.ByteSize,
+						GCThreshold:     math.SmallestNonzeroFloat32,
+						Instrumentation: PanicLogger(),
+					}))
 					Expect(db.Close()).To(Succeed())
 					Expect(db.GarbageCollect(ctx)).To(HaveOccurredAs(core.EntityClosed("domain.db")))
 				})

--- a/cesium/internal/domain/index_persist_test.go
+++ b/cesium/internal/domain/index_persist_test.go
@@ -28,7 +28,12 @@ var _ = Describe("Index Persist", Ordered, func() {
 			)
 			BeforeEach(func() {
 				fs, cleanUp = makeFS()
-				db = MustSucceed(domain.Open(domain.Config{FS: fs, FileSize: 5 * telem.ByteSize, GCThreshold: 0}))
+				db = MustSucceed(domain.Open(domain.Config{
+					FS:              fs,
+					FileSize:        5 * telem.ByteSize,
+					GCThreshold:     0,
+					Instrumentation: PanicLogger(),
+				}))
 			})
 			AfterEach(func() {
 				Expect(db.Close()).To(Succeed())
@@ -49,7 +54,12 @@ var _ = Describe("Index Persist", Ordered, func() {
 
 					By("Re-opening the database")
 					Expect(db.Close()).To(Succeed())
-					db = MustSucceed(domain.Open(domain.Config{FS: fs, FileSize: 5 * telem.ByteSize, GCThreshold: 0}))
+					db = MustSucceed(domain.Open(domain.Config{
+						FS:              fs,
+						FileSize:        5 * telem.ByteSize,
+						GCThreshold:     0,
+						Instrumentation: PanicLogger(),
+					}))
 
 					By("Asserting that the data is still there")
 					i := db.NewIterator(domain.IterRange(telem.TimeRangeMax))
@@ -104,7 +114,10 @@ var _ = Describe("Index Persist", Ordered, func() {
 
 				It("Should persist an empty index", func() {
 					Expect(db.Close()).To(Succeed())
-					db = MustSucceed(domain.Open(domain.Config{FS: fs}))
+					db = MustSucceed(domain.Open(domain.Config{
+						FS:              fs,
+						Instrumentation: PanicLogger(),
+					}))
 					i := db.NewIterator(domain.IterRange(telem.TimeRangeMax))
 					Expect(i.SeekFirst(ctx)).To(BeFalse())
 				})

--- a/cesium/internal/domain/iterator_behavior_test.go
+++ b/cesium/internal/domain/iterator_behavior_test.go
@@ -29,7 +29,10 @@ var _ = Describe("Iterator Behavior", Ordered, func() {
 			)
 			BeforeEach(func() {
 				fs, cleanUp = makeFS()
-				db = MustSucceed(domain.Open(domain.Config{FS: fs}))
+				db = MustSucceed(domain.Open(domain.Config{
+					FS:              fs,
+					Instrumentation: PanicLogger(),
+				}))
 			})
 			AfterEach(func() {
 				Expect(db.Close()).To(Succeed())

--- a/cesium/internal/domain/writer_behavior_test.go
+++ b/cesium/internal/domain/writer_behavior_test.go
@@ -55,7 +55,10 @@ var _ = Describe("Writer Behavior", Ordered, func() {
 			)
 			BeforeEach(func() {
 				fs, cleanUp = makeFS()
-				db = MustSucceed(domain.Open(domain.Config{FS: fs}))
+				db = MustSucceed(domain.Open(domain.Config{
+					FS:              fs,
+					Instrumentation: PanicLogger(),
+				}))
 			})
 			AfterEach(func() {
 				Expect(db.Close()).To(Succeed())
@@ -110,7 +113,11 @@ var _ = Describe("Writer Behavior", Ordered, func() {
 				Context("No preset end", func() {
 					It("Should start writing to a new file when one file is full", func() {
 						fs2, cleanUp2 := makeFS()
-						db2 := MustSucceed(domain.Open(domain.Config{FS: fs2, FileSize: 10 * telem.ByteSize}))
+						db2 := MustSucceed(domain.Open(domain.Config{
+							FS:              fs2,
+							FileSize:        10 * telem.ByteSize,
+							Instrumentation: PanicLogger(),
+						}))
 
 						By("Writing some telemetry")
 						w := MustSucceed(db2.NewWriter(ctx, domain.WriterConfig{Start: 1 * telem.SecondTS}))
@@ -162,7 +169,11 @@ var _ = Describe("Writer Behavior", Ordered, func() {
 
 					It("Should work when the file size exceeds the limit by just 1", func() {
 						fs2, cleanUp2 := makeFS()
-						db2 := MustSucceed(domain.Open(domain.Config{FS: fs2, FileSize: 5 * telem.ByteSize}))
+						db2 := MustSucceed(domain.Open(domain.Config{
+							FS:              fs2,
+							FileSize:        5 * telem.ByteSize,
+							Instrumentation: PanicLogger(),
+						}))
 
 						By("Writing some telemetry")
 						w := MustSucceed(db2.NewWriter(ctx, domain.WriterConfig{Start: 1 * telem.SecondTS}))
@@ -206,7 +217,11 @@ var _ = Describe("Writer Behavior", Ordered, func() {
 				Context("With preset end", func() {
 					It("Should start writing to a new file when one file is full", func() {
 						fs2, cleanUp2 := makeFS()
-						db2 := MustSucceed(domain.Open(domain.Config{FS: fs2, FileSize: 10 * telem.ByteSize}))
+						db2 := MustSucceed(domain.Open(domain.Config{
+							FS:              fs2,
+							FileSize:        10 * telem.ByteSize,
+							Instrumentation: PanicLogger(),
+						}))
 
 						By("Writing some telemetry")
 						w := MustSucceed(db2.NewWriter(ctx, domain.WriterConfig{Start: 1 * telem.SecondTS, End: 100 * telem.SecondTS}))

--- a/cesium/internal/index/domain_test.go
+++ b/cesium/internal/index/domain_test.go
@@ -30,7 +30,7 @@ var _ = Describe("Domain", func() {
 			)
 			BeforeEach(func() {
 				fs, cleanUp = makeFS()
-				db = MustSucceed(domain.Open(domain.Config{FS: fs}))
+				db = MustSucceed(domain.Open(domain.Config{FS: fs, Instrumentation: PanicLogger()}))
 				idx = &index.Domain{DB: db}
 			})
 			AfterEach(func() {

--- a/cesium/internal/meta/meta_test.go
+++ b/cesium/internal/meta/meta_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Meta", Ordered, func() {
 		AfterEach(func() { Expect(cleanUp()).To(Succeed()) })
 		Context("FS: "+fsName, Ordered, func() {
 			Specify("Corrupted meta.json", func() {
-				db := MustSucceed(cesium.Open("", cesium.WithFS(fs)))
+				db := MustSucceed(cesium.Open("", cesium.WithFS(fs), cesium.WithInstrumentation(PanicLogger())))
 				key := GenerateChannelKey()
 
 				Expect(db.CreateChannel(ctx, cesium.Channel{Key: key, Name: "Faraday", Rate: 1 * telem.Hz, DataType: telem.Int64T})).To(Succeed())
@@ -46,7 +46,7 @@ var _ = Describe("Meta", Ordered, func() {
 				Expect(err).ToNot(HaveOccurred())
 				Expect(f.Close()).To(Succeed())
 
-				db, err = cesium.Open("", cesium.WithFS(fs))
+				db, err = cesium.Open("", cesium.WithFS(fs), cesium.WithInstrumentation(PanicLogger()))
 				Expect(err).To(MatchError(ContainSubstring("error decoding meta in folder for channel %d", key)))
 			})
 
@@ -57,7 +57,7 @@ var _ = Describe("Meta", Ordered, func() {
 				)
 
 				DescribeTable("meta configs", func(badCh cesium.Channel, badField string) {
-					db := MustSucceed(cesium.Open("", cesium.WithFS(fs)))
+					db := MustSucceed(cesium.Open("", cesium.WithFS(fs), cesium.WithInstrumentation(PanicLogger())))
 					Expect(db.CreateChannel(ctx, cesium.Channel{Key: key, Rate: 1 * telem.Hz, DataType: telem.Int64T})).To(Succeed())
 					Expect(db.Close()).To(Succeed())
 
@@ -68,7 +68,7 @@ var _ = Describe("Meta", Ordered, func() {
 					Expect(err).ToNot(HaveOccurred())
 					Expect(f.Close()).To(Succeed())
 
-					db, err = cesium.Open("", cesium.WithFS(fs))
+					db, err = cesium.Open("", cesium.WithFS(fs), cesium.WithInstrumentation(PanicLogger()))
 					Expect(err).To(HaveOccurred())
 					Expect(err).To(MatchError(ContainSubstring(badField)))
 				},

--- a/cesium/internal/unary/delete_test.go
+++ b/cesium/internal/unary/delete_test.go
@@ -44,6 +44,7 @@ var _ = Describe("Delete", func() {
 						IsIndex:  true,
 						Index:    index,
 					},
+					Instrumentation: PanicLogger(),
 				}))
 				db = MustSucceed(unary.Open(unary.Config{
 					FS: MustSucceed(fs.Sub("data")),
@@ -52,6 +53,7 @@ var _ = Describe("Delete", func() {
 						DataType: telem.Int64T,
 						Index:    index,
 					},
+					Instrumentation: PanicLogger(),
 				}))
 				rateDB = MustSucceed(unary.Open(unary.Config{
 					FS: MustSucceed(fs.Sub("rate")),
@@ -60,6 +62,7 @@ var _ = Describe("Delete", func() {
 						DataType: telem.Int64T,
 						Rate:     1 * telem.Hz,
 					},
+					Instrumentation: PanicLogger(),
 				}))
 				db.SetIndex(indexDB.Index())
 			})

--- a/cesium/internal/unary/gc_test.go
+++ b/cesium/internal/unary/gc_test.go
@@ -43,8 +43,9 @@ var _ = Describe("Garbage Collection", func() {
 							DataType: telem.Int64T,
 							Rate:     1 * telem.Hz,
 						},
-						FileSize:    899 * telem.ByteSize,
-						GCThreshold: math.SmallestNonzeroFloat32,
+						FileSize:        899 * telem.ByteSize,
+						GCThreshold:     math.SmallestNonzeroFloat32,
+						Instrumentation: PanicLogger(),
 					}))
 					indexDB = MustSucceed(unary.Open(unary.Config{
 						FS: MustSucceed(fs.Sub("index")),
@@ -54,10 +55,10 @@ var _ = Describe("Garbage Collection", func() {
 							IsIndex:  true,
 							Index:    indexKey,
 						},
-						FileSize:    899 * telem.ByteSize,
-						GCThreshold: math.SmallestNonzeroFloat32,
+						FileSize:        899 * telem.ByteSize,
+						GCThreshold:     math.SmallestNonzeroFloat32,
+						Instrumentation: PanicLogger(),
 					}))
-
 					dataDB = MustSucceed(unary.Open(unary.Config{
 						FS: MustSucceed(fs.Sub("data")),
 						Channel: core.Channel{
@@ -65,8 +66,9 @@ var _ = Describe("Garbage Collection", func() {
 							DataType: telem.Int64T,
 							Index:    indexKey,
 						},
-						FileSize:    899 * telem.ByteSize,
-						GCThreshold: math.SmallestNonzeroFloat32,
+						FileSize:        899 * telem.ByteSize,
+						GCThreshold:     math.SmallestNonzeroFloat32,
+						Instrumentation: PanicLogger(),
 					}))
 					dataDB.SetIndex(indexDB.Index())
 				})
@@ -167,7 +169,8 @@ var _ = Describe("Garbage Collection", func() {
 							IsIndex:  true,
 							Index:    indexKey,
 						},
-						FileSize: 50 * telem.ByteSize,
+						FileSize:        50 * telem.ByteSize,
+						Instrumentation: PanicLogger(),
 					}))
 
 					dataDB = MustSucceed(unary.Open(unary.Config{
@@ -177,8 +180,9 @@ var _ = Describe("Garbage Collection", func() {
 							DataType: telem.Int64T,
 							Index:    indexKey,
 						},
-						GCThreshold: 0.5,
-						FileSize:    50 * telem.ByteSize,
+						GCThreshold:     0.5,
+						FileSize:        50 * telem.ByteSize,
+						Instrumentation: PanicLogger(),
 					}))
 					dataDB.SetIndex(indexDB.Index())
 				})

--- a/cesium/internal/unary/iterator_behavior_test.go
+++ b/cesium/internal/unary/iterator_behavior_test.go
@@ -44,6 +44,7 @@ var _ = Describe("Iterator Behavior", Ordered, func() {
 							IsIndex:  true,
 							Index:    index,
 						},
+						Instrumentation: PanicLogger(),
 					}))
 					db = MustSucceed(unary.Open(unary.Config{
 						FS: MustSucceed(fs.Sub("data")),
@@ -52,6 +53,7 @@ var _ = Describe("Iterator Behavior", Ordered, func() {
 							DataType: telem.Int64T,
 							Index:    index,
 						},
+						Instrumentation: PanicLogger(),
 					}))
 					db.SetIndex(indexDB.Index())
 				})
@@ -702,6 +704,7 @@ var _ = Describe("Iterator Behavior", Ordered, func() {
 							DataType: telem.TimeStampT,
 							IsIndex:  true,
 						},
+						Instrumentation: PanicLogger(),
 					}))
 				})
 				AfterEach(func() {

--- a/cesium/internal/unary/race_test.go
+++ b/cesium/internal/unary/race_test.go
@@ -45,7 +45,8 @@ var _ = Describe("Unary racing", func() {
 						DataType: telem.Int16T,
 						Rate:     2 * telem.Hz,
 					},
-					FileSize: 1 * telem.ByteSize,
+					FileSize:        1 * telem.ByteSize,
+					Instrumentation: PanicLogger(),
 				}))
 				indexDB = MustSucceed(unary.Open(unary.Config{
 					FS: indexFS,
@@ -54,7 +55,8 @@ var _ = Describe("Unary racing", func() {
 						IsIndex:  true,
 						DataType: telem.Int64T,
 					},
-					FileSize: 1 * telem.ByteSize,
+					FileSize:        1 * telem.ByteSize,
+					Instrumentation: PanicLogger(),
 				}))
 				dataDB = MustSucceed(unary.Open(unary.Config{
 					FS: dataFS,
@@ -63,7 +65,8 @@ var _ = Describe("Unary racing", func() {
 						DataType: telem.Int64T,
 						Index:    indexKey,
 					},
-					FileSize: 1 * telem.ByteSize,
+					FileSize:        1 * telem.ByteSize,
+					Instrumentation: PanicLogger(),
 				},
 				))
 				dataDB.SetIndex(indexDB.Index())

--- a/cesium/internal/unary/writer_behavior_test.go
+++ b/cesium/internal/unary/writer_behavior_test.go
@@ -42,6 +42,7 @@ var _ = Describe("Writer Behavior", Ordered, func() {
 							DataType: telem.TimeStampT,
 							IsIndex:  true,
 						},
+						Instrumentation: PanicLogger(),
 					}))
 				})
 				AfterEach(func() {
@@ -92,7 +93,8 @@ var _ = Describe("Writer Behavior", Ordered, func() {
 							DataType: telem.TimeStampT,
 							IsIndex:  true,
 						},
-						FileSize: telem.Size(10*telem.TimeStampT.Density()) * telem.ByteSize,
+						FileSize:        telem.Size(10*telem.TimeStampT.Density()) * telem.ByteSize,
+						Instrumentation: PanicLogger(),
 					}))
 					db = MustSucceed(unary.Open(unary.Config{
 						FS: MustSucceed(fs.Sub("data")),
@@ -102,7 +104,8 @@ var _ = Describe("Writer Behavior", Ordered, func() {
 							DataType: telem.Int64T,
 							Index:    index,
 						},
-						FileSize: telem.Size(5*telem.Int64T.Density()) * telem.ByteSize,
+						FileSize:        telem.Size(5*telem.Int64T.Density()) * telem.ByteSize,
+						Instrumentation: PanicLogger(),
 					}))
 					db.SetIndex(indexDB.Index())
 				})
@@ -446,7 +449,9 @@ var _ = Describe("Writer Behavior", Ordered, func() {
 							Key:      2,
 							DataType: telem.TimeStampT,
 							IsIndex:  true,
-						}}))
+						},
+						Instrumentation: PanicLogger(),
+					}))
 				})
 				AfterEach(func() {
 					Expect(db.Close()).To(Succeed())
@@ -522,7 +527,9 @@ var _ = Describe("Writer Behavior", Ordered, func() {
 							Name:     "gauss",
 							DataType: telem.TimeStampT,
 							IsIndex:  true,
-						}}))
+						},
+						Instrumentation: PanicLogger(),
+					}))
 				})
 				AfterEach(func() {
 					Expect(db.Close()).To(Succeed())

--- a/cesium/internal/version/migration_test.go
+++ b/cesium/internal/version/migration_test.go
@@ -40,7 +40,7 @@ var _ = Describe("Migration Test", func() {
 				Expect(testutil.CopyFS(sourceFS, destFS)).To(Succeed())
 
 				By("Opening the V1 database in V2")
-				db = MustSucceed(cesium.Open("", cesium.WithFS(fs)))
+				db = MustSucceed(cesium.Open("", cesium.WithFS(fs), cesium.WithInstrumentation(PanicLogger())))
 
 				By("Asserting that the version got migrated, the meta file got changed, and the format is correct")
 				for _, ch := range testdata.Channels {

--- a/cesium/writer_behavior_test.go
+++ b/cesium/writer_behavior_test.go
@@ -644,7 +644,9 @@ var _ = Describe("Writer Behavior", func() {
 					Specify("With AutoCommit", func() {
 						db2 = MustSucceed(cesium.Open("size-capped-db",
 							cesium.WithFS(fs),
-							cesium.WithFileSize(40*telem.ByteSize)))
+							cesium.WithFileSize(40*telem.ByteSize),
+							cesium.WithInstrumentation(PanicLogger()),
+						))
 
 						Expect(db2.CreateChannel(
 							ctx,
@@ -742,7 +744,9 @@ var _ = Describe("Writer Behavior", func() {
 					Specify("With AutoCommit: should not commit a tiny domain", func() {
 						db2 = MustSucceed(cesium.Open("size-capped-db",
 							cesium.WithFS(fs),
-							cesium.WithFileSize(80*telem.ByteSize)))
+							cesium.WithFileSize(80*telem.ByteSize),
+							cesium.WithInstrumentation(PanicLogger()),
+						))
 
 						Expect(db2.CreateChannel(
 							ctx,
@@ -839,7 +843,9 @@ var _ = Describe("Writer Behavior", func() {
 
 						db2 = MustSucceed(cesium.Open("size-capped-db",
 							cesium.WithFS(fs),
-							cesium.WithFileSize(64*telem.ByteSize)))
+							cesium.WithFileSize(64*telem.ByteSize),
+							cesium.WithInstrumentation(PanicLogger()),
+						))
 
 						By("Asserting that upon writing to the channels, the writes go to appropriate files", func() {
 							w = MustSucceed(db2.OpenWriter(ctx, cesium.WriterConfig{
@@ -902,7 +908,9 @@ var _ = Describe("Writer Behavior", func() {
 					Specify("Without AutoCommit", func() {
 						db2 = MustSucceed(cesium.Open("size-capped-db",
 							cesium.WithFS(fs),
-							cesium.WithFileSize(40*telem.ByteSize)))
+							cesium.WithFileSize(40*telem.ByteSize),
+							cesium.WithInstrumentation(PanicLogger()),
+						))
 
 						Expect(db2.CreateChannel(
 							ctx,
@@ -996,7 +1004,9 @@ var _ = Describe("Writer Behavior", func() {
 					It("Should not break when auto committing to not all channels", func() {
 						db2 = MustSucceed(cesium.Open("size-capped-db",
 							cesium.WithFS(fs),
-							cesium.WithFileSize(40*telem.ByteSize)))
+							cesium.WithFileSize(40*telem.ByteSize),
+							cesium.WithInstrumentation(PanicLogger()),
+						))
 
 						var (
 							index2 = GenerateChannelKey()

--- a/freighter/integration/main.go
+++ b/freighter/integration/main.go
@@ -34,7 +34,6 @@ func main() {
 	s := igrp.New()
 	s.BindTo(g)
 	configureInstrumentation()
-	zap.L().DPanic("HEHEHE")
 
 	err := func() error {
 		sCtx, cancel := xsig.Isolated()

--- a/freighter/integration/main.go
+++ b/freighter/integration/main.go
@@ -18,6 +18,7 @@ import (
 	xsig "github.com/synnaxlabs/x/signal"
 	"go.uber.org/zap"
 	"google.golang.org/grpc"
+	"log"
 	"net"
 	"os"
 	"os/signal"
@@ -32,6 +33,8 @@ func main() {
 	g := grpc.NewServer()
 	s := igrp.New()
 	s.BindTo(g)
+	configureInstrumentation()
+	zap.L().DPanic("HEHEHE")
 
 	err := func() error {
 		sCtx, cancel := xsig.Isolated()
@@ -58,4 +61,12 @@ func main() {
 	if err != nil {
 		zap.S().Fatalw("failed to start server", "error", err)
 	}
+}
+
+func configureInstrumentation() {
+	l, err := zap.NewDevelopmentConfig().Build()
+	if err != nil {
+		log.Fatal(err)
+	}
+	zap.ReplaceGlobals(l)
 }

--- a/synnax/cmd/instrumentation.go
+++ b/synnax/cmd/instrumentation.go
@@ -45,7 +45,7 @@ func cleanupInstrumentation(ctx context.Context, i alamos.Instrumentation) {
 	}
 }
 
-func configureLogger() (*alamos.Logger, error) {
+func configureLogger() (logger *alamos.Logger, err error) {
 	verbose := viper.GetBool("verbose")
 	debug := viper.GetBool("debug")
 	var cfg zap.Config
@@ -65,7 +65,13 @@ func configureLogger() (*alamos.Logger, error) {
 		cfg.DisableStacktrace = true
 		cfg.DisableCaller = true
 	}
-	return alamos.NewLogger(alamos.LoggerConfig{ZapConfig: cfg})
+	logger, err = alamos.NewLogger(alamos.LoggerConfig{ZapConfig: cfg})
+	if err != nil {
+		return
+	}
+
+	zap.ReplaceGlobals(logger.Zap())
+	return
 }
 
 func newPrettyLogger() *zap.Logger {

--- a/synnax/cmd/instrumentation.go
+++ b/synnax/cmd/instrumentation.go
@@ -13,6 +13,7 @@ import (
 	"context"
 	"github.com/spf13/viper"
 	"github.com/synnaxlabs/alamos"
+	"github.com/synnaxlabs/synnax/cmd/internal/invariants"
 	"github.com/uptrace/uptrace-go/uptrace"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
@@ -54,6 +55,8 @@ func configureLogger() (logger *alamos.Logger, err error) {
 	} else {
 		cfg = zap.NewProductionConfig()
 	}
+	cfg.Development = invariants.IsDevelopment
+
 	if verbose || debug {
 		cfg.EncoderConfig.EncodeLevel = zapcore.CapitalColorLevelEncoder
 		cfg.EncoderConfig.EncodeTime = zapcore.TimeEncoderOfLayout("15:04:05.000")

--- a/synnax/cmd/internal/invariants/development.go
+++ b/synnax/cmd/internal/invariants/development.go
@@ -1,0 +1,5 @@
+//go:build development
+
+package invariants
+
+var IsDevelopment = true

--- a/synnax/cmd/internal/invariants/production.go
+++ b/synnax/cmd/internal/invariants/production.go
@@ -1,0 +1,5 @@
+//go:build !development
+
+package invariants
+
+var IsDevelopment = false

--- a/x/go/testutil/instrumentation.go
+++ b/x/go/testutil/instrumentation.go
@@ -10,6 +10,8 @@
 package testutil
 
 import (
+	"fmt"
+	"github.com/google/uuid"
 	"github.com/samber/lo"
 	"github.com/synnaxlabs/alamos"
 	"github.com/synnaxlabs/x/config"
@@ -97,4 +99,19 @@ func Instrumentation(key string, configs ...InstrumentationConfig) alamos.Instru
 	}
 
 	return alamos.New(key, options...)
+}
+
+// PanicLogger returns an Instrumentation instance that only contains a logger that
+// only logs above PanicLevel and panics on DPanic.
+func PanicLogger() alamos.Instrumentation {
+	cfg := zap.NewDevelopmentConfig()
+	cfg.Level.SetLevel(zap.PanicLevel)
+	l := MustSucceed(alamos.NewLogger(alamos.LoggerConfig{
+		ZapConfig: cfg,
+	}))
+
+	return alamos.New(
+		fmt.Sprintf("cesium-testing-%s", uuid.New().String()),
+		alamos.WithLogger(l),
+	)
 }


### PR DESCRIPTION
# Feature Pull Request Template

## Key Information

- [SY-375](https://linear.app/synnaxlabs/issue/SY-375/[server]-register-global-zap-logger)

## Description

Initialized zap global logger when server starts.

**breaking changes**:
- freighter/integration has a global logger always configured to development mode.

## Basic Readiness Checklist

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes. - **None added**
- [x] I have updated user facing documentation accordingly. - **None added**

## Manual QA Additions

- [x] I have updated the [Release Candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template
with necessary manual QA steps to test my change. - **None aded**

## Breaking Changes

Please list any breaking changes to public or internal packages.
