### PR TITLE
Sy 1788 file drop does not work correctly on windows

### DIFF
--- a/pluto/src/haul/Haul.tsx
+++ b/pluto/src/haul/Haul.tsx
@@ -74,8 +74,13 @@ export const FILE_TYPE = "file";
 
 export const FILE: Item = { key: "file", type: FILE_TYPE };
 
+// Effects that indicate a file is being dragged. Downside is that this also
+// allows dragging links, but that's not a huge deal.
+const ALLOWED_FILE_DRAG_EFFECTS = new Set(["all", "copyLink"]);
+
 export const isFileDrag = (event: DragEvent, dragging: DraggingState): boolean =>
-  event.dataTransfer.effectAllowed === "all" && dragging.items.length === 0;
+  ALLOWED_FILE_DRAG_EFFECTS.has(event.dataTransfer.effectAllowed) &&
+  dragging.items.length === 0;
 
 type DragEndInterceptor = (state: DraggingState, cursor: xy.XY) => DropProps | null;
 export interface ContextValue {


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1788](https://linear.app/synnax/issue/SY-1788/file-drop-does-not-work-correctly-on-windows)

## Description

Fixes file drag and drop on console mosaic on windows.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
