### PR TITLE
SY-1365 protect main branch but allow auto pushes from workflows

### DIFF
--- a/.github/workflows/deploy.console.yaml
+++ b/.github/workflows/deploy.console.yaml
@@ -26,7 +26,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          base-ref: main
           ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Get Version

--- a/.github/workflows/deploy.console.yaml
+++ b/.github/workflows/deploy.console.yaml
@@ -23,7 +23,11 @@ jobs:
       changed: ${{ steps.filter.outputs.changed }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          base-ref: main
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Get Version
         id: version

--- a/.github/workflows/deploy.py.yaml
+++ b/.github/workflows/deploy.py.yaml
@@ -11,7 +11,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          base-ref: main
+          ssh-key: ${{ secrets.DEPLOY_KEY }}
 
       - name: Set up Python
         uses: actions/setup-python@v4


### PR DESCRIPTION
# Feature Pull Request Template

## Key Information

- **Linear Issue**: [SY-1365](https://linear.app/synnax/issue/1365)

## Description

This pr changes how workflows that make commits checkout the repository by passing in a deploy key that has been configured to allow for writes to `main`.


## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have needed QA steps to the [release
      candidate](/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

The following makes sure that this feature does not break backwards compatability.

### Data Structures

- [ ] Server - I have ensured that previous versions of stored data structures are
      properly migrated to new formats.
- [ ] Console - I have ensured that previous versions of stored data structures are
      properly migrated to new formats.

### API Changes

- [ ] Server - The server API is backwards-compatible
- The following client APIs are backwards-compatible:
  - [ ] C++
  - [ ] TypeScript
  - [ ] Python

### Breaking Changes

If anything in this section is not true, please list all breaking changes.
