### PR TITLE
Sy 1800 lower contrast threshold to trigger schematic color change

### DIFF
--- a/console/src/schematic/slice.ts
+++ b/console/src/schematic/slice.ts
@@ -401,23 +401,20 @@ export const { actions, reducer } = createSlice({
     fixThemeContrast: (state, { payload }: PayloadAction<FixThemeContrastPayload>) => {
       const { theme } = payload;
       const bgColor = new Color.Color(theme.colors.gray.l0);
+      const shouldChange = (crude: Color.Crude): boolean => {
+        const c = new Color.Color(crude);
+        return c.grayness > 0.85 && c.contrast(bgColor) < 1.3;
+      };
       Object.values(state.schematics).forEach((schematic) => {
         const { nodes, edges, props } = schematic;
         nodes.forEach((node) => {
           const nodeProps = props[node.key];
-          if ("color" in nodeProps) {
-            const c = new Color.Color(nodeProps.color as string);
-            // check the contrast of the color
-            if (c.contrast(bgColor) < 1.1)
-              // if the contrast is too low, change the color to the contrast color
+          if ("color" in nodeProps)
+            if (shouldChange(nodeProps.color as string))
               nodeProps.color = theme.colors.gray.l9;
-          }
         });
         edges.forEach((edge) => {
-          if (
-            edge.color != null &&
-            new Color.Color(edge.color as string).contrast(bgColor) < 1.1
-          )
+          if (edge.color != null && shouldChange(edge.color as string))
             edge.color = theme.colors.gray.l9;
           else edge.color ??= theme.colors.gray.l9;
         });

--- a/pluto/src/color/core/color.spec.ts
+++ b/pluto/src/color/core/color.spec.ts
@@ -135,13 +135,15 @@ describe("color.Color", () => {
   });
   describe("grayness", () => {
     const tests: Array<[string, number]> = [
-      ["#000000", 0],
+      ["#000000", 1],
       ["#ffffff", 1],
       ["#0000ff", 0],
       ["#00ff00", 0],
       ["#ff0000", 0],
       ["#ffff00", 0],
-      ["#fefed4", 0.786],
+      ["#fefed4", 0.834],
+      ["#5c6670", 0.92],
+      ["#d3c5c5", 0.945],
     ];
     tests.forEach(([hex, expected]) => {
       test(hex, () => {

--- a/pluto/src/color/core/color.spec.ts
+++ b/pluto/src/color/core/color.spec.ts
@@ -133,4 +133,21 @@ describe("color.Color", () => {
       expect(c.pickByContrast(c1, c2)).toEqual(c1);
     });
   });
+  describe("grayness", () => {
+    const tests: Array<[string, number]> = [
+      ["#000000", 0],
+      ["#ffffff", 1],
+      ["#0000ff", 0],
+      ["#00ff00", 0],
+      ["#ff0000", 0],
+      ["#ffff00", 0],
+      ["#fefed4", 0.786],
+    ];
+    tests.forEach(([hex, expected]) => {
+      test(hex, () => {
+        const c = new color.Color(hex);
+        expect(c.grayness).toBeCloseTo(expected);
+      });
+    });
+  });
 });

--- a/pluto/src/color/core/color.ts
+++ b/pluto/src/color/core/color.ts
@@ -198,10 +198,8 @@ export class Color {
    */
   get grayness(): number {
     const [r, g, b] = this.rgb1;
-    const maxDiff = Math.max(Math.abs(r - g), Math.abs(g - b), Math.abs(b - r));
-    const brightness = (r + g + b) / 3;
-    const graynessFromSimilarity = 1 - maxDiff; // Similarity-based grayness
-    return graynessFromSimilarity * brightness;
+    const deviation = Math.max(r, g, b) - Math.min(r, g, b);
+    return 1 - deviation;
   }
 
   /**

--- a/pluto/src/color/core/color.ts
+++ b/pluto/src/color/core/color.ts
@@ -194,6 +194,17 @@ export class Color {
   }
 
   /**
+   * @returns the grayness of the color, between 0 and 1.
+   */
+  get grayness(): number {
+    const [r, g, b] = this.rgb1;
+    const maxDiff = Math.max(Math.abs(r - g), Math.abs(g - b), Math.abs(b - r));
+    const brightness = (r + g + b) / 3;
+    const graynessFromSimilarity = 1 - maxDiff; // Similarity-based grayness
+    return graynessFromSimilarity * brightness;
+  }
+
+  /**
    * @returns the contrast ratio between this color and the given color. The contrast
    * ratio is a number between 1 and 21, where 1 is the lowest contrast and 21 is the
    * highest.


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1767](https://linear.app/synnax/issue/SY-1800/lower-contrast-threshold-to-trigger-schematic-color-change)

## Description

When we change the theme from light to dark or vice versa, we need to change some of the low contrast schematic components to white or black. Previously we just used a contrast threshold to do this, but this changed elements that were yellow or pink in color. Now we do a 'grayness' check instead that ensures we only change grays.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
