### PR TITLE
SY-1302: Duplicate Terminal Configuration in NI Analog Read Microphone

### DIFF
--- a/console/src/hardware/ni/task/ChannelForms.tsx
+++ b/console/src/hardware/ni/task/ChannelForms.tsx
@@ -1053,8 +1053,6 @@ export const ANALOG_INPUT_FORMS: Record<AIChanType, FC<FormProps>> = {
         <PortField path={prefix} />
         <Divider.Divider direction="x" padded="bottom" />
         <TerminalConfigField path={prefix} />
-        <Divider.Divider direction="x" padded="bottom" />
-        <TerminalConfigField path={prefix} />
         <UnitsField path={prefix} />
         <Divider.Divider direction="x" padded="bottom" />
         <Align.Space direction="x">


### PR DESCRIPTION
# Feature Pull Request Template

## Key Information

- **Linear Issue**: [SY-1285](https://linear.app/synnax/issue/SY-1285/opening-documentation-should-start-at-console-page)

## Description

Removed a duplicate form item for microphone channels in NI analog read task configuration.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have needed QA steps to the [release candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

The following makes sure that this feature does not break backwards compatibility.

### Data Structures

- [x] Server - I have ensured that previous versions of stored data structures are properly migrated to new formats.
- [x] Console - I have ensured that previous versions of stored data structures are properly migrated to new formats.

### API Changes

- [x] Server - The server API is backwards-compatible
- The following client APIs are backwards-compatible:
  - [x] C++
  - [x] TypeScript
  - [x] Python

### Breaking Changes

If anything in this section is not true, please list all breaking changes.
