### PR TITLE
Sy 1698 fix cmd channel only will not display on plot until written

### DIFF
--- a/pluto/src/vis/lineplot/aether/YAxis.ts
+++ b/pluto/src/vis/lineplot/aether/YAxis.ts
@@ -43,7 +43,9 @@ export class YAxis extends CoreAxis<typeof coreAxisStateZ, Children> {
 
   async xBounds(): Promise<bounds.Bounds> {
     return bounds.max(
-      await Promise.all(this.lines.map(async (el) => await el.xBounds())),
+      (await Promise.all(this.lines.map(async (el) => await el.xBounds()))).filter(
+        (b) => bounds.isFinite(b),
+      ),
     );
   }
 


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1698](https://linear.app/synnax/issue/SY-1698/fix-cmd-channel-only-will-not-display-on-plot-until-written-to)

## Description

Fixes an issue where a channel with no data will override the bounds of all other channels in a plot, leading the plot to show the default range as opposed to the viable range of the channels that do have data. 

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
