### PR TITLE
SY-1647 labjack error on all disabled channels in task

### DIFF
--- a/driver/labjack/reader.h
+++ b/driver/labjack/reader.h
@@ -317,7 +317,6 @@ private:
     bool ok_state = true;
     std::mutex mutex;
     std::shared_ptr<labjack::DeviceManager> device_manager;
-    std::string last_err;
 };
 
 ///////////////////////////////////////////////////////////////////////////////////

--- a/driver/labjack/reader.h
+++ b/driver/labjack/reader.h
@@ -294,6 +294,8 @@ private:
 
     void open_device();
 
+    void log_err(std::string err_msg);
+
     int handle;
     ReaderConfig reader_config;
     std::shared_ptr<task::Context> ctx;
@@ -315,6 +317,7 @@ private:
     bool ok_state = true;
     std::mutex mutex;
     std::shared_ptr<labjack::DeviceManager> device_manager;
+    std::string last_err;
 };
 
 ///////////////////////////////////////////////////////////////////////////////////

--- a/driver/labjack/reader_source.cpp
+++ b/driver/labjack/reader_source.cpp
@@ -214,10 +214,9 @@ void labjack::ReaderSource::init_stream() {
 };
 
 freighter::Error labjack::ReaderSource::start(const std::string &cmd_key) {
-    if(!this->ok()) {
-        this->log_err("Read task failed to start. " + this->last_err);
+    if(!this->ok())
         return freighter::Error("Device disconnected or is in error. Please reconfigure task and try again");
-    }
+
     if (this->breaker.running()) {
         LOG(INFO) << "[labjack.reader] breaker already running";
         return freighter::NIL;
@@ -529,7 +528,6 @@ std::vector<synnax::ChannelKey> labjack::ReaderSource::get_ai_channel_keys() {
 void labjack::ReaderSource::log_err(std::string msg){
     LOG(ERROR) << "[labjack.reader] " << msg;
     this->ok_state = false;
-    this->last_err = msg;
     ctx->set_state({
                        .task = this->task.key,
                        .variant = "error",

--- a/driver/labjack/reader_source.cpp
+++ b/driver/labjack/reader_source.cpp
@@ -56,7 +56,7 @@ std::vector<synnax::ChannelKey> labjack::ReaderSource::get_channel_keys() {
         // get index key
         auto [channel_info, err] = this->ctx->client->channels.retrieve(channel.key);
         if (err != freighter::NIL) {
-            this->log_err("Error retrieving channel: " + err.message());
+            this->log_err("Error retrieving channel for port: " + channel.location);
             continue;
         }
         channel.data_type = channel_info.data_type;
@@ -67,7 +67,7 @@ std::vector<synnax::ChannelKey> labjack::ReaderSource::get_channel_keys() {
         keys.push_back(channel.key);
         auto [channel_info, err] = this->ctx->client->channels.retrieve(channel.key);
         if (err != freighter::NIL) {
-            this->log_err("Error retrieving channel: " + err.message());
+            this->log_err("Error retrieving channel for port: " + channel.location);
             continue;
         }
         channel.data_type = channel_info.data_type;

--- a/driver/labjack/reader_source.cpp
+++ b/driver/labjack/reader_source.cpp
@@ -33,7 +33,6 @@ labjack::ReaderSource::ReaderSource(
 
     if (this->reader_config.channels.empty() && this->reader_config.tc_channels.empty())
         this->log_err("No channels enabled/set.");
-
 }
 
 void labjack::ReaderSource::stopped_with_err(const freighter::Error &err) {
@@ -81,7 +80,7 @@ std::vector<synnax::ChannelKey> labjack::ReaderSource::get_channel_keys() {
 
 
 void labjack::ReaderSource::init() {
-    if(!this->ok()) return;
+    if (!this->ok()) return;
     if (this->reader_config.device_type != "") {
         this->init_stream();
         this->init_tcs();
@@ -110,7 +109,7 @@ void labjack::ReaderSource::init() {
 
 void labjack::ReaderSource::init_tcs() {
     if (this->reader_config.tc_channels.empty()) return;
-    if(this->reader_config.device_type == "T4")
+    if (this->reader_config.device_type == "T4")
         return this->log_err("Thermocouple channels not currently supported for T4 devices");
 
     for (auto &channel: this->reader_config.channels) {
@@ -190,31 +189,31 @@ void labjack::ReaderSource::init_stream() {
         phys_channel_names.push_back(channel.c_str());
 
     check_err(
-            LJM_NamesToAddresses(
-                    this->reader_config.phys_channels.size(),
-                    phys_channel_names.data(),
-                    this->port_addresses.data(),
-                    NULL
-                ),
+        LJM_NamesToAddresses(
+            this->reader_config.phys_channels.size(),
+            phys_channel_names.data(),
+            this->port_addresses.data(),
+            NULL
+        ),
         "init_stream.LJM_NamesToAddresses"
     );
 
     LJM_eStreamStop(handle); // in case it was running
 
     check_err(
-            LJM_eStreamStart(
-                    handle,
-                    SCANS_PER_READ,
-                    this->reader_config.phys_channels.size(),
-                    this->port_addresses.data(),
-                    &scanRate
-                ),
+        LJM_eStreamStart(
+            handle,
+            SCANS_PER_READ,
+            this->reader_config.phys_channels.size(),
+            this->port_addresses.data(),
+            &scanRate
+        ),
         "init_stream.LJM_eStreamStart"
     );
 };
 
 freighter::Error labjack::ReaderSource::start(const std::string &cmd_key) {
-    if(!this->ok())
+    if (!this->ok())
         return freighter::Error("Device disconnected or is in error. Please reconfigure task and try again");
 
     if (this->breaker.running()) {
@@ -525,15 +524,15 @@ std::vector<synnax::ChannelKey> labjack::ReaderSource::get_ai_channel_keys() {
     return keys;
 }
 
-void labjack::ReaderSource::log_err(std::string msg){
+void labjack::ReaderSource::log_err(std::string msg) {
     LOG(ERROR) << "[labjack.reader] " << msg;
     this->ok_state = false;
     ctx->set_state({
-                       .task = this->task.key,
-                       .variant = "error",
-                       .details = {
-                               {"running", false},
-                               {"message", msg}
-                       }
-               });
+        .task = this->task.key,
+        .variant = "error",
+        .details = {
+            {"running", false},
+            {"message", msg}
+        }
+    });
 }

--- a/driver/labjack/reader_source.cpp
+++ b/driver/labjack/reader_source.cpp
@@ -57,7 +57,7 @@ std::vector<synnax::ChannelKey> labjack::ReaderSource::get_channel_keys() {
         auto [channel_info, err] = this->ctx->client->channels.retrieve(channel.key);
         if (err != freighter::NIL) {
             this->log_err("Error retrieving channel: " + err.message());
-            return keys;
+            continue;
         }
         channel.data_type = channel_info.data_type;
         this->reader_config.index_keys.insert(channel_info.index);
@@ -68,7 +68,7 @@ std::vector<synnax::ChannelKey> labjack::ReaderSource::get_channel_keys() {
         auto [channel_info, err] = this->ctx->client->channels.retrieve(channel.key);
         if (err != freighter::NIL) {
             this->log_err("Error retrieving channel: " + err.message());
-            return keys;
+            continue;
         }
         channel.data_type = channel_info.data_type;
         this->reader_config.index_keys.insert(channel_info.index);

--- a/driver/labjack/reader_task.cpp
+++ b/driver/labjack/reader_task.cpp
@@ -114,9 +114,8 @@ std::unique_ptr<task::Task> labjack::ReaderTask::configure(
         breaker_config
     );
 
-    if (!source->ok()) {
+    if (!source->ok())
         return nullptr;
-    }
 
     ctx->set_state({
         .task = task.key,

--- a/driver/labjack/reader_task.cpp
+++ b/driver/labjack/reader_task.cpp
@@ -114,8 +114,7 @@ std::unique_ptr<task::Task> labjack::ReaderTask::configure(
         breaker_config
     );
 
-    if (!source->ok())
-        return nullptr;
+    if (!source->ok()) return nullptr;
 
     ctx->set_state({
         .task = task.key,

--- a/driver/labjack/reader_task.cpp
+++ b/driver/labjack/reader_task.cpp
@@ -114,6 +114,10 @@ std::unique_ptr<task::Task> labjack::ReaderTask::configure(
         breaker_config
     );
 
+    if (!source->ok()) {
+        return nullptr;
+    }
+
     ctx->set_state({
         .task = task.key,
         .variant = "success",

--- a/driver/labjack/scanner.cpp
+++ b/driver/labjack/scanner.cpp
@@ -152,7 +152,7 @@ json labjack::ScannerTask::get_devices() {
 int labjack::ScannerTask::check_err(const int err) {
     // First check if it is LJME_AUTO_IPS_FILE_NOT_FOUND as this is a known
     // bug on the LJM Library when no devices are connected
-    if (err == LJME_AUTO_IPS_FILE_NOT_FOUND) return 0;
+    if (err == LJME_AUTO_IPS_FILE_NOT_FOUND || err == LJME_AUTO_IPS_FILE_INVALID) return 0;
     return labjack::check_err_internal(
         err,
         "",

--- a/driver/labjack/writer.h
+++ b/driver/labjack/writer.h
@@ -129,7 +129,7 @@ struct WriterConfig {
         parser.iter("channels", [this, ctx](config::Parser &channel_parser) {
             auto channel = WriterChannelConfig(channel_parser);
 
-            if(channel.enabled) channels.emplace_back(channel);
+            if (channel.enabled) channels.emplace_back(channel);
             else return;
 
             auto [channel_info, err] = ctx->client->channels.retrieve(channel.cmd_key);
@@ -190,7 +190,6 @@ public:
     void open_device();
 
 private:
-
     void log_err(std::string err_msg);
 
     int handle;

--- a/driver/labjack/writer.h
+++ b/driver/labjack/writer.h
@@ -129,6 +129,9 @@ struct WriterConfig {
         parser.iter("channels", [this, ctx](config::Parser &channel_parser) {
             auto channel = WriterChannelConfig(channel_parser);
 
+            if(channel.enabled) channels.emplace_back(channel);
+            else return;
+
             auto [channel_info, err] = ctx->client->channels.retrieve(channel.cmd_key);
             if (err) {
                 LOG(ERROR) << "Failed to retrieve channel info for key " << channel.cmd_key;
@@ -136,7 +139,6 @@ struct WriterConfig {
             }
             channel.data_type = channel_info.data_type;
 
-            if(channel.enabled) channels.emplace_back(channel);
 
             /// digital outputs start active high
             double initial_val = 0.0;

--- a/driver/labjack/writer.h
+++ b/driver/labjack/writer.h
@@ -135,7 +135,8 @@ struct WriterConfig {
                 return;
             }
             channel.data_type = channel_info.data_type;
-            channels.emplace_back(channel);
+
+            if(channel.enabled) channels.emplace_back(channel);
 
             /// digital outputs start active high
             double initial_val = 0.0;
@@ -187,6 +188,9 @@ public:
     void open_device();
 
 private:
+
+    void log_err(std::string err_msg);
+
     int handle;
     std::shared_ptr<task::Context> ctx;
     WriterConfig writer_config;

--- a/driver/labjack/writer_sink.cpp
+++ b/driver/labjack/writer_sink.cpp
@@ -152,7 +152,7 @@ labjack::WriteSink::WriteSink(
 
     this->handle = this->device_manager->get_device_handle(this->writer_config.serial_number);
 
-    if(this->writer_config.channels.empty())
+    if (this->writer_config.channels.empty())
         this->log_err("No channels enabled/set");
 }
 
@@ -206,7 +206,7 @@ freighter::Error labjack::WriteSink::write(synnax::Frame frame) {
 
 
 freighter::Error labjack::WriteSink::stop(const std::string &cmd_key) {
-    if(!this->ok())
+    if (!this->ok())
         return freighter::Error("Device disconnected or is in error. Please reconfigure task and try again");
     ctx->set_state({
         .task = task.key,
@@ -292,15 +292,15 @@ bool labjack::WriteSink::ok() {
     return this->ok_state;
 }
 
-void labjack::WriteSink::log_err(std::string msg){
+void labjack::WriteSink::log_err(std::string msg) {
     LOG(ERROR) << "[labjack.writer] " << msg;
     this->ok_state = false;
     ctx->set_state({
-                       .task = this->task.key,
-                       .variant = "error",
-                       .details = {
-                               {"running", false},
-                               {"message", msg}
-                       }
-               });
+        .task = this->task.key,
+        .variant = "error",
+        .details = {
+            {"running", false},
+            {"message", msg}
+        }
+    });
 }

--- a/driver/labjack/writer_sink.cpp
+++ b/driver/labjack/writer_sink.cpp
@@ -263,7 +263,7 @@ std::vector<synnax::ChannelKey> labjack::WriteSink::get_index_keys() {
     for (auto &channel: this->writer_config.channels) {
         auto [channel_info, err] = this->ctx->client->channels.retrieve(channel.state_key);
         if (err) {
-            this->log_err("Failed to retrieve channel.");
+            this->log_err("Failed to retrieve channel for port: " + channel.location);
             return {};
         }
         unique_keys.insert(channel_info.index);

--- a/driver/labjack/writer_task.cpp
+++ b/driver/labjack/writer_task.cpp
@@ -93,6 +93,10 @@ std::unique_ptr<task::Task> labjack::WriterTask::configure(
         breaker_config
     );
 
+    if(!sink->ok())
+        return nullptr;
+
+
     ctx->set_state({
         .task = task.key,
         .variant = "success",

--- a/driver/labjack/writer_task.cpp
+++ b/driver/labjack/writer_task.cpp
@@ -93,7 +93,7 @@ std::unique_ptr<task::Task> labjack::WriterTask::configure(
         breaker_config
     );
 
-    if(!sink->ok())
+    if (!sink->ok())
         return nullptr;
 
 


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1647](https://linear.app/synnax/issue/1647)

## Description

This PR checks if channels are enabled and returns an error on configure if you enabled channels are passed in. Also refactors some of the error logging in labjack tasks. 

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
