### PR TITLE
[console] - made sure that windows get closed on an empty workspace

### DIFF
--- a/console/src/layout/middleware.ts
+++ b/console/src/layout/middleware.ts
@@ -138,7 +138,7 @@ const deleteLayoutsOnMosaicCloseEffect: MiddlewareEffect<
 
 export const MIDDLEWARE = [
   effectMiddleware(
-    [moveMosaicTab.type, remove.type, clearWorkspace.type],
+    [moveMosaicTab.type, remove.type, clearWorkspace.type, setWorkspace.type],
     [closeWindowOnEmptyMosaicEffect],
   ),
   effectMiddleware([place.type], [createWindowOnPlaceEffect]),


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1699](https://linear.app/synnax/issue/SY-1699/fix-blank-dangling-popped-out-windows-when-switching-workspaces)

## Description

Makes sure that windows get closed when switching workspaces.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
