### PR TITLE
[drift] - added auto-removal of minimized state on existing window creation

### DIFF
--- a/console/src/layout/Window.tsx
+++ b/console/src/layout/Window.tsx
@@ -9,13 +9,13 @@
 
 import "@/layout/Window.css";
 
-import { setWindowDecorations, setWindowVisible } from "@synnaxlabs/drift";
+import { setWindowDecorations, setWindowMinimized, setWindowVisible } from "@synnaxlabs/drift";
 import { useSelectWindowAttribute, useSelectWindowKey } from "@synnaxlabs/drift/react";
 import { Logo } from "@synnaxlabs/media";
 import { Align, Menu as PMenu, Nav, OS, Text } from "@synnaxlabs/pluto";
 import { runtime } from "@synnaxlabs/x";
 import { getCurrent } from "@tauri-apps/api/window";
-import { type ReactElement, useEffect, useLayoutEffect } from "react";
+import { type ReactElement, useEffect, } from "react";
 import { useDispatch } from "react-redux";
 
 import { Controls } from "@/components";
@@ -90,8 +90,10 @@ export const Window = (): ReactElement | null => {
   const os = OS.use({ default: "Windows" }) as runtime.OS;
   const dispatch = useDispatch();
   useEffect(() => {
-    if (layout?.key != null)
+    if (layout?.key != null) {
       dispatch(setWindowVisible({ key: layout.key, value: true }));
+      dispatch(setWindowMinimized({ key: layout.key, value: false }));
+    }
     if (os === "Windows") dispatch(setWindowDecorations({ value: false }));
   }, [os, layout?.key]);
   const menuProps = PMenu.useContextMenu();

--- a/console/src/palette/Palette.tsx
+++ b/console/src/palette/Palette.tsx
@@ -29,7 +29,7 @@ import {
 import { Align } from "@synnaxlabs/pluto";
 import { Dropdown } from "@synnaxlabs/pluto/dropdown";
 import { List } from "@synnaxlabs/pluto/list";
-import { box, dimensions, xy } from "@synnaxlabs/x";
+import { box, dimensions, runtime, xy } from "@synnaxlabs/x";
 import { listen } from "@tauri-apps/api/event";
 import { Window } from "@tauri-apps/api/window";
 import {
@@ -61,11 +61,13 @@ export interface PaletteProps {
 type Entry = Command | ontology.Resource;
 type Key = string;
 
-const useDropOutside = ({ onDrop, canDrop, key, type }: Haul.UseDropOutsideProps) => {
+const macosUseDropOutside = ({ onDrop, canDrop, key, type }: Haul.UseDropOutsideProps) => {
   const ctx = Haul.useContext();
   if (ctx == null) return;
   const { drop } = ctx;
   const dragging = Haul.useDraggingRef();
+  const draggingState = Haul.useDraggingState();
+  console.log(draggingState)
   const key_ = key ?? useId();
   const target: Haul.Item = useMemo(() => ({ key: key_, type }), [key_, type]);
   const store = useStore<RootState>();
@@ -93,6 +95,8 @@ const useDropOutside = ({ onDrop, canDrop, key, type }: Haul.UseDropOutsideProps
     [target],
   );
 };
+
+const useDropOutside = runtime.getOS() === "MacOS" ? macosUseDropOutside : Haul.useDropOutside;
 
 export const Palette = ({
   commands,
@@ -129,7 +133,7 @@ export const Palette = ({
     ({ items: [item] }: Haul.OnDropProps, cursor?: xy.XY) => {
       const windows = Drift.selectWindows(store.getState());
       const boxes = windows
-        // .filter((w) => w.key.startsWith(MOSAIC_TYPE))
+        .filter((w) => w.stage === "created")
         .map((w) => box.construct(w.position, w.size));
       if (boxes.some((b) => box.contains(b, cursor))) return [];
       const { key } = placer(

--- a/console/src/palette/Palette.tsx
+++ b/console/src/palette/Palette.tsx
@@ -61,7 +61,7 @@ export interface PaletteProps {
 type Entry = Command | ontology.Resource;
 type Key = string;
 
-const macosUseDropOutside = ({ onDrop, canDrop, key, type }: Haul.UseDropOutsideProps) => {
+const useDropOutsideMacOS = ({ onDrop, canDrop, key, type }: Haul.UseDropOutsideProps) => {
   const ctx = Haul.useContext();
   if (ctx == null) return;
   const { drop } = ctx;
@@ -96,7 +96,7 @@ const macosUseDropOutside = ({ onDrop, canDrop, key, type }: Haul.UseDropOutside
   );
 };
 
-const useDropOutside = runtime.getOS() === "MacOS" ? macosUseDropOutside : Haul.useDropOutside;
+const useDropOutside = runtime.getOS() === "MacOS" ? useDropOutsideMacOS : Haul.useDropOutside;
 
 export const Palette = ({
   commands,

--- a/pluto/src/haul/Haul.tsx
+++ b/pluto/src/haul/Haul.tsx
@@ -123,7 +123,6 @@ export const Provider = ({
       let dropped: DropProps | null = null;
       interceptors.current.forEach((interceptor) => {
         if (dropped != null) return;
-        console.log("interceptor", interceptor);
         dropped = interceptor(ref.current, cursor);
       });
       if (dropped != null) drop(dropped);
@@ -296,7 +295,6 @@ export const useDropOutside = ({ type, key, ...rest }: UseDropOutsideProps): voi
   useEffect(() => {
     const release = bind((state, cursor) => {
       const { canDrop, onDrop } = propsRef.current;
-      console.log("state", state, isOutside.current, canDrop(state));
       if (!canDrop(state) || !isOutside.current) return null;
       const dropped = onDrop({ ...state }, cursor);
       return { target, dropped };
@@ -309,7 +307,6 @@ export const useDropOutside = ({ type, key, ...rest }: UseDropOutsideProps): voi
     const handleMouseLeave = (e: globalThis.DragEvent) => {
       const { onDragOver, canDrop } = propsRef.current;
       const windowBox = box.construct(window.document.documentElement);
-      console.log("box", windowBox, e.clientX, e.clientY);
       if (box.contains(windowBox, xy.construct(e.clientX, e.clientY)), false) return;
       isOutside.current = true;
       if (!canDrop(dragging.current)) return;

--- a/pluto/src/haul/Haul.tsx
+++ b/pluto/src/haul/Haul.tsx
@@ -123,6 +123,7 @@ export const Provider = ({
       let dropped: DropProps | null = null;
       interceptors.current.forEach((interceptor) => {
         if (dropped != null) return;
+        console.log("interceptor", interceptor);
         dropped = interceptor(ref.current, cursor);
       });
       if (dropped != null) drop(dropped);
@@ -295,6 +296,7 @@ export const useDropOutside = ({ type, key, ...rest }: UseDropOutsideProps): voi
   useEffect(() => {
     const release = bind((state, cursor) => {
       const { canDrop, onDrop } = propsRef.current;
+      console.log("state", state, isOutside.current, canDrop(state));
       if (!canDrop(state) || !isOutside.current) return null;
       const dropped = onDrop({ ...state }, cursor);
       return { target, dropped };
@@ -307,7 +309,8 @@ export const useDropOutside = ({ type, key, ...rest }: UseDropOutsideProps): voi
     const handleMouseLeave = (e: globalThis.DragEvent) => {
       const { onDragOver, canDrop } = propsRef.current;
       const windowBox = box.construct(window.document.documentElement);
-      if (box.contains(windowBox, xy.construct(e.clientX, e.clientY))) return;
+      console.log("box", windowBox, e.clientX, e.clientY);
+      if (box.contains(windowBox, xy.construct(e.clientX, e.clientY)), false) return;
       isOutside.current = true;
       if (!canDrop(dragging.current)) return;
       onDragOver?.(dragging.current);

--- a/pluto/src/os/Controls/Windows.tsx
+++ b/pluto/src/os/Controls/Windows.tsx
@@ -22,8 +22,9 @@ export const Windows = ({
   onMinimize,
   onMaximize,
   onClose,
-  // no-op on windows
+  // no-ops on windows
   onFullscreen: _,
+  focused: __,
   ...props
 }: InternalControlsProps): ReactElement => (
   <Align.Pack {...props}>

--- a/x/ts/src/spatial/box/box.spec.ts
+++ b/x/ts/src/spatial/box/box.spec.ts
@@ -308,29 +308,72 @@ describe("Box", () => {
     });
   });
   describe("contains", () => {
-    it("should return true if the box completely contains the other box", () => {
-      const b = box.construct(0, 0, 20, 20);
-      const b2 = box.construct(5, 5, 15, 15);
-      expect(box.contains(b, b2)).toBe(true);
+    describe("inclusive", () => {
+      it("should return true if the box completely contains the other box", () => {
+        const b = box.construct(0, 0, 20, 20);
+        const b2 = box.construct(5, 5, 15, 15);
+        expect(box.contains(b, b2)).toBe(true);
+      });
+      it("should return true if the box completely contains the other box", () => {
+        const b = box.construct(0, 0, 20, 20);
+        const b2 = box.construct(5, 5, 14, 14);
+        expect(box.contains(b, b2)).toBe(true);
+      });
+      it("should return false if the box does not completely contain the other box", () => {
+        const b = box.construct(0, 0, 10, 10);
+        const b2 = box.construct(5, 5, 15, 15);
+        expect(box.contains(b, b2)).toBe(false);
+      });
+      it("should return true if the two boxes are equal", () => {
+        const b = box.construct(0, 0, 10, 10);
+        expect(box.contains(b, b)).toBe(true);
+      });
+      it("should return true if the box contains the point", () => {
+        const b = box.construct(0, 0, 10, 10);
+        const p = { x: 5, y: 5 };
+        expect(box.contains(b, p)).toBe(true);
+      });
+      it("should return false if the box does not contain the point", () => {
+        const b = box.construct(0, 0, 10, 10);
+        const p = { x: 15, y: 15 };
+        expect(box.contains(b, p)).toBe(false);
+      });
     });
-    it("should return false if the box does not completely contain the other box", () => {
-      const b = box.construct(0, 0, 10, 10);
-      const b2 = box.construct(5, 5, 15, 15);
-      expect(box.contains(b, b2)).toBe(false);
-    });
-    it("should return true if the two boxes are equal", () => {
-      const b = box.construct(0, 0, 10, 10);
-      expect(box.contains(b, b)).toBe(true);
-    });
-    it("should return true if the box contains the point", () => {
-      const b = box.construct(0, 0, 10, 10);
-      const p = { x: 5, y: 5 };
-      expect(box.contains(b, p)).toBe(true);
-    });
-    it("should return false if the box does not contain the point", () => {
-      const b = box.construct(0, 0, 10, 10);
-      const p = { x: 15, y: 15 };
-      expect(box.contains(b, p)).toBe(false);
+    describe("borser - exclusive", () => {
+      it("should return false if the box completely contains the other box", () => {
+        const b = box.construct(0, 0, 20, 20);
+        const b2 = box.construct(5, 5, 15, 15);
+        expect(box.contains(b, b2, false)).toBe(false);
+      });
+      it("should return true if the box completely contains the other box", () => {
+        const b = box.construct(0, 0, 20, 20);
+        const b2 = box.construct(5, 5, 14, 14);
+        expect(box.contains(b, b2, false)).toBe(true);
+      });
+      it("should return false if the box does not completely contain the other box", () => {
+        const b = box.construct(0, 0, 10, 10);
+        const b2 = box.construct(5, 5, 15, 15);
+        expect(box.contains(b, b2, false)).toBe(false);
+      });
+      it("should return false if the two boxes are equal", () => {
+        const b = box.construct(0, 0, 10, 10);
+        expect(box.contains(b, b, false)).toBe(false);
+      });
+      it("should return false if the box contains the point", () => {
+        const b = box.construct(0, 0, 10, 10);
+        const p = { x: 5, y: 5 };
+        expect(box.contains(b, p, false)).toBe(true);
+      });
+      it("should return false if the box does not contain the point", () => {
+        const b = box.construct(0, 0, 10, 10);
+        const p = { x: 15, y: 15 };
+        expect(box.contains(b, p, false)).toBe(false);
+      });
+      it("should return false if the point is on the border", () => {
+        const b = box.construct(0, 0, 10, 10);
+        const p = { x: 10, y: 10 };
+        expect(box.contains(b, p, false)).toBe(false);
+      });
     });
   });
   describe("css", () => {

--- a/x/ts/src/spatial/box/box.spec.ts
+++ b/x/ts/src/spatial/box/box.spec.ts
@@ -308,7 +308,7 @@ describe("Box", () => {
     });
   });
   describe("contains", () => {
-    describe("inclusive", () => {
+    describe("inclusive of border", () => {
       it("should return true if the box completely contains the other box", () => {
         const b = box.construct(0, 0, 20, 20);
         const b2 = box.construct(5, 5, 15, 15);
@@ -338,8 +338,13 @@ describe("Box", () => {
         const p = { x: 15, y: 15 };
         expect(box.contains(b, p)).toBe(false);
       });
+      it("should return true if the point is on the border", () => {
+        const b = box.construct(0, 0, 10, 10);
+        const p = { x: 10, y: 10 };
+        expect(box.contains(b, p)).toBe(true);
+      });
     });
-    describe("borser - exclusive", () => {
+    describe("exclusive of border", () => {
       it("should return false if the box completely contains the other box", () => {
         const b = box.construct(0, 0, 20, 20);
         const b2 = box.construct(5, 5, 15, 15);

--- a/x/ts/src/spatial/box/box.ts
+++ b/x/ts/src/spatial/box/box.ts
@@ -152,23 +152,27 @@ export const resize: Resize = (
 /**
  * Checks if a box contains a point or another box.
  *
- * @param value - The point or box to check.
+ * @param container - The container box to check against.
+ * @param value - The point or box to check if it is contained in the container.
+ * @param inclusive - Whether the edges of the box are inclusive or exclusive.
  * @returns true if the box inclusively contains the point or box and false otherwise.
  */
-export const contains = (b: Crude, value: Box | xy.XY): boolean => {
-  const b_ = construct(b);
+export const contains = (container: Crude, value: Box | xy.XY, inclusive: boolean = true): boolean => {
+  const b_ = construct(container);
+  let comp = (a: number, b: number) => a < b;
+  if (inclusive) comp = (a: number, b: number) => a <= b;
   if ("one" in value)
     return (
-      left(value) >= left(b_) &&
-      right(value) <= right(b_) &&
-      top(value) >= top(b_) &&
-      bottom(value) <= bottom(b_)
+      comp(left(b_), left(value)) &&
+      comp(right(value), right(b_)) &&
+      comp(top(b_), top(value)) &&
+      comp(bottom(value), bottom(b_))
     );
   return (
-    value.x >= left(b_) &&
-    value.x <= right(b_) &&
-    value.y >= top(b_) &&
-    value.y <= bottom(b_)
+    comp(left(b_), value.x) &&
+    comp(value.x, right(b_)) &&
+    comp(top(b_), value.y) &&
+    comp(value.y, bottom(b_))
   );
 };
 


### PR DESCRIPTION
added auto-removal of minimized state on existing window creation

# Fix Pull Request Template

## Key Information

- Linear Issue: [SY-896](https://linear.app/synnaxlabs/issue/SY-896/fix-issues-with-drift-window-persistence)

## Description

Fixes issues hiding and showing drift windows by ensuring that windows that already exists, but are "recreated" are correctly un-minimized and centered in the viewport.

## Basic Readiness Checklist

- [z] I have performed a self-review of my code.
- [z] I have added sufficient regression tests to cover the changes.

## Manual QA Additions

- [z] I have updated the [Release Candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template
  with necessary manual QA steps to test my change.
