### PR TITLE
SY-1661: Sort Child Ranges in Range Overview by Start Time

### DIFF
--- a/client/ts/src/ranger/client.ts
+++ b/client/ts/src/ranger/client.ts
@@ -192,6 +192,14 @@ export class Range {
   }
 }
 
+export const sort = (a: Range, b: Range): -1 | 0 | 1 => {
+  if (a.timeRange.start.before(b.timeRange.start)) return -1;
+  if (a.timeRange.start.after(b.timeRange.start)) return 1;
+  if (a.timeRange.end.before(b.timeRange.end)) return -1;
+  if (a.timeRange.end.after(b.timeRange.end)) return 1;
+  return 0;
+};
+
 const retrieveReqZ = z.object({
   keys: keyZ.array().optional(),
   names: z.array(z.string()).optional(),

--- a/client/ts/src/ranger/client.ts
+++ b/client/ts/src/ranger/client.ts
@@ -8,7 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { sendRequired, type UnaryClient } from "@synnaxlabs/freighter";
-import { type CrudeTimeRange, observe, TimeRange } from "@synnaxlabs/x";
+import { type CrudeTimeRange, observe, sortTimeRange, TimeRange } from "@synnaxlabs/x";
 import { type AsyncTermSearcher } from "@synnaxlabs/x/search";
 import { type Series } from "@synnaxlabs/x/telem";
 import { toArray } from "@synnaxlabs/x/toArray";
@@ -192,13 +192,8 @@ export class Range {
   }
 }
 
-export const sort = (a: Range, b: Range): -1 | 0 | 1 => {
-  if (a.timeRange.start.before(b.timeRange.start)) return -1;
-  if (a.timeRange.start.after(b.timeRange.start)) return 1;
-  if (a.timeRange.end.before(b.timeRange.end)) return -1;
-  if (a.timeRange.end.after(b.timeRange.end)) return 1;
-  return 0;
-};
+export const sort = (a: Range, b: Range): -1 | 0 | 1 =>
+  sortTimeRange(a.timeRange, b.timeRange);
 
 const retrieveReqZ = z.object({
   keys: keyZ.array().optional(),

--- a/console/src/range/overview/ChildRanges.tsx
+++ b/console/src/range/overview/ChildRanges.tsx
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { type ranger } from "@synnaxlabs/client";
+import { ranger } from "@synnaxlabs/client";
 import { Icon } from "@synnaxlabs/media";
 import {
   Align,
@@ -69,6 +69,7 @@ export const ChildRanges: FC<ChildRangesProps> = ({ rangeKey }) => {
       if (client == null) return;
       const rng = await client.ranges.retrieve(rangeKey);
       const childRanges = await rng.retrieveChildren();
+      childRanges.sort(ranger.sort);
       setChildRanges(childRanges);
       const tracker = await rng.openChildRangeTracker();
       tracker.onChange((ranges) => setChildRanges(ranges));

--- a/console/src/range/overview/Snapshots.tsx
+++ b/console/src/range/overview/Snapshots.tsx
@@ -79,7 +79,7 @@ const SnapshotsListItem = (props: List.ItemProps<string, ontology.Resource>) => 
 
 const snapshotsListItem = componentRenderProp(SnapshotsListItem);
 
-const EmptyListContent = (
+const EMPTY_LIST_CONTENT = (
   <Text.Text level="p" weight={400} shade={6}>
     No Snapshots.
   </Text.Text>
@@ -116,7 +116,7 @@ export const Snapshots: FC<SnapshotsProps> = ({ rangeKey }) => {
       <Text.Text level="h4" shade={8} weight={500}>
         Snapshots
       </Text.Text>
-      <List.List data={snapshots} emptyContent={EmptyListContent}>
+      <List.List data={snapshots} emptyContent={EMPTY_LIST_CONTENT}>
         <List.Core empty>{snapshotsListItem}</List.Core>
       </List.List>
     </Align.Space>

--- a/console/src/range/overview/Snapshots.tsx
+++ b/console/src/range/overview/Snapshots.tsx
@@ -79,6 +79,12 @@ const SnapshotsListItem = (props: List.ItemProps<string, ontology.Resource>) => 
 
 const snapshotsListItem = componentRenderProp(SnapshotsListItem);
 
+const EmptyListContent = (
+  <Text.Text level="p" weight={400} shade={6}>
+    No Snapshots.
+  </Text.Text>
+);
+
 export interface SnapshotsProps {
   rangeKey: string;
 }
@@ -110,7 +116,7 @@ export const Snapshots: FC<SnapshotsProps> = ({ rangeKey }) => {
       <Text.Text level="h4" shade={8} weight={500}>
         Snapshots
       </Text.Text>
-      <List.List data={snapshots}>
+      <List.List data={snapshots} emptyContent={EmptyListContent}>
         <List.Core empty>{snapshotsListItem}</List.Core>
       </List.List>
     </Align.Space>

--- a/x/ts/src/telem/telem.ts
+++ b/x/ts/src/telem/telem.ts
@@ -1054,6 +1054,14 @@ export class TimeRange implements Stringer {
   ]);
 }
 
+export const sortTimeRange = (a: TimeRange, b: TimeRange): -1 | 0 | 1 => {
+  if (a.start.before(b.start)) return -1;
+  if (a.start.after(b.start)) return 1;
+  if (a.end.before(b.end)) return -1;
+  if (a.end.after(b.end)) return 1;
+  return 0;
+};
+
 /** DataType is a string that represents a data type. */
 export class DataType extends String implements Stringer {
   constructor(value: CrudeDataType) {


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1661](https://linear.app/synnax/issue/SY-1661/sort-child-ranges-in-range-overview-by-start-time)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Sort child ranges in the range overview by the start time of the range

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
