### PR TITLE
[pluto] - fixed creating groups with no name in ontology failing

### DIFF
--- a/console/src/ontology/Tree.tsx
+++ b/console/src/ontology/Tree.tsx
@@ -547,6 +547,7 @@ export const Tree = (): ReactElement => {
         onDoubleClick={handleDoubleClick}
         showRules
         loading={loading}
+        virtual={false}
         {...treeProps}
       >
         {item}

--- a/pluto/src/text/Editable.tsx
+++ b/pluto/src/text/Editable.tsx
@@ -58,12 +58,15 @@ export const edit = (
     }
     d.setAttribute("contenteditable", "true");
     if (onChange == null) return;
-    d.addEventListener(RENAMED_EVENT_NAME, (e) =>
-      onChange(getInnerText(e.target as HTMLElement), true),
-    );
-    d.addEventListener(ESCAPED_EVENT_NAME, (e) =>
-      onChange(getInnerText(e.target as HTMLElement), false),
-    );
+    d.addEventListener(RENAMED_EVENT_NAME, (e) => {
+      console.log("ABC");
+      onChange(getInnerText(e.target as HTMLElement), true);
+    });
+    d.addEventListener(ESCAPED_EVENT_NAME, (e) => {
+      console.log("CDE");
+
+      onChange(getInnerText(e.target as HTMLElement), false);
+    });
   };
   tryEdit();
 };
@@ -133,7 +136,11 @@ export const Editable = <L extends text.Level = text.Level>({
 
   const handleUpdate = (el: HTMLElement, forceEscape = false): void => {
     const innerText = getInnerText(el);
-    if (optimisticValueRef.current === innerText) return;
+    if (
+      optimisticValueRef.current === innerText &&
+      (innerText.length > 0 || allowEmpty)
+    )
+      return;
     if (forceEscape || (innerText.length === 0 && !allowEmpty)) {
       el.innerText = value;
       el.dispatchEvent(new Event(ESCAPED_EVENT_NAME));

--- a/pluto/src/text/Editable.tsx
+++ b/pluto/src/text/Editable.tsx
@@ -58,15 +58,12 @@ export const edit = (
     }
     d.setAttribute("contenteditable", "true");
     if (onChange == null) return;
-    d.addEventListener(RENAMED_EVENT_NAME, (e) => {
-      console.log("ABC");
-      onChange(getInnerText(e.target as HTMLElement), true);
-    });
-    d.addEventListener(ESCAPED_EVENT_NAME, (e) => {
-      console.log("CDE");
-
-      onChange(getInnerText(e.target as HTMLElement), false);
-    });
+    d.addEventListener(RENAMED_EVENT_NAME, (e) =>
+      onChange(getInnerText(e.target as HTMLElement), true),
+    );
+    d.addEventListener(ESCAPED_EVENT_NAME, (e) =>
+      onChange(getInnerText(e.target as HTMLElement), false),
+    );
   };
   tryEdit();
 };


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1680](https://linear.app/synnax/issue/SY-1680/fix-grouping-on-multiple-channels)

## Description

Fixes issue where grouping elements and then leaving a blank name caused problems.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
