### PR TITLE
SY-1787 Prevent Snapshot of Schematics from Toolbar Outside of Workspace

### DIFF
--- a/console/src/schematic/toolbar/Toolbar.tsx
+++ b/console/src/schematic/toolbar/Toolbar.tsx
@@ -103,7 +103,10 @@ export const Toolbar = ({ layoutKey }: ToolbarProps): ReactElement | null => {
   );
   const client = Synnax.use();
   useAsyncEffect(async () => {
-    if (client == null || existsOnServer) return;
+    if (client == null) {
+      setExistsOnServer(false);
+      return;
+    }
     try {
       const schematic = await client.workspaces.schematic.retrieve(layoutKey);
       setExistsOnServer(schematic.key === layoutKey);


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1787](https://linear.app/synnax/issue/SY-1787/prevent-snapshot-of-schematics-outside-of-workspace-in-toolbar)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Added a short useEffect in schematic toolbar to check if a schematic exists on server

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
