### PR TITLE
SY-1907 Cannot Delete any Line Plots

### DIFF
--- a/console/src/lineplot/services/ontology.tsx
+++ b/console/src/lineplot/services/ontology.tsx
@@ -7,7 +7,7 @@
 // Source License, use of this software will be governed by the Apache License,
 // Version 2.0, included in the file licenses/APL.txt.
 
-import { linePlot } from "@synnaxlabs/client";
+import { linePlot, ontology } from "@synnaxlabs/client";
 import { Icon } from "@synnaxlabs/media";
 import { Menu as PMenu, Mosaic, Tree } from "@synnaxlabs/pluto";
 import { errors } from "@synnaxlabs/x";
@@ -27,7 +27,7 @@ const useDelete = (): ((props: Ontology.TreeContextMenuProps) => void) => {
   return useMutation<void, Error, Ontology.TreeContextMenuProps, Tree.Node[]>({
     onMutate: async ({ selection, removeLayout, state: { nodes, setNodes } }) => {
       if (!(await confirm(selection.resources))) throw errors.CANCELED;
-      const ids = selection.resources.map((res) => linePlot.ontologyID(res.key));
+      const ids = selection.resources.map((res) => new ontology.ID(res.key));
       const keys = ids.map((id) => id.key);
       removeLayout(...keys);
       const prevNodes = Tree.deepCopy(nodes);
@@ -39,7 +39,7 @@ const useDelete = (): ((props: Ontology.TreeContextMenuProps) => void) => {
       return prevNodes;
     },
     mutationFn: async ({ client, selection }) => {
-      const ids = selection.resources.map((res) => linePlot.ontologyID(res.key));
+      const ids = selection.resources.map((res) => new ontology.ID(res.key));
       await new Promise((resolve) => setTimeout(resolve, 1000));
       await client.workspaces.linePlot.delete(ids.map((id) => id.key));
     },


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

  - **Linear Issue**: [SY-1907](https://linear.app/synnax/issue/SY-1907/cannot-delete-an-line-plots)

## Description

Fixes a regression introduced on 1/6/25 that incorrectly parses a resource key as the 'key' section of the ontology ID as opposed to the entire ID.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
