### PR TITLE
[pluto] - fixed issues with label wrapping

### DIFF
--- a/pluto/src/vis/schematic/Forms.tsx
+++ b/pluto/src/vis/schematic/Forms.tsx
@@ -289,7 +289,7 @@ export const TankForm = ({
   includeBorderRadius = false,
 }: TankFormProps): ReactElement => (
   <FormWrapper direction="x" align="stretch">
-    <Align.Space direction="y">
+    <Align.Space direction="y" grow>
       <LabelControls path="label" />
       <Align.Space direction="x">
         <ColorControl path="color" />

--- a/pluto/src/vis/schematic/Symbols.tsx
+++ b/pluto/src/vis/schematic/Symbols.tsx
@@ -67,7 +67,7 @@ const labelGridItem = (
         value={label}
         onChange={(value) => onChange?.({ label: { ...props, label: value } })}
         allowEmpty
-        style={{ maxInlineSize, textAlign: align as CSSProperties["textAlign"] }}
+        style={{ textAlign: align as CSSProperties["textAlign"], width: maxInlineSize }}
       />
     ),
     location: orientation,


### PR DESCRIPTION
# Issue Pull Request

## Key Information

- **Linear Issue**: [SY-1610](https://linear.app/synnax/issue/SY-1610/fix-label-width-on-schematic)

## Description

Fixes an issue where labels on the schematic would wrap too early.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
