### PR TITLE
SY-922 Fix Create Range from Line Plot Context Menu

### DIFF
--- a/console/src/layout/migrations/v0.ts
+++ b/console/src/layout/migrations/v0.ts
@@ -1,7 +1,7 @@
 import { Drift } from "@synnaxlabs/drift";
 import { Haul, Mosaic, Tabs, Theming } from "@synnaxlabs/pluto";
 import { theming } from "@synnaxlabs/pluto/ether";
-import { location, migrate } from "@synnaxlabs/x";
+import { location } from "@synnaxlabs/x";
 import { z } from "zod";
 
 export const placementLocationZ = z.union([

--- a/console/src/lineplot/LinePlot.tsx
+++ b/console/src/lineplot/LinePlot.tsx
@@ -333,7 +333,6 @@ const Loaded = ({ layoutKey }: { layoutKey: string }): ReactElement => {
           download({ timeRange, lines, client });
           break;
       }
-      console.log("bar");
     };
 
     return (

--- a/console/src/lineplot/LinePlot.tsx
+++ b/console/src/lineplot/LinePlot.tsx
@@ -326,21 +326,14 @@ const Loaded = ({ layoutKey }: { layoutKey: string }): ReactElement => {
           );
           break;
         case "range":
-          dispatch(
-            Range.setBuffer({
-              timeRange: {
-                start: Number(timeRange.start.valueOf()),
-                end: Number(timeRange.end.valueOf()),
-              },
-            }),
-          );
-          newLayout(Range.createEditLayout());
+          newLayout(Range.createEditLayout("", timeRange));
           break;
         case "download":
           if (client == null) return;
           download({ timeRange, lines, client });
           break;
       }
+      console.log("bar");
     };
 
     return (

--- a/console/src/lineplot/LinePlot.tsx
+++ b/console/src/lineplot/LinePlot.tsx
@@ -82,6 +82,7 @@ import {
   ZERO_STATE,
 } from "@/lineplot/slice";
 import { Range } from "@/range";
+import { type TimeRange as CTimeRange } from "@/range/migrations";
 import { Workspace } from "@/workspace";
 
 interface SyncPayload {
@@ -306,6 +307,10 @@ const Loaded = ({ layoutKey }: { layoutKey: string }): ReactElement => {
       s.pos(box.left(selection)),
       s.pos(box.right(selection)),
     );
+    const timeRangeNumber: CTimeRange = {
+      start: Number(timeRange.start.valueOf()),
+      end: Number(timeRange.end.valueOf()),
+    };
 
     const newLayout = Layout.usePlacer();
     const handleSelect = (key: string): void => {
@@ -326,7 +331,7 @@ const Loaded = ({ layoutKey }: { layoutKey: string }): ReactElement => {
           );
           break;
         case "range":
-          newLayout(Range.createEditLayout("", timeRange));
+          newLayout(Range.createEditLayout("", timeRangeNumber));
           break;
         case "download":
           if (client == null) return;

--- a/console/src/lineplot/LinePlot.tsx
+++ b/console/src/lineplot/LinePlot.tsx
@@ -82,7 +82,6 @@ import {
   ZERO_STATE,
 } from "@/lineplot/slice";
 import { Range } from "@/range";
-import { type TimeRange as CTimeRange } from "@/range/migrations";
 import { Workspace } from "@/workspace";
 
 interface SyncPayload {
@@ -301,18 +300,14 @@ const Loaded = ({ layoutKey }: { layoutKey: string }): ReactElement => {
   const ContextMenuContent = ({ layoutKey }: ContextMenuContentProps): ReactElement => {
     const { box: selection } = useSelectSelection(layoutKey);
     const bounds = useSelectAxisBounds(layoutKey, "x1");
-
     const s = scale.Scale.scale(1).scale(bounds);
+    const placer = Layout.usePlacer();
+
     const timeRange = new TimeRange(
       s.pos(box.left(selection)),
       s.pos(box.right(selection)),
     );
-    const timeRangeNumber: CTimeRange = {
-      start: Number(timeRange.start.valueOf()),
-      end: Number(timeRange.end.valueOf()),
-    };
 
-    const newLayout = Layout.usePlacer();
     const handleSelect = (key: string): void => {
       switch (key) {
         case "iso":
@@ -331,7 +326,12 @@ const Loaded = ({ layoutKey }: { layoutKey: string }): ReactElement => {
           );
           break;
         case "range":
-          newLayout(Range.createEditLayout("", timeRangeNumber));
+          placer(
+            Range.createEditLayout(undefined, {
+              start: Number(timeRange.start.valueOf()),
+              end: Number(timeRange.end.valueOf()),
+            }),
+          );
           break;
         case "download":
           if (client == null) return;

--- a/console/src/range/EditLayout.tsx
+++ b/console/src/range/EditLayout.tsx
@@ -53,7 +53,7 @@ export const createEditLayout = (
     size: { height: 290, width: 700 },
     navTop: true,
   },
-  args: timeRange ?? null,
+  args: timeRange,
 });
 
 type DefineRangeFormProps = z.infer<typeof formSchema>;
@@ -73,9 +73,9 @@ export const Edit = (props: Layout.RendererProps): ReactElement => {
         return {
           name: "",
           labels: [],
-          timeRange: {
-            start: args?.start ?? now,
-            end: args?.end ?? now,
+          timeRange: args ?? {
+            start: now,
+            end: now,
           },
         };
       }
@@ -99,7 +99,6 @@ export const Edit = (props: Layout.RendererProps): ReactElement => {
       };
     },
   });
-  console.log(initialValues.data);
   if (initialValues.isPending) return <Logo.Watermark variant="loader" />;
   if (initialValues.isError) throw initialValues.error;
   return (
@@ -127,7 +126,6 @@ const EditLayoutForm = ({
   const dispatch = useDispatch();
   const client = Synnax.use();
   const isCreate = layoutKey === EDIT_LAYOUT_TYPE;
-  console.log(initialValues);
 
   const { mutate, isPending } = useMutation({
     mutationFn: async (persist: boolean) => {

--- a/console/src/range/EditLayout.tsx
+++ b/console/src/range/EditLayout.tsx
@@ -101,8 +101,6 @@ export const Edit = (props: Layout.RendererProps): ReactElement => {
   });
   if (initialValues.isPending) return <Logo.Watermark variant="loader" />;
   if (initialValues.isError) throw initialValues.error;
-  console.log("Returning a EditLayoutForm with following data:");
-  console.log(initialValues.data);
   return (
     <EditLayoutForm
       isRemoteEdit={isRemoteEdit}

--- a/console/src/range/EditLayout.tsx
+++ b/console/src/range/EditLayout.tsx
@@ -21,6 +21,7 @@ import { z } from "zod";
 
 import { CSS } from "@/css";
 import { Layout } from "@/layout";
+import { type TimeRange as TimeRangeT } from "@/range/migrations";
 import { useSelect } from "@/range/selectors";
 import { add } from "@/range/slice";
 
@@ -39,7 +40,7 @@ const SAVE_TRIGGER: Triggers.Trigger = ["Control", "Enter"];
 
 export const createEditLayout = (
   name: string = "Range.Create",
-  initialValues?: TimeRange,
+  timeRange?: TimeRangeT,
 ): Layout.State => ({
   key: EDIT_LAYOUT_TYPE,
   type: EDIT_LAYOUT_TYPE,
@@ -52,7 +53,7 @@ export const createEditLayout = (
     size: { height: 290, width: 700 },
     navTop: true,
   },
-  args: initialValues,
+  args: timeRange ?? null,
 });
 
 type DefineRangeFormProps = z.infer<typeof formSchema>;
@@ -61,7 +62,7 @@ export const Edit = (props: Layout.RendererProps): ReactElement => {
   const { layoutKey } = props;
   const now = useRef(Number(TimeStamp.now().valueOf())).current;
   const range = useSelect(layoutKey);
-  const args = Layout.useSelectArgs<TimeRange>(layoutKey);
+  const args = Layout.useSelectArgs<TimeRangeT>(layoutKey);
   const client = Synnax.use();
   const isCreate = layoutKey === EDIT_LAYOUT_TYPE;
   const isRemoteEdit = !isCreate && (range == null || range.persisted);
@@ -73,10 +74,9 @@ export const Edit = (props: Layout.RendererProps): ReactElement => {
           name: "",
           labels: [],
           timeRange: {
-            start: now,
-            end: now,
+            start: args?.start ?? now,
+            end: args?.end ?? now,
           },
-          ...args,
         };
       }
       if (range == null || range.persisted) {
@@ -99,6 +99,7 @@ export const Edit = (props: Layout.RendererProps): ReactElement => {
       };
     },
   });
+  console.log(initialValues.data);
   if (initialValues.isPending) return <Logo.Watermark variant="loader" />;
   if (initialValues.isError) throw initialValues.error;
   return (
@@ -126,6 +127,7 @@ const EditLayoutForm = ({
   const dispatch = useDispatch();
   const client = Synnax.use();
   const isCreate = layoutKey === EDIT_LAYOUT_TYPE;
+  console.log(initialValues);
 
   const { mutate, isPending } = useMutation({
     mutationFn: async (persist: boolean) => {

--- a/console/src/range/Select.tsx
+++ b/console/src/range/Select.tsx
@@ -11,6 +11,7 @@ import { Icon } from "@synnaxlabs/media";
 import {
   Align,
   Button,
+  Input,
   List,
   Ranger,
   Select,
@@ -18,7 +19,6 @@ import {
   Text,
   TimeSpan,
 } from "@synnaxlabs/pluto";
-import { Input } from "@synnaxlabs/pluto/input";
 import { type ReactElement } from "react";
 
 import { Layout } from "@/layout";

--- a/console/src/range/external.ts
+++ b/console/src/range/external.ts
@@ -14,9 +14,9 @@ import { MetaData, metaDataWindowLayout } from "@/range/MetaData";
 export * from "@/range/ContextMenu";
 export * from "@/range/EditLayout";
 export * from "@/range/MetaData";
-export * from "@/range/slice";
 export * from "@/range/Select";
 export * from "@/range/selectors";
+export * from "@/range/slice";
 export * from "@/range/slice";
 export * from "@/range/Toolbar";
 

--- a/console/src/range/migrations/index.ts
+++ b/console/src/range/migrations/index.ts
@@ -13,6 +13,7 @@ import * as v0 from "@/range/migrations/v0";
 
 export type SliceState = v0.SliceState;
 export type Range = v0.Range;
+export type TimeRange = v0.TimeRange;
 export type DynamicRange = v0.DynamicRange;
 export type StaticRange = v0.StaticRange;
 export const ZERO_SLICE_STATE = v0.ZERO_SLICE_STATE;

--- a/console/src/range/migrations/v0.ts
+++ b/console/src/range/migrations/v0.ts
@@ -41,7 +41,6 @@ export const sliceStateZ = z.object({
   version: z.literal("0.0.0"),
   activeRange: z.string().nullable(),
   ranges: z.record(rangeZ),
-  buffer: staticRangeZ.partial().nullable(),
 });
 
 export type SliceState = z.infer<typeof sliceStateZ>;
@@ -49,7 +48,6 @@ export type SliceState = z.infer<typeof sliceStateZ>;
 export const ZERO_SLICE_STATE: SliceState = {
   version: "0.0.0",
   activeRange: null,
-  buffer: null,
   ranges: {
     rolling30s: {
       key: "recent",

--- a/console/src/range/migrations/v0.ts
+++ b/console/src/range/migrations/v0.ts
@@ -16,12 +16,14 @@ export const baseRangeZ = z.object({
   persisted: z.boolean(),
 });
 
+export const timeRangeZ = z.object({
+  start: z.number(),
+  end: z.number(),
+});
+
 export const staticRangeZ = baseRangeZ.extend({
   variant: z.literal("static"),
-  timeRange: z.object({
-    start: z.number(),
-    end: z.number(),
-  }),
+  timeRange: timeRangeZ,
 });
 
 export const dynamicRangeZ = baseRangeZ.extend({
@@ -30,6 +32,8 @@ export const dynamicRangeZ = baseRangeZ.extend({
 });
 
 export const rangeZ = z.union([staticRangeZ, dynamicRangeZ]);
+
+export type TimeRange = z.infer<typeof timeRangeZ>;
 
 export type StaticRange = z.infer<typeof staticRangeZ>;
 

--- a/console/src/range/migrations/v0.ts
+++ b/console/src/range/migrations/v0.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { migrate, TimeSpan } from "@synnaxlabs/x";
+import { TimeSpan } from "@synnaxlabs/x";
 import { z } from "zod";
 
 export const baseRangeZ = z.object({

--- a/console/src/range/selectors.ts
+++ b/console/src/range/selectors.ts
@@ -1,11 +1,11 @@
 // Copyright 2024 Synnax Labs, Inc.
 //
-// Use of this software is governed by the Business Source License included in the file
-// licenses/BSL.txt.
+// Use of this software is governed by the Business Source License included in
+// the file licenses/BSL.txt.
 //
-// As of the Change Date specified in that file, in accordance with the Business Source
-// License, use of this software will be governed by the Apache License, Version 2.0,
-// included in the file licenses/APL.txt.
+// As of the Change Date specified in that file, in accordance with the Business
+// Source License, use of this software will be governed by the Apache License,
+// Version 2.0, included in the file licenses/APL.txt.
 
 import { selectByKey, useMemoSelect } from "@/hooks";
 import {
@@ -23,21 +23,12 @@ import {
 const selectState = (state: StoreState): SliceState => state[SLICE_NAME];
 
 /**
- * Selects ranges with the given keys. If no keys are provided, all ranges are selected.
- *
- * @param state  - The state of the workspace store.
- * @param keys  - The keys of the ranges to select. If not provided, all ranges are
- * selected.
- * @returns The ranges with the given keys.
+ * Selects the workspace state.
+ * @returns The workspace state.
  */
-export const selectMultiple = (
-  state: StoreState,
-  keys?: string[] | string[],
-): Range[] => {
-  const all = Object.values(selectState(state).ranges);
-  if (keys == null) return all;
-  return all.filter((range) => keys.includes(range.key));
-};
+export const useSelectState = (): SliceState =>
+  useMemoSelect((state: StoreState) => selectState(state), []);
+
 /**
  * Selects the key of the active range.
  *
@@ -48,15 +39,23 @@ export const selectActiveKey = (state: StoreState): string | null =>
   selectState(state).activeRange;
 
 /**
+ * Selects the key of the active range.
+ *
+ * @returns The key of the active range, or null if no range is active.
+ */
+export const useSelectActiveKey = (): string | null =>
+  useMemoSelect((state: StoreState) => selectActiveKey(state), []);
+
+/**
  * Selects a range from the workspace store.
  *
  * @param state - The state of the workspace store.
- * @param key - The key of the range to select. If not provided, the active range key
- * will be used.
+ * @param key - The key of the range to select. If not provided, the active
+ * range key will be used.
  *
- * @returns The range with the given key. If no key is provided, the active range is
- * key is used. If no active range is set, returns null. If the range does not exist,
- * returns undefined.
+ * @returns The range with the given key. If the range does not exist, returns
+ * undefined. If no key is provided, the active range key is used. If no active
+ * range is set, returns null.
  */
 export const select = (
   state: StoreState,
@@ -67,18 +66,40 @@ export const select = (
 /**
  * Selects a range from the workspace store.
  *
- * @returns The range with the given key. If no key is provided, the active range is
- * key is used. If no active range is set, returns null. If the range does not exist,
- * returns undefined.
+ * @param key - The key of the range to select. If not provided, the active
+ * range key will be used.
+ *
+ * @returns The range with the given key. If the range does not exist, returns
+ * undefined. If no key is provided, the active range key is used. If no active
+ * range is set, returns null.
  */
 export const useSelect = (key?: string): Range | null | undefined =>
   useMemoSelect((state: StoreState) => select(state, key), [key]);
 
 /**
- * Selects ranges from the workspace store. If no keys are provided, all ranges are
+ * Selects ranges with the given keys. If no keys are provided, all ranges are
  * selected.
  *
- * @param keys - The keys of the ranges to select. If not provided, all ranges are
+ * @param state  - The state of the workspace store.
+ * @param keys  - The keys of the ranges to select. If not provided, all ranges
+ * are selected.
+ * @returns The ranges with the given keys.
+ */
+export const selectMultiple = (
+  state: StoreState,
+  keys?: string[] | string[],
+): Range[] => {
+  const all = Object.values(selectState(state).ranges);
+  if (keys == null) return all;
+  return all.filter((range) => keys.includes(range.key));
+};
+
+/**
+ * Selects ranges from the workspace store. If no keys are provided, all ranges
+ * are selected.
+ *
+ * @param keys - The keys of the ranges to select. If not provided, all ranges
+ * are selected.
  * @returns The ranges with the given keys.
  */
 export const useSelectMultiple = (keys?: string[]): Range[] =>

--- a/console/src/range/selectors.ts
+++ b/console/src/range/selectors.ts
@@ -8,8 +8,12 @@
 // included in the file licenses/APL.txt.
 
 import { selectByKey, useMemoSelect } from "@/hooks";
-import type { Range, StaticRange } from "@/range/slice";
-import { SLICE_NAME, type SliceState, type StoreState } from "@/range/slice";
+import {
+  type Range,
+  SLICE_NAME,
+  type SliceState,
+  type StoreState,
+} from "@/range/slice";
 
 /**
  * Selects the workspace state.
@@ -61,17 +65,6 @@ export const select = (
   selectByKey(selectState(state).ranges, key, selectActiveKey(state));
 
 /**
- * Selects information from the current edit range buffer.
- *
- * @param state - The state of the workspace store.
- *
- * @returns Information from the stored buffer. If no buffer is set, it returns null.
- */
-export const selectBuffer = (
-  state: StoreState,
-): Partial<StaticRange> | null | undefined => selectState(state).buffer;
-
-/**
  * Selects a range from the workspace store.
  *
  * @returns The range with the given key. If no key is provided, the active range is
@@ -80,14 +73,6 @@ export const selectBuffer = (
  */
 export const useSelect = (key?: string): Range | null | undefined =>
   useMemoSelect((state: StoreState) => select(state, key), [key]);
-
-/**
- * Selects information from the current edit range buffer.
- *
- * @returns Information from the stored buffer. If no buffer is set, it returns null.
- */
-export const useSelectBuffer = (): Partial<Range> | null | undefined =>
-  useMemoSelect((state: StoreState) => selectBuffer(state), []);
 
 /**
  * Selects ranges from the workspace store. If no keys are provided, all ranges are

--- a/console/src/range/slice.ts
+++ b/console/src/range/slice.ts
@@ -7,8 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import type { PayloadAction } from "@reduxjs/toolkit";
-import { createSlice } from "@reduxjs/toolkit";
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
 
 import * as latest from "@/range/migrations";
 
@@ -51,17 +50,11 @@ export const { actions, reducer } = createSlice({
         state.ranges[range.key] = range;
       });
     },
-    clearBuffer: (state) => {
-      state.buffer = null;
-    },
     remove: (state, { payload: { keys } }: PA<RemovePayload>) => {
       keys.forEach((k) => delete state.ranges[k]);
     },
     setActive: (state, { payload }: PA<SetActivePayload>) => {
       state.activeRange = payload;
-    },
-    setBuffer: (state, { payload }: PA<Partial<StaticRange>>) => {
-      state.buffer = payload;
     },
     rename: (state, { payload: { key, name } }: PA<RenamePayload>) => {
       const range = state.ranges[key];
@@ -70,7 +63,7 @@ export const { actions, reducer } = createSlice({
     },
   },
 });
-export const { add, remove, setActive, setBuffer, clearBuffer, rename } = actions;
+export const { add, remove, setActive, rename } = actions;
 
 export type Action = ReturnType<(typeof actions)[keyof typeof actions]>;
 export type Payload = Action["payload"];

--- a/console/src/range/slice.ts
+++ b/console/src/range/slice.ts
@@ -63,7 +63,7 @@ export const { actions, reducer } = createSlice({
     },
   },
 });
-export const { add, remove, setActive, rename } = actions;
+export const { add, remove, rename, setActive } = actions;
 
 export type Action = ReturnType<(typeof actions)[keyof typeof actions]>;
 export type Payload = Action["payload"];

--- a/pluto/src/form/Field.tsx
+++ b/pluto/src/form/Field.tsx
@@ -1,3 +1,12 @@
+// Copyright 2024 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in
+// the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business
+// Source License, use of this software will be governed by the Apache License,
+// Version 2.0, included in the file licenses/APL.txt.
+
 import { caseconv, deep, Key, Keyed } from "@synnaxlabs/x";
 import { FC, ReactElement } from "react";
 
@@ -12,7 +21,6 @@ import {
 } from "@/form/Form";
 import { Input } from "@/input";
 import { Select } from "@/select";
-import { Status } from "@/status";
 import { componentRenderProp, RenderProp } from "@/util/renderProp";
 
 export type FieldProps<


### PR DESCRIPTION
# Fix Pull Request Template

## Key Information

- **Linear Issue**: [SY-922](https://linear.app/synnaxlabs/issue/SY-922/fix-creating-range-from-line-plot-context-menu)

## Description

Removed the buffer from the range console and allowed ranges to be passed directly through the create range window layout form.

## Basic Readiness Checklist

- [x] I have performed a self-review of my code.
- [x] I have added sufficient regression tests to cover the changes.

## Manual QA Additions

- [x] I have updated the [Release Candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template
  with necessary manual QA steps to test my change.
