### PR TITLE
sy-964 server panic ni disconnect

### DIFF
--- a/cesium/internal/core/frame.go
+++ b/cesium/internal/core/frame.go
@@ -98,12 +98,17 @@ func (f Frame) SquashSameKeyData(key ChannelKey) (data []byte) {
 	return
 }
 
+// Len is meant for testing use only.
 func (f Frame) Len() int64 {
 	f.assertEven("Len")
 	if len(f.Series) == 0 {
 		return 0
 	}
 	return f.Series[0].Len()
+}
+
+func (f Frame) Empty() bool {
+	return len(f.Series) == 0
 }
 
 func (f Frame) assertEven(method string) {

--- a/cesium/writer_stream.go
+++ b/cesium/writer_stream.go
@@ -348,7 +348,7 @@ func (w *idxWriter) Write(fr Frame) (Frame, error) {
 			continue
 		}
 
-		if w.writingToIdx && w.idx.key == key {
+		if w.writingToIdx && w.idx.key == key && series.Len() > 0 {
 			if err = w.updateHighWater(series); err != nil {
 				return fr, err
 			}
@@ -470,13 +470,6 @@ func (w *idxWriter) updateHighWater(s telem.Series) error {
 			w.idx.key,
 			telem.TimeStampT,
 			s.DataType,
-		)
-	}
-	if s.Len() == 0 {		
-		return errors.Wrapf(
-			validate.Error,
-			"series for channel %d length is zero",
-			w.idx.key,
 		)
 	}
 	w.idx.highWaterMark = telem.ValueAt[telem.TimeStamp](s, s.Len()-1)

--- a/cesium/writer_stream.go
+++ b/cesium/writer_stream.go
@@ -370,6 +370,9 @@ func (w *idxWriter) Write(fr Frame) (Frame, error) {
 }
 
 func (w *idxWriter) Commit(ctx context.Context) (telem.TimeStamp, error) {
+	if w.sampleCount == 0 {
+		return w.start, nil
+	}
 	end, err := w.resolveCommitEnd(ctx)
 	if err != nil {
 		return 0, err

--- a/cesium/writer_stream.go
+++ b/cesium/writer_stream.go
@@ -338,18 +338,13 @@ func (w *idxWriter) Write(fr Frame) (Frame, error) {
 		return fr, err
 	}
 
-	// No data to write, so do nothing.
-	if fr.Len() == 0 || fr.Series[0].Len() == 0 {
-		return fr, nil
-	}
-
 	var incrementedSampleCount bool
 
 	for i, series := range fr.Series {
 		key := fr.Keys[i]
 		uWriter, ok := w.internal[key]
 
-		if !ok {
+		if !ok || series.Len() == 0 {
 			continue
 		}
 

--- a/cesium/writer_stream.go
+++ b/cesium/writer_stream.go
@@ -472,6 +472,13 @@ func (w *idxWriter) updateHighWater(s telem.Series) error {
 			s.DataType,
 		)
 	}
+	if s.Len() == 0 {		
+		return errors.Wrapf(
+			validate.Error,
+			"series for channel %d length is zero",
+			w.idx.key,
+		)
+	}
 	w.idx.highWaterMark = telem.ValueAt[telem.TimeStamp](s, s.Len()-1)
 	return nil
 }

--- a/cesium/writer_stream.go
+++ b/cesium/writer_stream.go
@@ -338,6 +338,11 @@ func (w *idxWriter) Write(fr Frame) (Frame, error) {
 		return fr, err
 	}
 
+	// No data to write, so do nothing.
+	if fr.Len() == 0 || fr.Series[0].Len() == 0 {
+		return fr, nil
+	}
+
 	var incrementedSampleCount bool
 
 	for i, series := range fr.Series {
@@ -348,7 +353,7 @@ func (w *idxWriter) Write(fr Frame) (Frame, error) {
 			continue
 		}
 
-		if w.writingToIdx && w.idx.key == key && series.Len() > 0 {
+		if w.writingToIdx && w.idx.key == key {
 			if err = w.updateHighWater(series); err != nil {
 				return fr, err
 			}

--- a/cesium/writer_test.go
+++ b/cesium/writer_test.go
@@ -280,11 +280,6 @@ var _ = Describe("Writer Behavior", func() {
 						Expect(end).To(Equal(10 * telem.SecondTS))
 
 						Expect(w.Close()).To(Succeed())
-
-						//By("Checking that the data is correct")
-						//f := MustSucceed(db.Read(ctx, telem.TimeRangeMax, rate1, rate2))
-						//Expect(f.Series[0].Data).To(BeEmpty())
-						//Expect(f.Series[1].Data).To(BeEmpty())
 					})
 				})
 				Describe("Auto-commit", func() {

--- a/cesium/writer_test.go
+++ b/cesium/writer_test.go
@@ -249,42 +249,43 @@ var _ = Describe("Writer Behavior", func() {
 						Expect(f.Series[2].Data).To(Equal(telem.NewSeriesV[int64](100, 105, 110, 115, 120, 125, 130, 135, 140, 145).Data))
 						Expect(f.Series[3].Data).To(Equal(telem.NewSeriesV[int64](100, 105, 110, 115, 120, 125, 130, 135, 140, 145).Data))
 					})
-					// It("Should write an empty frame properly", func() {	
-					// 	var (
-					// 		rate1  = GenerateChannelKey()
-					// 		rate2  = GenerateChannelKey()
-					// 		index1 = GenerateChannelKey()
-					// 		data1  = GenerateChannelKey()
-					// 	)
-					// 	By("Creating a channel")
-					// 	Expect(db.CreateChannel(
-					// 		ctx,
-					// 		cesium.Channel{Key: rate1, Rate: 2 * telem.Hz, DataType: telem.Int64T},
-					// 		cesium.Channel{Key: rate2, Rate: 2 * telem.Hz, DataType: telem.Int64T},
-					// 		cesium.Channel{Key: index1, DataType: telem.TimeStampT, IsIndex: true},
-					// 		cesium.Channel{Key: data1, DataType: telem.Int64T, Index: index1},
-					// 	)).To(Succeed())
-					// 	w := MustSucceed(db.OpenWriter(ctx, cesium.WriterConfig{
-					// 		Channels: []cesium.ChannelKey{index1, data1, rate1, rate2},
-					// 		Start:    10 * telem.SecondTS,
-					// 	}))
+					It("Should not write an empty frame", func() {
 
-					// 	By("Writing data")
-					// 	ok := w.Write(cesium.NewFrame(
-					// 		[]cesium.ChannelKey{index1, data1, rate1, rate2},
-					// 		[]telem.Series{},
-					// 	))
-					// 	Expect(ok).To(BeTrue())
-					// 	end, ok := w.Commit()
-					// 	Expect(end).To(Equal(10*telem.SecondTS + 1))
-					// 	Expect(ok).To(BeTrue())
+						var (
+							rate1 = GenerateChannelKey()
+							rate2 = GenerateChannelKey()
+						)
+						By("Creating a channel")
+						Expect(db.CreateChannel(
+							ctx,
+							cesium.Channel{Key: rate1, Rate: 2 * telem.Hz, DataType: telem.Int64T},
+							cesium.Channel{Key: rate2, Rate: 2 * telem.Hz, DataType: telem.Int64T},
+						)).To(Succeed())
+						w := MustSucceed(db.OpenWriter(ctx, cesium.WriterConfig{
+							Channels: []cesium.ChannelKey{rate1, rate2},
+							Start:    10 * telem.SecondTS,
+						}))
 
-					// 	Expect(w.Close()).To(Succeed())
+						By("Writing data")
+						ok := w.Write(cesium.NewFrame(
+							[]cesium.ChannelKey{rate1, rate2},
+							[]telem.Series{
+								telem.EmptySeries("int64"),
+								telem.EmptySeries("int64"),
+							},
+						))
+						Expect(ok).To(BeTrue())
+						end, ok := w.Commit()
+						Expect(ok).To(BeTrue())
+						Expect(end).To(Equal(10 * telem.SecondTS))
 
-					// 	By("Checking that the data is correct")
-					// 	f := MustSucceed(db.Read(ctx, telem.TimeRangeMax, index1, data1, rate1, rate2))
-					// 	Expect(f.Series).To(BeEmpty())
-					// })
+						Expect(w.Close()).To(Succeed())
+
+						//By("Checking that the data is correct")
+						//f := MustSucceed(db.Read(ctx, telem.TimeRangeMax, rate1, rate2))
+						//Expect(f.Series[0].Data).To(BeEmpty())
+						//Expect(f.Series[1].Data).To(BeEmpty())
+					})
 				})
 				Describe("Auto-commit", func() {
 					Describe("Indexed channels", func() {

--- a/cesium/writer_test.go
+++ b/cesium/writer_test.go
@@ -270,8 +270,8 @@ var _ = Describe("Writer Behavior", func() {
 						ok := w.Write(cesium.NewFrame(
 							[]cesium.ChannelKey{rate1, rate2},
 							[]telem.Series{
-								telem.EmptySeries("int64"),
-								telem.EmptySeries("int64"),
+								{DataType: "int64"},
+								{DataType: "int64"},
 							},
 						))
 						Expect(ok).To(BeTrue())

--- a/cesium/writer_test.go
+++ b/cesium/writer_test.go
@@ -249,6 +249,42 @@ var _ = Describe("Writer Behavior", func() {
 						Expect(f.Series[2].Data).To(Equal(telem.NewSeriesV[int64](100, 105, 110, 115, 120, 125, 130, 135, 140, 145).Data))
 						Expect(f.Series[3].Data).To(Equal(telem.NewSeriesV[int64](100, 105, 110, 115, 120, 125, 130, 135, 140, 145).Data))
 					})
+					// It("Should write an empty frame properly", func() {	
+					// 	var (
+					// 		rate1  = GenerateChannelKey()
+					// 		rate2  = GenerateChannelKey()
+					// 		index1 = GenerateChannelKey()
+					// 		data1  = GenerateChannelKey()
+					// 	)
+					// 	By("Creating a channel")
+					// 	Expect(db.CreateChannel(
+					// 		ctx,
+					// 		cesium.Channel{Key: rate1, Rate: 2 * telem.Hz, DataType: telem.Int64T},
+					// 		cesium.Channel{Key: rate2, Rate: 2 * telem.Hz, DataType: telem.Int64T},
+					// 		cesium.Channel{Key: index1, DataType: telem.TimeStampT, IsIndex: true},
+					// 		cesium.Channel{Key: data1, DataType: telem.Int64T, Index: index1},
+					// 	)).To(Succeed())
+					// 	w := MustSucceed(db.OpenWriter(ctx, cesium.WriterConfig{
+					// 		Channels: []cesium.ChannelKey{index1, data1, rate1, rate2},
+					// 		Start:    10 * telem.SecondTS,
+					// 	}))
+
+					// 	By("Writing data")
+					// 	ok := w.Write(cesium.NewFrame(
+					// 		[]cesium.ChannelKey{index1, data1, rate1, rate2},
+					// 		[]telem.Series{},
+					// 	))
+					// 	Expect(ok).To(BeTrue())
+					// 	end, ok := w.Commit()
+					// 	Expect(end).To(Equal(10*telem.SecondTS + 1))
+					// 	Expect(ok).To(BeTrue())
+
+					// 	Expect(w.Close()).To(Succeed())
+
+					// 	By("Checking that the data is correct")
+					// 	f := MustSucceed(db.Read(ctx, telem.TimeRangeMax, index1, data1, rate1, rate2))
+					// 	Expect(f.Series).To(BeEmpty())
+					// })
 				})
 				Describe("Auto-commit", func() {
 					Describe("Indexed channels", func() {

--- a/x/go/telem/series.go
+++ b/x/go/telem/series.go
@@ -54,7 +54,7 @@ func (s Series) Split() [][]byte {
 	return o
 }
 
-func ValueAt[T types.Numeric](a Series, i int64) T {
-	b := a.Data[i*int64(a.DataType.Density()) : (i+1)*int64(a.DataType.Density())]
-	return UnmarshalF[T](a.DataType)(b)
+func ValueAt[T types.Numeric](s Series, i int64) T {
+	b := s.Data[i*int64(s.DataType.Density()) : (i+1)*int64(s.DataType.Density())]
+	return UnmarshalF[T](s.DataType)(b)
 }

--- a/x/go/telem/series_factory.go
+++ b/x/go/telem/series_factory.go
@@ -14,6 +14,12 @@ import (
 	"github.com/synnaxlabs/x/types"
 )
 
+func EmptySeries(dt DataType) (series Series) {
+	series.DataType = dt
+	series.Data = make([]byte, 0)
+	return series
+}
+
 func NewSeries[T types.Numeric](data []T) (series Series) {
 	if len(data) == 0 {
 		panic("cannot infer data type from empty array")

--- a/x/go/telem/series_factory.go
+++ b/x/go/telem/series_factory.go
@@ -14,12 +14,6 @@ import (
 	"github.com/synnaxlabs/x/types"
 )
 
-func EmptySeries(dt DataType) (series Series) {
-	series.DataType = dt
-	series.Data = make([]byte, 0)
-	return series
-}
-
 func NewSeries[T types.Numeric](data []T) (series Series) {
 	if len(data) == 0 {
 		panic("cannot infer data type from empty array")


### PR DESCRIPTION
# Fix Pull Request Template

## Key Information

- **Linear Issue**: [SY-964]

## Description

Server would panic when disconnecting an NI device which is in use by a read task in the server. Added a check to UpdateHighWater to check for series length before using it to set the watermark.

## Basic Readiness Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added sufficient regression tests to cover the changes.

## Manual QA Additions

- [ ] I have updated the [Release Candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template
  with necessary manual QA steps to test my change.
