### PR TITLE
SY-1609 Add Workspace Saving Information to Documentation Website

### DIFF
--- a/docs/site/src/pages/reference/console/line-plots.mdx
+++ b/docs/site/src/pages/reference/console/line-plots.mdx
@@ -9,7 +9,7 @@ nextURL: "/reference/console/schematics"
 ---
 
 import { Icon } from "@synnaxlabs/media";
-import { Divider } from "@synnaxlabs/pluto";
+import { Divider, Note } from "@synnaxlabs/pluto";
 import { Image, Video } from "@/components/Media";
 import Table from "@/components/Table.astro";
 
@@ -24,6 +24,12 @@ Click the visualize <Icon.Visualize /> button in the bottom-right corner to open
 visualization toolbar.
 
 <Video client:only="react" id="console/line-plots/toolbar" />
+
+<Note.Note variant="warning">
+  Make sure that you are working in an active
+  [workspace](/reference/console/workspaces)! If your line plot is not created in a
+  workspace, it will not be saved permanently to Synnax.
+</Note.Note>
 
 <Divider.Divider direction="x" />
 

--- a/docs/site/src/pages/reference/console/logs.mdx
+++ b/docs/site/src/pages/reference/console/logs.mdx
@@ -8,7 +8,7 @@ next: "Users"
 nextURL: "/reference/console/tables"
 ---
 
-import { Divider } from "@synnaxlabs/pluto";
+import { Divider, Note } from "@synnaxlabs/pluto";
 
 import { Video, Image } from "@/components/Media";
 import Diagram from "@/components/Diagram.astro";
@@ -40,6 +40,12 @@ operations.
 To create a log, add a new tab and select the log visualization:
 
 <Video client:only="react" id="console/logs/log-create" />
+
+<Note.Note variant="warning">
+  Make sure that you are working in an active
+  [workspace](/reference/console/workspaces)! If your log is not created in a workspace,
+  it will not be saved permanently to Synnax.
+</Note.Note>
 
 <Divider.Divider direction="x" />
 

--- a/docs/site/src/pages/reference/console/schematics.mdx
+++ b/docs/site/src/pages/reference/console/schematics.mdx
@@ -54,10 +54,8 @@ the controls in the bottom-left hand corner of the schematic.
       <td>
         <b>View</b>
       </td>
-      <td>
-        Live data from the cluster is displayed on the schematic. Symbols are not
-        editable and the user cannot change the system state.
-      </td>
+      <td>Live data from the cluster is displayed on the schematic. Symbols are not
+          editable and the user cannot change the system state.</td>
     </tr>
     <tr>
       <td>
@@ -122,10 +120,8 @@ other visual properties.
       <td>
         <b>Normally Open</b>
       </td>
-      <td>
-        Causes the body of the solenoid valve to look different when it is open or
-        closed.
-      </td>
+      <td>Causes the body of the solenoid valve to look different when it is open or
+          closed.</td>
     </tr>
     <tr>
       <td>
@@ -155,10 +151,8 @@ other visual properties.
       <td>
         <b>Orientation</b>
       </td>
-      <td>
-        Determines the orientation of the symbol and the relative placement of the
-        label.
-      </td>
+      <td>Determines the orientation of the symbol and the relative placement of the
+          label.</td>
     </tr>
   </tbody>
 </Table>
@@ -195,10 +189,8 @@ The telemetry tab can have the following properties:
       <td>
         <b>Averaging Window</b>
       </td>
-      <td>
-        Can be used to display a rolling average. For example, a value of 2 will cause
-        the screen to display the average of the last 2 samples.
-      </td>
+      <td>Can be used to display a rolling average. For example, a value of 2 will cause
+          the screen to display the average of the last 2 samples.</td>
     </tr>
   </tbody>
 </Table>
@@ -222,21 +214,17 @@ two main properties:
       <td>
         <b>State Channel</b>
       </td>
-      <td>
-        Represents the display state of the symbol. If the input channel has a value of
-        1, the symbol will be display as activated.
-      </td>
+      <td>Represents the display state of the symbol. If the input channel has a value
+          of 1, the symbol will be display as activated.</td>
     </tr>
     <tr>
       <td>
         <b>Command Channel</b>
       </td>
-      <td>
-        Will be written to when you click on the symbol. If the symbol is de-activated,
-        clicking on it will write 1 to the output channel (an activation command). If
-        the symbol is activated, clicking on it will write 0 to the output channel (a
-        deactivation command).
-      </td>
+      <td>Will be written to when you click on the symbol. If the symbol is de-activated,
+          clicking on it will write 1 to the output channel (an activation command). If
+          the symbol is activated, clicking on it will write 0 to the output channel (a
+          deactivation command).</td>
     </tr>
   </tbody>
 </Table>
@@ -250,8 +238,8 @@ There are many ways that you can change the visuals of a schematic.
 ### Connection Lines
 
 Every symbol has locations to attach connection lines. When hovering over an symbol,
-these attachement points appear. To draw a connection line, click on an attachement
-point and drag the line to a different symbol:
+these attachment points appear. To draw a connection line, click on an attachment point
+and drag the line to a different symbol:
 
 <Video client:only="react" id="console/schematics/connections" />
 

--- a/docs/site/src/pages/reference/console/schematics.mdx
+++ b/docs/site/src/pages/reference/console/schematics.mdx
@@ -10,7 +10,7 @@ nextURL: "/reference/console/logs"
 ---
 
 import { Icon } from "@synnaxlabs/media";
-import { Divider } from "@synnaxlabs/pluto";
+import { Divider, Note } from "@synnaxlabs/pluto";
 import { Image, Video } from "@/components/Media";
 import Table from "@/components/Table.astro";
 
@@ -28,6 +28,12 @@ Creating a schematic is as simple as adding a new tab and selecting the schemati
 visualization:
 
 <Video client:only="react" id="console/schematics/create" />
+
+<Note.Note variant="warning">
+  Make sure that you are working in an active
+  [workspace](/reference/console/workspaces)! If your schematic is not created in a
+  workspace, it will not be saved permanently to Synnax.
+</Note.Note>
 
 <Divider.Divider direction="x" />
 

--- a/docs/site/src/pages/reference/console/tables.mdx
+++ b/docs/site/src/pages/reference/console/tables.mdx
@@ -8,7 +8,7 @@ next: "Users"
 nextURL: "/reference/console/tables"
 ---
 
-import { Divider } from "@synnaxlabs/pluto";
+import { Divider, Note } from "@synnaxlabs/pluto";
 
 import { Video, Image } from "@/components/Media";
 import Diagram from "@/components/Diagram.astro";
@@ -44,6 +44,12 @@ To create a table, add a new tab and select the table visualization:
 You can also create a table by opening the command palette at the top (`Ctrl+Shift+P`
 (Windows/Linux) or `Cmd+Shift+P` (macOS)) and searching for the "Create a Table"
 command.
+
+<Note.Note variant="warning">
+  Make sure that you are working in an active
+  [workspace](/reference/console/workspaces)! If your table is not created in a
+  workspace, it will not be saved permanently to Synnax.
+</Note.Note>
 
 <Divider.Divider direction="x" />
 

--- a/docs/site/src/pages/reference/console/workspaces.mdx
+++ b/docs/site/src/pages/reference/console/workspaces.mdx
@@ -11,7 +11,7 @@ nextURL: "/reference/console/ranges"
 
 import { Image } from "@/components/Media";
 import { Icon } from "@synnaxlabs/media";
-import { Divider } from "@synnaxlabs/pluto";
+import { Divider, Note } from "@synnaxlabs/pluto";
 import { Video } from "@/components/Media";
 
 import Diagram from "@/components/Diagram.astro";
@@ -26,14 +26,21 @@ import Diagram from "@/components/Diagram.astro";
       width: "fit-content",
       transform: "translate(-6%, -9%)",
       borderRadius: "1.5rem",
-      boxShadow: "-1rem -1rem 1rem 3px var(--pluto-gray-l1-15)"
+      boxShadow: "-1rem -1rem 1rem 3px var(--pluto-gray-l1-15)",
     }}
   />
 </Diagram>
 
 Workspaces allow you to save a particular console layout for later access and to share
-with others. This can be useful for organizing your console layouts for different tasks
-, component configurations, or to collaboratively develop a project.
+with others. This can be useful for organizing your console layouts for different tasks,
+component configurations, or to collaboratively develop a project.
+
+<Note.Note variant="warning">
+  Make sure that you are working in an active workspace! If you are working on a
+  visualization like a [schematic](/reference/console/schematics) or [line
+  plot](/reference/console/line-plots), your visualization will not be saved permanently
+  unless you are working in an active workspace.
+</Note.Note>
 
 <Divider.Divider direction="x" />
 


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1609](https://linear.app/synnax/issue/SY-1609/workspace-saving-documentation-to-website)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Added information about visualizations not getting saved unless workspaces are to the documentation site. Also fixed some formatting issues and typos.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
