### PR TITLE
SY-1509 Add Demo Cluster to Default Clusters and Fix Issues with Copying Local Cluster Link

### DIFF
--- a/console/src/Console.tsx
+++ b/console/src/Console.tsx
@@ -137,7 +137,7 @@ const MainUnderContext = (): ReactElement => {
           activeRange: activeRange?.persisted ? activeRange.key : undefined,
         }}
         workerEnabled
-        connParams={cluster == null ? undefined : { ...cluster }}
+        connParams={cluster ?? undefined}
         workerURL={WorkerURL}
         triggers={TRIGGERS_PROVIDER_PROPS}
         haul={{ useState: useHaulState }}

--- a/console/src/Console.tsx
+++ b/console/src/Console.tsx
@@ -137,7 +137,7 @@ const MainUnderContext = (): ReactElement => {
           activeRange: activeRange?.persisted ? activeRange.key : undefined,
         }}
         workerEnabled
-        connParams={cluster?.props}
+        connParams={cluster == null ? undefined : { ...cluster }}
         workerURL={WorkerURL}
         triggers={TRIGGERS_PROVIDER_PROPS}
         haul={{ useState: useHaulState }}

--- a/console/src/cluster/Connect.tsx
+++ b/console/src/cluster/Connect.tsx
@@ -9,11 +9,10 @@
 
 import "@/cluster/Connect.css";
 
-import { type connection, type SynnaxProps, synnaxPropsZ } from "@synnaxlabs/client";
+import { type connection } from "@synnaxlabs/client";
 import {
   Align,
   Button,
-  componentRenderProp,
   Form,
   Input,
   Nav,
@@ -24,21 +23,23 @@ import {
 import { caseconv } from "@synnaxlabs/x";
 import { type ReactElement, useState } from "react";
 import { useDispatch } from "react-redux";
-import { z } from "zod";
+import { type z } from "zod";
 
 import { statusVariants } from "@/cluster/Badges";
-import { useSelectMany } from "@/cluster/selectors";
-import { set, setActive } from "@/cluster/slice";
+import { useSelectAllNames } from "@/cluster/selectors";
+import { clusterZ, set, setActive } from "@/cluster/slice";
 import { testConnection } from "@/cluster/testConnection";
 import { CSS } from "@/css";
 import { Layout } from "@/layout";
 
 const SAVE_TRIGGER: Triggers.Trigger = ["Control", "Enter"];
 
+export const LAYOUT_TYPE = "connectCluster";
+
 export const connectWindowLayout: Layout.State = {
-  key: "connectCluster",
-  windowKey: "connectCluster",
-  type: "connectCluster",
+  key: LAYOUT_TYPE,
+  windowKey: LAYOUT_TYPE,
+  type: LAYOUT_TYPE,
   name: "Cluster.Connect",
   icon: "Cluster",
   location: "modal",
@@ -49,6 +50,15 @@ export const connectWindowLayout: Layout.State = {
   },
 };
 
+const ZERO_VALUES: z.infer<typeof clusterZ> = {
+  name: "",
+  host: "",
+  port: "",
+  username: "",
+  password: "",
+  secure: false,
+};
+
 /**
  * Connect implements the LayoutRenderer component type to provide a form for connecting
  * to a cluster.
@@ -57,27 +67,15 @@ export const Connect = ({ onClose }: Layout.RendererProps): ReactElement => {
   const dispatch = useDispatch();
   const [connState, setConnState] = useState<connection.State | null>(null);
   const [loading, setLoading] = useState<"test" | "submit" | null>(null);
-  const names = useSelectMany().map((c) => c.name);
-
-  const formSchema = synnaxPropsZ.omit({ connectivityPollFrequency: true }).extend({
-    name: z
-      .string()
-      .min(1, { message: "Name is required" })
-      .refine((n) => !names.includes(n), {
-        message: "A cluster with this name already exists",
-      }),
-  });
+  const names = useSelectAllNames();
+  const formSchema = clusterZ.refine(
+    ({ name }) => !names.includes(name),
+    ({ name }) => ({ message: `${name} is already in use.`, path: ["name"] }),
+  );
 
   const methods = Form.use<typeof formSchema>({
     schema: formSchema,
-    values: {
-      name: "",
-      host: "",
-      port: "",
-      username: "",
-      password: "",
-      secure: false,
-    },
+    values: { ...ZERO_VALUES },
   });
 
   const handleSubmit = (): void => {
@@ -89,13 +87,7 @@ export const Connect = ({ onClose }: Layout.RendererProps): ReactElement => {
       const state = await testConnection(data);
       setLoading(null);
       if (state.status !== "connected") return setConnState(state);
-      dispatch(
-        set({
-          key: state.clusterKey,
-          name: data.name,
-          props: data as SynnaxProps,
-        }),
-      );
+      dispatch(set({ ...data, key: state.clusterKey }));
       dispatch(setActive(state.clusterKey));
       onClose();
     })();
@@ -106,7 +98,7 @@ export const Connect = ({ onClose }: Layout.RendererProps): ReactElement => {
       if (!methods.validate()) return;
       setConnState(null);
       setLoading("test");
-      const state = await testConnection(methods.value() as SynnaxProps);
+      const state = await testConnection(methods.value());
       setConnState(state);
       setLoading(null);
     })();
@@ -141,7 +133,7 @@ export const Connect = ({ onClose }: Layout.RendererProps): ReactElement => {
               {(p) => <Input.Text {...p} placeholder="seldon" type="password" />}
             </Form.Field>
             <Form.Field<boolean> path="secure">
-              {componentRenderProp(Input.Switch)}
+              {(p) => <Input.Switch {...p} />}
             </Form.Field>
           </Align.Space>
         </Align.Space>

--- a/console/src/cluster/Connect.tsx
+++ b/console/src/cluster/Connect.tsx
@@ -132,9 +132,7 @@ export const Connect = ({ onClose }: Layout.RendererProps): ReactElement => {
             <Form.Field<string> path="password" className={CSS.BE("input", "password")}>
               {(p) => <Input.Text {...p} placeholder="seldon" type="password" />}
             </Form.Field>
-            <Form.Field<boolean> path="secure">
-              {(p) => <Input.Switch {...p} />}
-            </Form.Field>
+            <Form.SwitchField path="secure" label="Secure" />
           </Align.Space>
         </Align.Space>
       </Form.Form>

--- a/console/src/cluster/Dropdown.tsx
+++ b/console/src/cluster/Dropdown.tsx
@@ -16,6 +16,7 @@ import {
   Dropdown as Core,
   List as CoreList,
   Menu as PMenu,
+  Status,
   Synnax,
   Text,
 } from "@synnaxlabs/pluto";
@@ -42,13 +43,28 @@ export const List = (): ReactElement => {
   const active = useSelect();
   const openWindow = Layout.usePlacer();
   const selected = active?.key ?? null;
+  const addStatus = Status.useAggregator();
 
   const handleConnect = (key: string | null): void => {
     dispatch(setActive(key));
   };
 
+  const validateName = useCallback(
+    (name: string): boolean => {
+      const allNames = allClusters.map((c) => c.name);
+      if (!allNames.includes(name)) return true;
+      addStatus({
+        variant: "error",
+        message: `Cannot rename cluster to ${name}`,
+        description: `A cluster with name "${name}" already exists.`,
+      });
+      return false;
+    },
+    [allClusters, addStatus],
+  );
+
   const handleRemove = (key: string): void => {
-    dispatch(remove({ keys: [key] }));
+    dispatch(remove(key));
     if (key === active?.key) dispatch(setActive(null));
   };
 
@@ -151,7 +167,9 @@ export const List = (): ReactElement => {
             onChange={handleConnect}
           >
             <CoreList.Core<string, Cluster> style={{ height: "100%", width: "100%" }}>
-              {({ key, ...p }) => <ListItem key={key} {...p} />}
+              {({ key, ...p }) => (
+                <ListItem key={key} {...p} validateName={validateName} />
+              )}
             </CoreList.Core>
           </CoreList.Selector>
         </CoreList.List>
@@ -160,9 +178,14 @@ export const List = (): ReactElement => {
   );
 };
 
-const ListItem = (props: CoreList.ItemProps<string, Cluster>): ReactElement => {
+interface ListItemProps extends CoreList.ItemProps<string, Cluster> {
+  validateName: (name: string) => boolean;
+}
+
+const ListItem = ({ validateName, ...props }: ListItemProps): ReactElement => {
   const dispatch = useDispatch();
   const handleChange = (value: string) => {
+    // if (!validateName(value)) return;
     dispatch(rename({ key: props.entry.key, name: value }));
   };
 
@@ -183,7 +206,7 @@ const ListItem = (props: CoreList.ItemProps<string, Cluster>): ReactElement => {
           allowDoubleClick={false}
         />
         <Text.Text level="p" shade={6}>
-          {props.entry.props.host}:{props.entry.props.port}
+          {props.entry.host}:{props.entry.port}
         </Text.Text>
       </Align.Space>
     </CoreList.ItemFrame>

--- a/console/src/cluster/Dropdown.tsx
+++ b/console/src/cluster/Dropdown.tsx
@@ -185,7 +185,7 @@ interface ListItemProps extends CoreList.ItemProps<string, Cluster> {
 const ListItem = ({ validateName, ...props }: ListItemProps): ReactElement => {
   const dispatch = useDispatch();
   const handleChange = (value: string) => {
-    // if (!validateName(value)) return;
+    if (!validateName(value)) return;
     dispatch(rename({ key: props.entry.key, name: value }));
   };
 

--- a/console/src/cluster/Dropdown.tsx
+++ b/console/src/cluster/Dropdown.tsx
@@ -39,7 +39,7 @@ import { Link } from "@/link";
 export const List = (): ReactElement => {
   const menuProps = PMenu.useContextMenu();
   const dispatch = useDispatch();
-  const allClusters = useSelectMany();
+  const allClusters = useSelectMany().sort((a, b) => a.name.localeCompare(b.name));
   const active = useSelect();
   const openWindow = Layout.usePlacer();
   const selected = active?.key ?? null;

--- a/console/src/cluster/external.ts
+++ b/console/src/cluster/external.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { Connect, connectWindowLayout } from "@/cluster/Connect";
+import { Connect, LAYOUT_TYPE } from "@/cluster/Connect";
 import { versionOutdatedAdapter } from "@/cluster/notification";
 import { type Layout } from "@/layout";
 import { type NotificationAdapter } from "@/notifications/Notifications";
@@ -18,9 +18,10 @@ export * from "@/cluster/Dropdown";
 export * from "@/cluster/selectors";
 export * from "@/cluster/slice";
 export * from "@/cluster/testConnection";
+export * from "@/cluster/useSyncClusterKey";
 
 export const LAYOUTS: Record<string, Layout.Renderer> = {
-  [connectWindowLayout.type]: Connect,
+  [LAYOUT_TYPE]: Connect,
 };
 
 export const NOTIFICATION_ADAPTERS: NotificationAdapter[] = [versionOutdatedAdapter];

--- a/console/src/cluster/migrations/index.ts
+++ b/console/src/cluster/migrations/index.ts
@@ -9,22 +9,22 @@
 
 import { migrate } from "@synnaxlabs/x";
 
-import type * as v0 from "@/cluster/migrations/v0";
+import * as v0 from "@/cluster/migrations/v0";
 import * as v1 from "@/cluster/migrations/v1";
+import * as v2 from "@/cluster/migrations/v2";
 
-export type Cluster = v0.Cluster;
-export type SliceState = v1.SliceState;
-export type AnySliceState = v0.SliceState | v1.SliceState;
+export const clusterZ = v2.clusterZ;
+export type Cluster = v2.Cluster;
+export type SliceState = v2.SliceState;
+type AnySliceState = v0.SliceState | v1.SliceState | v2.SliceState;
 
-export const LOCAL = v1.LOCAL;
-export const LOCAL_CLUSTER_KEY = v1.LOCAL_CLUSTER_KEY;
-export const LOCAL_PROPS = v1.LOCAL_PROPS;
-export const isLocalCluster = v1.isLocalCluster;
+export const getPredefinedClusterKey = v2.getPredefinedClusterKey;
 
-export const ZERO_SLICE_STATE = v1.ZERO_SLICE_STATE;
+export const ZERO_SLICE_STATE = v2.ZERO_SLICE_STATE;
 
-export const SLICE_MIGRATIONS: migrate.Migrations = {
-  "0.0.1": v1.sliceMigration,
+const SLICE_MIGRATIONS: migrate.Migrations = {
+  [v0.VERSION]: v1.sliceMigration,
+  [v1.VERSION]: v2.sliceMigration,
 };
 
 export const migrateSlice = migrate.migrator<AnySliceState, SliceState>({

--- a/console/src/cluster/migrations/index.ts
+++ b/console/src/cluster/migrations/index.ts
@@ -16,7 +16,7 @@ import * as v2 from "@/cluster/migrations/v2";
 export const clusterZ = v2.clusterZ;
 export type Cluster = v2.Cluster;
 export type SliceState = v2.SliceState;
-type AnySliceState = v0.SliceState | v1.SliceState | v2.SliceState;
+export type AnySliceState = v0.SliceState | v1.SliceState | v2.SliceState;
 
 export const getPredefinedClusterKey = v2.getPredefinedClusterKey;
 

--- a/console/src/cluster/migrations/migrations.spec.ts
+++ b/console/src/cluster/migrations/migrations.spec.ts
@@ -12,13 +12,12 @@ import { describe, expect, it } from "vitest";
 import { migrateSlice, ZERO_SLICE_STATE } from "@/cluster/migrations";
 import * as v0 from "@/cluster/migrations/v0";
 import * as v1 from "@/cluster/migrations/v1";
+import * as v2 from "@/cluster/migrations/v2";
 
-describe("migrations", () => {
-  const STATES = [v0.ZERO_SLICE_STATE, v1.ZERO_SLICE_STATE];
-  STATES.forEach((state) => {
-    it(`should migrate slice from ${state.version} to latest`, () => {
-      const migrated = migrateSlice(state);
-      expect(migrated).toEqual(ZERO_SLICE_STATE);
-    });
-  });
-});
+const STATES = [v0.ZERO_SLICE_STATE, v1.ZERO_SLICE_STATE, v2.ZERO_SLICE_STATE];
+
+describe("migrations", () =>
+  STATES.forEach((state) =>
+    it(`should migrate slice from ${state.version} to latest`, () =>
+      expect(migrateSlice(state)).toEqual(ZERO_SLICE_STATE)),
+  ));

--- a/console/src/cluster/migrations/v0.ts
+++ b/console/src/cluster/migrations/v0.ts
@@ -7,27 +7,21 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { synnaxPropsZ } from "@synnaxlabs/client";
-import { z } from "zod";
+import { type SynnaxProps } from "@synnaxlabs/client";
 
-export const clusterZ = z.object({
-  key: z.string(),
-  name: z.string(),
-  props: synnaxPropsZ,
-});
+export const VERSION = "0.0.1";
+export type Version = typeof VERSION;
 
-export type Cluster = z.input<typeof clusterZ>;
+export type Cluster = { key: string; name: string; props: SynnaxProps };
 
-export const sliceStateZ = z.object({
-  version: z.literal("0.0.1"),
-  activeCluster: z.string().nullable(),
-  clusters: z.record(z.string(), clusterZ),
-});
-
-export type SliceState = z.input<typeof sliceStateZ>;
+export type SliceState = {
+  version: Version;
+  activeCluster: string | null;
+  clusters: Record<string, Cluster>;
+};
 
 export const ZERO_SLICE_STATE: SliceState = {
-  version: "0.0.1",
+  version: VERSION,
   activeCluster: null,
   clusters: {},
 };

--- a/console/src/cluster/migrations/v1.ts
+++ b/console/src/cluster/migrations/v1.ts
@@ -7,58 +7,45 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { type SynnaxProps } from "@synnaxlabs/client";
 import { migrate } from "@synnaxlabs/x";
-import { z } from "zod";
 
 import * as v0 from "@/cluster/migrations/v0";
 
-export const sliceStateZ = v0.sliceStateZ.omit({ version: true }).extend({
-  version: z.literal("1.0.0"),
-});
+export const VERSION = "1.0.0";
+export type Version = typeof VERSION;
 
-export type SliceState = z.input<typeof sliceStateZ>;
+export type SliceState = Omit<v0.SliceState, "version"> & { version: Version };
 
-export const LOCAL_PROPS: SynnaxProps = {
-  name: "Local",
+export const LOCAL_KEY = "LOCAL";
+const LOCAL_NAME = "Local";
+export const LOCAL_PROPS = {
+  name: LOCAL_NAME,
   host: "localhost",
   port: 9090,
   username: "synnax",
   password: "seldon",
   secure: false,
-};
+} as const;
 
-export const isLocalCluster = (props: any): boolean =>
-  props.host === LOCAL_PROPS.host &&
-  props.port == LOCAL_PROPS.port &&
-  props.username === LOCAL_PROPS.username &&
-  props.password === LOCAL_PROPS.password &&
-  props.secure === LOCAL_PROPS.secure;
-
-export const LOCAL_CLUSTER_KEY = "LOCAL";
-
-export const LOCAL: v0.Cluster = {
-  key: LOCAL_CLUSTER_KEY,
-  name: "Local",
+const LOCAL: v0.Cluster = {
+  key: LOCAL_KEY,
+  name: LOCAL_NAME,
   props: LOCAL_PROPS,
 };
 
 export const ZERO_SLICE_STATE: SliceState = {
   ...v0.ZERO_SLICE_STATE,
-  version: "1.0.0",
-  clusters: {
-    [LOCAL_CLUSTER_KEY]: LOCAL,
-  },
+  version: VERSION,
+  clusters: { [LOCAL_KEY]: LOCAL },
 };
 
+export const SLICE_MIGRATION_NAME = "cluster.slice";
+
 export const sliceMigration = migrate.createMigration<v0.SliceState, SliceState>({
-  name: "cluster.slice",
+  name: SLICE_MIGRATION_NAME,
   migrate: (slice) => ({
     ...slice,
-    version: "1.0.0",
-    clusters: {
-      ...slice.clusters,
-      [LOCAL_CLUSTER_KEY]: LOCAL,
-    },
+    version: VERSION,
+    clusters: { ...slice.clusters, [LOCAL_KEY]: LOCAL },
   }),
 });

--- a/console/src/cluster/migrations/v1.ts
+++ b/console/src/cluster/migrations/v1.ts
@@ -18,19 +18,17 @@ export type SliceState = Omit<v0.SliceState, "version"> & { version: Version };
 
 export const LOCAL_KEY = "LOCAL";
 const LOCAL_NAME = "Local";
-export const LOCAL_PROPS = {
-  name: LOCAL_NAME,
-  host: "localhost",
-  port: 9090,
-  username: "synnax",
-  password: "seldon",
-  secure: false,
-} as const;
-
-const LOCAL: v0.Cluster = {
+export const LOCAL: v0.Cluster = {
   key: LOCAL_KEY,
   name: LOCAL_NAME,
-  props: LOCAL_PROPS,
+  props: {
+    name: LOCAL_NAME,
+    host: "localhost",
+    port: 9090,
+    username: "synnax",
+    password: "seldon",
+    secure: false,
+  },
 };
 
 export const ZERO_SLICE_STATE: SliceState = {

--- a/console/src/cluster/migrations/v2.ts
+++ b/console/src/cluster/migrations/v2.ts
@@ -1,0 +1,94 @@
+// Copyright 2024 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { synnaxPropsZ } from "@synnaxlabs/client";
+import { deep, migrate } from "@synnaxlabs/x";
+import { z } from "zod";
+
+import * as v1 from "@/cluster/migrations/v1";
+
+export const VERSION = "2.0.0";
+export type Version = typeof VERSION;
+
+export const clusterZ = synnaxPropsZ
+  .extend({ name: z.string().min(1, { message: "Name is required" }) })
+  .omit({ connectivityPollFrequency: true, retry: true });
+export type Cluster = z.infer<typeof clusterZ> & { key: string };
+
+export type SliceState = Omit<v1.SliceState, "version" | "clusters"> & {
+  version: Version;
+  clusters: Record<string, Cluster>;
+};
+
+type LocalKey = typeof v1.LOCAL_KEY;
+const LOCAL = { ...v1.LOCAL_PROPS, key: v1.LOCAL_KEY } as const;
+
+const DEMO_KEY = "DEMO";
+type DemoKey = typeof DEMO_KEY;
+
+const DEMO_CLUSTER = {
+  key: DEMO_KEY,
+  name: "Demo",
+  host: "demo.synnaxlabs.com",
+  port: 9090,
+  username: "synnax",
+  password: "seldon",
+  secure: true,
+} as const;
+
+type PredefinedClusterKey = LocalKey | DemoKey;
+
+const ZERO_CLUSTERS = {
+  [v1.LOCAL_KEY]: LOCAL,
+  [DEMO_KEY]: DEMO_CLUSTER,
+} as const;
+
+type ClusterCore = Pick<Cluster, "host" | "port">;
+
+export const getPredefinedClusterKey = (
+  cluster: ClusterCore,
+): PredefinedClusterKey | null => {
+  for (const [key, c] of Object.entries(ZERO_CLUSTERS) as [
+    PredefinedClusterKey,
+    Cluster,
+  ][])
+    if (cluster.host === c.host && cluster.port == c.port) return key;
+  return null;
+};
+
+export const ZERO_SLICE_STATE: SliceState = {
+  ...v1.ZERO_SLICE_STATE,
+  version: VERSION,
+  clusters: deep.copy(ZERO_CLUSTERS),
+};
+
+export const sliceMigration = migrate.createMigration<v1.SliceState, SliceState>({
+  name: v1.SLICE_MIGRATION_NAME,
+  migrate: (slice) => {
+    const clusters: Record<string, Cluster> = { [DEMO_KEY]: { ...DEMO_CLUSTER } };
+    for (const [key, cluster] of Object.entries(slice.clusters))
+      clusters[key] = {
+        ...cluster.props,
+        name: cluster.name,
+        secure: cluster.props.secure ?? false,
+        key,
+      };
+
+    // check if the LOCAL or DEMO keys are duplicated by a cluster with a real cluster
+    // key. If so, delete those keys. This needs to be done after all clusters have been
+    // assigned incase the previous slice had a LOCAL key and a cluster with a real key
+    // at localhost:9090.
+    for (const [key, cluster] of Object.entries(ZERO_CLUSTERS)) {
+      const predefinedKey = getPredefinedClusterKey(cluster);
+      if (predefinedKey != null && key !== predefinedKey)
+        delete clusters[predefinedKey];
+    }
+    return { ...slice, version: VERSION, clusters };
+  },
+});

--- a/console/src/cluster/migrations/v2.ts
+++ b/console/src/cluster/migrations/v2.ts
@@ -27,7 +27,12 @@ export type SliceState = Omit<v1.SliceState, "version" | "clusters"> & {
 };
 
 type LocalKey = typeof v1.LOCAL_KEY;
-const LOCAL = { ...v1.LOCAL_PROPS, key: v1.LOCAL_KEY } as const;
+const LOCAL: Cluster = {
+  ...v1.LOCAL.props,
+  key: v1.LOCAL_KEY,
+  name: v1.LOCAL.name,
+  secure: v1.LOCAL.props.secure ?? false,
+};
 
 const DEMO_KEY = "DEMO";
 type DemoKey = typeof DEMO_KEY;
@@ -42,17 +47,17 @@ const DEMO_CLUSTER = {
   secure: true,
 } as const;
 
-type PredefinedClusterKey = LocalKey | DemoKey;
+export type PredefinedClusterKey = LocalKey | DemoKey;
 
-const ZERO_CLUSTERS = {
+const ZERO_CLUSTERS: Record<string, Cluster> = {
   [v1.LOCAL_KEY]: LOCAL,
   [DEMO_KEY]: DEMO_CLUSTER,
-} as const;
+};
 
-type ClusterCore = Pick<Cluster, "host" | "port">;
+export type CoreCluster = Pick<Cluster, "host" | "port">;
 
 export const getPredefinedClusterKey = (
-  cluster: ClusterCore,
+  cluster: CoreCluster,
 ): PredefinedClusterKey | null => {
   for (const [key, c] of Object.entries(ZERO_CLUSTERS) as [
     PredefinedClusterKey,
@@ -82,9 +87,9 @@ export const sliceMigration = migrate.createMigration<v1.SliceState, SliceState>
 
     // check if the LOCAL or DEMO keys are duplicated by a cluster with a real cluster
     // key. If so, delete those keys. This needs to be done after all clusters have been
-    // assigned incase the previous slice had a LOCAL key and a cluster with a real key
+    // assigned in case the previous slice had a LOCAL key and a cluster with a real key
     // at localhost:9090.
-    for (const [key, cluster] of Object.entries(ZERO_CLUSTERS)) {
+    for (const [key, cluster] of Object.entries(clusters)) {
       const predefinedKey = getPredefinedClusterKey(cluster);
       if (predefinedKey != null && key !== predefinedKey)
         delete clusters[predefinedKey];

--- a/console/src/cluster/selectors.ts
+++ b/console/src/cluster/selectors.ts
@@ -77,3 +77,9 @@ export const selectMany = (state: StoreState, keys?: string[]): Cluster[] =>
  */
 export const useSelectMany = (keys?: string[]): Cluster[] =>
   useMemoSelect((s: StoreState) => selectMany(s, keys), [keys]);
+
+export const selectAllNames = (state: StoreState): string[] =>
+  Object.values(selectSliceState(state).clusters).map((c) => c.name);
+
+export const useSelectAllNames = (): string[] =>
+  useMemoSelect((s: StoreState) => selectAllNames(s), []);

--- a/console/src/cluster/useSyncClusterKey.ts
+++ b/console/src/cluster/useSyncClusterKey.ts
@@ -1,0 +1,31 @@
+// Copyright 2024 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { Synnax } from "@synnaxlabs/pluto";
+import { useEffect } from "react";
+import { useDispatch } from "react-redux";
+
+import { useSelectActiveKey } from "@/cluster/selectors";
+import { changeKey } from "@/cluster/slice";
+
+// useSyncClusterKey synchronizes the actual cluster key of the cluster to the cluster
+// key in the redux store. This is needed for a few different reasons, such as
+// connecting to a different cluster at the same address or connecting to the local or
+// demo cluster that is already defined in the initial slice state.
+export const useSyncClusterKey = () => {
+  const activeClusterKey = useSelectActiveKey();
+  const { clusterKey, status } = Synnax.useConnectionState();
+  const dispatch = useDispatch();
+  useEffect(() => {
+    if (status !== "connected") return;
+    if (activeClusterKey == null) return;
+    if (activeClusterKey === clusterKey) return;
+    dispatch(changeKey({ oldKey: activeClusterKey, newKey: clusterKey }));
+  }, [status]);
+};

--- a/console/src/layouts/Main.tsx
+++ b/console/src/layouts/Main.tsx
@@ -57,6 +57,7 @@ const SideEffect = (): null => {
     dispatch(Layout.maybeCreateGetStartedTab());
   }, []);
   Version.useLoadTauri();
+  Cluster.useSyncClusterKey();
   Device.useListenForChanges();
   Workspace.useSyncLayout();
   Link.useDeep({ handlers: LINK_HANDLERS });

--- a/console/src/link/link.tsx
+++ b/console/src/link/link.tsx
@@ -74,7 +74,7 @@ export const useDeep = ({ handlers }: UseDeepProps): void => {
 
       // Connecting to the cluster
       const clusterKey = urlParts[1];
-      const connParams = Cluster.select(store.getState(), clusterKey)?.props;
+      const connParams = Cluster.select(store.getState(), clusterKey);
       const addClusterErrorStatus = () =>
         addStatus({
           variant: "error",

--- a/console/src/store.ts
+++ b/console/src/store.ts
@@ -28,7 +28,6 @@ import { Workspace } from "@/workspace";
 
 const PERSIST_EXCLUDE: Array<deep.Key<RootState>> = [
   ...Layout.PERSIST_EXCLUDE,
-  Cluster.PERSIST_EXCLUDE,
   ...Schematic.PERSIST_EXCLUDE,
 ];
 


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1509](https://linear.app/synnax/issue/SY-1509/add-demo-cluster-to-selector)
- **Linear Issue**: [SY-1270](https://linear.app/synnax/issue/SY-1270/link-copying-local-cluster)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

- Added a demo cluster to the default cluster list
- Fixed issues where the permanent store of the local cluster in the console state was LOCAL instead of the actual cluster key
- Chose better state structure for the cluster store slice (before, name was duplicated twice).

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
