### PR TITLE
[console/ops] - adjusted notarization behavior for MacOS in CI

### DIFF
--- a/.github/workflows/deploy.console.yaml
+++ b/.github/workflows/deploy.console.yaml
@@ -106,7 +106,9 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
       - name: MacOS - Import Apple Developer Certificate
-        if: matrix.platform == 'macos-12'
+        # Only notarize on MacOS and on push events, not on PRs. This prevents excessive
+        # notarization requests and long CI times on PRs.
+        if: matrix.platform == 'macos-12' && github.event_name == 'push'
         env:
           APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
           APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
@@ -121,7 +123,8 @@ jobs:
           security find-identity -v -p codesigning build.keychain
 
       - name: MacOS - Verify Certificate
-        if: matrix.platform == 'macos-12'
+        # Same as above - only notarize on MacOS and on push events, not on PRs
+        if: matrix.platform == 'macos-12' && github.event_name == 'push'
         run: |
           CERT_INFO=$(security find-identity -v -p codesigning build.keychain | grep "Developer ID Application")
           echo "Cert info"


### PR DESCRIPTION
# Feature Pull Request Template

## Key Information

- **Linear Issue**: [SY-1376](https://linear.app/synnax/issue/SY-1376/only-notarize-on-push)

## Description

Makes is to that MacOS builds only get notarized on push, preventing excessive CI times on pull requests.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have needed QA steps to the [release
      candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

The following makes sure that this feature does not break backwards compatability.

### Data Structures

- [ ] Server - I have ensured that previous versions of stored data structures are
      properly migrated to new formats.
- [ ] Console - I have ensured that previous versions of stored data structures are
      properly migrated to new formats.

### API Changes

- [ ] Server - The server API is backwards-compatible
- The following client APIs are backwards-compatible:
  - [ ] C++
  - [ ] TypeScript
  - [ ] Python

### Breaking Changes

If anything in this section is not true, please list all breaking changes.
