### PR TITLE
[drift] - fixed windows appearing out of bounds

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synnaxlabs/console",
   "private": true,
-  "version": "0.35.0",
+  "version": "0.35.1",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/drift/package.json
+++ b/drift/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synnaxlabs/drift",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "description": "State synchronization and Redux state synchronization for Tauri Apps",
   "repository": "https://github.com/synnaxlabs/synnax/tree/main/drift",
   "type": "module",

--- a/drift/src/tauri/index.ts
+++ b/drift/src/tauri/index.ts
@@ -172,6 +172,8 @@ export class TauriRuntime<S extends StoreState, A extends Action = UnknownAction
     if (size?.height != null) size.height = Math.max(size.height, MIN_DIM);
     if (maxSize?.width != null) maxSize.width = Math.max(maxSize.width, MIN_DIM);
     if (maxSize?.height != null) maxSize.height = Math.max(maxSize.height, MIN_DIM);
+    if (position?.x != null && position.x < 0) position.x = 0;
+    if (position?.y != null && position.y < 0) position.y = 0;
     try {
       const w = new WebviewWindow(label, {
         x: position?.x,
@@ -243,7 +245,10 @@ export class TauriRuntime<S extends StoreState, A extends Action = UnknownAction
   }
 
   async setPosition(xy: xy.XY): Promise<void> {
-    await this.win.setPosition(new LogicalPosition(xy.x, xy.y));
+    const logicalPos = new LogicalPosition(xy.x, xy.y);
+    if (logicalPos.x < 0) logicalPos.x = 0;
+    if (logicalPos.y < 0) logicalPos.y = 0;
+    await this.win.setPosition(logicalPos);
   }
 
   async setSize(dims: dimensions.Dimensions): Promise<void> {


### PR DESCRIPTION
# Issue Pull Request

## Key Information

- **Linear Issue**: [SY-1608](https://linear.app/synnax/issue/SY-1608/drift-fix-window-positioning)

## Description

Fixes an issue where newly created windows receive positions that are _very, very, very_ negative values. This issue causes the Tauri drift runtime to block such absurd positions, and defaults to positioning the window at { x:0, y: 0} when it encounters such a case. It doesn't fix the underlying issue, but it does prevent our users from losing their windows randomly.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
