### PR TITLE
SY-1660 Remove Bad Edges and Nodes when Importing Schematics

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synnaxlabs/console",
   "private": true,
-  "version": "0.35.2",
+  "version": "0.35.3",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/console/src/schematic/migrations/index.ts
+++ b/console/src/schematic/migrations/index.ts
@@ -32,15 +32,15 @@ export const ZERO_STATE = v3.ZERO_STATE;
 export const ZERO_SLICE_STATE = v3.ZERO_SLICE_STATE;
 
 const STATE_MIGRATIONS: migrate.Migrations = {
-  "0.0.0": v1.stateMigration,
-  "1.0.0": v2.stateMigration,
-  "2.0.0": v3.stateMigration,
+  [v0.VERSION]: v1.stateMigration,
+  [v1.VERSION]: v2.stateMigration,
+  [v2.VERSION]: v3.stateMigration,
 };
 
 const SLICE_MIGRATIONS: migrate.Migrations = {
-  "0.0.0": v1.sliceMigration,
-  "1.0.0": v2.sliceMigration,
-  "2.0.0": v3.sliceMigration,
+  [v0.VERSION]: v1.sliceMigration,
+  [v1.VERSION]: v2.sliceMigration,
+  [v2.VERSION]: v3.sliceMigration,
 };
 
 export const migrateState = migrate.migrator<AnyState, State>({

--- a/console/src/schematic/migrations/migrations.spec.ts
+++ b/console/src/schematic/migrations/migrations.spec.ts
@@ -25,7 +25,7 @@ describe("migrations", () => {
     STATES.forEach((state) => {
       it(`should migrate state from ${state.version} to latest`, () => {
         const migrated = migrateState(state);
-        expect(migrated).toEqual(ZERO_STATE);
+        expect({ ...migrated, key: expect.anything() }).toEqual(ZERO_STATE);
       });
     });
   });

--- a/console/src/schematic/migrations/v0.ts
+++ b/console/src/schematic/migrations/v0.ts
@@ -42,8 +42,14 @@ export const stateZ = z.object({
   snapshot: z.boolean(),
   remoteCreated: z.boolean(),
   viewport: Diagram.viewportZ,
-  nodes: z.array(Diagram.nodeZ),
-  edges: z.array(Diagram.edgeZ),
+  nodes: z
+    .array(z.any())
+    .transform((nodes) => nodes.filter((node) => Diagram.nodeZ.safeParse(node).success))
+    .pipe(z.array(Diagram.nodeZ)),
+  edges: z
+    .array(z.any())
+    .transform((edges) => edges.filter((edge) => Diagram.edgeZ.safeParse(edge).success))
+    .pipe(z.array(Diagram.edgeZ)),
   props: z.record(z.string(), nodePropsZ),
   control: control.statusZ,
   controlAcquireTrigger: z.number(),

--- a/console/src/schematic/migrations/v0.ts
+++ b/console/src/schematic/migrations/v0.ts
@@ -18,25 +18,23 @@ import {
 import { type migrate, xy } from "@synnaxlabs/x";
 import { z } from "zod";
 
+export const VERSION = "0.0.0";
+export type Version = typeof VERSION;
+
 export type NodeProps = object & {
   key: Schematic.Variant;
   color?: Color.Crude;
-  label?: {
-    label?: string;
-  };
+  label?: { label?: string };
 };
 
-export const nodePropsZ = z.object({}).and(
-  z
-    .object({
-      key: Schematic.variantZ,
-      color: Color.crudeZ.optional(),
-    })
-    .passthrough(),
-);
+export const nodePropsZ = z
+  .object({})
+  .and(
+    z.object({ key: Schematic.variantZ, color: Color.crudeZ.optional() }).passthrough(),
+  );
 
 export const stateZ = z.object({
-  version: z.literal("0.0.0"),
+  version: z.literal(VERSION),
   editable: z.boolean(),
   fitViewOnResize: z.boolean(),
   snapshot: z.boolean(),
@@ -55,7 +53,7 @@ export const stateZ = z.object({
   controlAcquireTrigger: z.number(),
 });
 
-export interface State extends migrate.Migratable<"0.0.0"> {
+export interface State extends migrate.Migratable<Version> {
   editable: boolean;
   fitViewOnResize: boolean;
   snapshot: boolean;
@@ -95,20 +93,18 @@ const TOOLBAR_TABS = ["symbols", "properties"] as const;
 export const toolbarTabZ = z.enum(TOOLBAR_TABS);
 export type ToolbarTab = z.infer<typeof toolbarTabZ>;
 
-export const toolbarStateZ = z.object({
-  activeTab: toolbarTabZ,
-});
+export const toolbarStateZ = z.object({ activeTab: toolbarTabZ });
 export type ToolbarState = z.infer<typeof toolbarStateZ>;
 
 export const sliceStateZ = z.object({
-  version: z.literal("0.0.0"),
+  version: z.literal(VERSION),
   mode: Viewport.modeZ,
   copy: copyBufferZ,
   toolbar: toolbarStateZ,
   schematics: z.record(z.string(), stateZ),
 });
 
-export interface SliceState extends migrate.Migratable<"0.0.0"> {
+export interface SliceState extends migrate.Migratable<Version> {
   mode: Viewport.Mode;
   copy: CopyBuffer;
   toolbar: ToolbarState;
@@ -116,7 +112,7 @@ export interface SliceState extends migrate.Migratable<"0.0.0"> {
 }
 
 export const ZERO_STATE: State = {
-  version: "0.0.0",
+  version: VERSION,
   snapshot: false,
   nodes: [],
   edges: [],
@@ -130,7 +126,7 @@ export const ZERO_STATE: State = {
 };
 
 export const ZERO_SLICE_STATE: SliceState = {
-  version: "0.0.0",
+  version: VERSION,
   mode: "select",
   copy: { ...ZERO_COPY_BUFFER },
   toolbar: { activeTab: "symbols" },

--- a/console/src/schematic/migrations/v1.ts
+++ b/console/src/schematic/migrations/v1.ts
@@ -13,57 +13,48 @@ import { z } from "zod";
 
 import * as v0 from "@/schematic/migrations/v0";
 
+export const VERSION = "1.0.0";
+export type Version = typeof VERSION;
+
 export const legendStateZ = z.object({
   visible: z.boolean(),
   position: Legend.stickyXYz,
 });
-
 export type LegendState = z.infer<typeof legendStateZ>;
 
 const ZERO_LEGEND_STATE: LegendState = {
   visible: false,
-  position: {
-    x: 50,
-    y: 50,
-    units: { x: "px", y: "px" },
-  },
+  position: { x: 50, y: 50, units: { x: "px", y: "px" } },
 };
 
 export const stateZ = v0.stateZ.omit({ version: true }).extend({
-  version: z.literal("1.0.0"),
+  version: z.literal(VERSION),
   legend: legendStateZ,
 });
 
 export interface State extends Omit<v0.State, "version"> {
-  version: "1.0.0";
+  version: Version;
   legend: LegendState;
 }
 
 export const ZERO_STATE: State = {
   ...v0.ZERO_STATE,
-  version: "1.0.0",
+  version: VERSION,
   legend: ZERO_LEGEND_STATE,
 };
 
 export const sliceStateZ = v0.sliceStateZ
   .omit({ version: true, schematics: true })
-  .extend({
-    version: z.literal("1.0.0"),
-    schematics: z.record(z.string(), stateZ),
-  });
+  .extend({ version: z.literal(VERSION), schematics: z.record(z.string(), stateZ) });
 
 export interface SliceState extends Omit<v0.SliceState, "version" | "schematics"> {
-  version: "1.0.0";
+  version: Version;
   schematics: Record<string, State>;
 }
 
 export const stateMigration = migrate.createMigration<v0.State, State>({
   name: "schematic.state",
-  migrate: (input) => ({
-    ...input,
-    legend: ZERO_LEGEND_STATE,
-    version: "1.0.0",
-  }),
+  migrate: (input) => ({ ...input, legend: ZERO_LEGEND_STATE, version: VERSION }),
 });
 
 export const sliceMigration = migrate.createMigration<v0.SliceState, SliceState>({
@@ -73,12 +64,12 @@ export const sliceMigration = migrate.createMigration<v0.SliceState, SliceState>
     schematics: Object.fromEntries(
       Object.entries(input.schematics).map(([k, v]) => [k, stateMigration(v)]),
     ),
-    version: "1.0.0",
+    version: VERSION,
   }),
 });
 
 export const ZERO_SLICE_STATE: SliceState = {
   ...v0.ZERO_SLICE_STATE,
-  version: "1.0.0",
+  version: VERSION,
   schematics: {},
 };

--- a/console/src/schematic/migrations/v2.ts
+++ b/console/src/schematic/migrations/v2.ts
@@ -8,35 +8,39 @@
 // Version 2.0, included in the file licenses/APL.txt.
 
 import { migrate } from "@synnaxlabs/x";
+import { v4 as uuid } from "uuid";
 import { z } from "zod";
 
 import * as v1 from "@/schematic/migrations/v1";
 
-const VERSION = "2.0.0";
-type Version = typeof VERSION;
+export const VERSION = "2.0.0";
+export type Version = typeof VERSION;
+
+const TYPE = "schematic";
+type Type = typeof TYPE;
 
 export const stateZ = v1.stateZ.omit({ version: true }).extend({
   version: z.literal(VERSION),
   key: z.string(),
-  type: z.literal("schematic"),
+  type: z.literal(TYPE),
 });
 
 export interface State extends Omit<v1.State, "version"> {
   version: Version;
   key: string;
-  type: "schematic";
+  type: Type;
 }
 
 export const ZERO_STATE: State = {
   ...v1.ZERO_STATE,
   version: VERSION,
   key: "",
-  type: "schematic",
+  type: TYPE,
 };
 
-export const sliceStateZ = v1.sliceStateZ.omit({ version: true }).extend({
-  version: z.literal(VERSION),
-});
+export const sliceStateZ = v1.sliceStateZ
+  .omit({ version: true })
+  .extend({ version: z.literal(VERSION) });
 
 export interface SliceState extends Omit<v1.SliceState, "version" | "schematics"> {
   schematics: Record<string, State>;
@@ -48,8 +52,8 @@ export const stateMigration = migrate.createMigration<v1.State, State>({
   migrate: (state) => ({
     ...state,
     version: VERSION,
-    key: "",
-    type: "schematic",
+    key: uuid(),
+    type: TYPE,
   }),
 });
 
@@ -60,10 +64,7 @@ export const sliceMigration = migrate.createMigration<v1.SliceState, SliceState>
     schematics: Object.fromEntries(
       Object.entries(sliceState.schematics).map(([key, state]) => [
         key,
-        {
-          ...stateMigration(state),
-          key,
-        },
+        { ...stateMigration(state), key },
       ]),
     ),
     version: VERSION,

--- a/console/src/schematic/migrations/v3.ts
+++ b/console/src/schematic/migrations/v3.ts
@@ -10,33 +10,28 @@
 import { migrate } from "@synnaxlabs/x";
 import { z } from "zod";
 
-import * as v2 from "@/schematic/migrations/v1";
+import * as v2 from "@/schematic/migrations/v2";
 
-const VERSION = "3.0.0";
-type Version = typeof VERSION;
+// This file is mostly pointless, as the state is exactly the same as the previous
+// version. But, customers have existing schematics and slices with the 'version' key
+// being 3.0.0, so we need to keep this file around for compatibility.
 
-export const stateZ = v2.stateZ.omit({ version: true }).extend({
-  version: z.literal(VERSION),
-  key: z.string(),
-  type: z.literal("schematic"),
-});
+export const VERSION = "3.0.0";
+export type Version = typeof VERSION;
+
+export const stateZ = v2.stateZ
+  .omit({ version: true })
+  .extend({ version: z.literal(VERSION) });
 
 export interface State extends Omit<v2.State, "version"> {
   version: Version;
-  key: string;
-  type: "schematic";
 }
 
-export const ZERO_STATE: State = {
-  ...v2.ZERO_STATE,
-  version: VERSION,
-  key: "",
-  type: "schematic",
-};
+export const ZERO_STATE: State = { ...v2.ZERO_STATE, version: VERSION };
 
-export const sliceStateZ = v2.sliceStateZ.omit({ version: true }).extend({
-  version: z.literal(VERSION),
-});
+export const sliceStateZ = v2.sliceStateZ
+  .omit({ version: true })
+  .extend({ version: z.literal(VERSION) });
 
 export interface SliceState extends Omit<v2.SliceState, "version" | "schematics"> {
   schematics: Record<string, State>;
@@ -47,13 +42,8 @@ export const stateMigration = migrate.createMigration<v2.State, State>({
   name: "schematic.state",
   migrate: (state) => ({
     ...state,
-    edges: state.edges.map((edge) => ({
-      ...edge,
-      segments: [],
-    })),
+    edges: state.edges.map((edge) => ({ ...edge, segments: [] })),
     version: VERSION,
-    key: "",
-    type: "schematic",
   }),
 });
 
@@ -64,10 +54,7 @@ export const sliceMigration = migrate.createMigration<v2.SliceState, SliceState>
     schematics: Object.fromEntries(
       Object.entries(sliceState.schematics).map(([key, state]) => [
         key,
-        {
-          ...stateMigration(state),
-          key,
-        },
+        { ...stateMigration(state) },
       ]),
     ),
     version: VERSION,


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1660](sy-1660-remove-bad-edges-and-nodes-when-importing-schematics

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Remove bad edges and nodes when parsing a schematic JSON file.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
