### PR TITLE
[pluto] - hotfixed dropdown positioning on MacOS

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synnaxlabs/console",
   "private": true,
-  "version": "0.33.0",
+  "version": "0.33.1",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/pluto/package.json
+++ b/pluto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synnaxlabs/pluto",
-  "version": "0.33.0",
+  "version": "0.33.1",
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit && vite build",

--- a/pluto/src/dropdown/Dropdown.tsx
+++ b/pluto/src/dropdown/Dropdown.tsx
@@ -314,10 +314,16 @@ const calcConnectedDialog = ({
     invert(location.y === "bottom") * CONNECTED_TRANSLATE_AMOUNT,
   );
 
+  // This is a temporary fix for the cross-browser issue where the container-type property
+  // behavior is not consistent across MacOS and Windows.
+  let stylePropertyValueFilter = (v: string) => ["inline-size", "size"].includes(v);
+  if (runtime.getOS() !== "MacOS")
+    stylePropertyValueFilter = (v: string) => v === "inline-size";
+
   let parent: HTMLElement | null = target.parentElement;
   while (parent != null) {
     const style = window.getComputedStyle(parent);
-    if (style.getPropertyValue("container-type") === "inline-size") {
+    if (stylePropertyValueFilter(style.getPropertyValue("container-type"))) {
       container = box.construct(parent);
       if (location.y === "bottom")
         adjustedDialog = box.translate(


### PR DESCRIPTION
# Feature Pull Request Template

## Key Information

- **Linear Issue**: [SY-1434](https://linear.app/synnax/issue/SY-1434/hotfix-dropdown-positioning-on-macos)

## Description

Fixes incorrect dropdown positioning on MacOS due to inconsistencies in the "container-type" css property on WebKit and WebView.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have needed QA steps to the [release
      candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

The following makes sure that this feature does not break backwards compatability.

### Data Structures

- [ ] Server - I have ensured that previous versions of stored data structures are
      properly migrated to new formats.
- [ ] Console - I have ensured that previous versions of stored data structures are
      properly migrated to new formats.

### API Changes

- [ ] Server - The server API is backwards-compatible
- The following client APIs are backwards-compatible:
  - [ ] C++
  - [ ] TypeScript
  - [ ] Python

### Breaking Changes

If anything in this section is not true, please list all breaking changes.
