### PR TITLE
[console] - fixed issues with importing schematics with empty keys

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synnaxlabs/console",
   "private": true,
-  "version": "0.36.1",
+  "version": "0.36.2",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/console/src/lineplot/LinePlot.tsx
+++ b/console/src/lineplot/LinePlot.tsx
@@ -37,7 +37,7 @@ import {
 import { useMutation } from "@tanstack/react-query";
 import { type ReactElement, useCallback, useEffect, useMemo, useState } from "react";
 import { useDispatch } from "react-redux";
-import { v4 as uuidv4 } from "uuid";
+import { v4 as uuid } from "uuid";
 
 import { Menu } from "@/components/menu";
 import { useLoadRemote } from "@/hooks/useLoadRemote";
@@ -512,7 +512,7 @@ export const create =
   (initial: Partial<State> & Omit<Partial<Layout.State>, "type">): Layout.Creator =>
   ({ dispatch }) => {
     const { name = "Line Plot", location = "mosaic", window, tab, ...rest } = initial;
-    const key = initial.key ?? uuidv4();
+    const key: string = primitiveIsZero(initial.key) ? uuid() : (initial.key as string);
     dispatch(internalCreate({ ...deep.copy(ZERO_STATE), ...rest, key }));
     return { key, name, location, type: LAYOUT_TYPE, icon: "Visualize", window, tab };
   };

--- a/console/src/log/Log.tsx
+++ b/console/src/log/Log.tsx
@@ -13,7 +13,7 @@ import { Icon } from "@synnaxlabs/media";
 import { Align, Log as Core, telem, Text, usePrevious } from "@synnaxlabs/pluto";
 import { deep, primitiveIsZero, TimeSpan, type UnknownRecord } from "@synnaxlabs/x";
 import { type ReactElement, useCallback, useEffect } from "react";
-import { v4 as uuidv4 } from "uuid";
+import { v4 as uuid } from "uuid";
 
 import { useLoadRemote } from "@/hooks/useLoadRemote";
 import { Layout } from "@/layout";
@@ -142,7 +142,7 @@ export const create =
   (initial: Partial<State> & Omit<Partial<Layout.State>, "type">): Layout.Creator =>
   ({ dispatch }) => {
     const { name = "Log", location = "mosaic", window, tab, ...rest } = initial;
-    const key = initial.key ?? uuidv4();
+    const key: string = primitiveIsZero(initial.key) ? uuid() : (initial.key as string);
     dispatch(internalCreate({ ...deep.copy(ZERO_STATE), ...rest, key }));
     return {
       key,

--- a/console/src/schematic/Schematic.tsx
+++ b/console/src/schematic/Schematic.tsx
@@ -29,7 +29,7 @@ import {
   useSyncedRef,
   Viewport,
 } from "@synnaxlabs/pluto";
-import { box, deep, id, xy } from "@synnaxlabs/x";
+import { box, deep, id, primitiveIsZero, xy } from "@synnaxlabs/x";
 import {
   type ReactElement,
   useCallback,
@@ -445,7 +445,7 @@ export const create =
     const canEditSchematic = selectHasPermission(store.getState());
     const { name = "Schematic", location = "mosaic", window, tab, ...rest } = initial;
     const newTab = canEditSchematic ? tab : { ...tab, editable: false };
-    const key = initial.key ?? uuid();
+    const key: string = primitiveIsZero(initial.key) ? uuid() : (initial.key as string);
     dispatch(internalCreate({ ...deep.copy(ZERO_STATE), ...rest, key }));
     return {
       key,

--- a/console/src/schematic/services/palette.tsx
+++ b/console/src/schematic/services/palette.tsx
@@ -10,11 +10,11 @@
 import { Icon } from "@synnaxlabs/media";
 
 import { type Command } from "@/palette/Palette";
+import { importSchematic } from "@/schematic/file";
 import { create } from "@/schematic/Schematic";
 import { selectHasPermission } from "@/schematic/selectors";
-import { importSchematic } from "@/schematic/file";
-import { Workspace } from "@/workspace";
 import { ImportIcon } from "@/schematic/services/Icon";
+import { Workspace } from "@/workspace";
 
 export const createCommand: Command = {
   key: "create-schematic",

--- a/console/src/table/Table.tsx
+++ b/console/src/table/Table.tsx
@@ -17,12 +17,13 @@ import {
   clamp,
   dimensions,
   type location,
+  primitiveIsZero,
   type UnknownRecord,
   xy,
 } from "@synnaxlabs/x";
 import { memo, type ReactElement, useCallback, useEffect, useRef } from "react";
 import { useDispatch } from "react-redux";
-import { v4 as uuidv4 } from "uuid";
+import { v4 as uuid } from "uuid";
 
 import { Menu as CMenu } from "@/components/menu";
 import { CSS } from "@/css";
@@ -361,8 +362,8 @@ interface CellContainerProps {
 export const create =
   (initial: Partial<State> & Omit<Partial<Layout.State>, "type">): Layout.Creator =>
   ({ dispatch }) => {
-    const key = initial.key ?? uuidv4();
     const { name = "Table", location = "mosaic", window, tab, ...rest } = initial;
+    const key: string = primitiveIsZero(initial.key) ? uuid() : (initial.key as string);
     dispatch(internalCreate({ ...ZERO_STATE, ...rest, key }));
     return {
       key,


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1728](https://linear.app/synnax/issue/SY-1728/fix-schematic-import-causing-new-window)

## Description

Schematics with empty keys (`""`) get imported with that as their key, which causes funky behaviors with pre-rendered windows.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
