### PR TITLE
SY-1891 - Drift - Correct Window Positioning for Multi-Monitor Setups

### DIFF
--- a/drift/src/tauri/index.ts
+++ b/drift/src/tauri/index.ts
@@ -85,7 +85,7 @@ const monitorBoxes = async (): Promise<box.Box[]> => {
 
 /**
  * @returns true whether the top-left corner of the window is visible on the user's
- * monitors. If not, shifts the window to the top-left corner of the primary monitor.
+ * monitors.
  */
 const isPositionVisible = async (position?: xy.XY): Promise<boolean> => {
   const boxes = await monitorBoxes();
@@ -201,7 +201,6 @@ export class TauriRuntime<S extends StoreState, A extends Action = UnknownAction
   async create(label: string, props: Omit<WindowProps, "key">): Promise<void> {
     props = deep.copy(props);
     const { size, minSize, maxSize, position, ...rest } = capWindowDimensions(props);
-
     if (size?.width != null) size.width = Math.max(size.width, MIN_DIM);
     if (size?.height != null) size.height = Math.max(size.height, MIN_DIM);
     if (maxSize?.width != null) maxSize.width = Math.max(maxSize.width, MIN_DIM);

--- a/drift/src/tauri/index.ts
+++ b/drift/src/tauri/index.ts
@@ -75,15 +75,11 @@ const capWindowDimensions = (
 
 const monitorBoxes = async (): Promise<box.Box[]> => {
   const monitors = await availableMonitors();
-  return monitors.map((monitor) =>
-    box.construct(
-      {
-        x: monitor.position.x,
-        y: monitor.position.y,
-      },
-      { width: monitor.size.width, height: monitor.size.height },
-    ),
-  );
+  return monitors.map((monitor) => {
+    const pos = parsePosition(monitor.position, monitor.scaleFactor);
+    const dims = { width: monitor.size.width, height: monitor.size.height };
+    return box.construct(pos, dims);
+  });
 };
 
 const isPositionVisible = async (position?: xy.XY): Promise<boolean> => {

--- a/drift/src/tauri/index.ts
+++ b/drift/src/tauri/index.ts
@@ -73,6 +73,7 @@ const capWindowDimensions = (
   return { ...props, maxSize: clampDims(maxSize), size: clampDims(size) };
 };
 
+/** @returns the bounding boxes for all available monitors. */
 const monitorBoxes = async (): Promise<box.Box[]> => {
   const monitors = await availableMonitors();
   return monitors.map((monitor) => {
@@ -82,6 +83,10 @@ const monitorBoxes = async (): Promise<box.Box[]> => {
   });
 };
 
+/**
+ * @returns true whether the top-left corner of the window is visible on the user's
+ * monitors. If not, shifts the window to the top-left corner of the primary monitor.
+ */
 const isPositionVisible = async (position?: xy.XY): Promise<boolean> => {
   const boxes = await monitorBoxes();
   return boxes.some((b) => box.contains(b, position));


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1891](https://linear.app/synnax/issue/SY-1891/drift-remember-monitor-locations)

## Description

Makes it so that drift properly positions windows for workspaces and persisted state on multiple monitors

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
