### PR TITLE
[console] - fixed improper setting of state resources on line plot an…

### DIFF
--- a/console/src/workspace/ontology.tsx
+++ b/console/src/workspace/ontology.tsx
@@ -61,13 +61,13 @@ const useDelete = (): ((props: Ontology.TreeContextMenuProps) => void) =>
 const useCreateSchematic = (): ((props: Ontology.TreeContextMenuProps) => void) =>
   useMutation<void, Error, Ontology.TreeContextMenuProps, Tree.Node[]>({
     mutationFn: async ({
-      selection: { resources },
+      selection,
       placeLayout,
       services,
-      state: { setResources, nodes, setNodes },
+      state: { resources, setResources, nodes, setNodes },
       client,
     }) => {
-      const workspace = resources[0].id.key;
+      const workspace = selection.resources[0].id.key;
       const schematic = await client.workspaces.schematic.create(workspace, {
         name: "New Schematic",
         snapshot: false,
@@ -87,7 +87,7 @@ const useCreateSchematic = (): ((props: Ontology.TreeContextMenuProps) => void) 
       setResources([...resources, otg]);
       const nextNodes = Tree.setNode({
         tree: nodes,
-        destination: resources[0].key,
+        destination: selection.resources[0].key,
         additions: Ontology.toTreeNodes(services, [otg]),
       });
       setNodes([...nextNodes]);
@@ -106,13 +106,13 @@ const useCreateSchematic = (): ((props: Ontology.TreeContextMenuProps) => void) 
 const useCreateLinePlot = (): ((props: Ontology.TreeContextMenuProps) => void) =>
   useMutation<void, Error, Ontology.TreeContextMenuProps, Tree.Node[]>({
     mutationFn: async ({
-      selection: { resources },
+      selection,
       placeLayout,
       services,
-      state: { setResources, nodes, setNodes },
+      state: { setResources, resources, nodes, setNodes },
       client,
     }) => {
-      const workspace = resources[0].id.key;
+      const workspace = selection.resources[0].id.key;
       const linePlot = await client.workspaces.linePlot.create(workspace, {
         name: "New Line Plot",
         data: deep.copy(LinePlot.ZERO_SLICE_STATE) as unknown as UnknownRecord,
@@ -130,7 +130,7 @@ const useCreateLinePlot = (): ((props: Ontology.TreeContextMenuProps) => void) =
       setResources([...resources, otg]);
       const nextNodes = Tree.setNode({
         tree: nodes,
-        destination: resources[0].key,
+        destination: selection.resources[0].key,
         additions: Ontology.toTreeNodes(services, [otg]),
       });
       setNodes([...nextNodes]);


### PR DESCRIPTION
# Fix Pull Request Template

## Key Information

- Linear Issue: Addresses [SY-908](https://linear.app/synnaxlabs/issue/SY-908/after-i-make-a-new-schematic-i-can-only-switch-to-other-schematics-in)

## Description

Fixes an issue where we would set ontology resources to the current selection instead of the entire state due to a similarly named variable.

## Basic Readiness Checklist

- [x] I have performed a self-review of my code.
- [x] I have added sufficient regression tests to cover the changes.

## Manual QA Additions

- [x] I have updated the [Release Candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template
  with necessary manual QA steps to test my change.
