### PR TITLE
[pluto] - fixed input onChange handler firing on empty strings

### DIFF
--- a/pluto/src/input/Input.spec.tsx
+++ b/pluto/src/input/Input.spec.tsx
@@ -87,6 +87,18 @@ describe("Input", () => {
       fireEvent.blur(input as HTMLInputElement);
       expect(onChange).not.toHaveBeenCalled();
     });
+    it("should not call the onChange handler when the user inputs a *", () => {
+      const onChange = vi.fn();
+      const c = render(
+        <Input.Numeric value={0} placeholder="Hello" onChange={onChange} />,
+      );
+      expect(onChange).not.toHaveBeenCalled();
+      const input = c.getByDisplayValue("0");
+      expect(input).not.toBeUndefined();
+      fireEvent.change(input as HTMLInputElement, { target: { value: '""' } });
+      fireEvent.blur(input as HTMLInputElement);
+      expect(onChange).not.toHaveBeenCalled();
+    });
     it("should correctly evaluate a mathematical expression", () => {
       const onChange = vi.fn();
       const c = render(

--- a/pluto/src/input/Numeric.tsx
+++ b/pluto/src/input/Numeric.tsx
@@ -88,7 +88,7 @@ export const Numeric = forwardRef<HTMLInputElement, NumericProps>(
         const ev = evaluate(internalValueRef.current);
         // Sometimes mathjs returns a Unit object, so we need to convert it to a number.
         if (ev instanceof Unit) v = ev.toNumber();
-        else if (!isNaN(ev)) v = ev;
+        else if (typeof ev === "number" && !isNaN(ev)) v = ev;
       } catch {
         v = null;
       }


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1799](https://linear.app/synnax/issue/SY-1799/entering-string-in-setpoint-causes-crash)

## Description

Turns out that you could enter quotations into the numeric input (`""`) and it would call the `onChange` handler with an empty string. This PR fixes that. 

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
