### PR TITLE
Sy 1679 persist commands to disk for write tasks

### DIFF
--- a/pluto/src/telem/control/aether/controller.ts
+++ b/pluto/src/telem/control/aether/controller.ts
@@ -145,6 +145,7 @@ export class Controller
         channels: needsControlOf,
         controlSubject: { key: this.key, name: this.state.name },
         authorities: this.state.authority,
+        enableAutoCommit: true,
       });
       this.setState((p) => ({ ...p, status: "acquired" }));
     } catch (e) {


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1679](https://linear.app/synnax/issue/SY-1679/persist-commands-to-disk-for-write-tasks)

## Description

Adds auto commit to the pluto controller, making schematic commands automatically persisted to disk.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
