### PR TITLE
[pluto] - fixed issues with bad box shadows under different themes

### DIFF
--- a/pluto/src/theming/Provider.tsx
+++ b/pluto/src/theming/Provider.tsx
@@ -11,7 +11,7 @@ import "@/theming/theme.css";
 
 import geistMono from "@fontsource/geist-mono/files/geist-mono-latin-400-normal.woff2";
 import interWoff from "@fontsource-variable/inter/files/inter-latin-standard-normal.woff2";
-import { deep } from "@synnaxlabs/x";
+import { caseconv, deep } from "@synnaxlabs/x";
 import {
   createContext,
   type PropsWithChildren,
@@ -121,6 +121,14 @@ export interface ProviderProps extends PropsWithChildren<unknown>, UseProviderPr
   defaultTheme?: string;
 }
 
+const CLASS_PREFIX = "pluto-theme-";
+
+const setThemeClass = (el: HTMLElement, theme: theming.Theme): void => {
+  const existing = Array.from(el.classList).find((c) => c.startsWith(CLASS_PREFIX));
+  if (existing != null) el.classList.remove(existing);
+  el.classList.add(`${CLASS_PREFIX}${caseconv.toKebab(theme.key)}`);
+};
+
 export const Provider = Aether.wrap<ProviderProps>(
   theming.Provider.TYPE,
   ({ children, aetherKey, applyCSSVars = true, ...props }): ReactElement => {
@@ -147,8 +155,10 @@ export const Provider = Aether.wrap<ProviderProps>(
     useEffect(() => setAetherTheme((p) => ({ ...p, theme: ret.theme })), [ret.theme]);
 
     useLayoutEffect(() => {
-      if (applyCSSVars) CSS.applyVars(document.documentElement, toCSSVars(ret.theme));
-      else CSS.removeVars(document.documentElement, "--pluto");
+      const el = document.documentElement;
+      setThemeClass(el, ret.theme);
+      if (applyCSSVars) CSS.applyVars(el, toCSSVars(ret.theme));
+      else CSS.removeVars(el, "--pluto");
     }, [ret.theme]);
     return (
       <Context.Provider value={ret}>

--- a/pluto/src/theming/theme.css
+++ b/pluto/src/theming/theme.css
@@ -26,12 +26,16 @@ button:is(:focus, :focus-within, :active, :hover) {
     --pluto-height-medium: 4.5rem;
     --pluto-height-small: 4rem;
     --pluto-height-huge: 8rem;
+}
+
+.pluto-theme-synnax-light {
     --pluto-shadow-menu: 0px 1px 1px rgba(0, 0, 0, 0.02),
         0px 4px 8px -4px rgba(0, 0, 0, 0.04), 0px 16px 24px -8px rgba(0, 0, 0, 0.06);
-    @media (prefers-color-scheme: dark) {
-        --pluto-shadow-menu: lch(0 0 0 / 0.188) 0px 3px 8px,
-            lch(0 0 0 / 0.188) 0px 2px 5px, lch(0 0 0 / 0.188) 0px 1px 1px;
-    }
+}
+
+.pluto-theme-synnax-dark {
+    --pluto-shadow-menu: lch(0 0 0 / 0.188) 0px 3px 8px, lch(0 0 0 / 0.188) 0px 2px 5px,
+        lch(0 0 0 / 0.188) 0px 1px 1px;
 }
 
 html {

--- a/x/ts/src/caseconv/caseconv.spec.ts
+++ b/x/ts/src/caseconv/caseconv.spec.ts
@@ -127,4 +127,20 @@ describe("caseconv", () => {
       });
     });
   });
+  describe("toKebab", () => {
+    const SPECS: [string, string][] = [
+      ["fooBar", "foo-bar"],
+      ["fooBarBaz", "foo-bar-baz"],
+      ["foo bar", "foo-bar"],
+      ["foo bar baz", "foo-bar-baz"],
+      ["foo.bar", "foo.bar"],
+      ["foo.bar.baz", "foo.bar.baz"],
+      ["Foo Bar", "foo-bar"],
+    ];
+    SPECS.forEach(([input, expected]) => {
+      it(`should convert ${input} to ${expected}`, () => {
+        expect(caseconv.toKebab(input)).toBe(expected);
+      });
+    });
+  });
 });

--- a/x/ts/src/caseconv/caseconv.ts
+++ b/x/ts/src/caseconv/caseconv.ts
@@ -77,6 +77,13 @@ const camelToSnakeStr = (str: string): string =>
   // Don't convert the first character and don't convert a character that is after a
   // non-alphanumeric character
   str.replace(/([a-z0-9])([A-Z])/g, (_, p1, p2) => `${p1}_${p2.toLowerCase()}`);
+
+/**
+ * Converts a camelCase string to snake_case.
+ *
+ * @param str - The string to convert
+ * @returns The converted string in snake_case
+ */
 export const camelToSnake = createConverter(camelToSnakeStr);
 
 /**
@@ -109,22 +116,44 @@ export interface Options {
 /**
  * Default options for convert function. This option is not recursive.
  */
-export const defaultOptions: Options = {
+const defaultOptions: Options = {
   recursive: true,
   recursiveInArray: true,
   keepTypesOnRecursion: [Number, String, Uint8Array],
 };
 
-export const validateOptions = (opt: Options = defaultOptions): Options => {
+const validateOptions = (opt: Options = defaultOptions): Options => {
   if (opt.recursive == null) opt = defaultOptions;
   else opt.recursiveInArray ??= false;
   return opt;
 };
 
-export const isArrayObject = (obj: any): boolean => obj != null && Array.isArray(obj);
+const isArrayObject = (obj: any): boolean => obj != null && Array.isArray(obj);
 
-export const isValidObject = (obj: any): boolean =>
+const isValidObject = (obj: any): boolean =>
   obj != null && typeof obj === "object" && !Array.isArray(obj);
 
-export const belongToTypes = (obj: any, types?: any[]): boolean =>
+const belongToTypes = (obj: any, types?: any[]): boolean =>
   (types || []).some((Type) => obj instanceof Type);
+
+/**
+ * Converts a string to kebab-case.
+ * Handles spaces, camelCase, and uppercase characters.
+ *
+ * @param str - The string to convert
+ * @returns The converted string in kebab-case
+ */
+const toKebabStr = (str: string): string =>
+  str
+    .replace(/\s+/g, "-")
+    .replace(/([a-z0-9])([A-Z])/g, (_, p1, p2) => `${p1}-${p2.toLowerCase()}`)
+    .toLowerCase();
+
+/**
+ * Converts a string to kebab-case.
+ * Handles spaces, camelCase, and uppercase characters.
+ *
+ * @param str - The string to convert
+ * @returns The converted string in kebab-case
+ */
+export const toKebab = createConverter(toKebabStr);


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1797](https://linear.app/synnax/issue/SY-1797/fix-box-shadows-on-windows)

## Description

Fixes bad box shadows when toggling the color theme on windows.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
