### PR TITLE
Sy 1792 minified react error 310 when opening workspace from search

### DIFF
--- a/console/src/log/Toolbar.tsx
+++ b/console/src/log/Toolbar.tsx
@@ -28,9 +28,9 @@ export const Toolbar = ({ layoutKey }: ToolbarProps): ReactElement | null => {
   const d = useSyncComponent(layoutKey);
   const { name } = Layout.useSelectRequired(layoutKey);
   const state = useSelectOptional(layoutKey);
-  if (state == null) return null;
   const handleChannelChange = (v: channel.Key) =>
     d(setChannels({ key: layoutKey, channels: [v ?? 0] }));
+  if (state == null) return null;
   return (
     <>
       <ToolbarHeader>

--- a/console/src/schematic/toolbar/Toolbar.tsx
+++ b/console/src/schematic/toolbar/Toolbar.tsx
@@ -104,7 +104,6 @@ export const Toolbar = ({ layoutKey }: ToolbarProps): ReactElement | null => {
   }, [snapshot, name, layoutKey]);
 
   const canEdit = useSelectHasPermission();
-  if (state == null) return null;
   const breadCrumbSegments: Breadcrumb.Segments = [
     {
       label: name,
@@ -124,6 +123,8 @@ export const Toolbar = ({ layoutKey }: ToolbarProps): ReactElement | null => {
 
   const activeRange = Range.useSelect();
   const hasActiveRange = activeRange != null;
+
+  if (state == null) return null;
 
   return (
     <Tabs.Provider


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1792](https://linear.app/synnax/issue/SY-1792/minified-react-error-310-when-opening-workspace-from-search-bar)

## Description

We were conditionally returning before a hook call in the schematic toolbar.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
