### PR TITLE
Sy 1771 bad ontology relationship created on grouped device

### DIFF
--- a/synnax/pkg/distribution/distribution.go
+++ b/synnax/pkg/distribution/distribution.go
@@ -87,8 +87,6 @@ func Open(ctx context.Context, cfg Config) (d Distribution, err error) {
 		return d, err
 	}
 
-	d.Ontology.RegisterService(d.Group)
-
 	nodeOntologySvc := &cluster.NodeOntologyService{
 		Ontology: d.Ontology,
 		Cluster:  d.Cluster,

--- a/synnax/pkg/distribution/ontology/group/service.go
+++ b/synnax/pkg/distribution/ontology/group/service.go
@@ -57,7 +57,9 @@ func OpenService(configs ...Config) (*Service, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &Service{Config: cfg}, nil
+	s := &Service{Config: cfg}
+	cfg.Ontology.RegisterService(s)
+	return s, nil
 }
 
 func (s *Service) CreateOrRetrieve(ctx context.Context, groupName string, parent ontology.ID) (g Group, err error) {

--- a/synnax/pkg/service/hardware/device/device.go
+++ b/synnax/pkg/service/hardware/device/device.go
@@ -12,6 +12,7 @@
 package device
 
 import (
+	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
 	"github.com/synnaxlabs/synnax/pkg/service/hardware/rack"
 	"github.com/synnaxlabs/x/gorp"
 	"github.com/synnaxlabs/x/validate"
@@ -46,6 +47,9 @@ func (d Device) GorpKey() string { return d.Key }
 
 // SetOptions implements gorp.Entry.
 func (d Device) SetOptions() []interface{} { return nil }
+
+// OntologyID returns the unique ID for the device within the ontology.
+func (d Device) OntologyID() ontology.ID { return OntologyID(d.Key) }
 
 // Validate validates the device for creation.
 func (d Device) Validate() error {

--- a/synnax/pkg/service/hardware/device/device_suite_test.go
+++ b/synnax/pkg/service/hardware/device/device_suite_test.go
@@ -1,0 +1,16 @@
+package device_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var ctx context.Context
+
+func TestDevice(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Device Suite")
+}

--- a/synnax/pkg/service/hardware/device/device_test.go
+++ b/synnax/pkg/service/hardware/device/device_test.go
@@ -62,11 +62,11 @@ var _ = Describe("Device", Ordered, func() {
 		It("Should not recreate the device in the ontology if it already exists", func() {
 			d := device.Device{Key: "device3", Rack: 1, Location: "dev3", Name: "Bird"}
 			Expect(w.Create(ctx, d)).To(Succeed())
-			Expect(otg.NewWriter(tx).DeleteRelationship(ctx, svc.RootGroup.OntologyID(), ontology.ParentOf, d.OntologyID())).To(Succeed())
+			Expect(otg.NewWriter(tx).DeleteRelationship(ctx, svc.RootGroup().OntologyID(), ontology.ParentOf, d.OntologyID())).To(Succeed())
 			Expect(w.Create(ctx, d)).To(Succeed())
 			var res ontology.Resource
 			Expect(otg.NewRetrieve().
-				WhereIDs(svc.RootGroup.OntologyID()).
+				WhereIDs(svc.RootGroup().OntologyID()).
 				TraverseTo(ontology.Children).
 				Entry(&res).
 				Exec(ctx, tx),

--- a/synnax/pkg/service/hardware/device/device_test.go
+++ b/synnax/pkg/service/hardware/device/device_test.go
@@ -1,0 +1,134 @@
+package device_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
+	"github.com/synnaxlabs/synnax/pkg/distribution/ontology/group"
+	"github.com/synnaxlabs/synnax/pkg/service/hardware/device"
+	"github.com/synnaxlabs/x/gorp"
+	"github.com/synnaxlabs/x/kv/memkv"
+	"github.com/synnaxlabs/x/query"
+	. "github.com/synnaxlabs/x/testutil"
+)
+
+var _ = Describe("Device", Ordered, func() {
+	var (
+		db  *gorp.DB
+		svc *device.Service
+		g   *group.Service
+		w   device.Writer
+		tx  gorp.Tx
+		otg *ontology.Ontology
+	)
+	BeforeAll(func() {
+		db = gorp.Wrap(memkv.New())
+		otg = MustSucceed(ontology.Open(ctx, ontology.Config{DB: db}))
+		g = MustSucceed(group.OpenService(group.Config{DB: db, Ontology: otg}))
+		svc = MustSucceed(device.OpenService(ctx, device.Config{
+			DB:       db,
+			Ontology: otg,
+			Group:    g,
+		}))
+	})
+	AfterAll(func() {
+		Expect(svc.Close()).To(Succeed())
+		Expect(g.Close()).To(Succeed())
+		Expect(otg.Close()).To(Succeed())
+		Expect(db.Close()).To(Succeed())
+	})
+	BeforeEach(func() {
+		tx = db.OpenTx()
+		w = svc.NewWriter(tx)
+	})
+	AfterEach(func() {
+		Expect(tx.Close()).To(Succeed())
+	})
+	Describe("Create", func() {
+		It("Should correctly create a device", func() {
+			d := device.Device{Key: "device1", Rack: 1, Location: "dev1", Name: "Dog"}
+			Expect(w.Create(ctx, d)).To(Succeed())
+			var res device.Device
+			Expect(svc.NewRetrieve().WhereKeys(d.Key).Entry(&res).Exec(ctx, tx)).To(Succeed())
+			Expect(res.Key).To(Equal(d.Key))
+		})
+		It("Should correctly create an ontology resource for the device", func() {
+			d := device.Device{Key: "device2", Rack: 1, Location: "dev2", Name: "Cat"}
+			Expect(w.Create(ctx, d)).To(Succeed())
+			var res ontology.Resource
+			Expect(otg.NewRetrieve().WhereIDs(d.OntologyID()).Entry(&res).Exec(ctx, tx)).To(Succeed())
+			Expect(res.ID).To(Equal(d.OntologyID()))
+		})
+		It("Should not recreate the device in the ontology if it already exists", func() {
+			d := device.Device{Key: "device3", Rack: 1, Location: "dev3", Name: "Bird"}
+			Expect(w.Create(ctx, d)).To(Succeed())
+			Expect(otg.NewWriter(tx).DeleteRelationship(ctx, svc.RootGroup.OntologyID(), ontology.ParentOf, d.OntologyID())).To(Succeed())
+			Expect(w.Create(ctx, d)).To(Succeed())
+			var res ontology.Resource
+			Expect(otg.NewRetrieve().
+				WhereIDs(svc.RootGroup.OntologyID()).
+				TraverseTo(ontology.Children).
+				Entry(&res).
+				Exec(ctx, tx),
+			).To(MatchError(query.NotFound))
+		})
+	})
+	Describe("Retrieve", func() {
+		It("Should correctly retrieve a device", func() {
+			d := device.Device{Key: "device4", Rack: 1, Location: "dev4", Name: "Fish"}
+			Expect(w.Create(ctx, d)).To(Succeed())
+			var res device.Device
+			Expect(svc.NewRetrieve().WhereKeys(d.Key).Entry(&res).Exec(ctx, tx)).To(Succeed())
+			Expect(res.Key).To(Equal(d.Key))
+		})
+		It("Should retrieve devices by their model", func() {
+			d1 := device.Device{Key: "device5", Rack: 1, Location: "dev5", Name: "Fish", Model: "A"}
+			d2 := device.Device{Key: "device6", Rack: 1, Location: "dev6", Name: "Fish", Model: "B"}
+			d2b := device.Device{Key: "device7", Rack: 1, Location: "dev7", Name: "Fish", Model: "B"}
+			Expect(w.Create(ctx, d1)).To(Succeed())
+			Expect(w.Create(ctx, d2)).To(Succeed())
+			Expect(w.Create(ctx, d2b)).To(Succeed())
+			var res []device.Device
+			Expect(svc.NewRetrieve().WhereModels("B").Entries(&res).Exec(ctx, tx)).To(Succeed())
+			Expect(res).To(ConsistOf(d2, d2b))
+		})
+		It("Should retrieve devices by their make", func() {
+			d1 := device.Device{Key: "device8", Rack: 1, Location: "dev8", Name: "Fish", Make: "A"}
+			d2 := device.Device{Key: "device9", Rack: 1, Location: "dev9", Name: "Fish", Make: "B"}
+			d2b := device.Device{Key: "device10", Rack: 1, Location: "dev10", Name: "Fish", Make: "B"}
+			Expect(w.Create(ctx, d1)).To(Succeed())
+			Expect(w.Create(ctx, d2)).To(Succeed())
+			Expect(w.Create(ctx, d2b)).To(Succeed())
+			var res []device.Device
+			Expect(svc.NewRetrieve().WhereMakes("B").Entries(&res).Exec(ctx, tx)).To(Succeed())
+			Expect(res).To(ConsistOf(d2, d2b))
+		})
+		It("Should retrieve devices by their location", func() {
+			d1 := device.Device{Key: "device11", Rack: 1, Location: "dev11", Name: "Fish"}
+			d2 := device.Device{Key: "device12", Rack: 1, Location: "dev12", Name: "Fish"}
+			d2b := device.Device{Key: "device13", Rack: 1, Location: "dev13", Name: "Fish"}
+			Expect(w.Create(ctx, d1)).To(Succeed())
+			Expect(w.Create(ctx, d2)).To(Succeed())
+			Expect(w.Create(ctx, d2b)).To(Succeed())
+			var res []device.Device
+			Expect(svc.NewRetrieve().WhereLocations("dev12").Entries(&res).Exec(ctx, tx)).To(Succeed())
+			Expect(res).To(ConsistOf(d2))
+		})
+	})
+	Describe("Delete", func() {
+		It("Should correctly delete a device", func() {
+			d := device.Device{Key: "device14", Rack: 1, Location: "dev14", Name: "Fish"}
+			Expect(w.Create(ctx, d)).To(Succeed())
+			Expect(w.Delete(ctx, d.Key)).To(Succeed())
+			var res device.Device
+			Expect(svc.NewRetrieve().WhereKeys(d.Key).Entry(&res).Exec(ctx, tx)).To(MatchError(query.NotFound))
+		})
+		It("Should correctly delete an ontology resource for the device", func() {
+			d := device.Device{Key: "device15", Rack: 1, Location: "dev15", Name: "Fish"}
+			Expect(w.Create(ctx, d)).To(Succeed())
+			Expect(w.Delete(ctx, d.Key)).To(Succeed())
+			var res ontology.Resource
+			Expect(otg.NewRetrieve().WhereIDs(d.OntologyID()).Entry(&res).Exec(ctx, tx)).To(MatchError(query.NotFound))
+		})
+	})
+})

--- a/synnax/pkg/service/hardware/device/service.go
+++ b/synnax/pkg/service/hardware/device/service.go
@@ -50,14 +50,14 @@ func (c Config) Validate() error {
 	v := validate.New("workspace")
 	validate.NotNil(v, "db", c.DB)
 	validate.NotNil(v, "ontology", c.Ontology)
-	validate.NotNil(v, "group", c.Group)
+	validate.NotNil(v, "RootGroup", c.Group)
 	return v.Error()
 }
 
 type Service struct {
 	Config
 	shutdownSignals io.Closer
-	group           group.Group
+	RootGroup       group.Group
 }
 
 const groupName = "Devices"
@@ -71,7 +71,7 @@ func OpenService(ctx context.Context, configs ...Config) (s *Service, err error)
 	if err != nil {
 		return
 	}
-	s = &Service{Config: cfg, group: g}
+	s = &Service{Config: cfg, RootGroup: g}
 	cfg.Ontology.RegisterService(s)
 	if cfg.Signals == nil {
 		return s, nil
@@ -95,7 +95,7 @@ func (s *Service) NewWriter(tx gorp.Tx) Writer {
 	return Writer{
 		tx:    gorp.OverrideTx(s.DB, tx),
 		otg:   s.Ontology.NewWriter(tx),
-		group: s.group,
+		group: s.RootGroup,
 	}
 }
 

--- a/synnax/pkg/service/hardware/rack/rack_test.go
+++ b/synnax/pkg/service/hardware/rack/rack_test.go
@@ -48,7 +48,7 @@ var _ = Describe("Rack", Ordered, func() {
 	AfterEach(func() {
 		Expect(tx.Close()).To(Succeed())
 	})
-	Describe("Task", func() {
+	Describe("Key", func() {
 		It("Should correctly construct and deconstruct key from its components", func() {
 			k := rack.NewKey(1, 2)
 			Expect(k.Node()).To(Equal(core.NodeKey(1)))


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1771](https://linear.app/synnax/issue/SY-1771/bad-ontology-relationship-created-on-grouped-device)

## Description

Fixes an issue where grouping a device before configuring it caused duplicate ontology relationships to appear. Also supplements device test cases.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
