### PR TITLE
Made the flushed timespan more lenient

### DIFF
--- a/pluto/src/telem/client/cache/dynamic.spec.ts
+++ b/pluto/src/telem/client/cache/dynamic.spec.ts
@@ -94,8 +94,8 @@ describe("DynamicCache", () => {
       );
       expect(allocated[0].timeRange.end.valueOf()).toEqual(TimeStamp.MAX.valueOf());
       expect(flushed).toHaveLength(1);
-      expect(flushed[0].timeRange.span.sub(waitSpan).valueOf()).toBeLessThan(
-        TimeSpan.milliseconds(3).valueOf(),
+      expect(flushed[0].timeRange.span.sub(waitSpan).valueOf()).toBeLessThanOrEqual(
+        TimeSpan.milliseconds(5).valueOf(),
       );
       expect(flushed[0].data.slice(0, 3)).toEqual(new Float32Array([1, 2, 3]));
       expect(flushed[0].data.slice(3, 6)).toEqual(new Float32Array([1, 2, 3]));


### PR DESCRIPTION
# Fix Pull Request Template

## Key Information

- **Linear Issue**: [SY-920](https://linear.app/synnaxlabs/issue/SY-920/fix-failing-dynamic-cache-spec)

## Description

Made a timing test more lenient so it fails in CI less often.

## Basic Readiness Checklist

- [x] I have performed a self-review of my code.
- [x] I have added sufficient regression tests to cover the changes.

## Manual QA Additions

- [x] I have updated the [Release Candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template
  with necessary manual QA steps to test my change.
