### PR TITLE
Sy 959 console old workspaces not migrating correctly

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/rc.md
+++ b/.github/PULL_REQUEST_TEMPLATE/rc.md
@@ -148,6 +148,8 @@ I can successfully:
 - [ ] Rename a schematic in a workspace.
 - [ ] Delete a line plot in a workspace.
 - [ ] Delete a schematic in a workspace.
+- [ ] Create a workspace in a previous version of Synnax, add visualizations, and open
+     it in the release candidate.
 
 ### Resources
 

--- a/console/package.json
+++ b/console/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synnaxlabs/console",
   "private": true,
-  "version": "0.24.2",
+  "version": "0.24.3",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/console/src/cluster/slice.ts
+++ b/console/src/cluster/slice.ts
@@ -95,7 +95,7 @@ export interface RenamePayload {
 
 export const MIGRATIONS: migrate.Migrations = {};
 
-export const migrateSlice = migrate.migrator<SliceState>({
+export const migrateSlice = migrate.migrator<SliceState, SliceState>({
   name: "cluster.slice",
   migrations: MIGRATIONS,
   def: ZERO_SLICE_STATE,

--- a/console/src/docs/slice.ts
+++ b/console/src/docs/slice.ts
@@ -48,7 +48,7 @@ export type SetLocationPayload = Location;
 
 export const MIGRATIONS: migrate.Migrations = {};
 
-export const migrateSlice = migrate.migrator<SliceState>({
+export const migrateSlice = migrate.migrator<SliceState, SliceState>({
   name: "docs.slice",
   migrations: MIGRATIONS,
   def: ZERO_SLICE_STATE,

--- a/console/src/layout/migrations/index.ts
+++ b/console/src/layout/migrations/index.ts
@@ -8,18 +8,25 @@ export type SliceState = v3.SliceState;
 export type NavDrawerLocation = v0.NavDrawerLocation;
 export type NavDrawerEntryState = v0.NavDrawerEntryState;
 export type WindowProps = v0.WindowProps;
+export type AnyState<A = any> = v0.State<A>;
+export type AnySliceState =
+  | v0.SliceState
+  | v3.SliceState
+  | (Omit<v3.SliceState, "version"> & { version: "0.2.0" })
+  | (Omit<v3.SliceState, "version"> & { version: "0.1.0" });
 
 export const SLICE_MIGRATIONS: migrate.Migrations = {
   "0.0.0": v3.sliceMigration,
   "0.1.0": v3.sliceMigration,
   "0.2.0": v3.sliceMigration,
+  "0.3.0": v3.sliceMigration,
 };
 
 export const ZERO_SLICE_STATE = v3.ZERO_SLICE_STATE;
 export const ZERO_MOSAIC_STATE = v0.ZERO_MOSAIC_STATE;
 export const MAIN_LAYOUT = v0.MAIN_LAYOUT;
 
-export const migrateSlice = migrate.migrator({
+export const migrateSlice = migrate.migrator<AnySliceState, SliceState>({
   name: "layout.slice",
   migrations: SLICE_MIGRATIONS,
   def: ZERO_SLICE_STATE,

--- a/console/src/layout/migrations/migrations.spec.ts
+++ b/console/src/layout/migrations/migrations.spec.ts
@@ -1,12 +1,16 @@
 import { describe, expect, it } from "vitest";
 
-import { migrateSlice, ZERO_SLICE_STATE } from "@/layout/migrations";
+import {
+  type AnySliceState,
+  migrateSlice,
+  ZERO_SLICE_STATE,
+} from "@/layout/migrations";
 import * as v0 from "@/layout/migrations/v0";
 import * as v3 from "@/layout/migrations/v3";
 
 describe("migrations", () => {
   describe("slice", () => {
-    const STATES = [
+    const STATES: AnySliceState[] = [
       v0.ZERO_SLICE_STATE,
       { ...v0.ZERO_SLICE_STATE, version: "0.1.0" },
       { ...v0.ZERO_SLICE_STATE, version: "0.2.0" },

--- a/console/src/layout/slice.ts
+++ b/console/src/layout/slice.ts
@@ -372,7 +372,7 @@ export const { actions, reducer } = createSlice({
       state,
       { payload: { slice, keepNav = true } }: PayloadAction<SetWorkspacePayload>,
     ) => {
-      return {
+      return migrateSlice({
         ...slice,
         layouts: {
           ...layoutsToPreserve(state.layouts),
@@ -383,7 +383,7 @@ export const { actions, reducer } = createSlice({
         themes: state.themes,
         activeTheme: state.activeTheme,
         nav: keepNav ? state.nav : slice.nav,
-      };
+      });
     },
     clearWorkspace: (state) => {
       return {

--- a/console/src/lineplot/LinePlot.tsx
+++ b/console/src/lineplot/LinePlot.tsx
@@ -513,12 +513,10 @@ export const LinePlot: Layout.Renderer = ({
     useSelect: useSelect,
     fetcher: async (client, layoutKey) => {
       const { data } = await client.workspaces.linePlot.retrieve(layoutKey);
-      console.log(data);
       return data as unknown as State;
     },
     actionCreator: internalCreate,
   });
-  console.log("RENDRE", linePlot);
   if (linePlot == null) return null;
   return <Loaded layoutKey={layoutKey} {...props} />;
 };

--- a/console/src/lineplot/LinePlot.tsx
+++ b/console/src/lineplot/LinePlot.tsx
@@ -513,6 +513,7 @@ export const LinePlot: Layout.Renderer = ({
     useSelect: useSelect,
     fetcher: async (client, layoutKey) => {
       const { data } = await client.workspaces.linePlot.retrieve(layoutKey);
+      console.log(data);
       return data as unknown as State;
     },
     actionCreator: internalCreate,

--- a/console/src/lineplot/LinePlot.tsx
+++ b/console/src/lineplot/LinePlot.tsx
@@ -518,6 +518,7 @@ export const LinePlot: Layout.Renderer = ({
     },
     actionCreator: internalCreate,
   });
+  console.log("RENDRE", linePlot);
   if (linePlot == null) return null;
   return <Loaded layoutKey={layoutKey} {...props} />;
 };

--- a/console/src/lineplot/migrations/index.ts
+++ b/console/src/lineplot/migrations/index.ts
@@ -77,7 +77,7 @@ export const STATE_MIGRATIONS: migrate.Migrations = {
   "0.0.0": v1.stateMigration,
 };
 
-export const migrateState = migrate.migrator<v1.State>({
+export const migrateState = migrate.migrator<AnyState, v1.State>({
   name: "lineplot.state",
   migrations: STATE_MIGRATIONS,
   def: v1.ZERO_STATE,
@@ -87,7 +87,7 @@ export const SLICE_MIGRATIONS: migrate.Migrations = {
   "0.0.0": v1.sliceMigration,
 };
 
-export const migrateSlice = migrate.migrator<v1.SliceState>({
+export const migrateSlice = migrate.migrator<AnySliceState, v1.SliceState>({
   name: "lineplot.slice",
   migrations: SLICE_MIGRATIONS,
   def: ZERO_SLICE_STATE,

--- a/console/src/range/migrations/index.ts
+++ b/console/src/range/migrations/index.ts
@@ -18,7 +18,7 @@ export type StaticRange = v0.StaticRange;
 export const ZERO_SLICE_STATE = v0.ZERO_SLICE_STATE;
 
 export const MIGRATIONS: migrate.Migrations = {};
-export const migrateSlice = migrate.migrator({
+export const migrateSlice = migrate.migrator<SliceState, SliceState>({
   name: "range.slice",
   migrations: MIGRATIONS,
   def: ZERO_SLICE_STATE,

--- a/console/src/schematic/migrations/index.ts
+++ b/console/src/schematic/migrations/index.ts
@@ -27,19 +27,21 @@ export const ZERO_SLICE_STATE = v1.ZERO_SLICE_STATE;
 
 export const STATE_MIGRATIONS: migrate.Migrations = {
   "0.0.0": v1.stateMigration,
+  "0.0.1": v1.stateMigration,
 };
 
 export const SLICE_MIGRATIONS: migrate.Migrations = {
   "0.0.0": v1.sliceMigration,
+  "0.0.1": v1.sliceMigration,
 };
 
-export const migrateState = migrate.migrator<v1.State>({
+export const migrateState = migrate.migrator<AnyState, v1.State>({
   name: "schematic.state",
   migrations: STATE_MIGRATIONS,
   def: v1.ZERO_STATE,
 });
 
-export const migrateSlice = migrate.migrator<v1.SliceState>({
+export const migrateSlice = migrate.migrator<AnySliceState, v1.SliceState>({
   name: "schematic.slice",
   migrations: SLICE_MIGRATIONS,
   def: ZERO_SLICE_STATE,

--- a/console/src/version/slice.ts
+++ b/console/src/version/slice.ts
@@ -10,7 +10,6 @@
 import type { PayloadAction } from "@reduxjs/toolkit";
 import { createSlice } from "@reduxjs/toolkit";
 import { migrate } from "@synnaxlabs/x";
-import { z } from "zod";
 
 export const SLICE_NAME = "version";
 

--- a/console/src/workspace/slice.ts
+++ b/console/src/workspace/slice.ts
@@ -10,7 +10,6 @@
 import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 import { type workspace } from "@synnaxlabs/client";
 import { migrate } from "@synnaxlabs/x";
-import { z } from "zod";
 
 export interface SliceState extends migrate.Migratable {
   active: string | null;
@@ -41,7 +40,7 @@ export interface RenamePayload {
 
 export const MIGRATIONS: migrate.Migrations = {};
 
-export const migrateSlice = migrate.migrator({
+export const migrateSlice = migrate.migrator<SliceState, SliceState>({
   name: "workspace.slice",
   migrations: MIGRATIONS,
   def: ZERO_SLICE_STATE,

--- a/x/ts/package.json
+++ b/x/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synnaxlabs/x",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "type": "module",
   "description": "Common Utilities for Synnax Labs",
   "repository": "https://github.com/synnaxlabs/synnax/tree/main/x/go",

--- a/x/ts/src/migrate/migrate.spec.ts
+++ b/x/ts/src/migrate/migrate.spec.ts
@@ -56,6 +56,13 @@ const migrations: migrate.Migrations = {
   "1.0.0": migrateV2,
 };
 
+describe("compareSemVer", () => {
+  it("should return true when the major version is higher", () => {
+    expect(migrate.compareSemVer("1.0.0", "0.0.0")).toBeGreaterThan(0);
+    expect(migrate.semVerNewer("3.0.0", "0.3.0")).toBeTruthy();
+  });
+});
+
 describe("migrator", () => {
   it("should migrate an entity from v0 to v2", () => {
     const entity: EntityV0 = { version: "0.0.0", name: "foo" };

--- a/x/ts/src/migrate/migrate.ts
+++ b/x/ts/src/migrate/migrate.ts
@@ -24,7 +24,7 @@ export type SemVer = z.infer<typeof semVerZ>;
  * than B, compare.EQUAL (0) if a is the same as b, and compare.GREATER_THAN (positive)
  * if a is NEWER than b.
  */
-const compareSemVer: compare.CompareF<string> = (a, b) => {
+export const compareSemVer: compare.CompareF<string> = (a, b) => {
   const semA = semVerZ.parse(a);
   const semB = semVerZ.parse(b);
   const [aMajor, aMinor, aPatch] = semA.split(".").map(Number);
@@ -39,7 +39,7 @@ const compareSemVer: compare.CompareF<string> = (a, b) => {
  * @param a The first semantic version.
  * @param b The second semantic version.
  */
-const semVerNewer = (a: SemVer, b: SemVer): boolean =>
+export const semVerNewer = (a: SemVer, b: SemVer): boolean =>
   compare.isGreaterThan(compareSemVer(a, b));
 
 export type Migratable<V extends string = string> = { version: V };
@@ -93,12 +93,16 @@ interface MigratorProps<O extends Migratable, ZO extends z.ZodTypeAny = z.ZodTyp
   targetSchema?: ZO;
 }
 
-export const migrator = <O extends Migratable, ZO extends z.ZodTypeAny = z.ZodTypeAny>({
+export const migrator = <
+  I extends Migratable,
+  O extends Migratable,
+  ZO extends z.ZodTypeAny = z.ZodTypeAny,
+>({
   name,
   migrations,
   targetSchema,
   def,
-}: MigratorProps<O, ZO>): ((v: Migratable) => O) => {
+}: MigratorProps<O, ZO>): ((v: I) => O) => {
   const latestMigrationVersion = Object.keys(migrations).sort(compareSemVer).pop();
   if (latestMigrationVersion == null)
     return (v: Migratable) => {

--- a/x/ts/src/migrate/migrate.ts
+++ b/x/ts/src/migrate/migrate.ts
@@ -42,6 +42,14 @@ export const compareSemVer: compare.CompareF<string> = (a, b) => {
 export const semVerNewer = (a: SemVer, b: SemVer): boolean =>
   compare.isGreaterThan(compareSemVer(a, b));
 
+/**
+ * @returns true if the first semantic version is older than the second.
+ * @param a The first semantic version.
+ * @param b The second semantic version.
+ */
+export const semVerOlder = (a: SemVer, b: SemVer): boolean =>
+  compare.isLessThan(compareSemVer(a, b));
+
 export type Migratable<V extends string = string> = { version: V };
 
 export type Migration<I extends Migratable, O extends Migratable> = (input: I) => O;


### PR DESCRIPTION
# Fix Pull Request Template

## Key Information

- **Linear Issue**: [SY-959](https://linear.app/synnaxlabs/issue/SY-959/[console]-old-workspaces-not-migrating-correctly)

## Description

How to Reproduce - Open Synnax version 23, create a workspace and add some schematics and line plots. Then, install Synnax version 24 and open the same workspace. Then, try to open one of the schematics or line plots.

Expected Behavior - The layouts should load in correctly.

Actual Behavior - You won't be able to load in any of the layouts.

This PR fixes this issue.

## Basic Readiness Checklist

- [x] I have performed a self-review of my code.
- [x] I have added sufficient regression tests to cover the changes.

## Manual QA Additions

- [x] I have updated the [Release Candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template
  with necessary manual QA steps to test my change.
