### PR TITLE
fix(console): remove unneeded label direction in off page reference form

### DIFF
--- a/pluto/src/vis/schematic/Forms.tsx
+++ b/pluto/src/vis/schematic/Forms.tsx
@@ -758,7 +758,7 @@ export const TextBoxForm = (): ReactElement => {
 export const OffPageReferenceForm = (): ReactElement => (
   <FormWrapper direction="x" align="stretch">
     <Align.Space direction="y" grow>
-      <LabelControls path="label" omit={["maxInlineSize", "align"]} />
+      <LabelControls path="label" omit={["maxInlineSize", "align", "direction"]} />
       <ColorControl path="color" />
     </Align.Space>
     <OrientationControl path="" showOuter={false} />


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1639](https://linear.app/synnax/issue/SY-1639/remove-label-direction-from-off-page-reference-element)

## Description

Remove the Label Direction Selection from the Off Page Reference Schematic Form.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
