### PR TITLE
[console & drift] - various performance improvements

### DIFF
--- a/console/index.html
+++ b/console/index.html
@@ -17,6 +17,16 @@
         <script src="http://localhost:8097"></script>
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Synnax</title>
+        <style>
+            body {
+                background-color: var(--pluto-gray-l0, rgb(255, 255, 255));
+            }
+            @media (prefers-color-scheme: dark) {
+                body {
+                    background-color: var(--pluto-gray-l0, rgb(0, 0, 0));
+                }
+            }
+        </style>
     </head>
     <body>
         <div id="root"></div>

--- a/console/src-tauri/src/main.rs
+++ b/console/src-tauri/src/main.rs
@@ -4,17 +4,22 @@
 #[cfg(target_os = "macos")]
 extern crate cocoa;
 
+#[cfg(target_os = "macos")]
 use device_query::{DeviceEvents, DeviceQuery, DeviceState, MouseState};
+#[cfg(target_os = "macos")]
 use std::thread;
+#[cfg(target_os = "macos")]
 use std::time::Duration;
-use tauri::{Emitter, Window};
-
+#[cfg(target_os = "macos")]
+use tauri::Emitted;
 #[cfg(target_os = "macos")]
 struct UnsafeWindowHandle(*mut std::ffi::c_void);
 #[cfg(target_os = "macos")]
 unsafe impl Send for UnsafeWindowHandle {}
 #[cfg(target_os = "macos")]
 unsafe impl Sync for UnsafeWindowHandle {}
+
+use tauri::Window;
 
 #[cfg(target_os = "macos")]
 fn set_transparent_titlebar(win: &Window, transparent: bool) {
@@ -87,7 +92,9 @@ fn main() {
             #[cfg(desktop)]
             app.handle()
                 .plugin(tauri_plugin_updater::Builder::new().build())?;
+            #[cfg(target_os = "macos")] 
             let app_handle = app.handle().clone();
+            #[cfg(target_os = "macos")] 
             thread::spawn(move || {
                 let app_handle = app_handle.clone();
                 let device_state = DeviceState::new();

--- a/console/src-tauri/src/main.rs
+++ b/console/src-tauri/src/main.rs
@@ -11,7 +11,7 @@ use std::thread;
 #[cfg(target_os = "macos")]
 use std::time::Duration;
 #[cfg(target_os = "macos")]
-use tauri::Emitted;
+use tauri::Emitter;
 #[cfg(target_os = "macos")]
 struct UnsafeWindowHandle(*mut std::ffi::c_void);
 #[cfg(target_os = "macos")]

--- a/console/src/layout/external.ts
+++ b/console/src/layout/external.ts
@@ -18,4 +18,5 @@ export * from "@/layout/Selector";
 export * from "@/layout/selectors";
 export * from "@/layout/slice";
 export * from "@/layout/slice";
+export * from "@/layout/useDropOutside";
 export * from "@/layout/Window";

--- a/console/src/layout/useDropOutside.ts
+++ b/console/src/layout/useDropOutside.ts
@@ -1,0 +1,131 @@
+// Copyright 2024 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { Drift } from "@synnaxlabs/drift";
+import { Haul, Mosaic, useAsyncEffect, useSyncedRef } from "@synnaxlabs/pluto";
+import { box, runtime, xy } from "@synnaxlabs/x";
+import { listen } from "@tauri-apps/api/event";
+import { Window } from "@tauri-apps/api/window";
+import { useCallback, useEffect, useId, useMemo } from "react";
+import { useDispatch, useStore } from "react-redux";
+
+import { usePlacer } from "@/layout/hooks";
+import { select } from "@/layout/selectors";
+import { createMosaicWindow, moveMosaicTab, type StoreState } from "@/layout/slice";
+
+const useWindowsContains = (): ((cursor: xy.XY) => boolean) => {
+  const store = useStore<Drift.StoreState>();
+  return useCallback(
+    (cursor) => {
+      const windows = Drift.selectWindows(store.getState());
+      const boxes = windows
+        .filter((w) => w.stage === "created" && w.reserved)
+        .map((w) => box.construct(w.position, w.size));
+      return boxes.some((b) => box.contains(b, cursor));
+    },
+    [store],
+  );
+};
+
+const useDropOutsideMacOS = ({
+  onDrop,
+  canDrop,
+  key,
+  type,
+}: Haul.UseDropOutsideProps) => {
+  const ctx = Haul.useContext();
+  if (ctx == null) return;
+  const { drop } = ctx;
+  const dragging = Haul.useDraggingRef();
+  const key_ = key ?? useId();
+  const target: Haul.Item = useMemo(() => ({ key: key_, type }), [key_, type]);
+  const windowsContain = useWindowsContains();
+  const store = useStore<StoreState & Drift.StoreState>();
+  useAsyncEffect(
+    async () =>
+      listen("mouse_up", async ({ payload: [x, y] }: { payload: [number, number] }) => {
+        if (dragging.current.items.length === 0 || !canDrop(dragging.current)) return;
+        const state = store.getState();
+        const layout = select(state, dragging.current.items[0].key as string);
+        if (layout?.windowKey == null) return;
+        const winLabel = Drift.selectWindowLabel(state, layout.windowKey);
+        if (winLabel == null || winLabel !== Drift.MAIN_WINDOW) return;
+        const win = await Window.getByLabel(winLabel);
+        if (win == null) return;
+        const sf = await win.scaleFactor();
+        const rawCursor = xy.construct(x, y);
+        const cursor = xy.scale(rawCursor, sf);
+        if (windowsContain(cursor)) return;
+        const dropped = onDrop(dragging.current, rawCursor);
+        drop({ target, dropped });
+      }),
+    [target],
+  );
+};
+
+interface UseDropOutsideProps extends Omit<Haul.UseDropProps, "onDrop"> {
+  onDrop: (props: Haul.OnDropProps, cursor: xy.XY) => Haul.Item[];
+}
+
+const useDropOutsideWindows = ({ type, key, ...rest }: UseDropOutsideProps): void => {
+  const ctx = Haul.useContext();
+  if (ctx == null) return;
+  const { bind } = ctx;
+  const key_ = key ?? useId();
+  const target: Haul.Item = useMemo(() => ({ key: key_, type }), [key_, type]);
+  const propsRef = useSyncedRef<UseDropOutsideProps>({ ...rest, type, key: key_ });
+  const windowsContain = useWindowsContains();
+  useEffect(() => {
+    const release = bind((state, cursor) => {
+      const { canDrop, onDrop } = propsRef.current;
+      if (!canDrop(state) || windowsContain(cursor)) return null;
+      const dropped = onDrop({ ...state }, cursor);
+      return { target, dropped };
+    });
+    return () => {
+      release();
+    };
+  }, []);
+};
+
+const canDrop: Haul.CanDrop = ({ items }) =>
+  items.length === 1 && items[0].type === Mosaic.HAUL_DROP_TYPE;
+
+export const useBase =
+  runtime.getOS() === "MacOS" ? useDropOutsideMacOS : useDropOutsideWindows;
+
+export const useDropOutside = () => {
+  const placer = usePlacer();
+  const dispatch = useDispatch();
+  const handleDrop = useCallback(
+    ({ items: [item] }: Haul.OnDropProps, cursor?: xy.XY) => {
+      const { key } = placer(
+        createMosaicWindow({
+          position: cursor ? xy.translate(cursor, { x: -80, y: -45 }) : undefined,
+        }),
+      );
+      dispatch(
+        moveMosaicTab({
+          windowKey: key,
+          key: 1,
+          tabKey: item.key as string,
+          loc: "center",
+        }),
+      );
+      return [item];
+    },
+    [placer],
+  );
+  const dropProps = {
+    type: "Palette",
+    canDrop,
+    onDrop: handleDrop,
+  };
+  useBase(dropProps);
+};

--- a/console/src/layouts/Main.tsx
+++ b/console/src/layouts/Main.tsx
@@ -60,6 +60,7 @@ const SideEffect = (): null => {
   Link.useDeep({ handlers: LINK_HANDLERS });
   Layout.useTriggers();
   Permissions.useFetchPermissions();
+  Layout.useDropOutside();
   return null;
 };
 

--- a/console/src/palette/Palette.tsx
+++ b/console/src/palette/Palette.tsx
@@ -9,39 +9,30 @@
 
 import "@/palette/Palette.css";
 
-import { ontology, Synnax } from "@synnaxlabs/client";
-import { Drift } from "@synnaxlabs/drift";
+import { ontology, type Synnax } from "@synnaxlabs/client";
 import { Icon } from "@synnaxlabs/media";
 import {
   Align,
   Button,
   componentRenderProp,
-  CSS as PCSS,
   Dropdown,
-  Haul,
   Input,
   List,
-  Mosaic,
   Status,
   Synnax as PSynnax,
   Text,
   Tooltip,
   Triggers,
-  useAsyncEffect,
 } from "@synnaxlabs/pluto";
-import { box, dimensions, runtime, xy } from "@synnaxlabs/x";
-import { listen } from "@tauri-apps/api/event";
-import { Window } from "@tauri-apps/api/window";
 import {
   type FC,
   type ReactElement,
   useCallback,
-  useId,
   useLayoutEffect,
   useMemo,
   useState,
 } from "react";
-import { useDispatch, useStore } from "react-redux";
+import { useStore } from "react-redux";
 
 import { Confirm } from "@/confirm";
 import { type CreateConfirmModal } from "@/confirm/Confirm";
@@ -63,47 +54,6 @@ export interface PaletteProps {
 
 type Entry = Command | ontology.Resource;
 type Key = string;
-
-const useDropOutsideMacOS = ({
-  onDrop,
-  canDrop,
-  key,
-  type,
-}: Haul.UseDropOutsideProps) => {
-  const ctx = Haul.useContext();
-  if (ctx == null) return;
-  const { drop } = ctx;
-  const dragging = Haul.useDraggingRef();
-  const key_ = key ?? useId();
-  const target: Haul.Item = useMemo(() => ({ key: key_, type }), [key_, type]);
-  const store = useStore<RootState>();
-  useAsyncEffect(
-    async () =>
-      listen("mouse_up", async ({ payload: [x, y] }: { payload: [number, number] }) => {
-        if (dragging.current.items.length === 0 || !canDrop(dragging.current)) return;
-        const state = store.getState();
-        const layout = Layout.select(state, dragging.current.items[0].key as string);
-        if (layout?.windowKey == null) return;
-        const winLabel = Drift.selectWindowLabel(state, layout.windowKey);
-        if (winLabel == null || winLabel !== Drift.MAIN_WINDOW) return;
-        const win = await Window.getByLabel(winLabel);
-        if (win == null) return;
-        const sf = await win.scaleFactor();
-        const rawCursor = xy.construct(x, y);
-        const cursor = xy.scale(rawCursor, sf);
-        const pos = xy.construct(await win.outerPosition());
-        const size = dimensions.construct(await win.innerSize());
-        const b = box.construct(pos, size);
-        if (box.contains(b, cursor)) return;
-        const dropped = onDrop(dragging.current, rawCursor);
-        drop({ target, dropped });
-      }),
-    [target],
-  );
-};
-
-const useDropOutside =
-  runtime.getOS() === "MacOS" ? useDropOutsideMacOS : Haul.useDropOutside;
 
 export const Palette = ({
   commands,
@@ -138,45 +88,6 @@ export const Palette = ({
 
   Triggers.use({ triggers, callback: handleTrigger });
 
-  const placer = Layout.usePlacer();
-  const dispatch = useDispatch();
-
-  const handleDrop = useCallback(
-    ({ items: [item] }: Haul.OnDropProps, cursor?: xy.XY) => {
-      const windows = Drift.selectWindows(store.getState());
-      const boxes = windows
-        .filter((w) => w.stage === "created")
-        .map((w) => box.construct(w.position, w.size));
-      if (boxes.some((b) => box.contains(b, cursor))) return [];
-      const { key } = placer(
-        Layout.createMosaicWindow({
-          position: cursor ? xy.translate(cursor, { x: -80, y: -45 }) : undefined,
-        }),
-      );
-      dispatch(
-        Layout.moveMosaicTab({
-          windowKey: key,
-          key: 1,
-          tabKey: item.key as string,
-          loc: "center",
-        }),
-      );
-      return [item];
-    },
-    [placer],
-  );
-
-  const dropProps = {
-    type: "Palette",
-    canDrop,
-    onDrop: handleDrop,
-  };
-
-  useDropOutside(dropProps);
-  const { onDragOver, onDrop } = Haul.useDrop(dropProps);
-
-  const dragging = Haul.useDraggingState();
-
   return (
     <List.List>
       <Tooltip.Dialog location="bottom" hide={dropdown.visible}>
@@ -191,18 +102,13 @@ export const Palette = ({
         >
           <Button.Button
             onClick={dropdown.open}
-            className={CSS(
-              CSS.BE("palette", "btn"),
-              PCSS.dropRegion(canDrop(dragging)),
-            )}
+            className={CSS(CSS.BE("palette", "btn"))}
             variant="outlined"
             align="center"
             size="medium"
             justify="center"
             startIcon={<Icon.Search />}
             shade={7}
-            onDragOver={onDragOver}
-            onDrop={onDrop}
           >
             Quick Search & Command
           </Button.Button>
@@ -220,8 +126,6 @@ export const Palette = ({
     </List.List>
   );
 };
-const canDrop: Haul.CanDrop = ({ items }) =>
-  items.length === 1 && items[0].type === Mosaic.HAUL_DROP_TYPE;
 
 export interface PaletteListProps {
   mode: Mode;

--- a/console/src/store.ts
+++ b/console/src/store.ts
@@ -91,6 +91,7 @@ export type RootStore = Store<RootState, RootAction>;
 const DEFAULT_WINDOW_VISIBLE = isDev();
 const DEFAULT_WINDOW_PROPS: Omit<Drift.WindowProps, "key"> = {
   visible: DEFAULT_WINDOW_VISIBLE,
+  minSize: { width: 625, height: 375 },
 };
 
 export const migrateState = (prev: RootState): RootState => {
@@ -121,7 +122,6 @@ export const migrateState = (prev: RootState): RootState => {
 };
 
 const newStore = async (): Promise<RootStore> => {
-  console.log(isDev());
   const [preloadedState, persistMiddleware] = await Persist.open<RootState>({
     initial: ZERO_STATE,
     migrator: migrateState,

--- a/drift/src/state.ts
+++ b/drift/src/state.ts
@@ -227,12 +227,13 @@ const slice = createSlice({
     },
     setWindowLabel: (s: SliceState, a: PayloadAction<SetWindowLabelPayload>) => {
       s.label = a.payload.label;
-      if (s.label !== MAIN_WINDOW && !s.config.enablePrerender) return;
-      const prerenderLabel = id.id();
-      s.windows[prerenderLabel] = {
-        ...s.config.defaultWindowProps,
-        ...INITIAL_PRERENDER_WINDOW_STATE,
-      };
+      if (s.label === MAIN_WINDOW && s.config.enablePrerender) {
+        const prerenderLabel = id.id();
+        s.windows[prerenderLabel] = {
+          ...s.config.defaultWindowProps,
+          ...INITIAL_PRERENDER_WINDOW_STATE,
+        };
+      }
     },
     createWindow: (s: SliceState, { payload }: PayloadAction<CreateWindowPayload>) => {
       if (payload.key === PRERENDER_WINDOW) return;

--- a/drift/src/sync.ts
+++ b/drift/src/sync.ts
@@ -143,6 +143,12 @@ export const syncCurrent = async (
       async () => await runtime.setMinimized(nextWin.minimized as boolean),
     ]);
 
+  if (nextWin.resizable != null && nextWin.resizable !== prevWin.resizable)
+    changes.push([
+      "resizable",
+      async () => await runtime.setResizable(nextWin.resizable as boolean),
+    ]);
+
   if (nextWin.minSize != null && !dimensions.equals(nextWin.minSize, prevWin.minSize))
     changes.push([
       "minSize",
@@ -175,12 +181,6 @@ export const syncCurrent = async (
       ["setVisible", async () => await runtime.setVisible(true)],
       ["focus", async () => await runtime.focus()],
     );
-
-  if (nextWin.resizable != null && nextWin.resizable !== prevWin.resizable)
-    changes.push([
-      "resizable",
-      async () => await runtime.setResizable(nextWin.resizable as boolean),
-    ]);
 
   if (nextWin.decorations != null && nextWin.decorations !== prevWin.decorations)
     changes.push([

--- a/drift/src/tauri/index.ts
+++ b/drift/src/tauri/index.ts
@@ -8,7 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { type Action, type UnknownAction } from "@reduxjs/toolkit";
-import { debounce as debounceF, dimensions, xy } from "@synnaxlabs/x";
+import { debounce as debounceF, dimensions, runtime, xy } from "@synnaxlabs/x";
 import {
   emit,
   type Event as TauriEvent,
@@ -76,6 +76,9 @@ export class TauriRuntime<S extends StoreState, A extends Action = UnknownAction
   }
 
   async configure(): Promise<void> {
+    // We only need to poll for fullscreen on MacOS, as tauri doesn't provide an
+    // emitted event for fullscreen changes.
+    if (runtime.getOS() !== "MacOS") return;
     let prevFullscreen = (await this.getProps()).fullscreen;
     this.fullscreenPoll = setInterval(() => {
       this.win

--- a/drift/src/tauri/index.ts
+++ b/drift/src/tauri/index.ts
@@ -8,7 +8,13 @@
 // included in the file licenses/APL.txt.
 
 import { type Action, type UnknownAction } from "@reduxjs/toolkit";
-import { debounce as debounceF, dimensions, runtime, xy } from "@synnaxlabs/x";
+import {
+  debounce as debounceF,
+  dimensions,
+  runtime,
+  TimeSpan,
+  xy,
+} from "@synnaxlabs/x";
 import {
   emit,
   type Event as TauriEvent,
@@ -39,7 +45,11 @@ const tauriCreated = "tauri://created";
 const notFound = (key: string): Error => new Error(`Window not found: ${key}`);
 
 //  Prevent the user or a programming error from creating a tiny window.
-const MIN_DIM = 100;
+const MIN_DIM = 250;
+
+// On MacOS, we need to poll for fullscreen changes, as tauri doesn't provide an
+// event for it. This is the interval at which we poll.
+const MACOS_FULLSCREEN_POLL_INTERVAL = TimeSpan.milliseconds(250);
 
 const clampDims = (dims?: dimensions.Dimensions): dimensions.Dimensions | undefined => {
   if (dims == null) return undefined;
@@ -99,7 +109,7 @@ export class TauriRuntime<S extends StoreState, A extends Action = UnknownAction
           }
         })
         .catch(console.error);
-    }, 250);
+    }, MACOS_FULLSCREEN_POLL_INTERVAL.milliseconds);
   }
 
   label(): string {
@@ -112,6 +122,7 @@ export class TauriRuntime<S extends StoreState, A extends Action = UnknownAction
 
   release(): void {
     Object.values(this.unsubscribe).forEach((f) => f?.());
+    if (this.fullscreenPoll != null) clearInterval(this.fullscreenPoll);
     this.unsubscribe = {};
   }
 

--- a/pluto/src/haul/Haul.tsx
+++ b/pluto/src/haul/Haul.tsx
@@ -10,7 +10,6 @@
 import "@/haul/Haul.css";
 
 import {
-  box,
   type Destructor,
   type Key,
   type Optional,
@@ -25,7 +24,6 @@ import React, {
   type PropsWithChildren,
   useCallback,
   useContext as reactUseContext,
-  useEffect,
   useId,
   useMemo,
   useRef,
@@ -302,40 +300,3 @@ export const filterByType = (type: string, entities: Item[]): Item[] =>
 export interface UseDropOutsideProps extends Omit<UseDropProps, "onDrop"> {
   onDrop: (props: OnDropProps, cursor: xy.XY) => Item[];
 }
-
-export const useDropOutside = ({ type, key, ...rest }: UseDropOutsideProps): void => {
-  const ctx = useContext();
-  if (ctx == null) return;
-  const dragging = useDraggingRef();
-  const { bind } = ctx;
-  const isOutside = useRef(false);
-  const key_ = key ?? useId();
-  const target: Item = useMemo(() => ({ key: key_, type }), [key_, type]);
-  const propsRef = useRef<UseDropOutsideProps>({ ...rest, type, key: key_ });
-  useEffect(() => {
-    const release = bind((state, cursor) => {
-      const { canDrop, onDrop } = propsRef.current;
-      if (!canDrop(state) || !isOutside.current) return null;
-      const dropped = onDrop({ ...state }, cursor);
-      return { target, dropped };
-    });
-    const handleMouseEnter = () => {
-      isOutside.current = false;
-    };
-    const handleMouseLeave = (e: globalThis.DragEvent) => {
-      const { onDragOver, canDrop } = propsRef.current;
-      const windowBox = box.construct(window.document.documentElement);
-      if (box.contains(windowBox, xy.construct(e.clientX, e.clientY))) return;
-      isOutside.current = true;
-      if (!canDrop(dragging.current)) return;
-      onDragOver?.(dragging.current);
-    };
-    document.body.addEventListener("dragleave", handleMouseLeave);
-    document.body.addEventListener("mouseenter", handleMouseEnter);
-    return () => {
-      release();
-      document.body.removeEventListener("dragleave", handleMouseLeave);
-      document.body.removeEventListener("mouseenter", handleMouseEnter);
-    };
-  }, []);
-};

--- a/pluto/src/vis/axis/canvas.ts
+++ b/pluto/src/vis/axis/canvas.ts
@@ -24,20 +24,59 @@ import { type render } from "@/vis/render";
 
 const TICK_LINE_SIZE = 4;
 
+class TickTextDimensions {
+  private readonly numberDims: dimensions.Dimensions;
+  private readonly negativeWidth: number;
+  private readonly periodWidth: number;
+  private readonly colonWidth: number;
+
+  constructor(canvas: OffscreenCanvasRenderingContext2D, font: string) {
+    this.numberDims = textDimensions("0", font, canvas);
+    this.negativeWidth = textDimensions("-", font, canvas).width;
+    this.periodWidth = textDimensions(".", font, canvas).width;
+    this.colonWidth = textDimensions(":", font, canvas).width;
+  }
+
+  get(label: string): dimensions.Dimensions {
+    const dimensions: dimensions.Dimensions = {
+      width: 0,
+      height: this.numberDims.height,
+    };
+    let count = label.length;
+    if (label.includes(".")) {
+      dimensions.width += this.periodWidth;
+      count -= 1;
+    }
+    if (label.startsWith("-")) {
+      dimensions.width += this.negativeWidth;
+      count -= 1;
+    }
+    if (label.includes(":")) {
+      dimensions.width += this.colonWidth;
+      count -= 1;
+    }
+    dimensions.width += count * this.numberDims.width;
+    return dimensions;
+  }
+}
+
 export class Canvas implements Axis {
   ctx: render.Context;
   state: ParsedAxisState;
   tickFactory: TickFactory;
+  dimensions: TickTextDimensions;
 
   constructor(ctx: render.Context, state: ParsedAxisState) {
     this.ctx = ctx;
     this.state = state;
     this.tickFactory = newTickFactory(this.state);
+    this.dimensions = new TickTextDimensions(ctx.lower2d, state.font);
   }
 
   setState(state: AxisState): void {
     this.state = prettyParse(axisStateZ, state);
     this.tickFactory = newTickFactory(state);
+    this.dimensions = new TickTextDimensions(this.ctx.lower2d, this.state.font);
   }
 
   render(props: AxisProps): RenderResult {
@@ -179,7 +218,7 @@ export class Canvas implements Axis {
   ): dimensions.Dimensions {
     let maxDimensions = dimensions.ZERO;
     ticks.forEach((tick) => {
-      const d = textDimensions(tick.label, this.state.font, this.ctx.lower2d);
+      const d = this.dimensions.get(tick.label);
       maxDimensions = dimensions.max([maxDimensions, d]);
       f(d, tick);
     });


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1554](https://linear.app/synnax/issue/SY-1554/remove-fullscreen-poll-from-drift-on-windows)

## Description

Fixes a few bugs and improves performance for a few console related tasks:

- On MacOS, we need to constantly poll for the windows Fullscreen state in order to make sure we correctly show and hide the traffic lights. On Windows, we don't need to do this, so I removed the fullscreen poll interval.
- On MacOS, we need to use an independent cursor tracking library to correctly position new windows when they are dragged out of the console. On Windows, we don't need to do this, so I removed that tracking. Ends up saving around 20% of an idle core - a lot.
- Fixe issues with the `useDropOutside` hook on windows that caused it to occasionally not detect the correct drop outside location. 

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
