### PR TITLE
SY-1916 Prevent racks from appearing in palette resource search

### DIFF
--- a/console/src/channel/services/palette.tsx
+++ b/console/src/channel/services/palette.tsx
@@ -9,28 +9,23 @@
 
 import { Icon } from "@synnaxlabs/media";
 
-import { CREATE_LAYOUT } from "@/channel/Create";
-import { createCalculatedLayout } from "@/channel/CreateCalculated";
-import { type Command, type CommandSelectionContext } from "@/palette/Palette";
+import { Channel } from "@/channel";
+import { type Palette } from "@/palette";
 import { Version } from "@/version";
 
-const CREATE_CMD: Command = {
+const CREATE_COMMAND: Palette.Command = {
   icon: <Icon.Channel />,
   name: "Create Channel",
   key: "create-channel",
-  onSelect: ({ placeLayout }: CommandSelectionContext) => {
-    placeLayout(CREATE_LAYOUT);
-  },
+  onSelect: ({ placeLayout }) => placeLayout(Channel.CREATE_LAYOUT),
 };
 
-const CREATE_CALCULATED_CMD: Command = {
+const CREATE_CALCULATED_COMMAND: Palette.Command = {
   icon: <Icon.Channel />,
   name: "Create Calculated Channel",
   key: "create-calculated-channel",
-  onSelect: ({ placeLayout }: CommandSelectionContext) => {
-    placeLayout(createCalculatedLayout({}));
-  },
+  onSelect: ({ placeLayout }) => placeLayout(Channel.createCalculatedLayout({})),
   actions: [<Version.BetaTag key="beta-tag" />],
 };
 
-export const COMMANDS = [CREATE_CMD, CREATE_CALCULATED_CMD];
+export const COMMANDS = [CREATE_COMMAND, CREATE_CALCULATED_COMMAND];

--- a/console/src/channel/services/palette.tsx
+++ b/console/src/channel/services/palette.tsx
@@ -25,7 +25,7 @@ const CREATE_CALCULATED_COMMAND: Palette.Command = {
   name: "Create Calculated Channel",
   key: "create-calculated-channel",
   onSelect: ({ placeLayout }) => placeLayout(Channel.createCalculatedLayout({})),
-  actions: [<Version.BetaTag key="beta-tag" />],
+  endContent: [<Version.BetaTag key="beta-tag" />],
 };
 
 export const COMMANDS = [CREATE_COMMAND, CREATE_CALCULATED_COMMAND];

--- a/console/src/cluster/services/palette.tsx
+++ b/console/src/cluster/services/palette.tsx
@@ -9,14 +9,14 @@
 
 import { AiFillApi } from "react-icons/ai";
 
-import { connectWindowLayout } from "@/cluster/Connect";
-import { type Command } from "@/palette/Palette";
+import { Cluster } from "@/cluster";
+import { type Palette } from "@/palette";
 
-export const connectCommand: Command = {
+const CONNECT_COMMAND: Palette.Command = {
   key: "connect-cluster",
   name: "Connect a Cluster",
   icon: <AiFillApi />,
-  onSelect: ({ placeLayout }) => placeLayout(connectWindowLayout),
+  onSelect: ({ placeLayout }) => placeLayout(Cluster.connectWindowLayout),
 };
 
-export const COMMANDS = [connectCommand];
+export const COMMANDS = [CONNECT_COMMAND];

--- a/console/src/confirm/Confirm.tsx
+++ b/console/src/confirm/Confirm.tsx
@@ -8,56 +8,40 @@
 // Version 2.0, included in the file licenses/APL.txt.
 
 import { Align, Button, Nav, type Status, Text, Triggers } from "@synnaxlabs/pluto";
-import { useDispatch, useStore } from "react-redux";
+import { useDispatch } from "react-redux";
 
 import { CSS } from "@/css";
 import { Layout } from "@/layout";
-import { selectArgs } from "@/layout/selectors";
-import { type RootState } from "@/store";
 
-interface ConfirmLayoutArgs {
+export interface LayoutArgs {
   message: string;
   description: string;
-  confirm?: {
-    variant?: Status.Variant;
-    label?: string;
-  };
-  cancel?: {
-    variant?: Status.Variant;
-    label?: string;
-  };
+  confirm?: { variant?: Status.Variant; label?: string };
+  cancel?: { variant?: Status.Variant; label?: string };
   result?: boolean;
 }
 
 export const LAYOUT_TYPE = "confirm";
 
-type LayoutOverrides = Omit<Partial<Layout.State>, "key" | "type">;
+export interface LayoutOverrides extends Omit<Partial<Layout.State>, "key" | "type"> {}
 
 export const configureLayout = (
-  args: ConfirmLayoutArgs,
+  args: LayoutArgs,
   layoutOverrides?: LayoutOverrides,
-): Layout.State<ConfirmLayoutArgs> => ({
+): Layout.BaseState<LayoutArgs> => ({
   name: "Confirm",
   type: LAYOUT_TYPE,
   key: LAYOUT_TYPE,
-  windowKey: LAYOUT_TYPE,
   location: "modal",
-  window: {
-    resizable: false,
-    size: { height: 250, width: 700 },
-    navTop: true,
-  },
+  window: { resizable: false, size: { height: 250, width: 700 }, navTop: true },
   ...layoutOverrides,
-  args: {
-    ...args,
-    result: undefined,
-  },
+  args: { ...args, result: undefined },
 });
 
 const SAVE_TRIGGER: Triggers.Trigger = ["Control", "Enter"];
 
 export const Confirm: Layout.Renderer = ({ layoutKey, onClose }) => {
-  const args = Layout.useSelectArgs<ConfirmLayoutArgs>(layoutKey);
+  const args = Layout.useSelectArgs<LayoutArgs>(layoutKey);
   const { message, description, confirm, cancel } = args;
   const { variant: confirmVariant = "error", label: confirmLabel = "Confirm" } =
     confirm ?? {};
@@ -65,7 +49,7 @@ export const Confirm: Layout.Renderer = ({ layoutKey, onClose }) => {
   const dispatch = useDispatch();
   const handleResult = (value: boolean) => {
     dispatch(
-      Layout.setArgs<ConfirmLayoutArgs>({
+      Layout.setArgs<LayoutArgs>({
         key: layoutKey,
         args: { ...args, result: value },
       }),
@@ -115,34 +99,4 @@ export const Confirm: Layout.Renderer = ({ layoutKey, onClose }) => {
       </Layout.BottomNavBar>
     </Align.Space>
   );
-};
-
-export type CreateConfirmModal = (
-  args: ConfirmLayoutArgs,
-  layoutOverrides?: LayoutOverrides,
-) => Promise<boolean>;
-
-export const useModal = (): CreateConfirmModal => {
-  const place = Layout.usePlacer();
-  const store = useStore<RootState>();
-  return async (args, layoutOverrides) => {
-    let unsubscribe: ReturnType<typeof store.subscribe> | null = null;
-    return await new Promise((resolve) => {
-      const layout = configureLayout(args, layoutOverrides);
-      place(layout);
-      unsubscribe = store.subscribe(() => {
-        const l = Layout.select(store.getState(), layout.key);
-        if (l == null) resolve(false);
-        const args = selectArgs<ConfirmLayoutArgs>(store.getState(), layout.key);
-        // This means the action was unrelated to the confirmation.
-        if (args != null && args.result == null) return;
-        // This means that the layout was removed by a separate mechanism than
-        // the user hitting 'Confirm' or 'Cancel'. We treat this as a cancellation.
-        if (args == null) resolve(false);
-        // Resolve with the standard result.
-        else resolve(args.result as boolean);
-        unsubscribe?.();
-      });
-    });
-  };
 };

--- a/console/src/confirm/external.ts
+++ b/console/src/confirm/external.ts
@@ -10,7 +10,7 @@
 import { Confirm, LAYOUT_TYPE } from "@/confirm/Confirm";
 import { type Layout } from "@/layout";
 
-export { useModal } from "@/confirm/Confirm";
+export * from "@/confirm/useModal";
 
 export const LAYOUTS: Record<string, Layout.Renderer> = {
   [LAYOUT_TYPE]: Confirm,

--- a/console/src/confirm/useModal.ts
+++ b/console/src/confirm/useModal.ts
@@ -1,0 +1,47 @@
+// Copyright 2024 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in
+// the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business
+// Source License, use of this software will be governed by the Apache License,
+// Version 2.0, included in the file licenses/APL.txt.
+
+import { useStore } from "react-redux";
+
+import {
+  configureLayout,
+  type LayoutArgs,
+  type LayoutOverrides,
+} from "@/confirm/Confirm";
+import { Layout } from "@/layout";
+import { type RootState } from "@/store";
+
+export interface CreateModal {
+  (args: LayoutArgs, layoutOverrides?: LayoutOverrides): Promise<boolean>;
+}
+
+export const useModal = (): CreateModal => {
+  const placeLayout = Layout.usePlacer();
+  const store = useStore<RootState>();
+  return async (args, layoutOverrides) => {
+    let unsubscribe: ReturnType<typeof store.subscribe> | null = null;
+    return await new Promise((resolve) => {
+      const layout = configureLayout(args, layoutOverrides);
+      placeLayout(layout);
+      unsubscribe = store.subscribe(() => {
+        const l = Layout.select(store.getState(), layout.key);
+        if (l == null) resolve(false);
+        const args = Layout.selectArgs<LayoutArgs>(store.getState(), layout.key);
+        // This means the action was unrelated to the confirmation.
+        if (args != null && args.result == null) return;
+        // This means that the layout was removed by a separate mechanism than
+        // the user hitting 'Confirm' or 'Cancel'. We treat this as a cancellation.
+        if (args == null) resolve(false);
+        // Resolve with the standard result.
+        else resolve(args.result as boolean);
+        unsubscribe?.();
+      });
+    });
+  };
+};

--- a/console/src/docs/palette.tsx
+++ b/console/src/docs/palette.tsx
@@ -10,13 +10,13 @@
 import { Icon } from "@synnaxlabs/media";
 
 import { createLayout } from "@/docs/Docs";
-import { type Command } from "@/palette/Palette";
+import { type Palette } from "@/palette";
 
-export const readCommand: Command = {
+const READ_COMMAND: Palette.Command = {
   key: "read-the-docs",
   name: "Read the docs",
   icon: <Icon.QuestionMark />,
-  onSelect: ({ placeLayout: layoutPlacer }) => layoutPlacer(createLayout()),
+  onSelect: ({ placeLayout }) => placeLayout(createLayout()),
 };
 
-export const COMMANDS = [readCommand];
+export const COMMANDS = [READ_COMMAND];

--- a/console/src/hardware/labjack/palette.tsx
+++ b/console/src/hardware/labjack/palette.tsx
@@ -10,11 +10,10 @@
 import { Icon } from "@synnaxlabs/media";
 import { Icon as PIcon } from "@synnaxlabs/pluto";
 
-import { createReadLayout } from "@/hardware/labjack/task/Read";
-import { createWriteLayout } from "@/hardware/labjack/task/Write";
-import { type Command } from "@/palette/Palette";
+import { Task } from "@/hardware/labjack/task";
+import { type Palette } from "@/palette";
 
-const createReadTaskCommand: Command = {
+const CREATE_READ_TASK_COMMAND: Palette.Command = {
   key: "labjack-create-read-task",
   name: "Create a LabJack Read Task",
   icon: (
@@ -22,10 +21,10 @@ const createReadTaskCommand: Command = {
       <Icon.Logo.LabJack />
     </PIcon.Create>
   ),
-  onSelect: ({ placeLayout }) => placeLayout(() => createReadLayout({ create: true })),
+  onSelect: ({ placeLayout }) => placeLayout(Task.createReadLayout({ create: true })),
 };
 
-const createWriteTaskCommand: Command = {
+const CREATE_WRITE_TASK_COMMAND: Palette.Command = {
   key: "labjack-create-write-task",
   name: "Create a LabJack Write Task",
   icon: (
@@ -33,7 +32,7 @@ const createWriteTaskCommand: Command = {
       <Icon.Logo.LabJack />
     </PIcon.Create>
   ),
-  onSelect: ({ placeLayout }) => placeLayout(createWriteLayout({ create: true })),
+  onSelect: ({ placeLayout }) => placeLayout(Task.createWriteLayout({ create: true })),
 };
 
-export const COMMANDS = [createReadTaskCommand, createWriteTaskCommand];
+export const COMMANDS = [CREATE_READ_TASK_COMMAND, CREATE_WRITE_TASK_COMMAND];

--- a/console/src/hardware/ni/palette.tsx
+++ b/console/src/hardware/ni/palette.tsx
@@ -10,13 +10,10 @@
 import { Icon } from "@synnaxlabs/media";
 import { Icon as PIcon } from "@synnaxlabs/pluto";
 
-import { createAnalogReadLayout } from "@/hardware/ni/task/AnalogRead";
-import { createDigitalReadLayout } from "@/hardware/ni/task/DigitalRead";
-import { createDigitalWriteLayout } from "@/hardware/ni/task/DigitalWrite";
-import { type ScanConfig } from "@/hardware/ni/task/types";
-import { type Command } from "@/palette/Palette";
+import { Task } from "@/hardware/ni/task";
+import { type Palette } from "@/palette";
 
-export const createAnalogReadTaskCommand: Command = {
+const CREATE_ANALOG_READ_TASK_COMMAND: Palette.Command = {
   key: "ni-create-analog-read-task",
   name: "Create an NI Analog Read Task",
   icon: (
@@ -25,10 +22,10 @@ export const createAnalogReadTaskCommand: Command = {
     </PIcon.Create>
   ),
   onSelect: ({ placeLayout }) =>
-    placeLayout(() => createAnalogReadLayout({ create: true })),
+    placeLayout(Task.createAnalogReadLayout({ create: true })),
 };
 
-export const createDigitalWriteTaskCommand: Command = {
+const CREATE_DIGITAL_WRITE_TASK_COMMAND: Palette.Command = {
   key: "ni-create-digital-write-task",
   name: "Create an NI Digital Write Task",
   icon: (
@@ -37,10 +34,10 @@ export const createDigitalWriteTaskCommand: Command = {
     </PIcon.Create>
   ),
   onSelect: ({ placeLayout }) =>
-    placeLayout(createDigitalWriteLayout({ create: true })),
+    placeLayout(Task.createDigitalWriteLayout({ create: true })),
 };
 
-export const createDigitalReadTaskCommand: Command = {
+const CREATE_DIGITAL_READ_TASK_COMMAND: Palette.Command = {
   key: "ni-create-digital-read-task",
   name: "Create an NI Digital Read Task",
   icon: (
@@ -48,10 +45,11 @@ export const createDigitalReadTaskCommand: Command = {
       <Icon.Logo.NI />
     </PIcon.Create>
   ),
-  onSelect: ({ placeLayout }) => placeLayout(createDigitalReadLayout({ create: true })),
+  onSelect: ({ placeLayout }) =>
+    placeLayout(Task.createDigitalReadLayout({ create: true })),
 };
 
-export const toggleNIScanner: Command = {
+const TOGGLE_NI_SCAN_TASK_COMMAND: Palette.Command = {
   key: "toggle-ni-scan-task",
   name: "Toggle NI Device Scanner",
   icon: (
@@ -64,9 +62,9 @@ export const toggleNIScanner: Command = {
     void (async () => {
       try {
         const tsk =
-          await client.hardware.tasks.retrieveByName<ScanConfig>("ni scanner");
+          await client.hardware.tasks.retrieveByName<Task.ScanConfig>("ni scanner");
         const enabled = tsk.config.enabled ?? true;
-        client.hardware.tasks.create<ScanConfig>({
+        await client.hardware.tasks.create<Task.ScanConfig>({
           ...tsk.payload,
           config: { enabled: !enabled },
         });
@@ -82,8 +80,8 @@ export const toggleNIScanner: Command = {
 };
 
 export const COMMANDS = [
-  createAnalogReadTaskCommand,
-  createDigitalWriteTaskCommand,
-  createDigitalReadTaskCommand,
-  toggleNIScanner,
+  CREATE_ANALOG_READ_TASK_COMMAND,
+  CREATE_DIGITAL_WRITE_TASK_COMMAND,
+  CREATE_DIGITAL_READ_TASK_COMMAND,
+  TOGGLE_NI_SCAN_TASK_COMMAND,
 ];

--- a/console/src/hardware/opc/device/palette.tsx
+++ b/console/src/hardware/opc/device/palette.tsx
@@ -13,7 +13,7 @@ import { Icon as PIcon } from "@synnaxlabs/pluto";
 import { createConfigureLayout } from "@/hardware/opc/device/Configure";
 import { type Palette } from "@/palette";
 
-const connectServerCommand: Palette.Command = {
+const CONNECT_SERVER_COMMAND: Palette.Command = {
   key: "opc-connect-server",
   name: "Connect an OPC UA Server",
   icon: (
@@ -24,4 +24,4 @@ const connectServerCommand: Palette.Command = {
   onSelect: ({ placeLayout }) => placeLayout(createConfigureLayout()),
 };
 
-export const COMMANDS: Palette.Command[] = [connectServerCommand];
+export const COMMANDS: Palette.Command[] = [CONNECT_SERVER_COMMAND];

--- a/console/src/hardware/opc/task/palette.tsx
+++ b/console/src/hardware/opc/task/palette.tsx
@@ -11,20 +11,20 @@ import { Icon } from "@synnaxlabs/media";
 
 import { configureReadLayout } from "@/hardware/opc/task/Read";
 import { createWriteLayout } from "@/hardware/opc/task/Write";
-import { type Command } from "@/palette/Palette";
+import { type Palette } from "@/palette";
 
-const createReadTaskCommand: Command = {
+const CREATE_READ_TASK_COMMAND: Palette.Command = {
   key: "opc-create-read-task",
   name: "Create an OPC UA Read Task",
   icon: <Icon.Logo.OPC />,
   onSelect: ({ placeLayout }) => placeLayout(configureReadLayout({ create: true })),
 };
 
-const createWriteTaskCommand: Command = {
+const CREATE_WRITE_TASK_COMMAND: Palette.Command = {
   key: "opc-create-write-task",
   name: "Create an OPC UA Write Task",
   icon: <Icon.Logo.OPC />,
   onSelect: ({ placeLayout }) => placeLayout(createWriteLayout({ create: true })),
 };
 
-export const COMMANDS = [createReadTaskCommand, createWriteTaskCommand];
+export const COMMANDS = [CREATE_READ_TASK_COMMAND, CREATE_WRITE_TASK_COMMAND];

--- a/console/src/label/services/palette.tsx
+++ b/console/src/label/services/palette.tsx
@@ -9,14 +9,14 @@
 
 import { Icon } from "@synnaxlabs/media";
 
-import { createEditLayout } from "@/label/Edit";
-import { type Command } from "@/palette/Palette";
+import { Label } from "@/label";
+import { type Palette } from "@/palette";
 
-export const editCommand: Command = {
+const EDIT_COMMAND: Palette.Command = {
   key: "edit-labels",
   name: "Edit Labels",
   icon: <Icon.Label />,
-  onSelect: ({ placeLayout }) => placeLayout(createEditLayout()),
+  onSelect: ({ placeLayout }) => placeLayout(Label.createEditLayout()),
 };
 
-export const COMMANDS = [editCommand];
+export const COMMANDS = [EDIT_COMMAND];

--- a/console/src/layout/palette.tsx
+++ b/console/src/layout/palette.tsx
@@ -10,15 +10,13 @@
 import { MdDarkMode } from "react-icons/md";
 
 import { setActiveTheme } from "@/layout/slice";
-import { type Command, type CommandSelectionContext } from "@/palette/Palette";
+import { type Palette } from "@/palette";
 
-export const toggleThemeCommand: Command = {
+const TOGGLE_THEME_COMMAND: Palette.Command = {
   icon: <MdDarkMode />,
   name: "Toggle Color Theme",
   key: "toggle-theme",
-  onSelect: (ctx: CommandSelectionContext) => {
-    ctx.store.dispatch(setActiveTheme());
-  },
+  onSelect: ({ store }) => store.dispatch(setActiveTheme()),
 };
 
-export const COMMANDS = [toggleThemeCommand];
+export const COMMANDS = [TOGGLE_THEME_COMMAND];

--- a/console/src/layout/slice.ts
+++ b/console/src/layout/slice.ts
@@ -22,6 +22,7 @@ import * as latest from "@/layout/types";
 import { type RootState } from "@/store";
 
 export type State<A = unknown> = latest.State<A>;
+export interface BaseState<A = unknown> extends Omit<latest.State<A>, "windowKey"> {}
 export type SliceState = latest.SliceState;
 export type NavDrawerLocation = latest.NavDrawerLocation;
 export type NavDrawerEntryState = latest.NavDrawerEntryState;

--- a/console/src/lineplot/services/palette.tsx
+++ b/console/src/lineplot/services/palette.tsx
@@ -9,19 +9,19 @@
 
 import { Icon } from "@synnaxlabs/media";
 
-import { create } from "@/lineplot/LinePlot";
+import { LinePlot } from "@/lineplot";
 import { ImportIcon } from "@/lineplot/services/Icon";
 import { import_ } from "@/lineplot/services/import";
-import { type Command } from "@/palette/Palette";
+import { type Palette } from "@/palette";
 
-const CREATE_COMMAND: Command = {
+const CREATE_COMMAND: Palette.Command = {
   key: "create-line-plot",
   name: "Create Line Plot",
   icon: <Icon.Visualize />,
-  onSelect: ({ placeLayout }) => placeLayout(create({})),
+  onSelect: ({ placeLayout }) => placeLayout(LinePlot.create({})),
 };
 
-const IMPORT_COMMAND: Command = {
+const IMPORT_COMMAND: Palette.Command = {
   key: "import-line-plot",
   name: "Import Line Plot(s)",
   icon: <ImportIcon />,

--- a/console/src/log/services/palette.tsx
+++ b/console/src/log/services/palette.tsx
@@ -9,19 +9,19 @@
 
 import { Icon } from "@synnaxlabs/media";
 
-import { create } from "@/log/Log";
+import { Log } from "@/log";
 import { ImportIcon } from "@/log/services/Icon";
 import { import_ } from "@/log/services/import";
-import { type Command } from "@/palette/Palette";
+import { type Palette } from "@/palette";
 
-const CREATE_COMMAND: Command = {
+const CREATE_COMMAND: Palette.Command = {
   key: "create-log",
   name: "Create Log",
   icon: <Icon.Log />,
-  onSelect: ({ placeLayout }) => placeLayout(create({})),
+  onSelect: ({ placeLayout }) => placeLayout(Log.create({})),
 };
 
-const IMPORT_COMMAND: Command = {
+const IMPORT_COMMAND: Palette.Command = {
   key: "import-log",
   name: "Import Log(s)",
   icon: <ImportIcon />,

--- a/console/src/ontology/service.ts
+++ b/console/src/ontology/service.ts
@@ -101,7 +101,7 @@ export interface Service {
     | ReactElement<Icon.BaseProps>
     | ((resource: ontology.Resource) => ReactElement<Icon.BaseProps>);
   hasChildren: boolean;
-  onSelect: HandleSelect;
+  onSelect?: HandleSelect;
   canDrop: Haul.CanDrop;
   haulItems: (resource: ontology.Resource) => Haul.Item[];
   allowRename: AllowRename;

--- a/console/src/palette/Palette.css
+++ b/console/src/palette/Palette.css
@@ -30,17 +30,6 @@
     min-height: 400px;
     max-width: 1200px;
     overflow: hidden;
-
-    .pluto-list__item {
-        .console-palette__actions {
-            opacity: 0;
-        }
-        &:is(:hover, .pluto--hovered) {
-            .console-palette__actions {
-                opacity: 1;
-            }
-        }
-    }
 }
 
 .console-palette__list {

--- a/console/src/palette/Palette.tsx
+++ b/console/src/palette/Palette.tsx
@@ -37,7 +37,6 @@ import {
 import { useStore } from "react-redux";
 
 import { Confirm } from "@/confirm";
-import { type CreateConfirmModal } from "@/confirm/Confirm";
 import { CSS } from "@/css";
 import { type FileIngestor } from "@/import/ingestor";
 import { INGESTORS } from "@/ingestors";
@@ -384,7 +383,7 @@ export interface CommandSelectionContext {
   store: RootStore;
   client: Synnax | null;
   placeLayout: Layout.Placer;
-  confirm: CreateConfirmModal;
+  confirm: Confirm.CreateModal;
   addStatus: Status.AddStatusFn;
   handleException: Status.HandleExcFn;
   ingestors: Record<string, FileIngestor>;

--- a/console/src/palette/command.tsx
+++ b/console/src/palette/command.tsx
@@ -1,0 +1,59 @@
+// Copyright 2024 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { type Synnax } from "@synnaxlabs/client";
+import { Align, type Icon, List, type Status, Text } from "@synnaxlabs/pluto";
+import { type ReactElement } from "react";
+
+import { type Confirm } from "@/confirm";
+import { type Import } from "@/import";
+import { type Layout } from "@/layout";
+import { type Permissions } from "@/permissions";
+import { type RootStore } from "@/store";
+
+export const CommandListItem = (
+  props: List.ItemProps<string, Command>,
+): ReactElement => {
+  const {
+    entry: { icon, name, endContent },
+  } = props;
+  return (
+    <List.ItemFrame
+      highlightHovered
+      style={{ height: "6.5rem" }}
+      justify="spaceBetween"
+      align="center"
+      {...props}
+    >
+      <Text.WithIcon startIcon={icon} level="p" weight={400} shade={9} size="medium">
+        {name}
+      </Text.WithIcon>
+      {endContent != null && <Align.Space direction="x">{endContent}</Align.Space>}
+    </List.ItemFrame>
+  );
+};
+
+export interface CommandSelectionContext {
+  store: RootStore;
+  client: Synnax | null;
+  placeLayout: Layout.Placer;
+  confirm: Confirm.CreateModal;
+  addStatus: Status.AddStatusFn;
+  handleException: Status.HandleExcFn;
+  ingestors: Record<string, Import.FileIngestor>;
+}
+
+export interface Command {
+  key: string;
+  name: ReactElement | string;
+  icon?: ReactElement<Icon.BaseProps>;
+  visible?: (state: Permissions.StoreState) => boolean;
+  onSelect: (ctx: CommandSelectionContext) => void;
+  endContent?: ReactElement[];
+}

--- a/console/src/palette/external.ts
+++ b/console/src/palette/external.ts
@@ -7,6 +7,6 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+export { type Command, type CommandSelectionContext } from "@/palette/command";
 export * from "@/palette/Palette";
-export * from "@/palette/Tooltip";
 export * from "@/palette/types";

--- a/console/src/palette/resource.tsx
+++ b/console/src/palette/resource.tsx
@@ -1,0 +1,52 @@
+// Copyright 2024 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { type ontology } from "@synnaxlabs/client";
+import { List, Text } from "@synnaxlabs/pluto";
+import { type FC, isValidElement, type ReactElement } from "react";
+
+import { type Ontology } from "@/ontology";
+
+interface OntologyListItemProps extends List.ItemProps<string, ontology.Resource> {}
+
+export const createResourceListItem = (
+  ontologyServices: Ontology.Services,
+): FC<OntologyListItemProps> => {
+  const ResourceListItem = (props: OntologyListItemProps): ReactElement | null => {
+    const {
+      entry,
+      entry: { name, id },
+    } = props;
+    // This null check is needed because sometimes when switching to search mode from command
+    // mode, the commands are passed in as resources.
+    if (id == null) return null;
+    const ontologyService = ontologyServices[id.type];
+    // return null if the ontology service does not have an onSelect method, that way we
+    // don't show pointless items in the palette.
+    if (ontologyService?.onSelect == null) return null;
+    const ListItem = ontologyService?.PaletteListItem;
+    if (ListItem != null) return <ListItem {...props} />;
+    const { icon } = ontologyService;
+    return (
+      <List.ItemFrame style={{ padding: "1.5rem" }} highlightHovered {...props}>
+        <Text.WithIcon
+          startIcon={isValidElement(icon) ? icon : icon(entry)}
+          level="p"
+          weight={450}
+          shade={9}
+          size="medium"
+        >
+          {name}
+        </Text.WithIcon>
+      </List.ItemFrame>
+    );
+  };
+  ResourceListItem.displayName = "ResourceListItem";
+  return ResourceListItem;
+};

--- a/console/src/palette/types.ts
+++ b/console/src/palette/types.ts
@@ -11,4 +11,4 @@ import { type Triggers } from "@synnaxlabs/pluto";
 
 export type Mode = "command" | "resource";
 
-export type TriggerConfig = Triggers.ModeConfig<Mode>;
+export interface TriggerConfig extends Triggers.ModeConfig<Mode> {}

--- a/console/src/persist/palette.tsx
+++ b/console/src/persist/palette.tsx
@@ -10,10 +10,10 @@
 import { type PayloadAction } from "@reduxjs/toolkit";
 import { Icon } from "@synnaxlabs/media";
 
-import { type Command } from "@/palette/Palette";
+import { type Palette } from "@/palette";
 import { CLEAR_STATE } from "@/persist/state";
 
-export const defineCommand: Command = {
+const CLEAR_LOCAL_STORAGE_COMMAND: Palette.Command = {
   key: "clear-local-storage",
   name: "Clear Local Storage",
   icon: <Icon.Close />,
@@ -32,4 +32,4 @@ export const defineCommand: Command = {
   },
 };
 
-export const COMMANDS = [defineCommand];
+export const COMMANDS = [CLEAR_LOCAL_STORAGE_COMMAND];

--- a/console/src/range/services/palette.tsx
+++ b/console/src/range/services/palette.tsx
@@ -9,14 +9,14 @@
 
 import { Icon } from "@synnaxlabs/media";
 
-import { type Command } from "@/palette/Palette";
-import { createLayout } from "@/range/CreateLayout";
+import { type Palette } from "@/palette";
+import { Range } from "@/range";
 
-export const defineCommand: Command = {
+const CREATE_COMMAND: Palette.Command = {
   key: "define-range",
   name: "Create a Range",
   icon: <Icon.Range />,
-  onSelect: ({ placeLayout }) => placeLayout(createLayout({})),
+  onSelect: ({ placeLayout }) => placeLayout(Range.createLayout({})),
 };
 
-export const COMMANDS = [defineCommand];
+export const COMMANDS = [CREATE_COMMAND];

--- a/console/src/schematic/services/palette.tsx
+++ b/console/src/schematic/services/palette.tsx
@@ -9,21 +9,20 @@
 
 import { Icon } from "@synnaxlabs/media";
 
-import { type Command } from "@/palette/Palette";
-import { create } from "@/schematic/Schematic";
-import { selectHasPermission } from "@/schematic/selectors";
+import { type Palette } from "@/palette";
+import { Schematic } from "@/schematic";
 import { ImportIcon } from "@/schematic/services/Icon";
 import { import_ } from "@/schematic/services/import";
 
-const CREATE_COMMAND: Command = {
+const CREATE_COMMAND: Palette.Command = {
   key: "create-schematic",
   name: "Create Schematic",
   icon: <Icon.Schematic />,
-  onSelect: ({ placeLayout }) => placeLayout(create({})),
-  visible: (state) => selectHasPermission(state),
+  onSelect: ({ placeLayout }) => placeLayout(Schematic.create({})),
+  visible: (state) => Schematic.selectHasPermission(state),
 };
 
-const IMPORT_COMMAND: Command = {
+const IMPORT_COMMAND: Palette.Command = {
   key: "import-schematic",
   name: "Import Schematic(s)",
   icon: <ImportIcon />,

--- a/console/src/services.tsx
+++ b/console/src/services.tsx
@@ -30,12 +30,8 @@ export const EMPTY_ONTOLOGY_SERVICE: Ontology.Service = {
   icon: <></>,
   hasChildren: true,
   canDrop: () => false,
-  onMosaicDrop: () => {},
-  TreeContextMenu: () => <></>,
-  onSelect: () => {},
   haulItems: () => [],
   allowRename: () => false,
-  onRename: undefined,
 };
 
 export const SERVICES: Ontology.Services = {

--- a/console/src/table/services/palette.tsx
+++ b/console/src/table/services/palette.tsx
@@ -9,19 +9,19 @@
 
 import { Icon } from "@synnaxlabs/media";
 
-import { type Command } from "@/palette/Palette";
+import { type Palette } from "@/palette";
+import { Table } from "@/table";
 import { ImportIcon } from "@/table/services/Icon";
 import { import_ } from "@/table/services/import";
-import { create } from "@/table/Table";
 
-const CREATE_COMMAND: Command = {
+const CREATE_COMMAND: Palette.Command = {
   key: "create-table",
   name: "Create Table",
   icon: <Icon.Table />,
-  onSelect: ({ placeLayout }) => placeLayout(create({})),
+  onSelect: ({ placeLayout }) => placeLayout(Table.create({})),
 };
 
-const IMPORT_COMMAND: Command = {
+const IMPORT_COMMAND: Palette.Command = {
   key: "import-table",
   name: "Import Table(s)",
   icon: <ImportIcon />,

--- a/console/src/user/services/palette.tsx
+++ b/console/src/user/services/palette.tsx
@@ -9,16 +9,15 @@
 
 import { Icon } from "@synnaxlabs/media";
 
-import { type Command } from "@/palette/Palette";
-import { registerLayout } from "@/user/RegisterModal";
-import { selectHasPermission } from "@/user/selectors";
+import { type Palette } from "@/palette";
+import { User } from "@/user";
 
-export const registerUserCommand: Command = {
+const REGISTER_USER_COMMAND: Palette.Command = {
   icon: <Icon.User />,
   name: "Register a User",
   key: "register-user",
-  onSelect: ({ placeLayout }) => placeLayout(registerLayout({})),
-  visible: (state) => selectHasPermission(state),
+  onSelect: ({ placeLayout }) => placeLayout(User.registerLayout({})),
+  visible: (state) => User.selectHasPermission(state),
 };
 
-export const COMMANDS = [registerUserCommand];
+export const COMMANDS = [REGISTER_USER_COMMAND];

--- a/console/src/workspace/services/palette.tsx
+++ b/console/src/workspace/services/palette.tsx
@@ -9,20 +9,19 @@
 
 import { Icon } from "@synnaxlabs/media";
 
-import { type Command } from "@/palette/Palette";
+import { type Palette } from "@/palette";
 import { Workspace } from "@/workspace";
 import { ImportIcon } from "@/workspace/services/Icon";
 import { import_ } from "@/workspace/services/import";
 
-const CREATE_COMMAND: Command = {
+const CREATE_COMMAND: Palette.Command = {
   key: "workspace-create",
   name: "Create Workspace",
   icon: <Icon.Workspace />,
-  onSelect: ({ placeLayout: layoutPlacer }) =>
-    layoutPlacer(Workspace.CREATE_WINDOW_LAYOUT),
+  onSelect: ({ placeLayout }) => placeLayout(Workspace.CREATE_WINDOW_LAYOUT),
 };
 
-const IMPORT_COMMAND: Command = {
+const IMPORT_COMMAND: Palette.Command = {
   key: "workspace-import",
   name: "Import Workspace",
   icon: <ImportIcon />,

--- a/pluto/src/dropdown/index.ts
+++ b/pluto/src/dropdown/index.ts
@@ -7,6 +7,4 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import * as Dropdown from "@/dropdown/Dropdown";
-
-export { Dropdown };
+export * as Dropdown from "@/dropdown/Dropdown";


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1916](https://linear.app/synnax/issue/SY-1916/sy-node-1-rack-shows-up-in-search-and-command-palette)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

- Refactored the `confirm` and `palette` console directories along with all `palette.tsx` files.
- Blocked showing ontology resources in the palette that do not have an `onSelect` method for their types respective `ontology.Service`

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
