### PR TITLE
SY-1321: Alphabetize NI Analog Read Types

### DIFF
--- a/console/src/hardware/ni/task/types.ts
+++ b/console/src/hardware/ni/task/types.ts
@@ -1470,10 +1470,6 @@ export const ZERO_AI_CHANNELS: Record<AIChanType, AIChan> = {
 };
 
 export const AI_CHANNEL_TYPE_NAMES: Record<AIChanType, string> = {
-  ai_voltage: "Voltage",
-  ai_thermocouple: "Thermocouple",
-  ai_rtd: "RTD",
-  ai_pressure_bridge_two_point_lin: "Pressure Bridge Two-Point Linear",
   ai_accel: "Accelerometer",
   ai_bridge: "Bridge",
   ai_current: "Current",
@@ -1482,12 +1478,16 @@ export const AI_CHANNEL_TYPE_NAMES: Record<AIChanType, string> = {
   ai_force_iepe: "Force IEPE",
   ai_microphone: "Microphone",
   ai_pressure_bridge_table: "Pressure Bridge Table",
+  ai_pressure_bridge_two_point_lin: "Pressure Bridge Two-Point Linear",
   ai_resistance: "Resistance",
+  ai_rtd: "RTD",
   ai_strain_gauge: "Strain Gauge",
-  ai_temp_builtin: "Temperature Built-In",
+  ai_temp_builtin: "Temperature Built-In Sensor",
+  ai_thermocouple: "Thermocouple",
   ai_torque_bridge_table: "Torque Bridge Table",
-  ai_torque_bridge_two_point_lin: "Torque Bridge - Two-Point Linear",
+  ai_torque_bridge_two_point_lin: "Torque Bridge Two-Point Linear",
   ai_velocity_iepe: "Velocity IEPE",
+  ai_voltage: "Voltage",
 };
 
 export type AnalogInputVoltageChannel = z.infer<typeof aiVoltageChanZ>;


### PR DESCRIPTION
# Feature Pull Request Template

## Key Information

- **Linear Issue**: [SY-1321](https://linear.app/synnax/issue/SY-1321/alphabetize-ni-analog-read-channel-dropdown)

## Description

Alphabetized the types of NI analog read task channels in the channel dropdown selector.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have needed QA steps to the [release candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

The following makes sure that this feature does not break backwards compatibility.

### Data Structures

- [x] Server - I have ensured that previous versions of stored data structures are properly migrated to new formats.
- [x] Console - I have ensured that previous versions of stored data structures are properly migrated to new formats.

### API Changes

- [x] Server - The server API is backwards-compatible
- The following client APIs are backwards-compatible:
  - [x] C++
  - [x] TypeScript
  - [x] Python

### Breaking Changes

If anything in this section is not true, please list all breaking changes.
