### PR TITLE
SY-1281 Change Label Arrow Direction under Line Plot Axes Tab

### DIFF
--- a/console/src/lineplot/toolbar/Axes.tsx
+++ b/console/src/lineplot/toolbar/Axes.tsx
@@ -199,12 +199,14 @@ export const LinePlotAxisControls = ({
             onChange={handleLabelChange}
           />
         </Input.Item>
-        <Input.Item label="Label Direction" style={{ minWidth: 90 }}>
-          <Select.Direction
-            value={axis.labelDirection}
-            onChange={handleLabelDirectionChange}
-          />
-        </Input.Item>
+        {axis.key.startsWith("y") && (
+          <Input.Item label="Label Direction" style={{ minWidth: 90 }}>
+            <Select.Direction
+              value={axis.labelDirection}
+              onChange={handleLabelDirectionChange}
+            />
+          </Input.Item>
+        )}
         <Input.Item label="Label Size">
           <Text.SelectLevel value={axis.labelLevel} onChange={handleLabelLevelChange} />
         </Input.Item>

--- a/pluto/src/select/Direction.tsx
+++ b/pluto/src/select/Direction.tsx
@@ -32,7 +32,7 @@ const DATA: Entry[] = [
   },
   {
     key: "y",
-    icon: <Icon.Arrow.Down />,
+    icon: <Icon.Arrow.Up />,
   },
 ];
 
@@ -41,25 +41,21 @@ const defaultSelectDirectionButton = ({
   entry,
   onClick,
   selected,
-}: ButtonOptionProps<direction.Crude, Entry>): ReactElement => {
-  return (
-    <CoreButton.Icon
-      key={key}
-      variant={selected ? "filled" : "outlined"}
-      onClick={onClick}
-    >
-      {entry.icon}
-    </CoreButton.Icon>
-  );
-};
+}: ButtonOptionProps<direction.Crude, Entry>): ReactElement => (
+  <CoreButton.Icon
+    key={key}
+    variant={selected ? "filled" : "outlined"}
+    onClick={onClick}
+  >
+    {entry.icon}
+  </CoreButton.Icon>
+);
 
 export const Direction = ({
   children = defaultSelectDirectionButton,
   ...props
-}: DirectionProps): ReactElement => {
-  return (
-    <Button {...props} allowMultiple={false} data={DATA}>
-      {children}
-    </Button>
-  );
-};
+}: DirectionProps): ReactElement => (
+  <Button {...props} allowMultiple={false} data={DATA}>
+    {children}
+  </Button>
+);


### PR DESCRIPTION
# Feature Pull Request Template

## Key Information

- **Linear Issue**: [SY-1281](https://linear.app/synnax/issue/SY-1281/change-label-arrow-direction-under-line-plot-axes-tab)

## Description

Change the Pluto direction selector to have a the default y icon be up instead of down. Hide label direction selector for x-axis on Console line plot.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have needed QA steps to the [release candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

The following makes sure that this feature does not break backwards compatibility.

### Data Structures

- [x] Server - I have ensured that previous versions of stored data structures are properly migrated to new formats.
- [x] Console - I have ensured that previous versions of stored data structures are properly migrated to new formats.

### API Changes

- [x] Server - The server API is backwards-compatible
- The following client APIs are backwards-compatible:
  - [x] C++
  - [x] TypeScript
  - [x] Python

### Breaking Changes

If anything in this section is not true, please list all breaking changes.
