### PR TITLE
Pluto - Minor Select.Multiple Remove Fix

### DIFF
--- a/pluto/src/select/Multiple.tsx
+++ b/pluto/src/select/Multiple.tsx
@@ -327,8 +327,8 @@ const MultipleInput = <K extends Key, E extends Keyed<K>>({
         grow
         size="small"
       >
-        {toArray(selectedKeys).map((k, i) => {
-          const e = selected[i];
+        {toArray(selectedKeys).map((k) => {
+          const e = selected.find((v) => v.key === k);
           return renderTag({
             key: k,
             entryKey: k,


### PR DESCRIPTION
# Fix Pull Request Template

## Key Information

- **Linear Issue**: [SY-1089](https://linear.app/synnaxlabs/issue/SY-1089/pluto-fix-select-tag-close-removing-the-wrong-item)

## Description

Minor fix that addresses a bug when you remove a tag from a `Select.Multiple` and it removes the wrong item.

## Basic Readiness Checklist

- [x] I have performed a self-review of my code.
- [x] I have added sufficient regression tests to cover the changes to CI.
- [x] I have added relevant tests to cover the changes or exposing bugs.
- [x] I have verified code coverage targets are met.

## Additional Notes
- [ ] These changes deal with concurrency.
- [x] These changes affect UI.

## Manual QA Additions

- [ ] I have updated the [Release Candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template
  with necessary manual QA steps to test my change.

## Reviewer Checklist
- [ ] Sufficient test coverage of new additions.
- [ ] Verified all steps in readiness checklists.
- [ ] UI changes have been tested.
- [ ] style and formatting is consistent.
- [ ] Reviewed any relevant changes to concurrent code for safety. 
- [ ] Sufficient comments and clarity of code.