### PR TITLE
Sy 1674 add more attachment points to schematic symbols

### DIFF
--- a/console/src/schematic/toolbar/Symbols.css
+++ b/console/src/schematic/toolbar/Symbols.css
@@ -23,11 +23,13 @@
     cursor: pointer;
     border-radius: var(--pluto-border-radius);
     min-width: 80px;
-    max-height: 110px;
+    max-width: 150px;
+    max-height: 130px;
     margin: 1rem 0.5rem;
 
     & > small {
         color: var(--pluto-gray-l7) !important;
+        text-align: center;
     }
 
     & .preview-wrapper {

--- a/console/src/schematic/toolbar/Symbols.tsx
+++ b/console/src/schematic/toolbar/Symbols.tsx
@@ -103,6 +103,7 @@ const SymbolsButton = ({
       className={CSS.BE("schematic-symbols", "button")}
       justify="spaceBetween"
       align="center"
+      size={0.5}
       draggable
       {...props}
       {...dragProps}
@@ -110,7 +111,7 @@ const SymbolsButton = ({
     >
       <Text.Text level="small">{name}</Text.Text>
       <Align.Space className="preview-wrapper" align="center" justify="center">
-        <Preview {...defaultProps(theme)} scale={0.8} />
+        <Preview {...defaultProps(theme)} scale={0.75} />
       </Align.Space>
     </Align.Space>
   );

--- a/pluto/src/vis/schematic/Forms.tsx
+++ b/pluto/src/vis/schematic/Forms.tsx
@@ -152,7 +152,18 @@ const ColorControl: Form.FieldT<Color.Crude> = (props): ReactElement => (
 
 const ScaleControl: Form.FieldT<number> = (props): ReactElement => (
   <Form.Field hideIfNull label="Scale" align="start" padHelpText={false} {...props}>
-    {(p) => <Input.Numeric dragScale={1} bounds={{ lower: 0.5, upper: 15 }} {...p} />}
+    {({ value, onChange }) => (
+      <Input.Numeric
+        dragScale={{
+          x: 0.75,
+          y: 0.5,
+        }}
+        bounds={{ lower: 50, upper: 1000 }}
+        endContent="%"
+        value={Math.round(value * 100)}
+        onChange={(v) => onChange(parseFloat((v / 100).toFixed(2)))}
+      />
+    )}
   </Form.Field>
 );
 

--- a/pluto/src/vis/schematic/Forms.tsx
+++ b/pluto/src/vis/schematic/Forms.tsx
@@ -767,7 +767,7 @@ export const OffPageReferenceForm = (): ReactElement => (
 
 export const CylinderForm = (): ReactElement => (
   <FormWrapper direction="x" align="stretch">
-    <Align.Space direction="y" grow empty>
+    <Align.Space direction="y" grow>
       <LabelControls path="label" />
       <Align.Space direction="x">
         <ColorControl path="color" />

--- a/pluto/src/vis/schematic/Symbols.tsx
+++ b/pluto/src/vis/schematic/Symbols.tsx
@@ -699,7 +699,7 @@ export const Cylinder = createLabeled<
     borderRadius,
   }): ReactElement => (
     <Primitives.Cylinder
-      onResize={(dims) => onChange({ dimensions: dims })}
+      onResize={(dimensions) => onChange({ dimensions })}
       orientation={orientation}
       color={color}
       dimensions={dimensions}

--- a/pluto/src/vis/schematic/primitives/Primitives.tsx
+++ b/pluto/src/vis/schematic/primitives/Primitives.tsx
@@ -799,7 +799,7 @@ export const ISOCap = ({
   className,
   orientation = "left",
   color,
-  scale,
+  scale = 1,
   ...props
 }: ISOCapProps): ReactElement => (
   <Div className={CSS(CSS.B("cap"), className)} {...props}>
@@ -810,7 +810,7 @@ export const ISOCap = ({
       color={color}
       dimensions={{ width: 36, height: 48 }}
       orientation={orientation}
-      scale={scale}
+      scale={scale * 0.6}
     >
       <Path
         d="M3 3H30C31.6569 3 33 4.34315 33 6V42C33 43.6569 31.6569 45 30 45H3"

--- a/pluto/src/vis/schematic/primitives/Primitives.tsx
+++ b/pluto/src/vis/schematic/primitives/Primitives.tsx
@@ -2390,8 +2390,19 @@ export const Cylinder = ({
         />
       </svg>
       <HandleBoundary refreshDeps={refreshDeps} orientation="left">
+        {/* Top  */}
         <Handle location="top" orientation="left" left={50} top={2} id="1" />
+        <Handle location="left" orientation="left" left={35} top={10} id="9" />
+        <Handle location="right" orientation="left" left={65} top={10} id="10" />
+        {/* Bottom */}
         <Handle location="bottom" orientation="left" left={50} top={98.3333} id="2" />
+        {/* Main body */}
+        <Handle location="left" orientation="left" left={4} top={40} id="3" />
+        <Handle location="right" orientation="left" left={96} top={40} id="4" />
+        <Handle location="left" orientation="left" left={4} top={60} id="5" />
+        <Handle location="right" orientation="left" left={96} top={60} id="6" />
+        <Handle location="left" orientation="left" left={4} top={80} id="7" />
+        <Handle location="right" orientation="left" left={96} top={80} id="8" />
       </HandleBoundary>
     </Div>
   );


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1674](https://linear.app/synnax/issue/SY-1674/add-more-attachment-points-to-schematic-symbols)

## Description

Adds more attachment points to the schematic cylinder as requested by a customer.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
