### PR TITLE
SY-1132 - fixed issues with device population when creating tasks

### DIFF
--- a/console/src/hardware/ni/device/ontology.tsx
+++ b/console/src/hardware/ni/device/ontology.tsx
@@ -10,16 +10,50 @@
 import { Icon } from "@synnaxlabs/media";
 import { Icon as PIcon, Menu } from "@synnaxlabs/pluto";
 
+import { createConfigureLayout } from "@/hardware/ni/device/Configure";
 import { configureAnalogReadLayout } from "@/hardware/ni/task/AnalogRead";
 import { configureDigitalReadLayout } from "@/hardware/ni/task/DigitalRead";
 import { configureDigitalWriteLayout } from "@/hardware/ni/task/DigitalWrite";
 import { Layout } from "@/layout";
+import { Ontology } from "@/ontology";
 
-export const ContextMenuItems = () => {
+export const ContextMenuItems = ({
+  selection: { resources },
+}: Ontology.TreeContextMenuProps) => {
   const place = Layout.usePlacer();
-  const handleCreateDigitalReadTask = () => place(configureDigitalReadLayout(true));
-  const handleCreateAnalogReadTask = () => place(configureAnalogReadLayout(true));
-  const handleCreateDigitalWriteTask = () => place(configureDigitalWriteLayout(true));
+  const first = resources[0];
+  const isSingle = resources.length === 1;
+  const handleCreateDigitalReadTask = () => {
+    if (first.data?.configured === false)
+      place(createConfigureLayout(first.id.key, {}));
+    place(
+      configureDigitalReadLayout({
+        create: true,
+        initialValues: { config: { device: first.id.key } },
+      }),
+    );
+  };
+  const handleCreateAnalogReadTask = () => {
+    if (first.data?.configured === false)
+      place(createConfigureLayout(first.id.key, {}));
+    place(
+      configureAnalogReadLayout({
+        create: true,
+        initialValues: { config: { device: first.id.key } },
+      }),
+    );
+  };
+  const handleCreateDigitalWriteTask = () => {
+    if (first.data?.configured === false)
+      place(createConfigureLayout(first.id.key, {}));
+    place(
+      configureDigitalWriteLayout({
+        create: true,
+        initialValues: { config: { device: first.id.key } },
+      }),
+    );
+  };
+  if (!isSingle) return null;
   return (
     <>
       <Menu.Divider />

--- a/console/src/hardware/ni/device/ontology.tsx
+++ b/console/src/hardware/ni/device/ontology.tsx
@@ -17,41 +17,36 @@ import { configureDigitalWriteLayout } from "@/hardware/ni/task/DigitalWrite";
 import { Layout } from "@/layout";
 import { Ontology } from "@/ontology";
 
+interface InitialArgs {
+  create: true;
+  initialValues: { config: { device: string } };
+}
+
 export const ContextMenuItems = ({
   selection: { resources },
 }: Ontology.TreeContextMenuProps) => {
   const place = Layout.usePlacer();
   const first = resources[0];
   const isSingle = resources.length === 1;
-  const handleCreateDigitalReadTask = () => {
+  const args: InitialArgs = {
+    create: true,
+    initialValues: { config: { device: first.id.key } },
+  };
+  const maybeConfigure = () => {
     if (first.data?.configured === false)
       place(createConfigureLayout(first.id.key, {}));
-    place(
-      configureDigitalReadLayout({
-        create: true,
-        initialValues: { config: { device: first.id.key } },
-      }),
-    );
+  };
+  const handleCreateDigitalReadTask = () => {
+    maybeConfigure();
+    place(configureDigitalReadLayout(args));
   };
   const handleCreateAnalogReadTask = () => {
-    if (first.data?.configured === false)
-      place(createConfigureLayout(first.id.key, {}));
-    place(
-      configureAnalogReadLayout({
-        create: true,
-        initialValues: { config: { device: first.id.key } },
-      }),
-    );
+    maybeConfigure();
+    place(configureAnalogReadLayout(args));
   };
   const handleCreateDigitalWriteTask = () => {
-    if (first.data?.configured === false)
-      place(createConfigureLayout(first.id.key, {}));
-    place(
-      configureDigitalWriteLayout({
-        create: true,
-        initialValues: { config: { device: first.id.key } },
-      }),
-    );
+    maybeConfigure();
+    place(configureDigitalWriteLayout(args));
   };
   if (!isSingle) return null;
   return (

--- a/console/src/hardware/ni/pallette.tsx
+++ b/console/src/hardware/ni/pallette.tsx
@@ -23,7 +23,12 @@ export const createAnalogReadTaskCommand: Command = {
       <Icon.Logo.NI />
     </PIcon.Create>
   ),
-  onSelect: ({ placeLayout }) => placeLayout(() => configureAnalogReadLayout(true)),
+  onSelect: ({ placeLayout }) =>
+    placeLayout(() =>
+      configureAnalogReadLayout({
+        create: true,
+      }),
+    ),
 };
 
 export const createDigitalWriteTaskCommand: Command = {
@@ -34,7 +39,8 @@ export const createDigitalWriteTaskCommand: Command = {
       <Icon.Logo.NI />
     </PIcon.Create>
   ),
-  onSelect: ({ placeLayout }) => placeLayout(configureDigitalWriteLayout(true)),
+  onSelect: ({ placeLayout }) =>
+    placeLayout(configureDigitalWriteLayout({ create: true })),
 };
 
 export const createDigitalReadTaskCommand: Command = {
@@ -45,7 +51,8 @@ export const createDigitalReadTaskCommand: Command = {
       <Icon.Logo.NI />
     </PIcon.Create>
   ),
-  onSelect: ({ placeLayout }) => placeLayout(configureDigitalReadLayout(true)),
+  onSelect: ({ placeLayout }) =>
+    placeLayout(configureDigitalReadLayout({ create: true })),
 };
 
 export const COMMANDS = [

--- a/console/src/hardware/ni/task/AnalogRead.tsx
+++ b/console/src/hardware/ni/task/AnalogRead.tsx
@@ -45,6 +45,7 @@ import {
   Controls,
   EnableDisableButton,
   ParentRangeButton,
+  TaskLayoutArgs,
   useCreate,
   useObserveState,
   WrappedTaskLayoutProps,
@@ -55,20 +56,25 @@ import { Layout } from "@/layout";
 
 import { ANALOG_INPUT_FORMS, SelectChannelTypeField } from "./ChannelForms";
 
-export const configureAnalogReadLayout = (create: boolean = false): Layout.State => ({
+export const configureAnalogReadLayout = (
+  args: TaskLayoutArgs<AnalogReadPayload> = { create: false },
+): Layout.State<TaskLayoutArgs<AnalogReadPayload>> => ({
   name: "Configure NI Analog Read Task",
   key: id.id(),
   type: ANALOG_READ_TYPE,
   windowKey: ANALOG_READ_TYPE,
   location: "mosaic",
-  args: { create },
+  args,
 });
 
 export const ANALOG_READ_SELECTABLE: Layout.Selectable = {
   key: ANALOG_READ_TYPE,
   title: "NI Analog Read Task",
   icon: <Icon.Logo.NI />,
-  create: (layoutKey) => ({ ...configureAnalogReadLayout(true), key: layoutKey }),
+  create: (layoutKey) => ({
+    ...configureAnalogReadLayout({ create: true }),
+    key: layoutKey,
+  }),
 };
 
 const Wrapped = ({

--- a/console/src/hardware/ni/task/DigitalRead.tsx
+++ b/console/src/hardware/ni/task/DigitalRead.tsx
@@ -29,7 +29,7 @@ import { z } from "zod";
 import { CSS } from "@/css";
 import { enrich } from "@/hardware/ni/device/enrich/enrich";
 import { Properties } from "@/hardware/ni/device/types";
-import { CopyButtons, SelectDevice, useCopyUtils } from "@/hardware/ni/task/common";
+import { CopyButtons, SelectDevice } from "@/hardware/ni/task/common";
 import {
   Chan,
   DIChan,
@@ -49,34 +49,33 @@ import {
   ChannelListHeader,
   Controls,
   EnableDisableButton,
+  TaskLayoutArgs,
   useCreate,
   useObserveState,
   WrappedTaskLayoutProps,
   wrapTaskLayout,
 } from "@/hardware/task/common/common";
-import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { Layout } from "@/layout";
 
-interface ConfigureDigitalReadArgs {
-  create: boolean;
-}
-
 export const configureDigitalReadLayout = (
-  create: boolean = false,
-): Layout.State<ConfigureDigitalReadArgs> => ({
+  args: TaskLayoutArgs<DigitalReadPayload> = { create: false },
+): Layout.State<TaskLayoutArgs<DigitalReadPayload>> => ({
   name: "Configure NI Digital Read Task",
   type: DIGITAL_READ_TYPE,
   key: id.id(),
   windowKey: DIGITAL_READ_TYPE,
   location: "mosaic",
-  args: { create },
+  args,
 });
 
 export const DIGITAL_READ_SELECTABLE: Layout.Selectable = {
   key: DIGITAL_READ_TYPE,
   title: "NI Digital Read Task",
   icon: <Icon.Logo.NI />,
-  create: (layoutKey) => ({ ...configureDigitalReadLayout(true), key: layoutKey }),
+  create: (layoutKey) => ({
+    ...configureDigitalReadLayout({ create: true }),
+    key: layoutKey,
+  }),
 };
 
 const Wrapped = ({

--- a/console/src/hardware/ni/task/DigitalRead.tsx
+++ b/console/src/hardware/ni/task/DigitalRead.tsx
@@ -209,7 +209,7 @@ const Wrapped = ({
   return (
     <Align.Space className={CSS.B("task-configure")} direction="y" grow empty>
       <Align.Space>
-        <Form.Form {...methods}>
+        <Form.Form {...methods} mode={task?.snapshot ? "preview" : "normal"}>
           <Align.Space direction="x" justify="spaceBetween">
             <Form.Field<string> path="name">
               {(p) => <Input.Text variant="natural" level="h1" {...p} />}
@@ -239,6 +239,7 @@ const Wrapped = ({
           >
             <ChannelList
               path="config.channels"
+              snapshot={task?.snapshot}
               selected={selectedChannels}
               onSelect={useCallback(
                 (v, i) => {
@@ -262,6 +263,7 @@ const Wrapped = ({
         </Form.Form>
         <Controls
           state={taskState}
+          snapshot={task?.snapshot}
           startingOrStopping={start.isPending}
           configuring={configure.isPending}
           onConfigure={configure.mutate}
@@ -291,9 +293,15 @@ interface ChannelListProps {
   path: string;
   onSelect: (keys: string[], index: number) => void;
   selected: string[];
+  snapshot?: boolean;
 }
 
-const ChannelList = ({ path, selected, onSelect }: ChannelListProps): ReactElement => {
+const ChannelList = ({
+  path,
+  selected,
+  onSelect,
+  snapshot,
+}: ChannelListProps): ReactElement => {
   const { value, push, remove } = Form.useFieldArray<DIChan>({ path });
   const handleAdd = (): void => {
     const availableLine = Math.max(0, ...value.map((v) => v.line)) + 1;
@@ -341,7 +349,9 @@ const ChannelList = ({ path, selected, onSelect }: ChannelListProps): ReactEleme
             replaceOnSingle
           >
             <List.Core<string, Chan> grow>
-              {(props) => <ChannelListItem {...props} path={path} />}
+              {(props) => (
+                <ChannelListItem {...props} snapshot={snapshot} path={path} />
+              )}
             </List.Core>
           </List.Selector>
         </List.List>
@@ -352,9 +362,11 @@ const ChannelList = ({ path, selected, onSelect }: ChannelListProps): ReactEleme
 
 const ChannelListItem = ({
   path,
+  snapshot = false,
   ...props
 }: List.ItemProps<string, Chan> & {
   path: string;
+  snapshot?: boolean;
 }): ReactElement => {
   const { entry } = props;
   const hasLine = "line" in entry;
@@ -414,6 +426,7 @@ const ChannelListItem = ({
       <EnableDisableButton
         value={childValues.enabled}
         onChange={(v) => ctx?.set(`${path}.${props.index}.enabled`, v)}
+        snapshot={snapshot}
       />
     </List.ItemFrame>
   );

--- a/console/src/hardware/ni/task/DigitalWrite.tsx
+++ b/console/src/hardware/ni/task/DigitalWrite.tsx
@@ -40,6 +40,7 @@ import {
   ChannelListHeader,
   Controls,
   EnableDisableButton,
+  TaskLayoutArgs,
   useCreate,
   useObserveState,
   WrappedTaskLayoutProps,
@@ -47,26 +48,25 @@ import {
 } from "@/hardware/task/common/common";
 import { Layout } from "@/layout";
 
-interface ConfigureDigitalWriteArgs {
-  create: boolean;
-}
-
 export const configureDigitalWriteLayout = (
-  create: boolean = false,
-): Layout.State<ConfigureDigitalWriteArgs> => ({
+  args: TaskLayoutArgs<DigitalWritePayload> = { create: true },
+): Layout.State<TaskLayoutArgs<DigitalWritePayload>> => ({
   name: "Configure NI Digital Write Task",
   key: id.id(),
   type: DIGITAL_WRITE_TYPE,
   windowKey: DIGITAL_WRITE_TYPE,
   location: "mosaic",
-  args: { create },
+  args,
 });
 
 export const DIGITAL_WRITE_SELECTABLE: Layout.Selectable = {
   key: DIGITAL_WRITE_TYPE,
   title: "NI Digital Write Task",
   icon: <Icon.Logo.NI />,
-  create: (layoutKey) => ({ ...configureDigitalWriteLayout(true), key: layoutKey }),
+  create: (layoutKey) => ({
+    ...configureDigitalWriteLayout({ create: true }),
+    key: layoutKey,
+  }),
 };
 
 const Wrapped = ({

--- a/console/src/hardware/ni/task/DigitalWrite.tsx
+++ b/console/src/hardware/ni/task/DigitalWrite.tsx
@@ -241,8 +241,11 @@ const Wrapped = ({
   return (
     <Align.Space className={CSS.B("task-configure")} direction="y" grow empty>
       <Align.Space grow>
-        <Form.Form {...methods}>
+        <Form.Form {...methods} mode={task?.snapshot ? "preview" : "normal"}>
           <Align.Space direction="x" justify="spaceBetween">
+            <Form.Field<string> path="name">
+              {(p) => <Input.Text variant="natural" level="h1" {...p} />}
+            </Form.Field>
             <CopyButtons
               importClass="DigitalWriteTask"
               taskKey={task?.key}
@@ -250,9 +253,6 @@ const Wrapped = ({
               getConfig={() => methods.get<DigitalWriteConfig>("config").value}
             />
           </Align.Space>
-          <Form.Field<string> path="name">
-            {(p) => <Input.Text variant="natural" level="h1" {...p} />}
-          </Form.Field>
           <Align.Space direction="x" className={CSS.B("task-properties")}>
             <SelectDevice />
             <Align.Space direction="x">
@@ -277,6 +277,7 @@ const Wrapped = ({
             <ChannelList
               path="config.channels"
               selected={selectedChannels}
+              snapshot={task?.snapshot}
               onSelect={useCallback(
                 (v, i) => {
                   setSelectedChannels(v);
@@ -300,6 +301,7 @@ const Wrapped = ({
         <Controls
           state={taskState}
           startingOrStopping={start.isPending}
+          snapshot={task?.snapshot}
           configuring={configure.isPending}
           onStartStop={start.mutate}
           onConfigure={configure.mutate}
@@ -328,9 +330,15 @@ interface ChannelListProps {
   path: string;
   onSelect: (keys: string[], index: number) => void;
   selected: string[];
+  snapshot?: boolean;
 }
 
-const ChannelList = ({ path, selected, onSelect }: ChannelListProps): ReactElement => {
+const ChannelList = ({
+  path,
+  snapshot,
+  selected,
+  onSelect,
+}: ChannelListProps): ReactElement => {
   const { value, push, remove } = Form.useFieldArray<DOChan>({ path });
   const handleAdd = (): void => {
     const availableLine = Math.max(0, ...value.map((v) => v.line)) + 1;
@@ -381,7 +389,9 @@ const ChannelList = ({ path, selected, onSelect }: ChannelListProps): ReactEleme
             replaceOnSingle
           >
             <List.Core<string, Chan> grow>
-              {(props) => <ChannelListItem {...props} path={path} />}
+              {(props) => (
+                <ChannelListItem {...props} path={path} snapshot={snapshot} />
+              )}
             </List.Core>
           </List.Selector>
         </List.List>
@@ -392,9 +402,11 @@ const ChannelList = ({ path, selected, onSelect }: ChannelListProps): ReactEleme
 
 const ChannelListItem = ({
   path,
+  snapshot = false,
   ...props
 }: List.ItemProps<string, Chan> & {
   path: string;
+  snapshot?: boolean;
 }): ReactElement => {
   const { entry } = props;
   const hasLine = "line" in entry;
@@ -481,6 +493,7 @@ const ChannelListItem = ({
       <EnableDisableButton
         value={childValues.enabled}
         onChange={(v) => ctx.set(`${path}.${props.index}.enabled`, v)}
+        snapshot={snapshot}
       />
     </List.ItemFrame>
   );

--- a/console/src/hardware/opc/device/Browser.tsx
+++ b/console/src/hardware/opc/device/Browser.tsx
@@ -10,6 +10,8 @@
 import { Icon } from "@synnaxlabs/media";
 import {
   Align,
+  Button,
+  Header,
   Icon as PIcon,
   Status,
   Synnax,
@@ -19,8 +21,9 @@ import {
 } from "@synnaxlabs/pluto";
 import { Optional } from "@synnaxlabs/x";
 import { useMutation, useQuery } from "@tanstack/react-query";
-import { ReactElement, useEffect, useState } from "react";
+import { ReactElement, useCallback, useEffect, useState } from "react";
 
+import { CSS } from "@/css";
 import {
   Device as OPCDevice,
   ScannerScanCommandResult,
@@ -106,12 +109,16 @@ export const Browser = ({ device }: BrowserProps): ReactElement => {
 
   const [initialLoading, setInitialLoading] = useState(false);
 
-  useEffect(() => {
+  const refresh = useCallback(() => {
     if (device == null || scanTask == null) return;
     setInitialLoading(true);
     expand.mutate({ action: "expand", current: [], delay: 200 });
     treeProps.clearExpanded();
   }, [device, scanTask?.key, treeProps.clearExpanded]);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
 
   let content: ReactElement | null = null;
   if (initialLoading)
@@ -146,8 +153,32 @@ export const Browser = ({ device }: BrowserProps): ReactElement => {
     );
 
   return (
-    <Align.Space direction="y" grow style={{ height: "100%", overflow: "hidden" }}>
-      {content}
+    <Align.Space
+      className={CSS.B("browser")}
+      direction="y"
+      grow
+      bordered
+      rounded
+      style={{
+        overflow: "hidden",
+        height: "100%",
+      }}
+      empty
+    >
+      <Header.Header level="h4">
+        <Header.Title weight={500}>Browser</Header.Title>
+        <Header.Actions>
+          <Button.Icon
+            onClick={refresh}
+            disabled={device == null || scanTask == null || initialLoading}
+          >
+            <Icon.Refresh style={{ color: "var(--pluto-gray-l9)" }} />
+          </Button.Icon>
+        </Header.Actions>
+      </Header.Header>
+      <Align.Space direction="y" grow style={{ height: "100%", overflow: "hidden" }}>
+        {content}
+      </Align.Space>
     </Align.Space>
   );
 };

--- a/console/src/hardware/opc/device/ontology.tsx
+++ b/console/src/hardware/opc/device/ontology.tsx
@@ -9,13 +9,26 @@
 
 import { Icon } from "@synnaxlabs/media";
 import { Icon as PIcon, Menu } from "@synnaxlabs/pluto";
+import { ReactElement } from "react";
 
 import { configureReadLayout } from "@/hardware/opc/task/ReadTask";
 import { Layout } from "@/layout";
+import { Ontology } from "@/ontology";
 
-export const ContextMenuItems = () => {
+export const ContextMenuItems = ({
+  selection: { resources },
+}: Ontology.TreeContextMenuProps): ReactElement | null => {
+  const first = resources[0];
+  const isSingle = resources.length === 1;
   const place = Layout.usePlacer();
-  const createReadTask = () => place(configureReadLayout(true));
+  const createReadTask = () =>
+    place(
+      configureReadLayout({
+        create: true,
+        initialValues: { config: { device: first.id.key } },
+      }),
+    );
+  if (!isSingle) return null;
   return (
     <>
       <Menu.Divider />

--- a/console/src/hardware/opc/palette.tsx
+++ b/console/src/hardware/opc/palette.tsx
@@ -29,7 +29,7 @@ export const createReadTaskCommand: Command = {
   key: "opc-create-read-task",
   name: "Create an OPC UA Read Task",
   icon: <Icon.Logo.OPC />,
-  onSelect: ({ placeLayout }) => placeLayout(configureReadLayout(true)),
+  onSelect: ({ placeLayout }) => placeLayout(configureReadLayout({ create: true })),
 };
 
 export const COMMANDS = [connectServerCommand, createReadTaskCommand];

--- a/console/src/hardware/opc/task/ReadTask.css
+++ b/console/src/hardware/opc/task/ReadTask.css
@@ -17,9 +17,6 @@
     }
     .console-channels {
         height: 100%;
-        .pluto-menu-context__container {
-            max-height: calc(100% - 200px);
-        }
         &.console-dragging {
             border-color: var(--pluto-primary-z);
         }

--- a/console/src/hardware/opc/task/ReadTask.tsx
+++ b/console/src/hardware/opc/task/ReadTask.tsx
@@ -26,7 +26,7 @@ import {
   useAsyncEffect,
   useSyncedRef,
 } from "@synnaxlabs/pluto";
-import { caseconv, deep, primitiveIsZero } from "@synnaxlabs/x";
+import { caseconv, primitiveIsZero } from "@synnaxlabs/x";
 import { useMutation } from "@tanstack/react-query";
 import { type ReactElement, useCallback, useState } from "react";
 import { v4 as uuid } from "uuid";
@@ -52,6 +52,7 @@ import {
   ChannelListContextMenu,
   Controls,
   EnableDisableButton,
+  TaskLayoutArgs,
   useCreate,
   useObserveState,
   WrappedTaskLayoutProps,
@@ -59,7 +60,9 @@ import {
 } from "@/hardware/task/common/common";
 import { Layout } from "@/layout";
 
-export const configureReadLayout = (create: boolean = false): Layout.State => ({
+export const configureReadLayout = (
+  args: TaskLayoutArgs<ReadPayload> = { create: false },
+): Layout.State<TaskLayoutArgs<ReadPayload>> => ({
   name: "Configure OPC UA Read Task",
   key: uuid(),
   type: READ_TYPE,
@@ -70,14 +73,14 @@ export const configureReadLayout = (create: boolean = false): Layout.State => ({
     size: { width: 1200, height: 900 },
     navTop: true,
   },
-  args: { create },
+  args,
 });
 
 export const READ_SELECTABLE: Layout.Selectable = {
   key: READ_TYPE,
   title: "OPC UA Read Task",
   icon: <Icon.Logo.OPC />,
-  create: (layoutKey) => ({ ...configureReadLayout(true), key: layoutKey }),
+  create: (layoutKey) => ({ ...configureReadLayout({ create: true }), key: layoutKey }),
 };
 
 const schema = z.object({
@@ -295,20 +298,7 @@ const Wrapped = ({
             grow
             style={{ overflow: "hidden", height: "500px" }}
           >
-            <Align.Space
-              className={CSS.B("browser")}
-              direction="y"
-              grow
-              bordered
-              rounded
-              style={{ overflow: "hidden", height: "100%" }}
-              empty
-            >
-              <Header.Header level="h4">
-                <Header.Title weight={500}>Browser</Header.Title>
-              </Header.Header>
-              <Browser device={device} />
-            </Align.Space>
+            <Browser device={device} />
             <ChannelList path="config.channels" device={device} />
           </Align.Space>
         </Form.Form>
@@ -394,6 +384,7 @@ export const ChannelList = ({ path, device }: ChannelListProps): ReactElement =>
         <Header.Title weight={500}>Channels</Header.Title>
       </Header.Header>
       <Menu.ContextMenu
+        style={{ maxHeight: value.length > 0 ? "calc(100% - 200px)" : "100%" }}
         menu={({ keys }: Menu.ContextMenuMenuProps): ReactElement => (
           <ChannelListContextMenu
             path={path}

--- a/console/src/hardware/task/common/common.css
+++ b/console/src/hardware/task/common/common.css
@@ -39,7 +39,7 @@
             .console-channels {
                 border-right: var(--pluto-border);
                 overflow: hidden;
-                max-width: 250px;
+                max-width: 300px;
                 height: 100%;
                 flex-shrink: 1;
                 flex-grow: 1;

--- a/console/src/hardware/task/common/common.tsx
+++ b/console/src/hardware/task/common/common.tsx
@@ -196,66 +196,76 @@ export const Controls = ({
   onConfigure,
   configuring,
   snapshot = false,
-}: ControlsProps) => (
-  <Align.Space direction="x" className={CSS.B("task-controls")} justify="spaceBetween">
-    <Align.Space
-      className={CSS.B("task-state")}
-      direction="x"
-      style={{
-        borderRadius: "1rem",
-        border: "var(--pluto-border)",
-        padding: "2rem",
-        width: "100%",
-      }}
-    >
-      {snapshot && (
-        <Status.Text.Centered variant="disabled" hideIcon>
-          This task is a snapshot and cannot be modified or started.
-        </Status.Text.Centered>
-      )}
-      {state?.details?.message != null && (
-        <Status.Text variant={state?.variant as Status.Variant}>
-          {state?.details?.message}
-        </Status.Text>
-      )}
-    </Align.Space>
+}: ControlsProps) => {
+  let content: ReactElement | null = null;
+  if (state?.details?.message != null)
+    content = (
+      <Status.Text variant={state?.variant as Status.Variant}>
+        {state?.details?.message}
+      </Status.Text>
+    );
+  if (snapshot)
+    content = (
+      <Status.Text.Centered variant="disabled" hideIcon>
+        This task is a snapshot and cannot be modified or started.
+      </Status.Text.Centered>
+    );
+  return (
     <Align.Space
       direction="x"
-      bordered
-      rounded
-      style={{
-        padding: "2rem",
-        borderRadius: "1rem",
-      }}
-      justify="end"
+      className={CSS.B("task-controls")}
+      justify="spaceBetween"
     >
-      <Button.Icon
-        loading={startingOrStopping}
-        disabled={startingOrStopping || state == null || snapshot}
-        onClick={onStartStop}
-        variant="outlined"
+      <Align.Space
+        className={CSS.B("task-state")}
+        direction="x"
+        style={{
+          borderRadius: "1rem",
+          border: "var(--pluto-border)",
+          padding: "2rem",
+          width: "100%",
+        }}
       >
-        {state?.details?.running === true ? <Icon.Pause /> : <Icon.Play />}
-      </Button.Icon>
-      <Button.Button
-        loading={configuring}
-        disabled={configuring || snapshot}
-        onClick={onConfigure}
-        triggers={[CONFIGURE_TRIGGER]}
-        tooltip={
-          <Align.Space direction="x" align="center" size="small">
-            <Triggers.Text shade={7} level="small" trigger={CONFIGURE_TRIGGER} />
-            <Text.Text shade={7} level="small">
-              To Configure
-            </Text.Text>
-          </Align.Space>
-        }
+        {content}
+      </Align.Space>
+      <Align.Space
+        direction="x"
+        bordered
+        rounded
+        style={{
+          padding: "2rem",
+          borderRadius: "1rem",
+        }}
+        justify="end"
       >
-        Configure
-      </Button.Button>
+        <Button.Icon
+          loading={startingOrStopping}
+          disabled={startingOrStopping || state == null || snapshot}
+          onClick={onStartStop}
+          variant="outlined"
+        >
+          {state?.details?.running === true ? <Icon.Pause /> : <Icon.Play />}
+        </Button.Icon>
+        <Button.Button
+          loading={configuring}
+          disabled={configuring || snapshot}
+          onClick={onConfigure}
+          triggers={[CONFIGURE_TRIGGER]}
+          tooltip={
+            <Align.Space direction="x" align="center" size="small">
+              <Triggers.Text shade={7} level="small" trigger={CONFIGURE_TRIGGER} />
+              <Text.Text shade={7} level="small">
+                To Configure
+              </Text.Text>
+            </Align.Space>
+          }
+        >
+          Configure
+        </Button.Button>
+      </Align.Space>
     </Align.Space>
-  </Align.Space>
-);
+  );
+};
 
 export interface ChannelListHeaderProps extends ChannelListEmptyContentProps {}
 

--- a/console/src/hardware/task/ontology.tsx
+++ b/console/src/hardware/task/ontology.tsx
@@ -23,7 +23,10 @@ import { Ontology } from "@/ontology";
 import { useConfirmDelete } from "@/ontology/hooks";
 import { Range } from "@/range";
 
-const ZERO_LAYOUT_STATES: Record<string, (create?: boolean) => Layout.State> = {
+const ZERO_LAYOUT_STATES: Record<
+  string,
+  ({ create }: { create: boolean }) => Layout.State
+> = {
   [OPC.Task.READ_TYPE]: OPC.Task.configureReadLayout,
   [NI.Task.ANALOG_READ_TYPE]: NI.Task.configureAnalogReadLayout,
   [NI.Task.DIGITAL_WRITE_TYPE]: NI.Task.configureDigitalWriteLayout,
@@ -33,7 +36,7 @@ const ZERO_LAYOUT_STATES: Record<string, (create?: boolean) => Layout.State> = {
 export const createTaskLayout = (key: string, type: string): Layout.State => {
   const baseLayout = ZERO_LAYOUT_STATES[type];
   return {
-    ...baseLayout(false),
+    ...baseLayout({ create: false }),
     key,
   };
 };
@@ -49,10 +52,9 @@ const handleSelect: Ontology.HandleSelect = ({
   void (async () => {
     try {
       const t = await client.hardware.tasks.retrieve(task.key);
-      console.log(t.type);
       const baseLayout = ZERO_LAYOUT_STATES[t.type];
       placeLayout({
-        ...baseLayout(false),
+        ...baseLayout({ create: false }),
         key: selection[0].id.key,
       });
     } catch (e) {
@@ -193,7 +195,7 @@ const handleMosaicDrop: Ontology.HandleMosaicDrop = async ({
 }) => {
   const task = await client.hardware.tasks.retrieve(id.key);
   placeLayout({
-    ...ZERO_LAYOUT_STATES[task.type](false),
+    ...ZERO_LAYOUT_STATES[task.type]({ create: false }),
     key: id.key,
     tab: {
       mosaicKey: nodeKey,

--- a/console/src/lineplot/services/palette.tsx
+++ b/console/src/lineplot/services/palette.tsx
@@ -17,13 +17,6 @@ export const createLinePlotCommand: Command = {
   name: "Create a Line Plot",
   icon: <Icon.Visualize />,
   onSelect: ({ placeLayout: layoutPlacer }) => layoutPlacer(create({})),
-  actions: [
-    {
-      name: "Create in New Window",
-      onClick: ({ placeLayout: layoutPlacer }) => layoutPlacer(create({})),
-      trigger: ["Enter"],
-    },
-  ],
 };
 
 export const COMMANDS = [createLinePlotCommand];

--- a/pluto/src/dropdown/Dropdown.css
+++ b/pluto/src/dropdown/Dropdown.css
@@ -42,7 +42,7 @@
         transform: translateY(-25%);
         --pluto-pack-br: 1rem;
         border-radius: 1rem;
-        background: var(--pluto-gray-l1);
+        background: var(--pluto-gray-l0);
         backdrop-filter: saturate(300%) blur(5rem);
         overflow: hidden;
     }


### PR DESCRIPTION
# Fix Pull Request Template

## Key Information

- **Linear Issue**: [SY-1132](https://linear.app/synnax/issue/SY-1132/fix-bad-pre-population-in-device-fields)

## Description

Previously, when you would click "Create X Task" on a device in the context menu, it would not populate the device field when creating a task. This fixes that issue, now the device field will be properly populated.

## Basic Readiness Checklist

- [x] I have performed a self-review of my code.
- [x] I have added sufficient regression tests to cover the changes to CI.
- [x] I have added relevant tests to cover the changes or exposing bugs.
- [x] I have verified code coverage targets are met.

## Additional Notes
- [ ] These changes deal with concurrency.
- [x] These changes affect UI.

## Manual QA Additions

- [ ] I have updated the [Release Candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template
  with necessary manual QA steps to test my change.

## Reviewer Checklist
- [ ] Sufficient test coverage of new additions.
- [ ] Verified all steps in readiness checklists.
- [ ] UI changes have been tested.
- [ ] style and formatting is consistent.
- [ ] Reviewed any relevant changes to concurrent code for safety. 
- [ ] Sufficient comments and clarity of code.