### PR TITLE
SY-1444 Fix Taring on Multiple Channels

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synnaxlabs/console",
   "private": true,
-  "version": "0.33.3",
+  "version": "0.33.4",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/console/src/hardware/labjack/task/Read.tsx
+++ b/console/src/hardware/labjack/task/Read.tsx
@@ -430,10 +430,13 @@ const ChannelListItem = ({
 }): ReactElement => {
   const { entry } = props;
   const ctx = Form.useContext();
-  const childValues = Form.useChildFieldValues<ReadChan>({
-    path: `${path}.${props.index}`,
-    optional: true,
-  });
+  // TODO: Fix bug in useChildFieldValues
+  const channels = Form.useChildFieldValues<ReadChan[]>({ path });
+  const childValues = channels?.[props.index];
+  // const childValues = Form.useChildFieldValues<ReadChan>({
+  //   path: `${path}.${props.index}`,
+  //   optional: true,
+  // });
   const channelName = Channel.useName(childValues?.channel ?? 0, "No Channel");
   const channelValid =
     Form.useField<number>({

--- a/console/src/hardware/ni/task/AnalogRead.tsx
+++ b/console/src/hardware/ni/task/AnalogRead.tsx
@@ -126,7 +126,6 @@ const Wrapped = ({
     mutationFn: async () => {
       if (!(await methods.validateAsync()) || client == null) return;
       const { name, config } = methods.value();
-
       const devices = unique(config.channels.map((c) => c.device));
 
       for (const devKey of devices) {
@@ -180,9 +179,11 @@ const Wrapped = ({
               index: dev.properties.analogInput.index,
             })),
           );
-          channels.forEach((c, i) => {
-            dev.properties.analogInput.channels[toCreate[i].port.toString()] = c.key;
-          });
+          channels.forEach(
+            (c, i) =>
+              (dev.properties.analogInput.channels[toCreate[i].port.toString()] =
+                c.key),
+          );
         }
 
         if (modified)
@@ -480,9 +481,15 @@ const ChannelListItem = ({
 }): ReactElement => {
   const ctx = Form.useContext();
   const path = `${basePath}.${props.index}`;
-  const childValues = Form.useChildFieldValues<AIChan>({ path, optional: true });
-  if (childValues == null) return <></>;
   const portValid = Form.useFieldValid(`${path}.port`);
+
+  // TODO: fix bug so I can refactor this to original code
+  const channels = Form.useChildFieldValues<AIChan[]>({ path: basePath });
+  if (channels == null || props?.index == null) return <></>;
+  const childValues = channels[props.index];
+  // const childValues = Form.useChildFieldValues<AIChan>({ path, optional: true });
+
+  if (childValues == null) return <></>;
   const showTareButton = childValues.channel != null && onTare != null;
   const tareIsDisabled =
     !childValues.enabled || snapshot || state?.details?.running !== true;

--- a/pluto/src/dropdown/Dropdown.tsx
+++ b/pluto/src/dropdown/Dropdown.tsx
@@ -339,6 +339,5 @@ const calcConnectedDialog = ({
     }
     parent = parent.parentElement;
   }
-  console.log(parent);
   return { adjustedDialog, location };
 };


### PR DESCRIPTION
# Feature Pull Request Template

## Key Information

- **Linear Issue**: [SY-1444](https://linear.app/synnax/issue/SY-1444/fix-taring-on-multiple-channel-read-tasks)

## Description

Hotfix to allow taring of multiple channels on a read tasks. Work to fix the underlying bug in Pluto Forms should be done later.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have needed QA steps to the [release candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

The following makes sure that this feature does not break backwards compatibility.

### Data Structures

- [x] Server - I have ensured that previous versions of stored data structures are properly migrated to new formats.
- [x] Console - I have ensured that previous versions of stored data structures are properly migrated to new formats.

### API Changes

- [x] Server - The server API is backwards-compatible
- The following client APIs are backwards-compatible:
  - [x] C++
  - [x] TypeScript
  - [x] Python

### Breaking Changes

If anything in this section is not true, please list all breaking changes.
