### PR TITLE
[docs/site] - updated console download url to use DMG on MacOS

### DIFF
--- a/docs/site/.astro/settings.json
+++ b/docs/site/.astro/settings.json
@@ -3,6 +3,6 @@
 		"enabled": false
 	},
 	"_variables": {
-		"lastUpdateCheck": 1732548532014
+		"lastUpdateCheck": 1734129716179
 	}
 }

--- a/docs/site/src/components/console/OSDownloadButton.tsx
+++ b/docs/site/src/components/console/OSDownloadButton.tsx
@@ -84,7 +84,7 @@ export const SynnaxConsoleDownloadButton = (): ReactElement | null => {
       entries={[
         {
           os: "MacOS",
-          href: updateFile.platforms[OSToUpdateFilePlatform.MacOS].url,
+          href: `https://github.com/synnaxlabs/synnax/releases/download/console-${updateFile.version}/Synnax_${updateFile.version.slice(1)}_aarch64.dmg`,
         },
         {
           os: "Windows",


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1673](https://linear.app/synnax/issue/SY-1673/docs-switch-to-using-dmg-over-app-file-on-download)

## Description

Downloading a DMG is a nicer UX than downloading a `.app` file as it prompts you to drag it into the `applications` folder, making sure auto-update works correctly.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
