### PR TITLE
SY-1367: Allow Silencing of Version Update Notification

### DIFF
--- a/console/src/cluster/external.ts
+++ b/console/src/cluster/external.ts
@@ -10,7 +10,7 @@
 import { Connect, connectWindowLayout } from "@/cluster/Connect";
 import { versionOutdatedAdapter } from "@/cluster/notification";
 import { Layout } from "@/layout";
-import { NotificationAdapter } from "@/notifications/Notifications";
+import { type NotificationAdapter } from "@/notifications/Notifications";
 
 export * from "@/cluster/Badges";
 export * from "@/cluster/Connect";

--- a/console/src/cluster/notification.tsx
+++ b/console/src/cluster/notification.tsx
@@ -10,10 +10,10 @@
 import { Button, Synnax } from "@synnaxlabs/pluto";
 
 import {
-  NotificationAdapter,
+  type NotificationAdapter,
   SugaredNotification,
 } from "@/notifications/Notifications";
-import { OpenUpdateDialogAction } from "@/version/Updater";
+import { Version } from "@/version";
 
 export const versionOutdatedAdapter: NotificationAdapter = (status) => {
   if (status.data == null) return null;
@@ -32,6 +32,6 @@ export const versionOutdatedAdapter: NotificationAdapter = (status) => {
         Update Cluster
       </Button.Link>,
     ];
-  else nextStatus.actions = [<OpenUpdateDialogAction key="update" />];
+  else nextStatus.actions = [<Version.OpenUpdateDialogAction key="update" />];
   return nextStatus;
 };

--- a/console/src/store.ts
+++ b/console/src/store.ts
@@ -76,8 +76,8 @@ export type RootAction =
   | Cluster.Action
   | LinePlot.Action
   | Schematic.Action
-  | Range.Action
   | Permissions.Action
+  | Version.Action
   | Workspace.Action;
 
 export type RootStore = Store<RootState, RootAction>;

--- a/console/src/version/Badge.tsx
+++ b/console/src/version/Badge.tsx
@@ -14,11 +14,11 @@ import { type ReactElement } from "react";
 
 import { Layout } from "@/layout";
 import { infoLayout } from "@/version/Info";
-import { useSelect } from "@/version/selectors";
+import { useSelectVersion } from "@/version/selectors";
 import { useCheckForUpdates } from "@/version/Updater";
 
 export const Badge = (): ReactElement => {
-  const v = useSelect();
+  const version = useSelectVersion();
   const placer = Layout.usePlacer();
   const updateAvailable = useCheckForUpdates();
   return (
@@ -28,7 +28,7 @@ export const Badge = (): ReactElement => {
       size="medium"
       color={updateAvailable ? "var(--pluto-secondary-z)" : "var(--pluto-text-color)"}
     >
-      {"v" + v}
+      {"v" + version}
     </Button.Button>
   );
 };

--- a/console/src/version/Info.tsx
+++ b/console/src/version/Info.tsx
@@ -16,7 +16,7 @@ import { check, DownloadEvent } from "@tauri-apps/plugin-updater";
 import { useState } from "react";
 
 import { Layout } from "@/layout";
-import { useSelect } from "@/version/selectors";
+import { useSelectVersion } from "@/version/selectors";
 
 export const infoLayout: Layout.State = {
   type: "versionInfo",
@@ -32,7 +32,7 @@ export const infoLayout: Layout.State = {
 };
 
 export const Info: Layout.Renderer = () => {
-  const version = useSelect();
+  const version = useSelectVersion();
   const updateQuery = useQuery({
     queryKey: ["version.update"],
     queryFn: async () => {

--- a/console/src/version/Updater.tsx
+++ b/console/src/version/Updater.tsx
@@ -17,12 +17,12 @@ import { useDispatch } from "react-redux";
 import { Layout } from "@/layout";
 import { type NotificationAdapter } from "@/notifications/Notifications";
 import { infoLayout } from "@/version/Info";
-import { useSelectSilenced } from "@/version/selectors";
-import { silence } from "@/version/slice";
+import { useSelectUpdateNotificationsSilenced } from "@/version/selectors";
+import { silenceUpdateNotifications } from "@/version/slice";
 
 export const useCheckForUpdates = (): boolean => {
   const addStatus = Status.useAggregator();
-  const isSilenced = useSelectSilenced();
+  const isSilenced = useSelectUpdateNotificationsSilenced();
   const [available, setAvailable] = useState(false);
 
   const checkForUpdates = async (addNotifications: boolean) => {
@@ -69,7 +69,7 @@ export const OpenUpdateDialogAction = () => {
 const SilenceAction = () => {
   const dispatch = useDispatch();
   return (
-    <Button.Icon variant="text" onClick={() => dispatch(silence())}>
+    <Button.Icon variant="text" onClick={() => dispatch(silenceUpdateNotifications())}>
       <Icon.Snooze />
     </Button.Icon>
   );

--- a/console/src/version/Updater.tsx
+++ b/console/src/version/Updater.tsx
@@ -61,7 +61,7 @@ export const OpenUpdateDialogAction = () => {
   const placer = Layout.usePlacer();
   return (
     <Button.Button variant="outlined" size="small" onClick={() => placer(infoLayout)}>
-      Update Action
+      Update
     </Button.Button>
   );
 };

--- a/console/src/version/external.ts
+++ b/console/src/version/external.ts
@@ -7,8 +7,8 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { Layout } from "@/layout";
-import { NotificationAdapter } from "@/notifications/Notifications";
+import { type Layout } from "@/layout";
+import { type NotificationAdapter } from "@/notifications/Notifications";
 import { Info, infoLayout } from "@/version/Info";
 import { notificationAdapter } from "@/version/Updater";
 

--- a/console/src/version/migrations/index.ts
+++ b/console/src/version/migrations/index.ts
@@ -1,0 +1,36 @@
+// Copyright 2024 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { migrate } from "@synnaxlabs/x";
+
+import * as v0 from "@/version/migrations/v0";
+import * as v1 from "@/version/migrations/v1";
+
+export type SliceState = v1.SliceState;
+export type AnySliceState = v0.SliceState | v1.SliceState;
+export const ZERO_SLICE_STATE = v1.ZERO_SLICE_STATE;
+
+export const SLICE_MIGRATIONS: migrate.Migrations = {};
+
+// Because the v0 state had a key called version, the usual migration pattern from X
+// does not work. Instead, we need to check if the state is a v0 state, manually convert
+// it to a v1 state, and then run the internal migrator.
+
+const internalMigrator = migrate.migrator<AnySliceState, SliceState>({
+  name: "version.slice",
+  migrations: SLICE_MIGRATIONS,
+  def: ZERO_SLICE_STATE,
+});
+
+const v0StrictSliceStateZ = v0.sliceStateZ.strict();
+
+export const migrateSlice: (v: AnySliceState) => SliceState = (v) => {
+  const state = v0StrictSliceStateZ.safeParse(v).success ? v1.migrate(v) : v;
+  return internalMigrator(state);
+};

--- a/console/src/version/migrations/migrations.spec.ts
+++ b/console/src/version/migrations/migrations.spec.ts
@@ -1,0 +1,42 @@
+// Copyright 2024 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in
+// the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business
+// Source License, use of this software will be governed by the Apache License,
+// Version 2.0, included in the file licenses/APL.txt.
+
+import { describe, expect, it } from "vitest";
+
+import { migrateSlice, ZERO_SLICE_STATE } from "@/version/migrations";
+import * as v0 from "@/version/migrations/v0";
+import * as v1 from "@/version/migrations/v1";
+
+describe("migrations", () => {
+  describe("slice", () => {
+    const STATES = [v0.ZERO_SLICE_STATE, v1.ZERO_SLICE_STATE];
+    STATES.forEach((state) =>
+      it(`should migrate slice from ${state.version} to latest`, () => {
+        const migrated = migrateSlice(state);
+        expect(migrated).toEqual(ZERO_SLICE_STATE);
+      }),
+    );
+  });
+  describe("slice with a version", () => {
+    const consoleVersion = "0.27.0";
+    const V0_STATE: v0.SliceState = {
+      version: consoleVersion,
+    };
+    const V1_STATE: v1.SliceState = {
+      version: "1.0.0",
+      consoleVersion,
+      silenced: false,
+    };
+    it(`should migrate slice from ${V0_STATE.version} to latest`, () => {
+      const migrated = migrateSlice(V0_STATE);
+      console.log(migrated);
+      expect(migrated).toEqual(migrateSlice(V1_STATE));
+    });
+  });
+});

--- a/console/src/version/migrations/migrations.spec.ts
+++ b/console/src/version/migrations/migrations.spec.ts
@@ -31,7 +31,7 @@ describe("migrations", () => {
     const V1_STATE: v1.SliceState = {
       version: "1.0.0",
       consoleVersion,
-      silenced: false,
+      updateNotificationsSilenced: false,
     };
     it(`should migrate slice from ${V0_STATE.version} to latest`, () => {
       const migrated = migrateSlice(V0_STATE);

--- a/console/src/version/migrations/v0.ts
+++ b/console/src/version/migrations/v0.ts
@@ -7,9 +7,14 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { notificationAdapter } from "@/hardware/device/useListenForChanges";
+import { z } from "zod";
 
-export * from "@/hardware/device/ontology";
-export * from "@/hardware/device/useListenForChanges";
+export const sliceStateZ = z.object({
+  version: z.string(),
+});
 
-export const NOTIFICATION_ADAPTERS = [notificationAdapter];
+export type SliceState = z.infer<typeof sliceStateZ>;
+
+export const ZERO_SLICE_STATE: SliceState = {
+  version: "0.0.0",
+};

--- a/console/src/version/migrations/v1.ts
+++ b/console/src/version/migrations/v1.ts
@@ -14,18 +14,18 @@ import * as v0 from "@/version/migrations/v0";
 export const sliceStateZ = z.object({
   version: z.literal("1.0.0"),
   consoleVersion: z.string(),
-  silenced: z.boolean(),
+  updateNotificationsSilenced: z.boolean(),
 });
 export type SliceState = z.infer<typeof sliceStateZ>;
 
 export const ZERO_SLICE_STATE: SliceState = {
   version: "1.0.0",
   consoleVersion: "0.0.0",
-  silenced: false,
+  updateNotificationsSilenced: false,
 };
 
 export const migrate: (state: v0.SliceState) => SliceState = (state) => ({
   version: "1.0.0",
   consoleVersion: state.version,
-  silenced: false,
+  updateNotificationsSilenced: false,
 });

--- a/console/src/version/migrations/v1.ts
+++ b/console/src/version/migrations/v1.ts
@@ -24,8 +24,8 @@ export const ZERO_SLICE_STATE: SliceState = {
   silenced: false,
 };
 
-export const migrate: (v: v0.SliceState) => SliceState = (v) => ({
+export const migrate: (state: v0.SliceState) => SliceState = (state) => ({
   version: "1.0.0",
-  consoleVersion: v.version,
+  consoleVersion: state.version,
   silenced: false,
 });

--- a/console/src/version/migrations/v1.ts
+++ b/console/src/version/migrations/v1.ts
@@ -1,0 +1,31 @@
+// Copyright 2024 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { z } from "zod";
+
+import * as v0 from "@/version/migrations/v0";
+
+export const sliceStateZ = z.object({
+  version: z.literal("1.0.0"),
+  consoleVersion: z.string(),
+  silenced: z.boolean(),
+});
+export type SliceState = z.infer<typeof sliceStateZ>;
+
+export const ZERO_SLICE_STATE: SliceState = {
+  version: "1.0.0",
+  consoleVersion: "0.0.0",
+  silenced: false,
+};
+
+export const migrate: (v: v0.SliceState) => SliceState = (v) => ({
+  version: "1.0.0",
+  consoleVersion: v.version,
+  silenced: false,
+});

--- a/console/src/version/selectors.ts
+++ b/console/src/version/selectors.ts
@@ -20,7 +20,8 @@ export const selectVersion = (state: StoreState): string =>
 
 export const useSelectVersion = (): string => useMemoSelect(selectVersion, []);
 
-export const selectSilenced = (state: StoreState): boolean =>
-  selectSliceState(state).silenced;
+export const selectUpdateNotificationsSilenced = (state: StoreState): boolean =>
+  selectSliceState(state).updateNotificationsSilenced;
 
-export const useSelectSilenced = (): boolean => useMemoSelect(selectSilenced, []);
+export const useSelectUpdateNotificationsSilenced = (): boolean =>
+  useMemoSelect(selectUpdateNotificationsSilenced, []);

--- a/console/src/version/selectors.ts
+++ b/console/src/version/selectors.ts
@@ -8,8 +8,19 @@
 // included in the file licenses/APL.txt.
 
 import { useMemoSelect } from "@/hooks";
-import { type StoreState } from "@/version/slice";
+import { SLICE_NAME, type SliceState, type StoreState } from "@/version/slice";
 
-export const select = (state: StoreState): string => state.version.version;
+export const selectSliceState = (state: StoreState): SliceState => state[SLICE_NAME];
 
-export const useSelect = (): string => useMemoSelect(select, []);
+export const useSelectSliceState = (): SliceState =>
+  useMemoSelect((state: StoreState) => selectSliceState(state), []);
+
+export const selectVersion = (state: StoreState): string =>
+  selectSliceState(state).consoleVersion;
+
+export const useSelectVersion = (): string => useMemoSelect(selectVersion, []);
+
+export const selectSilenced = (state: StoreState): boolean =>
+  selectSliceState(state).silenced;
+
+export const useSelectSilenced = (): boolean => useMemoSelect(selectSilenced, []);

--- a/console/src/version/slice.ts
+++ b/console/src/version/slice.ts
@@ -27,6 +27,7 @@ export const { actions, reducer } = createSlice({
   initialState: ZERO_SLICE_STATE,
   reducers: {
     set: (state, { payload: version }: SetVersionAction) => {
+      if (state.consoleVersion === version) return;
       state.consoleVersion = version;
       state.silenced = false;
     },

--- a/console/src/version/slice.ts
+++ b/console/src/version/slice.ts
@@ -29,14 +29,14 @@ export const { actions, reducer } = createSlice({
     set: (state, { payload: version }: SetVersionAction) => {
       if (state.consoleVersion === version) return;
       state.consoleVersion = version;
-      state.silenced = false;
+      state.updateNotificationsSilenced = false;
     },
-    silence: (state) => {
-      state.silenced = true;
+    silenceUpdateNotifications: (state) => {
+      state.updateNotificationsSilenced = true;
     },
   },
 });
 
-export const { set, silence } = actions;
+export const { set, silenceUpdateNotifications } = actions;
 
 export type Action = ReturnType<(typeof actions)[keyof typeof actions]>;

--- a/console/src/version/slice.ts
+++ b/console/src/version/slice.ts
@@ -7,45 +7,35 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import type { PayloadAction } from "@reduxjs/toolkit";
-import { createSlice } from "@reduxjs/toolkit";
-import { migrate } from "@synnaxlabs/x";
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+
+import * as latest from "@/version/migrations";
+
+export type SliceState = latest.SliceState;
+export const ZERO_SLICE_STATE = latest.ZERO_SLICE_STATE;
+export const migrateSlice = latest.migrateSlice;
 
 export const SLICE_NAME = "version";
-
-export interface SliceState {
-  version: string;
-}
 
 export interface StoreState {
   [SLICE_NAME]: SliceState;
 }
-
-export const ZERO_SLICE_STATE: SliceState = {
-  version: "0.0.0",
-};
-
 export type SetVersionAction = PayloadAction<string>;
-
-export const MIGRATIONS: migrate.Migrations = {};
-
-export const migrateSlice = migrate.migrator({
-  name: "version.slice",
-  migrations: MIGRATIONS,
-  def: ZERO_SLICE_STATE,
-});
 
 export const { actions, reducer } = createSlice({
   name: SLICE_NAME,
   initialState: ZERO_SLICE_STATE,
   reducers: {
     set: (state, { payload: version }: SetVersionAction) => {
-      state.version = version;
+      state.consoleVersion = version;
+      state.silenced = false;
+    },
+    silence: (state) => {
+      state.silenced = true;
     },
   },
 });
 
-export const { set } = actions;
+export const { set, silence } = actions;
 
 export type Action = ReturnType<(typeof actions)[keyof typeof actions]>;
-export type Payload = Action["payload"];

--- a/pluto/src/button/Button.tsx
+++ b/pluto/src/button/Button.tsx
@@ -167,6 +167,7 @@ export const Button = Tooltip.wrap(
         noWrap
         style={pStyle}
         startIcon={startIcon}
+        color={color}
         {...props}
       >
         {children}

--- a/x/media/src/Icon/index.tsx
+++ b/x/media/src/Icon/index.tsx
@@ -46,7 +46,7 @@ import { GrAttachment, GrDrag, GrPan } from "react-icons/gr";
 import { HiDownload, HiLightningBolt, HiOutlinePlus } from "react-icons/hi";
 import { HiSquare3Stack3D } from "react-icons/hi2";
 import { IoMdRefresh } from "react-icons/io";
-import { IoBookSharp, IoCopy, IoTime } from "react-icons/io5";
+import { IoBookSharp, IoCopy, IoNotificationsOff, IoTime } from "react-icons/io5";
 import {
   MdAlignHorizontalCenter,
   MdAlignHorizontalLeft,
@@ -371,6 +371,7 @@ export const Icon: IconType = {
   SplitY: wrapIcon(VscSplitVertical, "split-y"),
   AutoFitWidth: wrapIcon(TbArrowAutofitWidth, "auto-fit-width"),
   Commit: wrapIcon(MdCommit, "commit"),
+  Snooze: wrapIcon(IoNotificationsOff, "snooze"),
 };
 
 export interface IconType {
@@ -462,6 +463,7 @@ export interface IconType {
   Zoom: IconFC;
   Pan: IconFC;
   Selection: IconFC;
+  Snooze: IconFC;
   Tooltip: IconFC;
   Annotate: IconFC;
   Rule: IconFC;


### PR DESCRIPTION
# Feature Pull Request Template

## Key Information

- **Linear Issue**: [SY-1367](https://linear.app/synnax/issue/SY-1367/snooze-update-notifications)

## Description

Added a snooze button on the version update notification so that the version updates can be silenced.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have needed QA steps to the [release candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

The following makes sure that this feature does not break backwards compatibility.

### Data Structures

- [x] Server - I have ensured that previous versions of stored data structures are properly migrated to new formats.
- [x] Console - I have ensured that previous versions of stored data structures are properly migrated to new formats.

### API Changes

- [x] Server - The server API is backwards-compatible
- The following client APIs are backwards-compatible:
  - [x] C++
  - [x] TypeScript
  - [x] Python

### Breaking Changes

If anything in this section is not true, please list all breaking changes.
