### PR TITLE
fix(resources tree): give different items different keys

### DIFF
--- a/console/src/ontology/Tree.tsx
+++ b/console/src/ontology/Tree.tsx
@@ -530,7 +530,7 @@ export const Tree = (): ReactElement => {
 
   const item = useCallback(
     (props: Core.ItemProps): ReactElement => (
-      <AdapterItem {...props} key={`${props.entry.path}`} services={services} />
+      <AdapterItem {...props} key={props.entry.path} services={services} />
     ),
     [services],
   );

--- a/console/src/ontology/Tree.tsx
+++ b/console/src/ontology/Tree.tsx
@@ -530,7 +530,7 @@ export const Tree = (): ReactElement => {
 
   const item = useCallback(
     (props: Core.ItemProps): ReactElement => (
-      <AdapterItem {...props} key={props.entry.key} services={services} />
+      <AdapterItem {...props} key={`${props.entry.path}`} services={services} />
     ),
     [services],
   );
@@ -564,7 +564,7 @@ const AdapterItem = memo<AdapterItemProps>(
   ({ loading, services, ...props }): ReactElement => {
     const id = new ontology.ID(props.entry.key);
     const Item = useMemo(() => services[id.type]?.Item ?? Core.DefaultItem, [id.type]);
-    return <Item key={props.entry.key} loading={loading} {...props} />;
+    return <Item loading={loading} {...props} />;
   },
 );
 AdapterItem.displayName = "AdapterItem";

--- a/pluto/src/tree/core.ts
+++ b/pluto/src/tree/core.ts
@@ -77,7 +77,7 @@ export const flatten = ({
   if (depth === 0 && sort) nodes = nodes.sort((a, b) => a.name.localeCompare(b.name));
   const flattened: FlattenedNode[] = [];
   nodes.forEach((node, index) => {
-    const nextPath = `${path + node.key}/`;
+    const nextPath = `${path}${node.key}/`;
     const expand = shouldExpand(node, expanded);
     flattened.push({ ...node, depth, expanded: expand, index, path: nextPath });
     if (expand && node.children != null) {

--- a/pluto/src/tree/core.ts
+++ b/pluto/src/tree/core.ts
@@ -35,6 +35,7 @@ export interface FlattenedNode extends Node {
   index: number;
   depth: number;
   expanded: boolean;
+  path: string;
 }
 
 export const shouldExpand = (node: Node, expanded: string[]): boolean =>
@@ -45,6 +46,7 @@ export interface FlattenProps {
   expanded: string[];
   depth?: number;
   sort?: boolean;
+  path?: string;
 }
 
 export const sortAndSplice = (nodes: Node[], sort: boolean): Node[] => {
@@ -69,17 +71,25 @@ export const flatten = ({
   expanded,
   depth = 0,
   sort = true,
+  path = "",
 }: FlattenProps): FlattenedNode[] => {
   // Sort the first level of the tree independently of the rest
   if (depth === 0 && sort) nodes = nodes.sort((a, b) => a.name.localeCompare(b.name));
   const flattened: FlattenedNode[] = [];
   nodes.forEach((node, index) => {
+    const nextPath = `${path + node.key}/`;
     const expand = shouldExpand(node, expanded);
-    flattened.push({ ...node, depth, expanded: expand, index });
+    flattened.push({ ...node, depth, expanded: expand, index, path: nextPath });
     if (expand && node.children != null) {
       node.children = sortAndSplice(node.children, sort);
       flattened.push(
-        ...flatten({ nodes: node.children, expanded, depth: depth + 1, sort }),
+        ...flatten({
+          nodes: node.children,
+          expanded,
+          depth: depth + 1,
+          sort,
+          path: nextPath,
+        }),
       );
     }
   });


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-855](https://linear.app/synnax/issue/SY-855/give-items-in-resources-tree-unique-keys)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->
Fixed a rendering issue where different items in the resources toolbar had the same key.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
