### PR TITLE
Sy 1684 cannot drag groups

### DIFF
--- a/client/ts/src/index.ts
+++ b/client/ts/src/index.ts
@@ -32,6 +32,7 @@ export { rack } from "@/hardware/rack";
 export { task } from "@/hardware/task";
 export { label } from "@/label";
 export { ontology } from "@/ontology";
+export { group } from "@/ontology/group";
 export { ranger } from "@/ranger";
 export { signals } from "@/signals";
 export { user } from "@/user";

--- a/client/ts/src/ontology/group/payload.ts
+++ b/client/ts/src/ontology/group/payload.ts
@@ -9,6 +9,7 @@
 
 import { toArray } from "@synnaxlabs/x/toArray";
 import { z } from "zod";
+import { ontology } from "@/ontology";
 
 export const keyZ = z.string().uuid();
 export type Key = z.infer<typeof keyZ>;
@@ -17,10 +18,7 @@ export type Keys = Key[];
 export type Names = Name[];
 export type Params = Key | Name | Keys | Names;
 
-export const groupZ = z.object({
-  key: keyZ,
-  name: z.string(),
-});
+export const groupZ = z.object({ key: keyZ, name: z.string() });
 
 export type Payload = z.infer<typeof groupZ>;
 
@@ -52,9 +50,7 @@ export type ParamAnalysisResult =
 
 export const analyzeParams = (groups: Params): ParamAnalysisResult => {
   const normal = toArray(groups) as Keys | Names;
-  if (normal.length === 0) 
-    throw new Error("No groups specified");
-  
+  if (normal.length === 0) throw new Error("No groups specified");
   const isKey = keyZ.safeParse(normal[0]).success;
   return {
     single: !Array.isArray(groups),
@@ -63,3 +59,8 @@ export const analyzeParams = (groups: Params): ParamAnalysisResult => {
     actual: groups,
   } as const as ParamAnalysisResult;
 };
+
+export const ONTOLOGY_TYPE: ontology.ResourceType = "group";
+
+export const ontologyID = (key: Key): ontology.ID =>
+  new ontology.ID({ type: ONTOLOGY_TYPE, key });

--- a/console/src/group/ontology.tsx
+++ b/console/src/group/ontology.tsx
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { NotFoundError, ontology } from "@synnaxlabs/client";
+import { NotFoundError, ontology, group } from "@synnaxlabs/client";
 import { Icon } from "@synnaxlabs/media";
 import { Menu as PMenu } from "@synnaxlabs/pluto";
 import { Tree } from "@synnaxlabs/pluto/tree";
@@ -313,7 +313,7 @@ export const ONTOLOGY_SERVICE: Ontology.Service = {
   canDrop: () => true,
   onSelect: () => {},
   // This haul item allows the group to be dragged between nodes in the tree.
-  haulItems: ({ key }) => [{ type: "group", key }],
+  haulItems: ({ key }) => [group.ontologyID(key)],
   allowRename: () => true,
   onMosaicDrop: () => {},
   TreeContextMenu,

--- a/console/src/group/ontology.tsx
+++ b/console/src/group/ontology.tsx
@@ -312,7 +312,8 @@ export const ONTOLOGY_SERVICE: Ontology.Service = {
   onRename: handleRename,
   canDrop: () => true,
   onSelect: () => {},
-  haulItems: () => [],
+  // This haul item allows the group to be dragged between nodes in the tree.
+  haulItems: ({ key }) => [{ type: "group", key }],
   allowRename: () => true,
   onMosaicDrop: () => {},
   TreeContextMenu,


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1684](https://linear.app/synnax/issue/SY-1684/cannot-drag-groups)

## Description

Fixes an issue where groups cannot be dragged. 

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
