### PR TITLE
[pluto] - fixed annotation positioning with dynamic grid items

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synnaxlabs/console",
   "private": true,
-  "version": "0.36.0",
+  "version": "0.36.1",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/console/src/Console.tsx
+++ b/console/src/Console.tsx
@@ -9,7 +9,7 @@
 
 import "@/index.css";
 import "@synnaxlabs/media/dist/media.css";
-import "@synnaxlabs/pluto/dist/pluto.css";
+// import "@synnaxlabs/pluto/dist/pluto.css";
 
 import { Provider } from "@synnaxlabs/drift/react";
 import {

--- a/console/src/Console.tsx
+++ b/console/src/Console.tsx
@@ -9,7 +9,7 @@
 
 import "@/index.css";
 import "@synnaxlabs/media/dist/media.css";
-// import "@synnaxlabs/pluto/dist/pluto.css";
+import "@synnaxlabs/pluto/dist/pluto.css";
 
 import { Provider } from "@synnaxlabs/drift/react";
 import {

--- a/pluto/package.json
+++ b/pluto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synnaxlabs/pluto",
-  "version": "0.36.0",
+  "version": "0.36.1",
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit && vite build",

--- a/pluto/src/channel/LinePlot.tsx
+++ b/pluto/src/channel/LinePlot.tsx
@@ -273,6 +273,7 @@ const XAxis = ({
           onPositionChange={(value) =>
             onRuleChange?.({ key: rule.key, position: value })
           }
+          onUnitsChange={(value) => onRuleChange?.({ key: rule.key, units: value })}
           onSelect={() => onSelectRule?.(rule.key)}
         />
       ))}
@@ -341,6 +342,7 @@ const YAxis = ({
           key={r.key}
           onLabelChange={(value) => onRuleChange?.({ key: r.key, label: value })}
           onPositionChange={(value) => onRuleChange?.({ key: r.key, position: value })}
+          onUnitsChange={(value) => onRuleChange?.({ key: r.key, units: value })}
           onClick={() => onSelectRule?.(r.key)}
         />
       ))}

--- a/pluto/src/header/Header.css
+++ b/pluto/src/header/Header.css
@@ -16,6 +16,12 @@
     .pluto-header__text,
     .pluto-breadcrumb {
         padding: 1rem;
+        overflow: hidden;
+        .pluto-text {
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
     }
     .pluto-header-button-title {
         flex-grow: 1;

--- a/pluto/src/vis/rule/Rule.css
+++ b/pluto/src/vis/rule/Rule.css
@@ -21,7 +21,7 @@
         width: 100%;
     }
 
-    & > .pluto-rule__label {
+    & > .pluto-rule__tag {
         width: fit-content;
         margin-top: -0.5rem;
         border-top: none;
@@ -38,11 +38,11 @@
             line-height: 1;
             font-weight: 500;
         }
-        & .pluto-text--editable {
+        & .pluto-label {
+            margin-left: 1rem;
             line-height: 1;
-            padding-top: 1rem;
-            padding-bottom: 0.75rem;
-            padding-left: 1rem;
+            margin-top: 1rem;
+            margin-bottom: 0.75rem;
         }
         z-index: 20;
     }

--- a/pluto/src/vis/rule/Rule.tsx
+++ b/pluto/src/vis/rule/Rule.tsx
@@ -32,6 +32,7 @@ export interface RuleProps
   label?: string;
   onLabelChange?: (label: string) => void;
   units?: string;
+  onUnitsChange?: (label: string) => void;
   onPositionChange?: (position: number) => void;
   onSelect?: () => void;
 }
@@ -44,6 +45,7 @@ export const Rule = Aether.wrap<RuleProps>(
     position: propsPosition,
     onLabelChange,
     onPositionChange,
+    onUnitsChange,
     units = "",
     color,
     lineWidth,
@@ -134,7 +136,7 @@ export const Rule = Aether.wrap<RuleProps>(
         <Align.Space
           direction="x"
           align="center"
-          className={CSS(className, CSS.BE("rule", "label"))}
+          className={CSS(className, CSS.BE("rule", "tag"))}
           bordered
           onClick={onSelect}
           size={1}
@@ -147,6 +149,7 @@ export const Rule = Aether.wrap<RuleProps>(
           {...props}
         >
           <Text.Editable
+            className={CSS.B("label")}
             level="small"
             value={internalLabel}
             onChange={setInternalLabel}
@@ -156,9 +159,24 @@ export const Rule = Aether.wrap<RuleProps>(
             direction="y"
             style={{ borderColor: Color.cssString(color) }}
           />
-          <Text.Text level="small" color={textColor}>
-            {`${propsPosition.toFixed(2)} ${units}`}
-          </Text.Text>
+          <Align.Space size="small" direction="x" align="center">
+            <Text.Editable
+              value={propsPosition.toFixed(2)}
+              onChange={(v) => {
+                const num = Number(v);
+                if (!isFinite(num)) return;
+                onPositionChange?.(num);
+              }}
+              level="small"
+              color={textColor}
+            />
+            <Text.MaybeEditable
+              level="small"
+              color={textColor}
+              value={units}
+              onChange={onUnitsChange}
+            />
+          </Align.Space>
         </Align.Space>
       </div>
     );


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1720](https://linear.app/synnax/issue/SY-1720/fix-annotation-grid-positioning)

## Description

Fixes an issue where enabling and disabling the title on the plot itself results in the annotation being incorrectly positioned.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
