### PR TITLE
[client/py] - added type coersion for primitive non-string values in …

### DIFF
--- a/client/py/synnax/ranger/kv.py
+++ b/client/py/synnax/ranger/kv.py
@@ -14,7 +14,7 @@ from freighter import Payload, UnaryClient, send_required
 
 from synnax import ValidationError
 from synnax.util.normalize import normalize
-from synnax.util.primitive import Primitive, is_primitive
+from synnax.util.primitive import is_primitive
 
 
 class KVPair(Payload):
@@ -24,8 +24,8 @@ class KVPair(Payload):
 
     def __init__(self, **kwargs):
         value = kwargs.get("value")
-        if not isinstance(kwargs["value"], str):
-            if not is_primitive(value):
+        if not isinstance(value, str):
+            if not is_primitive(value) and type(value).__str__ == object.__str__:
                 raise ValidationError(f"""
                 Synnax has no way of casting {value} to a string when setting meta-data
                 on a range. Please convert the value to a string before setting it.
@@ -82,15 +82,15 @@ class KV:
         return {pair.key: pair.value for pair in res.pairs}
 
     @overload
-    def set(self, key: str, value: Primitive):
+    def set(self, key: str, value: any):
         ...
 
     @overload
-    def set(self, key: dict[str, Primitive]):
+    def set(self, key: dict[str, any]):
         ...
 
-    def set(self, key: str | dict[str, Primitive],
-            value: Primitive | None = None) -> None:
+    def set(self, key: str | dict[str, any],
+            value: any = None) -> None:
         pairs = list()
         if isinstance(key, str):
             pairs.append(KVPair(range=self._rng_key, key=key, value=value))

--- a/client/py/synnax/util/primitive.py
+++ b/client/py/synnax/util/primitive.py
@@ -1,0 +1,13 @@
+#  Copyright 2024 Synnax Labs, Inc.
+#
+#  Use of this software is governed by the Business Source License included in the file
+#  licenses/BSL.txt.
+#
+#  As of the Change Date specified in that file, in accordance with the Business Source
+#  License, use of this software will be governed by the Apache License, Version 2.0,
+#  included in the file licenses/APL.txt.
+
+Primitive = str | int | float | bool | None
+
+def is_primitive(value: object) -> bool:
+    return isinstance(value, (str, int, float, bool, type(None)))

--- a/client/py/tests/test_ranger.py
+++ b/client/py/tests/test_ranger.py
@@ -171,6 +171,23 @@ class TestRangeClient:
             with pytest.raises(sy.exceptions.QueryError):
                 rng.meta_data.get(["test", "test2"])
 
+        def test_set_non_string_primitive(self, client: sy.Synnax):
+            rng = client.ranges.create(
+                name="test",
+                time_range=sy.TimeStamp.now().span_range(10 * sy.TimeSpan.SECOND),
+            )
+            rng.meta_data["key"] = 1
+            assert rng.meta_data["key"] == "1"
+
+        def test_set_non_string_non_primitive(self, client: sy.Synnax):
+            rng = client.ranges.create(
+                name="test",
+                time_range=sy.TimeStamp.now().span_range(10 * sy.TimeSpan.SECOND),
+            )
+            with pytest.raises(sy.ValidationError):
+                rng.meta_data["key"] = object()
+
+
     @pytest.mark.ranger
     class TestRangeAlias:
         def test_basic_alias(self, client: sy.Synnax):

--- a/client/py/tests/test_ranger.py
+++ b/client/py/tests/test_ranger.py
@@ -187,6 +187,18 @@ class TestRangeClient:
             with pytest.raises(sy.ValidationError):
                 rng.meta_data["key"] = object()
 
+        def test_set_non_string_str_implemented_object(self, client: sy.Synnax):
+            rng = client.ranges.create(
+                name="test",
+                time_range=sy.TimeStamp.now().span_range(10 * sy.TimeSpan.SECOND),
+            )
+
+            class Test:
+                def __str__(self):
+                    return "test"
+
+            rng.meta_data["key"] = Test()
+            assert rng.meta_data["key"] == "test"
 
     @pytest.mark.ranger
     class TestRangeAlias:


### PR DESCRIPTION
…range KV

# Feature Pull Request Template

## Key Information

- **Linear Issue**: [SY-1452](https://linear.app/synnax/issue/SY-1452/add-auto-conversion-to-string-for-metadata-in-python)

## Description

Adds type coercion in the Python client for non-string values on the range key-value store. 

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [ ] I have needed QA steps to the [release
      candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

The following makes sure that this feature does not break backwards compatability.

### Data Structures

- [ ] Server - I have ensured that previous versions of stored data structures are
      properly migrated to new formats.
- [ ] Console - I have ensured that previous versions of stored data structures are
      properly migrated to new formats.

### API Changes

- [ ] Server - The server API is backwards-compatible
- The following client APIs are backwards-compatible:
  - [ ] C++
  - [ ] TypeScript
  - [ ] Python

### Breaking Changes

If anything in this section is not true, please list all breaking changes.
