### PR TITLE
[drift/tauri] - fixed logical and physical position calculations

### DIFF
--- a/drift/src/tauri/index.ts
+++ b/drift/src/tauri/index.ts
@@ -8,7 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { type Action, type UnknownAction } from "@reduxjs/toolkit";
-import { debounce as debounceF, type dimensions, type xy } from "@synnaxlabs/x";
+import { debounce as debounceF, dimensions, xy } from "@synnaxlabs/x";
 import {
   emit,
   type Event as TauriEvent,
@@ -278,8 +278,8 @@ export class TauriRuntime<S extends StoreState, A extends Action = UnknownAction
     const scaleFactor = await this.win.scaleFactor();
     const visible = await this.win.isVisible();
     return {
-      position: await parsePosition(await this.win.innerPosition(), scaleFactor),
-      size: await parseSize(await this.win.innerSize(), scaleFactor),
+      position: parsePosition(await this.win.innerPosition(), scaleFactor),
+      size: parseSize(await this.win.innerSize(), scaleFactor),
       maximized: await this.win.isMaximized(),
       visible,
       fullscreen: await this.win.isFullscreen(),
@@ -306,8 +306,8 @@ const newWindowPropsHandlers = (): HandlerEntry[] => [
         maximized: await window.isMaximized(),
         visible,
         minimized: !visible,
-        position: await parsePosition(await window.innerPosition(), scaleFactor),
-        size: await parseSize(await window.innerSize(), scaleFactor),
+        position: parsePosition(await window.innerPosition(), scaleFactor),
+        size: parseSize(await window.innerSize(), scaleFactor),
       };
       return setWindowProps(nextProps);
     },
@@ -318,7 +318,7 @@ const newWindowPropsHandlers = (): HandlerEntry[] => [
     handler: async (window) => {
       const scaleFactor = await window?.scaleFactor();
       if (scaleFactor == null) return null;
-      const position = await parsePosition(await window.innerPosition(), scaleFactor);
+      const position = parsePosition(await window.innerPosition(), scaleFactor);
       const visible = await window.isVisible();
       const nextProps: SetWindowPropsPayload = {
         label: window.label,
@@ -346,18 +346,8 @@ const newWindowPropsHandlers = (): HandlerEntry[] => [
   },
 ];
 
-const parsePosition = async (
-  position: PhysicalPosition,
-  scaleFactor: number,
-): Promise<xy.XY> => {
-  const logical = position.toLogical(scaleFactor);
-  return { x: logical.x, y: logical.y };
-};
+const parsePosition = (position: PhysicalPosition, scaleFactor: number): xy.XY =>
+  xy.scale(position, 1 / scaleFactor);
 
-const parseSize = async (
-  size: PhysicalSize,
-  scaleFactor: number,
-): Promise<dimensions.Dimensions> => {
-  const logical = size.toLogical(scaleFactor);
-  return { width: logical.width, height: logical.height };
-};
+const parseSize = (size: PhysicalSize, scaleFactor: number): dimensions.Dimensions =>
+  dimensions.scale(size, 1 / scaleFactor);


### PR DESCRIPTION
# Issue Pull Request

## Key Information

- **Linear Issue**: [SY-1544](https://linear.app/synnax/issue/SY-1544/fix-drift-logical-positioning)

## Description

Tauri has a bug where the `toLogical` and `toPhysical` methods on a position duplicate the X coordinate. This PR switches to using internal functions to calculate the logical position.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
