### PR TITLE
SY-1658 Fix Schematic Label Positioning and Remove Snap To Grid

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synnaxlabs/console",
   "private": true,
-  "version": "0.35.1",
+  "version": "0.35.2",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/pluto/package.json
+++ b/pluto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synnaxlabs/pluto",
-  "version": "0.35.1",
+  "version": "0.35.2",
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit && vite build",

--- a/pluto/src/text/Editable.css
+++ b/pluto/src/text/Editable.css
@@ -14,6 +14,7 @@
     user-select: text;
     -webkit-user-select: text;
     padding: 0.25rem 0;
+    box-sizing: content-box;
 
     &:focus {
         border: var(--pluto-border-width) solid var(--pluto-primary-z);

--- a/pluto/src/text/Editable.css
+++ b/pluto/src/text/Editable.css
@@ -11,10 +11,9 @@
 
 .pluto-text--editable {
     cursor: pointer;
-    user-select: text;
     -webkit-user-select: text;
+    user-select: text;
     padding: 0.25rem 0;
-    box-sizing: content-box;
 
     &:focus {
         border: var(--pluto-border-width) solid var(--pluto-primary-z);

--- a/pluto/src/text/Editable.tsx
+++ b/pluto/src/text/Editable.tsx
@@ -108,9 +108,12 @@ export const Editable = <L extends text.Level = text.Level>({
   // call onChange twice in quick succession.
   const optimisticValueRef = useSyncedRef(value);
 
+  // Turns out the writing modes like vertical-rl cause all sorts of problems with
+  // elements whose values change. The following section of code forces the browser
+  // to reflow the element when the value changes or the styles that affect the
+  // layout change.
   const stylesToTriggerReflow = useRef<StylesToTriggerReflow | undefined>(style);
   const valueRef = useRef(value);
-
   if (
     (stylesToTriggerReflow.current != null &&
       !compareStylesToTriggerReflow(style, stylesToTriggerReflow.current)) ||
@@ -183,11 +186,7 @@ export const Editable = <L extends text.Level = text.Level>({
     // @ts-expect-error - TODO: generic element behavior is funky
     <Text<L>
       ref={ref}
-      className={CSS(
-        className,
-        CSS.BM("text", "editable"),
-        editable && CSS.M("editing"),
-      )}
+      className={CSS(className, CSS.BM("text", "editable"))}
       onBlur={() => {
         setEditable(false);
         const el = ref.current;

--- a/pluto/src/text/Editable.tsx
+++ b/pluto/src/text/Editable.tsx
@@ -109,13 +109,16 @@ export const Editable = <L extends text.Level = text.Level>({
   const optimisticValueRef = useSyncedRef(value);
 
   const stylesToTriggerReflow = useRef<StylesToTriggerReflow | undefined>(style);
+  const valueRef = useRef(value);
 
   if (
-    stylesToTriggerReflow.current != null &&
-    !compareStylesToTriggerReflow(style, stylesToTriggerReflow.current)
+    (stylesToTriggerReflow.current != null &&
+      !compareStylesToTriggerReflow(style, stylesToTriggerReflow.current)) ||
+    value !== valueRef.current
   ) {
     triggerReflow(ref.current as HTMLElement);
     stylesToTriggerReflow.current = style;
+    valueRef.current = value;
   }
 
   const handleDoubleClick = (

--- a/pluto/src/text/Editable.tsx
+++ b/pluto/src/text/Editable.tsx
@@ -10,6 +10,7 @@
 import "@/text/Editable.css";
 
 import {
+  type CSSProperties,
   type KeyboardEvent,
   type ReactElement,
   useEffect,
@@ -24,6 +25,7 @@ import { type Input } from "@/input";
 import { type state } from "@/state";
 import { type text } from "@/text/core";
 import { Text, type TextProps } from "@/text/Text";
+import { triggerReflow } from "@/util/reflow";
 
 export type EditableProps<L extends text.Level = "h1"> = Omit<
   TextProps<L>,
@@ -75,13 +77,27 @@ export const asyncEdit = (id: string): Promise<[string, boolean]> =>
 
 const getInnerText = (el: HTMLElement): string => el.innerText.trim();
 
+interface StylesToTriggerReflow {
+  maxInlineSize?: CSSProperties["maxInlineSize"];
+}
+
+const compareStylesToTriggerReflow = (
+  a: StylesToTriggerReflow | undefined,
+  b: StylesToTriggerReflow | undefined,
+): boolean => {
+  if (a == null || b == null) return false;
+  return a.maxInlineSize === b.maxInlineSize;
+};
+
 export const Editable = <L extends text.Level = text.Level>({
   onChange,
   value,
+  className,
   useEditableState = useState,
   allowDoubleClick = true,
   onDoubleClick,
   allowEmpty = false,
+  style,
   ...props
 }: EditableProps<L>): ReactElement => {
   const [editable, setEditable] = useEditableState(false);
@@ -91,6 +107,16 @@ export const Editable = <L extends text.Level = text.Level>({
   // this value as an optimistic update to make sure we don't
   // call onChange twice in quick succession.
   const optimisticValueRef = useSyncedRef(value);
+
+  const stylesToTriggerReflow = useRef<StylesToTriggerReflow | undefined>(style);
+
+  if (
+    stylesToTriggerReflow.current != null &&
+    !compareStylesToTriggerReflow(style, stylesToTriggerReflow.current)
+  ) {
+    triggerReflow(ref.current as HTMLElement);
+    stylesToTriggerReflow.current = style;
+  }
 
   const handleDoubleClick = (
     e: React.MouseEvent<HTMLParagraphElement, MouseEvent>,
@@ -113,7 +139,9 @@ export const Editable = <L extends text.Level = text.Level>({
   };
 
   const handleKeyDown = (e: KeyboardEvent<HTMLParagraphElement>): void => {
-    if (!editable || !NOMINAL_EXIT_KEYS.includes(e.key) || ref.current == null) return;
+    if (ref.current == null) return;
+    triggerReflow(ref.current);
+    if (!editable || !NOMINAL_EXIT_KEYS.includes(e.key)) return;
     e.stopPropagation();
     e.preventDefault();
     const el = ref.current;
@@ -152,7 +180,11 @@ export const Editable = <L extends text.Level = text.Level>({
     // @ts-expect-error - TODO: generic element behavior is funky
     <Text<L>
       ref={ref}
-      className={CSS.BM("text", "editable")}
+      className={CSS(
+        className,
+        CSS.BM("text", "editable"),
+        editable && CSS.M("editing"),
+      )}
       onBlur={() => {
         setEditable(false);
         const el = ref.current;
@@ -167,6 +199,7 @@ export const Editable = <L extends text.Level = text.Level>({
       onDoubleClick={handleDoubleClick}
       contentEditable={editable}
       suppressContentEditableWarning
+      style={style}
       {...props}
     >
       {value}

--- a/pluto/src/util/reflow.ts
+++ b/pluto/src/util/reflow.ts
@@ -1,0 +1,10 @@
+// Trigger reflow causes the browser to re-paint the element. This is necessary to
+// fix white-spacing and wrapping issues in safari when the text gets dynamically
+// changed.
+export const triggerReflow = (el: HTMLElement): void => {
+  if (el == null) return;
+  el.style.display = "none";
+  // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+  el.offsetHeight;
+  el.style.display = "";
+};

--- a/pluto/src/vis/diagram/Diagram.tsx
+++ b/pluto/src/vis/diagram/Diagram.tsx
@@ -463,8 +463,6 @@ const Core = Aether.wrap<DiagramProps>(
               maxZoom={1.2}
               isValidConnection={isValidConnection}
               connectionMode={ConnectionMode.Loose}
-              snapGrid={[2, 2]}
-              snapToGrid
               fitViewOptions={FIT_VIEW_OPTIONS}
               selectionMode={SelectionMode.Partial}
               proOptions={PRO_OPTIONS}

--- a/pluto/src/vis/schematic/Forms.tsx
+++ b/pluto/src/vis/schematic/Forms.tsx
@@ -104,7 +104,7 @@ const LabelControls = ({ path, omit = [] }: LabelControlsProps): ReactElement =>
       path={`${path}.maxInlineSize`}
       hideIfNull
       label="Label Wrap Width"
-      inputProps={{ endContent: "px" }}
+      inputProps={{ endContent: "px", dragScale: { x: 1, y: 0.5 } }}
       padHelpText={false}
     />
     <Form.Field<Text.Level>

--- a/pluto/src/vis/schematic/Grid.tsx
+++ b/pluto/src/vis/schematic/Grid.tsx
@@ -12,10 +12,12 @@ import { location } from "@synnaxlabs/x";
 import {
   cloneElement,
   type DragEvent,
+  type FC,
   Fragment,
   type PropsWithChildren,
   type ReactElement,
   useCallback,
+  useRef,
   useState,
 } from "react";
 
@@ -24,6 +26,8 @@ import { Button } from "@/button";
 import { CSS } from "@/css";
 import { Haul } from "@/haul";
 import { useSyncedRef } from "@/hooks";
+import { triggerReflow } from "@/util/reflow";
+import { selectNode } from "@/vis/diagram/util";
 
 export interface GridItem {
   key: string;
@@ -43,124 +47,115 @@ interface GridElProps {
   editable: boolean;
   symbolKey: string;
   items: GridItem[];
-  loc: location.Outer;
   onLocationChange: (key: string, loc: location.Outer) => void;
 }
 
 const HAUL_TYPE = "Schematic.Grid";
 
-const EditableGridEl = ({
-  symbolKey,
-  items: fItems,
-  loc,
-  onLocationChange,
-}: GridElProps): ReactElement | null => {
-  const haulType = `${symbolKey}.${HAUL_TYPE}`;
-  const [draggingOver, setDraggingOver] = useState(false);
-  const canDrop: Haul.CanDrop = useCallback(
-    ({ items }) => items.every((i) => i.type === haulType),
-    [haulType],
-  );
-  const onLocationChangeRef = useSyncedRef(onLocationChange);
-  const { startDrag, onDragEnd, ...dropProps } = Haul.useDragAndDrop({
-    type: haulType,
-    canDrop,
-    onDrop: useCallback(({ items }) => items, []),
-    onDragOver: useCallback((props: Haul.OnDragOverProps) => {
-      setDraggingOver(canDrop(props));
-      props.items.forEach(({ key }) => onLocationChangeRef.current(key as string, loc));
-    }, []),
-  });
-
-  const items = fItems.filter((i) => i.location === loc);
-
-  const onDragStart = useCallback(
-    (_: DragEvent<HTMLDivElement>, key: string) => startDrag([{ key, type: haulType }]),
-    [startDrag, haulType],
-  );
-
-  return (
-    <Align.Space
-      direction={location.direction(loc)}
-      className={CSS(
-        CSS.BE("grid", "item"),
-        CSS.loc(loc),
-        CSS.dropRegion(true),
-        draggingOver && CSS.B("dragging-over"),
-      )}
-      onDragLeave={() => setDraggingOver(false)}
-      empty
-      {...dropProps}
-    >
-      {items.map(({ element, key }) => (
-        <Fragment key={key}>
-          {cloneElement(element, {
-            draggable: true,
-            onDragStart: (e: DragEvent<HTMLDivElement>) => onDragStart(e, key),
-            onDragEnd,
-            style: { cursor: "grab" },
-          })}
-        </Fragment>
-      ))}
-    </Align.Space>
-  );
+const reflowPane = (symbolKey: string) => {
+  const node = selectNode(symbolKey);
+  const nearestDiagram = node.closest(".react-flow__pane") as HTMLElement | null;
+  if (nearestDiagram != null) triggerReflow(nearestDiagram);
 };
 
-const GridEl = (props: GridElProps): ReactElement | null => {
-  const { editable, items: fItems, loc } = props;
-  if (editable) return <EditableGridEl {...props} />;
-  const items = fItems.filter((i) => i.location === loc);
-  if (items.length === 0) return null;
-  return (
-    <Align.Space
-      direction={location.direction(loc)}
-      className={CSS(CSS.BE("grid", "item"), CSS.loc(loc))}
-      empty
-    >
-      {items.map(({ element, key }) => (
-        <Fragment key={key}>{element}</Fragment>
-      ))}
-    </Align.Space>
-  );
+const createGridEl = (loc: location.Outer): FC<GridElProps> => {
+  const EditableGridEl = ({
+    symbolKey,
+    items: fItems,
+    onLocationChange,
+  }: GridElProps): ReactElement | null => {
+    const haulType = `${symbolKey}.${HAUL_TYPE}`;
+    const [draggingOver, setDraggingOver] = useState(false);
+    const canDrop: Haul.CanDrop = useCallback(
+      ({ items }) => items.every((i) => i.type === haulType),
+      [haulType],
+    );
+    const onLocationChangeRef = useSyncedRef(onLocationChange);
+    const { startDrag, onDragEnd, ...dropProps } = Haul.useDragAndDrop({
+      type: haulType,
+      canDrop,
+      onDrop: useCallback(({ items }) => items, []),
+      onDragOver: useCallback((props: Haul.OnDragOverProps) => {
+        setDraggingOver(canDrop(props));
+        props.items.forEach(({ key }) =>
+          onLocationChangeRef.current(key as string, loc),
+        );
+      }, []),
+    });
+
+    const items = fItems.filter((i) => i.location === loc);
+
+    const onDragStart = useCallback(
+      (_: DragEvent<HTMLDivElement>, key: string) =>
+        startDrag([{ key, type: haulType }]),
+      [startDrag, haulType],
+    );
+
+    return (
+      <Align.Space
+        direction={location.direction(loc)}
+        className={CSS(
+          CSS.BE("grid", "item"),
+          CSS.loc(loc),
+          CSS.dropRegion(true),
+          draggingOver && CSS.B("dragging-over"),
+        )}
+        onDragLeave={() => setDraggingOver(false)}
+        empty
+        {...dropProps}
+      >
+        {items.map(({ element, key }) => (
+          <Fragment key={key}>
+            {cloneElement(element, {
+              draggable: true,
+              onDragStart: (e: DragEvent<HTMLDivElement>) => onDragStart(e, key),
+              onDragEnd,
+              style: { ...element.props.style, cursor: "grab" },
+            })}
+          </Fragment>
+        ))}
+      </Align.Space>
+    );
+  };
+
+  const GridEl = ({ symbolKey, ...props }: GridElProps): ReactElement | null => {
+    const { editable, items: fItems } = props;
+
+    const prevEditable = useRef(editable);
+    if (editable !== prevEditable.current && loc === "top") {
+      reflowPane(symbolKey);
+      prevEditable.current = editable;
+    }
+
+    if (editable) return <EditableGridEl symbolKey={symbolKey} {...props} />;
+    const items = fItems.filter((i) => i.location === loc);
+    if (items.length === 0) return null;
+    return (
+      <Align.Space
+        direction={location.direction(loc)}
+        className={CSS(CSS.BE("grid", "item"), CSS.loc(loc))}
+        empty
+      >
+        {items.map(({ element, key }) => (
+          <Fragment key={key}>{element}</Fragment>
+        ))}
+      </Align.Space>
+    );
+  };
+  return GridEl;
 };
 
-export const Grid = ({
-  symbolKey,
-  editable,
-  children,
-  items,
-  onLocationChange,
-  onRotate,
-}: GridProps) => (
+const TopGridEl = createGridEl("top");
+const LeftGridEl = createGridEl("left");
+const RightGridEl = createGridEl("right");
+const BottomGridEl = createGridEl("bottom");
+
+export const Grid = ({ editable, onRotate, children, ...props }: GridProps) => (
   <>
-    <GridEl
-      editable={editable}
-      items={items}
-      loc="top"
-      onLocationChange={onLocationChange}
-      symbolKey={symbolKey}
-    />
-    <GridEl
-      editable={editable}
-      items={items}
-      loc="left"
-      onLocationChange={onLocationChange}
-      symbolKey={symbolKey}
-    />
-    <GridEl
-      editable={editable}
-      items={items}
-      loc="right"
-      onLocationChange={onLocationChange}
-      symbolKey={symbolKey}
-    />
-    <GridEl
-      editable={editable}
-      items={items}
-      loc="bottom"
-      onLocationChange={onLocationChange}
-      symbolKey={symbolKey}
-    />
+    <TopGridEl editable={editable} {...props} />
+    <LeftGridEl editable={editable} {...props} />
+    <RightGridEl editable={editable} {...props} />
+    <BottomGridEl editable={editable} {...props} />
     {editable && (
       <Button.Icon
         className={CSS.BE("grid", "rotate")}

--- a/pluto/src/vis/schematic/Symbols.css
+++ b/pluto/src/vis/schematic/Symbols.css
@@ -21,6 +21,14 @@
 .pluto-grid__item {
     border: var(--pluto-border);
     border-color: transparent;
+    width: max-content;
+    height: max-content;
+    overflow: hidden;
+    position: absolute;
+    --offset: 0.666rem;
+    justify-content: center;
+    align-items: center;
+
     &.pluto-haul-drop-region {
         background: var(--haul-background);
         border-color: var(--haul-border-color);
@@ -29,10 +37,6 @@
     &.pluto-dragging-over {
         border-color: var(--pluto-primary-z);
     }
-    position: absolute;
-    --offset: 0.666rem;
-    justify-content: center;
-    align-items: center;
 
     &.pluto--y {
         padding: 0 0.5rem;
@@ -69,9 +73,13 @@
 
 .pluto-symbol__label {
     --offset: 0.666rem;
+    -webkit-user-select: none;
     user-select: none;
     pointer-events: none;
     overflow-wrap: break-word;
+    width: max-content;
+    height: max-content;
+    padding: 0 !important;
     &.pluto--y {
         writing-mode: vertical-rl;
     }

--- a/pluto/src/vis/schematic/Symbols.tsx
+++ b/pluto/src/vis/schematic/Symbols.tsx
@@ -65,7 +65,7 @@ const labelGridItem = (
         className={CSS(CSS.BE("symbol", "label"), CSS.dir(direction))}
         level={level}
         value={label}
-        onChange={(value) => onChange?.({ label: { ...props, label: value } })}
+        onChange={(value: string) => onChange?.({ label: { ...props, label: value } })}
         allowEmpty
         style={{ textAlign: align as CSSProperties["textAlign"], maxInlineSize }}
       />

--- a/pluto/src/vis/schematic/Symbols.tsx
+++ b/pluto/src/vis/schematic/Symbols.tsx
@@ -67,7 +67,7 @@ const labelGridItem = (
         value={label}
         onChange={(value) => onChange?.({ label: { ...props, label: value } })}
         allowEmpty
-        style={{ textAlign: align as CSSProperties["textAlign"], width: maxInlineSize }}
+        style={{ textAlign: align as CSSProperties["textAlign"], maxInlineSize }}
       />
     ),
     location: orientation,

--- a/pluto/src/vis/schematic/registry.ts
+++ b/pluto/src/vis/schematic/registry.ts
@@ -454,7 +454,7 @@ const reliefValve: Spec<ReliefValveProps> = {
     ...zeroLabel("Relief Valve"),
     ...ZERO_DUMMY_TOGGLE_PROPS,
   }),
-  Preview: Primitives.ReliefValve,
+  Preview: ({ clickable, ...props }) => Primitives.ReliefValve(props),
   zIndex: Z_INDEX_UPPER,
 };
 
@@ -468,7 +468,7 @@ const springLoadedReliefValve: Spec<SpringLoadedReliefValveProps> = {
     ...zeroLabel("Spring Loaded Relief Valve"),
     ...ZERO_DUMMY_TOGGLE_PROPS,
   }),
-  Preview: Primitives.SpringLoadedReliefValve,
+  Preview: ({ clickable, ...props }) => Primitives.SpringLoadedReliefValve(props),
   zIndex: Z_INDEX_UPPER,
 };
 
@@ -482,7 +482,7 @@ const angledSpringLoadedReliefValve: Spec<AngledSpringLoadedReliefValveProps> = 
     ...zeroLabel("Angled Spring Loaded Relief Valve"),
     ...ZERO_DUMMY_TOGGLE_PROPS,
   }),
-  Preview: Primitives.AngledSpringLoadedReliefValve,
+  Preview: ({ clickable, ...props }) => Primitives.AngledSpringLoadedReliefValve(props),
   zIndex: Z_INDEX_UPPER,
 };
 
@@ -580,7 +580,7 @@ const manualValve: Spec<ManualValveProps> = {
     ...zeroLabel("Manual Valve"),
     ...ZERO_DUMMY_TOGGLE_PROPS,
   }),
-  Preview: Primitives.ManualValve,
+  Preview: ({ clickable, ...props }) => Primitives.ManualValve(props),
   zIndex: Z_INDEX_UPPER,
 };
 
@@ -636,7 +636,7 @@ const needleValve: Spec<NeedleValveProps> = {
     ...zeroLabel("Needle Valve"),
     ...ZERO_DUMMY_TOGGLE_PROPS,
   }),
-  Preview: Primitives.NeedleValve,
+  Preview: ({ clickable, ...props }) => Primitives.NeedleValve(props),
   zIndex: Z_INDEX_UPPER,
 };
 
@@ -678,7 +678,7 @@ const angledReliefValve: Spec<ReliefValveProps> = {
     ...zeroLabel("Angled Relief Valve"),
     ...ZERO_DUMMY_TOGGLE_PROPS,
   }),
-  Preview: Primitives.AngledReliefValve,
+  Preview: ({ clickable, ...props }) => Primitives.AngledReliefValve(props),
   zIndex: Z_INDEX_UPPER,
 };
 


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1658](https://linear.app/synnax/issue/SY-1658/fix-schematic-label-positioning-and-remove-snap-to-grid)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

- Fix issues with the schematic label positioning
- Remove schematic snap to grid
- Fix issue with the clickable prop being passed into schematic previews.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
