### PR TITLE
Sy 325 a to select all elements

### DIFF
--- a/console/src/Console.tsx
+++ b/console/src/Console.tsx
@@ -82,6 +82,7 @@ const PREVENT_DEFAULT_TRIGGERS: Triggers.Trigger[] = [
   ["Control", "Shift", "P"],
   ["Control", "MouseLeft"],
   ["Control", "W"],
+  ["Control", "A"],
 ];
 
 const TRIGGERS_PROVIDER_PROPS: Triggers.ProviderProps = {

--- a/console/src/schematic/Schematic.tsx
+++ b/console/src/schematic/Schematic.tsx
@@ -59,6 +59,7 @@ import {
   copySelection,
   internalCreate,
   pasteSelection,
+  selectAll,
   setControlStatus,
   setEdges,
   setEditable,
@@ -292,6 +293,7 @@ export const Loaded: Layout.Renderer = ({ layoutKey, visible }) => {
       ["Escape"],
       ["Control", "Z"],
       ["Control", "Shift", "Z"],
+      ["Control", "A"],
     ],
     loose: true,
     region: ref,
@@ -301,6 +303,7 @@ export const Loaded: Layout.Renderer = ({ layoutKey, visible }) => {
         const region = box.construct(ref.current);
         const copy = triggers.some((t) => t.includes("C"));
         const isClear = triggers.some((t) => t.includes("Escape"));
+        const isAll = triggers.some((t) => t.includes("A"));
         const isUndo =
           triggers.some((t) => t.includes("Z")) &&
           triggers.some((t) => t.includes("Control")) &&
@@ -314,6 +317,7 @@ export const Loaded: Layout.Renderer = ({ layoutKey, visible }) => {
         else if (isClear) dispatch(clearSelection({ key: layoutKey }));
         else if (isUndo) undo();
         else if (isRedo) redo();
+        else if (isAll) dispatch(selectAll({ key: layoutKey }));
         else undoableDispatch(pasteSelection({ pos, key: layoutKey }));
       },
       [layoutKey, undoableDispatch, undo, redo, dispatch],

--- a/console/src/schematic/slice.ts
+++ b/console/src/schematic/slice.ts
@@ -144,6 +144,10 @@ export interface SetLegendPayload {
   legend: Partial<LegendState>;
 }
 
+export interface SelectAllPayload {
+  key: string;
+}
+
 export const calculatePos = (
   region: box.Box,
   cursor: xy.XY,
@@ -426,6 +430,12 @@ export const { actions, reducer } = createSlice({
       const schematic = state.schematics[layoutKey];
       schematic.legend = { ...schematic.legend, ...legend };
     },
+    selectAll: (state, { payload }: PayloadAction<SelectAllPayload>) => {
+      const { key: layoutKey } = payload;
+      const schematic = state.schematics[layoutKey];
+      schematic.nodes.forEach((node) => (node.selected = true));
+      schematic.edges.forEach((edge) => (edge.selected = true));
+    },
   },
 });
 
@@ -452,6 +462,7 @@ export const {
   toggleControl,
   setControlStatus,
   addElement,
+  selectAll,
   setEdges,
   setNodes,
   remove,


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-325](https://linear.app/synnax/issue/SY-325/⌘-a-to-select-all-elements)

## Description

Adds the `Control + A` (Windows) and `Cmd + A` (MacOS) commands to select all schematic elements.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
