### PR TITLE
Sy 850 position groups above items in resources tree

### DIFF
--- a/console/src/ontology/Tree.tsx
+++ b/console/src/ontology/Tree.tsx
@@ -19,7 +19,7 @@ import {
   useStateRef as useRefAsState,
 } from "@synnaxlabs/pluto";
 import { Tree as Core } from "@synnaxlabs/pluto/tree";
-import { deep } from "@synnaxlabs/x";
+import { compare, deep } from "@synnaxlabs/x";
 import { type MutationFunction, useMutation } from "@tanstack/react-query";
 import { Mutex } from "async-mutex";
 import { memo, type ReactElement, useCallback, useMemo, useState } from "react";
@@ -183,6 +183,12 @@ const handleRelationshipsChange = async (
     setNodes([...nextTree]);
   });
 
+const sortFunc = (a: Core.Node, b: Core.Node) => {
+  if (a.key.startsWith("group")) return -1;
+  if (b.key.startsWith("group")) return 1;
+  return Core.defaultSort(a, b);
+};
+
 export const Tree = (): ReactElement => {
   const client = Synnax.use();
   const services = useServices();
@@ -290,6 +296,7 @@ export const Tree = (): ReactElement => {
     nodes,
     selected,
     onSelectedChange: setSelected,
+    sort: sortFunc,
   });
 
   const dropMutation = useMutation<

--- a/console/src/ontology/Tree.tsx
+++ b/console/src/ontology/Tree.tsx
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { ontology, type Synnax as Client } from "@synnaxlabs/client";
+import { group, ontology, type Synnax as Client } from "@synnaxlabs/client";
 import {
   Haul,
   Menu,
@@ -184,8 +184,10 @@ const handleRelationshipsChange = async (
   });
 
 const sortFunc = (a: Core.Node, b: Core.Node) => {
-  if (a.key.startsWith("group")) return -1;
-  if (b.key.startsWith("group")) return 1;
+  const aIsGroup = a.key.startsWith(group.ONTOLOGY_TYPE);
+  const bIsGroup = b.key.startsWith(group.ONTOLOGY_TYPE);
+  if (aIsGroup && !bIsGroup) return -1;
+  if (!aIsGroup && bIsGroup) return 1;
   return Core.defaultSort(a, b);
 };
 

--- a/pluto/src/tree/Tree.spec.tsx
+++ b/pluto/src/tree/Tree.spec.tsx
@@ -32,7 +32,7 @@ describe("Tree", () => {
         { key: "2", name: "2" },
         { key: "3", name: "3" },
       ];
-      const result = sortAndSplice(nodes, true);
+      const result = sortAndSplice(nodes);
       expect(result).toEqual([
         { key: "2", name: "2" },
         { key: "1", name: "1", forcePosition: 1 },

--- a/pluto/src/tree/Tree.tsx
+++ b/pluto/src/tree/Tree.tsx
@@ -35,7 +35,7 @@ import {
 import { CONTEXT_SELECTED, CONTEXT_TARGET } from "@/menu/ContextMenu";
 import { state } from "@/state";
 import { Text } from "@/text";
-import { flatten, type FlattenedNode, type Node } from "@/tree/core";
+import { flatten, SortOption, type FlattenedNode, type Node } from "@/tree/core";
 import { Triggers } from "@/triggers";
 import { componentRenderProp, type RenderProp } from "@/util/renderProp";
 
@@ -53,7 +53,7 @@ export interface UseProps {
   onSelectedChange?: state.Set<string[]>;
   initialExpanded?: string[];
   nodes: Node[];
-  sort?: boolean;
+  sort?: SortOption;
 }
 
 export interface UseReturn {
@@ -73,7 +73,7 @@ export const use = (props: UseProps): UseReturn => {
     onExpand,
     nodes,
     initialExpanded = [],
-    sort = true,
+    sort,
     selected: propsSelected,
     onSelectedChange,
   } = props ?? {};

--- a/pluto/src/tree/core.ts
+++ b/pluto/src/tree/core.ts
@@ -46,12 +46,20 @@ export interface FlattenProps {
   nodes: Node[];
   expanded: string[];
   depth?: number;
-  sort?: boolean;
+  sort?: SortOption;
   path?: string;
 }
 
-export const sortAndSplice = (nodes: Node[], sort: boolean): Node[] => {
-  if (sort) nodes.sort((a, b) => compare.stringsWithNumbers(a.name, b.name));
+export type SortOption = compare.CompareF<Node> | boolean;
+
+export const defaultSort: compare.CompareF<Node> = (a, b) =>
+  compare.stringsWithNumbers(a.name, b.name);
+
+export const sortAndSplice = (
+  nodes: Node[],
+  sort: SortOption = defaultSort,
+): Node[] => {
+  if (typeof sort === "function") nodes.sort(sort);
   let found = false;
   for (let i = 0; i < nodes.length; i++) {
     const node = nodes[i];
@@ -71,11 +79,12 @@ export const flatten = ({
   nodes,
   expanded,
   depth = 0,
-  sort = true,
+  sort,
   path = "",
 }: FlattenProps): FlattenedNode[] => {
   // Sort the first level of the tree independently of the rest
-  if (depth === 0 && sort) nodes = nodes.sort((a, b) => a.name.localeCompare(b.name));
+  if (depth === 0 && sort != false)
+    nodes = nodes.sort((a, b) => a.name.localeCompare(b.name));
   const flattened: FlattenedNode[] = [];
   nodes.forEach((node, index) => {
     const nextPath = `${path}${node.key}/`;


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-850](https://linear.app/synnax/issue/SY-850/position-groups-above-items-in-resources-tree)

## Description

Position groups above standalone items in ontology resources tree.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
