### PR TITLE
[console] - fixed LabJack port indices

### DIFF
--- a/console/src/hardware/labjack/device/types.ts
+++ b/console/src/hardware/labjack/device/types.ts
@@ -193,7 +193,7 @@ export const T7_AI_PORTS: AIPort[] = aiFactory(
 );
 export const T7_AO_PORTS: AOPort[] = aoFactory({ lower: 0, upper: 1 });
 export const T7_DI_PORTS: DIPort[] = [
-  ...diFactory({ lower: 4, upper: 7 }, [{ prefix: "FIO", offset: 0 }]),
+  ...diFactory({ lower: 0, upper: 7 }, [{ prefix: "FIO", offset: 0 }]),
   ...diFactory({ lower: 8, upper: 15 }, [{ prefix: "EIO", offset: 8 }]),
   ...diFactory({ lower: 16, upper: 19 }, [{ prefix: "CIO", offset: 16 }]),
   ...diFactory({ lower: 20, upper: 22 }, [{ prefix: "MIO", offset: 20 }]),

--- a/console/src/hardware/labjack/device/types.ts
+++ b/console/src/hardware/labjack/device/types.ts
@@ -111,33 +111,45 @@ const aiFactory = (
   voltageRange: bounds.Bounds,
   altConfigs: AltConfig[] = [],
 ): AIPort[] =>
-  Array.from({ length: bounds.span(b) + 1 }, (_, i) => ({
-    key: `AIN${i + b.lower}`,
-    type: "AI",
-    voltageRange,
-    aliases: altConfigs.map((config) => `${config.prefix}${i + config.offset}`),
-  }));
+  Array.from({ length: bounds.span(b) + 1 }, (_, i) => {
+    const port = i + b.lower;
+    return {
+      key: `AIN${port}`,
+      type: "AI",
+      voltageRange,
+      aliases: altConfigs.map((config) => `${config.prefix}${port - config.offset}`),
+    };
+  });
 
 const diFactory = (b: bounds.Bounds, altConfigs: AltConfig[] = []): DIPort[] =>
-  Array.from({ length: bounds.span(b) + 1 }, (_, i) => ({
-    key: `DIO${i + b.lower}`,
-    type: "DI",
-    aliases: altConfigs.map((config) => `${config.prefix}${i + config.offset}`),
-  }));
+  Array.from({ length: bounds.span(b) + 1 }, (_, i) => {
+    const port = i + b.lower;
+    return {
+      key: `DIO${port}`,
+      type: "DI",
+      aliases: altConfigs.map((config) => `${config.prefix}${port - config.offset}`),
+    };
+  });
 
 const doFactory = (b: bounds.Bounds, altConfigs: AltConfig[] = []): DOPort[] =>
-  Array.from({ length: bounds.span(b) + 1 }, (_, i) => ({
-    key: `DIO${i + b.lower}`,
-    type: "DO",
-    aliases: altConfigs.map((config) => `${config.prefix}${i + config.offset}`),
-  }));
+  Array.from({ length: bounds.span(b) + 1 }, (_, i) => {
+    const port = i + b.lower;
+    return {
+      key: `DIO${i + b.lower}`,
+      type: "DO",
+      aliases: altConfigs.map((config) => `${config.prefix}${port - config.offset}`),
+    };
+  });
 
 const aoFactory = (b: bounds.Bounds, altConfigs: AltConfig[] = []): AOPort[] =>
-  Array.from({ length: bounds.span(b) + 1 }, (_, i) => ({
-    key: `DAC${i + b.lower}`,
-    type: "AO",
-    aliases: altConfigs.map((config) => `${config.prefix}${i + config.offset}`),
-  }));
+  Array.from({ length: bounds.span(b) + 1 }, (_, i) => {
+    const port = i + b.lower;
+    return {
+      key: `DAC${port}`,
+      type: "AO",
+      aliases: altConfigs.map((config) => `${config.prefix}${port - config.offset}`),
+    };
+  });
 
 const AIN_HIGH_VOLTAGE = bounds.construct(-10, 10);
 const AIN_LOW_VOLTAGE = bounds.construct(0, 2.5);
@@ -181,7 +193,7 @@ export const T7_AI_PORTS: AIPort[] = aiFactory(
 );
 export const T7_AO_PORTS: AOPort[] = aoFactory({ lower: 0, upper: 1 });
 export const T7_DI_PORTS: DIPort[] = [
-  ...diFactory({ lower: 0, upper: 7 }, [{ prefix: "FIO", offset: 0 }]),
+  ...diFactory({ lower: 4, upper: 7 }, [{ prefix: "FIO", offset: 0 }]),
   ...diFactory({ lower: 8, upper: 15 }, [{ prefix: "EIO", offset: 8 }]),
   ...diFactory({ lower: 16, upper: 19 }, [{ prefix: "CIO", offset: 16 }]),
   ...diFactory({ lower: 20, upper: 22 }, [{ prefix: "MIO", offset: 20 }]),

--- a/console/src/hardware/labjack/task/Write.tsx
+++ b/console/src/hardware/labjack/task/Write.tsx
@@ -353,7 +353,7 @@ const ChannelForm = ({
         {(p) => (
           <SelectPort
             {...p}
-            model={(device?.model ?? "LJM_dtT8") as ModelKey}
+            model={(device?.model ?? "LJM_dtT4") as ModelKey}
             channelType={channelType}
           />
         )}

--- a/console/src/hardware/labjack/task/Write.tsx
+++ b/console/src/hardware/labjack/task/Write.tsx
@@ -353,7 +353,7 @@ const ChannelForm = ({
         {(p) => (
           <SelectPort
             {...p}
-            model={(device?.model ?? "LJM_dtT4") as ModelKey}
+            model={(device?.model ?? "LJM_dtT8") as ModelKey}
             channelType={channelType}
           />
         )}


### PR DESCRIPTION
# Issue Pull Request

## Key Information

- **Linear Issue**: [SY-1502](https://linear.app/synnax/issue/SY-1502/fix-labjack-port-indices)

## Description

Fixes incorrect alternate names in LabJack Ports

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
