### PR TITLE
SY-1823 Add Deprecation Warning to `synnax` and `synnaxkit` Python CLI Names

### DIFF
--- a/client/py/pyproject.toml
+++ b/client/py/pyproject.toml
@@ -47,6 +47,7 @@ ignore_missing_imports = true
 [tool.poetry.scripts]
 synnax = "synnax.cli.synnax:synnax"
 synnaxkit = "synnax.cli.synnax:synnax"
+sy = "synnax.cli.synnax:synnax"
 
 [tool.pytest.ini_options]
 markers = [

--- a/client/py/synnax/cli/ingest.py
+++ b/client/py/synnax/cli/ingest.py
@@ -25,6 +25,7 @@ from synnax.cli.connect import connect_client
 from synnax.cli.flow import Context, Flow
 from synnax.cli.io import prompt_file
 from synnax.cli.telem import select_data_type
+from synnax.cli.warning import warning
 from synnax.ingest.row import RowIngestionEngine
 from synnax.io import IO_FACTORY, ChannelMeta, IOFactory, ReaderType, RowFileReader
 from synnax.telem import DataType, Rate, TimeRange, TimeStamp
@@ -34,8 +35,10 @@ GROUP_ALL = "__all__"
 
 
 @click.command()
+@click.pass_context
 @click.argument("path_", type=click.Path(exists=True), required=False, default=None)
-def ingest(path_: str | None):
+def ingest(ctx: click.Context, path_: str | None) -> None:
+    warning(ctx)
     return pure_ingest(path_)
 
 

--- a/client/py/synnax/cli/login.py
+++ b/client/py/synnax/cli/login.py
@@ -6,13 +6,6 @@
 #  As of the Change Date specified in that file, in accordance with the Business Source
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
-#
-#  Use of this software is governed by the Business Source License included in the file
-#  licenses/BSL.txt.
-#
-#  As of the Change Date specified in that file, in accordance with the Business Source
-#  License, use of this software will be governed by the Apache License, Version 2.0,
-#  included in the file licenses/APL.txt.
 
 import os
 from pathlib import Path
@@ -22,14 +15,17 @@ import click
 from synnax.cli.connect import connect_from_options, prompt_client_options
 from synnax.cli.console.rich import RichConsole
 from synnax.cli.flow import Context
+from synnax.cli.warning import warning
 from synnax.config import ClusterConfig, ClustersConfig, ConfigFile
 
 
 @click.command()
-def login():
+@click.pass_context
+def login(ctx: click.Context) -> None:
     """Logs the user into a Synnax cluster and saves the parameters to the configuration
     file.
     """
+    warning(ctx)
     ctx = Context(console=RichConsole())
     options = prompt_client_options(ctx)
     synnax = connect_from_options(ctx, options)

--- a/client/py/synnax/cli/ts_convert.py
+++ b/client/py/synnax/cli/ts_convert.py
@@ -16,13 +16,13 @@ from rich.progress import (
     TimeElapsedColumn,
 )
 import click
-import time
 from datetime import datetime
 
 from synnax.cli import default
 from synnax.cli.flow import Context
 from synnax.cli.io import prompt_new_reader
 from synnax.cli.telem import ask_time_units_select
+from synnax.cli.warning import warning
 from synnax.io import BaseReader
 from synnax.io.factory import IO_FACTORY
 from synnax.telem import TimeSpanUnits, convert_time_units
@@ -40,6 +40,7 @@ OUTPUT_PRECISION_ARG_SHORT = "-op"
 
 
 @click.command()
+@click.pass_context
 @click.argument(
     "input_path",
     required=False,
@@ -87,6 +88,7 @@ OUTPUT_PRECISION_ARG_SHORT = "-op"
     default=True,
 )
 def tsconvert(
+    ctx: click.Context,
     input_path: str | None,
     output_path: str | None,
     input_channel: str | None,
@@ -100,6 +102,7 @@ def tsconvert(
     All arguments are optional. If not provided, the user will be prompted for
     the missing information.
     """
+    warning(ctx)
     pure_tsconvert(
         input_path,
         output_path,

--- a/client/py/synnax/cli/warning.py
+++ b/client/py/synnax/cli/warning.py
@@ -9,16 +9,16 @@
 
 from click import Context, echo, style
 
-correct_name = "synnaxkit"
+correct_name = "sy"
+styled_error = style("DEPRECATION WARNING:", fg="red")
+styled_correct_name = style(correct_name, fg="cyan")
 
 
 def warning(ctx: Context) -> None:
     """Warns the user if a deprecated command is used."""
     name = ctx.find_root().info_name
     if name != correct_name:
-        styled_error = style("DEPRECATION WARNING:", fg="red")
         styled_name = style(name, fg="cyan")
-        styled_correct_name = style(correct_name, fg="cyan")
         echo(
             f"{styled_error} The {styled_name} command has been deprecated and will be removed in a future release. Please use {styled_correct_name} instead."
         )

--- a/client/py/synnax/cli/warning.py
+++ b/client/py/synnax/cli/warning.py
@@ -1,0 +1,24 @@
+#  Copyright 2024 Synnax Labs, Inc.
+#
+#  Use of this software is governed by the Business Source License included in the file
+#  licenses/BSL.txt.
+#
+#  As of the Change Date specified in that file, in accordance with the Business Source
+#  License, use of this software will be governed by the Apache License, Version 2.0,
+#  included in the file licenses/APL.txt.
+
+from click import Context, echo, style
+
+correct_name = "synnaxkit"
+
+
+def warning(ctx: Context) -> None:
+    """Warns the user if a deprecated command is used."""
+    name = ctx.find_root().info_name
+    if name != correct_name:
+        styled_error = style("DEPRECATION WARNING:", fg="red")
+        styled_name = style(name, fg="cyan")
+        styled_correct_name = style(correct_name, fg="cyan")
+        echo(
+            f"{styled_error} The {styled_name} command has been deprecated and will be removed in a future release. Please use {styled_correct_name} instead."
+        )

--- a/client/py/synnax/cli/warning.py
+++ b/client/py/synnax/cli/warning.py
@@ -9,16 +9,16 @@
 
 from click import Context, echo, style
 
-correct_name = "sy"
-styled_error = style("DEPRECATION WARNING:", fg="red")
-styled_correct_name = style(correct_name, fg="cyan")
+CORRECT_NAME = "sy"
+STYLED_ERROR = style("DEPRECATION WARNING:", fg="red")
+STYLED_CORRECT_NAME = style(CORRECT_NAME, fg="cyan")
 
 
 def warning(ctx: Context) -> None:
     """Warns the user if a deprecated command is used."""
     name = ctx.find_root().info_name
-    if name != correct_name:
+    if name != CORRECT_NAME:
         styled_name = style(name, fg="cyan")
         echo(
-            f"{styled_error} The {styled_name} command has been deprecated and will be removed in a future release. Please use {styled_correct_name} instead."
+            f"{STYLED_ERROR} The {styled_name} command has been deprecated and will be removed in a future release. Please use {STYLED_CORRECT_NAME} instead."
         )

--- a/docs/site/src/pages/guides/analyst/exploratory-analysis-in-python.mdx
+++ b/docs/site/src/pages/guides/analyst/exploratory-analysis-in-python.mdx
@@ -45,7 +45,7 @@ curl -O https://raw.githubusercontent.com/synnaxlabs/synnax/main/docs/examples/a
 Next, we'll use the CLI to import our data set into Synnax. To do so, run
 
 ```bash
-synnax ingest april_9_wetdress.csv
+sy ingest april_9_wetdress.csv
 ```
 
 This command will begin an interactive import process that will prompt us with a few

--- a/docs/site/src/pages/reference/python-client/get-started.mdx
+++ b/docs/site/src/pages/reference/python-client/get-started.mdx
@@ -59,7 +59,7 @@ your credentials.
 To authenticate, run the following command:
 
 ```bash
-synnax login
+sy login
 ```
 
 <Note.Note variant="info">


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1823](https://linear.app/synnax/issue/SY-1823/python-and-server-cli-name-conflict)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Added a short deprecation warning for the `synnax` and `synnaxkit` Python CLI command, and made the new default command `sy`.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
