### PR TITLE
SY-1087 Fixed Issue with Undefined Result in Confirmation Arg

### DIFF
--- a/console/src/confirm/Confirm.tsx
+++ b/console/src/confirm/Confirm.tsx
@@ -134,7 +134,10 @@ export const useModal = (): CreateConfirmModal => {
         const l = Layout.select(store.getState(), layout.key);
         if (l == null) resolve(false);
         const args = selectArgs<ConfirmLayoutArgs>(store.getState(), layout.key);
-        if (args.result == null) return;
+        // This is a case where the dialog was closed by another mechanism, such as
+        // application restart or a different dialog being opened. In this case, resolve
+        // the promise as false.
+        if (args == null || args.result == null) return resolve(false);
         resolve(args.result);
         unsubscribe?.();
       });

--- a/console/src/confirm/Confirm.tsx
+++ b/console/src/confirm/Confirm.tsx
@@ -134,10 +134,9 @@ export const useModal = (): CreateConfirmModal => {
         const l = Layout.select(store.getState(), layout.key);
         if (l == null) resolve(false);
         const args = selectArgs<ConfirmLayoutArgs>(store.getState(), layout.key);
-        // This is a case where the dialog was closed by another mechanism, such as
-        // application restart or a different dialog being opened. In this case, resolve
-        // the promise as false.
-        if (args == null || args.result == null) return resolve(false);
+        // This means the action was unrelated to the confirmation or the modal
+        // was closed unexpectedly.
+        if (args == null || args.result == null) return;
         resolve(args.result);
         unsubscribe?.();
       });

--- a/console/src/confirm/Confirm.tsx
+++ b/console/src/confirm/Confirm.tsx
@@ -134,10 +134,13 @@ export const useModal = (): CreateConfirmModal => {
         const l = Layout.select(store.getState(), layout.key);
         if (l == null) resolve(false);
         const args = selectArgs<ConfirmLayoutArgs>(store.getState(), layout.key);
-        // This means the action was unrelated to the confirmation or the modal
-        // was closed unexpectedly.
-        if (args == null || args.result == null) return;
-        resolve(args.result);
+        // This means the action was unrelated to the confirmation.
+        if (args != null && args.result == null) return;
+        // This means that the layout was removed by a separate mechanism than
+        // the user hitting 'Confirm' or 'Cancel'. We treat this as a cancellation.
+        if (args == null) resolve(false);
+        // Resolve with the standard result.
+        else resolve(args.result as boolean);
         unsubscribe?.();
       });
     });


### PR DESCRIPTION
# Fix Pull Request Template

## Key Information

- **Linear Issue**: [SY-1087](https://linear.app/synnax/issue/SY-1087/[console]-deleting-workspace-caused-error-that-hard-reseting-didnt-fix)

## Description

Adds an explicit check for an undefined result in arguments for a confirmation modal. It resolves the confirmation to false if a valid result was not returned.

## Basic Readiness Checklist

- [x] I have performed a self-review of my code.
- [x] I have added sufficient regression tests to cover the changes to CI.
- [x] I have added relevant tests to cover the changes or exposing bugs.
- [x] I have verified code coverage targets are met.

## Additional Notes
- [ ] These changes deal with concurrency.
- [x] These changes affect UI.

## Manual QA Additions

- [ ] I have updated the [Release Candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template
  with necessary manual QA steps to test my change.

## Reviewer Checklist
- [ ] Sufficient test coverage of new additions.
- [ ] Verified all steps in readiness checklists.
- [ ] UI changes have been tested.
- [ ] style and formatting is consistent.
- [ ] Reviewed any relevant changes to concurrent code for safety. 
- [ ] Sufficient comments and clarity of code.