### PR TITLE
Remove `synnax` CLI Command from Python Client

### DIFF
--- a/client/py/pyproject.toml
+++ b/client/py/pyproject.toml
@@ -45,8 +45,6 @@ plugins = ["numpy.typing.mypy_plugin"]
 ignore_missing_imports = true
 
 [tool.poetry.scripts]
-synnax = "synnax.cli.synnax:synnax"
-synnaxkit = "synnax.cli.synnax:synnax"
 sy = "synnax.cli.synnax:synnax"
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
# Issue Pull Request

## Key Information

- **Linear Issue**: [SY-1981](https://linear.app/synnax/issue/SY-1981/remove-synnax-python-cli-command)

## Description

Remove the `synnax` and `synnax-kit` CLI commands from the Python client.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
