### PR TITLE
[pluto] - fixed text box preview alignment

### DIFF
--- a/pluto/src/vis/schematic/Symbols.tsx
+++ b/pluto/src/vis/schematic/Symbols.tsx
@@ -765,12 +765,9 @@ export const Light = ({
   );
 };
 
-export const TextBoxPreview = ({
-  level = "p",
-  width = 100,
-}: SymbolProps<Primitives.TextBoxProps>): ReactElement => (
-  <Primitives.TextBox level={level} width={width} text="Text Box" />
-);
+export const TextBoxPreview = (
+  props: SymbolProps<Primitives.TextBoxProps>,
+): ReactElement => <Primitives.TextBox {...props} autoFit text="Text Box" />;
 
 export interface OffPageReferenceProps
   extends Omit<Primitives.OffPageReferenceProps, "label"> {


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1783](https://linear.app/synnax/issue/SY-1783/align-text-box-preview-in-center)

## Description

Fixes the text box preview in the symbols library so that it remains aligned in the center. 

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
