### PR TITLE
[pluto] - made sure specs are always assigned a unique key

### DIFF
--- a/pluto/src/status/aether/aggregator.ts
+++ b/pluto/src/status/aether/aggregator.ts
@@ -32,7 +32,7 @@ export class Aggregator extends aether.Composite<typeof aggregatorStateZ> {
   add(spec: CrudeSpec): void {
     this.setState((p) => ({
       ...p,
-      statuses: [...p.statuses, { time: TimeStamp.now(), key: id.id(), ...spec }],
+      statuses: [...p.statuses, { time: TimeStamp.now(), ...spec, key: id.id() }],
     }));
   }
 }


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1675](https://linear.app/synnax/issue/SY-1707/fix-duplicate-keys-in-aether-status-aggregation)

## Description

Fixes duplicate keys in aether status aggregation causing the user to not be able to dismiss notifications. 

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
