### PR TITLE
SY-1030 Remove Windows Deep Link Warning from Docs

### DIFF
--- a/docs/site/src/pages/reference/console/clusters.mdx
+++ b/docs/site/src/pages/reference/console/clusters.mdx
@@ -7,6 +7,7 @@ prevURL: "/reference/console/get-started"
 next: "UI Overview"
 nextURL: "/reference/console/ui-overview"
 ---
+
 import { Divider, Note } from "@synnaxlabs/pluto";
 import Code from "@/components/code/Code.astro";
 import { Video } from "@/components/Media";
@@ -37,31 +38,44 @@ UI.
   </thead>
   <tbody>
     <tr>
-      <td><b>Host</b></td>
+      <td>
+        <b>Host</b>
+      </td>
       <td>The hostname or IP address of the cluster.</td>
     </tr>
     <tr>
-      <td><b>Port</b></td>
+      <td>
+        <b>Port</b>
+      </td>
       <td>The port number of the cluster.</td>
     </tr>
     <tr>
-      <td><b>Username</b></td>
+      <td>
+        <b>Username</b>
+      </td>
       <td>The username to use when connecting to the cluster.</td>
     </tr>
     <tr>
-      <td><b>Password</b></td>
+      <td>
+        <b>Password</b>
+      </td>
       <td>The password to use when connecting to the cluster.</td>
     </tr>
     <tr>
-      <td><b>Secure</b></td>
-      <td>Whether to use TLS when connecting to the cluster. This parameter only works with secure clusters.</td>
+      <td>
+        <b>Secure</b>
+      </td>
+      <td>
+        Whether to use TLS when connecting to the cluster. This parameter only works
+        with secure clusters.
+      </td>
     </tr>
   </tbody>
 </Table>
 
 <Note.Note variant="warning">
-The console will not connect to remote clusters (i.e. host is not 'localhost') started
-with the `--insecure` flag.
+  The console will not connect to remote clusters (i.e. host is not 'localhost') started
+  with the `--insecure` flag.
 </Note.Note>
 
 ### Demo Cluster
@@ -78,23 +92,33 @@ connect, enter the following parameters:
   </thead>
   <tbody>
     <tr>
-      <td><b>Host</b></td>
+      <td>
+        <b>Host</b>
+      </td>
       <td>demo.synnaxlabs.com</td>
     </tr>
     <tr>
-      <td><b>Port</b></td>
+      <td>
+        <b>Port</b>
+      </td>
       <td>9090</td>
     </tr>
     <tr>
-      <td><b>Username</b></td>
+      <td>
+        <b>Username</b>
+      </td>
       <td>synnax</td>
     </tr>
     <tr>
-      <td><b>Password</b></td>
+      <td>
+        <b>Password</b>
+      </td>
       <td>seldon</td>
     </tr>
     <tr>
-      <td><b>Secure</b></td>
+      <td>
+        <b>Secure</b>
+      </td>
       <td>true</td>
     </tr>
   </tbody>
@@ -119,11 +143,6 @@ connect from, disconnect from, rename, and remove the cluster:
 
 You can also copy a link to the cluster from the context menu. Opening this link will
 open the Synnax Console with the cluster already connected.
-
-<Note.Note variant="warning">
-Currently, opening by link is only supported on Mac. Other platforms are planned to be
-supported in the future.
-</Note.Note>
 
 <Divider.Divider direction="x" />
 

--- a/docs/site/src/pages/reference/console/clusters.mdx
+++ b/docs/site/src/pages/reference/console/clusters.mdx
@@ -65,10 +65,8 @@ UI.
       <td>
         <b>Secure</b>
       </td>
-      <td>
-        Whether to use TLS when connecting to the cluster. This parameter only works
-        with secure clusters.
-      </td>
+      <td>Whether to use TLS when connecting to the cluster. This parameter only works
+        with secure clusters.</td>
     </tr>
   </tbody>
 </Table>

--- a/docs/site/src/pages/reference/console/ui-overview.mdx
+++ b/docs/site/src/pages/reference/console/ui-overview.mdx
@@ -8,6 +8,7 @@ prevURL: "/reference/console/clusters"
 next: "Channels"
 nextURL: "/reference/console/channels"
 ---
+
 import { Icon } from "@synnaxlabs/media";
 import { Divider } from "@synnaxlabs/pluto";
 import { Image, Video } from "@/components/Media";
@@ -25,9 +26,9 @@ controls.
 
 ## Toolbars
 
-To kick things off, we'll walk you through each of the toolbars and their functionality. 
+To kick things off, we'll walk you through each of the toolbars and their functionality.
 
-### <Icon.Resources /> Resources 
+### <Icon.Resources /> Resources
 
 The resource toolbar displays a file tree with folders for channels, ranges, users, and
 workspaces.
@@ -75,7 +76,7 @@ workspaces.
 ### <Icon.Range /> Ranges
 
 The [range toolbar](/reference/console/ranges) allows you to create, view, and access
-the ranges you're interested in visualizing. 
+the ranges you're interested in visualizing.
 
 <Video client:only="react" id="console/ui-overview/range-toolbar" />
 
@@ -124,7 +125,7 @@ You can also have multiple visualizations displayed at the same time:
 ## Getting Help
 
 The Synnax documentation website can be opened from within the console by clicking the
-<Icon.QuestionMark/> icon.
+<Icon.QuestionMark /> icon.
 
 <Video client:only="react" id="console/ui-overview/documentation" />
 
@@ -134,13 +135,11 @@ The Synnax documentation website can be opened from within the console by clicki
 
 The search and command palette at the top can be used to search for resources or to
 activate commands. Searching for resouces can be done by searching or pressing
-<Icon.Keyboard.Control/>+`P` (Windows) / <Icon.Keyboard.Command />+`P` (MacOS). As an
+<Icon.Keyboard.Control />+`P` (Windows) / <Icon.Keyboard.Command />+`P` (MacOS). As an
 example of searching for resources, you could search for a test range and then
 automatically add it as the active range:
 
 <Video client:only="react" id="console/ui-overview/palette-search" />
-
-<Icon.Keyboard.Return />
 
 The search and command palette can run commands by entering a `>` into the toolbar or by
 pressing <Icon.Keyboard.Control />+<Icon.Keyboard.Shift />+`P` (Windows) /


### PR DESCRIPTION
# Feature Pull Request Template

## Key Information

- **Linear Issue**: [SY-1030](https://linear.app/synnax/issue/SY-1030/deep-linking-support-for-windows)

## Description

Removed a note on the documentation site stating that deep linking is unavailable for Windows. Currently, deep linking works on Windows, although it forces a [new instance](https://v2.tauri.app/reference/javascript/deep-link/#--windows--linux-unsupported-the-os-will-spawn-a-new-app-instance-passing-the-url-as-a-cli-argument) of the Console to open instead of opening the linked item in the current window.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have needed QA steps to the [release candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

The following makes sure that this feature does not break backwards compatibility.

### Data Structures

- [x] Server - I have ensured that previous versions of stored data structures are properly migrated to new formats.
- [x] Console - I have ensured that previous versions of stored data structures are properly migrated to new formats.

### API Changes

- [x] Server - The server API is backwards-compatible
- The following client APIs are backwards-compatible:
  - [x] C++
  - [x] TypeScript
  - [x] Python

### Breaking Changes

If anything in this section is not true, please list all breaking changes.
