### PR TITLE
Fix Play/Pause for NI Task

### DIFF
--- a/console/src/hardware/device/ontology.tsx
+++ b/console/src/hardware/device/ontology.tsx
@@ -117,11 +117,13 @@ const TreeContextMenu: Ontology.TreeContextMenu = (props) => {
       {singleResource && (
         <>
           <Menu.RenameItem />
-          <PMenu.Divider />
           {first.data?.configured !== true && (
-            <PMenu.Item itemKey="configure" startIcon={<Icon.Hardware />}>
-              Configure
-            </PMenu.Item>
+            <>
+              <PMenu.Divider />
+              <PMenu.Item itemKey="configure" startIcon={<Icon.Hardware />}>
+                Configure
+              </PMenu.Item>
+            </>
           )}
         </>
       )}

--- a/console/src/hardware/opc/task/ReadTask.tsx
+++ b/console/src/hardware/opc/task/ReadTask.tsx
@@ -20,12 +20,13 @@ import {
   Input,
   List,
   Menu,
+  Status,
   Synnax,
   Text,
   useAsyncEffect,
   useSyncedRef,
 } from "@synnaxlabs/pluto";
-import { caseconv, primitiveIsZero } from "@synnaxlabs/x";
+import { caseconv, deep, primitiveIsZero } from "@synnaxlabs/x";
 import { useMutation } from "@tanstack/react-query";
 import { type ReactElement, useCallback, useState } from "react";
 import { v4 as uuid } from "uuid";
@@ -93,6 +94,7 @@ const Wrapped = ({
   task,
 }: WrappedTaskLayoutProps<Read, ReadPayload>): ReactElement => {
   const client = Synnax.use();
+  const addStatus = Status.useAggregator();
   const [device, setDevice] = useState<device.Device<Device.Properties> | undefined>(
     undefined,
   );
@@ -126,7 +128,7 @@ const Wrapped = ({
     methods.setStatus,
     methods.clearStatuses,
     task?.key,
-    task?.state,
+    task?.state != null ? deep.copy(task.state) : undefined,
   );
   const createTask = useCreate<ReadConfig, ReadStateDetails, ReadType>(layoutKey);
 
@@ -205,6 +207,13 @@ const Wrapped = ({
         });
 
       createTask({ key: task?.key, name, type: READ_TYPE, config });
+    },
+    onError: (e) => {
+      addStatus({
+        variant: "error",
+        message: "Failed to configure task",
+        description: e.message,
+      });
     },
   });
 

--- a/console/src/hardware/opc/task/ReadTask.tsx
+++ b/console/src/hardware/opc/task/ReadTask.tsx
@@ -128,7 +128,7 @@ const Wrapped = ({
     methods.setStatus,
     methods.clearStatuses,
     task?.key,
-    task?.state != null ? deep.copy(task.state) : undefined,
+    task?.state,
   );
   const createTask = useCreate<ReadConfig, ReadStateDetails, ReadType>(layoutKey);
 

--- a/console/src/hardware/task/Toolbar.tsx
+++ b/console/src/hardware/task/Toolbar.tsx
@@ -122,13 +122,15 @@ const Content = (): ReactElement => {
       menu={({ keys }) => {
         const selected = keys.map((k) => tasks.find((t) => t.key === k));
         const canStart = selected.some((t) => t?.state?.details?.running !== true);
-        const canStop = selected.some((t) => t?.state?.details?.running === false);
+        const canStop = selected.some((t) => t?.state?.details?.running === true);
         return (
           <Menu.Menu
             level="small"
             iconSpacing="small"
             onChange={{
               delete: () => del.mutate(keys),
+              start: () => selected.forEach((t) => t?.executeCommand("start")),
+              stop: () => selected.forEach((t) => t?.executeCommand("stop")),
             }}
           >
             {canStart && (

--- a/console/src/hardware/task/common/common.tsx
+++ b/console/src/hardware/task/common/common.tsx
@@ -324,6 +324,8 @@ export const wrapTaskLayout = <T extends task.Task, P extends task.Payload>(
     const args = Layout.useSelectArgs<{ create: boolean }>(layoutKey);
     const altKey = Layout.useSelectAltKey(layoutKey);
     const id = useId();
+    // The query can't take into account state changes, so we need to use a unique
+    // key for every query.
     const fetchTask = useQuery<WrappedTaskLayoutProps<T, P>>({
       queryKey: [layoutKey, client?.key, altKey, id],
       queryFn: async () => {

--- a/console/src/hardware/task/common/common.tsx
+++ b/console/src/hardware/task/common/common.tsx
@@ -26,7 +26,7 @@ import {
 } from "@synnaxlabs/pluto";
 import { caseconv, deep, Key, Keyed, Optional, UnknownRecord } from "@synnaxlabs/x";
 import { useQuery } from "@tanstack/react-query";
-import { FC, ReactElement, useCallback, useState } from "react";
+import { FC, ReactElement, useCallback, useId, useState } from "react";
 import { useDispatch } from "react-redux";
 import { z } from "zod";
 
@@ -323,8 +323,9 @@ export const wrapTaskLayout = <T extends task.Task, P extends task.Payload>(
     const client = Synnax.use();
     const args = Layout.useSelectArgs<{ create: boolean }>(layoutKey);
     const altKey = Layout.useSelectAltKey(layoutKey);
+    const id = useId();
     const fetchTask = useQuery<WrappedTaskLayoutProps<T, P>>({
-      queryKey: [layoutKey, client?.key, altKey],
+      queryKey: [layoutKey, client?.key, altKey, id],
       queryFn: async () => {
         if (client == null || args.create)
           return { initialValues: deep.copy(zeroPayload), layoutKey };
@@ -352,7 +353,7 @@ export const wrapTaskLayout = <T extends task.Task, P extends task.Payload>(
           </Status.Text.Centered>
         </Align.Space>
       );
-    else if (!fetchTask.isPending)
+    else if (fetchTask.isSuccess)
       content = <Wrapped {...fetchTask.data} layoutKey={layoutKey} />;
     return <Eraser.Eraser>{content}</Eraser.Eraser>;
   };


### PR DESCRIPTION
# Fix Pull Request Template

## Key Information

- **Linear Issue**: [SY-1088](https://linear.app/synnaxlabs/issue/SY-1088/when-you-playpause-an-ni-task-and-clock-away-and-come-back-it-shows)

## Description

Fixes an issue where the correct task state would not show up in the dialog when switching to a different tab and coming back. 

## Basic Readiness Checklist

- [x] I have performed a self-review of my code.
- [x] I have added sufficient regression tests to cover the changes to CI.
- [x] I have added relevant tests to cover the changes or exposing bugs.
- [x] I have verified code coverage targets are met.

## Additional Notes
- [ ] These changes deal with concurrency.
- [x] These changes affect UI.

## Manual QA Additions

- [ ] I have updated the [Release Candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template
  with necessary manual QA steps to test my change.

## Reviewer Checklist
- [ ] Sufficient test coverage of new additions.
- [ ] Verified all steps in readiness checklists.
- [ ] UI changes have been tested.
- [ ] style and formatting is consistent.
- [ ] Reviewed any relevant changes to concurrent code for safety. 
- [ ] Sufficient comments and clarity of code.