### PR TITLE
SY-1835 Fix Duplicated Items in Resources Tree

### DIFF
--- a/client/ts/src/framer/frame.ts
+++ b/client/ts/src/framer/frame.ts
@@ -7,6 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+import { toArray, unique } from "@synnaxlabs/x";
 import {
   MultiSeries,
   Series,
@@ -17,8 +18,6 @@ import {
   TimeRange,
   TimeStamp,
 } from "@synnaxlabs/x/telem";
-import { toArray } from "@synnaxlabs/x/toArray";
-import { unique } from "@synnaxlabs/x/unique";
 import { z } from "zod";
 
 import {
@@ -177,7 +176,7 @@ export class Frame {
    * error otherwise.
    */
   get uniqueKeys(): Keys {
-    return unique(this.keys);
+    return unique.unique(this.keys);
   }
 
   /**
@@ -194,7 +193,7 @@ export class Frame {
    * otherwise.
    */
   get uniqueNames(): Names {
-    return unique(this.names);
+    return unique.unique(this.names);
   }
 
   /**

--- a/console/src/hardware/ni/task/AnalogRead.tsx
+++ b/console/src/hardware/ni/task/AnalogRead.tsx
@@ -118,7 +118,7 @@ const Wrapped = ({
     mutationFn: async () => {
       if (!(await methods.validateAsync()) || client == null) return;
       const { name, config } = methods.value();
-      const devices = unique(config.channels.map((c) => c.device));
+      const devices = unique.unique(config.channels.map((c) => c.device));
 
       for (const devKey of devices) {
         const dev = await client.hardware.devices.retrieve<Properties>(devKey);

--- a/console/src/layouts/GetStarted.tsx
+++ b/console/src/layouts/GetStarted.tsx
@@ -86,7 +86,7 @@ const NoCluster = (): ReactElement => {
 const Overview = (): ReactElement => {
   const place = Layout.usePlacer();
   const handleWorkspace: Button.ButtonProps["onClick"] = () =>
-    place(Workspace.createWindowLayout());
+    place(Workspace.CREATE_WINDOW_LAYOUT);
 
   return (
     <Eraser.Eraser>

--- a/console/src/lineplot/LinePlot.tsx
+++ b/console/src/lineplot/LinePlot.tsx
@@ -138,7 +138,7 @@ const Loaded: Layout.Renderer = ({ layoutKey, focused, visible }): ReactElement 
     const toFetch = lines.filter((line) => line.label == null);
     if (toFetch.length === 0) return;
     const fetched = await client.channels.retrieve(
-      unique(toFetch.map((line) => line.channels.y)) as channel.KeysOrNames,
+      unique.unique(toFetch.map((line) => line.channels.y)) as channel.KeysOrNames,
     );
     const update = toFetch.map((l) => ({
       key: l.key,

--- a/console/src/lineplot/download.ts
+++ b/console/src/lineplot/download.ts
@@ -45,14 +45,14 @@ export const download = ({
   name = "synnax-data",
 }: DownloadProps): void => {
   (async () => {
-    let keys = unique(
+    let keys = unique.unique(
       lines
         .flatMap((l) => [l.channels.y, l.channels.x])
         .filter((v) => v != null && v != 0),
     ) as channel.Keys;
     const channels = await client.channels.retrieve(keys);
-    const indexes = unique(channels.map((c) => c.index));
-    keys = unique([...keys, ...indexes]);
+    const indexes = unique.unique(channels.map((c) => c.index));
+    keys = unique.unique([...keys, ...indexes]);
     const indexChannels = await client.channels.retrieve(indexes);
     const columns = new Map<channel.Key, string>();
     channels.forEach((c) => {

--- a/console/src/lineplot/slice.ts
+++ b/console/src/lineplot/slice.ts
@@ -207,7 +207,7 @@ const generateTypedLineKeys = (state: State): TypedLineKey[] =>
 const updateLines = (state: State): LineState[] => {
   const keys = generateTypedLineKeys(state);
   const lines: LineState[] = [];
-  unique(keys).forEach((key) => {
+  unique.unique(keys).forEach((key) => {
     const strKey = typedLineKeyToString(key);
     const existing = state.lines.find((line) => strKey === line.key);
     if (existing != null) lines.push(existing);
@@ -264,7 +264,7 @@ export const { actions, reducer } = createSlice({
       const p = state.plots[layoutKey];
       const prevShouldDisplay = shouldDisplayAxis(axisKey, p);
       if (mode === "set") p.channels[axisKey] = channels;
-      else p.channels[axisKey] = unique([...p.channels[axisKey], ...channels]);
+      else p.channels[axisKey] = unique.unique([...p.channels[axisKey], ...channels]);
       const nextShouldDisplay = shouldDisplayAxis(axisKey, p);
       p.lines = updateLines(p);
       p.viewport = deep.copy(latest.ZERO_VIEWPORT_STATE);
@@ -284,7 +284,7 @@ export const { actions, reducer } = createSlice({
       const p = state.plots[layoutKey];
       if (mode === "set") p.ranges[axisKey] = ranges;
       else if (mode === "add")
-        p.ranges[axisKey] = unique([...p.ranges[axisKey], ...ranges]);
+        p.ranges[axisKey] = unique.unique([...p.ranges[axisKey], ...ranges]);
       p.axes.renderTrigger += 1;
       p.lines = updateLines(p);
     },

--- a/console/src/ontology/ContextMenu.tsx
+++ b/console/src/ontology/ContextMenu.tsx
@@ -21,6 +21,7 @@ export const MultipleSelectionContextMenu: TreeContextMenu = (props) => {
   return (
     <PMenu.Menu onChange={handleSelect} level="small" iconSpacing="small">
       <Group.GroupMenuItem selection={props.selection} />
+      <PMenu.Divider />
       <Menu.HardReloadItem />
     </PMenu.Menu>
   );

--- a/console/src/ontology/Tree.tsx
+++ b/console/src/ontology/Tree.tsx
@@ -19,7 +19,7 @@ import {
   useStateRef as useRefAsState,
 } from "@synnaxlabs/pluto";
 import { Tree as Core } from "@synnaxlabs/pluto/tree";
-import { deep } from "@synnaxlabs/x";
+import { deep, unique } from "@synnaxlabs/x";
 import { type MutationFunction, useMutation } from "@tanstack/react-query";
 import { Mutex } from "async-mutex";
 import { memo, type ReactElement, useCallback, useMemo, useState } from "react";
@@ -63,13 +63,10 @@ const updateResources = (
   removals: ontology.ID[] = [],
 ): ontology.Resource[] => {
   // If multiple additions have the same key, remove duplicates
-  const uniqueAdditions = Array.from(
-    additions
-      .reduce(
-        (map, resource) => map.set(resource.id.toString(), resource),
-        new Map<string, ontology.Resource>(),
-      )
-      .values(),
+  const uniqueAdditions = unique.by(
+    additions,
+    (resource) => resource.id.toString(),
+    false,
   );
   const addedIds = uniqueAdditions.map(({ id }) => id.toString());
   const removedIds = removals.map((id) => id.toString());

--- a/console/src/ontology/Tree.tsx
+++ b/console/src/ontology/Tree.tsx
@@ -62,14 +62,23 @@ const updateResources = (
   additions: ontology.Resource[] = [],
   removals: ontology.ID[] = [],
 ): ontology.Resource[] => {
-  const newIds = additions.map(({ id }) => id.toString());
-  const removalIds = removals.map((id) => id.toString());
+  // If multiple additions have the same key, remove duplicates
+  const uniqueAdditions = Array.from(
+    additions
+      .reduce(
+        (map, resource) => map.set(resource.id.toString(), resource),
+        new Map<string, ontology.Resource>(),
+      )
+      .values(),
+  );
+  const addedIds = uniqueAdditions.map(({ id }) => id.toString());
+  const removedIds = removals.map((id) => id.toString());
   return [
     ...p.filter(({ id }) => {
       const str = id.toString();
-      return !removalIds.includes(str) && !newIds.includes(str);
+      return !removedIds.includes(str) && !addedIds.includes(str);
     }),
-    ...additions,
+    ...uniqueAdditions,
   ];
 };
 
@@ -495,11 +504,7 @@ export const Tree = (): ReactElement => {
         removeLayout,
         handleException,
         addStatus,
-        selection: {
-          parent,
-          nodes: selectedNodes,
-          resources: selectedResources,
-        },
+        selection: { parent, nodes: selectedNodes, resources: selectedResources },
         state: {
           nodes: nodeSnapshot,
           resources,

--- a/console/src/ontology/builtin/ontology.tsx
+++ b/console/src/ontology/builtin/ontology.tsx
@@ -7,12 +7,13 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+import { ontology } from "@synnaxlabs/client";
 import { Icon } from "@synnaxlabs/media";
 
-import { type Service } from "../service";
+import { type Service } from "@/ontology/service";
 
 export const ONTOLOGY_SERVICE: Service = {
-  type: "builtin",
+  type: ontology.BUILTIN_TYPE,
   icon: <Icon.Cluster />,
   hasChildren: true,
   allowRename: () => false,

--- a/console/src/ontology/hooks.ts
+++ b/console/src/ontology/hooks.ts
@@ -32,10 +32,7 @@ export const useConfirmDelete = ({
         confirm: { variant: "error", label: "Delete" },
         cancel: { label: "Cancel" },
       },
-      {
-        name: `${type}.Delete`,
-        icon: type,
-      },
+      { name: `${type}.Delete`, icon: type },
     );
   };
 };

--- a/console/src/range/overview/Labels.tsx
+++ b/console/src/range/overview/Labels.tsx
@@ -37,12 +37,12 @@ export const Labels = ({ rangeKey }: LabelsProps) => {
     openObservable: async (client) => await client.labels.trackLabelsOf(otgID),
     applyObservable: async ({ changes, ctx }) => {
       const existing = ctx.get<string[]>("labels").value;
-      const next = unique(changes.map((c) => c.key));
+      const next = unique.unique(changes.map((c) => c.key));
       if (compare.unorderedPrimitiveArrays(existing, next) === compare.EQUAL) return;
       ctx.set("labels", next);
     },
     applyChanges: async ({ client, values, prev }) => {
-      const next = unique(values.labels);
+      const next = unique.unique(values.labels);
       if (
         client == null ||
         compare.unorderedPrimitiveArrays(prev as string[], next) === compare.EQUAL

--- a/console/src/workspace/Create.tsx
+++ b/console/src/workspace/Create.tsx
@@ -9,7 +9,6 @@
 
 import { Align, Button, Form, Nav, Synnax, Text, Triggers } from "@synnaxlabs/pluto";
 import { Input } from "@synnaxlabs/pluto/input";
-import { type UnknownRecord } from "@synnaxlabs/x";
 import { useMutation } from "@tanstack/react-query";
 import { type ReactElement } from "react";
 import { useDispatch } from "react-redux";
@@ -22,21 +21,15 @@ import { add } from "@/workspace/slice";
 
 export const CREATE_LAYOUT_TYPE = "createWorkspace";
 
-export const createWindowLayout = (
-  name: string = "Workspace.Create",
-): Layout.State => ({
+export const CREATE_WINDOW_LAYOUT: Layout.State = {
   key: CREATE_LAYOUT_TYPE,
   type: CREATE_LAYOUT_TYPE,
   windowKey: CREATE_LAYOUT_TYPE,
-  name,
+  name: "Workspace.Create",
   icon: "Workspace",
   location: "modal",
-  window: {
-    resizable: false,
-    size: { height: 225, width: 625 },
-    navTop: true,
-  },
-});
+  window: { resizable: false, size: { height: 225, width: 625 }, navTop: true },
+};
 
 const formSchema = z.object({
   name: z.string().min(1, { message: "Workspace must have a name" }),
@@ -45,29 +38,23 @@ const formSchema = z.object({
 const SAVE_TRIGGER: Triggers.Trigger = ["Control", "Enter"];
 
 export const Create = ({ onClose }: Layout.RendererProps): ReactElement => {
-  const methods = Form.use({
-    values: {
-      name: "",
-    },
-    schema: formSchema,
-  });
+  const methods = Form.use({ values: { name: "" }, schema: formSchema });
 
   const client = Synnax.use();
   const dispatch = useDispatch();
   const active = useSelectActiveKey();
 
   const { mutate, isPending } = useMutation({
-    mutationKey: [],
     mutationFn: async () => {
       if (!methods.validate() || client == null) return;
       const { name } = methods.value();
       const ws = await client.workspaces.create({
         name,
-        layout: Layout.ZERO_SLICE_STATE as unknown as UnknownRecord,
+        layout: Layout.ZERO_SLICE_STATE,
       });
       dispatch(add(ws));
       if (active != null)
-        dispatch(Layout.setWorkspace({ slice: ws.layout as unknown as SliceState }));
+        dispatch(Layout.setWorkspace({ slice: ws.layout as SliceState }));
       onClose();
     },
   });

--- a/console/src/workspace/Selector.tsx
+++ b/console/src/workspace/Selector.tsx
@@ -28,7 +28,7 @@ import { useDispatch } from "react-redux";
 import { Cluster } from "@/cluster";
 import { CSS } from "@/css";
 import { Layout } from "@/layout";
-import { createWindowLayout } from "@/workspace/Create";
+import { CREATE_WINDOW_LAYOUT } from "@/workspace/Create";
 import { useSelectActive } from "@/workspace/selectors";
 import { add, setActive } from "@/workspace/slice";
 
@@ -124,7 +124,7 @@ export const Selector = (): ReactElement => {
                       variant="outlined"
                       onClick={() => {
                         dProps.close();
-                        place(createWindowLayout());
+                        place(CREATE_WINDOW_LAYOUT);
                       }}
                       iconSpacing="small"
                       tooltip="Create a new workspace"

--- a/console/src/workspace/services/palette.tsx
+++ b/console/src/workspace/services/palette.tsx
@@ -19,7 +19,7 @@ const CREATE_COMMAND: Command = {
   name: "Create Workspace",
   icon: <Icon.Workspace />,
   onSelect: ({ placeLayout: layoutPlacer }) =>
-    layoutPlacer(Workspace.createWindowLayout()),
+    layoutPlacer(Workspace.CREATE_WINDOW_LAYOUT),
 };
 
 const IMPORT_COMMAND: Command = {

--- a/drift/src/sync.ts
+++ b/drift/src/sync.ts
@@ -58,7 +58,7 @@ export const syncInitial = async (
   log(debug, "non-main windows in state", nonMain.sort());
   groupEnd(debug);
   // Create windows that are not in runtime, delete windows that are not in state
-  const allLabels = unique([...runtimeLabels, ...nonMain]);
+  const allLabels = unique.unique([...runtimeLabels, ...nonMain]);
   // Only the main runtime is allowed to create windows.
   for (const label of allLabels)
     if (!runtimeLabels.includes(label) && runtime.isMain()) {

--- a/pluto/src/channel/Select.tsx
+++ b/pluto/src/channel/Select.tsx
@@ -122,7 +122,7 @@ export const SelectMultiple = ({
       ({ items }) => {
         const dropped = Haul.filterByType(HAUL_TYPE, items);
         if (dropped.length === 0) return [];
-        const v = unique([
+        const v = unique.unique([
           ...toArray(value),
           ...(dropped.map((c) => c.key) as channel.Keys),
         ]);

--- a/pluto/src/label/Select.tsx
+++ b/pluto/src/label/Select.tsx
@@ -98,7 +98,7 @@ export const SelectMultiple = ({
       ({ items }) => {
         const dropped = Haul.filterByType(HAUL_TYPE, items);
         if (dropped.length === 0) return [];
-        const v = unique([
+        const v = unique.unique([
           ...toArray(value),
           ...(dropped.map((c) => c.key) as label.Key[]),
         ]);

--- a/pluto/src/list/useSelect.ts
+++ b/pluto/src/list/useSelect.ts
@@ -216,7 +216,7 @@ export const useSelect = <K extends Key, E extends Keyed<K>>({
         else if (value.includes(key)) nextSelected = value.filter((k) => k !== key);
         else nextSelected = [...value, key];
       }
-      const v = unique(nextSelected);
+      const v = unique.unique(nextSelected);
       if (allowNone === false && v.length === 0)
         // If we're not allowed to have no select, still call handleChange with the same
         // value. This is useful when you want to close a dialog on selection.

--- a/pluto/src/menu/ContextMenu.tsx
+++ b/pluto/src/menu/ContextMenu.tsx
@@ -109,7 +109,7 @@ export const useContextMenu = (): UseContextMenuReturn => {
       // Prevent parent context menus from opening.
       e.stopPropagation();
       const selected = findSelected(e.target as HTMLElement);
-      keys ??= unique(selected.map((el) => el.id).filter((id) => id.length > 0));
+      keys ??= unique.unique(selected.map((el) => el.id).filter((id) => id.length > 0));
     } else keys = [];
     setMenuState({ visible: true, keys, position: p, cursor: p });
   };

--- a/pluto/src/ranger/Select.tsx
+++ b/pluto/src/ranger/Select.tsx
@@ -66,7 +66,7 @@ export const SelectMultiple = ({
       ({ items }) => {
         const dropped = Haul.filterByType(HAUL_TYPE, items);
         if (dropped.length === 0) return [];
-        const v = unique([
+        const v = unique.unique([
           ...toArray(value),
           ...(dropped.map((c) => c.key) as ranger.Keys),
         ]);

--- a/pluto/src/telem/control/Legend.tsx
+++ b/pluto/src/telem/control/Legend.tsx
@@ -37,7 +37,7 @@ export const Legend = Aether.wrap<LegendProps>(
     }, [needsControlOf]);
 
     // Filter out the unique subjects
-    const subjects = unique(states.map((s) => s.subject.key));
+    const subjects = unique.unique(states.map((s) => s.subject.key));
     const data = subjects.map((s) => {
       const d = states.find((s2) => s2.subject.key === s);
       if (d == null) throw new UnexpectedError("Legend subject not found");

--- a/pluto/src/telem/control/aether/state.ts
+++ b/pluto/src/telem/control/aether/state.ts
@@ -8,7 +8,12 @@
 // included in the file licenses/APL.txt.
 
 import { type Instrumentation } from "@synnaxlabs/alamos";
-import { type channel, control, type Synnax, UnexpectedError } from "@synnaxlabs/client";
+import {
+  type channel,
+  control,
+  type Synnax,
+  UnexpectedError,
+} from "@synnaxlabs/client";
 import { type Destructor, observe, unique } from "@synnaxlabs/x";
 import { z } from "zod";
 
@@ -115,7 +120,8 @@ export class StateProvider extends aether.Composite<
 
   get(key: channel.Key | channel.Key[]): SugaredState | SugaredState[] | undefined {
     if (Array.isArray(key))
-      return unique(key)
+      return unique
+        .unique(key)
         .map((k) => this.getOne(k))
         .filter((s) => s != null) as SugaredState[];
     return this.getOne(key);

--- a/pluto/src/tree/Tree.tsx
+++ b/pluto/src/tree/Tree.tsx
@@ -117,7 +117,7 @@ export const use = (props: UseProps): UseReturn => {
 
   const handleExpand = useCallback(
     (key: string): void => {
-      setExpanded((expanded) => unique([...expanded, key]));
+      setExpanded((expanded) => unique.unique([...expanded, key]));
       onExpand?.({ current: expanded, action: "expand", clicked: key });
     },
     [setExpanded],

--- a/pluto/src/tree/core.ts
+++ b/pluto/src/tree/core.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { compare, toArray } from "@synnaxlabs/x";
+import { compare, toArray, unique } from "@synnaxlabs/x";
 import { type ReactElement } from "react";
 
 import { type Haul } from "@/haul";
@@ -155,12 +155,7 @@ export const setNode = ({ tree, destination, additions }: SetNodeProps): Node[] 
   if (node == null) throw new Error(`Could not find node with key ${destination}`);
   node.children ??= [];
 
-  // If additions have the same key, remove duplicates
-  const uniqueAdditions = Array.from(
-    additions
-      .reduce((map, node) => map.set(node.key, node), new Map<string, Node>())
-      .values(),
-  );
+  const uniqueAdditions = unique.by(additions, (node) => node.key, false);
   const addedKeys = uniqueAdditions.map((node) => node.key);
   node.children = [
     ...uniqueAdditions,

--- a/pluto/src/tree/core.ts
+++ b/pluto/src/tree/core.ts
@@ -154,9 +154,16 @@ export const setNode = ({ tree, destination, additions }: SetNodeProps): Node[] 
   const node = findNode({ tree, key: destination });
   if (node == null) throw new Error(`Could not find node with key ${destination}`);
   node.children ??= [];
-  const addedKeys = additions.map((node) => node.key);
+
+  // If additions have the same key, remove duplicates
+  const uniqueAdditions = Array.from(
+    additions
+      .reduce((map, node) => map.set(node.key, node), new Map<string, Node>())
+      .values(),
+  );
+  const addedKeys = uniqueAdditions.map((node) => node.key);
   node.children = [
-    ...additions,
+    ...uniqueAdditions,
     ...node.children.filter((child) => !addedKeys.includes(child.key)),
   ];
   return tree;

--- a/pluto/src/triggers/hooks.tsx
+++ b/pluto/src/triggers/hooks.tsx
@@ -118,7 +118,8 @@ export const useHeldRef = ({
     callback: useCallback((e: UseEvent) => {
       setRef((prev) => {
         let next: Trigger[];
-        if (e.stage === "start") next = unique([...prev.triggers, ...e.triggers]);
+        if (e.stage === "start")
+          next = unique.unique([...prev.triggers, ...e.triggers]);
         else next = purge(prev.triggers, e.triggers);
         return { triggers: next, held: next.length > 0 };
       });
@@ -135,7 +136,8 @@ export const useHeld = ({ triggers, loose }: UseHeldProps): UseHeldReturn => {
     callback: useCallback((e: UseEvent) => {
       setHeld((prev) => {
         let next: Trigger[];
-        if (e.stage === "start") next = unique([...prev.triggers, ...e.triggers]);
+        if (e.stage === "start")
+          next = unique.unique([...prev.triggers, ...e.triggers]);
         else next = purge(prev.triggers, e.triggers);
         return { triggers: next, held: next.length > 0 };
       });

--- a/x/ts/src/compare/compare.ts
+++ b/x/ts/src/compare/compare.ts
@@ -99,8 +99,8 @@ export const uniqueUnorderedPrimitiveArrays = <T extends Primitive>(
   a: readonly T[] | T[],
   b: readonly T[] | T[],
 ): number => {
-  const uniqueA = unique(a);
-  const uniqueB = unique(b);
+  const uniqueA = unique.unique(a);
+  const uniqueB = unique.unique(b);
   return unorderedPrimitiveArrays(uniqueA, uniqueB);
 };
 

--- a/x/ts/src/unique/index.ts
+++ b/x/ts/src/unique/index.ts
@@ -7,4 +7,4 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-export const unique = <V>(values: V[] | readonly V[]): V[] => [...new Set(values)];
+export * as unique from "@/unique/unique";

--- a/x/ts/src/unique/unique.spec.ts
+++ b/x/ts/src/unique/unique.spec.ts
@@ -1,0 +1,192 @@
+// Copyright 2024 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { describe, expect, it } from "vitest";
+
+import { unique } from "@/unique";
+
+describe("unique", () => {
+  it("removes duplicate primitive values", () => {
+    const result = unique.unique([1, 2, 2, 3, 4, 4, 5]);
+    expect(result).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("works with strings", () => {
+    const result = unique.unique(["a", "b", "a", "c", "b"]);
+    expect(result).toEqual(["a", "b", "c"]);
+  });
+
+  it("works with mixed types", () => {
+    const result = unique.unique([1, "1", 2, "2", 1, "1"]);
+    expect(result).toEqual([1, "1", 2, "2"]);
+  });
+
+  it("handles an empty array", () => {
+    const result = unique.unique([]);
+    expect(result).toEqual([]);
+  });
+
+  it("works with readonly arrays", () => {
+    const values: readonly number[] = [1, 1, 2, 3];
+    const result = unique.unique(values);
+    expect(result).toEqual([1, 2, 3]);
+  });
+});
+
+describe("by", () => {
+  interface IDTestCase {
+    id: number;
+  }
+
+  it("removes duplicates based on a key function and keeps the first instance by default", () => {
+    const result = unique.by(
+      [
+        { id: 1, name: "A" },
+        { id: 2, name: "B" },
+        { id: 1, name: "C" },
+      ],
+      (value: IDTestCase) => value.id,
+    );
+    expect(result).toEqual([
+      { id: 1, name: "A" },
+      { id: 2, name: "B" },
+    ]);
+  });
+
+  it("removes duplicates based on a key function and keeps the first instance when keepFirst is true", () => {
+    const result = unique.by(
+      [
+        { id: 1, name: "A" },
+        { id: 2, name: "B" },
+        { id: 1, name: "C" },
+      ],
+      (value: IDTestCase) => value.id,
+      true,
+    );
+    expect(result).toEqual([
+      { id: 1, name: "A" },
+      { id: 2, name: "B" },
+    ]);
+  });
+
+  it("removes duplicates based on a key function and keeps the last instance when keepFirst is false", () => {
+    const result = unique.by(
+      [
+        { id: 1, name: "A" },
+        { id: 2, name: "B" },
+        { id: 1, name: "C" },
+      ],
+      (value: IDTestCase) => value.id,
+      false,
+    );
+    expect(result).toEqual([
+      { id: 2, name: "B" },
+      { id: 1, name: "C" },
+    ]);
+  });
+
+  interface ValueTestCase {
+    value: string;
+  }
+
+  it("works with a custom key function", () => {
+    const result = unique.by(
+      [{ value: "apple" }, { value: "banana" }, { value: "apple" }],
+      (v: ValueTestCase) => v.value,
+    );
+    expect(result).toEqual([{ value: "apple" }, { value: "banana" }]);
+  });
+
+  it("handles an empty array", () => {
+    const result = unique.by([], (v: unknown) => v);
+    expect(result).toEqual([]);
+  });
+
+  it("works with readonly arrays and keeps the first instance by default", () => {
+    const values: readonly { id: number; name: string }[] = [
+      { id: 1, name: "A" },
+      { id: 1, name: "B" },
+    ];
+    const result = unique.by(values, (v: IDTestCase) => v.id);
+    expect(result).toEqual([{ id: 1, name: "A" }]);
+  });
+
+  it("works with readonly arrays and keeps the last instance when keepFirst is false", () => {
+    const values: readonly { id: number; name: string }[] = [
+      { id: 1, name: "A" },
+      { id: 1, name: "B" },
+    ];
+    const result = unique.by(values, (v: IDTestCase) => v.id, false);
+    expect(result).toEqual([{ id: 1, name: "B" }]);
+  });
+
+  interface ComplexTestCase {
+    id: number;
+    nested: { value: string };
+  }
+
+  it("works with complex keys and keeps the first instance by default", () => {
+    const result = unique.by(
+      [
+        { id: 1, nested: { value: "A" } },
+        { id: 1, nested: { value: "B" } },
+        { id: 1, nested: { value: "A", otherKey: "4" } },
+      ],
+      (v: ComplexTestCase) => `${v.id}-${v.nested.value}`,
+    );
+    expect(result).toEqual([
+      { id: 1, nested: { value: "A" } },
+      { id: 1, nested: { value: "B" } },
+    ]);
+  });
+
+  it("works with complex keys and keeps the last instance when keepFirst is false", () => {
+    const result = unique.by(
+      [
+        { id: 1, nested: { value: "A" } },
+        { id: 1, nested: { value: "B" } },
+        { id: 1, nested: { value: "A", otherKey: "4" } },
+      ],
+      (v: ComplexTestCase) => `${v.id}-${v.nested.value}`,
+      false,
+    );
+    expect(result).toEqual([
+      { id: 1, nested: { value: "B" } },
+      { id: 1, nested: { value: "A", otherKey: "4" } },
+    ]);
+  });
+
+  it("handles cases where all keys are unique", () => {
+    const result = unique.by(
+      [
+        { id: 1, name: "A" },
+        { id: 2, name: "B" },
+        { id: 3, name: "C" },
+      ],
+      (v: IDTestCase) => v.id,
+    );
+    expect(result).toEqual([
+      { id: 1, name: "A" },
+      { id: 2, name: "B" },
+      { id: 3, name: "C" },
+    ]);
+  });
+
+  it("handles cases where all values are identical", () => {
+    const result = unique.by(
+      [
+        { id: 1, name: "A" },
+        { id: 1, name: "A" },
+        { id: 1, name: "A" },
+      ],
+      (v: IDTestCase) => v.id,
+    );
+    expect(result).toEqual([{ id: 1, name: "A" }]);
+  });
+});

--- a/x/ts/src/unique/unique.ts
+++ b/x/ts/src/unique/unique.ts
@@ -1,0 +1,67 @@
+// Copyright 2024 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+/**
+ * Removes duplicate values from an array, preserving the order of the first occurrence
+ * of each unique value.
+ *
+ * @param values - An array or readonly array of values to deduplicate.
+ * @returns A new array containing only unique values.
+ *
+ * @example
+ * ```typescript
+ * unique([1, 2, 2, 3, 4, 4, 5]); // [1, 2, 3, 4, 5]
+ * ```
+ */
+export const unique = <V>(values: V[] | readonly V[]): V[] => [...new Set(values)];
+
+/**
+ * Removes duplicate values from an array based on a key function, preserving either
+ * the first or last occurrence of each unique key. If
+ *
+ * @param values - An array or readonly array of values to deduplicate.
+ * @param key - A function that generates a unique key for each value.
+ * @param keepFirst - An optional boolean indicating whether to keep the first instance
+ *                    (`true`, default) or the last instance (`false`) of each unique key.
+ * @returns A new array containing only unique values based on the generated keys.
+ *
+ * @example
+ * // Default behavior (keep first instance):
+ * by(
+ *   [{ id: 1, name: "A" }, { id: 2, name: "B" }, { id: 1, name: "C" }],
+ *   (value) => value.id
+ * );
+ * // Result: [{ id: 1, name: "A" }, { id: 2, name: "B" }]
+ *
+ * @example
+ * // Keep last instance:
+ * by(
+ *   [{ id: 1, name: "A" }, { id: 2, name: "B" }, { id: 1, name: "C" }],
+ *   (value) => value.id,
+ *   false
+ * );
+ * // Result: [{ id: 2, name: "B" }, { id: 1, name: "C" }]
+ */
+export const by = <V>(
+  values: V[] | readonly V[],
+  key: (value: V) => unknown,
+  keepFirst: boolean = true,
+): V[] => {
+  const map = new Map<unknown, V>();
+  values.forEach((v) => {
+    const k = key(v);
+    if (map.has(k)) {
+      if (keepFirst) return;
+      map.delete(k);
+    }
+    // different delete and set operations for keepLast so order is preserved
+    map.set(k, v);
+  });
+  return Array.from(map.values());
+};

--- a/x/ts/vite.config.ts
+++ b/x/ts/vite.config.ts
@@ -42,7 +42,7 @@ export default defineConfig({
         destructor: path.resolve(".", "src/destructor.ts"),
         toArray: path.resolve(".", "src/toArray.ts"),
         search: path.resolve(".", "src/search.ts"),
-        unique: path.resolve(".", "src/unique.ts"),
+        unique: path.resolve(".", "src/unique/index.ts"),
         record: path.resolve(".", "src/record.ts"),
         change: path.resolve(".", "src/change/index.ts"),
         identity: path.resolve(".", "src/identity.ts"),


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1835](https://linear.app/synnax/issue/SY-1835/fix-duplicated-items-in-resources-tree)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Fix duplicated items in resources tree by making sure when nodes get added to the tree, only nodes with different keys get added.


## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
