### PR TITLE
Sy 1085 v27 server fix bad bootup from prev version

### DIFF
--- a/cesium/control.go
+++ b/cesium/control.go
@@ -11,8 +11,6 @@ package cesium
 
 import (
 	"context"
-	"github.com/synnaxlabs/x/config"
-
 	"github.com/google/uuid"
 	"github.com/synnaxlabs/cesium/internal/controller"
 	"github.com/synnaxlabs/cesium/internal/core"
@@ -52,20 +50,19 @@ func (db *DB) ConfigureControlUpdateChannel(ctx context.Context, key ChannelKey)
 		return errors.New("control update channel must be a string virtual channel.")
 	}
 
+	db.digests.key = key
 	w, err := db.newStreamWriter(ctx, WriterConfig{
 		ControlSubject: control.Subject{
 			Name: "cesium_internal_control_digest",
 			Key:  uuid.New().String(),
 		},
-		Start:                   telem.Now(),
-		Channels:                []ChannelKey{key},
-		propagateControlDigests: config.False(),
+		Start:    telem.Now(),
+		Channels: []ChannelKey{key},
 	})
 	if err != nil {
 		return err
 	}
 	db.digests.inlet, db.digests.outlet = confluence.Attach[WriterRequest, WriterResponse](w, 100)
-	db.digests.key = key
 	sCtx, _ := signal.Isolated()
 	w.Flow(
 		sCtx,

--- a/cesium/control.go
+++ b/cesium/control.go
@@ -11,6 +11,7 @@ package cesium
 
 import (
 	"context"
+	"github.com/synnaxlabs/x/config"
 
 	"github.com/google/uuid"
 	"github.com/synnaxlabs/cesium/internal/controller"
@@ -51,19 +52,20 @@ func (db *DB) ConfigureControlUpdateChannel(ctx context.Context, key ChannelKey)
 		return errors.New("control update channel must be a string virtual channel.")
 	}
 
-	db.digests.key = key
 	w, err := db.newStreamWriter(ctx, WriterConfig{
 		ControlSubject: control.Subject{
 			Name: "cesium_internal_control_digest",
 			Key:  uuid.New().String(),
 		},
-		Start:    telem.Now(),
-		Channels: []ChannelKey{key},
+		Start:                   telem.Now(),
+		Channels:                []ChannelKey{key},
+		propagateControlDigests: config.False(),
 	})
 	if err != nil {
 		return err
 	}
 	db.digests.inlet, db.digests.outlet = confluence.Attach[WriterRequest, WriterResponse](w, 100)
+	db.digests.key = key
 	sCtx, _ := signal.Isolated()
 	w.Flow(
 		sCtx,

--- a/cesium/internal/unary/db.go
+++ b/cesium/internal/unary/db.go
@@ -12,6 +12,8 @@ package unary
 import (
 	"context"
 	"fmt"
+	"sync/atomic"
+
 	"github.com/synnaxlabs/cesium/internal/controller"
 	"github.com/synnaxlabs/cesium/internal/core"
 	"github.com/synnaxlabs/cesium/internal/domain"
@@ -21,7 +23,6 @@ import (
 	"github.com/synnaxlabs/x/errors"
 	"github.com/synnaxlabs/x/override"
 	"github.com/synnaxlabs/x/telem"
-	"sync/atomic"
 )
 
 // DB is a database for a single channel. It executes reads (via iterators) and writes
@@ -40,6 +41,7 @@ type DB struct {
 	leadingAlignment *atomic.Uint32
 }
 
+// ErrDBClosed is returned when an operation is attempted on a closed unary database.
 var ErrDBClosed = core.EntityClosed("unary.db")
 
 // Channel returns the channel for this unary database.

--- a/cesium/internal/unary/db.go
+++ b/cesium/internal/unary/db.go
@@ -40,7 +40,7 @@ type DB struct {
 	leadingAlignment *atomic.Uint32
 }
 
-var errDBClosed = core.EntityClosed("unary.db")
+var ErrDBClosed = core.EntityClosed("unary.db")
 
 // Channel returns the channel for this unary database.
 func (db *DB) Channel() core.Channel { return db.cfg.Channel }
@@ -99,7 +99,7 @@ func (db *DB) OpenIterator(cfg IteratorConfig) *Iterator {
 // is an open writer that could write into the requested time range
 func (db *DB) HasDataFor(ctx context.Context, tr telem.TimeRange) (bool, error) {
 	if db.closed.Load() {
-		return false, errDBClosed
+		return false, ErrDBClosed
 	}
 	g, _, err := db.controller.OpenAbsoluteGateIfUncontrolled(
 		tr,
@@ -129,7 +129,7 @@ func (db *DB) HasDataFor(ctx context.Context, tr telem.TimeRange) (bool, error) 
 func (db *DB) Read(ctx context.Context, tr telem.TimeRange) (frame core.Frame, err error) {
 	defer func() { err = db.wrapError(err) }()
 	if db.closed.Load() {
-		return frame, errDBClosed
+		return frame, ErrDBClosed
 	}
 	iter := db.OpenIterator(IterRange(tr))
 	if err != nil {
@@ -160,7 +160,7 @@ func (db *DB) Close() error {
 // underlying file system.
 func (db *DB) RenameChannelInMeta(newName string) error {
 	if db.closed.Load() {
-		return errDBClosed
+		return ErrDBClosed
 	}
 	if db.cfg.Channel.Name == newName {
 		return nil
@@ -173,7 +173,7 @@ func (db *DB) RenameChannelInMeta(newName string) error {
 // and persists the change to the underlying file system.
 func (db *DB) SetIndexKeyInMeta(key core.ChannelKey) error {
 	if db.closed.Load() {
-		return errDBClosed
+		return ErrDBClosed
 	}
 	db.cfg.Channel.Index = key
 	return meta.Create(db.cfg.FS, db.cfg.MetaCodec, db.cfg.Channel)
@@ -183,7 +183,7 @@ func (db *DB) SetIndexKeyInMeta(key core.ChannelKey) error {
 // and persists the change to the underlying file system.
 func (db *DB) SetChannelKeyInMeta(key core.ChannelKey) error {
 	if db.closed.Load() {
-		return errDBClosed
+		return ErrDBClosed
 	}
 	if db.cfg.Channel.IsIndex {
 		db.cfg.Channel.Index = key

--- a/cesium/internal/unary/delete.go
+++ b/cesium/internal/unary/delete.go
@@ -22,7 +22,7 @@ import (
 // time range is inclusive whereas the end is note.
 func (db *DB) Delete(ctx context.Context, tr telem.TimeRange) error {
 	if db.closed.Load() {
-		return errDBClosed
+		return ErrDBClosed
 	}
 	return db.wrapError(db.delete(ctx, tr))
 }
@@ -31,7 +31,7 @@ func (db *DB) Delete(ctx context.Context, tr telem.TimeRange) error {
 // concurrently with other GarbageCollect methods.
 func (db *DB) GarbageCollect(ctx context.Context) error {
 	if db.closed.Load() {
-		return errDBClosed
+		return ErrDBClosed
 	}
 	return db.wrapError(db.domain.GarbageCollect(ctx))
 }

--- a/cesium/internal/unary/open.go
+++ b/cesium/internal/unary/open.go
@@ -27,6 +27,8 @@ import (
 	"sync/atomic"
 )
 
+// ErrVirtual is returned when the caller tried to open a unary database on a virtual
+// channel.
 var ErrVirtual = errors.New("cannot open a unary database on a virtual channel")
 
 // Config is the configuration for opening a DB.

--- a/cesium/internal/unary/open.go
+++ b/cesium/internal/unary/open.go
@@ -19,12 +19,15 @@ import (
 	"github.com/synnaxlabs/cesium/internal/version"
 	"github.com/synnaxlabs/x/binary"
 	"github.com/synnaxlabs/x/config"
+	"github.com/synnaxlabs/x/errors"
 	xfs "github.com/synnaxlabs/x/io/fs"
 	"github.com/synnaxlabs/x/override"
 	"github.com/synnaxlabs/x/telem"
 	"github.com/synnaxlabs/x/validate"
 	"sync/atomic"
 )
+
+var ErrVirtual = errors.New("cannot open a unary database on a virtual channel")
 
 // Config is the configuration for opening a DB.
 type Config struct {
@@ -90,6 +93,10 @@ func Open(configs ...Config) (*DB, error) {
 	if err != nil {
 		return nil, err
 	}
+	wrapError := core.NewErrorWrapper(cfg.Channel)
+	if cfg.Channel.Virtual {
+		return nil, wrapError(ErrVirtual)
+	}
 	domainDB, err := domain.Open(domain.Config{
 		FS:              cfg.FS,
 		Instrumentation: cfg.Instrumentation,
@@ -107,7 +114,7 @@ func Open(configs ...Config) (*DB, error) {
 		cfg:              cfg,
 		domain:           domainDB,
 		controller:       c,
-		wrapError:        core.NewErrorWrapper(cfg.Channel),
+		wrapError:        wrapError,
 		closed:           &atomic.Bool{},
 		leadingAlignment: &atomic.Uint32{},
 	}
@@ -117,21 +124,20 @@ func Open(configs ...Config) (*DB, error) {
 	} else if cfg.Channel.Index == 0 {
 		db._idx = index.Rate{Rate: cfg.Channel.Rate, Channel: cfg.Channel}
 	}
-	return db, err
+	return db, db.checkMigration()
 }
 
-// CheckMigration compares the version stored in channel to the current version of the
+// checkMigration compares the version stored in channel to the current version of the
 // data engine format. If there is a migration to be performed, data is migrated and
 // persisted to the new version.
-func (db *DB) CheckMigration(codec binary.Codec) error {
-	if db.cfg.Channel.Version != version.Current {
-		err := version.Migrate(db.cfg.FS, db.cfg.Channel.Version, version.Current)
-		if err != nil {
-			return err
-		}
-
-		db.cfg.Channel.Version = version.Current
-		return meta.Create(db.cfg.FS, codec, db.cfg.Channel)
+func (db *DB) checkMigration() error {
+	if db.cfg.Channel.Version == version.Current {
+		return nil
 	}
-	return nil
+	err := version.Migrate(db.cfg.FS, db.cfg.Channel.Version, version.Current)
+	if err != nil {
+		return err
+	}
+	db.cfg.Channel.Version = version.Current
+	return meta.Create(db.cfg.FS, db.cfg.MetaCodec, db.cfg.Channel)
 }

--- a/cesium/internal/unary/writer.go
+++ b/cesium/internal/unary/writer.go
@@ -143,7 +143,7 @@ type Writer struct {
 
 func (db *DB) OpenWriter(ctx context.Context, cfgs ...WriterConfig) (w *Writer, transfer controller.Transfer, err error) {
 	if db.closed.Load() {
-		return nil, transfer, db.wrapError(errDBClosed)
+		return nil, transfer, db.wrapError(ErrDBClosed)
 	}
 	cfg, err := config.New(DefaultWriterConfig, cfgs...)
 	if err != nil {

--- a/cesium/internal/virtual/db.go
+++ b/cesium/internal/virtual/db.go
@@ -42,8 +42,12 @@ type DB struct {
 	openWriters      *atomic.Int32
 }
 
-var dbClosed = core.EntityClosed("virtual.db")
-var ErrNotVirtual = errors.New("channel is not virtual")
+var (
+	// ErrNotVirtual is returned when the caller opens a DB on a non-virtual channel.
+	ErrNotVirtual = errors.New("channel is not virtual")
+	// DBClosed is returned when an operation is attempted on a closed DB.
+	DBClosed = core.EntityClosed("virtual.db")
+)
 
 // Config is the configuration for opening a DB.
 type Config struct {
@@ -149,7 +153,7 @@ func (db *DB) Close() error {
 // the underlying DB.
 func (db *DB) RenameChannel(newName string) error {
 	if db.closed.Load() {
-		return dbClosed
+		return DBClosed
 	}
 	if db.cfg.Channel.Name == newName {
 		return nil
@@ -162,7 +166,7 @@ func (db *DB) RenameChannel(newName string) error {
 // to the DB's meta file in the underlying filesystem.
 func (db *DB) SetChannelKeyInMeta(key core.ChannelKey) error {
 	if db.closed.Load() {
-		return dbClosed
+		return DBClosed
 	}
 	if db.cfg.Channel.Key == key {
 		return nil

--- a/cesium/internal/virtual/db.go
+++ b/cesium/internal/virtual/db.go
@@ -117,11 +117,11 @@ func Open(configs ...Config) (db *DB, err error) {
 }
 
 func (db *DB) checkMigration() error {
-	if db.cfg.Channel.Version != version.Current {
-		db.cfg.Channel.Version = version.Current
-		return meta.Create(db.cfg.FS, db.cfg.MetaCodec, db.cfg.Channel)
+	if db.cfg.Channel.Version == version.Current {
+		return nil
 	}
-	return nil
+	db.cfg.Channel.Version = version.Current
+	return meta.Create(db.cfg.FS, db.cfg.MetaCodec, db.cfg.Channel)
 }
 
 func (db *DB) Channel() core.Channel {

--- a/cesium/internal/virtual/writer.go
+++ b/cesium/internal/virtual/writer.go
@@ -84,7 +84,7 @@ type Writer struct {
 
 func (db *DB) OpenWriter(_ context.Context, cfgs ...WriterConfig) (w *Writer, transfer controller.Transfer, err error) {
 	if db.closed.Load() {
-		err = dbClosed
+		err = DBClosed
 		return nil, transfer, db.wrapError(err)
 	}
 	cfg, err := config.New(DefaultWriterConfig, cfgs...)

--- a/cesium/writer_open.go
+++ b/cesium/writer_open.go
@@ -85,6 +85,9 @@ type WriterConfig struct {
 	// to AlwaysIndexPersistOnAutoCommit.
 	// [OPTIONAL] - Defaults to 1s.
 	AutoIndexPersistInterval telem.TimeSpan
+	// propagateControlDigests determines whether the writer will propagate control changes
+	// to the rest of the DB.
+	propagateControlDigests *bool
 }
 
 const AlwaysIndexPersistOnAutoCommit telem.TimeSpan = -1
@@ -104,6 +107,7 @@ func DefaultWriterConfig() WriterConfig {
 		Mode:                     WriterPersistStream,
 		EnableAutoCommit:         config.Bool(false),
 		AutoIndexPersistInterval: 1 * telem.Second,
+		propagateControlDigests:  config.True(),
 	}
 }
 
@@ -119,6 +123,7 @@ func (c WriterConfig) Validate() error {
 		len(c.Authorities) != len(c.Channels) && len(c.Authorities) != 1,
 		"authority count must be 1 or equal to channel count",
 	)
+	validate.NotNil(v, "propagateControlDigests", c.propagateControlDigests)
 	return v.Error()
 }
 
@@ -134,6 +139,7 @@ func (c WriterConfig) Override(other WriterConfig) WriterConfig {
 	c.Mode = override.Numeric(c.Mode, other.Mode)
 	c.EnableAutoCommit = override.Nil(c.EnableAutoCommit, other.EnableAutoCommit)
 	c.AutoIndexPersistInterval = override.Zero(c.AutoIndexPersistInterval, other.AutoIndexPersistInterval)
+	c.propagateControlDigests = override.Nil(c.propagateControlDigests, other.propagateControlDigests)
 	return c
 }
 
@@ -274,7 +280,7 @@ func (db *DB) newStreamWriter(ctx context.Context, cfgs ...WriterConfig) (w *str
 		}
 	}
 
-	if len(controlUpdate.Transfers) > 0 {
+	if len(controlUpdate.Transfers) > 0 && *cfg.propagateControlDigests {
 		if err = db.updateControlDigests(ctx, controlUpdate); err != nil {
 			return nil, err
 		}
@@ -285,11 +291,15 @@ func (db *DB) newStreamWriter(ctx context.Context, cfgs ...WriterConfig) (w *str
 		internal:     make([]*idxWriter, 0, len(domainWriters)+len(rateWriters)),
 		relay:        db.relay.inlet,
 		virtual:      &virtualWriter{internal: virtualWriters, digestKey: db.digests.key},
-		updateDBControl: func(ctx context.Context, update ControlUpdate) error {
+	}
+	if *cfg.propagateControlDigests {
+		w.updateDBControl = func(ctx context.Context, update ControlUpdate) error {
 			db.mu.RLock()
 			defer db.mu.RUnlock()
 			return db.updateControlDigests(ctx, update)
-		},
+		}
+	} else {
+		w.updateDBControl = func(ctx context.Context, update ControlUpdate) error { return nil }
 	}
 	for _, idx := range domainWriters {
 		w.internal = append(w.internal, idx)

--- a/cesium/writer_open.go
+++ b/cesium/writer_open.go
@@ -285,16 +285,12 @@ func (db *DB) newStreamWriter(ctx context.Context, cfgs ...WriterConfig) (w *str
 		internal:     make([]*idxWriter, 0, len(domainWriters)+len(rateWriters)),
 		relay:        db.relay.inlet,
 		virtual:      &virtualWriter{internal: virtualWriters, digestKey: db.digests.key},
+		updateDBControl: func(ctx context.Context, update ControlUpdate) error {
+			db.mu.RLock()
+			defer db.mu.RUnlock()
+			return db.updateControlDigests(ctx, update)
+		},
 	}
-	//if *cfg.propagateControlDigests {
-	w.updateDBControl = func(ctx context.Context, update ControlUpdate) error {
-		db.mu.RLock()
-		defer db.mu.RUnlock()
-		return db.updateControlDigests(ctx, update)
-	}
-	//} else {
-	//	w.updateDBControl = func(ctx context.Context, update ControlUpdate) error { return nil }
-	//}
 	for _, idx := range domainWriters {
 		w.internal = append(w.internal, idx)
 	}


### PR DESCRIPTION
# Fix Pull Request Template

## Key Information

- **Linear Issue**: [SY-1085](https://linear.app/synnaxlabs/issue/SY-1085/v27-server-fix-bad-bootup-from-prev-version)

## Description

Addresses two issues:

1. Cesium would panic when opening from a previous version that had an existing control digest channel. It would attempt to send a value to a go channel that didn't exist.
2. Fixes an issue where cesium would complain about open writers/iterators on Synnax DB shutdown. Adds a WaitGroup that waits for all streaming transports to shutdown before moving to the next steps. 

## Basic Readiness Checklist

- [x] I have performed a self-review of my code.
- [x] I have added sufficient regression tests to cover the changes to CI.
- [x] I have added relevant tests to cover the changes or exposing bugs.
- [x] I have verified code coverage targets are met.

## Additional Notes
- [ ] These changes deal with concurrency.
- [ ] These changes affect UI.

## Manual QA Additions

- [ ] I have updated the [Release Candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template
  with necessary manual QA steps to test my change.

## Reviewer Checklist
- [ ] Sufficient test coverage of new additions.
- [ ] Verified all steps in readiness checklists.
- [ ] UI changes have been tested.
- [ ] style and formatting is consistent.
- [ ] Reviewed any relevant changes to concurrent code for safety. 
- [ ] Sufficient comments and clarity of code.