### PR TITLE
Sy 1159 schematic cannot get edited on windows

### DIFF
--- a/console/src/layout/slice.ts
+++ b/console/src/layout/slice.ts
@@ -49,7 +49,7 @@ export interface StoreState {
   [SLICE_NAME]: SliceState;
 }
 
-export const PERSIST_EXCLUDE = ["alreadyCheckedGetStarted"].map(
+export const PERSIST_EXCLUDE = ["hauling", "alreadyCheckedGetStarted"].map(
   (key) => `${SLICE_NAME}.${key}`,
 ) as Array<deep.Key<StoreState>>;
 


### PR DESCRIPTION
# Fix Pull Request Template

## Key Information

- **Linear Issue**: [SY-1159](https://linear.app/synnax/issue/SY-1159/schematic-cannot-get-edited-on-windows)

## Description

Fixes an issue where haul state gets incorrectly persisted, causing schematics not to be editable.

## Basic Readiness Checklist

- [ ] I have performed a self-review of my code.
- [ ] I have added sufficient regression tests to cover the changes to CI.
- [ ] I have added relevant tests to cover the changes or exposing bugs.
- [ ] I have verified code coverage targets are met.

## Additional Notes
- [ ] These changes deal with concurrency.
- [ ] These changes affect UI.

## Manual QA Additions

- [ ] I have updated the [Release Candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template
  with necessary manual QA steps to test my change.

## Reviewer Checklist
- [ ] Sufficient test coverage of new additions.
- [ ] Verified all steps in readiness checklists.
- [ ] UI changes have been tested.
- [ ] style and formatting is consistent.
- [ ] Reviewed any relevant changes to concurrent code for safety. 
- [ ] Sufficient comments and clarity of code.