### PR TITLE
[pluto] - added T-Junction schematic symbol

### DIFF
--- a/pluto/src/vis/schematic/Symbols.tsx
+++ b/pluto/src/vis/schematic/Symbols.tsx
@@ -1613,3 +1613,22 @@ export const ISOBurstDisc = ({
 export const ISOBurstDiscPreview = (props: ISOBurstDiscProps): ReactElement => (
   <Primitives.ISOBurstDisc {...props} />
 );
+
+export interface TJunctionProps extends Primitives.TJunctionProps {
+  label?: LabelExtensionProps;
+}
+
+export const TJunction = ({
+  label,
+  aetherKey,
+  onChange,
+  ...rest
+}: SymbolProps<TJunctionProps>): ReactElement => (
+  <Labeled {...label} onChange={onChange}>
+    <Primitives.TJunction {...rest} />
+  </Labeled>
+);
+
+export const TJunctionPreview = (props: TJunctionProps): ReactElement => (
+  <Primitives.TJunction {...props} />
+);

--- a/pluto/src/vis/schematic/primitives/Primitives.tsx
+++ b/pluto/src/vis/schematic/primitives/Primitives.tsx
@@ -2465,3 +2465,39 @@ export const AngledSpringLoadedReliefValve = ({
     </Div>
   );
 };
+
+export interface TJunctionProps extends DivProps, SVGBasedPrimitiveProps {}
+
+export const TJunction = ({
+  className,
+  orientation = "left",
+  color,
+  scale,
+  ...props
+}: TJunctionProps): ReactElement => (
+  <Div className={CSS(CSS.B("t-junction"), className)} {...props}>
+    <HandleBoundary orientation={orientation}>
+      <Handle location="left" orientation={orientation} left={1.6667} top={20} id="1" />
+      <Handle
+        location="right"
+        orientation={orientation}
+        left={98.3333}
+        top={20}
+        id="2"
+      />
+      <Handle location="bottom" orientation={orientation} left={50} top={95} id="3" />
+    </HandleBoundary>
+    <InternalSVG
+      dimensions={{ width: 36, height: 18 }}
+      color={color}
+      orientation={orientation}
+      scale={scale}
+    >
+      <Path
+        d="M0 4V2C0 0.895431 0.895431 0 2 0H34C35.1046 0 36 0.89543 36 2V4C36 5.10457 35.1046 6 34 6H23C21.8954 6 21 6.89543 21 8V16C21 17.1046 20.1046 18 19 18H17C15.8954 18 15 17.1046 15 16V8C15 6.89543 14.1046 6 13 6H2C0.895431 6 0 5.10457 0 4Z"
+        fill={Color.cssString(color)}
+        stroke="none"
+      />
+    </InternalSVG>
+  </Div>
+);

--- a/pluto/src/vis/schematic/registry.ts
+++ b/pluto/src/vis/schematic/registry.ts
@@ -1019,7 +1019,7 @@ const tJunction: Spec<TJunctionProps> = {
   Symbol: TJunction,
   defaultProps: (t) => ({
     color: t.colors.gray.l9.rgba255,
-    ...zeroLabel("T Junction"),
+    ...zeroLabel(""),
     ...ZERO_PROPS,
   }),
   Preview: TJunctionPreview,

--- a/pluto/src/vis/schematic/registry.ts
+++ b/pluto/src/vis/schematic/registry.ts
@@ -155,6 +155,9 @@ import {
   ThreeWayValve,
   ThreeWayValvePreview,
   type ThreeWayValveProps,
+  TJunction,
+  TJunctionPreview,
+  type TJunctionProps,
   VacuumPump,
   VacuumPumpPreview,
   type VacuumPumpProps,
@@ -231,6 +234,7 @@ const VARIANTS = [
   "value",
   "valve",
   "vent",
+  "tJunction",
 ] as const;
 
 export const typeZ = z.enum(VARIANTS);
@@ -1008,10 +1012,25 @@ const vent: Spec<VentProps> = {
   zIndex: Z_INDEX_UPPER,
 };
 
+const tJunction: Spec<TJunctionProps> = {
+  name: "T Junction",
+  key: "tJunction",
+  Form: CommonStyleForm,
+  Symbol: TJunction,
+  defaultProps: (t) => ({
+    color: t.colors.gray.l9.rgba255,
+    ...zeroLabel("T Junction"),
+    ...ZERO_PROPS,
+  }),
+  Preview: TJunctionPreview,
+  zIndex: Z_INDEX_UPPER + 20,
+};
+
 export const SYMBOLS: Record<Variant, Spec<any>> = {
   value,
   button,
   tank,
+  tJunction,
   switch: switch_,
   offPageReference,
   light,


### PR DESCRIPTION
# Issue Pull Request

## Key Information

- **Linear Issue**: [SY-1560](https://linear.app/synnax/issue/SY-1560/t-junction)

## Description

Simple T-Junction Schematic Symbol

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
