### PR TITLE
SY-1265: Remove "View Details" and "Create Child Range" from Local Range Context Menu

### DIFF
--- a/console/src/range/Toolbar.tsx
+++ b/console/src/range/Toolbar.tsx
@@ -352,10 +352,10 @@ const List = (): ReactElement => {
           <>
             <PMenu.Divider />
             {rng.key !== activeRange?.key && setAsActiveMenuItem}
-            {viewDetailsMenuItem}
-            <PMenu.Divider />
+            {rng.persisted && viewDetailsMenuItem}
+            {(rng.key !== activeRange?.key || rng.persisted) && <PMenu.Divider />}
             <Menu.RenameItem />
-            {addChildRangeMenuItem}
+            {rng.persisted && addChildRangeMenuItem}
             <PMenu.Divider />
             {activeLayout?.type === "lineplot" && addToActivePlotMenuItem}
             {addToNewPlotMenuItem}
@@ -390,7 +390,7 @@ const List = (): ReactElement => {
   return (
     <PMenu.ContextMenu menu={(p) => <ContextMenu {...p} />} {...menuProps}>
       <Core.List<string, StaticRange>
-        data={ranges.filter((r) => r.variant === "static") as StaticRange[]}
+        data={ranges.filter((r) => r.variant === "static")}
         emptyContent={<NoRanges onLinkClick={handleCreate} />}
       >
         <Core.Selector


### PR DESCRIPTION
# Feature Pull Request Template

## Key Information

- **Linear Issue**: [SY-1265](https://linear.app/synnax/issue/SY-1265/hide-view-details-and-create-child-range-for-a-local-range-in-range)

## Description

Removed the view details and create child range from context menu options for a local range in the range toolbar.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have needed QA steps to the [release candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

The following makes sure that this feature does not break backwards compatability.

### Data Structures

- [x] Server - I have ensured that previous versions of stored data structures are properly migrated to new formats.
- [x] Console - I have ensured that previous versions of stored data structures are properly migrated to new formats.

### API Changes

- [x] Server - The server API is backwards-compatible
- The following client APIs are backwards-compatible:
  - [x] C++
  - [x] TypeScript
  - [x] Python

### Breaking Changes

If anything in this section is not true, please list all breaking changes.
