### PR TITLE
SY 1646 Disable Switch Fields when Variant Is Preview

### DIFF
--- a/pluto/src/input/Switch.tsx
+++ b/pluto/src/input/Switch.tsx
@@ -30,26 +30,41 @@ const CLS = "input-switch";
  */
 export const Switch = forwardRef<HTMLInputElement, SwitchProps>(
   (
-    { className, value, disabled, onChange, size = "medium", ...props }: SwitchProps,
+    {
+      className,
+      value,
+      disabled,
+      onChange,
+      size = "medium",
+      variant,
+      ...props
+    }: SwitchProps,
     ref,
-  ) => (
-    <div
-      className={CSS(CSS.BE(CLS, "container"), CSS.disabled(disabled), CSS.size(size))}
-    >
-      <label className={CSS(CSS.BE(CLS, "track"), className)}>
-        <input
-          className={CSS.BE(CLS, "input")}
-          type="checkbox"
-          ref={ref}
-          checked={value}
-          onChange={(e) => onChange(e.target.checked)}
-          value=""
-          disabled={disabled}
-          {...props}
-        />
-        <span className="pluto-input-switch__slider" />
-      </label>
-    </div>
-  ),
+  ) => {
+    if (variant === "preview") disabled = true;
+    return (
+      <div
+        className={CSS(
+          CSS.BE(CLS, "container"),
+          CSS.disabled(disabled),
+          CSS.size(size),
+        )}
+      >
+        <label className={CSS(CSS.BE(CLS, "track"), className)}>
+          <input
+            className={CSS.BE(CLS, "input")}
+            type="checkbox"
+            ref={ref}
+            checked={value}
+            onChange={(e) => onChange(e.target.checked)}
+            value=""
+            disabled={disabled}
+            {...props}
+          />
+          <span className="pluto-input-switch__slider" />
+        </label>
+      </div>
+    );
+  },
 );
 Switch.displayName = "InputSwitch";


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1646](https://linear.app/synnax/issue/SY-1646/disable-form-switch-fields-when-form-mode-is-preview)

## Description

Disable a switch input when the variant is preview.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
