### PR TITLE
[driver/opc] use scalarcopy instead of set scalar

### DIFF
--- a/driver/opc/writer.h
+++ b/driver/opc/writer.h
@@ -35,7 +35,6 @@ struct WriterChannelConfig {
     UA_NodeId node;
     /// @brief the corresponding channel key to write the variable for the node from.
     ChannelKey cmd_channel;
-    ChannelKey state_channel;
     bool enabled;
     /// @brief the channel fetched from the Synnax server. This does not need to
     /// be provided via the JSON configuration.

--- a/driver/opc/writer_sink.cpp
+++ b/driver/opc/writer_sink.cpp
@@ -53,41 +53,41 @@ opc::WriterSink::WriterSink(
     this->keep_alive_thread = std::thread(&opc::WriterSink::maintain_connection, this);
 };
 
-void opc::WriterSink::set_variant(
+inline void opc::WriterSink::set_variant(
     UA_Variant *val, const synnax::Frame &frame,
     const uint32_t &series_index,
     const synnax::DataType &type) {
     UA_StatusCode status = UA_STATUSCODE_GOOD;
     if (type == synnax::FLOAT64) {
         double data = frame.series->at(series_index).values<double>()[0];
-        UA_Variant_setScalar(val, &data, &UA_TYPES[UA_TYPES_DOUBLE]);
+        status = UA_Variant_setScalarCopy(val, &data, &UA_TYPES[UA_TYPES_DOUBLE]);
     } else if (type == synnax::FLOAT32) {
         float data = frame.series->at(series_index).values<float>()[0];
-        UA_Variant_setScalar(val, &data, &UA_TYPES[UA_TYPES_FLOAT]);
+        status = UA_Variant_setScalarCopy(val, &data, &UA_TYPES[UA_TYPES_FLOAT]);
     } else if (type == synnax::INT32) {
         int32_t data = frame.series->at(series_index).values<int32_t>()[0];
-        UA_Variant_setScalar(val, &data, &UA_TYPES[UA_TYPES_INT32]);
+        status = UA_Variant_setScalarCopy(val, &data, &UA_TYPES[UA_TYPES_INT32]);
     } else if (type == synnax::INT16) {
         int16_t data = frame.series->at(series_index).values<int16_t>()[0];
-        UA_Variant_setScalar(val, &data, &UA_TYPES[UA_TYPES_INT16]);
+        status = UA_Variant_setScalarCopy(val, &data, &UA_TYPES[UA_TYPES_INT16]);
     } else if (type == synnax::INT8) {
         int8_t data = frame.series->at(series_index).values<int8_t>()[0];
-        UA_Variant_setScalar(val, &data, &UA_TYPES[UA_TYPES_SBYTE]);
+        status = UA_Variant_setScalarCopy(val, &data, &UA_TYPES[UA_TYPES_SBYTE]);
     } else if (type == synnax::UINT64) {
         uint64_t data = frame.series->at(series_index).values<uint64_t>()[0];
-        UA_Variant_setScalar(val, &data, &UA_TYPES[UA_TYPES_UINT64]);
+        status = UA_Variant_setScalarCopy(val, &data, &UA_TYPES[UA_TYPES_UINT64]);
     } else if (type == synnax::UINT32) {
         uint32_t data = frame.series->at(series_index).values<uint32_t>()[0];
-        UA_Variant_setScalar(val, &data, &UA_TYPES[UA_TYPES_UINT32]);
+        status = UA_Variant_setScalarCopy(val, &data, &UA_TYPES[UA_TYPES_UINT32]);
     } else if (type == synnax::SY_UINT16) {
         uint16_t data = frame.series->at(series_index).values<uint16_t>()[0];
-        UA_Variant_setScalar(val, &data, &UA_TYPES[UA_TYPES_UINT16]);
+        status = UA_Variant_setScalarCopy(val, &data, &UA_TYPES[UA_TYPES_UINT16]);
     } else if (type == synnax::SY_UINT8) {
         uint8_t data = frame.series->at(series_index).values<uint8_t>()[0];
         status = UA_Variant_setScalarCopy(val, &data, &UA_TYPES[UA_TYPES_BYTE]);
     } else if (type == synnax::TIMESTAMP) {
         uint64_t data = frame.series->at(series_index).values<uint64_t>()[0];
-        UA_Variant_setScalar(val, &data, &UA_TYPES[UA_TYPES_DATETIME]);
+        status = UA_Variant_setScalarCopy(val, &data, &UA_TYPES[UA_TYPES_DATETIME]);
     }
     if (status != UA_STATUSCODE_GOOD) {
         LOG(ERROR) << "[opc.sink] Failed to set variant";


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1809](https://linear.app/synnax/issue/SY-1809/opc-ua-write-value-copy)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
