### PR TITLE
SY-1275 Change Channel Deep Linking Line Plot Name

### DIFF
--- a/console/src/channel/services/link.ts
+++ b/console/src/channel/services/link.ts
@@ -7,8 +7,9 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { create as createLinePlot } from "@/lineplot/LinePlot";
-import { ZERO_CHANNELS_STATE } from "@/lineplot/slice";
+import { channel } from "@synnaxlabs/client";
+
+import { LinePlot } from "@/lineplot";
 import { Link } from "@/link";
 
 export const linkHandler: Link.Handler = async ({
@@ -18,21 +19,24 @@ export const linkHandler: Link.Handler = async ({
   placer,
   addStatus,
 }): Promise<boolean> => {
-  if (resource != "channel") return false;
+  if (resource !== channel.ONTOLOGY_TYPE) return false;
   try {
     const channel = await client.channels.retrieve(resourceKey);
     placer(
-      createLinePlot({
+      LinePlot.create({
         channels: {
-          ...ZERO_CHANNELS_STATE,
+          ...LinePlot.ZERO_CHANNELS_STATE,
           y1: [channel.key],
         },
+        name: `${channel.name} Plot`,
       }),
     );
   } catch (e) {
+    if (!(e instanceof Error)) throw e;
     addStatus({
       variant: "error",
-      message: (e as Error).message,
+      description: "Failed to open channel from URL",
+      message: e.message,
     });
   }
   return true;

--- a/console/src/link/link.tsx
+++ b/console/src/link/link.tsx
@@ -107,7 +107,7 @@ export const useDeep = ({ handlers }: UseDeepProps): void => {
         message: `Cannot open link, ${resource} is unknown`,
       });
     });
-    return () => unlisten();
+    return unlisten;
   }, []);
 };
 
@@ -138,18 +138,16 @@ export const useCopyToClipboard = (): ((props: CopyToClipboardProps) => void) =>
     url += key;
     if (ontologyID != undefined) url += `/${ontologyID.type}/${ontologyID.key}`;
     navigator.clipboard.writeText(url).then(
-      () => {
+      () =>
         addStatus({
           variant: "success",
           message: `Link to ${name} copied to clipboard.`,
-        });
-      },
-      () => {
+        }),
+      () =>
         addStatus({
           variant: "error",
           message: `Failed to copy link to ${name} to clipboard.`,
-        });
-      },
+        }),
     );
   };
 };


### PR DESCRIPTION
# Feature Pull Request Template

## Key Information

- **Linear Issue**: [SY-1275](https://linear.app/synnax/issue/SY-1275/change-channel-deep-linking-line-plot-name)

## Description

Change the default line plot name used when channel deep linking.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have needed QA steps to the [release candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

The following makes sure that this feature does not break backwards compitability.

### Data Structures

- [x] Server - I have ensured that previous versions of stored data structures are properly migrated to new formats.
- [x] Console - I have ensured that previous versions of stored data structures are properly migrated to new formats.

### API Changes

- [x] Server - The server API is backwards-compatible
- The following client APIs are backwards-compatible:
  - [x] C++
  - [x] TypeScript
  - [x] Python

### Breaking Changes

If anything in this section is not true, please list all breaking changes.
