### PR TITLE
[pluto] - fixed issues with table rendering

### DIFF
--- a/pluto/src/table/aether/Table.ts
+++ b/pluto/src/table/aether/Table.ts
@@ -50,6 +50,7 @@ export class Table extends aether.Composite<typeof tableStateZ, InternalState, C
   }
 
   async render(): Promise<render.Cleanup | undefined> {
+    if (this.deleted) return;
     const eraseRegion = box.copy(this.state.region);
     if (!this.state.visible)
       return async () =>

--- a/pluto/src/vis/lineplot/aether/LinePlot.ts
+++ b/pluto/src/vis/lineplot/aether/LinePlot.ts
@@ -124,15 +124,11 @@ export class LinePlot extends aether.Composite<
     await Promise.all(this.tooltips.map(async (t) => await t.render(p)));
   }
 
-  private async renderMeasures(
-    region: box.Box,
-    canvases: render.CanvasVariant[],
-  ): Promise<void> {
-    const p = {
+  private async renderMeasures(region: box.Box): Promise<void> {
+    const p: measure.MeasureProps = {
       findByXDecimal: this.findByXDecimal.bind(this),
       findByXValue: this.findByXValue.bind(this),
       region,
-      canvases,
     };
     await Promise.all(this.measures.map(async (m) => await m.render(p)));
   }
@@ -182,7 +178,7 @@ export class LinePlot extends aether.Composite<
     try {
       await this.renderAxes(plot, canvases);
       await this.renderTooltips(plot, canvases);
-      await this.renderMeasures(plot, canvases);
+      await this.renderMeasures(plot);
       renderCtx.gl.finish();
       renderCtx.gl.flush();
       renderCtx.gl.finish();

--- a/pluto/src/vis/value/aether/value.ts
+++ b/pluto/src/vis/value/aether/value.ts
@@ -82,11 +82,14 @@ export class Value
   }
 
   async afterDelete(): Promise<void> {
-    const { requestRender, telem, render: renderCtx } = this.internal;
-    await telem.cleanup?.();
-    if (requestRender == null)
-      renderCtx.erase(box.construct(this.state.box), xy.ZERO, ...CANVAS_VARIANTS);
-    else requestRender(render.REASON_LAYOUT);
+    const { internal: i } = this;
+    i.stopListening?.();
+    i.stopListeningBackground?.();
+    await i.telem.cleanup?.();
+    await i.backgroundTelem.cleanup?.();
+    if (i.requestRender == null)
+      i.render.erase(box.construct(this.state.box), xy.ZERO, ...CANVAS_VARIANTS);
+    else i.requestRender(render.REASON_LAYOUT);
   }
 
   private requestRender(): void {


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1760](https://linear.app/synnax/issue/SY-1760/table-render-loop-doesnt-garbage-correctly)

## Description

Fixes an issue where the table render loop continues to render even after it gets deleted. Resolved by doing two things:

1. Skipping renders if the table is not deleted (this is a failsafe, which makes sure even if we haven't stopped telemetry sources correctly the table won't render again).
2. _The actual fix_ -> Make sure we cleaned up the color source telemetry and stop listening on the aether value component. 


## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
