### PR TITLE
[HOTFIX] - [client] - iterator `Prev` command

### DIFF
--- a/client/py/pyproject.toml
+++ b/client/py/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "synnax"
-version = "0.24.3"
+version = "0.24.4"
 description = "Synnax Client Library"
 keywords = ["Synnax", "Synnax Python Client"]
 authors = ["emiliano bonilla <emilbon99@gmail.com>"]

--- a/client/py/synnax/framer/iterator.py
+++ b/client/py/synnax/framer/iterator.py
@@ -132,7 +132,7 @@ class Iterator:
         :returns: False if a segment satisfying the request can't be found for a particular
         channel or the iterator has accumulated an error.
         """
-        return self._exec(command=_Command.NEXT, span=span)
+        return self._exec(command=_Command.PREV, span=span)
 
     @trace("debug")
     def seek_first(self) -> bool:
@@ -157,7 +157,7 @@ class Iterator:
         return self._exec(command=_Command.SEEK_LAST)
 
     @trace("debug")
-    def seek_lt(self, stamp: TimeStamp) -> bool:
+    def seek_le(self, stamp: TimeStamp) -> bool:
         """Seeks the iterator to the first segment whose start is less than or equal to
         the provided timestamp. Also invalidates the iterator. The iterator will not be
         considered valid until a call to first, last, next, prev, prev_span, next_span, or next_range.

--- a/client/py/tests/test_framer.py
+++ b/client/py/tests/test_framer.py
@@ -68,6 +68,38 @@ class TestIterator:
 
             assert not i.next(sy.framer.AUTO_SPAN)
 
+    def test_advanced_iterate(self, client: sy.Synnax, indexed_pair: tuple[sy.Channel, sy.Channel]):
+        [idx_ch, data_ch] = indexed_pair
+        idx_ch.write(0, np.array([0, 1 * sy.TimeSpan.SECOND, 2 * sy.TimeSpan.SECOND, 3 * sy.TimeSpan.SECOND, 4 * sy.TimeSpan.SECOND, 5 * sy.TimeSpan.SECOND]).astype(np.int64))
+        data_ch.write(0, np.array([0, 1, 2, 3, 4, 5]).astype(np.int64))
+        idx_ch.write(TimeStamp(10 * sy.TimeSpan.SECOND), np.array([10 * sy.TimeSpan.SECOND, 11 * sy.TimeSpan.SECOND, 12 * sy.TimeSpan.SECOND, 13 * sy.TimeSpan.SECOND]).astype(np.int64))
+        data_ch.write(TimeStamp(10 * sy.TimeSpan.SECOND), np.array([10, 11, 12, 13]).astype(np.int64))
+        idx_ch.write(TimeStamp(15 * sy.TimeSpan.SECOND), np.array([15 * sy.TimeSpan.SECOND, 16 * sy.TimeSpan.SECOND, 17 * sy.TimeSpan.SECOND, 18 * sy.TimeSpan.SECOND, 19 * sy.TimeSpan.SECOND]).astype(np.int64))
+        data_ch.write(TimeStamp(15 * sy.TimeSpan.SECOND), np.array([15, 16, 17, 18, 19]).astype(np.int64))
+        with client.open_iterator(sy.TimeRange.MAX, data_ch.key) as i:
+            assert i.seek_ge(sy.TimeStamp(16 * sy.TimeSpan.SECOND))
+            assert i.next(4 * sy.TimeSpan.SECOND)
+            l = i.value.get(data_ch.key).to_numpy().tolist()
+            assert l == [16, 17, 18, 19]
+
+            assert i.seek_last()
+            assert i.prev(4 * sy.TimeSpan.SECOND)
+            l = i.value.get(data_ch.key).to_numpy().tolist()
+            assert l == [16, 17, 18, 19]
+
+            assert i.prev(11 * sy.TimeSpan.SECOND)
+            l = i.value.get(data_ch.key).to_numpy().tolist()
+            assert l == [5, 10, 11, 12, 13, 15]
+
+            assert i.seek_le(sy.TimeStamp(6 * sy.TimeSpan.SECOND))
+            assert i.prev(3 * sy.TimeSpan.SECOND)
+            l = i.value.get(data_ch.key).to_numpy().tolist()
+            assert l == [3, 4, 5]
+
+            assert not i.seek_le(-1)
+            assert not i.seek_ge(sy.TimeStamp(20 * sy.TimeSpan.SECOND))
+
+
 
 @pytest.mark.framer
 @pytest.mark.writer


### PR DESCRIPTION
# Fix Pull Request Template

## Key Information

- **Linear Issue**: [SY-972](https://linear.app/synnaxlabs/issue/SY-972/hotfix-[py-client]-iterator-prev)

## Description

Our iterator `prev` command currently calls `NEXT` to the server. It should call `PREV`

## Basic Readiness Checklist

- [x] I have performed a self-review of my code.
- [x] I have added sufficient regression tests to cover the changes. - added regression tests to cover all iterator methods

## Manual QA Additions

- [x] I have updated the [Release Candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template
  with necessary manual QA steps to test my change.
