### PR TITLE
[ops/ts] - improved error matching semantics

### DIFF
--- a/client/ts/src/auth/auth.ts
+++ b/client/ts/src/auth/auth.ts
@@ -73,7 +73,7 @@ export class Client {
       }
       reqCtx.params.Authorization = `Bearer ${this.token}`;
       const [resCtx, err] = await next(reqCtx);
-      if (err instanceof InvalidTokenError && this.retryCount < MAX_RETRIES) {
+      if (InvalidTokenError.matches(err) && this.retryCount < MAX_RETRIES) {
         this.authenticated = false;
         this.authenticating = undefined;
         this.retryCount += 1;

--- a/client/ts/src/errors.spec.ts
+++ b/client/ts/src/errors.spec.ts
@@ -1,0 +1,40 @@
+import { BaseTypedError, TypedError } from "@synnaxlabs/freighter";
+import { MatchableErrorType } from "@synnaxlabs/freighter/src/errors";
+import { describe, expect, test } from "vitest";
+
+import {
+  AuthError,
+  ContiguityError,
+  ControlError,
+  FieldError,
+  InvalidTokenError,
+  MultipleFoundError,
+  NotFoundError,
+  QueryError,
+  RouteError,
+  UnauthorizedError,
+  UnexpectedError,
+  ValidationError,
+} from "@/errors";
+
+describe("error", () => {
+  describe("type matching", () => {
+    const ERRORS: [string, Error, MatchableErrorType][] = [
+      [ValidationError.TYPE, new ValidationError(), ValidationError],
+      [FieldError.TYPE, new FieldError("field", "message"), FieldError],
+      [AuthError.TYPE, new AuthError(), AuthError],
+      [InvalidTokenError.TYPE, new InvalidTokenError(), InvalidTokenError],
+      [UnexpectedError.TYPE, new UnexpectedError("message"), UnexpectedError],
+      [QueryError.TYPE, new QueryError("message"), QueryError],
+      [NotFoundError.TYPE, new NotFoundError("message"), NotFoundError],
+      [MultipleFoundError.TYPE, new MultipleFoundError("message"), MultipleFoundError],
+      [RouteError.TYPE, new RouteError("message", ""), RouteError],
+      [ControlError.TYPE, new ControlError("message"), ControlError],
+      [UnauthorizedError.TYPE, new UnauthorizedError("message"), UnauthorizedError],
+      [ContiguityError.TYPE, new ContiguityError("message"), ContiguityError],
+    ];
+    ERRORS.forEach(([typeName, error, type]) =>
+      test(`matches ${typeName}`, () => expect(type.matches(error)).toBeTruthy()),
+    );
+  });
+});

--- a/client/ts/src/errors.ts
+++ b/client/ts/src/errors.ts
@@ -29,6 +29,7 @@ export interface Field {
 export class ValidationError extends BaseTypedError {
   static readonly TYPE = _FREIGHTER_EXCEPTION_PREFIX + "validation";
   type = ValidationError.TYPE;
+  static readonly matches = errorMatcher(ValidationError.TYPE);
 }
 
 export class FieldError extends ValidationError {
@@ -126,6 +127,7 @@ export class ControlError extends BaseTypedError {
 
 export class UnauthorizedError extends ControlError {
   static readonly TYPE = ControlError.TYPE + ".unauthorized";
+  type = UnauthorizedError.TYPE;
   static readonly matches = errorMatcher(UnauthorizedError.TYPE);
 }
 

--- a/client/ts/src/errors.ts
+++ b/client/ts/src/errors.ts
@@ -8,6 +8,8 @@
 // included in the file licenses/APL.txt.
 
 import {
+  BaseTypedError,
+  errorMatcher,
   type ErrorPayload,
   type Middleware,
   registerError,
@@ -24,12 +26,15 @@ export interface Field {
 /**
  * Raised when a validation error occurs.
  */
-export class ValidationError extends Error {
+export class ValidationError extends BaseTypedError {
   static readonly TYPE = _FREIGHTER_EXCEPTION_PREFIX + "validation";
+  type = ValidationError.TYPE;
 }
 
 export class FieldError extends ValidationError {
   static readonly TYPE = ValidationError.TYPE + ".field";
+  type = FieldError.TYPE;
+  static readonly matches = errorMatcher(FieldError.TYPE);
   readonly field: string;
   readonly message: string;
 
@@ -43,8 +48,10 @@ export class FieldError extends ValidationError {
 /**
  * AuthError is raised when an authentication error occurs.
  */
-export class AuthError extends Error {
+export class AuthError extends BaseTypedError {
   static readonly TYPE = _FREIGHTER_EXCEPTION_PREFIX + "auth";
+  type = AuthError.TYPE;
+  static readonly matches = errorMatcher(AuthError.TYPE);
 }
 
 /**
@@ -52,13 +59,17 @@ export class AuthError extends Error {
  */
 export class InvalidTokenError extends AuthError {
   static readonly TYPE = AuthError.TYPE + ".invalid-token";
+  type = InvalidTokenError.TYPE;
+  static readonly matches = errorMatcher(InvalidTokenError.TYPE);
 }
 
 /**
  * UnexpectedError is raised when an unexpected error occurs.
  */
-export class UnexpectedError extends Error {
+export class UnexpectedError extends BaseTypedError {
   static readonly TYPE = _FREIGHTER_EXCEPTION_PREFIX + "unexpected";
+  type = UnexpectedError.TYPE;
+  static readonly matches = errorMatcher(UnexpectedError.TYPE);
 
   constructor(message: string) {
     super(`
@@ -74,23 +85,31 @@ export class UnexpectedError extends Error {
 /**
  * QueryError is raised when a query error occurs.
  */
-export class QueryError extends Error {
+export class QueryError extends BaseTypedError {
   static readonly TYPE = _FREIGHTER_EXCEPTION_PREFIX + "query";
+  type = QueryError.TYPE;
+  static readonly matches = errorMatcher(QueryError.TYPE);
 }
 
 export class NotFoundError extends QueryError {
   static readonly TYPE = QueryError.TYPE + ".not_found";
+  type = NotFoundError.TYPE;
+  static readonly matches = errorMatcher(NotFoundError.TYPE);
 }
 
 export class MultipleFoundError extends QueryError {
   static readonly TYPE = QueryError.TYPE + ".multiple_results";
+  type = MultipleFoundError.TYPE;
+  static readonly matches = errorMatcher(MultipleFoundError.TYPE);
 }
 
 /**
  * RouteError is raised when a routing error occurs.
  */
-export class RouteError extends Error {
+export class RouteError extends BaseTypedError {
   static readonly TYPE = _FREIGHTER_EXCEPTION_PREFIX + "route";
+  type = RouteError.TYPE;
+  static readonly matches = errorMatcher(RouteError.TYPE);
   path: string;
 
   constructor(message: string, path: string) {
@@ -99,18 +118,25 @@ export class RouteError extends Error {
   }
 }
 
-export class ControlError extends Error {
+export class ControlError extends BaseTypedError {
   static readonly TYPE = _FREIGHTER_EXCEPTION_PREFIX + "control";
+  type = ControlError.TYPE;
+  static readonly matches = errorMatcher(ControlError.TYPE);
 }
 
 export class UnauthorizedError extends ControlError {
   static readonly TYPE = ControlError.TYPE + ".unauthorized";
+  static readonly matches = errorMatcher(UnauthorizedError.TYPE);
 }
 
 /**
  * Raised when time-series data is not contiguous.
  */
-export class ContiguityError extends Error {}
+export class ContiguityError extends BaseTypedError {
+  static readonly TYPE = _FREIGHTER_EXCEPTION_PREFIX + "contiguity";
+  type = ContiguityError.TYPE;
+  static readonly matches = errorMatcher(ContiguityError.TYPE);
+}
 
 const decode = (payload: ErrorPayload): Error | null => {
   if (!payload.type.startsWith(_FREIGHTER_EXCEPTION_PREFIX)) return null;

--- a/client/ts/src/framer/streamProxy.ts
+++ b/client/ts/src/framer/streamProxy.ts
@@ -39,7 +39,7 @@ export class StreamProxy<RQ extends z.ZodTypeAny, RS extends z.ZodTypeAny> {
         Please report this error to the Synnax team. ${JSON.stringify(res)}`,
         );
       if (err != null) {
-        if (err instanceof EOF) return;
+        if (EOF.matches(err)) return;
         throw err;
       }
     }

--- a/client/ts/src/framer/streamer.ts
+++ b/client/ts/src/framer/streamer.ts
@@ -68,7 +68,7 @@ export class Streamer implements AsyncIterator<Frame>, AsyncIterable<Frame> {
       const frame = await this.read();
       return { done: false, value: frame };
     } catch (err) {
-      if (err instanceof EOF) return { done: true, value: undefined };
+      if (EOF.matches(err)) return { done: true, value: undefined };
       throw err;
     }
   }

--- a/client/ts/src/ranger/active.ts
+++ b/client/ts/src/ranger/active.ts
@@ -11,7 +11,7 @@ import { sendRequired, type UnaryClient } from "@synnaxlabs/freighter";
 import { z } from "zod";
 
 import { QueryError } from "@/errors";
-import { type Key, keyZ,type Payload, payloadZ } from "@/ranger/payload";
+import { type Key, keyZ, type Payload, payloadZ } from "@/ranger/payload";
 
 const setActiveResZ = z.object({});
 
@@ -57,7 +57,7 @@ export class Active {
       z.object({}),
       retrieveActiveResZ,
     );
-    if (err instanceof QueryError) return null;
+    if (QueryError.matches(err)) return null;
     if (err != null) throw err;
     return res.range;
   }

--- a/console/src/group/ontology.tsx
+++ b/console/src/group/ontology.tsx
@@ -118,8 +118,10 @@ const useUngroupSelection = (): ((props: Ontology.TreeContextMenuProps) => void)
     if (selection.parent == null) return;
     // Sort the groups by depth that way deeper nested groups are ungrouped first.
     selection.resources.sort((a, b) => {
-      const a_depth = selection.nodes.find((n) => n.key === a.id.toString())?.depth ?? 0;
-      const b_depth = selection.nodes.find((n) => n.key === b.id.toString())?.depth ?? 0;
+      const a_depth =
+        selection.nodes.find((n) => n.key === a.id.toString())?.depth ?? 0;
+      const b_depth =
+        selection.nodes.find((n) => n.key === b.id.toString())?.depth ?? 0;
       return b_depth - a_depth;
     });
     const prevNodes = Tree.deepCopy(nodes);
@@ -290,7 +292,7 @@ const handleRename: Ontology.HandleTreeRename = {
       // We check for this because the rename might be a side effect of creating
       // a new group, in which case the group might not exist yet. This is fine
       // and we don't want to throw an error.
-      if (!(e instanceof NotFoundError)) throw e;
+      if (!NotFoundError.matches(e)) throw e;
     }
   },
 };

--- a/console/src/hardware/ni/task/AnalogRead.tsx
+++ b/console/src/hardware/ni/task/AnalogRead.tsx
@@ -83,8 +83,6 @@ const Wrapped = ({
     }),
   });
 
-  console.log(initialValues);
-
   const [selectedChannels, setSelectedChannels] = useState<string[]>(
     initialValues.config.channels.length ? [initialValues.config.channels[0].key] : [],
   );

--- a/console/src/hardware/ni/task/AnalogRead.tsx
+++ b/console/src/hardware/ni/task/AnalogRead.tsx
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { QueryError } from "@synnaxlabs/client";
+import { NotFoundError, QueryError } from "@synnaxlabs/client";
 import { Icon } from "@synnaxlabs/media";
 import { Button, Form, Header, Menu, Status, Synnax } from "@synnaxlabs/pluto";
 import { Align } from "@synnaxlabs/pluto/align";
@@ -83,6 +83,8 @@ const Wrapped = ({
     }),
   });
 
+  console.log(initialValues);
+
   const [selectedChannels, setSelectedChannels] = useState<string[]>(
     initialValues.config.channels.length ? [initialValues.config.channels[0].key] : [],
   );
@@ -126,7 +128,7 @@ const Wrapped = ({
         try {
           await client.channels.retrieve(dev.properties.analogInput.index);
         } catch (e) {
-          if (e instanceof QueryError) shouldCreateIndex = true;
+          if (NotFoundError.matches(e)) shouldCreateIndex = true;
           else throw e;
         }
       }
@@ -151,7 +153,7 @@ const Wrapped = ({
           try {
             await client.channels.retrieve(exKey.toString());
           } catch (e) {
-            if (e instanceof QueryError) toCreate.push(channel);
+            if (QueryError.matches(e)) toCreate.push(channel);
             else throw e;
           }
         }

--- a/console/src/hardware/ni/task/DigitalRead.tsx
+++ b/console/src/hardware/ni/task/DigitalRead.tsx
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { QueryError } from "@synnaxlabs/client";
+import { NotFoundError, QueryError } from "@synnaxlabs/client";
 import { Icon } from "@synnaxlabs/media";
 import {
   Align,
@@ -132,7 +132,7 @@ const Wrapped = ({
         try {
           await client.channels.retrieve(dev.properties.digitalInput.index);
         } catch (e) {
-          if (e instanceof QueryError) shouldCreateIndex = true;
+          if (NotFoundError.matches(e)) shouldCreateIndex = true;
           else throw e;
         }
       }
@@ -158,7 +158,7 @@ const Wrapped = ({
           try {
             await client.channels.retrieve(exKey.toString());
           } catch (e) {
-            if (e instanceof QueryError) toCreate.push(channel);
+            if (NotFoundError.matches(e)) toCreate.push(channel);
             else throw e;
           }
         }

--- a/console/src/hardware/ni/task/DigitalWrite.tsx
+++ b/console/src/hardware/ni/task/DigitalWrite.tsx
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { QueryError } from "@synnaxlabs/client";
+import { NotFoundError, QueryError } from "@synnaxlabs/client";
 import { Icon } from "@synnaxlabs/media";
 import {
   Button,
@@ -132,7 +132,7 @@ const Wrapped = ({
         try {
           await client.channels.retrieve(dev.properties.digitalOutput.stateIndex);
         } catch (e) {
-          if (e instanceof QueryError) shouldCreateStateIndex = true;
+          if (NotFoundError.matches(e)) shouldCreateStateIndex = true;
           else throw e;
         }
       }
@@ -160,13 +160,13 @@ const Wrapped = ({
           try {
             await client.channels.retrieve([exPair.state]);
           } catch (e) {
-            if (e instanceof QueryError) statesToCreate.push(channel);
+            if (NotFoundError.matches(e)) statesToCreate.push(channel);
             else throw e;
           }
           try {
             await client.channels.retrieve([exPair.command]);
           } catch (e) {
-            if (e instanceof QueryError) commandsToCreate.push(channel);
+            if (NotFoundError.matches(e)) commandsToCreate.push(channel);
             else throw e;
           }
         }

--- a/console/src/workspace/syncer.ts
+++ b/console/src/workspace/syncer.ts
@@ -42,7 +42,7 @@ export const useSyncLayout = async (): Promise<void> => {
       [client],
     ),
     onError: (e) => {
-      if (e instanceof QueryError) {
+      if (QueryError.matches(e)) {
         addStatus({
           key: "workspace.save",
           variant: "error",

--- a/drift/src/configureStore.ts
+++ b/drift/src/configureStore.ts
@@ -110,7 +110,7 @@ const receivePreloadedState = async <
  * be chosen based on the platform you are running on (Tauri, Electron, etc.).
  * @param options.debug - If true, drift will log debug information to the
  * console. @default false
- * @param props.enablePrerender - If true, drift will create an invisible, prerendered
+ * @param props.enablePrerender - If true, drift will create an invisible, pre-rendered
  * window before it is needed. While it adds an additional process to your application,
  * it also dramatically reduces the time it takes to open a new window. @default true
  * @param props.defaultWindowProps - A partial set of window props to merge with

--- a/freighter/ts/src/errors.spec.ts
+++ b/freighter/ts/src/errors.spec.ts
@@ -34,7 +34,8 @@ class MyCustomError extends BaseTypedError {
   }
 }
 
-const myCustomErrorEncoder = (error: MyCustomError): ErrorPayload => {
+const myCustomErrorEncoder = (error: MyCustomError): ErrorPayload | null => {
+  if (error.type !== "MyCustomError") return null;
   return { type: "MyCustomError", data: error.message };
 };
 

--- a/freighter/ts/src/errors.spec.ts
+++ b/freighter/ts/src/errors.spec.ts
@@ -28,8 +28,9 @@ import {
 } from "@/errors";
 
 class MyCustomError extends BaseTypedError {
+  type = "MyCustomError";
   constructor(message: string) {
-    super(message, "MyCustomError");
+    super(message);
   }
 }
 

--- a/freighter/ts/src/errors.ts
+++ b/freighter/ts/src/errors.ts
@@ -10,6 +10,15 @@
 import { URL } from "@synnaxlabs/x";
 import { z } from "zod";
 
+/** Basic interface for an error or error type that can be matched against a candidate error */
+export interface MatchableErrorType {
+  /**
+   * @returns a function that matches errors of the given type. Returns true if
+   * the provided instance of Error or a string message contains the provided error type.
+   */
+  matches: (e: string | Error | unknown) => boolean;
+}
+
 export interface TypedError extends Error {
   discriminator: "FreighterError";
   /**
@@ -163,8 +172,8 @@ const FREIGHTER_ERROR_TYPE = "freighter.";
 /** Thrown/returned when a stream closed normally. */
 export class EOF extends BaseTypedError implements TypedError {
   static readonly TYPE = FREIGHTER_ERROR_TYPE + "eof";
-  static readonly matches = errorMatcher(EOF.TYPE);
   type = EOF.TYPE;
+  static readonly matches = errorMatcher(EOF.TYPE);
 
   constructor() {
     super("EOF");
@@ -202,7 +211,7 @@ export class Unreachable extends BaseTypedError implements TypedError {
 }
 
 const freighterErrorEncoder: ErrorEncoder = (error: TypedError) => {
-  if (error.type !== FREIGHTER) return null;
+  if (!error.type.startsWith(FREIGHTER)) return null;
   if (EOF.matches(error)) return { type: EOF.TYPE, data: "EOF" };
   if (StreamClosed.matches(error))
     return { type: StreamClosed.TYPE, data: "StreamClosed" };

--- a/freighter/ts/src/errors.ts
+++ b/freighter/ts/src/errors.ts
@@ -19,13 +19,27 @@ export interface TypedError extends Error {
   type: string;
 }
 
+/**
+ * @param type - the error type to match
+ * @returns a function that matches errors of the given type. Returns true if
+ * the provided instance of Error or a string message contains the provided error type.
+ */
+export const errorMatcher =
+  (type: string) =>
+  (e: string | Error | unknown): boolean => {
+    if (e != null && typeof e === "object" && "type" in e && typeof e.type === "string")
+      return e.type.includes(type);
+    if (e instanceof Error) return e.message.includes(type);
+    if (typeof e !== "string") return false;
+    return e.includes(type);
+  };
+
 export class BaseTypedError extends Error implements TypedError {
   readonly discriminator = "FreighterError";
-  type: string;
+  type: string = "";
 
-  constructor(message: string, type: string) {
+  constructor(message?: string) {
     super(message);
-    this.type = type;
   }
 }
 
@@ -138,8 +152,9 @@ export const decodeError = (payload: ErrorPayload): Error | null => {
 };
 
 export class UnknownError extends BaseTypedError implements TypedError {
+  type = "unknown";
   constructor(message: string) {
-    super(message, UNKNOWN);
+    super(message);
   }
 }
 
@@ -148,18 +163,22 @@ const FREIGHTER_ERROR_TYPE = "freighter.";
 /** Thrown/returned when a stream closed normally. */
 export class EOF extends BaseTypedError implements TypedError {
   static readonly TYPE = FREIGHTER_ERROR_TYPE + "eof";
+  static readonly matches = errorMatcher(EOF.TYPE);
+  type = EOF.TYPE;
 
   constructor() {
-    super("EOF", FREIGHTER);
+    super("EOF");
   }
 }
 
 /** Thrown/returned when a stream is closed abnormally. */
 export class StreamClosed extends BaseTypedError implements TypedError {
   static readonly TYPE = FREIGHTER_ERROR_TYPE + "stream_closed";
+  static readonly matches = errorMatcher(StreamClosed.TYPE);
+  type = StreamClosed.TYPE;
 
   constructor() {
-    super("StreamClosed", FREIGHTER);
+    super("StreamClosed");
   }
 }
 
@@ -171,21 +190,23 @@ export interface UnreachableArgs {
 /** Thrown when a target is unreachable. */
 export class Unreachable extends BaseTypedError implements TypedError {
   static readonly TYPE = FREIGHTER_ERROR_TYPE + "unreachable";
+  type = Unreachable.TYPE;
+  static readonly matches = errorMatcher(Unreachable.TYPE);
   url: URL;
 
   constructor(args: UnreachableArgs = {}) {
     const { message = "Unreachable", url = URL.UNKNOWN } = args;
-    super(message, FREIGHTER);
+    super(message);
     this.url = url;
   }
 }
 
 const freighterErrorEncoder: ErrorEncoder = (error: TypedError) => {
   if (error.type !== FREIGHTER) return null;
-  if (error instanceof EOF) return { type: EOF.TYPE, data: "EOF" };
-  if (error instanceof StreamClosed)
+  if (EOF.matches(error)) return { type: EOF.TYPE, data: "EOF" };
+  if (StreamClosed.matches(error))
     return { type: StreamClosed.TYPE, data: "StreamClosed" };
-  if (error instanceof Unreachable)
+  if (Unreachable.matches(error))
     return { type: Unreachable.TYPE, data: "Unreachable" };
   throw new Error(`Unknown error type: ${error.type}: ${error.message}`);
 };

--- a/freighter/ts/src/index.ts
+++ b/freighter/ts/src/index.ts
@@ -13,6 +13,7 @@ export {
   decodeError,
   encodeError,
   EOF,
+  errorMatcher,
   errorZ,
   registerError,
   StreamClosed,

--- a/freighter/ts/src/index.ts
+++ b/freighter/ts/src/index.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-export type { ErrorPayload, TypedError } from "@/errors";
+export type { ErrorPayload, MatchableErrorType, TypedError } from "@/errors";
 export {
   BaseTypedError,
   decodeError,

--- a/freighter/ts/src/websocket.spec.ts
+++ b/freighter/ts/src/websocket.spec.ts
@@ -35,9 +35,10 @@ const client = new WebSocketClient(url, new binary.JSONEncoderDecoder());
 
 class MyCustomError extends BaseTypedError {
   code: number;
+  type = "integration.error";
 
   constructor(message: string, code: number) {
-    super(message, "integration.error");
+    super(message);
     this.code = code;
   }
 }


### PR DESCRIPTION
# Fix Pull Request Template

## Key Information

- Linear Issue: [SY-897](https://linear.app/synnaxlabs/issue/SY-897/ni-fix-channel-recreation-in-task-configuration-workflows)

## Description

Improves error matching by adding a new `matches` function instead of using `instanceof`. `instanceof` can cause problems when multiple projects that have different versions of dependencies are bundled together. In these cases, `instanceof` will not work. Instead, we match by the `type` filed on the error.

## Basic Readiness Checklist

- [x] I have performed a self-review of my code.
- [x] I have added sufficient regression tests to cover the changes.

## Manual QA Additions

- [x] I have updated the [Release Candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template
  with necessary manual QA steps to test my change.
