### PR TITLE
[pluto] - fixed unique ID generation in pluto statuses

### DIFF
--- a/pluto/src/status/aether/aggregator.ts
+++ b/pluto/src/status/aether/aggregator.ts
@@ -7,11 +7,11 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { TimeStamp } from "@synnaxlabs/x";
+import { id, TimeStamp } from "@synnaxlabs/x";
 import { z } from "zod";
 
 import { aether } from "@/aether/aether";
-import { type CrudeSpec,specZ } from "@/status/aether/types";
+import { type CrudeSpec, specZ } from "@/status/aether/types";
 
 export const aggregatorStateZ = z.object({
   statuses: specZ.array(),
@@ -30,10 +30,9 @@ export class Aggregator extends aether.Composite<typeof aggregatorStateZ> {
   }
 
   add(spec: CrudeSpec): void {
-    const time = TimeStamp.now();
     this.setState((p) => ({
       ...p,
-      statuses: [...p.statuses, { time, key: time.toString(), ...spec }],
+      statuses: [...p.statuses, { time: TimeStamp.now(), key: id.id(), ...spec }],
     }));
   }
 }


### PR DESCRIPTION
# Fix Pull Request Template

## Key Information

- **Linear Issue**: [SY-1227](https://linear.app/synnax/issue/SY-1227/errors-that-cant-be-closed)

## Description

Unique keys on the aether side were generated using timestamps, which means that, occasionally, keys for two notifications would collide. This uses ID generation instead.

## Basic Readiness Checklist

- [x] I have performed a self-review of my code.
- [x] I have added sufficient regression tests to cover the changes to CI.
- [x] I have added relevant tests to cover the changes or exposing bugs.
- [ ] I have verified code coverage targets are met.

## Additional Notes
- [ ] These changes deal with concurrency.
- [ ] These changes affect UI.

## Manual QA Additions

- [ ] I have updated the [Release Candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template
  with necessary manual QA steps to test my change.

## Reviewer Checklist
- [ ] Sufficient test coverage of new additions.
- [ ] Verified all steps in readiness checklists.
- [ ] UI changes have been tested.
- [ ] style and formatting is consistent.
- [ ] Reviewed any relevant changes to concurrent code for safety. 
- [ ] Sufficient comments and clarity of code.