### PR TITLE
SY-1435 Fix Add to New Plot on Line Plot Range Highlight

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synnaxlabs/console",
   "private": true,
-  "version": "0.33.3",
+  "version": "0.33.4",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/console/src/lineplot/LinePlot.tsx
+++ b/console/src/lineplot/LinePlot.tsx
@@ -83,7 +83,6 @@ import {
   ZERO_STATE,
 } from "@/lineplot/slice";
 import { Range } from "@/range";
-import { overviewLayout } from "@/range/external";
 import { Workspace } from "@/workspace";
 
 interface SyncPayload {
@@ -378,7 +377,7 @@ const Loaded: Layout.Renderer = ({ layoutKey, focused, visible }): ReactElement 
       </PMenu.Menu>
     );
   };
-
+  const addRangeToNewPlot = Range.useAddToNewPlot();
   return (
     <PMenu.ContextMenu
       {...props}
@@ -420,13 +419,15 @@ const Loaded: Layout.Renderer = ({ layoutKey, focused, visible }): ReactElement 
                     download({ client, lines, timeRange, name });
                     break;
                   case "meta-data":
-                    placer({ ...overviewLayout, name, key });
+                    placer({ ...Range.overviewLayout, name, key });
+                    break;
+                  case "line-plot":
+                    addRangeToNewPlot(key);
                     break;
                   default:
                     break;
                 }
               };
-
               return (
                 <PMenu.Menu level="small" key={key} onChange={handleSelect}>
                   <PMenu.Item itemKey="download" startIcon={<Icon.Download />}>

--- a/console/src/range/Toolbar.tsx
+++ b/console/src/range/Toolbar.tsx
@@ -182,7 +182,7 @@ const useViewDetails = (): ((key: string) => void) => {
   }).mutate;
 };
 
-const useAddToNewPlot = (): ((key: string) => void) => {
+export const useAddToNewPlot = (): ((key: string) => void) => {
   const store = useStore<RootState>();
   const client = Synnax.use();
   const placer = Layout.usePlacer();


### PR DESCRIPTION
# Feature Pull Request Template

## Key Information

- **Linear Issue**: [SY-1435](https://linear.app/synnax/issue/SY-1435/fix-open-new-plot-on-range-highlight)

## Description

Fix an issue

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have needed QA steps to the [release candidate](https://github.com/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

The following makes sure that this feature does not break backwards compatibility.

### Data Structures

- [x] Server - I have ensured that previous versions of stored data structures are properly migrated to new formats.
- [x] Console - I have ensured that previous versions of stored data structures are properly migrated to new formats.

### API Changes

- [x] Server - The server API is backwards-compatible
- The following client APIs are backwards-compatible:
  - [x] C++
  - [x] TypeScript
  - [x] Python

### Breaking Changes

If anything in this section is not true, please list all breaking changes.
