### PR TITLE
SY-577 Documentation Links, SY-883 TypeScript README

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ scale.
 Synnax is currently in beta and is under active development. The APIs are stable
 and are unlikely to change significantly.
 
-Versions prior to 1.x.x follow modified Semantic Versioning. Versions with the same 
-patch (e.g. 0.0.1 and 0.0.2) are guaranteed to maintain the same API, while minor 
+Versions prior to 1.x.x follow modified Semantic Versioning. Versions with the same
+patch (e.g. 0.0.1 and 0.0.2) are guaranteed to maintain the same API, while minor
 versions may include API changes.
 
 Our team is targeting a v1 release before the end of 2024, at which point all APIs
@@ -44,10 +44,9 @@ will be stable and follow strict semantic versioning.
 
 # How to Contribute
 
-Help us modernize industrial control! Reach out
-to [Emiliano](mailto:ebonilla@synnaxlabs.com)(ebonilla@synnaxlabs.com) if you'd like to
-get involved. While you wait for a response, check out
-the [New Contributor Guide](docs/CONTRIBUTING.md) to get up to speed.
+Help us modernize industrial control! Reach out to [Emiliano](mailto:ebonilla@synnaxlabs.com)
+if you'd like to get involved. While you wait for a response, check out the [New
+Contributor Guide](docs/CONTRIBUTING.md) to get up to speed.
 
 # Repository Organization
 

--- a/README.md
+++ b/README.md
@@ -42,12 +42,6 @@ versions may include API changes.
 Our team is targeting a v1 release before the end of 2024, at which point all APIs
 will be stable and follow strict semantic versioning.
 
-# How to Contribute
-
-Help us modernize industrial control! Reach out to [Emiliano](mailto:ebonilla@synnaxlabs.com)
-if you'd like to get involved. While you wait for a response, check out the [New
-Contributor Guide](docs/CONTRIBUTING.md) to get up to speed.
-
 # Repository Organization
 
 Synnax is built as a collection of several projects, all of which are collected

--- a/client/cpp/channel/channel.h
+++ b/client/cpp/channel/channel.h
@@ -37,9 +37,9 @@ typedef freighter::UnaryClient<
 class ChannelClient;
 
 /// @brief A channel is a logical collection of samples emitted by or representing the
-/// values of a single source, typically a sensor, actuator, or software generated value.
-/// See https:://docs.synnaxlabs.com/concepts/channels for an introduction to channels
-/// and how they work.
+/// values of a single source, typically a sensor, actuator, or software generated
+/// value. See https://docs.synnaxlabs.com/reference/concepts/channels for an
+/// introduction to channels and how they work.
 class Channel {
 public:
     /// @brief A human-readable name for the channel.

--- a/client/cpp/framer/framer.h
+++ b/client/cpp/framer/framer.h
@@ -275,13 +275,13 @@ public:
     ///
     /// 1. The frame must have at most 1 series per channel.
     /// 2. The frame may not have series for any channel not specified in the
-    ///  WriterConfig when opening the writer.
+    /// WriterConfig when opening the writer.
     /// 3. All series' that are written to the same index must have the same number of
     /// samples.
     /// 4. When writing to an index, the series' for the index must have monotonically
     /// increasing int64 unix epoch timestamps.
     ///
-    /// For more information, see https://docs.synnaxlabs.com/concepts/write.
+    /// For more information, see https://docs.synnaxlabs.com/reference/concepts/writes.
     ///
     /// @returns false if an error occurred in the write pipeline. After an error occurs,
     /// the caller must acknowledge the error by calling error() or close() on the writer.

--- a/client/cpp/ranger/ranger.h
+++ b/client/cpp/ranger/ranger.h
@@ -102,9 +102,9 @@ public:
     [[nodiscard]] freighter::Error del(const std::string &key) const;
 };
 
-/// @brief a range is a user-defined region of a cluster's data. It's identified
-/// by a name, time range, and uniquely generated. See
-/// https://docs.synnaxlabs.com/concepts/read-ranges for an introduction to ranges
+/// @brief a range is a user-defined region of a cluster's data. It's identified by a
+/// name, time range, and uniquely generated. See
+/// https://docs.synnaxlabs.com/reference/concepts/ranges for an introduction to ranges
 /// and how they work.
 class Range {
 public:

--- a/client/py/examples/control/tpc/README.md
+++ b/client/py/examples/control/tpc/README.md
@@ -7,15 +7,16 @@ This example demonstrates how to use Synnax to control the pressure of a simulat
 There are three scripts in this example:
 
 1. `simulated_daq.py` - This script simulates the data acquisition system that responds
-to valves being open and closed on the tank.
+   to valves being open and closed on the tank.
 2. `auto.py` - The auto-sequence that controls the tank pressure.
 3. `auto_analysis.py` - A simple automated analysis script that outputs a plot of
    the tank pressure to the directory where the script is run.
 
 To run the example, first make sure you have a running Synnax database at
 `localhost:9090`. Then, make sure you have the Synnax Python client installed on your
-system. See [the Synnax Python client documentation](https://docs.synnaxlabs.com/python-client/get-started)
-Then, start by running the simulated DAQ:
+system. See [the Synnax Python client
+documentation](https://docs.synnaxlabs.com/reference/python-client/get-started) Then,
+start by running the simulated DAQ:
 
 ```bash
 python simulated_daq.py
@@ -41,4 +42,3 @@ example of a good console setup looks like for this example:
     <br />
     <img src="./img/console-setup.png" width="80%">
 </p>
-

--- a/client/py/synnax/channel/client.py
+++ b/client/py/synnax/channel/client.py
@@ -43,8 +43,9 @@ CHANNEL_ONTOLOGY_TYPE = ID(type="channel")
 
 class Channel(ChannelPayload):
     """A channel is a logical collection of samples emitted by or representing the
-    values of a single source. See https://docs.synnaxlabs.com/concepts/channels for an
-    introduction to channels and how they work.
+    values of a single source. See
+    https://docs.synnaxlabs.com/reference/concepts/channels for an introduction to
+    channels and how they work.
     """
 
     ___frame_client: FrameClient | None = PrivateAttr(None)
@@ -106,16 +107,14 @@ class Channel(ChannelPayload):
     def read(
         self,
         start_or_range: TimeRange,
-    ) -> Series:
-        ...
+    ) -> Series: ...
 
     @overload
     def read(
         self,
         start_or_range: CrudeTimeStamp,
         end: CrudeTimeStamp,
-    ) -> Series:
-        ...
+    ) -> Series: ...
 
     def read(
         self,
@@ -209,20 +208,17 @@ class ChannelClient:
         is_index: bool = False,
         leaseholder: int = 0,
         retrieve_if_name_exists: bool = False,
-    ) -> Channel:
-        ...
+    ) -> Channel: ...
 
     @overload
     def create(
         self, channels: Channel, *, retrieve_if_name_exists: bool = False
-    ) -> Channel:
-        ...
+    ) -> Channel: ...
 
     @overload
     def create(
         self, channels: list[Channel], *, retrieve_if_name_exists: bool = False
-    ) -> list[Channel]:
-        ...
+    ) -> list[Channel]: ...
 
     def create(
         self,
@@ -296,15 +292,13 @@ class ChannelClient:
         return created if isinstance(channels, list) else created[0]
 
     @overload
-    def retrieve(self, channel: ChannelKey | ChannelName) -> Channel:
-        ...
+    def retrieve(self, channel: ChannelKey | ChannelName) -> Channel: ...
 
     @overload
     def retrieve(
         self,
         channel: ChannelKeys | ChannelNames,
-    ) -> list[Channel]:
-        ...
+    ) -> list[Channel]: ...
 
     def retrieve(self, channel: ChannelParams) -> Channel | list[Channel]:
         """Retrieves a channel or set of channels from the cluster.

--- a/client/py/synnax/ranger/client.py
+++ b/client/py/synnax/ranger/client.py
@@ -255,8 +255,8 @@ Please call client.ranges.create(range) before attempting to read from a range."
 class Range(RangePayload):
     """A range is a user-defined region of a cluster's data. It's identified by a name,
     time range, and uniquely generated key. See
-    https://docs.synnaxlabs.com/concepts/read-ranges for an introduction to ranges and
-    how they work.
+    https://docs.synnaxlabs.com/reference/concepts/ranges for an introduction to ranges
+    and how they work.
     """
 
     __frame_client: Client | None = PrivateAttr(None)
@@ -378,12 +378,10 @@ class Range(RangePayload):
         return self._channels
 
     @overload
-    def set_alias(self, channel: ChannelKey | ChannelName, alias: str):
-        ...
+    def set_alias(self, channel: ChannelKey | ChannelName, alias: str): ...
 
     @overload
-    def set_alias(self, channel: dict[ChannelKey | ChannelName, str]):
-        ...
+    def set_alias(self, channel: dict[ChannelKey | ChannelName, str]): ...
 
     def set_alias(
         self,
@@ -409,20 +407,19 @@ class Range(RangePayload):
         return RangePayload(name=self.name, time_range=self.time_range, key=self.key)
 
     @overload
-    def write(self, to: ChannelKey | ChannelName | ChannelPayload, data: CrudeSeries):
-        ...
+    def write(
+        self, to: ChannelKey | ChannelName | ChannelPayload, data: CrudeSeries
+    ): ...
 
     @overload
     def write(
         self,
         to: ChannelKeys | ChannelNames | list[ChannelPayload],
         series: list[CrudeSeries],
-    ):
-        ...
+    ): ...
 
     @overload
-    def write(self, frame: CrudeFrame):
-        ...
+    def write(self, frame: CrudeFrame): ...
 
     def write(
         self,
@@ -596,20 +593,16 @@ class RangeClient:
         return res if not is_single else res[0]
 
     @overload
-    def retrieve(self, *, key: RangeKey) -> Range:
-        ...
+    def retrieve(self, *, key: RangeKey) -> Range: ...
 
     @overload
-    def retrieve(self, *, name: RangeName) -> Range:
-        ...
+    def retrieve(self, *, name: RangeName) -> Range: ...
 
     @overload
-    def retrieve(self, *, names: RangeNames) -> list[Range]:
-        ...
+    def retrieve(self, *, names: RangeNames) -> list[Range]: ...
 
     @overload
-    def retrieve(self, *, keys: RangeKeys) -> list[Range]:
-        ...
+    def retrieve(self, *, keys: RangeKeys) -> list[Range]: ...
 
     def retrieve(
         self,

--- a/client/ts/CONTRIBUTING.md
+++ b/client/ts/CONTRIBUTING.md
@@ -18,27 +18,27 @@ pnpm build:freighter
 To make sure the client builds properly, run the following command in the `client/ts`
 directory:
 
-```shell
+```bash
 pnpm build
 ```
 
 Synnax's TypeScript client unit tests are written with [Vitest](https://vitest.dev/). To
 test the framework, run the following command in the `client/ts` directory:
 
-```shell
+```bash
 pnpm test
 ```
 
 To check code for linting errors, please run the following command in the `client/ts` directory:
 
-```shell
+```bash
 pnpm lint
 ```
 
 If you create changes to the API for the client, generate a new API document by running
 the following command in the `client/ts` directory:
 
-```shell
+```bash
 pnpm genApi
 ```
 

--- a/client/ts/CONTRIBUTING.md
+++ b/client/ts/CONTRIBUTING.md
@@ -43,5 +43,5 @@ pnpm genApi
 ```
 
 Finally, if changes to the code warrant changing the documentation website, please edit
-the correct pages on our [TypeScript Documentation
-pages](../../docs/site/src/pages/reference/typescript-client/)
+the pages on the [TypeScript
+client](../../docs/site/src/pages/reference/typescript-client/)

--- a/client/ts/CONTRIBUTING.md
+++ b/client/ts/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing to the TypeScript Client Library
+
+First, please read our [contribution guidelines](../../docs/CONTRIBUTING.md) and the
+TypeScript [build document](../../docs/tech/typescript/build.md) for information on
+developing in the Synnax repository with TypeScript.
+
+## Setup
+
+To properly build upstream packages for developing the client, run the following
+command in the root of the monorepo:
+
+```shell
+pnpm build:freighter
+```
+
+## Build
+
+To make sure the client builds properly, run the following command in the `client/ts`
+directory:
+
+```shell
+pnpm build
+```
+
+Synnax's TypeScript client unit tests are written with [Vitest](https://vitest.dev/). To
+test the framework, run the following command in the `client/ts` directory:
+
+```shell
+pnpm test
+```
+
+To check code for linting errors, please run the following command in the `client/ts` directory:
+
+```shell
+pnpm lint
+```
+
+If you create changes to the API for the client, generate a new API document by running
+the following command in the `client/ts` directory:
+
+```shell
+pnpm genApi
+```
+
+Finally, if changes to the code warrant changing the documentation website, please edit
+the correct pages on our [TypeScript Documentation
+pages](../../docs/site/src/pages/reference/typescript-client/)

--- a/client/ts/README.md
+++ b/client/ts/README.md
@@ -1,9 +1,14 @@
+<a href="https://synnaxlabs.com/" style="display: block; text-align: center;">
+    <img src="../../x/media/static/logo/icon-white-on-black.png" width="20%"/>
+</a>
+
 # Synnax TypeScript Client Library
 
-The Synnax TypeScript client is a client library for interacting with a Synnax cluster.
-The client library can be used in both node and browser environments. The [Synnax documentation
-website](https://docs.synnaxlabs.com/typescript-client/get-started) contains more
-information about using the client.
+The Synnax TypeScript client library is used for interacting with a Synnax cluster. The
+client library can be used in both node and browser environments. The [Synnax
+documentation
+website](https://docs.synnaxlabs.com/reference/typescript-client/get-started) contains
+more information about using the TypeScript client.
 
 ## Installation
 
@@ -11,41 +16,21 @@ If you want to install the client library, please install it via a package manag
 as npm or yarn:
 
 ```shell
-npm install @synnaxlabs/client
+npm i @synnaxlabs/client
 ```
 
 ## Examples
 
 Examples of usage of the TypeScript client can be found in our [examples
-folder](./examples/node/)
+folder](examples/node).
 
 ## Development
 
-First, please read our [contribution guidelines](../../docs/CONTRIBUTING.md) and the
-TypeScript [build document](../../docs/tech/typescript/build.md) for information on
-developing in the Synnax repository with TypeScript.
+If you are interested in contributing, please read both the
+[Synnax](../../docs/CONTRIBUTING.md) and [TypeScript client](CONTRIBUTING.md)
+contribution guides.
 
-To properly build upstream packages for developing the client, run the following
-command:
+## Bugs
 
-```shell
-pnpm build:freighter
-```
-
-Synnax's TypeScript client unit tests are written in [Vitest](https://vitest.dev/). To
-test the framework, run the following command:
-
-```shell
-pnpm test
-```
-
-If you create changes to the API for the client, generate a new API document by running
-the following command:
-
-```shell
-pnpm genApi
-```
-
-Finally, if changes to the code warrant changing the documentation website, please edit
-the correct pages on our [TypeScript Documentation
-pages](../../docs/site/src/pages/reference/typescript-client/)
+If you run into any bugs, open an issue on our [GitHub
+repository](https://github.com/synnaxlabs/synnax/issues).

--- a/client/ts/README.md
+++ b/client/ts/README.md
@@ -15,7 +15,7 @@ more information about using the TypeScript client.
 If you want to install the client library, please install it via a package manager such
 as npm or yarn:
 
-```shell
+```bash
 npm i @synnaxlabs/client
 ```
 

--- a/client/ts/README.md
+++ b/client/ts/README.md
@@ -16,7 +16,7 @@ If you want to install the client library, please install it via a package manag
 as npm or yarn:
 
 ```bash
-npm i @synnaxlabs/client
+npm install @synnaxlabs/client
 ```
 
 ## Examples

--- a/client/ts/package.json
+++ b/client/ts/package.json
@@ -1,10 +1,7 @@
 {
   "name": "@synnaxlabs/client",
-  "private": false,
   "version": "0.28.0",
-  "type": "module",
-  "description": "The Client Library for Synnax",
-  "repository": "https://github.com/synnaxlabs/synnax/tree/main/client/ts",
+  "description": "The Synnax Client Library",
   "keywords": [
     "synnax",
     "grpc",
@@ -15,6 +12,17 @@
     "telemetry",
     "control systems"
   ],
+  "homepage": "https://github.com/synnaxlabs/synnax/tree/main/client/ts",
+  "bugs": {
+    "url": "https://github.com/synnaxlabs/synnax/issues"
+  },
+  "license": "BUSL-1.1",
+  "main": "dist/client.cjs",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/synnaxlabs/synnax.git",
+    "directory": "client/ts"
+  },
   "scripts": {
     "build": "tsc --noEmit && vite build",
     "watch": "tsc --noEmit && vite build --watch",
@@ -45,7 +53,7 @@
   "peerDependencies": {
     "zod": "^3.23.8"
   },
-  "main": "dist/client.cjs",
-  "module": "dist/client.js",
-  "types": "dist/index.d.ts"
+  "type": "module",
+  "types": "dist/index.d.ts",
+  "module": "dist/client.js"
 }

--- a/client/ts/src/channel/client.ts
+++ b/client/ts/src/channel/client.ts
@@ -53,7 +53,8 @@ interface CreateOptions {
  * instantiated directly, but instead created via the `.channels.create` or retrieved
  * via the `.channels.retrieve` method on a Synnax client.
  *
- * Please refer to the [Synnax documentation](https://docs.synnaxlabs.com) for detailed
+ * Please refer to the [Synnax
+ * documentation](https://docs.synnaxlabs.com/reference/concepts/channels) for detailed
  * information on what channels are and how to use them.
  */
 export class Channel {
@@ -228,13 +229,14 @@ export class Client implements AsyncTermSearcher<string, Key, Channel> {
    * @param rate - The rate of the channel. This only applies to fixed rate channels.
    * @param dataType - The data type for the samples stored in the channel.
    * @param index - The key of the index channel that this channel should be associated
-   * with. An 'index' channel is a channel that stores timestamps for other channels. Refer
-   * to the Synnax documentation (https://docs.synnaxlabs.com) for more information. The
-   * index channel must have already been created. This field does not need to be specified
-   * if the channel is an index channel, or the channel is a fixed rate channel. If this
-   * value is specified, the 'rate' parameter will be ignored.
-   * @param isIndex - Set to true if the channel is an index channel, and false otherwise.
-   * Index channels must have a data type of `DataType.TIMESTAMP`.
+   * with. An 'index' channel is a channel that stores timestamps for other channels.
+   * Refer to the Synnax documentation
+   * (https://docs.synnaxlabs.com/reference/concepts/channels) for more information. The
+   * index channel must have already been created. This field does not need to be
+   * specified if the channel is an index channel, or the channel is a fixed rate
+   * channel. If this value is specified, the 'rate' parameter will be ignored.
+   * @param isIndex - Set to true if the channel is an index channel, and false
+   * otherwise. Index channels must have a data type of `DataType.TIMESTAMP`.
    * @returns the created channel. {@see Channel}
    * @throws {ValidationError} if any of the parameters for creating the channel are
    * invalid.

--- a/console/README.md
+++ b/console/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-<a href="https://docs.synnaxlabs.com/visualize/get-started">
+<a href="https://docs.synnaxlabs.com/reference/console/get-started">
 <img src="../x/media/static/logo/icon-white-on-black.png" width="20%"/>
 </a>
 </p>
@@ -10,8 +10,13 @@ The Synnax visualization, control, and cluster operations UI.
 
 ## Installation
 
-The latest stable release for Console can be found in the [synnax documentation](https://docs.synnaxlabs.com/visualize/get-started). To find the latest development version, see the [synnax github releases page](https://github.com/synnaxlabs/synnax/releases).
+The latest stable release for the Synnax Console can be found on the Synnax
+[documentation website](https://docs.synnaxlabs.com/reference/console/get-started). To
+find the latest development version, see the [releases
+page](https://github.com/synnaxlabs/synnax/releases) on the Synnax GitHub repository.
 
 ## Contributing
 
-Read both the [Synnax Contribution Guide](../docs/CONTRIBUTING.md) and the [Console Contribution Guide](./CONTRIBUTING.md) to learn about the codebase and our process for working with it.
+Read both the [Synnax Contribution Guide](../docs/CONTRIBUTING.md) and the [Console
+Contribution Guide](./CONTRIBUTING.md) to learn about the codebase and our process for
+working with it.

--- a/docs/tech/README.md
+++ b/docs/tech/README.md
@@ -27,8 +27,8 @@ The purpose of this document, and the entire `docs/tech` directory, is to:
 
 The first step to working with the Synnax platform is to understand the high level
 components that make up the system. The best way to do this is to read the
-[concepts](https://docs.synnaxlabs.com/concepts/overview?) section of the official
-documentation.
+[concepts](https://docs.synnaxlabs.com/reference/concepts/overview) section of the
+official documentation.
 
 As a supplement, read through the [telemetry concepts](telemetry.md) document. This
 provides a detailed guide on what telemetry is, and how Synnax leverages the properties
@@ -56,5 +56,5 @@ you need to be familiar with when working on a specific area of the codebase.
 # 6 - Language Specific Guides
 
 We also have language specific guides for developing in [python](./python/python.md) and
-[typescript](./typescript/typescript.md). These includes information on the correct 
+[typescript](./typescript/typescript.md). These includes information on the correct
 processes for working on the codebase in that language.

--- a/freighter/README.md
+++ b/freighter/README.md
@@ -11,11 +11,9 @@ Freighter defines a protocol agnostic transport interface that allows libraries
 in a variety of languages to communicate without needing to know protocol, routing,
 or encoding details.
 
-It's interface is similar to [gRPC](https://grpc.io/), but it can be implemented
-by HTTP, WebSockets, WebRTC, UDP, TCP, etc. For more information on its design,
-see the [Freighter RFC](https://docs.synnaxlabs.com/rfc/6-220809-freighter).
+It's interface is similar to [gRPC](https://grpc.io/), but it can be implemented by
+HTTP, WebSockets, WebRTC, UDP, TCP, etc. For more information on its design, see the
+[Freighter RFC](/docs/tech/rfc/0006-220809-freighter.md).
 
 The implementations for specific languages are contained in subdirectories of
 this directory.
-
-

--- a/synnax/README.md
+++ b/synnax/README.md
@@ -6,16 +6,17 @@
 
 # Synnax
 
-Synnax Server (also known as "Synnax", "Server", "Engine") is the core of the Synnax
-platform. For an introduction to Synnax server, see the [architecture](../docs/tech/architecture.md)
-document.
+The Synnax server is the core of the Synnax platform. For an introduction to the Synnax
+server, see the [architecture](../docs/tech/architecture.md) document.
 
 ## Getting Started
 
-To start a Synnax cluster, visit the [deployment](https://docs.synnaxlabs.com/deploy/get-started?)
-section of the Synnax documentation.
+To start a Synnax cluster, visit the
+[deployment](https://docs.synnaxlabs.com/reference/cluster/quick-start) section of the
+Synnax documentation.
 
 ## Contributing
 
-Read both the [Synnax Contribution Guide](../docs/CONTRIBUTING.md) and the
-[Synnax Server Contribution Guide](./CONTRIBUTING.md) to learn about the codebase and our
+Read both the [Synnax Contribution Guide](../docs/CONTRIBUTING.md) and the [server
+Contribution Guide](CONTRIBUTING.md) to learn about the codebase and our development
+practices.


### PR DESCRIPTION
1. Updated links to the documentation website in the repository ([SY-577](https://linear.app/synnax/issue/SY-577/fix-in-code-documentation-links)).

2. Updated TypeScript Client `package.json`, `README.md`, and made a separate `CONTRIBUTING.md` file ([SY-883](https://linear.app/synnax/issue/SY-883/fix-typescript-client-readme)).