### PR TITLE
SY-1143 Added onlyChangeonBlur to DateTime input

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synnaxlabs/console",
   "private": true,
-  "version": "0.28.1",
+  "version": "0.28.2",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/console/src/range/EditLayout.tsx
+++ b/console/src/range/EditLayout.tsx
@@ -293,7 +293,7 @@ const EditLayoutForm = ({
             disabled={isPending}
             triggers={[SAVE_TRIGGER]}
           >
-            {isRemoteEdit ? "Edit" : "Save"}
+            Save
           </Button.Button>
         </Nav.Bar.End>
       </Layout.BottomNavBar>

--- a/console/src/range/overview/Details.tsx
+++ b/console/src/range/overview/Details.tsx
@@ -256,7 +256,9 @@ export const Details: FC<DetailsProps> = ({ rangeKey }) => {
           align="center"
         >
           <Form.Field<number> path="timeRange.start" padHelpText={false} label="From">
-            {(p) => <Input.DateTime level="h4" variant="natural" {...p} />}
+            {(p) => (
+              <Input.DateTime level="h4" variant="natural" onlyChangeOnBlur {...p} />
+            )}
           </Form.Field>
           <Text.WithIcon
             className={CSS.B("time-range-divider")}
@@ -264,7 +266,9 @@ export const Details: FC<DetailsProps> = ({ rangeKey }) => {
             startIcon={<Icon.Arrow.Right />}
           />
           <Form.Field<number> padHelpText={false} path="timeRange.end" label="To">
-            {(p) => <Input.DateTime level="h4" variant="natural" {...p} />}
+            {(p) => (
+              <Input.DateTime onlyChangeOnBlur level="h4" variant="natural" {...p} />
+            )}
           </Form.Field>
         </Align.Space>
       </Align.Space>

--- a/pluto/package.json
+++ b/pluto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synnaxlabs/pluto",
-  "version": "0.28.1",
+  "version": "0.28.2",
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit && vite build",

--- a/pluto/src/input/DateTime.tsx
+++ b/pluto/src/input/DateTime.tsx
@@ -56,14 +56,12 @@ export const DateTime = ({
   };
 
   const handleBlur: React.FocusEventHandler<HTMLInputElement> = (e) => {
-    console.log("ABC");
     handleChange(e.target.value, true);
     setTempValue(null);
     onBlur?.(e);
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
-    console.log("DEF");
     if (!onlyChangeOnBlur) return;
     if (e.key === "Enter") e.currentTarget.blur();
   };

--- a/pluto/src/input/Text.tsx
+++ b/pluto/src/input/Text.tsx
@@ -16,7 +16,7 @@ import { CSS } from "@/css";
 import { useCombinedRefs } from "@/hooks";
 import { type BaseProps } from "@/input/types";
 import { Status } from "@/status";
-import { Text as BaseText, Text as CoreText } from "@/text";
+import { Text as CoreText } from "@/text";
 
 export interface TextExtraProps {
   selectOnFocus?: boolean;
@@ -24,8 +24,6 @@ export interface TextExtraProps {
   resetOnBlurIfEmpty?: boolean;
   status?: Status.Variant;
   onlyChangeOnBlur?: boolean;
-  shade?: BaseText.Shade;
-  weight?: BaseText.Weight;
 }
 
 export interface TextProps extends BaseProps<string>, TextExtraProps {}
@@ -101,6 +99,7 @@ export const Text = forwardRef<HTMLInputElement, TextProps>(
     };
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
+      console.log(e);
       if (!onlyChangeOnBlur) return;
       if (e.key === "Enter") e.currentTarget.blur();
     };

--- a/pluto/src/input/Text.tsx
+++ b/pluto/src/input/Text.tsx
@@ -99,7 +99,6 @@ export const Text = forwardRef<HTMLInputElement, TextProps>(
     };
 
     const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>): void => {
-      console.log(e);
       if (!onlyChangeOnBlur) return;
       if (e.key === "Enter") e.currentTarget.blur();
     };

--- a/pluto/src/input/types.ts
+++ b/pluto/src/input/types.ts
@@ -37,6 +37,8 @@ export interface ExtensionProps<I extends Value = Value, O extends Value = I>
   placeholder?: ReactNode;
   children?: ReactNode;
   level?: Text.Level;
+  shade?: Text.Shade;
+  weight?: Text.Weight;
 }
 
 export interface BaseProps<I extends Value = Value, O extends Value = I>


### PR DESCRIPTION
# Fix Pull Request Template

## Key Information

- **Linear Issue**: [SY-1143](https://linear.app/synnax/issue/SY-1143/stop-flickering-on-range-dates)

## Description

Implements a change to the `DateTime` input so it only changes when the user blurs the input or hits the enter key. This fixes flickering issues when quickly editing range dates.

## Basic Readiness Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added sufficient regression tests to cover the changes to CI.
- [ ] I have added relevant tests to cover the changes or exposing bugs.
- [ ] I have verified code coverage targets are met.

## Additional Notes
- [ ] These changes deal with concurrency.
- [x] These changes affect UI.

## Manual QA Additions

- [ ] I have updated the [Release Candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template
  with necessary manual QA steps to test my change.

## Reviewer Checklist
- [ ] Sufficient test coverage of new additions.
- [ ] Verified all steps in readiness checklists.
- [ ] UI changes have been tested.
- [ ] style and formatting is consistent.
- [ ] Reviewed any relevant changes to concurrent code for safety. 
- [ ] Sufficient comments and clarity of code.