### PR TITLE
[console] - added workspace exclusion functionality

### DIFF
--- a/console/src/layout/migrations/v0.ts
+++ b/console/src/layout/migrations/v0.ts
@@ -32,6 +32,7 @@ export const stateZ = z.object({
   windowProps: z.record(z.unknown()).optional(),
   tab: z.record(z.unknown()).optional(),
   args: z.unknown(),
+  excludeFromWorkspace: z.boolean().optional(),
 });
 
 /**
@@ -104,6 +105,11 @@ export interface State<A = any | undefined> {
    * A typically optional set of arguments to pass to the layout
    */
   args?: A;
+  /**
+   * excludeFromWorkspace is a flag that indicates whether the layout should be
+   * excluded from the workspace. This is typically used for modal layouts.
+   */
+  excludeFromWorkspace?: boolean;
 }
 
 export type RenderableLayout = Omit<State, "window">;

--- a/console/src/version/Info.tsx
+++ b/console/src/version/Info.tsx
@@ -29,6 +29,7 @@ export const infoLayout: Layout.State = {
     navTop: true,
     size: { width: 500, height: 325 },
   },
+  excludeFromWorkspace: true,
 };
 
 export const Info: Layout.Renderer = () => {

--- a/console/src/workspace/syncer.ts
+++ b/console/src/workspace/syncer.ts
@@ -35,8 +35,13 @@ export const useSyncLayout = async (): Promise<void> => {
         if (key == null || client == null) return;
         const layoutSlice = Layout.selectSliceState(s);
         if (deep.equal(prevSync.current, layoutSlice)) return;
+        const toSave = deep.copy(layoutSlice);
+        Object.entries(toSave.layouts).forEach(([key, layout]) => {
+          if (layout.excludeFromWorkspace == true || layout.location === "modal")
+            delete toSave.layouts[key];
+        });
         prevSync.current = layoutSlice;
-        await client.workspaces.setLayout(key, layoutSlice as unknown as UnknownRecord);
+        await client.workspaces.setLayout(key, toSave as unknown as UnknownRecord);
       },
       250,
       [client],


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1278](https://linear.app/synnax/issue/SY-1278/clear-modals-when-switching-workspaces)

## Description

Adds the ability to exclude a layout from the workspace, and automatically removes all modals from the workspace.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
