### PR TITLE
Sy 1805 fix setpoint over activating

### DIFF
--- a/.vscode/synnax.code-workspace
+++ b/.vscode/synnax.code-workspace
@@ -244,6 +244,7 @@
       "Swatinem",
       "syncer",
       "Syncer",
+      "synnax",
       "Synnax",
       "synnaxlabs",
       "tauri",

--- a/pluto/src/telem/control/aether/controller.ts
+++ b/pluto/src/telem/control/aether/controller.ts
@@ -91,18 +91,9 @@ export class Controller
     this.internal.addStatus = status.useAggregate(this.ctx);
 
     // Acquire or release control if necessary.
-<<<<<<< Updated upstream
-    if (this.state.acquireTrigger > this.internal.prevTrigger) {
-      void this.acquire();
-      this.internal.prevTrigger = this.state.acquireTrigger;
-    } else if (this.state.acquireTrigger < this.internal.prevTrigger) {
-      void this.release();
-      this.internal.prevTrigger = this.state.acquireTrigger;
-    }
-=======
-    if (this.state.acquireTrigger > this.internal.prevTrigger) void this.acquire();
-    else if (this.state.acquireTrigger < this.internal.prevTrigger) void this.release();
->>>>>>> Stashed changes
+    if (this.state.acquireTrigger > this.internal.prevTrigger) await this.acquire();
+    else if (this.state.acquireTrigger < this.internal.prevTrigger)
+      await this.release();
   }
 
   async afterDelete(): Promise<void> {

--- a/pluto/src/telem/control/aether/controller.ts
+++ b/pluto/src/telem/control/aether/controller.ts
@@ -91,6 +91,7 @@ export class Controller
     this.internal.addStatus = status.useAggregate(this.ctx);
 
     // Acquire or release control if necessary.
+<<<<<<< Updated upstream
     if (this.state.acquireTrigger > this.internal.prevTrigger) {
       void this.acquire();
       this.internal.prevTrigger = this.state.acquireTrigger;
@@ -98,6 +99,10 @@ export class Controller
       void this.release();
       this.internal.prevTrigger = this.state.acquireTrigger;
     }
+=======
+    if (this.state.acquireTrigger > this.internal.prevTrigger) void this.acquire();
+    else if (this.state.acquireTrigger < this.internal.prevTrigger) void this.release();
+>>>>>>> Stashed changes
   }
 
   async afterDelete(): Promise<void> {
@@ -124,6 +129,7 @@ export class Controller
   }
 
   private async acquire(): Promise<void> {
+    this.internal.prevTrigger = this.state.acquireTrigger;
     const { client, addStatus } = this.internal;
     if (client == null)
       return addStatus({
@@ -160,6 +166,7 @@ export class Controller
   }
 
   private async release(): Promise<void> {
+    this.internal.prevTrigger = this.state.acquireTrigger;
     try {
       await this.writer?.close();
       this.setState((p) => ({ ...p, status: "released" }));


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1805](https://linear.app/synnax/issue/SY-1805/fix-setpoint-over-activating)

## Description

Fixed an issue where the setpoint component would fire even if the button was not clicked.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
