### PR TITLE
SY-1606 Capitalize Documentation Site Breadcrumbs

### DIFF
--- a/pluto/package.json
+++ b/pluto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synnaxlabs/pluto",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit && vite build",

--- a/pluto/src/breadcrumb/Breadcrumb.tsx
+++ b/pluto/src/breadcrumb/Breadcrumb.tsx
@@ -165,10 +165,23 @@ export const URL = ({
   className,
   level = "p",
   separator = ".",
-  weight,
   shade = 7,
 }: URLProps) => {
-  const content = getContent({ segments: url, separator, shade, level, weight });
+  const split = toArray(url)
+    .map((el) => el.split(separator))
+    .flat();
+  const content: (ReactElement | string)[] = split
+    .map((el, index) => [
+      <Icon.Caret.Right
+        key={`${el}-${index}`}
+        style={{
+          transform: "scale(0.8) translateY(1px)",
+          color: CSS.shade(shade),
+        }}
+      />,
+      el,
+    ])
+    .flat();
   return (
     <Align.Space
       className={CSS(className, CSS.B("breadcrumb"))}

--- a/pluto/src/breadcrumb/Breadcrumb.tsx
+++ b/pluto/src/breadcrumb/Breadcrumb.tsx
@@ -68,6 +68,7 @@ interface GetContentArgs {
   level: Text.Level;
   weight?: Text.Weight;
   separator: string;
+  capitalized?: boolean;
 }
 
 const getContent = ({
@@ -76,6 +77,7 @@ const getContent = ({
   level,
   weight,
   separator,
+  capitalized = false,
 }: GetContentArgs): (ReactElement | string)[] => {
   const normalized = normalizeSegments(segments, separator);
   const content: (ReactElement | string)[] = normalized
@@ -102,7 +104,7 @@ const getContent = ({
           level={level}
           {...el}
         >
-          {el.label}
+          {capitalized ? caseconv.capitalize(el.label) : el.label}
         </Text.Text>,
       );
       return base;
@@ -165,23 +167,17 @@ export const URL = ({
   className,
   level = "p",
   separator = ".",
+  weight,
   shade = 7,
 }: URLProps) => {
-  const split = toArray(url)
-    .map((el) => el.split(separator))
-    .flat();
-  const content: (ReactElement | string)[] = split
-    .map((el, index) => [
-      <Icon.Caret.Right
-        key={`${el}-${index}`}
-        style={{
-          transform: "scale(0.8) translateY(1px)",
-          color: CSS.shade(shade),
-        }}
-      />,
-      el,
-    ])
-    .flat();
+  const content = getContent({
+    segments: url,
+    separator,
+    shade,
+    level,
+    weight,
+    capitalized: true,
+  });
   return (
     <Align.Space
       className={CSS(className, CSS.B("breadcrumb"))}


### PR DESCRIPTION
# Issue Pull Request

## Key Information

- **Linear Issue**: [SY-1606](https://linear.app/synnax/issue/SY-1606/capitalize-documentation-site-breadcrumbs)

## Description

Fix breadcrumbs on documentation site, live version looks ugly

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
