### PR TITLE
[console] - added aliases to labjack port selection

### DIFF
--- a/console/src/hardware/labjack/device/Select.tsx
+++ b/console/src/hardware/labjack/device/Select.tsx
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { Form, Select } from "@synnaxlabs/pluto";
+import { Form, Select, Text } from "@synnaxlabs/pluto";
 import { deep, KeyedNamed } from "@synnaxlabs/x";
 
 import {
@@ -37,7 +37,18 @@ export const SelectPort = ({ model, channelType, ...props }: SelectPortProps) =>
   return (
     <Select.Single<string, Port>
       data={data}
-      columns={[{ key: "key", name: "Port" }]}
+      columns={[
+        { key: "key", name: "Port" },
+        {
+          key: "aliases",
+          name: "Aliases",
+          render: ({ entry: { aliases } }) => (
+            <Text.Text level="small" shade={8}>
+              {aliases.join(", ")}
+            </Text.Text>
+          ),
+        },
+      ]}
       allowNone={false}
       entryRenderKey="key"
       {...props}

--- a/console/src/hardware/labjack/device/types.ts
+++ b/console/src/hardware/labjack/device/types.ts
@@ -72,45 +72,71 @@ export const aiPortZ = z.object({
   key: z.string(),
   type: aiChannelTypeZ,
   voltageRange: bounds.bounds,
+  aliases: z.array(z.string()),
 });
 export type AIPort = z.infer<typeof aiPortZ>;
 
-export const diPortZ = z.object({ key: z.string(), type: diChannelTypeZ });
+export const diPortZ = z.object({
+  key: z.string(),
+  type: diChannelTypeZ,
+  aliases: z.array(z.string()),
+});
 export type DIPort = z.infer<typeof diPortZ>;
 
-export const doPortZ = z.object({ key: z.string(), type: doChannelTypeZ });
+export const doPortZ = z.object({
+  key: z.string(),
+  type: doChannelTypeZ,
+  aliases: z.array(z.string()),
+});
 export type DOPort = z.infer<typeof doPortZ>;
 
-export const aoPortZ = z.object({ key: z.string(), type: aoChannelTypeZ });
+export const aoPortZ = z.object({
+  key: z.string(),
+  type: aoChannelTypeZ,
+  aliases: z.array(z.string()),
+});
 export type AOPort = z.infer<typeof aoPortZ>;
 
 export const portZ = z.union([aoPortZ, aiPortZ, doPortZ, diPortZ]);
 
 export type Port = z.infer<typeof portZ>;
 
-const aiFactory = (b: bounds.Bounds, voltageRange: bounds.Bounds): AIPort[] =>
+interface AltConfig {
+  prefix: string;
+  offset: number;
+}
+
+const aiFactory = (
+  b: bounds.Bounds,
+  voltageRange: bounds.Bounds,
+  altConfigs: AltConfig[] = [],
+): AIPort[] =>
   Array.from({ length: bounds.span(b) + 1 }, (_, i) => ({
     key: `AIN${i + b.lower}`,
     type: "AI",
     voltageRange,
+    aliases: altConfigs.map((config) => `${config.prefix}${i + config.offset}`),
   }));
 
-const diFactory = (b: bounds.Bounds): DIPort[] =>
+const diFactory = (b: bounds.Bounds, altConfigs: AltConfig[] = []): DIPort[] =>
   Array.from({ length: bounds.span(b) + 1 }, (_, i) => ({
     key: `DIO${i + b.lower}`,
     type: "DI",
+    aliases: altConfigs.map((config) => `${config.prefix}${i + config.offset}`),
   }));
 
-const doFactory = (b: bounds.Bounds): DOPort[] =>
+const doFactory = (b: bounds.Bounds, altConfigs: AltConfig[] = []): DOPort[] =>
   Array.from({ length: bounds.span(b) + 1 }, (_, i) => ({
     key: `DIO${i + b.lower}`,
     type: "DO",
+    aliases: altConfigs.map((config) => `${config.prefix}${i + config.offset}`),
   }));
 
-const aoFactory = (b: bounds.Bounds): AOPort[] =>
+const aoFactory = (b: bounds.Bounds, altConfigs: AltConfig[] = []): AOPort[] =>
   Array.from({ length: bounds.span(b) + 1 }, (_, i) => ({
     key: `DAC${i + b.lower}`,
     type: "AO",
+    aliases: altConfigs.map((config) => `${config.prefix}${i + config.offset}`),
   }));
 
 const AIN_HIGH_VOLTAGE = bounds.construct(-10, 10);
@@ -131,8 +157,15 @@ export const T4_AI_PORTS: AIPort[] = [
   ...aiFactory({ lower: 5, upper: 11 }, AIN_LOW_VOLTAGE),
 ];
 export const T4_AO_PORTS: AOPort[] = aoFactory({ lower: 0, upper: 1 });
-export const T4_DI_PORTS: DIPort[] = diFactory({ lower: 4, upper: 15 });
-export const T4_DO_PORTS: DOPort[] = doFactory({ lower: 4, upper: 15 });
+export const T4_DI_PORTS: DIPort[] = [
+  ...diFactory({ lower: 4, upper: 7 }, [{ prefix: "FIO", offset: 0 }]),
+  ...diFactory({ lower: 8, upper: 15 }, [{ prefix: "EIO", offset: 8 }]),
+];
+export const T4_DO_PORTS: DOPort[] = [
+  ...doFactory({ lower: 4, upper: 7 }, [{ prefix: "FIO", offset: 0 }]),
+  ...doFactory({ lower: 8, upper: 15 }, [{ prefix: "EIO", offset: 8 }]),
+];
+
 export const T4_PORTS: Ports = {
   AI: T4_AI_PORTS,
   AO: T4_AO_PORTS,
@@ -147,8 +180,18 @@ export const T7_AI_PORTS: AIPort[] = aiFactory(
   AIN_HIGH_VOLTAGE,
 );
 export const T7_AO_PORTS: AOPort[] = aoFactory({ lower: 0, upper: 1 });
-export const T7_DI_PORTS: DIPort[] = diFactory({ lower: 0, upper: 22 });
-export const T7_DO_PORTS: DOPort[] = doFactory({ lower: 0, upper: 22 });
+export const T7_DI_PORTS: DIPort[] = [
+  ...diFactory({ lower: 0, upper: 7 }, [{ prefix: "FIO", offset: 0 }]),
+  ...diFactory({ lower: 8, upper: 15 }, [{ prefix: "EIO", offset: 8 }]),
+  ...diFactory({ lower: 16, upper: 19 }, [{ prefix: "CIO", offset: 16 }]),
+  ...diFactory({ lower: 20, upper: 22 }, [{ prefix: "MIO", offset: 20 }]),
+];
+export const T7_DO_PORTS: DOPort[] = [
+  ...doFactory({ lower: 0, upper: 7 }, [{ prefix: "FIO", offset: 0 }]),
+  ...doFactory({ lower: 8, upper: 15 }, [{ prefix: "EIO", offset: 8 }]),
+  ...doFactory({ lower: 16, upper: 19 }, [{ prefix: "CIO", offset: 16 }]),
+  ...doFactory({ lower: 20, upper: 22 }, [{ prefix: "MIO", offset: 20 }]),
+];
 export const T7_PORTS: Ports = {
   AI: T7_AI_PORTS,
   AO: T7_AO_PORTS,
@@ -163,8 +206,16 @@ export const T8_AI_PORTS: AIPort[] = aiFactory(
   AIN_HIGH_VOLTAGE,
 );
 export const T8_AO_PORTS: AOPort[] = aoFactory({ lower: 0, upper: 1 });
-export const T8_DI_PORTS: DIPort[] = diFactory({ lower: 0, upper: 19 });
-export const T8_DO_PORTS: DOPort[] = doFactory({ lower: 0, upper: 19 });
+export const T8_DI_PORTS: DIPort[] = [
+  ...diFactory({ lower: 0, upper: 7 }, [{ prefix: "FIO", offset: 0 }]),
+  ...diFactory({ lower: 8, upper: 15 }, [{ prefix: "EIO", offset: 8 }]),
+  ...diFactory({ lower: 16, upper: 19 }, [{ prefix: "CIO", offset: 16 }]),
+];
+export const T8_DO_PORTS: DOPort[] = [
+  ...doFactory({ lower: 0, upper: 7 }, [{ prefix: "FIO", offset: 0 }]),
+  ...doFactory({ lower: 8, upper: 15 }, [{ prefix: "EIO", offset: 8 }]),
+  ...doFactory({ lower: 16, upper: 19 }, [{ prefix: "CIO", offset: 16 }]),
+];
 export const T8_PORTS: Ports = {
   AI: T8_AI_PORTS,
   AO: T8_AO_PORTS,


### PR DESCRIPTION
# Feature Pull Request Template

## Key Information

- **Linear Issue**: [SY-1463](https://linear.app/synnax/issue/SY-1463/add-labjack-port-aliases)

## Description

Shows the alternative LabJack port names that show up on the device so that it's easier to figure out what things are.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have needed QA steps to the [release
      candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

The following makes sure that this feature does not break backwards compatability.

### Data Structures

- [ ] Server - I have ensured that previous versions of stored data structures are
      properly migrated to new formats.
- [ ] Console - I have ensured that previous versions of stored data structures are
      properly migrated to new formats.

### API Changes

- [ ] Server - The server API is backwards-compatible
- The following client APIs are backwards-compatible:
  - [ ] C++
  - [ ] TypeScript
  - [ ] Python

### Breaking Changes

If anything in this section is not true, please list all breaking changes.
