### PR TITLE
rSy 1784 fix randomly appearing f in previews

### DIFF
--- a/pluto/src/vis/schematic/primitives/Primitives.tsx
+++ b/pluto/src/vis/schematic/primitives/Primitives.tsx
@@ -1143,6 +1143,8 @@ export const OrificePlate = ({
 
 export interface FilterProps extends SVGBasedPrimitiveProps, DivProps {}
 
+const pixelToPercent = (pixel: number, total: number): number => (pixel / total) * 100;
+
 export const Filter = ({
   className,
   orientation = "left",
@@ -1240,6 +1242,7 @@ export const Tank = ({
   const detailedRadius = parseBorderRadius(borderRadius);
   const hasCornerBoundaries = boxBorderRadius == null;
   const t = Theming.use();
+  const { width, height } = dimensions;
   const refreshDeps = useMemo(
     () => [dimensions, borderRadius, detailedRadius],
     [
@@ -1247,10 +1250,14 @@ export const Tank = ({
       detailedRadius.bottomRight,
       detailedRadius.topLeft,
       detailedRadius.topRight,
-      dimensions.height,
-      dimensions.width,
+      height,
+      width,
     ],
   );
+  const leftOffset = pixelToPercent(1, width);
+  const rightOffset = 100 - leftOffset;
+  const topOffset = pixelToPercent(1, height);
+  const bottomOffset = 100 - topOffset;
   return (
     <Div
       className={CSS(className, CSS.B("tank"))}
@@ -1258,52 +1265,63 @@ export const Tank = ({
         ...dimensions,
         borderRadius: boxBorderRadius ?? cssBorderRadius(detailedRadius),
         borderColor: Color.cssString(color ?? t.colors.gray.l9),
-        backgroundColor:
-          backgroundColor == null ? undefined : Color.cssString(backgroundColor),
+        backgroundColor: Color.cssString(backgroundColor),
       }}
       {...props}
     >
       <HandleBoundary refreshDeps={refreshDeps} orientation="left">
-        <Handle location="top" orientation="left" left={50} top={0} id="1" />
+        <Handle location="top" orientation="left" left={50} top={topOffset} id="1" />
         {hasCornerBoundaries && (
           <>
             <Handle
               location="top"
               orientation="left"
-              left={-0.5}
-              top={detailedRadius.topLeft.y - 1}
+              left={leftOffset}
+              top={detailedRadius.topLeft.y}
               id="2"
             />
             <Handle
               location="top"
               orientation="left"
-              left={101}
-              top={detailedRadius.topRight.y - 1}
+              left={rightOffset}
+              top={detailedRadius.topRight.y}
               id="3"
             />
           </>
         )}
-        <Handle location="bottom" orientation="left" left={50} top={100} id="4" />
+        <Handle
+          location="bottom"
+          orientation="left"
+          left={50}
+          top={bottomOffset}
+          id="4"
+        />
         {hasCornerBoundaries && (
           <>
             <Handle
               location="bottom"
               orientation="left"
-              left={-0.5}
-              top={100 - detailedRadius.bottomLeft.y + 1}
+              left={leftOffset}
+              top={100 - detailedRadius.bottomLeft.y}
               id="5"
             />
             <Handle
               location="bottom"
               orientation="left"
-              left={101}
-              top={100 - detailedRadius.bottomRight.y + 1}
+              left={rightOffset}
+              top={100 - detailedRadius.bottomRight.y}
               id="6"
             />
           </>
         )}
-        <Handle location="left" orientation="left" left={-0.5} top={50} id="7" />
-        <Handle location="right" orientation="left" left={101} top={50} id="8" />
+        <Handle location="left" orientation="left" left={leftOffset} top={50} id="7" />
+        <Handle
+          location="right"
+          orientation="left"
+          left={rightOffset}
+          top={50}
+          id="8"
+        />
       </HandleBoundary>
     </Div>
   );
@@ -1513,7 +1531,6 @@ export const Value = ({
             theme.colors.gray.l9,
           ),
         );
-  const offset = (2.5 * (dimensions?.width ?? 0)) / 500;
   return (
     <Div
       className={CSS(CSS.B("value"), className)}
@@ -1531,14 +1548,8 @@ export const Value = ({
         {children}
       </div>
       <HandleBoundary orientation={orientation}>
-        <Handle location="left" orientation="left" left={-2 + offset} top={50} id="1" />
-        <Handle
-          location="right"
-          orientation="left"
-          left={102 - offset}
-          top={50}
-          id="2"
-        />
+        <Handle location="left" orientation="left" left={0} top={50} id="1" />
+        <Handle location="right" orientation="left" left={100} top={50} id="2" />
         <Handle location="top" orientation="left" left={50} top={-2} id="3" />
         <Handle location="bottom" orientation="left" left={50} top={102} id="4" />
       </HandleBoundary>
@@ -2167,7 +2178,6 @@ export interface AgitatorProps extends ToggleProps, SVGBasedPrimitiveProps {
 }
 
 export const Agitator = ({
-  height = 86,
   orientation = "left",
   color,
   scale,
@@ -2192,7 +2202,6 @@ export const Agitator = ({
 export interface PropellerAgitatorProps extends AgitatorProps {}
 
 export const PropellerAgitator = ({
-  height = 86,
   orientation = "left",
   color,
   scale,
@@ -2217,7 +2226,6 @@ export const PropellerAgitator = ({
 export interface FlatBladeAgitatorProps extends AgitatorProps {}
 
 export const FlatBladeAgitator = ({
-  height = 86,
   orientation = "left",
   color,
   scale,
@@ -2243,7 +2251,6 @@ export interface PaddleAgitatorProps extends AgitatorProps {}
 
 export const PaddleAgitator = ({
   className,
-  height = 86,
   orientation = "left",
   color,
   scale,
@@ -2271,7 +2278,6 @@ export interface CrossBeamAgitatorProps extends AgitatorProps {}
 
 export const CrossBeamAgitator = ({
   className,
-  height = 86,
   orientation = "left",
   color,
   scale,
@@ -2298,7 +2304,6 @@ export interface HelicalAgitatorProps extends AgitatorProps {}
 
 export const HelicalAgitator = ({
   className,
-  height = 86,
   orientation = "left",
   color,
   scale,
@@ -2741,6 +2746,22 @@ export const CrossJunction = ({
 
 export interface FlowmeterGeneralProps extends DivProps, SVGBasedPrimitiveProps {}
 
+interface FlowLabelProps {
+  position?: xy.XY;
+  color: Color.Crude;
+}
+
+const FlowmeterLabel = ({ position, color }: FlowLabelProps) => (
+  <text
+    x={position?.x ?? 57}
+    y={position?.y ?? 27}
+    style={{ fill: Color.cssString(color), fontWeight: 450 }}
+    stroke="none"
+  >
+    F
+  </text>
+);
+
 export const FlowmeterGeneral = ({
   id,
   className,
@@ -2775,20 +2796,8 @@ export const FlowmeterGeneral = ({
       scale={scale}
     >
       <Rect x="2" y="2" width="67" height="31" rx="2" />
+      <FlowmeterLabel position={{ x: 56, y: 25 }} color={color} />
     </InternalSVG>
-    <Text.Text
-      level="p"
-      className={CSS.BE("flowmeter-text", "f")}
-      style={{
-        position: "absolute",
-        top: "70%",
-        right: "7%",
-        transform: "translateY(-50%)",
-        fontSize: `${scale * 10}px`,
-      }}
-    >
-      F
-    </Text.Text>
   </Div>
 );
 
@@ -2844,20 +2853,8 @@ export const FlowmeterElectromagnetic = ({
         d="M39.5 17.5C39.5 16.9747 39.6035 16.4546 39.8045 15.9693C40.0055 15.484 40.3001 15.043 40.6716 14.6716C41.043 14.3001 41.484 14.0055 41.9693 13.8045C42.4546 13.6035 42.9747 13.5 43.5 13.5C44.0253 13.5 44.5454 13.6035 45.0307 13.8045C45.516 14.0055 45.957 14.3001 46.3284 14.6716C46.6999 15.043 46.9945 15.484 47.1955 15.9693C47.3965 16.4546 47.5 16.9747 47.5 17.5"
         stroke-width="2"
       />
+      <FlowmeterLabel position={{ x: 58, y: 29 }} color={color} />
     </InternalSVG>
-    <Text.Text
-      level="p"
-      className={CSS.BE("flowmeter-text", "f")}
-      style={{
-        position: "absolute",
-        top: "70%",
-        right: "7%",
-        transform: "translateY(-50%)",
-        fontSize: `${scale * 10}px`,
-      }}
-    >
-      F
-    </Text.Text>
   </Div>
 );
 
@@ -2901,20 +2898,8 @@ export const FlowmeterVariableArea = ({
       <Path d="M23 13V22" />
       <Path d="M23 13L46 10" />
       <Path d="M23 22L46 25" />
+      <FlowmeterLabel color={color} />
     </InternalSVG>
-    <Text.Text
-      level="p"
-      className={CSS.BE("flowmeter-text", "f")}
-      style={{
-        position: "absolute",
-        top: "70%",
-        right: "7%",
-        transform: "translateY(-50%)",
-        fontSize: `${scale * 10}px`,
-      }}
-    >
-      F
-    </Text.Text>
   </Div>
 );
 
@@ -2927,66 +2912,45 @@ export const FlowmeterCoriolis = ({
   color = "black",
   scale = 1,
   ...props
-}: FlowmeterCoriolisProps): ReactElement => {
-  const colorStr = Color.cssString(color);
-  return (
-    <Div {...props} className={CSS(CSS.B("flowmeter-Coriolis"), className)}>
-      <HandleBoundary orientation={orientation}>
-        <Handle
-          location="left"
-          orientation={orientation}
-          left={1.6667}
-          top={50}
-          id="1"
-        />
-        <Handle
-          location="right"
-          orientation={orientation}
-          left={98.3333}
-          top={50}
-          id="2"
-        />
-        <Handle location="top" orientation={orientation} left={50} top={5.714} id="3" />
-        <Handle
-          location="bottom"
-          orientation={orientation}
-          left={50}
-          top={94.386}
-          id="3"
-        />
-      </HandleBoundary>
-      <InternalSVG
-        dimensions={{ width: 71, height: 35 }}
-        color={color}
+}: FlowmeterCoriolisProps): ReactElement => (
+  <Div {...props} className={CSS(CSS.B("flowmeter-Coriolis"), className)}>
+    <HandleBoundary orientation={orientation}>
+      <Handle location="left" orientation={orientation} left={1.6667} top={50} id="1" />
+      <Handle
+        location="right"
         orientation={orientation}
-        scale={scale}
-      >
-        <Rect x="2" y="2" width="67" height="31" rx="2" />
-        <Path d="M2 17.6024H28.5" stroke-linecap="round" />
-        <Path d="M28.5 17.6024L34.6834 14.0324" stroke-linecap="round" />
-        <Path d="M34.8 14L45.9058 20.9666" stroke-linecap="round" />
-        <Path d="M51.5 17.6024L46.0141 20.8987" stroke-linecap="round" />
-        <Path d="M20.5 17.6024L26.6574 14.0474" stroke-linecap="round" />
-        <Path d="M26.75 14.1024L37.788 21.0265" stroke-linecap="round" />
-        <Path d="M43.5 17.6024L37.8427 21.0017" stroke-linecap="round" />
-        <Path d="M43.5 17.6024H69" stroke-linecap="round" />
-      </InternalSVG>
-      <Text.Text
-        level="p"
-        className={CSS.BE("flowmeter-text", "f")}
-        style={{
-          position: "absolute",
-          top: "70%",
-          right: "7%",
-          transform: "translateY(-50%)",
-          fontSize: `${scale * 10}px`,
-        }}
-      >
-        F
-      </Text.Text>
-    </Div>
-  );
-};
+        left={98.3333}
+        top={50}
+        id="2"
+      />
+      <Handle location="top" orientation={orientation} left={50} top={5.714} id="3" />
+      <Handle
+        location="bottom"
+        orientation={orientation}
+        left={50}
+        top={94.386}
+        id="3"
+      />
+    </HandleBoundary>
+    <InternalSVG
+      dimensions={{ width: 71, height: 35 }}
+      color={color}
+      orientation={orientation}
+      scale={scale}
+    >
+      <Rect x="2" y="2" width="67" height="31" rx="2" />
+      <Path d="M2 17.6024H28.5" stroke-linecap="round" />
+      <Path d="M28.5 17.6024L34.6834 14.0324" stroke-linecap="round" />
+      <Path d="M34.8 14L45.9058 20.9666" stroke-linecap="round" />
+      <Path d="M51.5 17.6024L46.0141 20.8987" stroke-linecap="round" />
+      <Path d="M20.5 17.6024L26.6574 14.0474" stroke-linecap="round" />
+      <Path d="M26.75 14.1024L37.788 21.0265" stroke-linecap="round" />
+      <Path d="M43.5 17.6024L37.8427 21.0017" stroke-linecap="round" />
+      <Path d="M43.5 17.6024H69" stroke-linecap="round" />
+      <FlowmeterLabel position={{ x: 58, y: 29 }} color={color} />
+    </InternalSVG>
+  </Div>
+);
 
 export interface FlowmeterNozzleProps extends DivProps, SVGBasedPrimitiveProps {}
 
@@ -2997,62 +2961,41 @@ export const FlowmeterNozzle = ({
   color = "black",
   scale = 1,
   ...props
-}: FlowmeterNozzleProps): ReactElement => {
-  const colorStr = Color.cssString(color);
-  return (
-    <Div {...props} className={CSS(CSS.B("flowmeter-Nozzle"), className)}>
-      <HandleBoundary orientation={orientation}>
-        <Handle
-          location="left"
-          orientation={orientation}
-          left={1.6667}
-          top={50}
-          id="1"
-        />
-        <Handle
-          location="right"
-          orientation={orientation}
-          left={98.3333}
-          top={50}
-          id="2"
-        />
-        <Handle location="top" orientation={orientation} left={50} top={5.714} id="3" />
-        <Handle
-          location="bottom"
-          orientation={orientation}
-          left={50}
-          top={94.386}
-          id="3"
-        />
-      </HandleBoundary>
-      <InternalSVG
-        dimensions={{ width: 71, height: 35 }}
-        color={color}
+}: FlowmeterNozzleProps): ReactElement => (
+  <Div {...props} className={CSS(CSS.B("flowmeter-Nozzle"), className)}>
+    <HandleBoundary orientation={orientation}>
+      <Handle location="left" orientation={orientation} left={1.6667} top={50} id="1" />
+      <Handle
+        location="right"
         orientation={orientation}
-        scale={scale}
-      >
-        <Rect x="2" y="2" width="67" height="31" rx="2" />
-        <Path d="M24 2V7V12" stroke-linecap="round" />
-        <Path d="M24 12H34" stroke-linecap="round" />
-        <Path d="M24 23H29H34" stroke-linecap="round" />
-        <Path d="M24 33V23" stroke-linecap="round" />
-      </InternalSVG>
-      <Text.Text
-        level="p"
-        className={CSS.BE("flowmeter-text", "f")}
-        style={{
-          position: "absolute",
-          top: "70%",
-          right: "7%",
-          transform: "translateY(-50%)",
-          fontSize: `${scale * 10}px`,
-        }}
-      >
-        F
-      </Text.Text>
-    </Div>
-  );
-};
+        left={98.3333}
+        top={50}
+        id="2"
+      />
+      <Handle location="top" orientation={orientation} left={50} top={5.714} id="3" />
+      <Handle
+        location="bottom"
+        orientation={orientation}
+        left={50}
+        top={94.386}
+        id="3"
+      />
+    </HandleBoundary>
+    <InternalSVG
+      dimensions={{ width: 71, height: 35 }}
+      color={color}
+      orientation={orientation}
+      scale={scale}
+    >
+      <Rect x="2" y="2" width="67" height="31" rx="2" />
+      <Path d="M24 2V7V12" stroke-linecap="round" />
+      <Path d="M24 12H34" stroke-linecap="round" />
+      <Path d="M24 23H29H34" stroke-linecap="round" />
+      <Path d="M24 33V23" stroke-linecap="round" />
+      <FlowmeterLabel color={color} />
+    </InternalSVG>
+  </Div>
+);
 
 export interface FlowmeterVenturiProps extends DivProps, SVGBasedPrimitiveProps {}
 
@@ -3063,62 +3006,41 @@ export const FlowmeterVenturi = ({
   color = "black",
   scale = 1,
   ...props
-}: FlowmeterVenturiProps): ReactElement => {
-  const colorStr = Color.cssString(color);
-  return (
-    <Div {...props} className={CSS(CSS.B("flowmeter-Venturi"), className)}>
-      <HandleBoundary orientation={orientation}>
-        <Handle
-          location="left"
-          orientation={orientation}
-          left={1.6667}
-          top={50}
-          id="1"
-        />
-        <Handle
-          location="right"
-          orientation={orientation}
-          left={98.3333}
-          top={50}
-          id="2"
-        />
-        <Handle location="top" orientation={orientation} left={50} top={5.714} id="3" />
-        <Handle
-          location="bottom"
-          orientation={orientation}
-          left={50}
-          top={94.386}
-          id="3"
-        />
-      </HandleBoundary>
-      <InternalSVG
-        dimensions={{ width: 71, height: 35 }}
-        color={color}
+}: FlowmeterVenturiProps): ReactElement => (
+  <Div {...props} className={CSS(CSS.B("flowmeter-Venturi"), className)}>
+    <HandleBoundary orientation={orientation}>
+      <Handle location="left" orientation={orientation} left={1.6667} top={50} id="1" />
+      <Handle
+        location="right"
         orientation={orientation}
-        scale={scale}
-      >
-        <Rect x="2" y="2" width="67" height="31" rx="2" />
-        <Path d="M8 33L26.5329 22.3" stroke-linecap="round" />
-        <Path d="M8 2L26.5329 12.7" stroke-linecap="round" />
-        <Path d="M56 33L26.5876 22.2948" stroke-linecap="round" />
-        <Path d="M56 2L26.5876 12.7052" stroke-linecap="round" />
-      </InternalSVG>
-      <Text.Text
-        level="p"
-        className={CSS.BE("flowmeter-text", "f")}
-        style={{
-          position: "absolute",
-          top: "70%",
-          right: "7%",
-          transform: "translateY(-50%)",
-          fontSize: `${scale * 10}px`,
-        }}
-      >
-        F
-      </Text.Text>
-    </Div>
-  );
-};
+        left={98.3333}
+        top={50}
+        id="2"
+      />
+      <Handle location="top" orientation={orientation} left={50} top={5.714} id="3" />
+      <Handle
+        location="bottom"
+        orientation={orientation}
+        left={50}
+        top={94.386}
+        id="3"
+      />
+    </HandleBoundary>
+    <InternalSVG
+      dimensions={{ width: 71, height: 35 }}
+      color={color}
+      orientation={orientation}
+      scale={scale}
+    >
+      <Rect x="2" y="2" width="67" height="31" rx="2" />
+      <Path d="M8 33L26.5329 22.3" stroke-linecap="round" />
+      <Path d="M8 2L26.5329 12.7" stroke-linecap="round" />
+      <Path d="M56 33L26.5876 22.2948" stroke-linecap="round" />
+      <Path d="M56 2L26.5876 12.7052" stroke-linecap="round" />
+      <FlowmeterLabel position={{ x: 56, y: 29 }} color={color} />
+    </InternalSVG>
+  </Div>
+);
 
 export interface FlowmeterRingPistonProps extends DivProps, SVGBasedPrimitiveProps {}
 
@@ -3129,60 +3051,39 @@ export const FlowmeterRingPiston = ({
   color = "black",
   scale = 1,
   ...props
-}: FlowmeterRingPistonProps): ReactElement => {
-  const colorStr = Color.cssString(color);
-  return (
-    <Div {...props} className={CSS(CSS.B("flowmeter-RingPiston"), className)}>
-      <HandleBoundary orientation={orientation}>
-        <Handle
-          location="left"
-          orientation={orientation}
-          left={1.6667}
-          top={50}
-          id="1"
-        />
-        <Handle
-          location="right"
-          orientation={orientation}
-          left={98.3333}
-          top={50}
-          id="2"
-        />
-        <Handle location="top" orientation={orientation} left={50} top={5.714} id="3" />
-        <Handle
-          location="bottom"
-          orientation={orientation}
-          left={50}
-          top={94.386}
-          id="3"
-        />
-      </HandleBoundary>
-      <InternalSVG
-        dimensions={{ width: 71, height: 35 }}
-        color={color}
+}: FlowmeterRingPistonProps): ReactElement => (
+  <Div {...props} className={CSS(CSS.B("flowmeter-RingPiston"), className)}>
+    <HandleBoundary orientation={orientation}>
+      <Handle location="left" orientation={orientation} left={1.6667} top={50} id="1" />
+      <Handle
+        location="right"
         orientation={orientation}
-        scale={scale}
-      >
-        <Rect x="2" y="2" width="67" height="31" rx="2" />
-        <Circle cx="36.5" cy="17.5" r="10.5" stroke-width="2" />
-        <Circle cx="36.5" cy="21.5" r="6.5" stroke-width="2" />
-      </InternalSVG>
-      <Text.Text
-        level="p"
-        className={CSS.BE("flowmeter-text", "f")}
-        style={{
-          position: "absolute",
-          top: "70%",
-          right: "7%",
-          transform: "translateY(-50%)",
-          fontSize: `${scale * 10}px`,
-        }}
-      >
-        F
-      </Text.Text>
-    </Div>
-  );
-};
+        left={98.3333}
+        top={50}
+        id="2"
+      />
+      <Handle location="top" orientation={orientation} left={50} top={5.714} id="3" />
+      <Handle
+        location="bottom"
+        orientation={orientation}
+        left={50}
+        top={94.386}
+        id="3"
+      />
+    </HandleBoundary>
+    <InternalSVG
+      dimensions={{ width: 71, height: 35 }}
+      color={color}
+      orientation={orientation}
+      scale={scale}
+    >
+      <Rect x="2" y="2" width="67" height="31" rx="2" />
+      <Circle cx="36.5" cy="17.5" r="10.5" stroke-width="2" />
+      <Circle cx="36.5" cy="21.5" r="6.5" stroke-width="2" />
+      <FlowmeterLabel position={{ x: 56, y: 29 }} color={color} />
+    </InternalSVG>
+  </Div>
+);
 
 export interface FlowmeterPositiveDisplacementProps
   extends DivProps,
@@ -3195,66 +3096,45 @@ export const FlowmeterPositiveDisplacement = ({
   color = "black",
   scale = 1,
   ...props
-}: FlowmeterPositiveDisplacementProps): ReactElement => {
-  const colorStr = Color.cssString(color);
-  return (
-    <Div {...props} className={CSS(CSS.B("flowmeter-PositiveDisplacement"), className)}>
-      <HandleBoundary orientation={orientation}>
-        <Handle
-          location="left"
-          orientation={orientation}
-          left={1.6667}
-          top={50}
-          id="1"
-        />
-        <Handle
-          location="right"
-          orientation={orientation}
-          left={98.3333}
-          top={50}
-          id="2"
-        />
-        <Handle location="top" orientation={orientation} left={50} top={5.714} id="3" />
-        <Handle
-          location="bottom"
-          orientation={orientation}
-          left={50}
-          top={94.386}
-          id="3"
-        />
-      </HandleBoundary>
-      <InternalSVG
-        dimensions={{ width: 71, height: 35 }}
-        color={color}
+}: FlowmeterPositiveDisplacementProps): ReactElement => (
+  <Div {...props} className={CSS(CSS.B("flowmeter-PositiveDisplacement"), className)}>
+    <HandleBoundary orientation={orientation}>
+      <Handle location="left" orientation={orientation} left={1.6667} top={50} id="1" />
+      <Handle
+        location="right"
         orientation={orientation}
-        scale={scale}
-      >
-        <Rect x="2" y="2" width="67" height="31" rx="2" />
-        <Path
-          d="M41 13C41 15.4853 38.9853 17.5 36.5 17.5C34.0147 17.5 32 15.4853 32 13C32 10.5147 34.0147 8.5 36.5 8.5C38.9853 8.5 41 10.5147 41 13Z"
-          stroke-width="2"
-        />
-        <Path
-          d="M41 22C41 24.4853 38.9853 26.5 36.5 26.5C34.0147 26.5 32 24.4853 32 22C32 19.5147 34.0147 17.5 36.5 17.5C38.9853 17.5 41 19.5147 41 22Z"
-          stroke-width="2"
-        />
-      </InternalSVG>
-      <Text.Text
-        level="p"
-        className={CSS.BE("flowmeter-text", "f")}
-        style={{
-          position: "absolute",
-          top: "70%",
-          right: "7%",
-          transform: "translateY(-50%)",
-          fontSize: `${scale * 10}px`,
-        }}
-      >
-        F
-      </Text.Text>
-    </Div>
-  );
-};
+        left={98.3333}
+        top={50}
+        id="2"
+      />
+      <Handle location="top" orientation={orientation} left={50} top={5.714} id="3" />
+      <Handle
+        location="bottom"
+        orientation={orientation}
+        left={50}
+        top={94.386}
+        id="3"
+      />
+    </HandleBoundary>
+    <InternalSVG
+      dimensions={{ width: 71, height: 35 }}
+      color={color}
+      orientation={orientation}
+      scale={scale}
+    >
+      <Rect x="2" y="2" width="67" height="31" rx="2" />
+      <Path
+        d="M41 13C41 15.4853 38.9853 17.5 36.5 17.5C34.0147 17.5 32 15.4853 32 13C32 10.5147 34.0147 8.5 36.5 8.5C38.9853 8.5 41 10.5147 41 13Z"
+        stroke-width="2"
+      />
+      <Path
+        d="M41 22C41 24.4853 38.9853 26.5 36.5 26.5C34.0147 26.5 32 24.4853 32 22C32 19.5147 34.0147 17.5 36.5 17.5C38.9853 17.5 41 19.5147 41 22Z"
+        stroke-width="2"
+      />
+      <FlowmeterLabel color={color} />
+    </InternalSVG>
+  </Div>
+);
 
 export interface FlowmeterTurbineProps extends DivProps, SVGBasedPrimitiveProps {}
 
@@ -3265,71 +3145,50 @@ export const FlowmeterTurbine = ({
   color = "black",
   scale = 1,
   ...props
-}: FlowmeterTurbineProps): ReactElement => {
-  const colorStr = Color.cssString(color);
-  return (
-    <Div {...props} className={CSS(CSS.B("flowmeter-Turbine"), className)}>
-      <HandleBoundary orientation={orientation}>
-        <Handle
-          location="left"
-          orientation={orientation}
-          left={1.6667}
-          top={50}
-          id="1"
-        />
-        <Handle
-          location="right"
-          orientation={orientation}
-          left={98.3333}
-          top={50}
-          id="2"
-        />
-        <Handle location="top" orientation={orientation} left={50} top={5.714} id="3" />
-        <Handle
-          location="bottom"
-          orientation={orientation}
-          left={50}
-          top={94.386}
-          id="3"
-        />
-      </HandleBoundary>
-      <InternalSVG
-        dimensions={{ width: 71, height: 35 }}
-        color={color}
+}: FlowmeterTurbineProps): ReactElement => (
+  <Div {...props} className={CSS(CSS.B("flowmeter-Turbine"), className)}>
+    <HandleBoundary orientation={orientation}>
+      <Handle location="left" orientation={orientation} left={1.6667} top={50} id="1" />
+      <Handle
+        location="right"
         orientation={orientation}
-        scale={scale}
-      >
-        <Rect x="2" y="2" width="67" height="31" rx="2" />
-        <Path d="M16.5 17.5H54.5" stroke-linecap="round" />
-        <Path d="M32.5 9L35.4756 17.1753" stroke-linecap="round" />
-        <Path d="M38.5 26L35.5244 17.8247" stroke-linecap="round" />
-        <Path d="M32.5 26L35.4756 17.8247" stroke-linecap="round" />
-        <Path d="M38.5 9L35.5244 17.1753" stroke-linecap="round" />
-        <Path
-          d="M32.5 9C32.5 8.20435 32.8161 7.44129 33.3787 6.87868C33.9413 6.31607 34.7044 6 35.5 6C36.2956 6 37.0587 6.31607 37.6213 6.87868C38.1839 7.44129 38.5 8.20435 38.5 9"
-          stroke-width="2"
-        />
-        <Path
-          d="M38.5 26C38.5 26.7956 38.1839 27.5587 37.6213 28.1213C37.0587 28.6839 36.2956 29 35.5 29C34.7044 29 33.9413 28.6839 33.3787 28.1213C32.8161 27.5587 32.5 26.7956 32.5 26"
-          stroke-width="2"
-        />
-      </InternalSVG>
-      <Text.Text
-        level="p"
-        className={CSS.BE("flowmeter-text", "f")}
-        style={{
-          position: "absolute",
-          top: "70%",
-          right: "7%",
-          transform: "translateY(-50%)",
-          fontSize: `${scale * 10}px`,
-        }}
-      >
-        F
-      </Text.Text>
-    </Div>
-  );
-};
+        left={98.3333}
+        top={50}
+        id="2"
+      />
+      <Handle location="top" orientation={orientation} left={50} top={5.714} id="3" />
+      <Handle
+        location="bottom"
+        orientation={orientation}
+        left={50}
+        top={94.386}
+        id="3"
+      />
+    </HandleBoundary>
+    <InternalSVG
+      dimensions={{ width: 71, height: 35 }}
+      color={color}
+      orientation={orientation}
+      scale={scale}
+    >
+      <Rect x="2" y="2" width="67" height="31" rx="2" />
+      <Path d="M16.5 17.5H54.5" stroke-linecap="round" />
+      <Path d="M32.5 9L35.4756 17.1753" stroke-linecap="round" />
+      <Path d="M38.5 26L35.5244 17.8247" stroke-linecap="round" />
+      <Path d="M32.5 26L35.4756 17.8247" stroke-linecap="round" />
+      <Path d="M38.5 9L35.5244 17.1753" stroke-linecap="round" />
+      <Path
+        d="M32.5 9C32.5 8.20435 32.8161 7.44129 33.3787 6.87868C33.9413 6.31607 34.7044 6 35.5 6C36.2956 6 37.0587 6.31607 37.6213 6.87868C38.1839 7.44129 38.5 8.20435 38.5 9"
+        stroke-width="2"
+      />
+      <Path
+        d="M38.5 26C38.5 26.7956 38.1839 27.5587 37.6213 28.1213C37.0587 28.6839 36.2956 29 35.5 29C34.7044 29 33.9413 28.6839 33.3787 28.1213C32.8161 27.5587 32.5 26.7956 32.5 26"
+        stroke-width="2"
+      />
+      <FlowmeterLabel color={color} />
+    </InternalSVG>
+  </Div>
+);
 
 export interface FlowmeterPulseProps extends DivProps, SVGBasedPrimitiveProps {}
 
@@ -3340,63 +3199,42 @@ export const FlowmeterPulse = ({
   color = "black",
   scale = 1,
   ...props
-}: FlowmeterPulseProps): ReactElement => {
-  const colorStr = Color.cssString(color);
-  return (
-    <Div {...props} className={CSS(CSS.B("flowmeter-Pulse"), className)}>
-      <HandleBoundary orientation={orientation}>
-        <Handle
-          location="left"
-          orientation={orientation}
-          left={1.6667}
-          top={50}
-          id="1"
-        />
-        <Handle
-          location="right"
-          orientation={orientation}
-          left={98.3333}
-          top={50}
-          id="2"
-        />
-        <Handle location="top" orientation={orientation} left={50} top={5.714} id="3" />
-        <Handle
-          location="bottom"
-          orientation={orientation}
-          left={50}
-          top={94.386}
-          id="3"
-        />
-      </HandleBoundary>
-      <InternalSVG
-        dimensions={{ width: 71, height: 35 }}
-        color={color}
+}: FlowmeterPulseProps): ReactElement => (
+  <Div {...props} className={CSS(CSS.B("flowmeter-Pulse"), className)}>
+    <HandleBoundary orientation={orientation}>
+      <Handle location="left" orientation={orientation} left={1.6667} top={50} id="1" />
+      <Handle
+        location="right"
         orientation={orientation}
-        scale={scale}
-      >
-        <Rect x="2" y="2" width="67" height="31" rx="2" />
-        <Path d="M31 13.5H39" stroke-linecap="round" />
-        <Path d="M23 21.5H31" stroke-linecap="round" />
-        <Path d="M39 21.5H47" stroke-linecap="round" />
-        <Path d="M39 13.5V21.5" stroke-linecap="round" />
-        <Path d="M31 13.5V21.5" stroke-linecap="round" />
-      </InternalSVG>
-      <Text.Text
-        level="p"
-        className={CSS.BE("flowmeter-text", "f")}
-        style={{
-          position: "absolute",
-          top: "70%",
-          right: "7%",
-          transform: "translateY(-50%)",
-          fontSize: `${scale * 10}px`,
-        }}
-      >
-        F
-      </Text.Text>
-    </Div>
-  );
-};
+        left={98.3333}
+        top={50}
+        id="2"
+      />
+      <Handle location="top" orientation={orientation} left={50} top={5.714} id="3" />
+      <Handle
+        location="bottom"
+        orientation={orientation}
+        left={50}
+        top={94.386}
+        id="3"
+      />
+    </HandleBoundary>
+    <InternalSVG
+      dimensions={{ width: 71, height: 35 }}
+      color={color}
+      orientation={orientation}
+      scale={scale}
+    >
+      <Rect x="2" y="2" width="67" height="31" rx="2" />
+      <Path d="M31 13.5H39" stroke-linecap="round" />
+      <Path d="M23 21.5H31" stroke-linecap="round" />
+      <Path d="M39 21.5H47" stroke-linecap="round" />
+      <Path d="M39 13.5V21.5" stroke-linecap="round" />
+      <Path d="M31 13.5V21.5" stroke-linecap="round" />
+      <FlowmeterLabel color={color} />
+    </InternalSVG>
+  </Div>
+);
 
 export interface FlowmeterFloatSensorProps extends DivProps, SVGBasedPrimitiveProps {}
 
@@ -3407,54 +3245,33 @@ export const FlowmeterFloatSensor = ({
   color = "black",
   scale = 1,
   ...props
-}: FlowmeterFloatSensorProps): ReactElement => {
-  const colorStr = Color.cssString(color);
-  return (
-    <Div {...props} className={CSS(CSS.B("flowmeter-FloatSensor"), className)}>
-      <HandleBoundary orientation={orientation}>
-        <Handle
-          location="left"
-          orientation={orientation}
-          left={1.6667}
-          top={50}
-          id="1"
-        />
-        <Handle
-          location="right"
-          orientation={orientation}
-          left={98.3333}
-          top={50}
-          id="2"
-        />
-      </HandleBoundary>
-      <InternalSVG
-        dimensions={{ width: 71, height: 35 }}
-        color={color}
+}: FlowmeterFloatSensorProps): ReactElement => (
+  <Div {...props} className={CSS(CSS.B("flowmeter-FloatSensor"), className)}>
+    <HandleBoundary orientation={orientation}>
+      <Handle location="left" orientation={orientation} left={1.6667} top={50} id="1" />
+      <Handle
+        location="right"
         orientation={orientation}
-        scale={scale}
-      >
-        <Rect x="2" y="2" width="67" height="31" rx="2" />
-        <Path d="M25 8H46" stroke-linecap="round" />
-        <Path d="M31 27H40" stroke-linecap="round" />
-        <Path d="M31 27L25.046 8.11641" stroke-linecap="round" />
-        <Path d="M40 27L45.954 8.11641" stroke-linecap="round" />
-      </InternalSVG>
-      <Text.Text
-        level="p"
-        className={CSS.BE("flowmeter-text", "f")}
-        style={{
-          position: "absolute",
-          top: "70%",
-          right: "7%",
-          transform: "translateY(-50%)",
-          fontSize: `${scale * 10}px`,
-        }}
-      >
-        F
-      </Text.Text>
-    </Div>
-  );
-};
+        left={98.3333}
+        top={50}
+        id="2"
+      />
+    </HandleBoundary>
+    <InternalSVG
+      dimensions={{ width: 71, height: 35 }}
+      color={color}
+      orientation={orientation}
+      scale={scale}
+    >
+      <Rect x="2" y="2" width="67" height="31" rx="2" />
+      <Path d="M25 8H46" stroke-linecap="round" />
+      <Path d="M31 27H40" stroke-linecap="round" />
+      <Path d="M31 27L25.046 8.11641" stroke-linecap="round" />
+      <Path d="M40 27L45.954 8.11641" stroke-linecap="round" />
+      <FlowmeterLabel color={color} />
+    </InternalSVG>
+  </Div>
+);
 
 export interface HeatExchangerGeneralProps extends DivProps, SVGBasedPrimitiveProps {}
 
@@ -3465,46 +3282,37 @@ export const HeatExchangerGeneral = ({
   color = "black",
   scale = 1,
   ...props
-}: HeatExchangerGeneralProps): ReactElement => {
-  const colorStr = Color.cssString(color);
-  return (
-    <Div {...props} className={CSS(CSS.B("heat-exchanger-general"), className)}>
-      <HandleBoundary orientation={orientation}>
-        <Handle
-          location="left"
-          orientation={orientation}
-          left={4.545}
-          top={50}
-          id="1"
-        />
-        <Handle
-          location="right"
-          orientation={orientation}
-          left={95.454}
-          top={50}
-          id="2"
-        />
-        <Handle location="top" orientation={orientation} left={50} top={4.545} id="3" />
-        <Handle
-          location="bottom"
-          orientation={orientation}
-          left={50}
-          top={95.454}
-          id="4"
-        />
-      </HandleBoundary>
-      <InternalSVG
-        dimensions={{ width: 66, height: 66 }}
-        color={color}
+}: HeatExchangerGeneralProps): ReactElement => (
+  <Div {...props} className={CSS(CSS.B("heat-exchanger-general"), className)}>
+    <HandleBoundary orientation={orientation}>
+      <Handle location="left" orientation={orientation} left={4.545} top={50} id="1" />
+      <Handle
+        location="right"
         orientation={orientation}
-        scale={scale}
-      >
-        <Path d="M3 33H18.3956L33.1284 18.1508M33.4276 47.8492L48.1604 33H63M33.278 48V18" />
-        <Path d="M63 33C63 36.9397 62.224 40.8407 60.7164 44.4805C59.2087 48.1203 56.999 51.4274 54.2132 54.2132C51.4274 56.999 48.1203 59.2087 44.4805 60.7164C40.8407 62.224 36.9397 63 33 63C29.0603 63 25.1593 62.224 21.5195 60.7164C17.8797 59.2087 14.5726 56.999 11.7868 54.2132C9.00104 51.4274 6.79125 48.1203 5.28361 44.4805C3.77597 40.8407 3 36.9397 3 33C3 29.0603 3.77597 25.1593 5.28362 21.5195C6.79126 17.8797 9.00104 14.5726 11.7868 11.7868C14.5726 9.00104 17.8797 6.79125 21.5195 5.28361C25.1593 3.77597 29.0603 3 33 3C36.9397 3 40.8407 3.77597 44.4805 5.28362C48.1203 6.79126 51.4274 9.00104 54.2132 11.7868C56.999 14.5726 59.2087 17.8797 60.7164 21.5195C62.224 25.1593 63 29.0603 63 33L63 33Z" />
-      </InternalSVG>
-    </Div>
-  );
-};
+        left={95.454}
+        top={50}
+        id="2"
+      />
+      <Handle location="top" orientation={orientation} left={50} top={4.545} id="3" />
+      <Handle
+        location="bottom"
+        orientation={orientation}
+        left={50}
+        top={95.454}
+        id="4"
+      />
+    </HandleBoundary>
+    <InternalSVG
+      dimensions={{ width: 66, height: 66 }}
+      color={color}
+      orientation={orientation}
+      scale={scale}
+    >
+      <Path d="M3 33H18.3956L33.1284 18.1508M33.4276 47.8492L48.1604 33H63M33.278 48V18" />
+      <Path d="M63 33C63 36.9397 62.224 40.8407 60.7164 44.4805C59.2087 48.1203 56.999 51.4274 54.2132 54.2132C51.4274 56.999 48.1203 59.2087 44.4805 60.7164C40.8407 62.224 36.9397 63 33 63C29.0603 63 25.1593 62.224 21.5195 60.7164C17.8797 59.2087 14.5726 56.999 11.7868 54.2132C9.00104 51.4274 6.79125 48.1203 5.28361 44.4805C3.77597 40.8407 3 36.9397 3 33C3 29.0603 3.77597 25.1593 5.28362 21.5195C6.79126 17.8797 9.00104 14.5726 11.7868 11.7868C14.5726 9.00104 17.8797 6.79125 21.5195 5.28361C25.1593 3.77597 29.0603 3 33 3C36.9397 3 40.8407 3.77597 44.4805 5.28362C48.1203 6.79126 51.4274 9.00104 54.2132 11.7868C56.999 14.5726 59.2087 17.8797 60.7164 21.5195C62.224 25.1593 63 29.0603 63 33L63 33Z" />
+    </InternalSVG>
+  </Div>
+);
 
 export interface HeatExchangerMProps extends DivProps, SVGBasedPrimitiveProps {}
 
@@ -3515,53 +3323,32 @@ export const HeatExchangerM = ({
   color = "black",
   scale = 1,
   ...props
-}: HeatExchangerMProps): ReactElement => {
-  const colorStr = Color.cssString(color);
-  return (
-    <Div {...props} className={CSS(CSS.B("heat-exchanger-M"), className)}>
-      <HandleBoundary orientation={orientation}>
-        <Handle
-          location="right"
-          orientation={orientation}
-          left={89}
-          top={27.27}
-          id="1"
-        />
-        <Handle
-          location="right"
-          orientation={orientation}
-          left={89}
-          top={72.73}
-          id="2"
-        />
-        <Handle location="top" orientation={orientation} left={50} top={4.545} id="3" />
-        <Handle
-          location="bottom"
-          orientation={orientation}
-          left={50}
-          top={95.455}
-          id="4"
-        />
-        <Handle
-          location="left"
-          orientation={orientation}
-          left={4.545}
-          top={50}
-          id="5"
-        />
-      </HandleBoundary>
-      <InternalSVG
-        dimensions={{ width: 66, height: 66 }}
-        color={color}
+}: HeatExchangerMProps): ReactElement => (
+  <Div {...props} className={CSS(CSS.B("heat-exchanger-M"), className)}>
+    <HandleBoundary orientation={orientation}>
+      <Handle location="right" orientation={orientation} left={89} top={27.27} id="1" />
+      <Handle location="right" orientation={orientation} left={89} top={72.73} id="2" />
+      <Handle location="top" orientation={orientation} left={50} top={4.545} id="3" />
+      <Handle
+        location="bottom"
         orientation={orientation}
-        scale={scale}
-      >
-        <Path d="M63 33C63 36.9397 62.224 40.8407 60.7164 44.4805C59.2087 48.1203 56.999 51.4274 54.2132 54.2132C51.4274 56.999 48.1203 59.2087 44.4805 60.7164C40.8407 62.224 36.9397 63 33 63C29.0603 63 25.1593 62.224 21.5195 60.7164C17.8797 59.2087 14.5726 56.999 11.7868 54.2132C9.00104 51.4274 6.79125 48.1203 5.28361 44.4805C3.77597 40.8407 3 36.9397 3 33C3 29.0603 3.77597 25.1593 5.28362 21.5195C6.79126 17.8797 9.00104 14.5726 11.7868 11.7868C14.5726 9.00104 17.8797 6.79125 21.5195 5.28361C25.1593 3.77597 29.0603 3 33 3C36.9397 3 40.8407 3.77597 44.4805 5.28362C48.1203 6.79126 51.4274 9.00104 54.2132 11.7868C56.999 14.5726 59.2087 17.8797 60.7164 21.5195C62.224 25.1593 63 29.0603 63 33L63 33Z" />
-        <Path d="M58.9698 18H23.56L38.5623 33.0023M38.5623 32.9977L23.56 48H58.9698" />
-      </InternalSVG>
-    </Div>
-  );
-};
+        left={50}
+        top={95.455}
+        id="4"
+      />
+      <Handle location="left" orientation={orientation} left={4.545} top={50} id="5" />
+    </HandleBoundary>
+    <InternalSVG
+      dimensions={{ width: 66, height: 66 }}
+      color={color}
+      orientation={orientation}
+      scale={scale}
+    >
+      <Path d="M63 33C63 36.9397 62.224 40.8407 60.7164 44.4805C59.2087 48.1203 56.999 51.4274 54.2132 54.2132C51.4274 56.999 48.1203 59.2087 44.4805 60.7164C40.8407 62.224 36.9397 63 33 63C29.0603 63 25.1593 62.224 21.5195 60.7164C17.8797 59.2087 14.5726 56.999 11.7868 54.2132C9.00104 51.4274 6.79125 48.1203 5.28361 44.4805C3.77597 40.8407 3 36.9397 3 33C3 29.0603 3.77597 25.1593 5.28362 21.5195C6.79126 17.8797 9.00104 14.5726 11.7868 11.7868C14.5726 9.00104 17.8797 6.79125 21.5195 5.28361C25.1593 3.77597 29.0603 3 33 3C36.9397 3 40.8407 3.77597 44.4805 5.28362C48.1203 6.79126 51.4274 9.00104 54.2132 11.7868C56.999 14.5726 59.2087 17.8797 60.7164 21.5195C62.224 25.1593 63 29.0603 63 33L63 33Z" />
+      <Path d="M58.9698 18H23.56L38.5623 33.0023M38.5623 32.9977L23.56 48H58.9698" />
+    </InternalSVG>
+  </Div>
+);
 
 export interface HeatExchangerStraightTubeProps
   extends DivProps,
@@ -3574,56 +3361,47 @@ export const HeatExchangerStraightTube = ({
   color = "black",
   scale = 1,
   ...props
-}: HeatExchangerStraightTubeProps): ReactElement => {
-  const colorStr = Color.cssString(color);
-  return (
-    <Div {...props} className={CSS(CSS.B("heat-exchanger-M"), className)}>
-      <HandleBoundary orientation={orientation}>
-        <Handle location="top" orientation={orientation} left={9} top={6.25} id="1" />
-        <Handle
-          location="bottom"
-          orientation={orientation}
-          left={24}
-          top={93.75}
-          id="2"
-        />
-        <Handle location="top" orientation={orientation} left={76} top={6.25} id="3" />
-        <Handle
-          location="bottom"
-          orientation={orientation}
-          left={91}
-          top={93.75}
-          id="4"
-        />
-        <Handle
-          location="left"
-          orientation={orientation}
-          left={1.508}
-          top={50}
-          id="5"
-        />
-        <Handle
-          location="right"
-          orientation={orientation}
-          left={98.492}
-          top={50}
-          id="6"
-        />
-      </HandleBoundary>
-      <InternalSVG
-        dimensions={{ width: 199, height: 48 }}
-        color={color}
+}: HeatExchangerStraightTubeProps): ReactElement => (
+  <Div {...props} className={CSS(CSS.B("heat-exchanger-M"), className)}>
+    <HandleBoundary orientation={orientation}>
+      <Handle location="top" orientation={orientation} left={9} top={6.25} id="1" />
+      <Handle
+        location="bottom"
         orientation={orientation}
-        scale={scale}
-      >
-        <Rect x="3" y="3" width="193" height="42" rx="1" stroke-width="2" />
-        <Rect x="32.397" y="3" width="134.206" height="42" rx="1" stroke-width="2" />
-        <Rect x="32.397" y="13.5" width="134.206" height="21" rx="1" stroke-width="2" />
-        <Line x1="32.3769" y1="24" x2="166.623" y2="24" stroke-width="2" />
-      </InternalSVG>
-    </Div>
-  );
-};
+        left={24}
+        top={93.75}
+        id="2"
+      />
+      <Handle location="top" orientation={orientation} left={76} top={6.25} id="3" />
+      <Handle
+        location="bottom"
+        orientation={orientation}
+        left={91}
+        top={93.75}
+        id="4"
+      />
+      <Handle location="left" orientation={orientation} left={1.508} top={50} id="5" />
+      <Handle
+        location="right"
+        orientation={orientation}
+        left={98.492}
+        top={50}
+        id="6"
+      />
+    </HandleBoundary>
+    <InternalSVG
+      dimensions={{ width: 199, height: 48 }}
+      color={color}
+      orientation={orientation}
+      scale={scale}
+    >
+      <Rect x="3" y="3" width="193" height="42" rx="1" stroke-width="2" />
+      <Rect x="32.397" y="3" width="134.206" height="42" rx="1" stroke-width="2" />
+      <Rect x="32.397" y="13.5" width="134.206" height="21" rx="1" stroke-width="2" />
+      <Line x1="32.3769" y1="24" x2="166.623" y2="24" stroke-width="2" />
+    </InternalSVG>
+  </Div>
+);
 
 export interface DiaphragmPumpProps extends ToggleProps, SVGBasedPrimitiveProps {}
 


### PR DESCRIPTION
…oning

# Issue Pull Request

## Key Information

- **Linear Issue: Weird Multi-Drag Out in Symbol Previews**: [SY-1786](https://linear.app/synnax/issue/SY-1786/weird-multi-drag-out-in-symbol-previews)
- **Linear Issue: Cylinder Preview is Very Small**: [SY-1785](https://linear.app/synnax/issue/SY-1785/cylinder-preview-is-very-small)
- **Linear Issue: Fix Randomly Appearing F in Previews**: [SY-1784](https://linear.app/synnax/issue/SY-1784/fix-randomly-appearing-f-in-previews)
- **Linear Issue: Fix Tank Endpoint Positioning**: [SY-1782](https://linear.app/synnax/issue/SY-1782/fix-tank-endpoint-positioning)

## Description

Fixes a number of issues related to schematic symbols discovered in v0.37 QA.

1. Dragging out flow symbols from library would cause multiple symbols to appear in preview.
2. Cylinder preview in symbols library was very small.
3. An F would randomly appear in symbols.
4. Tank endpoint positioning was just a little bit off. Fix calculation of endpoint positioning to make for smoother connections. 

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
