### PR TITLE
Sy 1724 fix fgrpc race condition/deadlock

### DIFF
--- a/freighter/cpp/fgrpc/BUILD.bazel
+++ b/freighter/cpp/fgrpc/BUILD.bazel
@@ -10,7 +10,6 @@ cc_library(
     deps = [
         "//freighter/cpp:freighter",
         "@com_github_grpc_grpc//:grpc++",
-        "@com_github_google_glog//:glog",
     ],
 )
 

--- a/freighter/cpp/fgrpc/BUILD.bazel
+++ b/freighter/cpp/fgrpc/BUILD.bazel
@@ -10,6 +10,7 @@ cc_library(
     deps = [
         "//freighter/cpp:freighter",
         "@com_github_grpc_grpc//:grpc++",
+        "@com_github_google_glog//:glog",
     ],
 )
 

--- a/freighter/cpp/fgrpc/fgrpc.h
+++ b/freighter/cpp/fgrpc/fgrpc.h
@@ -201,12 +201,12 @@ public:
         for (const auto &[k, v]: grpc_ctx.GetServerInitialMetadata())
             res_ctx.set(k.data(), v.data());
     }
-
+    /// @brief Streamer send.
     freighter::Error send(RQ &request) const override {
         if (stream->Write(request)) return freighter::NIL;
         return freighter::STREAM_CLOSED;
     }
-
+    /// @brief Streamer receive.
     std::pair<RS, freighter::Error> receive() override {
         RS res;
         bool read_success;

--- a/freighter/cpp/fgrpc/fgrpc.h
+++ b/freighter/cpp/fgrpc/fgrpc.h
@@ -186,6 +186,7 @@ private:
 template<typename RQ, typename RS, typename RPC>
 class Stream final : public freighter::Stream<RQ, RS> {
 public:
+    /// @brief Ctor saves GRPCUnaryClient stream object to use under the hood.
     Stream(
         std::shared_ptr<grpc::Channel> ch,
         const freighter::MiddlewareCollector<std::nullptr_t, std::unique_ptr<
@@ -201,12 +202,13 @@ public:
         for (const auto &[k, v]: grpc_ctx.GetServerInitialMetadata())
             res_ctx.set(k.data(), v.data());
     }
+
     /// @brief Streamer send.
     freighter::Error send(RQ &request) const override {
         if (stream->Write(request)) return freighter::NIL;
         return freighter::STREAM_CLOSED;
     }
-    /// @brief Streamer receive.
+    /// @brief Streamer read.
     std::pair<RS, freighter::Error> receive() override {
         RS res;
         bool read_success;

--- a/freighter/cpp/fgrpc/fgrpc.h
+++ b/freighter/cpp/fgrpc/fgrpc.h
@@ -11,7 +11,6 @@
 
 #include <mutex>
 #include <thread>
-#include "glog/logging.h"
 
 #include "freighter/cpp/freighter.h"
 #include "grpc/grpc.h"

--- a/freighter/cpp/fgrpc/fgrpc.h
+++ b/freighter/cpp/fgrpc/fgrpc.h
@@ -241,7 +241,10 @@ public:
 
 private:
     freighter::MiddlewareCollector<std::nullptr_t, std::unique_ptr<freighter::Stream<RQ, RS>>> mw;
+
     std::unique_ptr<grpc::ClientReaderWriter<RQ, RS>> stream;
+    /// For god knows what reason, GRPC requries us to keep these around so
+    /// the stream doesn't die.
     grpc::ClientContext grpc_ctx{};
     std::unique_ptr<typename RPC::Stub> stub;
 

--- a/freighter/cpp/fgrpc/fgrpc.h
+++ b/freighter/cpp/fgrpc/fgrpc.h
@@ -228,7 +228,7 @@ public:
         writes_done_called.store(true);
     }
 
-    freighter::FinalizerReturn<std::unique_ptr<freighter::Stream<RQ, RS>>> operator()(
+    freighter::FinalizerReturn<std::unique_ptr<freighter::Stream<RQ, RS > > > operator()(
         freighter::Context outbound,
         std::nullptr_t &_
     ) {
@@ -240,9 +240,10 @@ public:
     }
 
 private:
-    freighter::MiddlewareCollector<std::nullptr_t, std::unique_ptr<freighter::Stream<RQ, RS>>> mw;
+    freighter::MiddlewareCollector<std::nullptr_t, std::unique_ptr<freighter::Stream<RQ,
+        RS> > > mw;
 
-    std::unique_ptr<grpc::ClientReaderWriter<RQ, RS>> stream;
+    std::unique_ptr<grpc::ClientReaderWriter<RQ, RS > > stream;
     /// For god knows what reason, GRPC requries us to keep these around so
     /// the stream doesn't die.
     grpc::ClientContext grpc_ctx{};

--- a/freighter/cpp/fgrpc/fgrpc.h
+++ b/freighter/cpp/fgrpc/fgrpc.h
@@ -208,6 +208,7 @@ public:
         if (stream->Write(request)) return freighter::NIL;
         return freighter::STREAM_CLOSED;
     }
+
     /// @brief Streamer read.
     std::pair<RS, freighter::Error> receive() override {
         RS res;
@@ -224,6 +225,7 @@ public:
         return {res, close_err};
     }
 
+    /// @brief Closing streamer.
     void closeSend() override {
         if (writes_done_called.load()) return;
         stream->WritesDone();

--- a/freighter/cpp/fgrpc/fgrpc.h
+++ b/freighter/cpp/fgrpc/fgrpc.h
@@ -206,7 +206,6 @@ public:
         if (closed.load() || writes_done_called.load())
             return freighter::STREAM_CLOSED;
 
-        std::lock_guard<std::mutex> lock(mutex);
         if (closed.load() || writes_done_called.load())
             return freighter::STREAM_CLOSED;
 
@@ -221,7 +220,6 @@ public:
         RS res;
         bool read_success;
         {
-            std::lock_guard<std::mutex> lock(mutex);
             if (closed.load()) return {RS(), close_err};
             read_success = stream->Read(&res);
         }
@@ -238,7 +236,6 @@ public:
     void closeSend() override {
         if (writes_done_called.load()) return;
         {
-            std::lock_guard<std::mutex> lock(mutex);
             if (writes_done_called.load()) return;
             stream->WritesDone();
             writes_done_called.store(true);
@@ -254,7 +251,6 @@ private:
     std::atomic<bool> closed{false};
     freighter::Error close_err = freighter::NIL;
     std::atomic<bool> writes_done_called{false};
-    mutable std::mutex mutex;
 };
 
 /// @brief An implementation of freighter::StreamClient that uses GRPC as the backing

--- a/freighter/cpp/fgrpc/fgrpc.h
+++ b/freighter/cpp/fgrpc/fgrpc.h
@@ -229,8 +229,8 @@ public:
     }
 
     freighter::FinalizerReturn<std::unique_ptr<freighter::Stream<RQ, RS>>> operator()(
-    freighter::Context outbound,
-    std::nullptr_t &_
+        freighter::Context outbound,
+        std::nullptr_t &_
     ) {
         if (closed.load()) return {outbound, close_err};
         const grpc::Status status = stream->Finish();

--- a/freighter/cpp/fgrpc/fgrpc.h
+++ b/freighter/cpp/fgrpc/fgrpc.h
@@ -188,7 +188,8 @@ class Stream final : public freighter::Stream<RQ, RS> {
 public:
     Stream(
         std::shared_ptr<grpc::Channel> ch,
-        const freighter::MiddlewareCollector<std::nullptr_t, std::unique_ptr<freighter::Stream<RQ, RS>>> &mw,
+        const freighter::MiddlewareCollector<std::nullptr_t, std::unique_ptr<
+            freighter::Stream<RQ, RS> > > &mw,
         freighter::Context &req_ctx,
         freighter::Context &res_ctx
     ) : mw(mw) {


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1724](https://linear.app/synnax/issue/1724)

## Description

Originally an issue was found when the driver crashed if you very quickly started and stopped an OPC read task. I don't think this is the correct solution, but the crashing issue was resolved by removing the double inheritance happening with the stream class.  This, however, required me to call the middleware chain in this class no longer, which can pose other issues. This then led to a deadlock issue which was resolved by atomically setting the writes_done_called and the closed variables. 

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
