### PR TITLE
SY-1285: Opening Documentation Should Start at Console Page

### DIFF
--- a/console/src/docs/Docs.tsx
+++ b/console/src/docs/Docs.tsx
@@ -11,7 +11,7 @@ import "@/docs/Docs.css";
 
 import { Logo } from "@synnaxlabs/media";
 import { Theming, Triggers } from "@synnaxlabs/pluto";
-import { buildQueryString,URL } from "@synnaxlabs/x";
+import { buildQueryString, URL } from "@synnaxlabs/x";
 import { memo, useEffect, useState } from "react";
 import { useDispatch } from "react-redux";
 
@@ -24,6 +24,7 @@ const HOST = new URL({
   host: "docs.synnaxlabs.com",
   port: 443,
   protocol: "https",
+  pathPrefix: "reference/console/get-started",
 });
 
 export const LAYOUT_TYPE = "docs";


### PR DESCRIPTION
# Feature Pull Request Template

## Key Information

- **Linear Issue**: [SY-1285](https://linear.app/synnax/issue/SY-1285/opening-documentation-should-start-at-console-page)

## Description

Opening documentation from the console now starts at the console page.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have needed QA steps to the [release candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

The following makes sure that this feature does not break backwards compatibility.

### Data Structures

- [x] Server - I have ensured that previous versions of stored data structures are properly migrated to new formats.
- [x] Console - I have ensured that previous versions of stored data structures are properly migrated to new formats.

### API Changes

- [x] Server - The server API is backwards-compatible
- The following client APIs are backwards-compatible:
  - [x] C++
  - [x] TypeScript
  - [x] Python

### Breaking Changes

If anything in this section is not true, please list all breaking changes.
