### PR TITLE
SY-1924 Fix Clear Local Storage Command

### DIFF
--- a/console/src/persist/state.ts
+++ b/console/src/persist/state.ts
@@ -106,12 +106,13 @@ interface Engine<S extends RequiredState> {
  * @param config - The configuration for the engine.
  * @returns A new engine instance.
  */
-export const open = async <S extends RequiredState>({
-  exclude = [],
-  initial,
-  migrator,
-  openKV,
-}: Config<S>): Promise<Engine<S>> => {
+export const open = async <S extends RequiredState>(
+  config: Config<S>,
+): Promise<Engine<S>> => {
+  const { exclude = [], initial, migrator, openKV } = config;
+  // We need to make sure we copy the initial state because we're going to mutate it,
+  // and we don't want to accidentally mutate the initial state, or run into errors
+  // with readonly properties.
   const copiedInitial = deep.copy(initial);
   const db = await openAndMigrateKV(openKV);
   const kvVersion = (await db.get(DB_VERSION_KEY)) as StateVersionValue;


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1924](https://linear.app/synnax/issue/SY-1924/fix-clear-local-storage-command)

## Description

Fixes issues clearing local storage, and makes sure that initial state gets properly copied to avoid issues with readonly initial state fields. 

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
