### PR TITLE
[pluto] - fixed schematic edge coloring

### DIFF
--- a/pluto/src/vis/diagram/edge/paths.tsx
+++ b/pluto/src/vis/diagram/edge/paths.tsx
@@ -69,7 +69,7 @@ const JackedPipe = ({ points, color, ...props }: PathProps): ReactElement => {
   );
 };
 
-const JOINT_REMOVE_THRESHOLD = 15;
+const JOINT_REMOVE_THRESHOLD = 5;
 
 const computeSymbolPositions = (points: xy.XY[], interval: number): SymbolProps[] => {
   const positions: SymbolProps[] = [];
@@ -188,7 +188,7 @@ const createSymbolLine = (C: FC<SymbolProps>) => {
     const positions = computeSymbolPositions(points, 40); // Adjust the interval as needed
     return (
       <>
-        <BaseEdge path={path} {...props} color={Color.cssString(color)} />
+        <BaseEdge path={path} {...props} style={{ stroke: Color.cssString(color) }} />
         {positions.map(({ position, direction }, index) => (
           <C key={index} position={position} direction={direction} color={color} />
         ))}


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1766](https://linear.app/synnax/issue/SY-1766/fix-schematic-edge-coloring)

## Description

Fixes schematic edge coloring not working correctly on lines with embedded symbols.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
