### PR TITLE
[pluto] - fixed issues with bad writer commit on control release for …

### DIFF
--- a/pluto/src/telem/control/aether/controller.ts
+++ b/pluto/src/telem/control/aether/controller.ts
@@ -20,6 +20,7 @@ import {
   control as xControl,
   type CrudeSeries,
   type Destructor,
+  TimeSpan,
 } from "@synnaxlabs/x";
 import { z } from "zod";
 
@@ -92,11 +93,11 @@ export class Controller
 
     // Acquire or release control if necessary.
     if (this.state.acquireTrigger > this.internal.prevTrigger) {
+      this.internal.prevTrigger = this.state.acquireTrigger;
       void this.acquire();
-      this.internal.prevTrigger = this.state.acquireTrigger;
     } else if (this.state.acquireTrigger < this.internal.prevTrigger) {
-      void this.release();
       this.internal.prevTrigger = this.state.acquireTrigger;
+      void this.release();
     }
   }
 
@@ -140,8 +141,12 @@ export class Controller
           variant: "warning",
         });
 
+      // Subtracting 1 millisecond makes sure that we avoid accidentally
+      // setting the start timestamp over the writer earlier than the first
+      // sample we write, preventing a validation error when releasing control.
+      const start = TimeStamp.now().sub(TimeSpan.milliseconds(1));
       this.writer = await client.openWriter({
-        start: TimeStamp.now(),
+        start,
         channels: needsControlOf,
         controlSubject: { key: this.key, name: this.state.name },
         authorities: this.state.authority,

--- a/pluto/src/telem/control/aether/controller.ts
+++ b/pluto/src/telem/control/aether/controller.ts
@@ -143,7 +143,8 @@ export class Controller
 
       // Subtracting 1 millisecond makes sure that we avoid accidentally
       // setting the start timestamp over the writer earlier than the first
-      // sample we write, preventing a validation error when releasing control.
+      // sample we write, preventing a validation error when releasing control. We
+      // choose 1 ms because it is the resolution of a JS timestamp.
       const start = TimeStamp.now().sub(TimeSpan.milliseconds(1));
       this.writer = await client.openWriter({
         start,


### PR DESCRIPTION
…the console schematic

# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1801](https://linear.app/synnax/issue/SY-1801/issue-releasing-control-on-early-commit-timestamp)

## Description

When you "auto-acquire" control on the schematic by clicking an interactive element, the writer start timestamp would sometimes be 1 millisecond later than the first sample timestamp, which would result in a commit failure. This PR shifts the writer start timestamp back by 1 millisecond in the aether telem controller to compensate.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
