### PR TITLE
[HOTFIX] SY-1212 set ni device properties to default

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synnaxlabs/console",
   "private": true,
-  "version": "0.28.5",
+  "version": "0.28.6",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/console/src/hardware/ni/device/Configure.tsx
+++ b/console/src/hardware/ni/device/Configure.tsx
@@ -18,8 +18,9 @@ import { type ReactElement, useRef, useState } from "react";
 
 import { CSS } from "@/css";
 import { enrich } from "@/hardware/ni/device/enrich/enrich";
-import { configurablePropertiesZ, Properties } from "@/hardware/ni/device/types";
+import { configurablePropertiesZ, Properties, ZERO_PROPERTIES } from "@/hardware/ni/device/types";
 import { type Layout } from "@/layout";
+import { deep } from "@synnaxlabs/x";
 
 export const Configure = ({
   layoutKey,
@@ -117,13 +118,14 @@ const ConfigureInternal = ({
         }
       } else if (step === "identifier") {
         if (!methods.validate("identifier")) return;
-        const er = enrich(device.model, device.properties);
         await client.hardware.devices.create({
           ...device,
           configured: true,
           name: methods.get<string>("name").value,
           properties: {
-            ...er,
+            ...device.properties,
+            ...deep.copy(ZERO_PROPERTIES),
+            enriched: true,
             identifier: methods.get<string>("identifier").value,
           },
         });


### PR DESCRIPTION
# Fix Pull Request Template

## Key Information

- **Linear Issue**: [SY-1212](https://linear.app/synnax/my-issues/assigned)

## Description

This pr fixes the issue where certain ni devices with limited "enriched" data stored will not populate all the necessary properties. Now they will be set to their default properties, rather than using enrich.

## Basic Readiness Checklist

- [x] I have performed a self-review of my code.
- [ ] I have added sufficient regression tests to cover the changes to CI.
- [ ] I have added relevant tests to cover the changes or exposing bugs.
- [ ] I have verified code coverage targets are met.

## Additional Notes
- [ ] These changes deal with concurrency.
- [ ] These changes affect UI.

## Manual QA Additions

- [ ] I have updated the [Release Candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template
  with necessary manual QA steps to test my change.

## Reviewer Checklist
- [ ] Sufficient test coverage of new additions.
- [ ] Verified all steps in readiness checklists.
- [ ] UI changes have been tested.
- [ ] style and formatting is consistent.
- [ ] Reviewed any relevant changes to concurrent code for safety. 
- [ ] Sufficient comments and clarity of code.