### PR TITLE
SY 1769 - Remove Focus Trap

### DIFF
--- a/console/src/layout/Modal.tsx
+++ b/console/src/layout/Modal.tsx
@@ -45,7 +45,6 @@ export const Modal = ({ state, remove, centered, root }: ModalProps) => {
         close={() => remove(key)}
         style={layoutCSS(window)}
         root={root}
-        trapFocus
       >
         {window?.navTop && (
           <Nav.Bar location="top" size="6rem">

--- a/pluto/package.json
+++ b/pluto/package.json
@@ -26,7 +26,6 @@
     "compromise": "^14.14.3",
     "compromise-dates": "^3.7.0",
     "d3-scale": "^4.0.2",
-    "focus-trap-react": "^11.0.1",
     "fuse.js": "^7.0.0",
     "mathjs": "^14.0.1",
     "proxy-memoize": "2.0.3",

--- a/pluto/src/modal/Modal.tsx
+++ b/pluto/src/modal/Modal.tsx
@@ -18,7 +18,6 @@ import { type Dialog as Core } from "@/dialog";
 import { useClickOutside } from "@/hooks";
 import { Triggers } from "@/triggers";
 import { findParent } from "@/util/findParent";
-import { FocusTrap } from "@/util/FocusTrap";
 import { getRootElement } from "@/util/rootElement";
 
 export interface ModalProps
@@ -26,7 +25,6 @@ export interface ModalProps
     Align.SpaceProps {
   centered?: boolean;
   enabled?: boolean;
-  trapFocus?: boolean;
   root?: string;
 }
 
@@ -35,7 +33,6 @@ export const Dialog = ({
   centered,
   visible,
   enabled = true,
-  trapFocus = true,
   close,
   style,
   ...props
@@ -82,11 +79,9 @@ export const Dialog = ({
         {...props}
         style={{ zIndex: enabled ? 11 : undefined, ...style }}
       >
-        <FocusTrap disabled={!trapFocus || !enabled}>
-          <Align.Space className={CSS(CSS.BE("modal", "content"))} empty>
-            {children}
-          </Align.Space>
-        </FocusTrap>
+        <Align.Space className={CSS(CSS.BE("modal", "content"))} empty>
+          {children}
+        </Align.Space>
       </Align.Space>
     </Align.Space>
   );

--- a/pluto/src/util/FocusTrap.tsx
+++ b/pluto/src/util/FocusTrap.tsx
@@ -1,8 +1,0 @@
-import { FocusTrap as FocusTrapReact, type FocusTrapProps } from "focus-trap-react";
-import { type FC } from "react";
-
-import { canDisable } from "@/util/canDisable";
-
-export const FocusTrap = canDisable<FocusTrapProps>(
-  FocusTrapReact as unknown as FC<FocusTrapProps>,
-);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -623,9 +623,6 @@ importers:
       d3-scale:
         specifier: ^4.0.2
         version: 4.0.2
-      focus-trap-react:
-        specifier: ^11.0.1
-        version: 11.0.1(@types/react-dom@19.0.2(@types/react@19.0.1))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       fuse.js:
         specifier: ^7.0.0
         version: 7.0.0
@@ -3362,17 +3359,6 @@ packages:
     resolution: {integrity: sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==}
     engines: {node: '>=8'}
 
-  focus-trap-react@11.0.1:
-    resolution: {integrity: sha512-vxv2lglW41sBgREiVbWUMf0QzCDn84lCQhfdyELNPkfsH2VdB3XheEYBk2HK/XhpghBtbkXCGORPX6otehi+uw==}
-    peerDependencies:
-      '@types/react': ^19.0.1
-      '@types/react-dom': ^19.0.2
-      react: ^19.0.0
-      react-dom: ^19.0.0
-
-  focus-trap@7.6.2:
-    resolution: {integrity: sha512-9FhUxK1hVju2+AiQIDJ5Dd//9R2n2RAfJ0qfhF4IHGHgcoEUTMpbTeG/zbEuwaiYXfuAH6XE0/aCyxDdRM+W5w==}
-
   for-each@0.3.3:
     resolution: {integrity: sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==}
 
@@ -5059,9 +5045,6 @@ packages:
 
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
-
-  tabbable@6.2.0:
-    resolution: {integrity: sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==}
 
   table@6.9.0:
     resolution: {integrity: sha512-9kY+CygyYM6j02t5YFHbNz2FN5QmYGv9zAjVp4lCDjlCw7amdckXlEt/bjMhUIfj4ThGRE4gCUH5+yGnNuPo5A==}
@@ -8673,19 +8656,6 @@ snapshots:
 
   flattie@1.1.1: {}
 
-  focus-trap-react@11.0.1(@types/react-dom@19.0.2(@types/react@19.0.1))(@types/react@19.0.1)(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
-    dependencies:
-      '@types/react': 19.0.1
-      '@types/react-dom': 19.0.2(@types/react@19.0.1)
-      focus-trap: 7.6.2
-      react: 19.0.0
-      react-dom: 19.0.0(react@19.0.0)
-      tabbable: 6.2.0
-
-  focus-trap@7.6.2:
-    dependencies:
-      tabbable: 6.2.0
-
   for-each@0.3.3:
     dependencies:
       is-callable: 1.2.7
@@ -10923,8 +10893,6 @@ snapshots:
   svg-tags@1.0.0: {}
 
   symbol-tree@3.2.4: {}
-
-  tabbable@6.2.0: {}
 
   table@6.9.0:
     dependencies:


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1769](https://linear.app/synnax/issue/SY-1769/enter-key-causes-delete-modal-to-close-prematurely)

## Description

Removes the focus trap dependency until we can better handle side effects.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
