### PR TITLE
[cesium] added length check for series when updating high watermark

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE/rc.md
+++ b/.github/PULL_REQUEST_TEMPLATE/rc.md
@@ -193,6 +193,7 @@ I can successfully:
 - [ ] Recognize and connect to a National Instruments device available on local machine.
 - [ ] Recognize and connect to a National Instruments devices available on network.
 - [ ] Recognize and connect to physcial and simulated devices.
+- [ ] Disconnect a physical device from the machine with a task running without faulting.
 - [ ] Save device configuration.
 - [ ] Not see chassis devices connected to the machine
 - [ ] See devices connected to a chassis

--- a/cesium/writer_stream.go
+++ b/cesium/writer_stream.go
@@ -472,7 +472,15 @@ func (w *idxWriter) updateHighWater(s telem.Series) error {
 			s.DataType,
 		)
 	}
+	if s.Len() == 0 {
+		return errors.Wrapf(
+			validate.Error,
+			"series for channel %d length is zero",
+			w.idx.key,
+		)
+	}
 	w.idx.highWaterMark = telem.ValueAt[telem.TimeStamp](s, s.Len()-1)
+
 	return nil
 }
 

--- a/x/go/telem/series.go
+++ b/x/go/telem/series.go
@@ -54,9 +54,9 @@ func (s Series) Split() [][]byte {
 	return o
 }
 
-func ValueAt[T types.Numeric](a Series, i int64) T {
-	start := i * int64(a.DataType.Density())
-	end := (i + 1) * int64(a.DataType.Density())
-	b := a.Data[start:end]
-	return UnmarshalF[T](a.DataType)(b)
+func ValueAt[T types.Numeric](s Series, i int64) T {
+	start := i * int64(s.DataType.Density())
+	end := (i + 1) * int64(s.DataType.Density())
+	b := s.Data[start:end]
+	return UnmarshalF[T](s.DataType)(b)
 }

--- a/x/go/telem/series.go
+++ b/x/go/telem/series.go
@@ -55,6 +55,8 @@ func (s Series) Split() [][]byte {
 }
 
 func ValueAt[T types.Numeric](a Series, i int64) T {
-	b := a.Data[i*int64(a.DataType.Density()) : (i+1)*int64(a.DataType.Density())]
+	start := i * int64(a.DataType.Density())
+	end := (i + 1) * int64(a.DataType.Density())
+	b := a.Data[start:end]
 	return UnmarshalF[T](a.DataType)(b)
 }


### PR DESCRIPTION
# Fix Pull Request Template

## Key Information

- **Linear Issue**: [SY-964]()

## Description

Maximum 2-3 sentence description describing the changes.

Server would panic when disconnecting an NI device which is in use by a read task in the server.  Added a check to `UpdateHighWater` to check for series length before using it to set the watermark.

## Basic Readiness Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added sufficient regression tests to cover the changes.

## Manual QA Additions

- [ ] I have updated the [Release Candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template
  with necessary manual QA steps to test my change.
