### PR TITLE
Sy 1681 fix range rename in toolbar

### DIFF
--- a/console/src/Console.tsx
+++ b/console/src/Console.tsx
@@ -20,7 +20,7 @@ import {
   type Triggers,
 } from "@synnaxlabs/pluto";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import React, { type ReactElement, useCallback, useEffect } from "react";
+import { type ReactElement, useCallback, useEffect } from "react";
 import { useDispatch } from "react-redux";
 
 import { Channel } from "@/channel";

--- a/pluto/src/text/Editable.css
+++ b/pluto/src/text/Editable.css
@@ -25,7 +25,8 @@
             right: -0.666rem;
             bottom: -1px;
             border-radius: var(--pluto-border-radius);
-            border: 1px solid var(--pluto-primary-z);
+            border: var(--pluto-border);
+            border-color: var(--pluto-primary-z);
         }
     }
 }

--- a/pluto/src/text/Editable.css
+++ b/pluto/src/text/Editable.css
@@ -13,15 +13,19 @@
     cursor: pointer;
     -webkit-user-select: text;
     user-select: text;
-    padding: 0.25rem 0;
+    position: relative;
 
     &:focus {
-        border: var(--pluto-border-width) solid var(--pluto-primary-z);
-        z-index: 2;
-        border-radius: var(--pluto-border-radius);
         outline: none;
-        display: inline-block;
-        cursor: text;
-        padding: 0.25rem 1rem;
+        &::after {
+            content: "";
+            position: absolute;
+            top: -1px;
+            left: -0.666rem;
+            right: -0.666rem;
+            bottom: -1px;
+            border-radius: var(--pluto-border-radius);
+            border: 1px solid var(--pluto-primary-z);
+        }
     }
 }

--- a/pluto/src/text/Editable.tsx
+++ b/pluto/src/text/Editable.tsx
@@ -20,7 +20,7 @@ import {
 } from "react";
 
 import { CSS } from "@/css";
-import { useSyncedRef } from "@/hooks";
+import { usePrevious, useSyncedRef } from "@/hooks";
 import { type Input } from "@/input";
 import { type state } from "@/state";
 import { type text } from "@/text/core";
@@ -127,7 +127,10 @@ export const Editable = <L extends text.Level = text.Level>({
   const handleDoubleClick = (
     e: React.MouseEvent<HTMLParagraphElement, MouseEvent>,
   ): void => {
-    if (allowDoubleClick) setEditable(true);
+    if (allowDoubleClick) {
+      setEditable(true);
+      triggerReflow(ref.current as HTMLElement);
+    }
     onDoubleClick?.(e);
   };
 
@@ -159,6 +162,7 @@ export const Editable = <L extends text.Level = text.Level>({
 
   useLayoutEffect(() => {
     if (ref.current == null || !editable) return;
+    triggerReflow(ref.current);
     const { current: el } = ref;
     el.focus();
     const range = document.createRange();

--- a/pluto/src/vis/schematic/Symbols.css
+++ b/pluto/src/vis/schematic/Symbols.css
@@ -23,7 +23,6 @@
     border-color: transparent;
     width: max-content;
     height: max-content;
-    overflow: hidden;
     position: absolute;
     --offset: 0.666rem;
     justify-content: center;


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1681](https://linear.app/synnax/issue/SY-1681/fix-range-rename-in-toolbar)

## Description

Fixes text artifacting when renaming a range on macos. 

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
