### PR TITLE
Sy 1159 schematic cannot get edited on windows

### DIFF
--- a/console/src/docs/slice.ts
+++ b/console/src/docs/slice.ts
@@ -34,7 +34,7 @@ export interface StoreState {
   [SLICE_NAME]: SliceState;
 }
 
-const ZERO_SLICE_STATE: SliceState = {
+export const ZERO_SLICE_STATE: SliceState = {
   version: "0.0.0",
   location: {
     path: "",

--- a/console/src/layout/slice.ts
+++ b/console/src/layout/slice.ts
@@ -17,7 +17,7 @@ import {
 import { type Synnax } from "@synnaxlabs/client";
 import { MAIN_WINDOW } from "@synnaxlabs/drift";
 import { Haul, Mosaic } from "@synnaxlabs/pluto";
-import { direction, id, type location } from "@synnaxlabs/x";
+import { deep, direction, id, type location } from "@synnaxlabs/x";
 import { ComponentType } from "react";
 
 import { CreateConfirmModal } from "@/confirm/Confirm";
@@ -49,7 +49,9 @@ export interface StoreState {
   [SLICE_NAME]: SliceState;
 }
 
-export const PERSIST_EXCLUDE = `${SLICE_NAME}.alreadyCheckedGetStarted`;
+export const PERSIST_EXCLUDE = ["hauling", "alreadyCheckedGetStarted"].map(
+  (key) => `${SLICE_NAME}.${key}`,
+) as Array<deep.Key<StoreState>>;
 
 /** Signature for the placeLayout action. */
 export type PlacePayload = State;

--- a/console/src/range/slice.ts
+++ b/console/src/range/slice.ts
@@ -16,6 +16,7 @@ export type DynamicRange = latest.DynamicRange;
 export type StaticRange = latest.StaticRange;
 export type Range = latest.Range;
 export const migrateSlice = latest.migrateSlice;
+export const ZERO_SLICE_STATE = latest.ZERO_SLICE_STATE;
 
 export const SLICE_NAME = "range";
 
@@ -43,7 +44,7 @@ type PA<P> = PayloadAction<P>;
 
 export const { actions, reducer } = createSlice({
   name: SLICE_NAME,
-  initialState: latest.ZERO_SLICE_STATE,
+  initialState: ZERO_SLICE_STATE,
   reducers: {
     add: (state, { payload: { ranges, switchActive = true } }: PA<AddPayload>) => {
       ranges.forEach((range) => {

--- a/console/src/schematic/slice.ts
+++ b/console/src/schematic/slice.ts
@@ -24,6 +24,7 @@ export type LegendState = latest.LegendState;
 export type ToolbarTab = latest.ToolbarTab;
 export type ToolbarState = latest.ToolbarState;
 export const ZERO_STATE = latest.ZERO_STATE;
+export const ZERO_SLICE_STATE = latest.ZERO_SLICE_STATE;
 export const migrateSlice = latest.migrateSlice;
 export const migrateState = latest.migrateState;
 export const parser = latest.parser;

--- a/console/src/store.ts
+++ b/console/src/store.ts
@@ -24,9 +24,22 @@ import { Version } from "@/version";
 import { Workspace } from "@/workspace";
 
 const PERSIST_EXCLUDE: Array<deep.Key<RootState>> = [
-  Layout.PERSIST_EXCLUDE,
+  ...Layout.PERSIST_EXCLUDE,
   Cluster.PERSIST_EXCLUDE,
 ];
+
+const ZERO_STATE: RootState = {
+  [Drift.SLICE_NAME]: Drift.ZERO_SLICE_STATE,
+  [Layout.SLICE_NAME]: Layout.ZERO_SLICE_STATE,
+  [Cluster.SLICE_NAME]: Cluster.ZERO_SLICE_STATE,
+  [Range.SLICE_NAME]: Range.ZERO_SLICE_STATE,
+  [Version.SLICE_NAME]: Version.ZERO_SLICE_STATE,
+  [Docs.SLICE_NAME]: Docs.ZERO_SLICE_STATE,
+  [Schematic.SLICE_NAME]: Schematic.ZERO_SLICE_STATE,
+  [LinePlot.SLICE_NAME]: LinePlot.ZERO_SLICE_STATE,
+  [Workspace.SLICE_NAME]: Workspace.ZERO_SLICE_STATE,
+  [Permissions.SLICE_NAME]: Permissions.ZERO_SLICE_STATE,
+};
 
 const reducer = combineReducers({
   [Drift.SLICE_NAME]: Drift.reducer,
@@ -99,6 +112,7 @@ export const migrateState = (prev: RootState): RootState => {
 
 const newStore = async (): Promise<RootStore> => {
   const [preloadedState, persistMiddleware] = await Persist.open<RootState>({
+    initial: ZERO_STATE,
     migrator: migrateState,
     exclude: PERSIST_EXCLUDE,
   });

--- a/console/src/version/slice.ts
+++ b/console/src/version/slice.ts
@@ -21,7 +21,7 @@ export interface StoreState {
   [SLICE_NAME]: SliceState;
 }
 
-const ZERO_SLICE_STATE: SliceState = {
+export const ZERO_SLICE_STATE: SliceState = {
   version: "0.0.0",
 };
 

--- a/drift/src/external.ts
+++ b/drift/src/external.ts
@@ -40,7 +40,6 @@ export {
   completeProcess,
   createWindow,
   focusWindow,
-  initialState,
   reducer,
   registerProcess,
   reloadWindow,
@@ -59,6 +58,7 @@ export {
   setWindowTitle,
   setWindowVisible,
   SLICE_NAME,
+  ZERO_SLICE_STATE,
 } from "@/state";
 export type { WindowProps, WindowStage, WindowState } from "@/window";
 export { MAIN_WINDOW } from "@/window";

--- a/drift/src/listener.spec.ts
+++ b/drift/src/listener.spec.ts
@@ -12,10 +12,10 @@ import { describe, expect, it, vi } from "vitest";
 
 import { listen, type StoreDispatch, type StoreStateGetter } from "@/listener";
 import { MockRuntime } from "@/mock/runtime";
-import { initialState, type StoreState } from "@/state";
+import { ZERO_SLICE_STATE, type StoreState } from "@/state";
 
 const state = {
-  drift: initialState,
+  drift: ZERO_SLICE_STATE,
 };
 
 const mockStoreFn = (): StoreStateGetter<StoreState> &

--- a/drift/src/middleware.spec.ts
+++ b/drift/src/middleware.spec.ts
@@ -10,12 +10,12 @@
 import { describe, expect, it, vi } from "vitest";
 
 import { MockRuntime } from "@/mock/runtime";
-import { initialState, setWindowStage, StoreState } from "@/state";
+import { ZERO_SLICE_STATE, setWindowStage, StoreState } from "@/state";
 
 import { configureMiddleware, GetDefaultMiddleware, middleware } from "./middleware";
 
 const state = {
-  drift: initialState,
+  drift: ZERO_SLICE_STATE,
 };
 
 describe("middleware", () => {

--- a/drift/src/state.ts
+++ b/drift/src/state.ts
@@ -122,7 +122,7 @@ export type Payload =
 /** Type representing all possible actions that are drift related. */
 export type Action = PayloadAction<Payload>;
 
-export const initialState: SliceState = {
+export const ZERO_SLICE_STATE: SliceState = {
   label: MAIN_WINDOW,
   config: {
     enablePrerender: true,
@@ -207,7 +207,7 @@ export const SLICE_NAME = "drift";
 
 const slice = createSlice({
   name: SLICE_NAME,
-  initialState,
+  initialState: ZERO_SLICE_STATE,
   reducers: {
     setConfig: (s: SliceState, a: PayloadAction<SetConfigPayload>) => {
       s.config = { ...s.config, ...a.payload };

--- a/drift/src/sync.spec.ts
+++ b/drift/src/sync.spec.ts
@@ -11,7 +11,7 @@ import { deep } from "@synnaxlabs/x";
 import { describe, expect, it } from "vitest";
 
 import { MockRuntime } from "@/mock";
-import { initialState } from "@/state";
+import { ZERO_SLICE_STATE } from "@/state";
 import { sync } from "@/sync";
 import { type WindowProps, type WindowState } from "@/window";
 
@@ -36,10 +36,10 @@ describe("sync", () => {
   TESTS.forEach(([keyToSet, keyToCheck, valueToSet, expectedValue]) => {
     it(`should set ${keyToSet} to ${JSON.stringify(valueToSet)}`, async () => {
       const runtime = new MockRuntime(true, { key: "main" });
-      const nextState = deep.copy(initialState);
+      const nextState = deep.copy(ZERO_SLICE_STATE);
       const win = nextState.windows[runtime.label()];
       nextState.windows[runtime.label()] = { ...win, [keyToSet]: valueToSet };
-      await sync(initialState, nextState, runtime, false);
+      await sync(ZERO_SLICE_STATE, nextState, runtime, false);
       expect(runtime.props[keyToCheck]).toStrictEqual(expectedValue);
     });
   });


### PR DESCRIPTION
# Fix Pull Request Template

## Key Information

- **Linear Issue**: [SY-1159](https://linear.app/synnax/issue/SY-1159/schematic-cannot-get-edited-on-windows)

## Description

Fixes an issue where hauls state gets persisted after reload, preventing the user from clicking on elements because the mosaic drag mask is activate it. This update causes the haul state to be cleared on reload/restart.

## Basic Readiness Checklist

- [x] I have performed a self-review of my code.
- [x] I have added sufficient regression tests to cover the changes to CI.
- [x] I have added relevant tests to cover the changes or exposing bugs.
- [x] I have verified code coverage targets are met.

## Additional Notes
- [ ] These changes deal with concurrency.
- [ ] These changes affect UI.

## Manual QA Additions

- [ ] I have updated the [Release Candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template
  with necessary manual QA steps to test my change.

## Reviewer Checklist
- [ ] Sufficient test coverage of new additions.
- [ ] Verified all steps in readiness checklists.
- [ ] UI changes have been tested.
- [ ] style and formatting is consistent.
- [ ] Reviewed any relevant changes to concurrent code for safety. 
- [ ] Sufficient comments and clarity of code.