### PR TITLE
SY-1776 Add Group Item to Visualization Context Menus

### DIFF
--- a/console/src/group/ontology.tsx
+++ b/console/src/group/ontology.tsx
@@ -70,13 +70,7 @@ const TreeContextMenu: Ontology.TreeContextMenu = (props) => {
   );
 };
 
-export const UngroupMenuItem = (): ReactElement => (
-  <PMenu.Item itemKey="ungroup" startIcon={<Icon.Group />}>
-    Ungroup
-  </PMenu.Item>
-);
-
-const createNewID = (): ontology.ID => new ontology.ID({ type: "group", key: uuid() });
+const createNewID = (): ontology.ID => group.ontologyID(uuid());
 
 export interface GroupMenuItemProps {
   selection: Ontology.TreeContextMenuProps["selection"];

--- a/console/src/lineplot/services/ontology.tsx
+++ b/console/src/lineplot/services/ontology.tsx
@@ -14,6 +14,7 @@ import { errors } from "@synnaxlabs/x";
 import { useMutation } from "@tanstack/react-query";
 
 import { Menu } from "@/components/menu";
+import { Group } from "@/group";
 import { Layout } from "@/layout";
 import { useExport } from "@/lineplot/file";
 import { create } from "@/lineplot/LinePlot";
@@ -56,7 +57,10 @@ const useDelete = (): ((props: Ontology.TreeContextMenuProps) => void) => {
 };
 
 const TreeContextMenu: Ontology.TreeContextMenu = (props) => {
-  const { resources } = props.selection;
+  const {
+    selection,
+    selection: { resources },
+  } = props;
   const del = useDelete();
   const handleLink = Link.useCopyToClipboard();
   const handleExport = useExport(resources[0].name);
@@ -64,10 +68,7 @@ const TreeContextMenu: Ontology.TreeContextMenu = (props) => {
     delete: () => del(props),
     rename: () => Tree.startRenaming(resources[0].key),
     link: () =>
-      handleLink({
-        name: resources[0].name,
-        ontologyID: resources[0].id.payload,
-      }),
+      handleLink({ name: resources[0].name, ontologyID: resources[0].id.payload }),
     export: () => handleExport(resources[0].id.key),
   };
   const isSingle = resources.length === 1;
@@ -79,6 +80,7 @@ const TreeContextMenu: Ontology.TreeContextMenu = (props) => {
           <PMenu.Divider />
         </>
       )}
+      <Group.GroupMenuItem selection={selection} />
       <PMenu.Item itemKey="delete" startIcon={<Icon.Delete />}>
         Delete
       </PMenu.Item>
@@ -137,10 +139,7 @@ const handleMosaicDrop: Ontology.HandleMosaicDrop = ({
           key: linePlot.key,
           name: linePlot.name,
           location: "mosaic",
-          tab: {
-            mosaicKey: nodeKey,
-            location,
-          },
+          tab: { mosaicKey: nodeKey, location },
         }),
       );
     } catch (err) {
@@ -157,12 +156,7 @@ export const ONTOLOGY_SERVICE: Ontology.Service = {
   type: "lineplot",
   icon: <Icon.Visualize />,
   hasChildren: false,
-  haulItems: (r) => [
-    {
-      type: Mosaic.HAUL_CREATE_TYPE,
-      key: r.id.toString(),
-    },
-  ],
+  haulItems: (r) => [{ type: Mosaic.HAUL_CREATE_TYPE, key: r.id.toString() }],
   allowRename: () => true,
   onRename: handleRename,
   canDrop: () => false,

--- a/console/src/log/services/ontology.tsx
+++ b/console/src/log/services/ontology.tsx
@@ -14,6 +14,7 @@ import { errors } from "@synnaxlabs/x";
 import { useMutation } from "@tanstack/react-query";
 
 import { Menu } from "@/components/menu";
+import { Group } from "@/group";
 import { useAsyncActionMenu } from "@/hooks/useAsyncAction";
 import { Layout } from "@/layout";
 import { Link } from "@/link";
@@ -56,6 +57,7 @@ const useDelete = (): ((props: Ontology.TreeContextMenuProps) => void) => {
 
 const TreeContextMenu: Ontology.TreeContextMenu = (props) => {
   const {
+    selection,
     selection: { resources },
   } = props;
   const del = useDelete();
@@ -64,16 +66,14 @@ const TreeContextMenu: Ontology.TreeContextMenu = (props) => {
     delete: () => del(props),
     rename: () => Tree.startRenaming(resources[0].key),
     link: () =>
-      handleLink({
-        name: resources[0].name,
-        ontologyID: resources[0].id.payload,
-      }),
+      handleLink({ name: resources[0].name, ontologyID: resources[0].id.payload }),
   });
   const isSingle = resources.length === 1;
   return (
     <PMenu.Menu onChange={onSelect} level="small" iconSpacing="small">
       <Menu.RenameItem />
       <Menu.DeleteItem />
+      <Group.GroupMenuItem selection={selection} />
       <PMenu.Divider />
       {isSingle && (
         <>
@@ -128,10 +128,7 @@ const handleMosaicDrop: Ontology.HandleMosaicDrop = ({
           ...(log.data as unknown as Log.State),
           key: id.key,
           location: "mosaic",
-          tab: {
-            mosaicKey: nodeKey,
-            location,
-          },
+          tab: { mosaicKey: nodeKey, location },
         }),
       );
     } catch (err) {
@@ -148,12 +145,7 @@ export const ONTOLOGY_SERVICE: Ontology.Service = {
   type: "log",
   icon: <Icon.Log />,
   hasChildren: false,
-  haulItems: (r) => [
-    {
-      type: Mosaic.HAUL_CREATE_TYPE,
-      key: r.id.toString(),
-    },
-  ],
+  haulItems: (r) => [{ type: Mosaic.HAUL_CREATE_TYPE, key: r.id.toString() }],
   allowRename: () => true,
   onRename: handleRename,
   canDrop: () => false,

--- a/console/src/schematic/services/ontology.tsx
+++ b/console/src/schematic/services/ontology.tsx
@@ -14,6 +14,7 @@ import { errors } from "@synnaxlabs/x";
 import { useMutation } from "@tanstack/react-query";
 
 import { Menu } from "@/components/menu";
+import { Group } from "@/group";
 import { useAsyncActionMenu } from "@/hooks/useAsyncAction";
 import { Layout } from "@/layout";
 import { Link } from "@/link";
@@ -106,6 +107,7 @@ const useSnapshot = (): ((props: Ontology.TreeContextMenuProps) => void) => {
 
 const TreeContextMenu: Ontology.TreeContextMenu = (props) => {
   const {
+    selection,
     selection: { resources },
   } = props;
   const activeRange = Range.useSelect();
@@ -131,6 +133,7 @@ const TreeContextMenu: Ontology.TreeContextMenu = (props) => {
         <>
           <Menu.RenameItem />
           <Menu.DeleteItem />
+          <Group.GroupMenuItem selection={selection} />
           <PMenu.Divider />
         </>
       )}

--- a/console/src/table/services/ontology.tsx
+++ b/console/src/table/services/ontology.tsx
@@ -14,6 +14,7 @@ import { errors } from "@synnaxlabs/x";
 import { useMutation } from "@tanstack/react-query";
 
 import { Menu } from "@/components/menu";
+import { Group } from "@/group";
 import { useAsyncActionMenu } from "@/hooks/useAsyncAction";
 import { Layout } from "@/layout";
 import { Link } from "@/link";
@@ -56,6 +57,7 @@ const useDelete = (): ((props: Ontology.TreeContextMenuProps) => void) => {
 
 const TreeContextMenu: Ontology.TreeContextMenu = (props) => {
   const {
+    selection,
     selection: { resources },
   } = props;
   const del = useDelete();
@@ -64,16 +66,14 @@ const TreeContextMenu: Ontology.TreeContextMenu = (props) => {
     delete: () => del(props),
     rename: () => Tree.startRenaming(resources[0].key),
     link: () =>
-      handleLink({
-        name: resources[0].name,
-        ontologyID: resources[0].id.payload,
-      }),
+      handleLink({ name: resources[0].name, ontologyID: resources[0].id.payload }),
   });
   const isSingle = resources.length === 1;
   return (
     <PMenu.Menu onChange={onSelect} level="small" iconSpacing="small">
       <Menu.RenameItem />
       <Menu.DeleteItem />
+      <Group.GroupMenuItem selection={selection} />
       <PMenu.Divider />
       {isSingle && (
         <>
@@ -132,10 +132,7 @@ const handleMosaicDrop: Ontology.HandleMosaicDrop = ({
           ...(table.data as unknown as Table.State),
           key: id.key,
           location: "mosaic",
-          tab: {
-            mosaicKey: nodeKey,
-            location,
-          },
+          tab: { mosaicKey: nodeKey, location },
         }),
       );
     } catch (err) {
@@ -152,12 +149,7 @@ export const ONTOLOGY_SERVICE: Ontology.Service = {
   type: "table",
   icon: <Icon.Table />,
   hasChildren: false,
-  haulItems: (r) => [
-    {
-      type: Mosaic.HAUL_CREATE_TYPE,
-      key: r.id.toString(),
-    },
-  ],
+  haulItems: (r) => [{ type: Mosaic.HAUL_CREATE_TYPE, key: r.id.toString() }],
   allowRename: () => true,
   onRename: handleRename,
   canDrop: () => false,


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1776](https://linear.app/synnax/issue/SY-1776/add-group-context-menu-item-to-visualizations)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Add group item to visualization context menu and format some code.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
