### PR TITLE
SY-1187 Verify Error Matching Works with `NotFoundError` on Windows

### DIFF
--- a/client/ts/package.json
+++ b/client/ts/package.json
@@ -45,6 +45,8 @@
     "@types/node": "^22.7.5",
     "@vitest/coverage-v8": "^2.1.2",
     "eslint": "^9.12.0",
+    "uuid": "^10.0.0",
+    "@types/uuid": "^10.0.0",
     "eslint-config-synnaxlabs": "workspace:*",
     "typescript": "^5.6.3",
     "vite": "^5.4.8",

--- a/client/ts/src/errors.spec.ts
+++ b/client/ts/src/errors.spec.ts
@@ -8,6 +8,8 @@
 // included in the file licenses/APL.txt.
 
 import { MatchableErrorType } from "@synnaxlabs/freighter/src/errors";
+import { id } from "@synnaxlabs/x";
+import { v4 as uuid } from "uuid";
 import { describe, expect, test } from "vitest";
 
 import {
@@ -24,6 +26,7 @@ import {
   UnexpectedError,
   ValidationError,
 } from "@/errors";
+import { newClient } from "@/setupspecs";
 
 describe("error", () => {
   describe("type matching", () => {
@@ -45,4 +48,20 @@ describe("error", () => {
       test(`matches ${typeName}`, () => expect(type.matches(error)).toBeTruthy()),
     );
   });
+});
+
+const client = newClient();
+
+test("Match NotFoundError", async () => {
+  expect.assertions(2);
+  try {
+    await client.channels.retrieve(id.id());
+  } catch (error) {
+    expect(NotFoundError.matches(error)).toBe(true);
+  }
+  try {
+    await client.workspaces.schematic.retrieve(uuid());
+  } catch (error) {
+    expect(NotFoundError.matches(error)).toBe(true);
+  }
 });

--- a/client/ts/src/errors.spec.ts
+++ b/client/ts/src/errors.spec.ts
@@ -52,16 +52,16 @@ describe("error", () => {
 
 const client = newClient();
 
-test("Match NotFoundError", async () => {
+test("client", async () => {
   expect.assertions(2);
   try {
     await client.channels.retrieve(id.id());
-  } catch (error) {
-    expect(NotFoundError.matches(error)).toBe(true);
+  } catch (e) {
+    expect(NotFoundError.matches(e)).toBe(true);
   }
   try {
     await client.workspaces.schematic.retrieve(uuid());
-  } catch (error) {
-    expect(NotFoundError.matches(error)).toBe(true);
+  } catch (e) {
+    expect(NotFoundError.matches(e)).toBe(true);
   }
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -108,6 +108,9 @@ importers:
       '@types/node':
         specifier: ^22.7.5
         version: 22.7.5
+      '@types/uuid':
+        specifier: ^10.0.0
+        version: 10.0.0
       '@vitest/coverage-v8':
         specifier: ^2.1.2
         version: 2.1.2(vitest@2.1.2(@types/node@22.7.5)(jsdom@25.0.1))
@@ -120,6 +123,9 @@ importers:
       typescript:
         specifier: ^5.6.3
         version: 5.6.3
+      uuid:
+        specifier: ^10.0.0
+        version: 10.0.0
       vite:
         specifier: ^5.4.8
         version: 5.4.8(@types/node@22.7.5)


### PR DESCRIPTION
# Feature Pull Request Template

## Key Information

- **Linear Issue**: [SY-1187](https://linear.app/synnax/issue/SY-1187/verify-error-matching-works-with-notfounderror-on-windows)

## Description

Added a test to verify that error matching works on Windows. Ran the test on a local machine running Windows. Test is not currently run in CI on Windows because client tests are not run on Windows.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have needed QA steps to the [release candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

The following makes sure that this feature does not break backwards compatibility.

### Data Structures

- [x] Server - I have ensured that previous versions of stored data structures are properly migrated to new formats.
- [x] Console - I have ensured that previous versions of stored data structures are properly migrated to new formats.

### API Changes

- [x] Server - The server API is backwards-compatible
- The following client APIs are backwards-compatible:
  - [x] C++
  - [x] TypeScript
  - [x] Python

### Breaking Changes

If anything in this section is not true, please list all breaking changes.
