### PR TITLE
[freighter/py] - implemented websocket receive timeout

### DIFF
--- a/client/py/examples/control/press/simulated_daq.py
+++ b/client/py/examples/control/press/simulated_daq.py
@@ -100,9 +100,10 @@ with client.open_streamer([c.key for c in valve_command_channels]) as streamer:
         press = 0
         while True:
             time.sleep(rate)
-
-            if streamer.received:
-                f = streamer.read()
+            while True:
+                f = streamer.read(0)
+                if f is None:
+                    break
                 for k in f.channels:
                     state[valve_command_to_response_channels[k]] = f[k][-1]
 

--- a/client/py/examples/control/tpc/simulated_daq.py
+++ b/client/py/examples/control/tpc/simulated_daq.py
@@ -139,11 +139,12 @@ with client.open_streamer([cmd for cmd in VALVES.keys()]) as streamer:
         while True:
             try:
                 time.sleep(rate)
-                if streamer.received:
-                    while streamer.received:
-                        f = streamer.read()
-                        for k in f.channels:
-                            DAQ_STATE[k] = f[k][0]
+                while True:
+                    f = streamer.read(0)
+                    if f is None:
+                        break
+                    for k in f.channels:
+                        DAQ_STATE[k] = f[k][0]
 
                 if DAQ_STATE[OX_MPV_CMD] == 1 and OX_MPV_LAST_OPEN is None:
                     OX_MPV_LAST_OPEN = sy.TimeStamp.now()

--- a/freighter/py/freighter/stream.py
+++ b/freighter/py/freighter/stream.py
@@ -30,9 +30,15 @@ class AsyncStreamReceiver(Protocol[RS]):
 class StreamReceiver(Protocol[RS]):
     """Protocol for an entity that receives a stream of responses."""
 
-    def receive(self) -> tuple[RS, None] | tuple[None, Exception]:
+    def receive(
+        self,
+        timeout: float | None = None
+    ) -> tuple[RS, None] | tuple[None, Exception]:
         """
         Receives a response from the stream. It's not safe to call receive concurrently.
+
+        :param timeout: the maximum amount of time to wait for a response. If None, the
+        method will block indefinitely. Not all implementations support this parameter.
 
         :returns freighter.errors.EOF: if the server closed the stream nominally.
         :returns Exception: if the server closed the stream abnormally,

--- a/freighter/py/freighter/websocket.py
+++ b/freighter/py/freighter/websocket.py
@@ -9,6 +9,7 @@
 
 import ssl
 from typing import Any, Generic, Literal, Type, MutableMapping
+from warnings import warn
 
 from pydantic import BaseModel
 from websockets.client import WebSocketClientProtocol, connect
@@ -60,8 +61,13 @@ class AsyncWebsocketStream(AsyncStream[RQ, RS]):
         self.__server_closed = None
         self.__res_msg_t = _new_res_msg_t(res_t)
 
-    async def receive(self) -> tuple[RS | None, Exception | None]:
+    async def receive(
+        self,
+        timeout: float | None = None,
+    ) -> tuple[RS | None, Exception | None]:
         """Implements the AsyncStream protocol."""
+        if timeout is not None:
+            warn("Timeout is not supported for async websockets", stacklevel=2)
         if self.__server_closed is not None:
             return None, self.__server_closed
 
@@ -120,7 +126,7 @@ class AsyncWebsocketStream(AsyncStream[RQ, RS]):
             await self.__internal.close()
 
 
-DEFAULT_MAX_SIZE = 2**20
+DEFAULT_MAX_SIZE = 2 ** 20
 
 
 class SyncWebsocketStream(Stream[RQ, RS]):
@@ -142,11 +148,14 @@ class SyncWebsocketStream(Stream[RQ, RS]):
         self.__server_closed = None
         self.__res_msg_t = _new_res_msg_t(res_t)
 
-    def receive(self) -> tuple[RS | None, Exception | None]:
+    def receive(
+        self,
+        timeout: float | None = None
+    ) -> tuple[RS | None, Exception | None]:
         if self.__server_closed is not None:
             return None, self.__server_closed
 
-        data = self.__internal.recv()
+        data = self.__internal.recv(timeout)
         assert isinstance(data, bytes)
         msg = self.__encoder.decode(data, self.__res_msg_t)
 


### PR DESCRIPTION
# Fix Pull Request Template

## Key Information

- Linear Issue: [SY-923](https://linear.app/synnaxlabs/issue/SY-923/fix-sync-websocket-received-method)

## Description

Adds optional timeout parameter to `streamer.read` that allows for checking received messages without blocking.

## Basic Readiness Checklist

- [x] I have performed a self-review of my code.
- [x] I have added sufficient regression tests to cover the changes.

## Manual QA Additions

- [x] I have updated the [Release Candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template
  with necessary manual QA steps to test my change.
