### PR TITLE
[aspen] - fixed issues with concurrent modification of cluster store

### DIFF
--- a/aspen/internal/cluster/cluster.go
+++ b/aspen/internal/cluster/cluster.go
@@ -136,16 +136,30 @@ type Cluster struct {
 }
 
 // Key implements the Cluster interface.
-func (c *Cluster) Key() uuid.UUID { return c.Store.PeekState().ClusterKey }
+func (c *Cluster) Key() uuid.UUID {
+	s, release := c.Store.PeekState()
+	defer release()
+	return s.ClusterKey
+}
 
 // Host implements the Cluster interface.
-func (c *Cluster) Host() node.Node { return c.Store.GetHost() }
+func (c *Cluster) Host() node.Node {
+	return c.Store.GetHost()
+}
 
 // HostKey implements the Cluster interface.
-func (c *Cluster) HostKey() node.Key { return c.Store.PeekState().HostKey }
+func (c *Cluster) HostKey() node.Key {
+	s, release := c.Store.PeekState()
+	defer release()
+	return s.HostKey
+}
 
 // Nodes implements the Cluster interface.
-func (c *Cluster) Nodes() node.Group { return c.Store.PeekState().Nodes }
+func (c *Cluster) Nodes() node.Group {
+	s, release := c.Store.PeekState()
+	defer release()
+	return s.Nodes
+}
 
 // Node implements the Cluster interface.
 func (c *Cluster) Node(key node.Key) (node.Node, error) {

--- a/aspen/internal/cluster/pledge/pledge_test.go
+++ b/aspen/internal/cluster/pledge/pledge_test.go
@@ -243,9 +243,11 @@ var _ = Describe("PledgeServer", func() {
 					mu         sync.Mutex
 					nodes      = make(node.Group)
 					candidates = func(i int) func() node.Group {
-						mu.Lock()
-						defer mu.Unlock()
-						return func() node.Group { return nodes.Copy() }
+						return func() node.Group {
+							mu.Lock()
+							defer mu.Unlock()
+							return nodes.Copy()
+						}
 					}
 					numCandidates = 10
 					numPledges    = 2

--- a/aspen/internal/kv/gossip.go
+++ b/aspen/internal/kv/gossip.go
@@ -79,7 +79,9 @@ func (g *operationReceiver) handle(ctx context.Context, req TxRequest) (TxReques
 		return TxRequest{}, ctx.Err()
 	case g.Out.Inlet() <- req:
 	}
-	br := g.store.PeekState().toBatchRequest(ctx)
+	s, release := g.store.PeekState()
+	defer release()
+	br := s.toBatchRequest(ctx)
 	br.Sender = g.Cluster.HostKey()
 	return br, nil
 }

--- a/aspen/internal/kv/store.go
+++ b/aspen/internal/kv/store.go
@@ -57,7 +57,9 @@ func newStoreEmitter(s store, cfg Config) source {
 }
 
 func (e *storeEmitter) Emit(ctx context.Context) (TxRequest, error) {
-	return e.store.PeekState().toBatchRequest(ctx), nil
+	s, release := e.store.PeekState()
+	defer release()
+	return s.toBatchRequest(ctx), nil
 }
 
 type storeSink struct {

--- a/synnax/pkg/distribution/cluster/ontology.go
+++ b/synnax/pkg/distribution/cluster/ontology.go
@@ -76,7 +76,7 @@ func (s *NodeOntologyService) ListenForChanges(ctx context.Context) {
 	if err := s.Ontology.NewWriter(nil).DefineResource(ctx, NodeOntologyID(core.Free)); err != nil {
 		s.L.Error("failed to define free node ontology resource", zap.Error(err))
 	}
-	s.update(ctx, s.Cluster.PeekState())
+	s.update(ctx, s.Cluster.CopyState())
 	s.Cluster.OnChange(func(ctx context.Context, change core.ClusterChange) {
 		s.update(ctx, change.State)
 	})
@@ -102,7 +102,7 @@ func (s *NodeOntologyService) OnChange(f func(context.Context, iter.Nexter[schem
 // OpenNexter implements ontology.Service.
 func (s *NodeOntologyService) OpenNexter() (iter.NexterCloser[ontology.Resource], error) {
 	return iter.NexterNopCloser(
-		iter.All(lo.MapToSlice(s.Cluster.PeekState().Nodes, func(_ core.NodeKey, n core.Node) ontology.Resource {
+		iter.All(lo.MapToSlice(s.Cluster.CopyState().Nodes, func(_ core.NodeKey, n core.Node) ontology.Resource {
 			return newNodeResource(n)
 		})),
 	), nil


### PR DESCRIPTION
# Fix Pull Request Template

## Key Information

- **Linear Issue**: [SY-1075](https://linear.app/synnaxlabs/issue/SY-1075/fix-aspen-concurrent-map-read-and-write)

## Description

Fixes an issue where the aspen store that holds information about a cluster concurrently reads and writes from a map. Adjusts the implementation of `PeekState` in `x/go/store` to hold a mutex until it is released. 

## Basic Readiness Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added sufficient regression tests to cover the changes to CI.
- [ ] I have added relevant tests to cover the changes or exposing bugs.
- [ ] I have verified code coverage targets are met.

## Additional Notes
- [ ] These changes deal with concurrency.
- [ ] These changes affect UI.

## Manual QA Additions

- [ ] I have updated the [Release Candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template
  with necessary manual QA steps to test my change.

## Reviewer Checklist
- [ ] Sufficient test coverage of new additions.
- [ ] Verified all steps in readiness checklists.
- [ ] UI changes have been tested.
- [ ] style and formatting is consistent.
- [ ] Reviewed any relevant changes to concurrent code for safety. 
- [ ] Sufficient comments and clarity of code.