### PR TITLE
Sy 1704 import lineplotschematic command not available from palette

### DIFF
--- a/console/src/lineplot/services/palette.tsx
+++ b/console/src/lineplot/services/palette.tsx
@@ -11,6 +11,9 @@ import { Icon } from "@synnaxlabs/media";
 
 import { create } from "@/lineplot/LinePlot";
 import { type Command } from "@/palette/Palette";
+import { importPlot } from "@/lineplot/file";
+import { Workspace } from "@/workspace";
+import { ImportIcon } from "@/lineplot/services/Icon";
 
 export const createLinePlotCommand: Command = {
   key: "create-line-plot",
@@ -19,4 +22,21 @@ export const createLinePlotCommand: Command = {
   onSelect: ({ placeLayout }) => placeLayout(create({})),
 };
 
-export const COMMANDS = [createLinePlotCommand];
+export const importLinePlotCommand: Command = {
+  key: "import-line-plot",
+  name: "Import Line Plot",
+  icon: <ImportIcon />,
+  onSelect: ({ placeLayout, ...props }) => {
+    const { store } = props;
+    const state = store.getState();
+    const activeWorkspaceKey = Workspace.selectActiveKey(state);
+    importPlot({
+      activeWorkspaceKey,
+      placer: placeLayout,
+      dispatch: store.dispatch,
+      ...props,
+    });
+  },
+};
+
+export const COMMANDS = [createLinePlotCommand, importLinePlotCommand];

--- a/console/src/schematic/services/palette.tsx
+++ b/console/src/schematic/services/palette.tsx
@@ -12,6 +12,9 @@ import { Icon } from "@synnaxlabs/media";
 import { type Command } from "@/palette/Palette";
 import { create } from "@/schematic/Schematic";
 import { selectHasPermission } from "@/schematic/selectors";
+import { importSchematic } from "@/schematic/file";
+import { Workspace } from "@/workspace";
+import { ImportIcon } from "@/schematic/services/Icon";
 
 export const createCommand: Command = {
   key: "create-schematic",
@@ -21,4 +24,21 @@ export const createCommand: Command = {
   visible: (state) => selectHasPermission(state),
 };
 
-export const COMMANDS = [createCommand];
+export const importSchematicCommand: Command = {
+  key: "import-schematic",
+  name: "Import Schematic",
+  icon: <ImportIcon />,
+  onSelect: ({ placeLayout, ...props }) => {
+    const { store } = props;
+    const state = store.getState();
+    const activeWorkspaceKey = Workspace.selectActiveKey(state);
+    importSchematic({
+      activeWorkspaceKey,
+      placer: placeLayout,
+      dispatch: store.dispatch,
+      ...props,
+    });
+  },
+};
+
+export const COMMANDS = [createCommand, importSchematicCommand];


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1704]()https://linear.app/synnax/issue/SY-1704/import-lineplotschematic-command-not-available-from-palette)

## Description

Import line plot and schematic now available from command line. 

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
