### PR TITLE
SY-1098 Add Ability to Resize Most Schematic Symbols

### DIFF
--- a/docs/site/src/pages/reference/console/schematics.mdx
+++ b/docs/site/src/pages/reference/console/schematics.mdx
@@ -4,6 +4,7 @@ title: "Schematics"
 heading: "Schematics"
 description: "Control hardware using schematics."
 ---
+
 import { Icon } from "@synnaxlabs/media";
 import { Divider } from "@synnaxlabs/pluto";
 import { Image, Video } from "@/components/Media";
@@ -13,7 +14,7 @@ A schematic is used to see a diagram of your physical or simulated system. It di
 live sensor data and can be used to exercise manual control by changing the values of
 channels tied to actuators. We've added a simple example of a schematic below:
 
-<Image client:only="react" id="console/schematics/example"  />
+<Image client:only="react" id="console/schematics/example" />
 
 <Divider.Divider direction="x" />
 
@@ -40,15 +41,22 @@ the controls in the bottom-left hand corner of the schematic.
   </thead>
   <tbody>
     <tr>
-      <td><b>Edit</b></td>
+      <td>
+        <b>Edit</b>
+      </td>
       <td>Symbols can be added and moved, and their properties can be edited.</td>
     </tr>
     <tr>
-      <td><b>View</b></td>
-      <td>Live data from the cluster is displayed on the schematic. Symbols are not editable and the user cannot change the system state.</td>
+      <td>
+        <b>View</b>
+      </td>
+      <td>Live data from the cluster is displayed on the schematic. Symbols are not
+        editable and the user cannot change the system state.</td>
     </tr>
     <tr>
-      <td><b>Control</b></td>
+      <td>
+        <b>Control</b>
+      </td>
       <td>The user can click on symbols such as valves and buttons to control them.</td>
     </tr>
   </tbody>
@@ -87,36 +95,60 @@ other visual properties.
   </thead>
   <tbody>
     <tr>
-      <td><b>Label</b></td>
+      <td>
+        <b>Label</b>
+      </td>
       <td>The text that appears by the symbol.</td>
     </tr>
     <tr>
-      <td><b>Label Size</b></td>
+      <td>
+        <b>Label Size</b>
+      </td>
       <td>The size of the label.</td>
     </tr>
     <tr>
-      <td><b>Color</b></td>
+      <td>
+        <b>Color</b>
+      </td>
       <td>The color of the symbol.</td>
     </tr>
     <tr>
-      <td><b>Normally Open</b></td>
-      <td>Causes the body of the solenoid valve to look different when it is open or closed.</td>
+      <td>
+        <b>Normally Open</b>
+      </td>
+      <td>Causes the body of the solenoid valve to look different when it is open or
+        closed.</td>
     </tr>
     <tr>
-      <td><b>Width</b></td>
+      <td>
+        <b>Width</b>
+      </td>
       <td>Changes the size of a tank.</td>
     </tr>
     <tr>
-      <td><b>Height</b></td>
+      <td>
+        <b>Height</b>
+      </td>
       <td>Changes the size of a tank.</td>
     </tr>
     <tr>
-      <td><b>Units</b></td>
+      <td>
+        <b>Scale</b>
+      </td>
+      <td>Changes the size of an element.</td>
+    </tr>
+    <tr>
+      <td>
+        <b>Units</b>
+      </td>
       <td>Determines what units a value symbol is displaying.</td>
     </tr>
     <tr>
-      <td><b>Orientation</b></td>
-      <td>Determines the orientation of the symbol and the relative placement of the label.</td>
+      <td>
+        <b>Orientation</b>
+      </td>
+      <td>Determines the orientation of the symbol and the relative placement of the
+        label.</td>
     </tr>
   </tbody>
 </Table>
@@ -138,17 +170,23 @@ The telemetry tab can have the following properties:
   </thead>
   <tbody>
     <tr>
-      <td><b>Input Channel</b></td>
+      <td>
+        <b>Input Channel</b>
+      </td>
       <td>The channel to stream data from.</td>
     </tr>
     <tr>
-      <td><b>Precision</b></td>
+      <td>
+        <b>Precision</b>
+      </td>
       <td>The number of decimal places to display.</td>
     </tr>
     <tr>
-      <td><b>Averaging Window</b></td>
-      <td>Can be used to display a rolling average. For example, a value of 2 will cause 
-      the screen to display the average of the last 2 samples.</td>
+      <td>
+        <b>Averaging Window</b>
+      </td>
+      <td>Can be used to display a rolling average. For example, a value of 2 will cause
+        the screen to display the average of the last 2 samples.</td>
     </tr>
   </tbody>
 </Table>
@@ -169,16 +207,20 @@ two main properties:
   </thead>
   <tbody>
     <tr>
-      <td><b>State Channel</b></td>
-      <td>Represents the display state of the symbol. If the input channel has
-a value of 1, the symbol will be display as activated.</td>
+      <td>
+        <b>State Channel</b>
+      </td>
+      <td>Represents the display state of the symbol. If the input channel has a value
+        of 1, the symbol will be display as activated.</td>
     </tr>
     <tr>
-      <td><b>Command Channel</b></td>
+      <td>
+        <b>Command Channel</b>
+      </td>
       <td>Will be written to when you click on the symbol. If the symbol is
-de-activated, clicking on it will write 1 to the output channel (an activation command).
-If the symbol is activated, clicking on it will write 0 to the output channel (a
-deactivation command)</td>
+        de-activated, clicking on it will write 1 to the output channel (an activation
+        command). If the symbol is activated, clicking on it will write 0 to the output
+        channel (a deactivation command).</td>
     </tr>
   </tbody>
 </Table>

--- a/pluto/src/input/DragButton.tsx
+++ b/pluto/src/input/DragButton.tsx
@@ -10,7 +10,7 @@
 import "@/input/DragButton.css";
 
 import { Icon } from "@synnaxlabs/media";
-import { box,type direction, xy } from "@synnaxlabs/x";
+import { box, type direction, xy } from "@synnaxlabs/x";
 import { type ReactElement, useCallback, useMemo, useRef } from "react";
 
 import { Button } from "@/button";

--- a/pluto/src/pluto/aether/pluto.ts
+++ b/pluto/src/pluto/aether/pluto.ts
@@ -20,6 +20,7 @@ import { button } from "@/vis/button/aether";
 import { canvas } from "@/vis/canvas/aether";
 import { diagram } from "@/vis/diagram/aether";
 import { eraser } from "@/vis/eraser/aether";
+import { light } from "@/vis/light/aether";
 import { line } from "@/vis/line/aether";
 import { lineplot } from "@/vis/lineplot/aether";
 import { range } from "@/vis/lineplot/range/aether";
@@ -42,6 +43,7 @@ export const render = (): void => {
     ...control.REGISTRY,
     ...diagram.REGISTRY,
     ...eraser.REGISTRY,
+    ...light.REGISTRY,
     ...line.REGISTRY,
     ...lineplot.REGISTRY,
     ...measure.REGISTRY,

--- a/pluto/src/vis/light/aether/index.ts
+++ b/pluto/src/vis/light/aether/index.ts
@@ -1,0 +1,10 @@
+// Copyright 2024 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+export * as light from "@/vis/light/aether/light";

--- a/pluto/src/vis/light/aether/light.ts
+++ b/pluto/src/vis/light/aether/light.ts
@@ -1,0 +1,83 @@
+// Copyright 2024 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { type Destructor } from "@synnaxlabs/x";
+import { z } from "zod";
+
+import { aether } from "@/aether/aether";
+import { status } from "@/status/aether";
+import { telem } from "@/telem/aether";
+import { type diagram } from "@/vis/diagram/aether";
+
+export const lightStateZ = z.object({
+  enabled: z.boolean(),
+  source: telem.booleanSourceSpecZ.optional().default(telem.noopBooleanSourceSpec),
+});
+
+export type LightState = z.input<typeof lightStateZ>;
+
+interface InternalState {
+  source: telem.BooleanSource;
+  addStatus: status.Aggregate;
+  stopListening: Destructor;
+}
+
+// Light is a component that listens to a boolean telemetry source to update its state.
+export class Light
+  extends aether.Leaf<typeof lightStateZ, InternalState>
+  implements diagram.Element
+{
+  static readonly TYPE = "Light";
+
+  schema = lightStateZ;
+
+  async afterUpdate(): Promise<void> {
+    this.internal.addStatus = status.useOptionalAggregate(this.ctx);
+    const { source: sourceProps } = this.state;
+    const { internal: i } = this;
+    this.internal.source = await telem.useSource(
+      this.ctx,
+      sourceProps,
+      this.internal.source,
+    );
+
+    await this.updateEnabledState();
+    i.stopListening?.();
+    i.stopListening = i.source.onChange(() =>
+      this.updateEnabledState().catch(this.reportError.bind(this)),
+    );
+  }
+
+  private reportError(e: Error): void {
+    this.internal.addStatus({
+      key: this.key,
+      variant: "error",
+      message: `Failed to update Light: ${e.message}`,
+    });
+  }
+
+  private async updateEnabledState(): Promise<void> {
+    const nextEnabled = await this.internal.source.value();
+    if (nextEnabled !== this.state.enabled)
+      this.setState((p) => ({ ...p, enabled: nextEnabled }));
+  }
+
+  async afterDelete(): Promise<void> {
+    await this.internalAfterDelete();
+  }
+
+  private async internalAfterDelete(): Promise<void> {
+    this.internal.stopListening();
+    await this.internal.source.cleanup?.();
+  }
+
+  async render(): Promise<void> {}
+}
+
+export const REGISTRY: aether.ComponentRegistry = { [Light.TYPE]: Light };

--- a/pluto/src/vis/light/index.ts
+++ b/pluto/src/vis/light/index.ts
@@ -1,0 +1,10 @@
+// Copyright 2024 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+export * as Light from "@/vis/light/use";

--- a/pluto/src/vis/light/use.ts
+++ b/pluto/src/vis/light/use.ts
@@ -1,0 +1,43 @@
+// Copyright 2024 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { useEffect } from "react";
+import { type z } from "zod";
+
+import { Aether } from "@/aether";
+import { useMemoDeepEqualProps } from "@/memo";
+import { light } from "@/vis/light/aether";
+
+export interface UseProps extends Pick<z.input<typeof light.lightStateZ>, "source"> {
+  aetherKey: string;
+}
+
+export interface UseReturn
+  extends Pick<z.output<typeof light.lightStateZ>, "enabled"> {}
+
+export const use = ({ aetherKey, source }: UseProps): UseReturn => {
+  const memoProps = useMemoDeepEqualProps({ source });
+  const [, { enabled }, setState] = Aether.use({
+    aetherKey,
+    type: light.Light.TYPE,
+    schema: light.lightStateZ,
+    initialState: {
+      enabled: false,
+      ...memoProps,
+    },
+  });
+  console.log("use.ts: enabled", enabled);
+
+  useEffect(
+    () => setState((state) => ({ ...state, ...memoProps })),
+    [memoProps, setState],
+  );
+
+  return { enabled };
+};

--- a/pluto/src/vis/schematic/Forms.tsx
+++ b/pluto/src/vis/schematic/Forms.tsx
@@ -472,9 +472,7 @@ export const ValueForm = (): ReactElement => {
 interface LightTelemFormT extends Omit<Toggle.UseProps, "aetherKey"> {}
 
 const LightTelemForm = ({ path }: { path: string }): ReactElement => {
-  const { value, onChange } = Form.useField<LightTelemFormT>({
-    path,
-  });
+  const { value, onChange } = Form.useField<LightTelemFormT>({ path });
   const sourceP = telem.sourcePipelinePropsZ.parse(value.source?.props);
   const source = telem.streamChannelValuePropsZ.parse(
     sourceP.segments.valueStream.props,
@@ -500,9 +498,7 @@ const LightTelemForm = ({ path }: { path: string }): ReactElement => {
 
   const c = Channel.useName(source.channel as number);
 
-  useEffect(() => {
-    onChange({ ...value });
-  }, [c]);
+  useEffect(() => onChange({ ...value }), [c]);
 
   return (
     <FormWrapper direction="x" align="stretch">

--- a/pluto/src/vis/schematic/Forms.tsx
+++ b/pluto/src/vis/schematic/Forms.tsx
@@ -114,7 +114,7 @@ export const CommonStyleForm = (): ReactElement => (
     <Align.Space direction="y" grow>
       <LabelControls path="label" />
       <Align.Space direction="x" grow>
-        <ColorControl path="color" hideIfNull optional />
+        <ColorControl path="color" optional />
         <Form.Field<boolean>
           path="normallyOpen"
           label="Normally Open"
@@ -124,7 +124,7 @@ export const CommonStyleForm = (): ReactElement => (
         >
           {(p) => <Input.Switch {...p} />}
         </Form.Field>
-        <ScaleControl path="scale" hideIfNull optional />
+        <ScaleControl path="scale" />
       </Align.Space>
     </Align.Space>
     <OrientationControl path="" />

--- a/pluto/src/vis/schematic/Forms.tsx
+++ b/pluto/src/vis/schematic/Forms.tsx
@@ -32,17 +32,6 @@ import { type Toggle } from "@/vis/toggle";
 
 export interface SymbolFormProps {}
 
-const COMMON_TOGGLE_FORM_TABS: Tabs.Tab[] = [
-  {
-    tabKey: "style",
-    name: "Style",
-  },
-  {
-    tabKey: "control",
-    name: "Control",
-  },
-];
-
 interface FormWrapperProps extends Align.SpaceProps {}
 
 const FormWrapper: FC<FormWrapperProps> = ({
@@ -114,7 +103,35 @@ const ColorControl: Form.FieldT<Color.Crude> = (props): ReactElement => (
   </Form.Field>
 );
 
-export const ToggleControlForm = ({ path }: { path: string }): ReactElement => {
+const ScaleControl: Form.FieldT<number> = (props): ReactElement => (
+  <Form.Field hideIfNull label="Scale" align="start" padHelpText={false} {...props}>
+    {(p) => <Input.Numeric dragScale={1} bounds={{ lower: 0.5, upper: 10 }} {...p} />}
+  </Form.Field>
+);
+
+export const CommonStyleForm = (): ReactElement => (
+  <FormWrapper direction="x" align="stretch">
+    <Align.Space direction="y" grow>
+      <LabelControls path="label" />
+      <Align.Space direction="x" grow>
+        <ColorControl path="color" hideIfNull optional />
+        <Form.Field<boolean>
+          path="normallyOpen"
+          label="Normally Open"
+          padHelpText={false}
+          hideIfNull
+          optional
+        >
+          {(p) => <Input.Switch {...p} />}
+        </Form.Field>
+        <ScaleControl path="scale" hideIfNull optional />
+      </Align.Space>
+    </Align.Space>
+    <OrientationControl path="" />
+  </FormWrapper>
+);
+
+const ToggleControlForm = ({ path }: { path: string }): ReactElement => {
   const { value, onChange } = Form.useField<
     Omit<Toggle.UseProps, "aetherKey"> & { control: ControlStateProps }
   >({ path });
@@ -202,70 +219,30 @@ export const ToggleControlForm = ({ path }: { path: string }): ReactElement => {
   );
 };
 
+const COMMON_TOGGLE_FORM_TABS: Tabs.Tab[] = [
+  {
+    tabKey: "style",
+    name: "Style",
+  },
+  {
+    tabKey: "control",
+    name: "Control",
+  },
+];
+
 export const CommonToggleForm = (): ReactElement => {
   const content: Tabs.RenderProp = useCallback(({ tabKey }) => {
     switch (tabKey) {
       case "control":
         return <ToggleControlForm path="" />;
-      default: {
-        return (
-          <FormWrapper direction="x" align="stretch">
-            <Align.Space direction="y" grow>
-              <LabelControls path="label" />
-              <ColorControl path="color" hideIfNull optional />
-            </Align.Space>
-            <OrientationControl path="" />
-          </FormWrapper>
-        );
-      }
+      default:
+        return <CommonStyleForm />;
     }
   }, []);
 
   const props = Tabs.useStatic({ tabs: COMMON_TOGGLE_FORM_TABS, content });
   return <Tabs.Tabs {...props} />;
 };
-
-export const SolenoidValveForm = (): ReactElement => {
-  const content: Tabs.RenderProp = useCallback(({ tabKey }) => {
-    switch (tabKey) {
-      case "control":
-        return <ToggleControlForm path="" />;
-      default: {
-        return (
-          <FormWrapper direction="x" align="stretch">
-            <Align.Space direction="y" grow>
-              <LabelControls path="label" />
-              <Align.Space direction="x">
-                <ColorControl path="color" />
-                <Form.Field<boolean>
-                  path="normallyOpen"
-                  label="Normally Open"
-                  padHelpText={false}
-                >
-                  {(p) => <Input.Switch {...p} />}
-                </Form.Field>
-              </Align.Space>
-            </Align.Space>
-            <OrientationControl path="" />
-          </FormWrapper>
-        );
-      }
-    }
-  }, []);
-
-  const props = Tabs.useStatic({ tabs: COMMON_TOGGLE_FORM_TABS, content });
-  return <Tabs.Tabs {...props} />;
-};
-
-export const CommonNonToggleForm = (): ReactElement => (
-  <FormWrapper direction="x">
-    <Align.Space direction="y" grow>
-      <LabelControls path="label" />
-      <ColorControl path="color" />
-    </Align.Space>
-    <OrientationControl path="" />
-  </FormWrapper>
-);
 
 const DIMENSIONS_DRAG_SCALE: xy.Crude = { y: 2, x: 0.25 };
 const DIMENSIONS_BOUNDS: bounds.Bounds = { lower: 0, upper: 2000 };
@@ -466,7 +443,7 @@ export const ValueForm = (): ReactElement => {
     switch (tabKey) {
       case "telemetry":
         return <ValueTelemForm path="" />;
-      default: {
+      default:
         return (
           <FormWrapper direction="x">
             <Align.Space direction="y" grow>
@@ -486,7 +463,6 @@ export const ValueForm = (): ReactElement => {
             <OrientationControl path="" />
           </FormWrapper>
         );
-      }
     }
   }, []);
   const props = Tabs.useStatic({ tabs: VALUE_FORM_TABS, content });
@@ -545,19 +521,8 @@ export const LightForm = (): ReactElement => {
     switch (tabKey) {
       case "telemetry":
         return <LightTelemForm path="" />;
-      default: {
-        return (
-          <FormWrapper direction="x">
-            <Align.Space direction="y" grow>
-              <LabelControls path="label" />
-              <Align.Space direction="x">
-                <ColorControl path="color" />
-              </Align.Space>
-            </Align.Space>
-            <OrientationControl path="" />
-          </FormWrapper>
-        );
-      }
+      default:
+        return <CommonStyleForm />;
     }
   }, []);
   const props = Tabs.useStatic({ tabs: VALUE_FORM_TABS, content });
@@ -632,17 +597,7 @@ export const ButtonForm = (): ReactElement => {
       case "control":
         return <ButtonTelemForm path="" />;
       default:
-        return (
-          <FormWrapper direction="x" align="stretch">
-            <Align.Space direction="y" grow>
-              <LabelControls path="label" />
-              <Align.Space direction="x">
-                <ColorControl path="color" />
-              </Align.Space>
-            </Align.Space>
-            <OrientationControl path="" />
-          </FormWrapper>
-        );
+        return <CommonStyleForm />;
     }
   }, []);
 

--- a/pluto/src/vis/schematic/Symbols.tsx
+++ b/pluto/src/vis/schematic/Symbols.tsx
@@ -42,7 +42,7 @@ const swapXLocation = (l: location.Outer): location.Outer =>
 const swapYLocation = (l: location.Outer): location.Outer =>
   direction.construct(l) === "y" ? (location.swap(l) as location.Outer) : l;
 
-export const ControlState = ({
+const ControlState = ({
   showChip = true,
   showIndicator = true,
   indicator,
@@ -95,7 +95,7 @@ export const ThreeWayValve = Aether.wrap<SymbolProps<ThreeWayValveProps>>(
     source,
     sink,
     orientation = "left",
-    color,
+    ...rest
   }): ReactElement => {
     const { enabled, triggered, toggle } = Toggle.use({
       aetherKey,
@@ -110,7 +110,7 @@ export const ThreeWayValve = Aether.wrap<SymbolProps<ThreeWayValveProps>>(
             triggered={triggered}
             onClick={toggle}
             orientation={orientation}
-            color={color}
+            {...rest}
           />
         </ControlState>
       </Labeled>
@@ -139,7 +139,7 @@ export const Valve = Aether.wrap<SymbolProps<ValveProps>>(
     source,
     sink,
     orientation,
-    color,
+    ...rest
   }): ReactElement => {
     const { enabled, triggered, toggle } = Toggle.use({ aetherKey, source, sink });
     return (
@@ -150,7 +150,7 @@ export const Valve = Aether.wrap<SymbolProps<ValveProps>>(
             triggered={triggered}
             onClick={toggle}
             orientation={orientation}
-            color={color}
+            {...rest}
           />
         </ControlState>
       </Labeled>
@@ -177,10 +177,10 @@ export const SolenoidValve = Aether.wrap<SymbolProps<SolenoidValveProps>>(
     onChange,
     orientation = "left",
     normallyOpen,
-    color,
     source,
     sink,
     control,
+    ...rest
   }): ReactElement => {
     const { enabled, triggered, toggle } = Toggle.use({ aetherKey, source, sink });
     return (
@@ -191,8 +191,8 @@ export const SolenoidValve = Aether.wrap<SymbolProps<SolenoidValveProps>>(
             triggered={triggered}
             onClick={toggle}
             orientation={orientation}
-            color={color}
             normallyOpen={normallyOpen}
+            {...rest}
           />
         </ControlState>
       </Labeled>
@@ -219,9 +219,9 @@ export const FourWayValve = Aether.wrap<SymbolProps<FourWayValveProps>>(
     label,
     onChange,
     orientation,
-    color,
     source,
     sink,
+    ...rest
   }): ReactElement => {
     const { enabled, triggered, toggle } = Toggle.use({ aetherKey, source, sink });
     return (
@@ -232,7 +232,7 @@ export const FourWayValve = Aether.wrap<SymbolProps<FourWayValveProps>>(
             triggered={triggered}
             onClick={toggle}
             orientation={orientation}
-            color={color}
+            {...rest}
           />
         </ControlState>
       </Labeled>
@@ -259,9 +259,9 @@ export const AngledValve = Aether.wrap<SymbolProps<AngledValveProps>>(
     control,
     onChange,
     orientation = "left",
-    color,
     source,
     sink,
+    ...rest
   }): ReactElement => {
     const { enabled, triggered, toggle } = Toggle.use({ aetherKey, source, sink });
     return (
@@ -272,7 +272,7 @@ export const AngledValve = Aether.wrap<SymbolProps<AngledValveProps>>(
             triggered={triggered}
             onClick={toggle}
             orientation={orientation}
-            color={color}
+            {...rest}
           />
         </ControlState>
       </Labeled>
@@ -299,9 +299,9 @@ export const Pump = Aether.wrap<SymbolProps<PumpProps>>(
     control,
     onChange,
     orientation,
-    color,
     source,
     sink,
+    ...rest
   }): ReactElement => {
     const { enabled, triggered, toggle } = Toggle.use({ aetherKey, source, sink });
     return (
@@ -312,7 +312,7 @@ export const Pump = Aether.wrap<SymbolProps<PumpProps>>(
             triggered={triggered}
             onClick={toggle}
             orientation={orientation}
-            color={color}
+            {...rest}
           />
         </ControlState>
       </Labeled>
@@ -375,11 +375,10 @@ export interface ReliefValveProps extends Primitives.ReliefValveProps {
 export const ReliefValve = ({
   label,
   onChange,
-  orientation,
-  color,
+  ...rest
 }: SymbolProps<ReliefValveProps>): ReactElement => (
   <Labeled {...label} onChange={onChange}>
-    <Primitives.ReliefValve orientation={orientation} color={color} />
+    <Primitives.ReliefValve {...rest} />
   </Labeled>
 );
 
@@ -394,11 +393,10 @@ export interface RegulatorProps extends Primitives.RegulatorProps {
 export const Regulator = ({
   label,
   onChange,
-  orientation,
-  color,
+  ...rest
 }: SymbolProps<RegulatorProps>): ReactElement => (
   <Labeled {...label} onChange={onChange}>
-    <Primitives.Regulator orientation={orientation} color={color} />
+    <Primitives.Regulator {...rest} />
   </Labeled>
 );
 
@@ -413,11 +411,10 @@ export interface ElectricRegulatorProps extends Primitives.ElectricRegulatorProp
 export const ElectricRegulator = ({
   label,
   onChange,
-  orientation,
-  color,
+  ...rest
 }: SymbolProps<ElectricRegulatorProps>): ReactElement => (
   <Labeled {...label} onChange={onChange}>
-    <Primitives.ElectricRegulator orientation={orientation} color={color} />
+    <Primitives.ElectricRegulator {...rest} />
   </Labeled>
 );
 
@@ -432,11 +429,10 @@ export interface BurstDiscProps extends Primitives.BurstDiscProps {
 export const BurstDisc = ({
   label,
   onChange,
-  orientation,
-  color,
+  ...rest
 }: SymbolProps<BurstDiscProps>): ReactElement => (
   <Labeled {...label} onChange={onChange}>
-    <Primitives.BurstDisc orientation={orientation} color={color} />
+    <Primitives.BurstDisc {...rest} />
   </Labeled>
 );
 
@@ -451,11 +447,10 @@ export interface CapProps extends Primitives.CapProps {
 export const Cap = ({
   label,
   onChange,
-  orientation,
-  color,
+  ...rest
 }: SymbolProps<CapProps>): ReactElement => (
   <Labeled {...label} onChange={onChange}>
-    <Primitives.Cap orientation={orientation} color={color} />
+    <Primitives.Cap {...rest} />
   </Labeled>
 );
 
@@ -470,11 +465,10 @@ export interface ManualValveProps extends Primitives.ManualValveProps {
 export const ManualValve = ({
   label,
   onChange,
-  orientation,
-  color,
+  ...rest
 }: SymbolProps<ManualValveProps>): ReactElement => (
   <Labeled {...label} onChange={onChange}>
-    <Primitives.ManualValve orientation={orientation} color={color} />
+    <Primitives.ManualValve {...rest} />
   </Labeled>
 );
 
@@ -534,11 +528,10 @@ export interface FilterProps extends Primitives.FilterProps {
 export const Filter = ({
   label,
   onChange,
-  orientation,
-  color,
+  ...rest
 }: SymbolProps<FilterProps>): ReactElement => (
   <Labeled {...label} onChange={onChange}>
-    <Primitives.Filter orientation={orientation} color={color} />
+    <Primitives.Filter {...rest} />
   </Labeled>
 );
 
@@ -553,11 +546,10 @@ export interface NeedleValveProps extends Primitives.NeedleValveProps {
 export const NeedleValve = ({
   label,
   onChange,
-  orientation,
-  color,
+  ...rest
 }: SymbolProps<NeedleValveProps>): ReactElement => (
   <Labeled {...label} onChange={onChange}>
-    <Primitives.NeedleValve orientation={orientation} color={color} />
+    <Primitives.NeedleValve {...rest} />
   </Labeled>
 );
 
@@ -572,11 +564,10 @@ export interface CheckValveProps extends Primitives.CheckValveProps {
 export const CheckValve = ({
   label,
   onChange,
-  orientation,
-  color,
+  ...rest
 }: SymbolProps<CheckValveProps>): ReactElement => (
   <Labeled {...label} onChange={onChange}>
-    <Primitives.CheckValve orientation={orientation} color={color} />
+    <Primitives.CheckValve {...rest} />
   </Labeled>
 );
 
@@ -591,11 +582,10 @@ export interface OrificeProps extends Primitives.OrificeProps {
 export const Orifice = ({
   label,
   onChange,
-  orientation,
-  color,
+  ...rest
 }: SymbolProps<OrificeProps>): ReactElement => (
   <Labeled {...label} onChange={onChange}>
-    <Primitives.Orifice orientation={orientation} color={color} />
+    <Primitives.Orifice {...rest} />
   </Labeled>
 );
 
@@ -610,11 +600,10 @@ export interface AngledReliefValveProps extends Primitives.AngledReliefValveProp
 export const AngledReliefValve = ({
   label,
   onChange,
-  orientation,
-  color,
+  ...rest
 }: SymbolProps<AngledReliefValveProps>): ReactElement => (
   <Labeled {...label} onChange={onChange}>
-    <Primitives.AngledReliefValve orientation={orientation} color={color} />
+    <Primitives.AngledReliefValve {...rest} />
   </Labeled>
 );
 
@@ -795,9 +784,9 @@ export const Switch = Aether.wrap<SymbolProps<SwitchProps>>(
     control,
     onChange,
     orientation,
-    color,
     source,
     sink,
+    ...rest
   }): ReactElement => {
     const { enabled, triggered, toggle } = Toggle.use({ aetherKey, source, sink });
     return (
@@ -808,7 +797,7 @@ export const Switch = Aether.wrap<SymbolProps<SwitchProps>>(
             triggered={triggered}
             onClick={toggle}
             orientation={orientation}
-            color={color}
+            {...rest}
           />
         </ControlState>
       </Labeled>
@@ -829,16 +818,11 @@ export interface ButtonProps
 
 export const Button = Aether.wrap<SymbolProps<ButtonProps>>(
   "Button",
-  ({ aetherKey, label, orientation, sink, control, color }) => {
+  ({ aetherKey, label, orientation, sink, control, ...rest }) => {
     const { click } = CoreButton.use({ aetherKey, sink });
     return (
       <ControlState {...control} className={CSS.B("symbol")} orientation={orientation}>
-        <Primitives.Button
-          label={label?.label}
-          onClick={click}
-          color={color}
-          level={label?.level}
-        />
+        <Primitives.Button {...label} onClick={click} {...rest} />
       </ControlState>
     );
   },
@@ -863,9 +847,9 @@ export const ScrewPump = Aether.wrap<SymbolProps<ScrewPumpProps>>(
     control,
     onChange,
     orientation,
-    color,
     source,
     sink,
+    ...rest
   }): ReactElement => {
     const { enabled, triggered, toggle } = Toggle.use({ aetherKey, source, sink });
     return (
@@ -876,7 +860,7 @@ export const ScrewPump = Aether.wrap<SymbolProps<ScrewPumpProps>>(
             triggered={triggered}
             onClick={toggle}
             orientation={orientation}
-            color={color}
+            {...rest}
           />
         </ControlState>
       </Labeled>
@@ -903,9 +887,9 @@ export const VacuumPump = Aether.wrap<SymbolProps<VacuumPumpProps>>(
     control,
     onChange,
     orientation,
-    color,
     source,
     sink,
+    ...rest
   }): ReactElement => {
     const { enabled, triggered, toggle } = Toggle.use({ aetherKey, source, sink });
     return (
@@ -916,7 +900,7 @@ export const VacuumPump = Aether.wrap<SymbolProps<VacuumPumpProps>>(
             triggered={triggered}
             onClick={toggle}
             orientation={orientation}
-            color={color}
+            {...rest}
           />
         </ControlState>
       </Labeled>
@@ -943,9 +927,9 @@ export const CavityPump = Aether.wrap<SymbolProps<CavityPumpProps>>(
     control,
     onChange,
     orientation,
-    color,
     source,
     sink,
+    ...rest
   }): ReactElement => {
     const { enabled, triggered, toggle } = Toggle.use({ aetherKey, source, sink });
     return (
@@ -956,7 +940,7 @@ export const CavityPump = Aether.wrap<SymbolProps<CavityPumpProps>>(
             triggered={triggered}
             onClick={toggle}
             orientation={orientation}
-            color={color}
+            {...rest}
           />
         </ControlState>
       </Labeled>
@@ -983,9 +967,9 @@ export const PistonPump = Aether.wrap<SymbolProps<PistonPumpProps>>(
     control,
     onChange,
     orientation,
-    color,
     source,
     sink,
+    ...rest
   }): ReactElement => {
     const { enabled, triggered, toggle } = Toggle.use({ aetherKey, source, sink });
     return (
@@ -996,7 +980,7 @@ export const PistonPump = Aether.wrap<SymbolProps<PistonPumpProps>>(
             triggered={triggered}
             onClick={toggle}
             orientation={orientation}
-            color={color}
+            {...rest}
           />
         </ControlState>
       </Labeled>
@@ -1014,9 +998,9 @@ export interface StaticMixerProps extends Primitives.StaticMixerProps {
 
 export const StaticMixer = Aether.wrap<SymbolProps<StaticMixerProps>>(
   "statixMixer",
-  ({ label, onChange, orientation, color }): ReactElement => (
+  ({ label, onChange, ...rest }): ReactElement => (
     <Labeled {...label} onChange={onChange}>
-      <Primitives.StaticMixer orientation={orientation} color={color} />
+      <Primitives.StaticMixer {...rest} />
     </Labeled>
   ),
 );
@@ -1040,9 +1024,9 @@ export const RotaryMixer = Aether.wrap<SymbolProps<RotaryMixerProps>>(
     control,
     onChange,
     orientation,
-    color,
     source,
     sink,
+    ...rest
   }): ReactElement => {
     const { enabled, triggered, toggle } = Toggle.use({ aetherKey, source, sink });
     return (
@@ -1053,7 +1037,7 @@ export const RotaryMixer = Aether.wrap<SymbolProps<RotaryMixerProps>>(
             triggered={triggered}
             onClick={toggle}
             orientation={orientation}
-            color={color}
+            {...rest}
           />
         </ControlState>
       </Labeled>
@@ -1078,18 +1062,18 @@ export const Light = Aether.wrap<SymbolProps<LightProps>>(
     label,
     className,
     orientation = "left",
-    color,
     source,
     onChange,
+    ...rest
   }): ReactElement => {
     const { enabled } = Toggle.use({ aetherKey, source });
     return (
       <Labeled {...label} onChange={onChange}>
         <Primitives.Light
-          color={color}
           enabled={enabled}
           className={className}
           orientation={orientation}
+          {...rest}
         />
       </Labeled>
     );

--- a/pluto/src/vis/schematic/Symbols.tsx
+++ b/pluto/src/vis/schematic/Symbols.tsx
@@ -23,6 +23,7 @@ import { Theming } from "@/theming";
 import { Tooltip } from "@/tooltip";
 import { Button as CoreButton } from "@/vis/button";
 import { useInitialViewport } from "@/vis/diagram/aether/Diagram";
+import { Light as CoreLight } from "@/vis/light";
 import { Labeled, type LabelExtensionProps } from "@/vis/schematic/Labeled";
 import { Primitives } from "@/vis/schematic/primitives";
 import { Setpoint as CoreSetpoint } from "@/vis/setpoint";
@@ -1051,30 +1052,17 @@ export const RotaryMixerPreview = (props: RotaryMixerProps): ReactElement => (
 
 export interface LightProps
   extends Primitives.LightProps,
-    Omit<Toggle.UseProps, "aetherKey"> {
+    Omit<CoreLight.UseProps, "aetherKey"> {
   label?: LabelExtensionProps;
 }
 
 export const Light = Aether.wrap<SymbolProps<LightProps>>(
   "light",
-  ({
-    aetherKey,
-    label,
-    className,
-    orientation = "left",
-    source,
-    onChange,
-    ...rest
-  }): ReactElement => {
-    const { enabled } = Toggle.use({ aetherKey, source });
+  ({ aetherKey, label, source, onChange, ...rest }): ReactElement => {
+    const { enabled } = CoreLight.use({ aetherKey, source });
     return (
       <Labeled {...label} onChange={onChange}>
-        <Primitives.Light
-          enabled={enabled}
-          className={className}
-          orientation={orientation}
-          {...rest}
-        />
+        <Primitives.Light enabled={enabled} {...rest} />
       </Labeled>
     );
   },

--- a/pluto/src/vis/schematic/primitives/Primitives.css
+++ b/pluto/src/vis/schematic/primitives/Primitives.css
@@ -57,6 +57,11 @@
     }
 }
 
+.pluto--enabled svg {
+    stroke: rgba(var(--pluto-symbol-color), 0.8) !important;
+    fill: rgba(var(--pluto-symbol-color), 0.8) !important;
+}
+
 .pluto-symbol-primitive-toggle {
     cursor: pointer;
     background: none;

--- a/pluto/src/vis/schematic/primitives/Primitives.tsx
+++ b/pluto/src/vis/schematic/primitives/Primitives.tsx
@@ -1297,21 +1297,40 @@ export const RotaryMixer = ({
   </Toggle>
 );
 
-export interface LightProps extends ToggleProps, SVGBasedPrimitiveProps {}
+export interface LightProps extends DivProps, SVGBasedPrimitiveProps {
+  enabled?: boolean;
+}
 
 export const Light = ({
   className,
   color,
   orientation = "left",
+  enabled,
   scale,
   ...props
 }: LightProps): ReactElement => (
-  <Toggle {...props} className={CSS(CSS.B("light"), className)}>
+  <Div
+    {...props}
+    orientation={orientation}
+    className={CSS(CSS.B("light"), enabled && CSS.M("enabled"), className)}
+  >
     <HandleBoundary orientation={orientation}>
-      <Handle location="left" orientation={orientation} left={0} top={50} id="1" />
-      <Handle location="right" orientation={orientation} left={100} top={50} id="2" />
-      <Handle location="top" orientation={orientation} left={50} top={0} id="3" />
-      <Handle location="bottom" orientation={orientation} left={50} top={100} id="4" />
+      <Handle location="left" orientation={orientation} left={3.125} top={50} id="1" />
+      <Handle
+        location="right"
+        orientation={orientation}
+        left={96.875}
+        top={50}
+        id="2"
+      />
+      <Handle location="top" orientation={orientation} left={50} top={3.125} id="3" />
+      <Handle
+        location="bottom"
+        orientation={orientation}
+        left={50}
+        top={96.75}
+        id="4"
+      />
     </HandleBoundary>
     <InternalSVG
       dimensions={{ width: 64, height: 64 }}
@@ -1321,7 +1340,7 @@ export const Light = ({
     >
       <Circle cx="32" cy="32" r="30" />
     </InternalSVG>
-  </Toggle>
+  </Div>
 );
 
 export interface ElectricRegulatorProps extends DivProps, SVGBasedPrimitiveProps {}

--- a/pluto/src/vis/schematic/primitives/Primitives.tsx
+++ b/pluto/src/vis/schematic/primitives/Primitives.tsx
@@ -214,10 +214,11 @@ interface SVGBasedPrimitiveProps extends OrientableProps {
 
 interface InternalSVGProps
   extends SVGBasedPrimitiveProps,
-    Omit<ComponentPropsWithoutRef<"svg">, "direction" | "color" | "orientation"> {
+    Omit<
+      ComponentPropsWithoutRef<"svg">,
+      "direction" | "color" | "orientation" | "scale"
+    > {
   dimensions: dimensions.Dimensions;
-  color?: Color.Crude;
-  scale?: number;
 }
 
 const BASE_SCALE = 0.8;

--- a/pluto/src/vis/schematic/primitives/Primitives.tsx
+++ b/pluto/src/vis/schematic/primitives/Primitives.tsx
@@ -57,34 +57,6 @@ const Line = (props: LineProps): ReactElement => (
   <line vectorEffect="non-scaling-stroke" {...props} />
 );
 
-export interface OrientableProps {
-  orientation?: location.Outer;
-}
-
-export interface SVGBasedPrimitiveProps extends OrientableProps {
-  color?: Color.Crude;
-  scale?: number;
-}
-
-export interface DivProps
-  extends Omit<ComponentPropsWithoutRef<"div">, "color" | "onResize">,
-    OrientableProps {}
-
-interface ToggleProps
-  extends Omit<ComponentPropsWithoutRef<"button">, "color" | "value"> {
-  triggered?: boolean;
-  enabled?: boolean;
-  color?: Color.Crude;
-}
-
-interface HandleProps extends Omit<RFHandleProps, "type" | "position"> {
-  orientation: location.Outer;
-  location: location.Outer;
-  left: number;
-  top: number;
-  id: string;
-}
-
 const ORIENTATION_RF_POSITIONS: Record<
   location.Outer,
   Record<location.Outer, RFPosition>
@@ -131,7 +103,11 @@ const adjustHandle = (
   return { top: left, left: 100 - top };
 };
 
-export interface SmartHandlesProps extends PropsWithChildren<{}>, OrientableProps {}
+interface OrientableProps {
+  orientation?: location.Outer;
+}
+
+interface SmartHandlesProps extends PropsWithChildren<{}>, OrientableProps {}
 
 const HandleBoundary = ({ children, orientation }: SmartHandlesProps): ReactElement => {
   let updateInternals: ReturnType<typeof useUpdateNodeInternals> | undefined;
@@ -161,6 +137,14 @@ const HandleBoundary = ({ children, orientation }: SmartHandlesProps): ReactElem
   );
 };
 
+interface HandleProps extends Omit<RFHandleProps, "type" | "position"> {
+  orientation: location.Outer;
+  location: location.Outer;
+  left: number;
+  top: number;
+  id: string;
+}
+
 const Handle = ({
   location,
   orientation,
@@ -184,9 +168,14 @@ const Handle = ({
   );
 };
 
-interface ToggleValveButtonProps extends ToggleProps {
-  orientation?: location.Outer;
+interface ToggleProps
+  extends Omit<ComponentPropsWithoutRef<"button">, "color" | "value"> {
+  triggered?: boolean;
+  enabled?: boolean;
+  color?: Color.Crude;
 }
+
+interface ToggleValveButtonProps extends ToggleProps, OrientableProps {}
 
 const Toggle = ({
   className,
@@ -210,11 +199,20 @@ const Toggle = ({
   />
 );
 
+interface DivProps
+  extends Omit<ComponentPropsWithoutRef<"div">, "color" | "onResize">,
+    OrientableProps {}
+
 const Div = ({ className, ...props }: DivProps): ReactElement => (
   <div className={CSS(CSS.B("symbol-primitive"), className)} {...props} />
 );
 
-export interface InternalSVGProps
+interface SVGBasedPrimitiveProps extends OrientableProps {
+  color?: Color.Crude;
+  scale?: number;
+}
+
+interface InternalSVGProps
   extends SVGBasedPrimitiveProps,
     Omit<ComponentPropsWithoutRef<"svg">, "direction" | "color" | "orientation"> {
   dimensions: dimensions.Dimensions;
@@ -412,7 +410,7 @@ export const ReliefValve = ({
       scale={scale}
     >
       <Path d="M43.5 37L6.35453 18.2035C4.35901 17.1937 2 18.6438 2 20.8803V53.1197C2 55.3562 4.35901 56.8063 6.35453 55.7965L43.5 37ZM43.5 37L80.6455 18.2035C82.641 17.1937 85 18.6438 85 20.8803V53.1197C85 55.3562 82.641 56.8063 80.6455 55.7965L43.5 37Z" />
-      <Path d="M43.5 2L43.5 38" strokeLinecap="round" />
+      <Path d="M43.5 2 L43.5 37" strokeLinecap="round" />
       <Path d="M31.8011 14.0802L55.1773 4.29611" strokeLinecap="round" />
       <Path d="M31.8011 20.0802L55.1773 10.2961" strokeLinecap="round" />
       <Path d="M31.8011 26.0802L55.1773 16.2961" strokeLinecap="round" />
@@ -444,7 +442,7 @@ export const CheckValve = ({
       orientation={orientation}
       scale={scale}
     >
-      <Path d="M43 2L43 40" strokeLinecap="round" />
+      <Line x1="42.3917" y1="2" x2="42.3917" y2="40" strokeLinecap="round" />
       <Path d="M41.6607 21.8946C42.3917 21.5238 42.3906 20.4794 41.6589 20.1101L6.25889 2.2412C4.26237 1.23341 1.90481 2.68589 1.90704 4.92235L1.93925 37.1617C1.94148 39.3982 4.30194 40.846 6.29644 39.8342L41.6607 21.8946Z" />
     </InternalSVG>
   </Div>
@@ -476,7 +474,6 @@ export const AngledValve = ({
     >
       <Path d="M22.3611 20.1077C21.6298 20.4778 21.6298 21.5222 22.3611 21.8923L57.7433 39.7965C59.7388 40.8063 62.0978 39.3562 62.0978 37.1197L62.0978 4.88029C62.0978 2.64384 59.7388 1.19372 57.7433 2.2035L22.3611 20.1077Z" />
       <Path d="M21.8923 22.3611C21.5222 21.6298 20.4778 21.6298 20.1077 22.3611L2.20349 57.7433C1.19372 59.7388 2.64384 62.0978 4.8803 62.0978L37.1197 62.0978C39.3562 62.0978 40.8063 59.7388 39.7965 57.7433L21.8923 22.3611Z" />
-      <Path d="M24.3461 18.5709L21.7484 19.88C20.9998 20.2572 20.3887 20.8601 20.0012 21.6035L19.3383 22.8756" />
     </InternalSVG>
   </Toggle>
 );
@@ -601,7 +598,7 @@ export const ManualValve = ({
       scale={scale}
     >
       <Line x1="43.5" y1="27" x2="43.5" y2="1" />
-      <Path d="M19.64 2L66.68 2" strokeLinecap="round" />
+      <Path d="M19.64 1 L66.68 1" strokeLinecap="round" />
       <Path d="M43.5 27L6.35453 8.20349C4.35901 7.19372 2 8.64384 2 10.8803V43.1197C2 45.3562 4.35901 46.8063 6.35453 45.7965L43.5 27ZM43.5 27L80.6455 8.20349C82.641 7.19372 85 8.64384 85 10.8803V43.1197C85 45.3562 82.641 46.8063 80.6455 45.7965L43.5 27Z" />
     </InternalSVG>
   </Div>
@@ -844,13 +841,12 @@ export const AngledReliefValve = ({
       color={color}
       scale={scale}
     >
-      <Path d="M20.75 2L20.75 38" strokeLinecap="round" />
+      <Line x1={21} y1={2} x2={21} y2={36.7} strokeLinecap="round" />
       <Path d="M9.05106 14.0802L32.4273 4.29611" strokeLinecap="round" />
       <Path d="M9.05106 20.0802L32.4273 10.2961" strokeLinecap="round" />
       <Path d="M9.05106 26.0802L32.4273 16.2961" strokeLinecap="round" />
       <Path d="M22.3611 35.1077C21.6298 35.4778 21.6298 36.5222 22.3611 36.8923L57.7433 54.7965C59.7388 55.8063 62.0978 54.3562 62.0978 52.1197L62.0978 19.8803C62.0978 17.6438 59.7388 16.1937 57.7433 17.2035L22.3611 35.1077Z" />
       <Path d="M21.8923 37.3611C21.5222 36.6298 20.4778 36.6298 20.1077 37.3611L2.20349 72.7433C1.19372 74.7388 2.64384 77.0978 4.8803 77.0978H37.1197C39.3562 77.0978 40.8063 74.7388 39.7965 72.7433L21.8923 37.3611Z" />
-      <Path d="M24.3461 33.5709L21.7484 34.88C20.9998 35.2572 20.3887 35.8601 20.0012 36.6035L19.3383 37.8756" />
     </InternalSVG>
   </Div>
 );
@@ -912,7 +908,7 @@ export const Value = ({
   );
 };
 
-export interface SwitchProps extends Omit<ToggleProps, "onClick">, OrientableProps {
+export interface SwitchProps extends Omit<ToggleValveButtonProps, "onClick"> {
   onClick?: MouseEventHandler<HTMLInputElement>;
 }
 
@@ -1300,9 +1296,7 @@ export const RotaryMixer = ({
   </Toggle>
 );
 
-export interface LightProps extends ToggleProps, SVGBasedPrimitiveProps {
-  color?: Color.Crude;
-}
+export interface LightProps extends ToggleProps, SVGBasedPrimitiveProps {}
 
 export const Light = ({
   className,

--- a/pluto/src/vis/schematic/registry.ts
+++ b/pluto/src/vis/schematic/registry.ts
@@ -15,11 +15,10 @@ import { control } from "@/telem/control/aether";
 import { type Theming } from "@/theming";
 import {
   ButtonForm,
-  CommonNonToggleForm,
+  CommonStyleForm,
   CommonToggleForm,
   LightForm,
   SetpointForm,
-  SolenoidValveForm,
   type SymbolFormProps,
   TankForm,
   ValueForm,
@@ -167,6 +166,7 @@ export type Variant = z.infer<typeof typeZ>;
 
 const ZERO_PROPS = {
   orientation: "left" as const,
+  scale: 1,
 };
 
 const ZERO_NUMERIC_STRINGER_SOURCE_PROPS = {
@@ -295,7 +295,7 @@ const valve: Spec<ValveProps> = {
 const solenoidValve: Spec<SolenoidValveProps> = {
   name: "Solenoid Valve",
   key: "solenoidValve",
-  Form: SolenoidValveForm,
+  Form: CommonToggleForm,
   Symbol: SolenoidValve,
   defaultProps: (t) => ({
     color: t.colors.gray.l9.rgba255,
@@ -403,7 +403,7 @@ const box: Spec<BoxProps> = {
 const reliefValve: Spec<ReliefValveProps> = {
   name: "Relief Valve",
   key: "reliefValve",
-  Form: CommonNonToggleForm,
+  Form: CommonStyleForm,
   Symbol: ReliefValve,
   defaultProps: (t) => ({
     color: t.colors.gray.l9.rgba255,
@@ -417,7 +417,7 @@ const reliefValve: Spec<ReliefValveProps> = {
 const regulator: Spec<RegulatorProps> = {
   name: "Regulator",
   key: "regulator",
-  Form: CommonNonToggleForm,
+  Form: CommonStyleForm,
   Symbol: Regulator,
   defaultProps: (t) => ({
     color: t.colors.gray.l9.rgba255,
@@ -431,7 +431,7 @@ const regulator: Spec<RegulatorProps> = {
 const electricRegulator: Spec<ElectricRegulatorProps> = {
   name: "Electric Regulator",
   key: "electricRegulator",
-  Form: CommonNonToggleForm,
+  Form: CommonStyleForm,
   Symbol: ElectricRegulator,
   defaultProps: (t) => ({
     color: t.colors.gray.l9.rgba255,
@@ -445,7 +445,7 @@ const electricRegulator: Spec<ElectricRegulatorProps> = {
 const burstDisc: Spec<ReliefValveProps> = {
   name: "Burst Disc",
   key: "burstDisc",
-  Form: CommonNonToggleForm,
+  Form: CommonStyleForm,
   Symbol: BurstDisc,
   defaultProps: (t) => ({
     color: t.colors.gray.l9.rgba255,
@@ -459,7 +459,7 @@ const burstDisc: Spec<ReliefValveProps> = {
 const cap: Spec<ReliefValveProps> = {
   name: "Cap",
   key: "cap",
-  Form: CommonNonToggleForm,
+  Form: CommonStyleForm,
   Symbol: Cap,
   defaultProps: (t) => ({
     color: t.colors.gray.l9.rgba255,
@@ -473,7 +473,7 @@ const cap: Spec<ReliefValveProps> = {
 const manualValve: Spec<ManualValveProps> = {
   name: "Manual Valve",
   key: "manualValve",
-  Form: CommonNonToggleForm,
+  Form: CommonStyleForm,
   Symbol: ManualValve,
   defaultProps: (t) => ({
     color: t.colors.gray.l9.rgba255,
@@ -487,7 +487,7 @@ const manualValve: Spec<ManualValveProps> = {
 const filter: Spec<FilterProps> = {
   name: "Filter",
   key: "filter",
-  Form: CommonNonToggleForm,
+  Form: CommonStyleForm,
   Symbol: Filter,
   defaultProps: (t) => ({
     color: t.colors.gray.l9.rgba255,
@@ -501,7 +501,7 @@ const filter: Spec<FilterProps> = {
 const needleValve: Spec<NeedleValveProps> = {
   name: "Needle Valve",
   key: "needleValve",
-  Form: CommonNonToggleForm,
+  Form: CommonStyleForm,
   Symbol: NeedleValve,
   defaultProps: (t) => ({
     color: t.colors.gray.l9.rgba255,
@@ -515,7 +515,7 @@ const needleValve: Spec<NeedleValveProps> = {
 const checkValve: Spec<CheckValveProps> = {
   name: "Check Valve",
   key: "checkValve",
-  Form: CommonNonToggleForm,
+  Form: CommonStyleForm,
   Symbol: CheckValve,
   defaultProps: (t) => ({
     color: t.colors.gray.l9.rgba255,
@@ -529,7 +529,7 @@ const checkValve: Spec<CheckValveProps> = {
 const orifice: Spec<OrificeProps> = {
   name: "Orifice",
   key: "orifice",
-  Form: CommonNonToggleForm,
+  Form: CommonStyleForm,
   Symbol: Orifice,
   defaultProps: (t) => ({
     color: t.colors.gray.l9.rgba255,
@@ -543,7 +543,7 @@ const orifice: Spec<OrificeProps> = {
 const angledReliefValve: Spec<ReliefValveProps> = {
   name: "Angled Relief Valve",
   key: "angledReliefValve",
-  Form: CommonNonToggleForm,
+  Form: CommonStyleForm,
   Symbol: AngledReliefValve,
   defaultProps: (t) => ({
     color: t.colors.gray.l9.rgba255,
@@ -581,6 +581,7 @@ const button: Spec<ButtonProps> = {
     color: t.colors.primary.z.rgba255,
     ...zeroLabel("Button"),
     ...ZERO_BOOLEAN_SINK_PROPS,
+    scale: null,
   }),
   zIndex: Z_INDEX_UPPER,
 };
@@ -594,6 +595,7 @@ const switch_: Spec<SwitchProps> = {
   defaultProps: () => ({
     ...zeroLabel("Switch"),
     ...ZERO_TOGGLE_PROPS,
+    scale: null,
   }),
   zIndex: Z_INDEX_UPPER,
 };
@@ -644,7 +646,7 @@ const staticMixer: Spec<StaticMixerProps> = {
   name: "Static Mixer",
   key: "staticMixer",
   Symbol: StaticMixer,
-  Form: CommonNonToggleForm,
+  Form: CommonStyleForm,
   defaultProps: (t) => ({
     color: t.colors.gray.l9.rgba255,
     ...zeroLabel("Static Mixer"),


### PR DESCRIPTION
# Feature Pull Request Template

## Key Information

- **Linear Issue**: [SY-1098](https://linear.app/synnax/issue/SY-1098/add-ability-to-resize-any-schematic-symbol)

## Description

Added ability to resize (almost) any schematic symbols - buttons, switches, values, and setpoints still cannot be resized. Also refactored some code in relevant files.

NOTE: Previous versions of the schematic will have a `scale` of `null`, so the options for scaling them will not show up. I don't know a great way to fix this problem, and don't think it matters too much - all it means is that the elements created before this version gets released cannot be scaled. If someone wants to scale that element, they could delete it and replace it with a new one.

## Basic Readiness Checklist

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have updated user facing documentation accordingly.
- [x] I have verified code coverage targets are met.

## Migrations

- [ ] Console - I have ensured that previous versions of stored data structures are 
properly migrated to new formats.
- [ ] Server - I have ensured that previous versions of stored data structures are 
properly migrated to new formats.

##  Additional Notes
- [ ] These changes deal with concurrency.
- [ ] These changes affect UI.

## Manual QA Additions

- [ ] I have updated the [Release Candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template
with necessary manual QA steps to test my change.

## Breaking Changes

Please list any breaking changes to public or internal packages.

## Reviwer Checklist
- [ ] Sufficient test coverage of new additions.
- [ ] Verified all steps in the Readiness checklists.
- [ ] UI changes have been tested.
- [ ] Style and formatting is consistent.
- [ ] Reviewed any relevant changes to concurrent code for safety. 
- [ ] Sufficient comments and clarity of code.
- [ ] Any additional documentation necessary for feature is provided and has been reviewed for clarity.