### PR TITLE
SY-1586 Allow Renaming Schematic Snapshots from Tab Name

### DIFF
--- a/console/src/schematic/Schematic.tsx
+++ b/console/src/schematic/Schematic.tsx
@@ -90,13 +90,16 @@ const useSyncComponent = (
     layoutKey,
     async (ws, store, client) => {
       const storeState = store.getState();
+      if (!selectHasPermission(storeState)) return;
       const data = select(storeState, layoutKey);
-      if (data == null || data.snapshot) return;
+      if (data == null) return;
       const layout = Layout.selectRequired(storeState, layoutKey);
+      if (data.snapshot) {
+        await client.workspaces.schematic.rename(layoutKey, layout.name);
+        return;
+      }
       const setData = { ...data, key: undefined, snapshot: undefined };
       if (!data.remoteCreated) store.dispatch(setRemoteCreated({ key: layoutKey }));
-      const canSave = selectHasPermission(storeState);
-      if (!canSave) return;
       await client.workspaces.schematic.create(ws, {
         key: layoutKey,
         name: layout.name,

--- a/console/src/schematic/Schematic.tsx
+++ b/console/src/schematic/Schematic.tsx
@@ -98,7 +98,7 @@ const useSyncComponent = (
         await client.workspaces.schematic.rename(layoutKey, layout.name);
         return;
       }
-      const setData = { ...data, key: undefined, snapshot: undefined };
+      const setData = { ...data, key: undefined };
       if (!data.remoteCreated) store.dispatch(setRemoteCreated({ key: layoutKey }));
       await client.workspaces.schematic.create(ws, {
         key: layoutKey,

--- a/console/src/schematic/selectors.ts
+++ b/console/src/schematic/selectors.ts
@@ -164,3 +164,9 @@ export const selectVersion = (state: StoreState, key: string): string | undefine
 
 export const useSelectVersion = (key: string): string | undefined =>
   useMemoSelect((state: StoreState) => selectVersion(state, key), [key]);
+
+export const selectIsSnapshot = (state: StoreState, key: string): boolean =>
+  select(state, key).snapshot;
+
+export const useSelectIsSnapshot = (key: string): boolean =>
+  useMemoSelect((state: StoreState) => selectIsSnapshot(state, key), [key]);

--- a/console/src/schematic/toolbar/Toolbar.tsx
+++ b/console/src/schematic/toolbar/Toolbar.tsx
@@ -9,7 +9,7 @@
 
 import { schematic } from "@synnaxlabs/client";
 import { Icon } from "@synnaxlabs/media";
-import { Align, Breadcrumb, Button, Header, Status, Tabs } from "@synnaxlabs/pluto";
+import { Align, Breadcrumb, Button, Status, Tabs } from "@synnaxlabs/pluto";
 import { Text } from "@synnaxlabs/pluto/text";
 import { type ReactElement, useCallback } from "react";
 import { useDispatch } from "react-redux";
@@ -19,9 +19,9 @@ import { Layout } from "@/layout";
 import { Link } from "@/link";
 import { useExport } from "@/schematic/file";
 import {
-  useSelect,
   useSelectControlStatus,
   useSelectHasPermission,
+  useSelectIsSnapshot,
   useSelectOptional,
   useSelectSelectedElementNames,
   useSelectToolbar,
@@ -46,16 +46,17 @@ interface NotEditableContentProps extends ToolbarProps {}
 const NotEditableContent = ({ layoutKey }: NotEditableContentProps): ReactElement => {
   const dispatch = useDispatch();
   const controlState = useSelectControlStatus(layoutKey);
-  const canEdit = useSelectHasPermission();
+  const hasEditingPermissions = useSelectHasPermission();
+  const isSnapshot = useSelectIsSnapshot(layoutKey);
+  const isEditable = hasEditingPermissions && !isSnapshot;
   const name = Layout.useSelectRequired(layoutKey).name;
-
   return (
     <Align.Center direction="x" size="small">
       <Status.Text variant="disabled" hideIcon>
         {name} is not editable.
-        {canEdit ? " To make changes," : ""}
+        {isEditable ? " To make changes," : ""}
       </Status.Text>
-      {canEdit && (
+      {isEditable && (
         <Text.Link
           onClick={(e) => {
             e.stopPropagation();


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1586](https://linear.app/synnax/issue/SY-1586/renaming-schematic-snapshots-from-tab-name-does-not-work)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Allow Schematic Snapshots to be renamed from their tab. Change Schematic toolbar to hide editing option text for a snapshot.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
