### PR TITLE
SY-1936 - Fix Bad Contraction Behavior in Ontology Tree

### DIFF
--- a/console/src/ontology/Tree.tsx
+++ b/console/src/ontology/Tree.tsx
@@ -366,11 +366,12 @@ export const Tree = (): ReactElement => {
       });
       if (parent == null) return [];
       const moved = dropped.filter(({ data }) => data?.depth === minDepth);
+      const keys = moved.map(({ key }) => key as string);
       const sourceID = new ontology.ID(parent.key);
-      moved.forEach((id) => treeProps.contract(id.toString()));
+      treeProps.contract(...keys);
       dropMutation.mutate({
         source: sourceID,
-        ids: moved.map(({ key }) => new ontology.ID(key as string)),
+        ids: keys.map((key) => new ontology.ID(key)),
         destination,
       });
       return moved;

--- a/pluto/src/tree/Tree.tsx
+++ b/pluto/src/tree/Tree.tsx
@@ -61,7 +61,7 @@ export interface UseReturn {
   expanded: string[];
   onSelect: UseSelectMultipleProps<string, FlattenedNode>["onChange"];
   expand: (key: string) => void;
-  contract: (key: string) => void;
+  contract: (...keys: string[]) => void;
   clearExpanded: () => void;
   nodes: FlattenedNode[];
 }
@@ -124,9 +124,12 @@ export const use = (props: UseProps): UseReturn => {
   );
 
   const handleContract = useCallback(
-    (key: string): void => {
-      setExpanded((expanded) => expanded.filter((k) => k !== key));
-      onExpand?.({ current: expanded, action: "contract", clicked: key });
+    (...keys: string[]): void => {
+      setExpanded((expanded) => expanded.filter((k) => !keys.includes(k)));
+      // Call onExpand for each contracted key
+      keys.forEach((key) => {
+        onExpand?.({ current: expanded, action: "contract", clicked: key });
+      });
     },
     [setExpanded],
   );


### PR DESCRIPTION
# Issue Pull Request

## Key Information

- **Linear Issue**: [SY-1936](https://linear.app/synnax/issue/SY-1936/fix-bad-expansion-and-contraction-behavior-in-ontology-tree)

## Description

We were incorrectly passing bad keys to the `contract` function on the ontology tree, which caused funky behavior with moving around expanded folders. This PR makes sure we pass in the right keys.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
