### PR TITLE
[pluto] - fixed meta data link highlight

### DIFF
--- a/pluto/src/input/Text.tsx
+++ b/pluto/src/input/Text.tsx
@@ -132,8 +132,6 @@ export const Text = forwardRef<HTMLInputElement, TextProps>(
 
     const C = variant === "natural" ? Align.Space : Align.Pack;
 
-    if (color != null) console.log(Color.cssString(color));
-
     return (
       <C
         direction="x"

--- a/pluto/src/input/Text.tsx
+++ b/pluto/src/input/Text.tsx
@@ -24,6 +24,7 @@ export interface TextExtraProps {
   centerPlaceholder?: boolean;
   resetOnBlurIfEmpty?: boolean;
   status?: Status.Variant;
+  outlineColor?: Color.Crude;
   color?: Color.Crude;
 }
 
@@ -66,6 +67,7 @@ export const Text = forwardRef<HTMLInputElement, TextProps>(
       shade,
       weight,
       style,
+      outlineColor,
       color,
       onlyChangeOnBlur = false,
       endContent,
@@ -119,16 +121,18 @@ export const Text = forwardRef<HTMLInputElement, TextProps>(
 
     const combinedRef = useCombinedRefs(ref, internalRef);
 
-    const res = Color.Color.z.safeParse(color);
-    const hasCustomColor = res.success && variant == "outlined";
+    const parsedOutlineColor = Color.Color.z.safeParse(outlineColor);
+    const hasCustomColor = parsedOutlineColor.success && variant == "outlined";
 
     if (variant === "preview") disabled = true;
     if (hasCustomColor)
-      style = { ...style, [CSS.var("input-color")]: res.data.rgbString };
+      style = { ...style, [CSS.var("input-color")]: parsedOutlineColor.data.rgbString };
 
     const showPlaceholder = (value == null || value.length === 0) && tempValue == null;
 
     const C = variant === "natural" ? Align.Space : Align.Pack;
+
+    if (color != null) console.log(Color.cssString(color));
 
     return (
       <C
@@ -181,7 +185,7 @@ export const Text = forwardRef<HTMLInputElement, TextProps>(
             className={CSS(CSS.visible(false), level != null && CSS.BM("text", level))}
             disabled={disabled}
             placeholder={typeof placeholder === "string" ? placeholder : undefined}
-            style={{ fontWeight: weight }}
+            style={{ fontWeight: weight, color: Color.cssString(color) }}
             {...props}
           />
           {endContent != null && (

--- a/pluto/src/vis/schematic/primitives/Primitives.tsx
+++ b/pluto/src/vis/schematic/primitives/Primitives.tsx
@@ -1704,7 +1704,7 @@ export const Setpoint = ({
         showDragHandle={false}
         selectOnFocus
         endContent={units}
-        color={color}
+        outlineColor={color}
         borderWidth={1}
       >
         <CoreButton.Button


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1779](https://linear.app/synnax/issue/SY-1779/fix-metadata-link-highlight)

## Description

Fixes an issue caused by changes to the input element for adding better highlighting to the schematic endpoint. This cause the highlight in the range meta data links to not turn blue. 

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
