### PR TITLE
Sy 1676 connect opc ua server modal is messed up

### DIFF
--- a/pluto/src/select/Button.tsx
+++ b/pluto/src/select/Button.tsx
@@ -67,7 +67,7 @@ export const Button = <K extends Key = Key, E extends Keyed<K> = Keyed<K>>({
   className,
   size = "small",
   actions,
-  pack = false,
+  pack = true,
   ...props
 }: ButtonProps<K, E>): ReactElement => {
   const { onSelect } = useSelect<K, E>({
@@ -99,6 +99,7 @@ export const Button = <K extends Key = Key, E extends Keyed<K> = Keyed<K>>({
       size={size}
       {...props}
     >
+      {mapped}
       {actions}
     </Align.Pack>
   );


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1676](https://linear.app/synnax/issue/SY-1676/connect-opc-ua-server-modal-is-messed-up)

## Description

Fixes issues with the Select.Button not packing elements correctly. 

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
