### PR TITLE
SY-1112 NI Analog Read - Allow for variable precision floating point

### DIFF
--- a/driver/ni/analog_read.cpp
+++ b/driver/ni/analog_read.cpp
@@ -276,7 +276,7 @@ int ni::AnalogReadSource::validate_channels() {
                 .variant = "error",
                 .details = {
                     {"running", false},
-                    {"message", "Channel " + channel.name + " must be type float32 or float64. Got " + channel_info.data_type.value} 
+                    {"message", "Channel " + channel.name + " must be type float32 or float64. Got " + channel_info.data_type.value}, 
                     {"path", channel.name}
                 }
             });

--- a/driver/ni/analog_read.cpp
+++ b/driver/ni/analog_read.cpp
@@ -276,7 +276,7 @@ int ni::AnalogReadSource::validate_channels() {
                 .variant = "error",
                 .details = {
                     {"running", false},
-                    {"message", "Channel " + channel.name + " must be type float32 or float64. Got " + channel_info.data_type} // TODO: rephrase to say "channel should be. got : "
+                    {"message", "Channel " + channel.name + " must be type float32 or float64. Got " + channel_info.data_type.value} 
                     {"path", channel.name}
                 }
             });

--- a/driver/ni/analog_read.cpp
+++ b/driver/ni/analog_read.cpp
@@ -225,7 +225,6 @@ std::pair<synnax::Frame, freighter::Error> ni::AnalogReadSource::read(
         synnax::Series series = synnax::Series(synnax::FLOAT32, s);
         if(this->reader_config.channels[ch].data_type == synnax::FLOAT32) series = synnax::Series(synnax::FLOAT32, s);
         else if(this->reader_config.channels[ch].data_type == synnax::FLOAT64) series = synnax::Series(synnax::FLOAT64, s);
-        // copy data from start to end into series
         for(int i = 0; i < d.samples_read_per_channel; i++) 
             this->write_to_series(series, d.analog_data[data_index*d.samples_read_per_channel + i], this->reader_config.channels[ch].data_type);
         


### PR DESCRIPTION
# Fix Pull Request Template

## Key Information

- **Linear Issue**: [SY-1112]()

## Description

This pr fixes a bug that wouldn't allow ni analg read tasks to be constructed with float64 precision as frames were hard coded to only write float32 type series.

## Basic Readiness Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added sufficient regression tests to cover the changes to CI.
- [ ] I have added relevant tests to cover the changes or exposing bugs.
- [ ] I have verified code coverage targets are met.

## Additional Notes
- [ ] These changes deal with concurrency.
- [ ] These changes affect UI.

## Manual QA Additions

- [ ] I have updated the [Release Candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template
  with necessary manual QA steps to test my change.

## Reviewer Checklist
- [ ] Sufficient test coverage of new additions.
- [ ] Verified all steps in readiness checklists.
- [ ] UI changes have been tested.
- [ ] style and formatting is consistent.
- [ ] Reviewed any relevant changes to concurrent code for safety. 
- [ ] Sufficient comments and clarity of code.