### PR TITLE
SY-1263: Open Links in Range Overview Window

### DIFF
--- a/pluto/src/button/Link.tsx
+++ b/pluto/src/button/Link.tsx
@@ -16,6 +16,10 @@ import { type Text } from "@/text";
 export interface LinkProps<L extends Text.Level = "h1">
   extends ButtonProps,
     Pick<Text.LinkProps<L>, "href" | "target"> {}
+
+const schemeSeperator = "://";
+const httpSecureScheme = "https" + schemeSeperator;
+
 /**
  * Use.Link renders a button that looks like a link and redirects to the given href
  * when clicked.
@@ -25,12 +29,16 @@ export interface LinkProps<L extends Text.Level = "h1">
  * @param props.href - The URL to redirect to when the button is clicked.
  * @param props.target - The target of the link. Defaults to "_self".
  */
-
 export const Link = <L extends Text.Level = "h1">({
   href,
   target,
   ...props
 }: LinkProps<L>): ReactElement => {
+  let newHref = href;
+  if (newHref != null && !newHref.includes(schemeSeperator))
+    // @ts-expect-error - generic element issues
+    newHref = httpSecureScheme + newHref;
+
   // @ts-expect-error - generic element issues
-  return <Button<"a"> el="a" href={href} target={target} {...props} />;
+  return <Button<"a"> el="a" href={newHref} target={target} {...props} />;
 };

--- a/pluto/src/input/Input.css
+++ b/pluto/src/input/Input.css
@@ -65,7 +65,7 @@
     }
 
     & > .pluto-input__internal:focus-within {
-        border-color: var(--pluto-input-color, var(--pluto-primary-z)) !important;
+        border-color: var(--pluto-primary-z) !important;
         & input {
             outline: none;
         }

--- a/pluto/src/input/Input.css
+++ b/pluto/src/input/Input.css
@@ -49,6 +49,7 @@
         text-overflow: ellipsis;
         white-space: nowrap;
         height: 100%;
+        color: var(--pluto-input-color);
 
         padding: 0 1.5rem;
 


### PR DESCRIPTION
# Feature Pull Request Template

## Key Information

- **Linear Issue**: [SY-1263](https://linear.app/synnax/issue/SY-1263/open-links-in-range-overview-window)

## Description

Changed the coloring of input boxes so that the text color is the same as the input color. Also fixed an issue where links that do not have a scheme prepended are automatically prepended with HTTPS, which caused some issues with opening links in the range metadata overview.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have needed QA steps to the [release candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

The following makes sure that this feature does not break backwards compatibility.

### Data Structures

- [x] Server - I have ensured that previous versions of stored data structures are
      properly migrated to new formats.
- [x] Console - I have ensured that previous versions of stored data structures are
      properly migrated to new formats.

### API Changes

- [x] Server - The server API is backwards-compatible
- The following client APIs are backwards-compatible:
  - [x] C++
  - [x] TypeScript
  - [x] Python

### Breaking Changes

If anything in this section is not true, please list all breaking changes.
