### PR TITLE
SY-1282: Line Plot Download as CSV Should Suggest Better File Name

### DIFF
--- a/console/src/lineplot/LinePlot.tsx
+++ b/console/src/lineplot/LinePlot.tsx
@@ -346,7 +346,7 @@ const Loaded: Layout.Renderer = ({ layoutKey, focused, visible }): ReactElement 
           break;
         case "download":
           if (client == null) return;
-          download({ timeRange, lines, client });
+          download({ timeRange, lines, client, name: name + "-data" });
           break;
       }
     };


### PR DESCRIPTION
# Feature Pull Request Template

## Key Information

- **Linear Issue**: [SY-1282](https://linear.app/synnax/issue/SY-1282/line-plot-download-as-csv-should-suggest-better-file-name)

## Description

Suggested a better name for the CSV file when downloading data from a line plot as CSV.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have needed QA steps to the [release candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

The following makes sure that this feature does not break backwards compatibility.

### Data Structures

- [x] Server - I have ensured that previous versions of stored data structures are properly migrated to new formats.
- [x] Console - I have ensured that previous versions of stored data structures are properly migrated to new formats.

### API Changes

- [x] Server - The server API is backwards-compatible
- The following client APIs are backwards-compatible:
  - [x] C++
  - [x] TypeScript
  - [x] Python

### Breaking Changes

If anything in this section is not true, please list all breaking changes.
