### PR TITLE
SY-1470 Block Variable Length Persisted Channel in Console Channel Creation

### DIFF
--- a/console/src/channel/Create.tsx
+++ b/console/src/channel/Create.tsx
@@ -58,24 +58,29 @@ const schema = channel.newPayload
   .refine((v) => v.isIndex || v.index !== 0 || v.virtual, {
     message: "Data channel must have an index",
     path: ["index"],
+  })
+  .refine((v) => v.virtual || !new DataType(v.dataType).isVariable, {
+    message: "Persisted channels must have a fixed-size data type",
+    path: ["dataType"],
   });
+
+type Schema = typeof schema;
+
+const ZERO_CHANNEL: z.infer<Schema> = {
+  key: 0,
+  name: "",
+  index: 0,
+  dataType: DataType.FLOAT32.toString(),
+  internal: false,
+  isIndex: false,
+  leaseholder: 0,
+  rate: Rate.hz(0),
+  virtual: false,
+};
 
 export const CreateModal: Layout.Renderer = ({ onClose }): ReactElement => {
   const client = Synnax.use();
-  const methods = Form.use<typeof schema>({
-    schema,
-    values: {
-      key: 0,
-      name: "",
-      index: 0,
-      dataType: "float32",
-      internal: false,
-      isIndex: false,
-      leaseholder: 0,
-      rate: Rate.hz(0),
-      virtual: false,
-    },
-  });
+  const methods = Form.use<Schema>({ schema, values: { ...ZERO_CHANNEL } });
   const [createMore, setCreateMore] = useState(false);
 
   const { mutate, isPending } = useMutation({
@@ -85,27 +90,16 @@ export const CreateModal: Layout.Renderer = ({ onClose }): ReactElement => {
       d.dataType = d.dataType.toString();
       await client.channels.create(methods.value());
       if (!createMore) onClose();
-      else
-        methods.reset({
-          key: 0,
-          name: "",
-          index: 0,
-          dataType: "float32",
-          isIndex: false,
-          leaseholder: 0,
-          virtual: false,
-          rate: Rate.hz(0),
-          internal: false,
-        });
+      else methods.reset({ ...ZERO_CHANNEL });
     },
   });
 
-  const isIndex = Form.useFieldValue<boolean, boolean, typeof schema>(
+  const isIndex = Form.useFieldValue<boolean, boolean, Schema>(
     "isIndex",
     false,
     methods,
   );
-  const isVirtual = Form.useFieldValue<boolean, boolean, typeof schema>(
+  const isVirtual = Form.useFieldValue<boolean, boolean, Schema>(
     "virtual",
     false,
     methods,
@@ -132,7 +126,12 @@ export const CreateModal: Layout.Renderer = ({ onClose }): ReactElement => {
               label="Virtual"
               inputProps={{ disabled: isIndex }}
               onChange={(v, ctx) => {
-                if (!v) return;
+                if (!v) {
+                  const dType = ctx.get<string>("dataType").value;
+                  if (new DataType(dType).isVariable)
+                    ctx.set("dataType", DataType.FLOAT32.toString());
+                  return;
+                }
                 ctx.set("isIndex", false);
                 ctx.set("index", 0);
               }}
@@ -154,6 +153,7 @@ export const CreateModal: Layout.Renderer = ({ onClose }): ReactElement => {
                   disabled={isIndex}
                   maxHeight="small"
                   zIndex={100}
+                  hideVariableDensity={!isVirtual}
                 />
               )}
             </Form.Field>

--- a/pluto/src/select/DataType.tsx
+++ b/pluto/src/select/DataType.tsx
@@ -27,20 +27,27 @@ const DATA: ListEntry[] = TelemDataType.ALL.filter(
   name: ALLCAPS.has(d) ? d.toString().toUpperCase() : caseconv.capitalize(d.toString()),
 }));
 
+const FIXED_DENSITY_DATA = DATA.filter((d) => !new TelemDataType(d.key).isVariable);
+
 const COLUMNS: Array<List.ColumnSpec<string, ListEntry>> = [
-  {
-    key: "name",
-    name: "Name",
-  },
+  { key: "name", name: "Name" },
 ];
 
 export interface DataTypeProps
-  extends Omit<DropdownButtonProps<string, ListEntry>, "data" | "columns"> {}
+  extends Omit<
+    DropdownButtonProps<string, ListEntry>,
+    "data" | "columns" | "entryRenderKey"
+  > {
+  hideVariableDensity?: boolean;
+}
 
-export const DataType = (props: DataTypeProps): ReactElement => (
+export const DataType = ({
+  hideVariableDensity = false,
+  ...props
+}: DataTypeProps): ReactElement => (
   <DropdownButton<string, ListEntry>
     {...props}
-    data={DATA}
+    data={hideVariableDensity ? FIXED_DENSITY_DATA : DATA}
     columns={COLUMNS}
     entryRenderKey="name"
   />


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1470](https://linear.app/synnax/issue/SY-1470/block-variable-length-channel-in-console-channel-creation)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Block the creation of persisted, variable-length channels (JSONs, strings) in the Console create channel modal.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
