### PR TITLE
[cesium] - changed seekLE and seekGE behaviour when result is not exact

### DIFF
--- a/cesium/internal/unary/iterator.go
+++ b/cesium/internal/unary/iterator.go
@@ -89,13 +89,17 @@ func (i *Iterator) SeekLE(ctx context.Context, ts telem.TimeStamp) bool {
 		return false
 	}
 
-	if i.bounds.OverlapsWith(ts.SpanRange(0)) {
+	ok := i.internal.SeekLE(ctx, ts)
+
+	if i.internal.TimeRange().OverlapsWith(ts.SpanRange(0)) {
+		// If the provided ts is in the seeked domain, set the view to be ts.
 		i.seekReset(ts)
 	} else {
-		i.seekReset(i.bounds.End)
+		// Otherwise, set the view to the end of the seeked domain or bounds, whichever
+		// one is earlier.
+		i.seekReset(i.internal.TimeRange().BoundBy(i.bounds).End)
 	}
-
-	return i.internal.SeekLE(ctx, ts)
+	return ok
 }
 
 func (i *Iterator) SeekGE(ctx context.Context, ts telem.TimeStamp) bool {
@@ -104,13 +108,17 @@ func (i *Iterator) SeekGE(ctx context.Context, ts telem.TimeStamp) bool {
 		return false
 	}
 
-	if i.bounds.OverlapsWith(ts.SpanRange(0)) {
+	ok := i.internal.SeekGE(ctx, ts)
+
+	if i.internal.TimeRange().OverlapsWith(ts.SpanRange(0)) {
+		// If the provided ts is in the seeked domain, set the view to be ts.
 		i.seekReset(ts)
 	} else {
-		i.seekReset(i.bounds.Start)
+		// Otherwise, set the view to the start of the seeked domain or bounds, whichever
+		// one is later.
+		i.seekReset(i.internal.TimeRange().BoundBy(i.bounds).Start)
 	}
-
-	return i.internal.SeekGE(ctx, ts)
+	return ok
 }
 
 // Next moves the iterator forward by span. More specifically, if the current view is


### PR DESCRIPTION
# Fix Pull Request Template

## Key Information

- **Linear Issue**: [SY-973](https://linear.app/synnaxlabs/issue/SY-973/[cesium]-iterator-seekge-and-seekle-clip-to-startend-of-resulting)

## Description

Originally, when SeekGE finds a domain that is greater than the provided timestamp but does not contain it, it leaves the iterator's view at the provided timestamp. This PR changes this behaviour so the iterator's view is set at the start/end of the sought domain instead.

A similar behaviour adjustment is put in place for SeekLE as well.
## Basic Readiness Checklist

- [x] I have performed a self-review of my code.
- [x] I have added sufficient regression tests to cover the changes.

## Manual QA Additions

- [x] I have updated the [Release Candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template
  with necessary manual QA steps to test my change.
