### PR TITLE
[pluto] - improved value font sizing and spacing

### DIFF
--- a/pluto/src/text/SelectLevel.tsx
+++ b/pluto/src/text/SelectLevel.tsx
@@ -35,7 +35,7 @@ const DATA: Entry[] = [
     label: "M",
   },
   {
-    key: "p",
+    key: "h5",
     label: "S",
   },
   {

--- a/pluto/src/text/core/types.ts
+++ b/pluto/src/text/core/types.ts
@@ -15,6 +15,30 @@ import { type ComponentSize } from "@/util/component";
 export const LEVELS = ["h1", "h2", "h3", "h4", "h5", "p", "small"] as const;
 export const levelZ = z.enum(LEVELS);
 
+const DOWN_LEVELS: Record<Level, Level> = {
+  h1: "h2",
+  h2: "h3",
+  h3: "h4",
+  h4: "h5",
+  h5: "p",
+  p: "small",
+  small: "small",
+};
+
+export const downLevel = (level: Level): Level => DOWN_LEVELS[level];
+
+const UP_LEVELS: Record<Level, Level> = {
+  h1: "h1",
+  h2: "h1",
+  h3: "h2",
+  h4: "h3",
+  h5: "h4",
+  p: "h5",
+  small: "p",
+};
+
+export const upLevel = (level: Level): Level => UP_LEVELS[level];
+
 /* Level of typography i.e paragraph and heading */
 export type Level = z.infer<typeof levelZ>;
 

--- a/pluto/src/theming/core/fontString.ts
+++ b/pluto/src/theming/core/fontString.ts
@@ -11,11 +11,15 @@ import { text } from "@/text/core";
 import { type ThemeSpec } from "@/theming/core/theme";
 import { type ComponentSize, isComponentSize } from "@/util/component";
 
+interface FontStringOptions {
+  level: text.Level | ComponentSize;
+  weight?: text.Weight;
+  code?: boolean;
+}
+
 export const fontString = (
   theme: ThemeSpec,
-  level: text.Level | ComponentSize,
-  weight?: text.Weight,
-  code?: boolean,
+  { level, weight, code }: FontStringOptions,
 ): string => {
   const {
     typography,

--- a/pluto/src/theming/font.ts
+++ b/pluto/src/theming/font.ts
@@ -23,7 +23,7 @@ export const useTypography = (level: Text.Level): UseTypographyReturn => {
   const t = theme.typography[level];
   return {
     ...t,
-    toString: () => fontString(theme, level),
+    toString: () => fontString(theme, { level }),
     baseSize: theme.sizes.base,
     lineHeightPx: t.lineHeight * theme.sizes.base,
     sizePx: t.size * theme.sizes.base,

--- a/pluto/src/vis/draw2d/index.ts
+++ b/pluto/src/vis/draw2d/index.ts
@@ -239,7 +239,7 @@ export class Draw2D {
     spacing = 1,
     level = "p",
   }: Draw2DMeasureTextContainerProps): [dimensions.Dimensions, (base: xy.XY) => void] {
-    const font = fontString(this.theme, level);
+    const font = fontString(this.theme, { level });
     const textDims = text.map((t) => textDimensions(t, font, this.canvas));
     const spacingPx = this.theme.sizes.base * spacing;
     const offset =
@@ -253,7 +253,7 @@ export class Draw2D {
       },
 
       (position: xy.XY) => {
-        const font = fontString(this.theme, level);
+        const font = fontString(this.theme, { level });
         this.canvas.font = font;
         this.canvas.fillStyle = this.theme.colors.text.hex;
         this.canvas.textBaseline = "top";
@@ -279,7 +279,7 @@ export class Draw2D {
     maxWidth,
     code,
   }: DrawTextProps): void {
-    this.canvas.font = fontString(this.theme, level, weight, code);
+    this.canvas.font = fontString(this.theme, { level, weight, code });
     if (shade == null) this.canvas.fillStyle = this.theme.colors.text.hex;
     else this.canvas.fillStyle = this.theme.colors.gray[`l${shade}`].hex;
     this.canvas.textBaseline = "top";

--- a/pluto/src/vis/lineplot/aether/axis.ts
+++ b/pluto/src/vis/lineplot/aether/axis.ts
@@ -115,7 +115,7 @@ export class CoreAxis<
         : DEFAULT_X_BOUND_PADDING;
     this.internal.core = new axis.Canvas(this.internal.render, {
       color: theme.colors.gray.l8,
-      font: fontString(theme, "small"),
+      font: fontString(theme, { level: "small" }),
       gridColor: theme.colors.gray.l1,
       ...this.state,
     });

--- a/pluto/src/vis/schematic/Forms.tsx
+++ b/pluto/src/vis/schematic/Forms.tsx
@@ -555,14 +555,6 @@ export const ValueForm = (): ReactElement => {
                 >
                   {(p) => <Text.SelectLevel {...p} />}
                 </Form.Field>
-                <Form.Field<Text.Level>
-                  path="unitsLevel"
-                  label="Units Size"
-                  hideIfNull
-                  padHelpText={false}
-                >
-                  {(p) => <Text.SelectLevel {...p} />}
-                </Form.Field>
               </Align.Space>
             </Align.Space>
             <OrientationControl path="" showInner={false} />
@@ -871,7 +863,7 @@ export const TextBoxForm = (): ReactElement => {
 
 export const OffPageReferenceForm = (): ReactElement => (
   <FormWrapper direction="x" align="stretch">
-    <Align.Space direction="y" grow >
+    <Align.Space direction="y" grow>
       <LabelControls path="label" omit={["maxInlineSize", "align"]} />
       <ColorControl path="color" />
     </Align.Space>

--- a/pluto/src/vis/schematic/Symbols.tsx
+++ b/pluto/src/vis/schematic/Symbols.tsx
@@ -675,7 +675,6 @@ export const Value = Aether.wrap<SymbolProps<ValueProps>>(
     onChange,
     tooltip,
     inlineSize,
-    unitsLevel,
   }): ReactElement => {
     const font = Theming.useTypography(level);
     const [dims, setDims] = useState<ValueDimensionsState>({
@@ -749,7 +748,7 @@ export const Value = Aether.wrap<SymbolProps<ValueProps>>(
             }}
             inlineSize={inlineSize}
             units={units}
-            unitsLevel={unitsLevel}
+            unitsLevel={Text.downLevel(level)}
           />
         </Labeled>
       </Tooltip.Dialog>
@@ -785,24 +784,17 @@ const adjustValueBox = ({
     position = xy.translate(
       position,
       "y",
-      Math.max((labelDims.height - valueBoxHeight) / 2 - 1, 0),
+      Math.max((labelDims.height - valueBoxHeight) / 2 - 1, 1),
     );
   if (hasLabel && labelOrientation === "left")
-    position = xy.translate(position, "x", labelDims.width + 4);
+    position = xy.translate(position, { x: labelDims.width + 6, y: 0 });
   else if (hasLabel && labelOrientation === "top")
-    position = xy.translate(position, "y", labelDims.height + 4);
+    position = xy.translate(position, "y", labelDims.height + 6);
   return box.construct(position.x, position.y, box.width(outerBox), valueBoxHeight);
 };
 
 export const ValuePreview = ({ color }: ValueProps): ReactElement => (
-  <Primitives.Value
-    color={color}
-    dimensions={{
-      width: 60,
-      height: 25,
-    }}
-    units={"psi"}
-  >
+  <Primitives.Value color={color} dimensions={{ width: 60, height: 25 }} units={"psi"}>
     <Text.Text level="p">50.00</Text.Text>
   </Primitives.Value>
 );

--- a/pluto/src/vis/schematic/primitives/Primitives.css
+++ b/pluto/src/vis/schematic/primitives/Primitives.css
@@ -166,6 +166,15 @@
         background: var(--pluto-gray-l7);
         padding-top: 1px;
         margin-right: -1px;
+        text-align: center;
+
+        &.pluto--h4 {
+            padding: 0 1.5rem;
+        }
+
+        &.pluto--h3 {
+            padding: 0 2rem;
+        }
 
         & small {
             color: var(--pluto-gray-l0);

--- a/pluto/src/vis/schematic/primitives/Primitives.tsx
+++ b/pluto/src/vis/schematic/primitives/Primitives.tsx
@@ -1095,7 +1095,10 @@ export const Value = ({
         <Handle location="top" orientation="left" left={50} top={-2} id="3" />
         <Handle location="bottom" orientation="left" left={50} top={102} id="4" />
       </HandleBoundary>
-      <div className={CSS.BE("value", "units")} style={{ background: borderColor }}>
+      <div
+        className={CSS(CSS.BE("value", "units"), CSS.M(unitsLevel))}
+        style={{ background: borderColor }}
+      >
         <Text.Text level={unitsLevel} color={textColor}>
           {units}
         </Text.Text>

--- a/pluto/src/vis/schematic/registry.ts
+++ b/pluto/src/vis/schematic/registry.ts
@@ -574,7 +574,6 @@ const value: Spec<ValueProps> = {
     color: t.colors.gray.l9.rgba255,
     units: "psi",
     level: "h5",
-    unitsLevel: "small",
     inlineSize: 70,
     ...zeroLabel("Value"),
     ...ZERO_PROPS,

--- a/pluto/src/vis/value/aether/value.ts
+++ b/pluto/src/vis/value/aether/value.ts
@@ -44,8 +44,6 @@ interface InternalState {
   textColor: color.Color;
 }
 
-const SIZE_CHANGE_THRESHOLD = 9;
-
 export class Value
   extends aether.Leaf<typeof valueState, InternalState>
   implements Element
@@ -91,11 +89,11 @@ export class Value
     const requiredWidth = width + theme.sizes.base + this.fontHeight;
     if (
       this.state.width == null ||
-      this.state.width + SIZE_CHANGE_THRESHOLD < requiredWidth ||
+      this.state.width + this.fontHeight * 0.5 < requiredWidth ||
       (this.state.minWidth > requiredWidth && this.state.width !== this.state.minWidth)
     )
       this.setState((p) => ({ ...p, width: Math.max(requiredWidth, p.minWidth) }));
-    else if (this.state.width - SIZE_CHANGE_THRESHOLD > requiredWidth)
+    else if (this.state.width - this.fontHeight > requiredWidth)
       this.setState((p) => ({ ...p, width: Math.max(requiredWidth, p.minWidth) }));
   }
 
@@ -117,9 +115,10 @@ export class Value
     this.maybeUpdateWidth(width);
     const isNegative = value[0] == "-";
     const labelPosition = xy.translate(box.topLeft(b), {
-      x: 12 + fontHeight / 5,
-      y: (box.height(b) + fontHeight) / 2,
+      x: 6 + fontHeight * 0.75,
+      y: box.height(b) / 2,
     });
+    canvas.textBaseline = "middle";
     canvas.fillStyle = this.internal.textColor.hex;
     // If the value is negative, chop of the negative sign and draw it separately
     // so that the first digit always stays in the same position, regardless of the sign.


### PR DESCRIPTION
# Feature Pull Request Template

## Key Information

- **Linear Issue**: [SY-1440](https://linear.app/synnax/issue/SY-1440/switch-schematic-values-to-monospaced-font)

## Description

Switches to use a monospaced font on schematic values, makes the "Small" font option slightly larger, and makes it so that values that switch between - and + frequently don't shift their digits.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have needed QA steps to the [release
      candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

The following makes sure that this feature does not break backwards compatability.

### Data Structures

- [ ] Server - I have ensured that previous versions of stored data structures are
      properly migrated to new formats.
- [ ] Console - I have ensured that previous versions of stored data structures are
      properly migrated to new formats.

### API Changes

- [ ] Server - The server API is backwards-compatible
- The following client APIs are backwards-compatible:
  - [ ] C++
  - [ ] TypeScript
  - [ ] Python

### Breaking Changes

If anything in this section is not true, please list all breaking changes.
