### PR TITLE
SY-1935 - Prevent Non-Empty Groups from Being Deleted

### DIFF
--- a/synnax/pkg/api/hardware.go
+++ b/synnax/pkg/api/hardware.go
@@ -1,13 +1,11 @@
-/*
- * Copyright 2024 Synnax Labs, Inc.
- *
- * Use of this software is governed by the Business Source License included in the file
- * licenses/BSL.txt.
- *
- * As of the Change Date specified in that file, in accordance with the Business Source
- * License, use of this software will be governed by the Apache License, Version 2.0,
- * included in the file licenses/APL.txt.
- */
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
 
 package api
 

--- a/synnax/pkg/distribution/channel/lease_proxy.go
+++ b/synnax/pkg/distribution/channel/lease_proxy.go
@@ -442,6 +442,8 @@ func (lp *leaseProxy) deleteGateway(ctx context.Context, tx gorp.Tx, keys Keys) 
 	if err := lp.maybeDeleteResources(ctx, tx, keys); err != nil {
 		return err
 	}
+	// It's very important that this goes last, as it's the only operation that can fail
+	// without an atomic guarantee.
 	return lp.TSChannel.DeleteChannels(keys.Storage())
 }
 

--- a/synnax/pkg/distribution/channel/lease_proxy.go
+++ b/synnax/pkg/distribution/channel/lease_proxy.go
@@ -439,10 +439,10 @@ func (lp *leaseProxy) deleteGateway(ctx context.Context, tx gorp.Tx, keys Keys) 
 		return err
 	}
 	lp.external.Remove(keys.Local()...)
-	if err := lp.TSChannel.DeleteChannels(keys.Storage()); err != nil {
+	if err := lp.maybeDeleteResources(ctx, tx, keys); err != nil {
 		return err
 	}
-	return lp.maybeDeleteResources(ctx, tx, keys)
+	return lp.TSChannel.DeleteChannels(keys.Storage())
 }
 
 func (lp *leaseProxy) maybeDeleteResources(

--- a/synnax/pkg/distribution/ontology/group/group_suite_test.go
+++ b/synnax/pkg/distribution/ontology/group/group_suite_test.go
@@ -1,3 +1,12 @@
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
 package group_test
 
 import (

--- a/synnax/pkg/distribution/ontology/group/group_suite_test.go
+++ b/synnax/pkg/distribution/ontology/group/group_suite_test.go
@@ -1,0 +1,16 @@
+package group_test
+
+import (
+	"context"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var ctx = context.Background()
+
+func TestGroup(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Group Suite")
+}

--- a/synnax/pkg/distribution/ontology/group/group_test.go
+++ b/synnax/pkg/distribution/ontology/group/group_test.go
@@ -1,3 +1,12 @@
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
 package group_test
 
 import (

--- a/synnax/pkg/distribution/ontology/group/group_test.go
+++ b/synnax/pkg/distribution/ontology/group/group_test.go
@@ -1,0 +1,152 @@
+package group_test
+
+import (
+	"github.com/google/uuid"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
+	"github.com/synnaxlabs/synnax/pkg/distribution/ontology/group"
+	"github.com/synnaxlabs/x/errors"
+	"github.com/synnaxlabs/x/gorp"
+	"github.com/synnaxlabs/x/kv/memkv"
+	. "github.com/synnaxlabs/x/testutil"
+	"github.com/synnaxlabs/x/validate"
+)
+
+var _ = Describe("Group", Ordered, func() {
+	var (
+		db  *gorp.DB
+		svc *group.Service
+		otg *ontology.Ontology
+		w   group.Writer
+	)
+
+	BeforeAll(func() {
+		db = gorp.Wrap(memkv.New())
+		otg = MustSucceed(ontology.Open(ctx, ontology.Config{DB: db}))
+		svc = MustSucceed(group.OpenService(group.Config{DB: db, Ontology: otg}))
+		w = svc.NewWriter(nil)
+	})
+
+	AfterAll(func() {
+		Expect(otg.Close()).To(Succeed())
+		Expect(db.Close()).To(Succeed())
+	})
+
+	Describe("Create", func() {
+		It("Should create a new group", func() {
+			g, err := w.Create(ctx, "test1", ontology.RootID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(g.Key).ToNot(Equal(uuid.Nil))
+			Expect(g.Name).To(Equal("test1"))
+		})
+
+		It("Should create a group with a specific key", func() {
+			key := uuid.New()
+			g, err := w.CreateWithKey(ctx, key, "test2", ontology.RootID)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(g.Key).To(Equal(key))
+			Expect(g.Name).To(Equal("test2"))
+		})
+
+		It("Should create a nested group", func() {
+			parent, err := w.Create(ctx, "parent", ontology.RootID)
+			Expect(err).ToNot(HaveOccurred())
+
+			child, err := w.Create(ctx, "child", group.OntologyID(parent.Key))
+			Expect(err).ToNot(HaveOccurred())
+			Expect(child.Name).To(Equal("child"))
+		})
+
+	})
+
+	Describe("Retrieve", func() {
+		It("Should retrieve a group by its key", func() {
+			created, err := w.Create(ctx, "retrieve-test", ontology.RootID)
+			Expect(err).ToNot(HaveOccurred())
+
+			var g group.Group
+			err = svc.NewRetrieve().WhereKeys(created.Key).Entry(&g).Exec(ctx, nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(g).To(Equal(created))
+		})
+
+		It("Should retrieve multiple groups by keys", func() {
+			g1, err := w.Create(ctx, "multi1", ontology.RootID)
+			Expect(err).ToNot(HaveOccurred())
+
+			g2, err := w.Create(ctx, "multi2", ontology.RootID)
+			Expect(err).ToNot(HaveOccurred())
+
+			var ret []group.Group
+			err = svc.NewRetrieve().WhereKeys(g1.Key, g2.Key).Entries(&ret).Exec(ctx, nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(ret).To(ConsistOf(g1, g2))
+		})
+
+		It("Should retrieve a group by its name", func() {
+			created, err := w.Create(ctx, "name-test", ontology.RootID)
+			Expect(err).ToNot(HaveOccurred())
+
+			var g group.Group
+			err = svc.NewRetrieve().WhereNames(created.Name).Entry(&g).Exec(ctx, nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(g).To(Equal(created))
+		})
+	})
+
+	Describe("Rename", func() {
+		It("Should rename a group", func() {
+			created, err := w.Create(ctx, "original-name", ontology.RootID)
+			Expect(err).ToNot(HaveOccurred())
+
+			newName := "renamed"
+			Expect(w.Rename(ctx, created.Key, newName)).To(Succeed())
+
+			var g group.Group
+			err = svc.NewRetrieve().WhereKeys(created.Key).Entry(&g).Exec(ctx, nil)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(g.Name).To(Equal(newName))
+		})
+	})
+
+	Describe("Delete", func() {
+		It("Should not delete a group with children", func() {
+			parent, err := w.Create(ctx, "parent-to-keep", ontology.RootID)
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = w.Create(ctx, "child-blocking-delete", group.OntologyID(parent.Key))
+			Expect(err).ToNot(HaveOccurred())
+
+			err = w.Delete(ctx, parent.Key)
+			Expect(err).To(HaveOccurred())
+			Expect(errors.Is(err, validate.Error)).To(BeTrue())
+		})
+
+		It("Should delete a group without children", func() {
+			created, err := w.Create(ctx, "to-delete", ontology.RootID)
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(w.Delete(ctx, created.Key)).To(Succeed())
+
+			var g group.Group
+			err = svc.NewRetrieve().WhereKeys(created.Key).Entry(&g).Exec(ctx, nil)
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("Should delete multiple groups", func() {
+			parent, err := w.Create(ctx, "parent-for-deletion", ontology.RootID)
+			Expect(err).ToNot(HaveOccurred())
+
+			child, err := w.Create(ctx, "child-for-deletion", group.OntologyID(parent.Key))
+			Expect(err).ToNot(HaveOccurred())
+
+			Expect(w.Delete(ctx, child.Key)).To(Succeed())
+			Expect(w.Delete(ctx, parent.Key)).To(Succeed())
+
+			var g group.Group
+			err = svc.NewRetrieve().WhereKeys(parent.Key, child.Key).Entry(&g).Exec(ctx, nil)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})

--- a/synnax/pkg/distribution/ontology/group/service.go
+++ b/synnax/pkg/distribution/ontology/group/service.go
@@ -11,10 +11,10 @@ package group
 
 import (
 	"context"
-	"errors"
 	"github.com/google/uuid"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
 	"github.com/synnaxlabs/x/config"
+	"github.com/synnaxlabs/x/errors"
 	"github.com/synnaxlabs/x/gorp"
 	"github.com/synnaxlabs/x/override"
 	"github.com/synnaxlabs/x/query"
@@ -139,6 +139,19 @@ func (w Writer) CreateWithKey(
 // Delete deletes the Groups with the given keys.
 func (w Writer) Delete(ctx context.Context, keys ...uuid.UUID) error {
 	for _, key := range keys {
+		var children []ontology.Resource
+		if err := w.otg.NewRetrieve().
+			WhereIDs(OntologyID(key)).
+			TraverseTo(ontology.Children).
+			IncludeSchema(false).
+			ExcludeFieldData(true).
+			Entries(&children).
+			Exec(ctx, w.tx); err != nil {
+			return err
+		}
+		if len(children) > 0 {
+			return errors.Wrap(validate.Error, "cannot delete a group with children")
+		}
 		if err := w.otg.DeleteResource(ctx, OntologyID(key)); err != nil {
 			return err
 		}

--- a/synnax/pkg/distribution/ontology/schema/resource_test.go
+++ b/synnax/pkg/distribution/ontology/schema/resource_test.go
@@ -1,13 +1,11 @@
-/*
- * Copyright 2024 Synnax Labs, Inc.
- *
- * Use of this software is governed by the Business Source License included in the file
- * licenses/BSL.txt.
- *
- * As of the Change Date specified in that file, in accordance with the Business Source
- * License, use of this software will be governed by the Apache License, Version 2.0,
- * included in the file licenses/APL.txt.
- */
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
 
 package schema_test
 

--- a/synnax/pkg/service/hardware/device/device.go
+++ b/synnax/pkg/service/hardware/device/device.go
@@ -1,13 +1,11 @@
-/*
- * Copyright 2024 Synnax Labs, Inc.
- *
- * Use of this software is governed by the Business Source License included in the file
- * licenses/BSL.txt.
- *
- * As of the Change Date specified in that file, in accordance with the Business Source
- * License, use of this software will be governed by the Apache License, Version 2.0,
- * included in the file licenses/APL.txt.
- */
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
 
 package device
 

--- a/synnax/pkg/service/hardware/device/ontology.go
+++ b/synnax/pkg/service/hardware/device/ontology.go
@@ -1,13 +1,11 @@
-/*
- * Copyright 2024 Synnax Labs, Inc.
- *
- * Use of this software is governed by the Business Source License included in the file
- * licenses/BSL.txt.
- *
- * As of the Change Date specified in that file, in accordance with the Business Source
- * License, use of this software will be governed by the Apache License, Version 2.0,
- * included in the file licenses/APL.txt.
- */
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
 
 package device
 

--- a/synnax/pkg/service/hardware/device/retrieve.go
+++ b/synnax/pkg/service/hardware/device/retrieve.go
@@ -1,13 +1,11 @@
-/*
- * Copyright 2024 Synnax Labs, Inc.
- *
- * Use of this software is governed by the Business Source License included in the file
- * licenses/BSL.txt.
- *
- * As of the Change Date specified in that file, in accordance with the Business Source
- * License, use of this software will be governed by the Apache License, Version 2.0,
- * included in the file licenses/APL.txt.
- */
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
 
 package device
 

--- a/synnax/pkg/service/hardware/device/service.go
+++ b/synnax/pkg/service/hardware/device/service.go
@@ -1,13 +1,11 @@
-/*
- * Copyright 2024 Synnax Labs, Inc.
- *
- * Use of this software is governed by the Business Source License included in the file
- * licenses/BSL.txt.
- *
- * As of the Change Date specified in that file, in accordance with the Business Source
- * License, use of this software will be governed by the Apache License, Version 2.0,
- * included in the file licenses/APL.txt.
- */
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
 
 package device
 

--- a/synnax/pkg/service/hardware/device/writer.go
+++ b/synnax/pkg/service/hardware/device/writer.go
@@ -1,13 +1,11 @@
-/*
- * Copyright 2024 Synnax Labs, Inc.
- *
- * Use of this software is governed by the Business Source License included in the file
- * licenses/BSL.txt.
- *
- * As of the Change Date specified in that file, in accordance with the Business Source
- * License, use of this software will be governed by the Apache License, Version 2.0,
- * included in the file licenses/APL.txt.
- */
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
 
 package device
 

--- a/synnax/pkg/service/hardware/rack/ontology.go
+++ b/synnax/pkg/service/hardware/rack/ontology.go
@@ -1,13 +1,11 @@
-/*
- * Copyright 2024 Synnax Labs, Inc.
- *
- * Use of this software is governed by the Business Source License included in the file
- * licenses/BSL.txt.
- *
- * As of the Change Date specified in that file, in accordance with the Business Source
- * License, use of this software will be governed by the Apache License, Version 2.0,
- * included in the file licenses/APL.txt.
- */
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
 
 package rack
 

--- a/synnax/pkg/service/hardware/rack/rack.go
+++ b/synnax/pkg/service/hardware/rack/rack.go
@@ -1,13 +1,11 @@
-/*
- * Copyright 2024 Synnax Labs, Inc.
- *
- * Use of this software is governed by the Business Source License included in the file
- * licenses/BSL.txt.
- *
- * As of the Change Date specified in that file, in accordance with the Business Source
- * License, use of this software will be governed by the Apache License, Version 2.0,
- * included in the file licenses/APL.txt.
- */
+// Copyright 2023 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
 
 package rack
 

--- a/synnax/pkg/service/hardware/rack/retrieve.go
+++ b/synnax/pkg/service/hardware/rack/retrieve.go
@@ -1,13 +1,11 @@
-/*
- * Copyright 2024 Synnax Labs, Inc.
- *
- * Use of this software is governed by the Business Source License included in the file
- * licenses/BSL.txt.
- *
- * As of the Change Date specified in that file, in accordance with the Business Source
- * License, use of this software will be governed by the Apache License, Version 2.0,
- * included in the file licenses/APL.txt.
- */
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
 
 package rack
 

--- a/synnax/pkg/service/hardware/rack/service.go
+++ b/synnax/pkg/service/hardware/rack/service.go
@@ -1,13 +1,11 @@
-/*
- * Copyright 2024 Synnax Labs, Inc.
- *
- * Use of this software is governed by the Business Source License included in the file
- * licenses/BSL.txt.
- *
- * As of the Change Date specified in that file, in accordance with the Business Source
- * License, use of this software will be governed by the Apache License, Version 2.0,
- * included in the file licenses/APL.txt.
- */
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
 
 package rack
 

--- a/synnax/pkg/service/hardware/rack/writer.go
+++ b/synnax/pkg/service/hardware/rack/writer.go
@@ -1,13 +1,11 @@
-/*
- * Copyright 2024 Synnax Labs, Inc.
- *
- * Use of this software is governed by the Business Source License included in the file
- * licenses/BSL.txt.
- *
- * As of the Change Date specified in that file, in accordance with the Business Source
- * License, use of this software will be governed by the Apache License, Version 2.0,
- * included in the file licenses/APL.txt.
- */
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
 
 package rack
 

--- a/synnax/pkg/service/hardware/service.go
+++ b/synnax/pkg/service/hardware/service.go
@@ -1,13 +1,11 @@
-/*
- * Copyright 2024 Synnax Labs, Inc.
- *
- * Use of this software is governed by the Business Source License included in the file
- * licenses/BSL.txt.
- *
- * As of the Change Date specified in that file, in accordance with the Business Source
- * License, use of this software will be governed by the Apache License, Version 2.0,
- * included in the file licenses/APL.txt.
- */
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
 
 package hardware
 

--- a/synnax/pkg/service/hardware/task/ontology.go
+++ b/synnax/pkg/service/hardware/task/ontology.go
@@ -1,13 +1,11 @@
-/*
- * Copyright 2024 Synnax Labs, Inc.
- *
- * Use of this software is governed by the Business Source License included in the file
- * licenses/BSL.txt.
- *
- * As of the Change Date specified in that file, in accordance with the Business Source
- * License, use of this software will be governed by the Apache License, Version 2.0,
- * included in the file licenses/APL.txt.
- */
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
 
 package task
 

--- a/synnax/pkg/service/hardware/task/retrieve.go
+++ b/synnax/pkg/service/hardware/task/retrieve.go
@@ -1,13 +1,11 @@
-/*
- * Copyright 2024 Synnax Labs, Inc.
- *
- * Use of this software is governed by the Business Source License included in the file
- * licenses/BSL.txt.
- *
- * As of the Change Date specified in that file, in accordance with the Business Source
- * License, use of this software will be governed by the Apache License, Version 2.0,
- * included in the file licenses/APL.txt.
- */
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
 
 package task
 

--- a/synnax/pkg/service/hardware/task/service.go
+++ b/synnax/pkg/service/hardware/task/service.go
@@ -1,13 +1,11 @@
-/*
- * Copyright 2024 Synnax Labs, Inc.
- *
- * Use of this software is governed by the Business Source License included in the file
- * licenses/BSL.txt.
- *
- * As of the Change Date specified in that file, in accordance with the Business Source
- * License, use of this software will be governed by the Apache License, Version 2.0,
- * included in the file licenses/APL.txt.
- */
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
 
 package task
 

--- a/synnax/pkg/service/hardware/task/task.go
+++ b/synnax/pkg/service/hardware/task/task.go
@@ -1,13 +1,11 @@
-/*
- * Copyright 2024 Synnax Labs, Inc.
- *
- * Use of this software is governed by the Business Source License included in the file
- * licenses/BSL.txt.
- *
- * As of the Change Date specified in that file, in accordance with the Business Source
- * License, use of this software will be governed by the Apache License, Version 2.0,
- * included in the file licenses/APL.txt.
- */
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
 
 package task
 

--- a/synnax/pkg/service/hardware/task/writer.go
+++ b/synnax/pkg/service/hardware/task/writer.go
@@ -1,13 +1,11 @@
-/*
- * Copyright 2024 Synnax Labs, Inc.
- *
- * Use of this software is governed by the Business Source License included in the file
- * licenses/BSL.txt.
- *
- * As of the Change Date specified in that file, in accordance with the Business Source
- * License, use of this software will be governed by the Apache License, Version 2.0,
- * included in the file licenses/APL.txt.
- */
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
 
 package task
 


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1935](https://linear.app/synnax/issue/SY-1935/prevent-non-empty-groups-from-being-deleted)

## Description

Prevents groups that still have children from being deleted. 

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
