### PR TITLE
Disable Editing Channel Lists in Task Snapshot

### DIFF
--- a/client/py/examples/opcua/read_task.py
+++ b/client/py/examples/opcua/read_task.py
@@ -19,7 +19,7 @@ This example demonstrates how to start and configure a Read Task on an OPC UA se
 client = sy.Synnax()
 
 # Retrieve the OPC UA server from Synnax.
-dev = client.hardware.devices.retrieve(name="My OPC Server")
+dev = client.hardware.devices.retrieve(name="New OPC Server")
 
 # Create an index channel that will be used to store the timestamps for the data.
 opcua_time = client.channels.create(

--- a/console/src/hardware/labjack/task/Read.tsx
+++ b/console/src/hardware/labjack/task/Read.tsx
@@ -68,6 +68,7 @@ import {
   ChannelListHeader,
   Controls,
   EnableDisableButton,
+  ParentRangeButton,
   TareButton,
   useCreate,
   useObserveState,
@@ -215,10 +216,11 @@ const Wrapped = ({
       <Align.Space>
         <Form.Form {...methods} mode={task?.snapshot ? "preview" : "normal"}>
           <Align.Space direction="x" justify="spaceBetween">
-            <Form.Field<string> path="name">
+            <Form.Field<string> path="name" padHelpText={!task?.snapshot}>
               {(p) => <Input.Text variant="natural" level="h1" {...p} />}
             </Form.Field>
           </Align.Space>
+          <ParentRangeButton taskKey={task?.key} />
           <Align.Space direction="x" className={CSS.B("task-properties")}>
             <SelectDevice />
             <Align.Space direction="x">
@@ -368,7 +370,7 @@ const ChannelList = ({
   const menuProps = Menu.useContextMenu();
   return (
     <Align.Space className={CSS.B("channels")} grow empty>
-      <ChannelListHeader onAdd={handleAdd} />
+      <ChannelListHeader onAdd={handleAdd} snapshot={snapshot} />
       <Menu.ContextMenu
         menu={({ keys }: Menu.ContextMenuMenuProps) => (
           <ChannelListContextMenu
@@ -377,6 +379,7 @@ const ChannelList = ({
             value={value}
             remove={remove}
             onSelect={onSelect}
+            snapshot={snapshot}
             allowTare={
               value.some((v) => v.type === "AI") && state?.details?.running === true
             }
@@ -391,7 +394,9 @@ const ChannelList = ({
       >
         <List.List<string, ReadChan>
           data={value}
-          emptyContent={<ChannelListEmptyContent onAdd={handleAdd} />}
+          emptyContent={
+            <ChannelListEmptyContent onAdd={handleAdd} snapshot={snapshot} />
+          }
         >
           <List.Selector<string, ReadChan>
             value={selected}

--- a/console/src/hardware/labjack/task/Write.tsx
+++ b/console/src/hardware/labjack/task/Write.tsx
@@ -56,6 +56,7 @@ import {
   ChannelListHeader,
   Controls,
   EnableDisableButton,
+  ParentRangeButton,
   useCreate,
   useObserveState,
   type WrappedTaskLayoutProps,
@@ -251,10 +252,11 @@ const Wrapped = ({
         <Form.Form {...methods} mode={task?.snapshot ? "preview" : "normal"}>
           <Align.Space direction="y" empty>
             <Align.Space direction="x" justify="spaceBetween">
-              <Form.Field<string> path="name">
+              <Form.Field<string> path="name" padHelpText={!task?.snapshot}>
                 {(p) => <Input.Text variant="natural" level="h2" {...p} />}
               </Form.Field>
             </Align.Space>
+            <ParentRangeButton taskKey={task?.key} />
             <Align.Space direction="x" className={CSS.B("task-properties")}>
               <SelectDevice />
               <Align.Space direction="x">
@@ -316,9 +318,11 @@ const MainContent = ({ snapshot }: MainContentProps): ReactElement => {
     return (
       <Align.Space grow align="center" justify="center" direction="y">
         <Text.Text level="p">{`${device.name} is not configured.`}</Text.Text>
-        <Text.Link level="p" onClick={handleConfigure}>
-          {`Configure ${device.name}.`}
-        </Text.Link>
+        {snapshot !== true && (
+          <Text.Link level="p" onClick={handleConfigure}>
+            {`Configure ${device.name}.`}
+          </Text.Link>
+        )}
       </Align.Space>
     );
   return <ChannelList path="config.channels" snapshot={snapshot} device={device} />;
@@ -360,13 +364,16 @@ const ChannelList = ({ path, snapshot, device }: ChannelListProps): ReactElement
               value={value}
               remove={remove}
               onSelect={(keys) => setSelected(keys)}
+              snapshot={snapshot}
             />
           )}
           {...menuProps}
         >
           <List.List<string, WriteChan>
             data={value}
-            emptyContent={<ChannelListEmptyContent onAdd={handleAdd} />}
+            emptyContent={
+              <ChannelListEmptyContent onAdd={handleAdd} snapshot={snapshot} />
+            }
           >
             <List.Selector<string, WriteChan>
               value={selected}

--- a/console/src/hardware/ni/task/AnalogRead.tsx
+++ b/console/src/hardware/ni/task/AnalogRead.tsx
@@ -444,7 +444,7 @@ const ChannelList = ({
           <List.Selector<string, Chan>
             value={selected}
             allowNone={false}
-            allowMultiple={true}
+            allowMultiple
             onChange={(keys, { clickedIndex }) =>
               clickedIndex != null && onSelect(keys, clickedIndex)
             }

--- a/console/src/hardware/ni/task/DigitalRead.tsx
+++ b/console/src/hardware/ni/task/DigitalRead.tsx
@@ -50,6 +50,7 @@ import {
   ChannelListHeader,
   Controls,
   EnableDisableButton,
+  ParentRangeButton,
   useCreate,
   useObserveState,
   type WrappedTaskLayoutProps,
@@ -212,7 +213,7 @@ const Wrapped = ({
       <Align.Space>
         <Form.Form {...methods} mode={task?.snapshot ? "preview" : "normal"}>
           <Align.Space direction="x" justify="spaceBetween">
-            <Form.Field<string> path="name">
+            <Form.Field<string> path="name" padHelpText={!task?.snapshot}>
               {(p) => <Input.Text variant="natural" level="h1" {...p} />}
             </Form.Field>
             <CopyButtons
@@ -222,6 +223,7 @@ const Wrapped = ({
               getConfig={() => methods.get("config").value}
             />
           </Align.Space>
+          <ParentRangeButton taskKey={task?.key} />
           <Align.Space direction="x" className={CSS.B("task-properties")}>
             <SelectDevice />
             <Align.Space direction="x">
@@ -329,7 +331,7 @@ const ChannelList = ({
   const menuProps = Menu.useContextMenu();
   return (
     <Align.Space className={CSS.B("channels")} grow empty>
-      <ChannelListHeader onAdd={handleAdd} />
+      <ChannelListHeader onAdd={handleAdd} snapshot={snapshot} />
       <Menu.ContextMenu
         menu={({ keys }: Menu.ContextMenuMenuProps) => (
           <ChannelListContextMenu
@@ -337,6 +339,7 @@ const ChannelList = ({
             keys={keys}
             value={value}
             remove={remove}
+            snapshot={snapshot}
             onSelect={onSelect}
             onDuplicate={(indices) => {
               const newChannels = indices.map((i) => ({
@@ -351,7 +354,9 @@ const ChannelList = ({
       >
         <List.List<string, Chan>
           data={value}
-          emptyContent={<ChannelListEmptyContent onAdd={handleAdd} />}
+          emptyContent={
+            <ChannelListEmptyContent onAdd={handleAdd} snapshot={snapshot} />
+          }
         >
           <List.Selector<string, Chan>
             value={selected}
@@ -363,8 +368,8 @@ const ChannelList = ({
             replaceOnSingle
           >
             <List.Core<string, Chan> grow>
-              {(props) => (
-                <ChannelListItem {...props} snapshot={snapshot} path={path} />
+              {({ key, ...props }) => (
+                <ChannelListItem key={key} {...props} snapshot={snapshot} path={path} />
               )}
             </List.Core>
           </List.Selector>

--- a/console/src/hardware/ni/task/DigitalWrite.tsx
+++ b/console/src/hardware/ni/task/DigitalWrite.tsx
@@ -41,6 +41,7 @@ import {
   ChannelListHeader,
   Controls,
   EnableDisableButton,
+  ParentRangeButton,
   useCreate,
   useObserveState,
   type WrappedTaskLayoutProps,
@@ -245,7 +246,7 @@ const Wrapped = ({
       <Align.Space grow>
         <Form.Form {...methods} mode={task?.snapshot ? "preview" : "normal"}>
           <Align.Space direction="x" justify="spaceBetween">
-            <Form.Field<string> path="name">
+            <Form.Field<string> path="name" padHelpText={!task?.snapshot}>
               {(p) => <Input.Text variant="natural" level="h1" {...p} />}
             </Form.Field>
             <CopyButtons
@@ -255,6 +256,7 @@ const Wrapped = ({
               getConfig={() => methods.get<DigitalWriteConfig>("config").value}
             />
           </Align.Space>
+          <ParentRangeButton taskKey={task?.key} />
           <Align.Space direction="x" className={CSS.B("task-properties")}>
             <SelectDevice />
             <Align.Space direction="x">
@@ -359,7 +361,7 @@ const ChannelList = ({
   const menuProps = Menu.useContextMenu();
   return (
     <Align.Space className={CSS.B("channels")} grow empty>
-      <ChannelListHeader onAdd={handleAdd} />
+      <ChannelListHeader onAdd={handleAdd} snapshot={snapshot} />
       <Menu.ContextMenu
         menu={({ keys }): ReactElement => (
           <ChannelListContextMenu
@@ -368,6 +370,7 @@ const ChannelList = ({
             value={value}
             remove={remove}
             onSelect={onSelect}
+            snapshot={snapshot}
             onDuplicate={(indices): void => {
               push(
                 indices.map((i) => ({
@@ -384,7 +387,9 @@ const ChannelList = ({
       >
         <List.List<string, Chan>
           data={value}
-          emptyContent={<ChannelListEmptyContent onAdd={handleAdd} />}
+          emptyContent={
+            <ChannelListEmptyContent onAdd={handleAdd} snapshot={snapshot} />
+          }
         >
           <List.Selector<string, Chan>
             value={selected}
@@ -396,8 +401,8 @@ const ChannelList = ({
             replaceOnSingle
           >
             <List.Core<string, Chan> grow>
-              {(props) => (
-                <ChannelListItem {...props} path={path} snapshot={snapshot} />
+              {({ key, ...props }) => (
+                <ChannelListItem key={key} {...props} path={path} snapshot={snapshot} />
               )}
             </List.Core>
           </List.Selector>

--- a/console/src/hardware/ni/task/common.tsx
+++ b/console/src/hardware/ni/task/common.tsx
@@ -7,6 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+import { task } from "@synnaxlabs/client";
 import { Icon } from "@synnaxlabs/media";
 import { Align, Button, Device, Form, Synnax, Text } from "@synnaxlabs/pluto";
 import { binary } from "@synnaxlabs/x";
@@ -93,11 +94,7 @@ export const CopyButtons = (props: UseCopyRetrievalCodeProps) => {
     <Align.Space direction="x" size="small">
       {taskKey != null && (
         <Button.Icon
-          tooltip={() => (
-            <Text.Text level="small">
-              Copy Python code to retrieve {getName()}
-            </Text.Text>
-          )}
+          tooltip={() => <Text.Text level="small">Copy Python Code</Text.Text>}
           tooltipLocation="left"
           variant="text"
           onClick={copyPython}
@@ -106,9 +103,7 @@ export const CopyButtons = (props: UseCopyRetrievalCodeProps) => {
         </Button.Icon>
       )}
       <Button.Icon
-        tooltip={() => (
-          <Text.Text level="small">Copy JSON configuration for {getName()}</Text.Text>
-        )}
+        tooltip={() => <Text.Text level="small">Copy JSON Configuration</Text.Text>}
         tooltipLocation="left"
         variant="text"
         onClick={copyJSON}
@@ -117,13 +112,13 @@ export const CopyButtons = (props: UseCopyRetrievalCodeProps) => {
       </Button.Icon>
       {taskKey != null && (
         <Button.Icon
-          tooltip={() => <Text.Text level="small">Copy link to {getName()}</Text.Text>}
+          tooltip={() => <Text.Text level="small">Copy Link</Text.Text>}
           tooltipLocation="left"
           variant="text"
           onClick={() =>
             handleCopyToClipBoard({
               name: getName(),
-              ontologyID: { type: "task", key: taskKey },
+              ontologyID: task.ontologyID(taskKey),
             })
           }
         >

--- a/console/src/hardware/opc/device/Configure.tsx
+++ b/console/src/hardware/opc/device/Configure.tsx
@@ -80,7 +80,7 @@ export const Configure: Layout.Renderer = ({ onClose, layoutKey }): ReactElement
     queryFn: async () => {
       if (client == null || layoutKey === CONFIGURE_LAYOUT_TYPE)
         return [
-          { name: "My OPC Server", connection: { ...ZERO_CONNECTION_CONFIG } },
+          { name: "New OPC Server", connection: { ...ZERO_CONNECTION_CONFIG } },
           undefined,
         ];
       const dev = await client.hardware.devices.retrieve<Properties>(layoutKey);

--- a/console/src/hardware/opc/task/Read.tsx
+++ b/console/src/hardware/opc/task/Read.tsx
@@ -52,6 +52,7 @@ import {
   ChannelListContextMenu,
   Controls,
   EnableDisableButton,
+  ParentRangeButton,
   useCreate,
   useObserveState,
   type WrappedTaskLayoutProps,
@@ -286,18 +287,14 @@ const Wrapped = ({
       empty
     >
       <Align.Space direction="y" grow>
-        <Form.Form {...methods}>
+        <Form.Form {...methods} mode={task?.snapshot ? "preview" : "normal"}>
           <Align.Space direction="x" justify="spaceBetween">
-            <Form.Field<string> path="name" label="Name">
+            <Form.Field<string> path="name" label="Name" padHelpText={!task?.snapshot}>
               {(p) => <Input.Text variant="natural" level="h1" {...p} />}
             </Form.Field>
             {key != null && (
               <Button.Icon
-                tooltip={
-                  <Text.Text level="small">
-                    {name == null ? "Copy link" : `Copy link to ${name}`}
-                  </Text.Text>
-                }
+                tooltip={<Text.Text level="small">Copy Link</Text.Text>}
                 tooltipLocation="left"
                 variant="text"
                 onClick={() => handleLink({ name, ontologyID: { key, type: "task" } })}
@@ -306,6 +303,7 @@ const Wrapped = ({
               </Button.Icon>
             )}
           </Align.Space>
+          <ParentRangeButton taskKey={task?.key} />
           <Align.Space direction="x" className={CSS.B("task-properties")}>
             <Form.Field<string>
               path="config.device"
@@ -358,8 +356,12 @@ const Wrapped = ({
             grow
             style={{ overflow: "hidden", height: "500px" }}
           >
-            <Browser device={dev} />
-            <ChannelList path="config.channels" device={dev} />
+            {task?.snapshot !== true && <Browser device={dev} />}
+            <ChannelList
+              path="config.channels"
+              device={dev}
+              snapshot={task?.snapshot}
+            />
           </Align.Space>
         </Form.Form>
         <Controls
@@ -373,6 +375,7 @@ const Wrapped = ({
           configuring={configure.isPending}
           onStartStop={start.mutate}
           onConfigure={configure.mutate}
+          snapshot={task?.snapshot}
         />
       </Align.Space>
     </Align.Space>
@@ -382,9 +385,10 @@ const Wrapped = ({
 interface ChannelListProps {
   path: string;
   device?: device.Device<Device.Properties>;
+  snapshot?: boolean;
 }
 
-const ChannelList = ({ path, device }: ChannelListProps): ReactElement => {
+const ChannelList = ({ path, device, snapshot }: ChannelListProps): ReactElement => {
   const { value, push, remove } = Form.useFieldArray<ReadChannelConfig>({ path });
   const valueRef = useSyncedRef(value);
 
@@ -461,6 +465,7 @@ const ChannelList = ({ path, device }: ChannelListProps): ReactElement => {
               setSelectedChannels(k);
               setSelectedChannelIndex(i);
             }}
+            snapshot={snapshot}
           />
         )}
         {...menuProps}
@@ -505,6 +510,7 @@ const ChannelList = ({ path, device }: ChannelListProps): ReactElement => {
                     setSelectedChannels([]);
                     setSelectedChannelIndex(null);
                   }}
+                  snapshot={snapshot}
                 />
               )}
             </List.Core>
@@ -512,23 +518,24 @@ const ChannelList = ({ path, device }: ChannelListProps): ReactElement => {
         </List.List>
       </Menu.ContextMenu>
       {value.length > 0 && (
-        <ChannelForm
-          selectedChannelIndex={selectedChannelIndex}
-          deviceProperties={device?.properties}
-        />
+        <ChannelForm selectedChannelIndex={selectedChannelIndex} snapshot={snapshot} />
       )}
     </Align.Space>
   );
 };
 
+interface ChannelListItemProps extends List.ItemProps<string, ReadChannelConfig> {
+  path: string;
+  remove?: () => void;
+  snapshot?: boolean;
+}
+
 export const ChannelListItem = ({
   path,
   remove,
+  snapshot,
   ...props
-}: List.ItemProps<string, ReadChannelConfig> & {
-  path: string;
-  remove?: () => void;
-}): ReactElement => {
+}: ChannelListItemProps): ReactElement => {
   const { entry } = props;
   const ctx = Form.useContext();
   const childValues = Form.useChildFieldValues<ReadChannelConfig>({
@@ -579,6 +586,7 @@ export const ChannelListItem = ({
         <EnableDisableButton
           value={childValues.enabled}
           onChange={(v) => ctx.set(`${path}.${props.index}.enabled`, v)}
+          snapshot={snapshot}
         />
       </Align.Space>
     </List.ItemFrame>
@@ -587,11 +595,15 @@ export const ChannelListItem = ({
 
 interface ChannelFormProps {
   selectedChannelIndex?: number | null;
-  deviceProperties?: Device.Properties;
+  snapshot?: boolean;
 }
 
-const ChannelForm = ({ selectedChannelIndex }: ChannelFormProps): ReactElement => {
-  if (selectedChannelIndex == null || selectedChannelIndex == -1)
+const ChannelForm = ({
+  selectedChannelIndex,
+  snapshot,
+}: ChannelFormProps): ReactElement | null => {
+  if (selectedChannelIndex == null || selectedChannelIndex == -1) {
+    if (snapshot === true) return null;
     return (
       <Align.Center className={CSS.B("channel-form")}>
         <Text.Text level="p" shade={6}>
@@ -599,14 +611,17 @@ const ChannelForm = ({ selectedChannelIndex }: ChannelFormProps): ReactElement =
         </Text.Text>
       </Align.Center>
     );
+  }
   const prefix = `config.channels.${selectedChannelIndex}`;
   return (
     <Align.Space direction="x" grow className={CSS.B("channel-form")} empty>
-      <Form.TextField
+      <Form.Field<string>
         path={`${prefix}.name`}
+        padHelpText={!snapshot}
         label="Channel Name"
-        inputProps={{ variant: "natural", level: "h3" }}
-      />
+      >
+        {(p) => <Input.Text variant="natural" level="h3" {...p} />}
+      </Form.Field>
       <Form.SwitchField
         path={`${prefix}.useAsIndex`}
         label="Use as Index"

--- a/console/src/hardware/opc/task/Write.tsx
+++ b/console/src/hardware/opc/task/Write.tsx
@@ -52,6 +52,7 @@ import {
   ChannelListContextMenu,
   Controls,
   EnableDisableButton,
+  ParentRangeButton,
   useCreate,
   useObserveState,
   type WrappedTaskLayoutProps,
@@ -230,6 +231,8 @@ const Wrapped = ({
   const key = task?.key;
   const handleLink = Link.useCopyToClipboard();
 
+  console.log("opc", task);
+
   return (
     <Align.Space
       className={CSS(CSS.B("task-configure"), CSS.B("opcua"))}
@@ -238,26 +241,23 @@ const Wrapped = ({
       empty
     >
       <Align.Space direction="y" grow>
-        <Form.Form {...methods}>
+        <Form.Form {...methods} mode={task?.snapshot ? "preview" : "normal"}>
           <Align.Space direction="x" justify="spaceBetween">
-            <Form.Field<string> path="name" label="Name">
+            <Form.Field<string> path="name" label="Name" padHelpText={!task?.snapshot}>
               {(p) => <Input.Text variant="natural" level="h1" {...p} />}
             </Form.Field>
             {key != null && (
               <Button.Icon
-                tooltip={
-                  <Text.Text level="small">
-                    {name == null ? "Copy link" : `Copy link to ${name}`}
-                  </Text.Text>
-                }
+                tooltip={<Text.Text level="small">Copy Link</Text.Text>}
                 tooltipLocation="left"
                 variant="text"
                 onClick={() => handleLink({ name, ontologyID: { key, type: "task" } })}
               >
                 <Icon.Link />
               </Button.Icon>
-            )}{" "}
+            )}
           </Align.Space>
+          <ParentRangeButton taskKey={task?.key} />
           <Align.Space direction="x" className={CSS.B("task-properties")}>
             <Form.Field<string>
               path="config.device"
@@ -300,8 +300,12 @@ const Wrapped = ({
             grow
             style={{ overflow: "hidden", height: "500px" }}
           >
-            <Browser device={device} />
-            <WriterChannelList path="config.channels" device={device} />
+            {task?.snapshot !== true && <Browser device={device} />}
+            <ChannelList
+              path="config.channels"
+              device={device}
+              snapshot={task?.snapshot}
+            />
           </Align.Space>
         </Form.Form>
         <Controls
@@ -315,18 +319,20 @@ const Wrapped = ({
           configuring={configure.isPending}
           onStartStop={start.mutate}
           onConfigure={configure.mutate}
+          snapshot={task?.snapshot}
         />
       </Align.Space>
     </Align.Space>
   );
 };
 
-interface WriterChannelListProps {
+interface ChannelListProps {
   path: string;
   device?: device.Device<Device.Properties>;
+  snapshot?: boolean;
 }
 
-const WriterChannelList = ({ path, device }: WriterChannelListProps): ReactElement => {
+const ChannelList = ({ path, device, snapshot }: ChannelListProps): ReactElement => {
   const { value, push, remove } = Form.useFieldArray<WriteChannelConfig>({ path });
   const valueRef = useSyncedRef(value);
 
@@ -400,6 +406,7 @@ const WriterChannelList = ({ path, device }: WriterChannelListProps): ReactEleme
               setSelectedChannels(k);
               setSelectedChannelIndex(i);
             }}
+            snapshot={snapshot}
           />
         )}
         {...menuProps}
@@ -432,7 +439,7 @@ const WriterChannelList = ({ path, device }: WriterChannelListProps): ReactEleme
           >
             <List.Core<string, WriteChannelConfig> grow>
               {({ key, ...props }) => (
-                <WriterChannelListItem
+                <ChannelListItem
                   key={key}
                   {...props}
                   path={path}
@@ -444,6 +451,7 @@ const WriterChannelList = ({ path, device }: WriterChannelListProps): ReactEleme
                     setSelectedChannels([]);
                     setSelectedChannelIndex(null);
                   }}
+                  snapshot={snapshot}
                 />
               )}
             </List.Core>
@@ -451,23 +459,24 @@ const WriterChannelList = ({ path, device }: WriterChannelListProps): ReactEleme
         </List.List>
       </Menu.ContextMenu>
       {value.length > 0 && (
-        <ChannelForm
-          selectedChannelIndex={selectedChannelIndex}
-          deviceProperties={device?.properties}
-        />
+        <ChannelForm selectedChannelIndex={selectedChannelIndex} snapshot={snapshot} />
       )}
     </Align.Space>
   );
 };
 
-const WriterChannelListItem = ({
-  path,
-  remove,
-  ...props
-}: List.ItemProps<string, WriteChannelConfig> & {
+interface ChannelListItemProps extends List.ItemProps<string, WriteChannelConfig> {
   path: string;
   remove?: () => void;
-}): ReactElement => {
+  snapshot?: boolean;
+}
+
+const ChannelListItem = ({
+  path,
+  remove,
+  snapshot,
+  ...props
+}: ChannelListItemProps): ReactElement => {
   const { entry } = props;
   const ctx = Form.useContext();
   const childValues = Form.useChildFieldValues<WriteChannelConfig>({
@@ -513,6 +522,7 @@ const WriterChannelListItem = ({
         <EnableDisableButton
           value={childValues.enabled}
           onChange={(v) => ctx.set(`${path}.${props.index}.enabled`, v)}
+          snapshot={snapshot}
         />
       </Align.Space>
     </List.ItemFrame>
@@ -521,11 +531,15 @@ const WriterChannelListItem = ({
 
 interface ChannelFormProps {
   selectedChannelIndex?: number | null;
-  deviceProperties?: Device.Properties;
+  snapshot?: boolean;
 }
 
-const ChannelForm = ({ selectedChannelIndex }: ChannelFormProps): ReactElement => {
-  if (selectedChannelIndex == null || selectedChannelIndex == -1)
+const ChannelForm = ({
+  selectedChannelIndex,
+  snapshot,
+}: ChannelFormProps): ReactElement | null => {
+  if (selectedChannelIndex == null || selectedChannelIndex == -1) {
+    if (snapshot === true) return null;
     return (
       <Align.Center className={CSS.B("channel-form")}>
         <Text.Text level="p" shade={6}>
@@ -533,14 +547,17 @@ const ChannelForm = ({ selectedChannelIndex }: ChannelFormProps): ReactElement =
         </Text.Text>
       </Align.Center>
     );
+  }
   const prefix = `config.channels.${selectedChannelIndex}`;
   return (
     <Align.Space direction="y" grow className={CSS.B("channel-form")} empty>
-      <Form.TextField
+      <Form.Field<string>
         path={`${prefix}.name`}
+        padHelpText={!snapshot}
         label="Channel Name"
-        inputProps={{ variant: "natural", level: "h3" }}
-      />
+      >
+        {(p) => <Input.Text variant="natural" level="h3" {...p} />}
+      </Form.Field>
     </Align.Space>
   );
 };

--- a/console/src/hardware/task/ontology.tsx
+++ b/console/src/hardware/task/ontology.tsx
@@ -200,12 +200,11 @@ const TreeContextMenu: Ontology.TreeContextMenu = (props) => {
     group: () => group(props),
   };
   const singleResource = resources.length === 1;
+  const hasNoSnapshots = resources.every((r) => r.data?.snapshot === false);
   return (
     <PMenu.Menu level="small" iconSpacing="small" onChange={onSelect}>
       <Group.GroupMenuItem selection={selection} />
-      {resources.every((r) => r.data?.snapshot === false) && (
-        <Range.SnapshotMenuItem key="snapshot" range={range} />
-      )}
+      {hasNoSnapshots && <Range.SnapshotMenuItem key="snapshot" range={range} />}
       {singleResource && (
         <>
           <Menu.RenameItem />

--- a/pluto/src/input/Input.css
+++ b/pluto/src/input/Input.css
@@ -196,12 +196,6 @@
         border-color: transparent !important;
     }
 
-    &:not(:hover) {
-        & > *:not(.pluto-input__internal) {
-            opacity: 0;
-        }
-    }
-
     & .pluto-input__internal {
         border: none !important;
         background: none !important;

--- a/pluto/src/select/Button.tsx
+++ b/pluto/src/select/Button.tsx
@@ -53,6 +53,7 @@ export type ButtonProps<K extends Key = Key, E extends Keyed<K> = Keyed<K>> = Om
     size?: ComponentSize;
     actions?: Align.PackProps["children"];
     pack?: boolean;
+    variant?: Input.Variant;
   };
 
 export const Button = <K extends Key = Key, E extends Keyed<K> = Keyed<K>>({
@@ -68,6 +69,7 @@ export const Button = <K extends Key = Key, E extends Keyed<K> = Keyed<K>>({
   size = "small",
   actions,
   pack = true,
+  variant,
   ...props
 }: ButtonProps<K, E>): ReactElement => {
   const { onSelect } = useSelect<K, E>({
@@ -79,10 +81,15 @@ export const Button = <K extends Key = Key, E extends Keyed<K> = Keyed<K>>({
     onChange,
   } as const as UseSelectProps<K, E>);
 
+  const handleClick = (key: E["key"]) => {
+    if (variant === "preview") return;
+    onSelect(key);
+  };
+
   const mapped = data?.map((e) =>
     children({
       key: e.key,
-      onClick: () => onSelect(e.key),
+      onClick: () => handleClick(e.key),
       size,
       selected: e.key === value,
       entry: e,


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1690](https://linear.app/synnax/issue/SY-1690/disable-editing-channel-lists-in-task-snapshot)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Made sure all task snapshots were disabled from editing

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
