### PR TITLE
fix(console): Close Version Update Notification when Clicking Snooze

### DIFF
--- a/console/src/notifications/Notifications.tsx
+++ b/console/src/notifications/Notifications.tsx
@@ -29,6 +29,7 @@ export interface SugaredNotification extends Status.NotificationSpec {
 
 export type NotificationAdapter = (
   status: Status.NotificationSpec,
+  silence: (key: string) => void,
 ) => null | SugaredNotification;
 
 const DEFAULT_EXPIRATION = TimeSpan.seconds(7);
@@ -40,7 +41,7 @@ export const Notifications = ({ adapters }: NotificationsProps): ReactElement =>
   const sugared = statuses.map((status) => {
     if (adapters == null || adapters.length === 0) return status;
     for (const adapter of adapters) {
-      const result = adapter(status);
+      const result = adapter(status, silence);
       if (result != null) return result;
     }
     return status;


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1669](https://linear.app/synnax/issue/SY-1669/close-update-available-notification-when-you-click-snooze)

## Description

Fixed an issue where the version update notification remained open even after hitting the snooze action.


## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
