### PR TITLE
SY-1934 - Fix Shift-Select Resource Grouping

### DIFF
--- a/pluto/src/text/Editable.tsx
+++ b/pluto/src/text/Editable.tsx
@@ -209,10 +209,6 @@ export const Editable = <L extends text.Level = text.Level>({
         handleUpdate(el);
       }}
       onKeyDown={handleKeyDown}
-      onKeyUp={(e: KeyboardEvent<HTMLParagraphElement>) => {
-        e.stopPropagation();
-        e.preventDefault();
-      }}
       onDoubleClick={handleDoubleClick}
       contentEditable={editable}
       suppressContentEditableWarning

--- a/pluto/src/triggers/Provider.tsx
+++ b/pluto/src/triggers/Provider.tsx
@@ -65,7 +65,10 @@ export interface ProviderProps extends PropsWithChildren {
 
 const isInputOrContentEditable = (e: KeyboardEvent): boolean => {
   if (e.target instanceof HTMLInputElement) return true;
-  if (e.target instanceof HTMLElement && e.target.matches("[contenteditable]"))
+  if (
+    e.target instanceof HTMLElement &&
+    e.target.getAttribute("contenteditable") === "true"
+  )
     return true;
   return false;
 };
@@ -86,7 +89,7 @@ export const Provider = ({
   preventDefaultOn,
   preventDefaultOptions,
 }: ProviderProps): ReactElement => {
-  // We track mouse movement to allow for cursor position on keybord events;
+  // We track mouse movement to allow for cursor position on keyboard events;
   const cursor = useRef<xy.XY>(xy.ZERO);
   const handleMouseMove = useCallback((e: MouseEvent): void => {
     cursor.current = xy.construct(e);


### PR DESCRIPTION
# Issue Pull Request

## Key Information

- **Linear Issue**: [SY-1934](https://linear.app/synnax/issue/SY-1934/fix-resource-grouping)

## Description

1. Pressed down on Shift
2. You selected several resources in the tree
3. Grouped them
4. Renamed the group
5. Hit enter
6. Let go of shift

The Triggers system would not detect that you released the shift key, causing problems with expanding and contracting groups. This removes a propagation/default behavior stopper in the editable text component, which fixes that issue. Unfortunately, this might have unexpected side effects that are difficult to track. 

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
