### PR TITLE
SY-1697: Add Edit Configuration to Task Ontology Context Menu and Remove Snapshots from Task Toolbar

### DIFF
--- a/console/src/hardware/task/Toolbar.tsx
+++ b/console/src/hardware/task/Toolbar.tsx
@@ -124,7 +124,7 @@ const Content = (): ReactElement => {
   useAsyncEffect(async () => {
     if (client == null) return;
     const v = (await client.hardware.tasks.list({ includeState: true })).filter(
-      (t) => !t.internal,
+      (t) => !t.internal && !t.snapshot,
     );
     setTasks(v);
   }, [client]);
@@ -171,7 +171,9 @@ const Content = (): ReactElement => {
           const nextKeys = next.map((t) => t.key);
           return [
             ...next,
-            ...nextTasks.filter((u) => !u.internal && !nextKeys.includes(u.key)),
+            ...nextTasks.filter(
+              (u) => !u.internal && !u.snapshot && !nextKeys.includes(u.key),
+            ),
           ];
         });
       });

--- a/console/src/hardware/task/ontology.tsx
+++ b/console/src/hardware/task/ontology.tsx
@@ -204,10 +204,16 @@ const TreeContextMenu: Ontology.TreeContextMenu = (props) => {
     <PMenu.Menu level="small" iconSpacing="small" onChange={onSelect}>
       <Group.GroupMenuItem selection={selection} />
       {resources.every((r) => r.data?.snapshot === false) && (
-        <Range.SnapshotMenuItem key="snapshot" range={range} />
+        <>
+          <Range.SnapshotMenuItem key="snapshot" range={range} />
+          <PMenu.Divider />
+        </>
       )}
       {singleResource && (
         <>
+          <PMenu.Item itemKey="edit" startIcon={<Icon.Edit />}>
+            {`${resources[0].data?.snapshot ? "View" : "Edit"} Configuration`}
+          </PMenu.Item>
           <Menu.RenameItem />
           <Link.CopyMenuItem />
           <PMenu.Divider />


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1697](https://linear.app/synnax/issue/SY-1697/snapshots-should-not-appear-in-task-toolbar)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

- Added an edit configuration menu item to the task ontology context menu
- Removed snapshots from the task toolbar

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
