### PR TITLE
SY-1178 Add Snapshot to Schematic Toolbar

### DIFF
--- a/console/src/link/Buttons.tsx
+++ b/console/src/link/Buttons.tsx
@@ -26,16 +26,11 @@ export const ToolbarCopyButton = ({
   const handleLink = Link.useCopyToClipboard();
   return (
     <Button.Icon
-      tooltip={`Copy link to ${name}`}
+      tooltip={"Copy link"}
       sharp
       size="medium"
       style={{ height: "100%", width: "var(--pluto-height-medium)" }}
-      onClick={() =>
-        handleLink({
-          name,
-          ontologyID,
-        })
-      }
+      onClick={() => handleLink({ name, ontologyID })}
       {...props}
     >
       <Icon.Link />

--- a/console/src/schematic/external.ts
+++ b/console/src/schematic/external.ts
@@ -17,6 +17,7 @@ export * from "@/schematic/Schematic";
 export * from "@/schematic/selectors";
 export * from "@/schematic/slice";
 export * from "@/schematic/toolbar";
+export * from "@/schematic/useRangeSnapshot";
 
 export const LAYOUTS: Record<string, Layout.Renderer> = {
   [LAYOUT_TYPE]: Schematic,

--- a/console/src/schematic/useRangeSnapshot.ts
+++ b/console/src/schematic/useRangeSnapshot.ts
@@ -1,0 +1,52 @@
+// Copyright 2024 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { ranger, schematic } from "@synnaxlabs/client";
+import { Status, Synnax } from "@synnaxlabs/pluto";
+import { strings, toArray } from "@synnaxlabs/x";
+import { useMutation } from "@tanstack/react-query";
+
+import { Range } from "@/range";
+
+interface SchematicNameAndKey extends Pick<schematic.Schematic, "key" | "name"> {}
+
+export const useRangeSnapshot = () => {
+  const addStatus = Status.useAggregator();
+  const rng = Range.useSelect();
+  const client = Synnax.use();
+  const mut = useMutation<void, Error, SchematicNameAndKey | SchematicNameAndKey[]>({
+    onError: (err, schematics) => {
+      const schematicNames = strings.naturalLanguageJoin(
+        toArray(schematics).map((s) => s.name),
+        "schematic",
+      );
+      addStatus({
+        variant: "error",
+        message: `Failed to snapshot ${schematicNames} to ${rng?.name ?? "active range"}`,
+        description: err.message,
+      });
+    },
+    mutationFn: async (schematics) => {
+      if (client == null) throw new Error("Server is not available");
+      if (rng == null) throw new Error("No active range selected");
+      const ids = await Promise.all(
+        toArray(schematics).map(async (s) => {
+          const newSchematic = await client.workspaces.schematic.copy(
+            s.key,
+            `${s.name} (Snapshot)`,
+            true,
+          );
+          return schematic.ontologyID(newSchematic.key);
+        }),
+      );
+      await client.ontology.addChildren(ranger.rangeOntologyID(rng.key), ...ids);
+    },
+  });
+  return mut.mutate;
+};

--- a/console/src/schematic/useRangeSnapshot.ts
+++ b/console/src/schematic/useRangeSnapshot.ts
@@ -20,7 +20,11 @@ export const useRangeSnapshot = () => {
   const addStatus = Status.useAggregator();
   const rng = Range.useSelect();
   const client = Synnax.use();
-  const mut = useMutation<void, Error, SchematicNameAndKey | SchematicNameAndKey[]>({
+  const { mutate: snapshot } = useMutation<
+    void,
+    Error,
+    SchematicNameAndKey | SchematicNameAndKey[]
+  >({
     onError: (err, schematics) => {
       const schematicNames = strings.naturalLanguageJoin(
         toArray(schematics).map((s) => s.name),
@@ -48,5 +52,5 @@ export const useRangeSnapshot = () => {
       await client.ontology.addChildren(ranger.rangeOntologyID(rng.key), ...ids);
     },
   });
-  return mut.mutate;
+  return snapshot;
 };

--- a/console/src/schematic/useRangeSnapshot.ts
+++ b/console/src/schematic/useRangeSnapshot.ts
@@ -23,19 +23,25 @@ export const useRangeSnapshot = () => {
   const { mutate: snapshot } = useMutation<
     void,
     Error,
-    SchematicNameAndKey | SchematicNameAndKey[]
+    SchematicNameAndKey | SchematicNameAndKey[],
+    string
   >({
-    onError: (err, schematics) => {
-      const schematicNames = strings.naturalLanguageJoin(
+    onMutate: (schematics) =>
+      `${strings.naturalLanguageJoin(
         toArray(schematics).map((s) => s.name),
         "schematic",
-      );
+      )} to ${rng?.name ?? "active range"}`,
+    onError: (err, context) =>
       addStatus({
         variant: "error",
-        message: `Failed to snapshot ${schematicNames} to ${rng?.name ?? "active range"}`,
+        message: `Failed to snapshot ${context}}`,
         description: err.message,
-      });
-    },
+      }),
+    onSuccess: (_, __, context) =>
+      addStatus({
+        variant: "success",
+        message: `Successfully snapshotted ${context}`,
+      }),
     mutationFn: async (schematics) => {
       if (client == null) throw new Error("Server is not available");
       if (rng == null) throw new Error("No active range selected");


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1178](https://linear.app/synnax/issue/SY-1178/add-snapshot-to-schematic-toolbar)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Moved logic for snapshotting a schematic to a range to a separate hook.
Added a range button to the schematic toolbar header that let's the user snapshot the schematic to the

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
