### PR TITLE
Replace `...props` with `..rest` and remove unneeded children destructuring

### DIFF
--- a/console/src/hardware/ni/task/DigitalChannelList.tsx
+++ b/console/src/hardware/ni/task/DigitalChannelList.tsx
@@ -86,10 +86,10 @@ export interface DigitalChannelListProps<C extends DigitalChannel>
 
 export const DigitalChannelList = <C extends DigitalChannel>({
   NameComponent,
-  ...props
+  ...rest
 }: DigitalChannelListProps<C>) => (
   <Common.Task.Layouts.List<C>
-    {...props}
+    {...rest}
     ListItem={(p) => <ListItem {...p} NameComponent={NameComponent} />}
   />
 );

--- a/docs/site/src/components/Diagram.astro
+++ b/docs/site/src/components/Diagram.astro
@@ -1,9 +1,9 @@
 ---
 import { Icon } from "@synnaxlabs/media";
-const { preview, variant, ...props } = Astro.props;
+const { preview, variant, ...rest } = Astro.props;
 ---
 
-<div class=`diagram ${preview ? 'preview' : ''} ${variant}` {...props}>
+<div class=`diagram ${preview ? 'preview' : ''} ${variant}` {...rest}>
     <div class="internal"></div>
     <slot />
 </div>

--- a/docs/site/src/components/Media.tsx
+++ b/docs/site/src/components/Media.tsx
@@ -51,7 +51,7 @@ const useLiveTheme = (): string => {
   return theme;
 };
 
-export const Video = ({ id, themed = true, ...props }: VideoProps): ReactElement => {
+export const Video = ({ id, themed = true, ...rest }: VideoProps): ReactElement => {
   const theme = useLiveTheme();
   const url = `${CDN_ROOT}/${id}${themed ? `-${theme}` : ""}.mp4`;
   const ref = useRef<HTMLVideoElement>(null);
@@ -75,7 +75,7 @@ export const Video = ({ id, themed = true, ...props }: VideoProps): ReactElement
     };
   }, []);
 
-  return <Core.Video ref={ref} href={url} loop muted {...props} />;
+  return <Core.Video ref={ref} href={url} loop muted {...rest} />;
 };
 
 export interface ImageProps extends VideoProps {
@@ -87,7 +87,7 @@ export const Image = ({
   themed = true,
   className,
   extension = "png",
-  ...props
+  ...rest
 }: ImageProps): ReactElement => {
   const theme = useLiveTheme();
   let url = `${CDN_ROOT}/${id}`;
@@ -97,5 +97,5 @@ export const Image = ({
   useEffect(() => {
     if (ref.current) ref.current.src = url;
   }, []);
-  return <img src={url} {...props} />;
+  return <img src={url} {...rest} />;
 };

--- a/docs/site/src/components/StepText.astro
+++ b/docs/site/src/components/StepText.astro
@@ -5,10 +5,10 @@ import { caseconv } from "@synnaxlabs/x";
 export interface StepTextProps extends Text.TextProps {
     step: string | number;
 }
-const { step, level, name = "Step", ...props } = Astro.props;
+const { step, level, name = "Step", ...rest } = Astro.props;
 ---
 
-<Text.Text className="no-link" id={caseconv.toKebab(name)} level={level} {...props}>
+<Text.Text className="no-link" id={caseconv.toKebab(name)} level={level} {...rest}>
     <span
         style={{
             color: "var(--pluto-gray-l7)",

--- a/docs/site/src/components/Tabs.tsx
+++ b/docs/site/src/components/Tabs.tsx
@@ -15,10 +15,10 @@ export interface TabsProps extends Record<string, ReactElement | any> {
   queryParamKey?: string;
 }
 
-export const Tabs = ({ tabs, queryParamKey, ...props }: TabsProps): ReactElement => {
+export const Tabs = ({ tabs, queryParamKey, ...rest }: TabsProps): ReactElement => {
   tabs = tabs.map((tab) => ({
     ...tab,
-    icon: tab.icon ?? props[`${tab.tabKey}-icon`],
+    icon: tab.icon ?? rest[`${tab.tabKey}-icon`],
   }));
   const [selected, setSelected] = useState<string>(tabs[0].tabKey);
 
@@ -53,6 +53,6 @@ export const Tabs = ({ tabs, queryParamKey, ...props }: TabsProps): ReactElement
   });
 
   return (
-    <Core.Tabs {...staticProps}>{(tab) => <div>{props[tab.tabKey]}</div>}</Core.Tabs>
+    <Core.Tabs {...staticProps}>{(tab) => <div>{rest[tab.tabKey]}</div>}</Core.Tabs>
   );
 };

--- a/docs/site/src/components/code/Code.astro
+++ b/docs/site/src/components/code/Code.astro
@@ -3,7 +3,7 @@ import { Icon } from "@synnaxlabs/media";
 import { Button } from "@synnaxlabs/pluto";
 import { Fragment } from "react";
 
-const { tabindex, variant, wrap = false, ...props } = Astro.props;
+const { tabindex, variant, wrap = false, ...rest } = Astro.props;
 let className = "astro-code-wrapper";
 if (variant != null) className += ` ${variant}`;
 if (wrap) className += " wrap";
@@ -15,7 +15,7 @@ if (wrap) className += " wrap";
             <Icon.Copy className="copy" /><Icon.Check className="check" />
         </Fragment>
     </Button.Icon>
-    <pre {...props} class="styled-scrollbar"><slot /></pre>
+    <pre {...rest} class="styled-scrollbar"><slot /></pre>
 </div>
 
 <style is:global>

--- a/docs/site/src/components/platform/Tabs.tsx
+++ b/docs/site/src/components/platform/Tabs.tsx
@@ -24,7 +24,7 @@ export interface TabsProps extends Omit<CoreProps, "tabs" | "queryParamKey"> {
   priority?: Platform[];
 }
 
-export const Tabs = ({ exclude = [], priority = [], ...props }: TabsProps) => {
+export const Tabs = ({ exclude = [], priority = [], ...rest }: TabsProps) => {
   useLayoutEffect(() => {
     const platform = getFromURL(true);
     if (platform) setInURL(platform);
@@ -42,5 +42,5 @@ export const Tabs = ({ exclude = [], priority = [], ...props }: TabsProps) => {
       return aIndex - bIndex;
     });
 
-  return <Core queryParamKey="platform" tabs={tabs} {...props} />;
+  return <Core queryParamKey="platform" tabs={tabs} {...rest} />;
 };

--- a/pluto/src/accordion/Accordion.tsx
+++ b/pluto/src/accordion/Accordion.tsx
@@ -64,7 +64,7 @@ const DEFAULT_EXPAND_SIZE = 0.5;
  * @param props.entries - The entries to display in the accordion. See the
  * {@link Entry} interface for more details.
  */
-export const Accordion = ({ data, ...props }: AccordionProps): ReactElement => {
+export const Accordion = ({ data, ...rest }: AccordionProps): ReactElement => {
   const {
     setSize,
     props: { sizeDistribution: sizes, ref, ...resizeProps },
@@ -88,7 +88,7 @@ export const Accordion = ({ data, ...props }: AccordionProps): ReactElement => {
       className={CSS.B("accordion")}
       sizeDistribution={sizes}
       ref={ref}
-      {...props}
+      {...rest}
       {...resizeProps}
     >
       {data.map((entry, i) => (

--- a/pluto/src/aether/main.tsx
+++ b/pluto/src/aether/main.tsx
@@ -225,9 +225,9 @@ export interface UseUnidirectionalProps<S extends z.ZodTypeAny>
  */
 export const useUnidirectional = <S extends z.ZodTypeAny>({
   state,
-  ...props
+  ...rest
 }: UseUnidirectionalProps<S>): ComponentContext => {
-  const { path, setState } = useLifecycle({ ...props, initialState: state });
+  const { path, setState } = useLifecycle({ ...rest, initialState: state });
   const ref = useRef(null);
   if (!deep.equal(ref.current, state)) {
     ref.current = state;

--- a/pluto/src/alamos/Provider.tsx
+++ b/pluto/src/alamos/Provider.tsx
@@ -25,11 +25,11 @@ export interface ProviderProps extends PropsWithChildren, alamos.ProviderState {
 
 export const useInstrumentation = () => use(Context).instrumentation;
 
-export const Provider = ({ children, ...props }: ProviderProps): ReactElement => {
+export const Provider = ({ children, ...rest }: ProviderProps): ReactElement => {
   const { path } = Aether.useUnidirectional({
     type: alamos.Provider.TYPE,
     schema: alamos.providerStateZ,
-    state: props,
+    state: rest,
   });
   return <Aether.Composite path={path}>{children}</Aether.Composite>;
 };

--- a/pluto/src/align/Center.tsx
+++ b/pluto/src/align/Center.tsx
@@ -22,15 +22,13 @@ export const Center = <E extends SpaceElementType = "div">({
   className,
   justify = "center",
   align = "center",
-  ref,
-  ...props
+  ...rest
 }: SpaceProps<E>): ReactElement => (
   // @ts-expect-error - generic element issues
   <Space<E>
-    ref={ref}
     justify={justify}
     align={align}
     className={CSS(CSS.BM("space", "centered"), className)}
-    {...props}
+    {...rest}
   />
 );

--- a/pluto/src/align/Pack.tsx
+++ b/pluto/src/align/Pack.tsx
@@ -50,7 +50,7 @@ export const Pack = <E extends SpaceElementType = "div">({
   shadow = false,
   borderWidth,
   style,
-  ...props
+  ...rest
 }: PackProps<E>): ReactElement => {
   const pStyle = {
     [CSS.var("pack-border-shade")]: CSS.shadeVar(borderShade),
@@ -76,7 +76,7 @@ export const Pack = <E extends SpaceElementType = "div">({
       style={pStyle}
       bordered={bordered}
       rounded={rounded}
-      {...props}
+      {...rest}
       empty
     />
   );

--- a/pluto/src/align/Space.tsx
+++ b/pluto/src/align/Space.tsx
@@ -118,7 +118,7 @@ export const Space = <E extends SpaceElementType = "div">({
   rounded = false,
   el = "div",
   background,
-  ...props
+  ...rest
 }: SpaceProps<E>): ReactElement => {
   const dir = direction.construct(direction_);
   reverse = shouldReverse(direction_, reverse);
@@ -155,7 +155,7 @@ export const Space = <E extends SpaceElementType = "div">({
         className,
       )}
       style={style}
-      {...props}
+      {...rest}
     />
   );
 };

--- a/pluto/src/breadcrumb/Breadcrumb.tsx
+++ b/pluto/src/breadcrumb/Breadcrumb.tsx
@@ -137,7 +137,7 @@ export const Breadcrumb = <
   separator = ".",
   className,
   hideFirst = true,
-  ...props
+  ...rest
 }: BreadcrumbProps<E, L>): ReactElement => {
   if (url != null) segments = url;
   const content = getContent({ segments, separator, shade, level, weight });
@@ -150,7 +150,7 @@ export const Breadcrumb = <
       weight={weight}
       size={size}
       direction="x"
-      {...props}
+      {...rest}
     >
       {PIcon.resolve(icon)}
       {...content}

--- a/pluto/src/button/Button.tsx
+++ b/pluto/src/button/Button.tsx
@@ -110,7 +110,7 @@ export const Button = Tooltip.wrap(
     endContent,
     onMouseDown,
     stopPropagation,
-    ...props
+    ...rest
   }: ButtonProps): ReactElement => {
     const parsedDelay = TimeSpan.fromMilliseconds(onClickDelay);
     if (loading) startIcon = [...toArray(startIcon), <Icon.Loading key="loader" />];
@@ -198,7 +198,7 @@ export const Button = Tooltip.wrap(
         style={pStyle}
         startIcon={startIcon}
         color={color}
-        {...props}
+        {...rest}
       >
         {children}
         {endContent != null ? (

--- a/pluto/src/button/Icon.tsx
+++ b/pluto/src/button/Icon.tsx
@@ -52,7 +52,7 @@ export const Icon = Tooltip.wrap(
     loading = false,
     onClick,
     color: propColor,
-    ...props
+    ...rest
   }: IconProps): ReactElement => {
     if (loading) children = <MediaIcon.Loading />;
     const isDisabled = disabled || loading;
@@ -77,7 +77,7 @@ export const Icon = Tooltip.wrap(
           CSS.disabled(isDisabled),
         )}
         onClick={handleClick}
-        {...props}
+        {...rest}
       >
         {typeof children === "string"
           ? children

--- a/pluto/src/button/Link.tsx
+++ b/pluto/src/button/Link.tsx
@@ -35,12 +35,12 @@ export const Link = <L extends Text.Level = "h1">({
   href,
   target,
   autoFormat = false,
-  ...props
+  ...rest
 }: LinkProps<L>): ReactElement => {
   let newHref = href;
   if (autoFormat && href != null && !href.includes(SCHEME_SEPARATOR))
     // @ts-expect-error - generic element issues
     newHref = HTTP_SECURE_SCHEME + newHref;
   // @ts-expect-error - generic element issues
-  return <Button<"a"> el="a" href={newHref} target={target} {...props} />;
+  return <Button<"a"> el="a" href={newHref} target={target} {...rest} />;
 };

--- a/pluto/src/button/Toggle.tsx
+++ b/pluto/src/button/Toggle.tsx
@@ -38,11 +38,11 @@ const toggleFactory =
     uncheckedVariant = "outlined",
     rightClickToggle = false,
     stopPropagation,
-    ...props
+    ...rest
   }) => (
     // @ts-expect-error - generic component issues
     <Base
-      {...props}
+      {...rest}
       checked={value}
       onClick={(e) => {
         if (stopPropagation) e.stopPropagation();
@@ -56,7 +56,7 @@ const toggleFactory =
         if (!rightClickToggle) return;
         onChange(!value);
       }}
-      className={CSS(CSS.B("btn-toggle"), props.className)}
+      className={CSS(CSS.B("btn-toggle"), rest.className)}
       variant={value ? checkedVariant : uncheckedVariant}
     />
   );

--- a/pluto/src/channel/AliasProvider.tsx
+++ b/pluto/src/channel/AliasProvider.tsx
@@ -142,7 +142,7 @@ export const AliasInput = ({
   value,
   shadow,
   className,
-  ...props
+  ...rest
 }: AliasInputProps): ReactElement => {
   const [loading, setLoading] = useState(false);
   const { setAlias } = useContext();
@@ -164,7 +164,7 @@ export const AliasInput = ({
 
   const handleSetValueToAlias = (): void => {
     if (alias == null) return;
-    props.onChange?.(alias);
+    rest.onChange?.(alias);
   };
 
   const SetAliasTooltip = (): ReactElement => {
@@ -192,7 +192,7 @@ export const AliasInput = ({
   };
 
   return (
-    <Input.Text value={value} {...props}>
+    <Input.Text value={value} {...rest}>
       {canSetAlias && (
         <Button.Icon
           onClick={handleSetValueToAlias}

--- a/pluto/src/channel/LinePlot.tsx
+++ b/pluto/src/channel/LinePlot.tsx
@@ -134,19 +134,19 @@ export const LinePlot = ({
   viewportTriggers,
   annotationProvider,
   onSelectRule,
-  ...props
+  ...rest
 }: LinePlotProps): ReactElement => {
   const xAxes = axes.filter(({ location: l }) => loc.isY(l));
   const ref = useRef<Viewport.UseRefValue | null>(null);
   const prevLinesLength = usePrevious(lines.length);
-  const prevHold = usePrevious(props.hold);
+  const prevHold = usePrevious(rest.hold);
   if (
     (prevLinesLength === 0 && lines.length !== 0) ||
-    (prevHold === true && props.hold === false)
+    (prevHold === true && rest.hold === false)
   )
     ref.current?.reset();
   return (
-    <Core.LinePlot {...props}>
+    <Core.LinePlot {...rest}>
       {xAxes.map((a, i) => {
         const axisLines = lines.filter((l) => l.axes.x === a.key);
         const yAxes = axes.filter(({ location: l }) => loc.isX(l));
@@ -359,7 +359,7 @@ const DynamicLine = ({
     timeSpan,
     channels: { x, y },
     axes: _,
-    ...props
+    ...rest
   },
 }: {
   line: DynamicLineProps;
@@ -380,7 +380,7 @@ const DynamicLine = ({
     });
     return { xTelem, yTelem };
   }, [timeSpan.valueOf(), x, y]);
-  return <Core.Line aetherKey={key} y={yTelem} x={xTelem} {...props} />;
+  return <Core.Line aetherKey={key} y={yTelem} x={xTelem} {...rest} />;
 };
 
 const StaticLine = ({
@@ -388,7 +388,7 @@ const StaticLine = ({
     timeRange,
     key,
     channels: { x, y },
-    ...props
+    ...rest
   },
 }: {
   line: StaticLineProps;
@@ -403,5 +403,5 @@ const StaticLine = ({
     });
     return { xTelem, yTelem };
   }, [timeRange.start.valueOf(), timeRange.end.valueOf(), x, y]);
-  return <Core.Line aetherKey={key} y={yTelem} x={xTelem} {...props} />;
+  return <Core.Line aetherKey={key} y={yTelem} x={xTelem} {...rest} />;
 };

--- a/pluto/src/channel/Select.tsx
+++ b/pluto/src/channel/Select.tsx
@@ -77,9 +77,9 @@ export const resolveIcon = (ch?: channel.Payload): PIcon.Element => {
 
 const renderTag = ({
   key,
-  ...props
+  ...rest
 }: Select.MultipleTagProps<channel.Key, channel.Payload>): ReactElement => (
-  <Select.MultipleTag key={key} icon={resolveIcon(props.entry)} {...props} />
+  <Select.MultipleTag key={key} icon={resolveIcon(rest.entry)} {...rest} />
 );
 
 export const SelectMultiple = ({
@@ -88,7 +88,7 @@ export const SelectMultiple = ({
   className,
   value,
   searchOptions,
-  ...props
+  ...rest
 }: SelectMultipleProps): ReactElement => {
   const client = Synnax.use();
   const aliases = useAliases();
@@ -176,7 +176,7 @@ export const SelectMultiple = ({
       entryRenderKey={entryRenderKey}
       renderTag={renderTag}
       {...dropProps}
-      {...props}
+      {...rest}
     />
   );
 };
@@ -194,7 +194,7 @@ export const SelectSingle = ({
   className,
   data,
   searchOptions,
-  ...props
+  ...rest
 }: SelectSingleProps): ReactElement => {
   const client = Synnax.use();
   const aliases = useAliases();
@@ -269,7 +269,7 @@ export const SelectSingle = ({
       emptyContent={emptyContent}
       entryRenderKey={entryRenderKey}
       {...dragProps}
-      {...props}
+      {...rest}
     />
   );
 };

--- a/pluto/src/color/Picker.tsx
+++ b/pluto/src/color/Picker.tsx
@@ -35,7 +35,7 @@ export const Picker = ({
   onChange,
   position,
   onDelete,
-  ...props
+  ...rest
 }: PickerProps): ReactElement => {
   const updateFreq = useFrequentUpdater();
   const updateFreqDebounced = useDebouncedCallback(updateFreq, 1000, [updateFreq]);
@@ -83,7 +83,7 @@ export const Picker = ({
         color={new color.Color(value).hex}
         onChange={pickerHandleChange}
         presetColors={[]}
-        {...props}
+        {...rest}
       />
       <Frequent onChange={baseHandleChange} />
     </Align.Space>

--- a/pluto/src/color/Swatch.tsx
+++ b/pluto/src/color/Swatch.tsx
@@ -45,7 +45,7 @@ export const Swatch = ({
   draggable = true,
   style,
   onClick,
-  ...props
+  ...rest
 }: SwatchProps): ReactElement => {
   const { visible, open, close } = Dropdown.use({ onVisibleChange, initialVisible });
 
@@ -95,7 +95,7 @@ export const Swatch = ({
         canPick ? <Text.Text level="small">Click to change color</Text.Text> : undefined
       }
       {...haulProps}
-      {...props}
+      {...rest}
     />
   );
 

--- a/pluto/src/divider/Divider.tsx
+++ b/pluto/src/divider/Divider.tsx
@@ -31,7 +31,7 @@ export const Divider = ({
   direction = "y",
   className,
   padded = false,
-  ...props
+  ...rest
 }: DividerProps): ReactElement => {
   if (padded === true) padded = "center";
   return (
@@ -43,7 +43,7 @@ export const Divider = ({
         typeof padded === "string" && CSS.loc(padded),
         className,
       )}
-      {...props}
+      {...rest}
     />
   );
 };

--- a/pluto/src/dropdown/Dropdown.tsx
+++ b/pluto/src/dropdown/Dropdown.tsx
@@ -98,7 +98,7 @@ export const Dialog = ({
   open,
   toggle,
   zIndex = 5,
-  ...props
+  ...rest
 }: DialogProps): ReactElement => {
   const targetRef = useRef<HTMLDivElement>(null);
   const visibleRef = useSyncedRef(visible);
@@ -214,7 +214,7 @@ export const Dialog = ({
   return (
     <CoreDialog.Provider value={ctxValue}>
       <C
-        {...props}
+        {...rest}
         ref={combinedParentRef}
         borderShade={4}
         className={CSS(
@@ -228,7 +228,7 @@ export const Dialog = ({
         direction="y"
         reverse={dialogLoc.y === "top"}
         style={{
-          ...props.style,
+          ...rest.style,
           // @ts-expect-error - css variable
           [Z_INDEX_VARIABLE]: zIndex,
         }}

--- a/pluto/src/form/Field.tsx
+++ b/pluto/src/form/Field.tsx
@@ -58,7 +58,7 @@ export const Field = <
   optional,
   onChange,
   className,
-  ...props
+  ...rest
 }: FieldProps<I, O>): ReactElement | null => {
   const field = useField<I, O>({
     path,
@@ -87,7 +87,7 @@ export const Field = <
         CSS.BE("field", path.split(".").join("-")),
         CSS.M(field.status.variant),
       )}
-      {...props}
+      {...rest}
     >
       {children(childrenProps)}
     </Input.Item>
@@ -126,11 +126,11 @@ export const fieldBuilder =
       inputProps,
       path,
       fieldKey = baseFieldKey,
-      ...props
+      ...rest
     }: BuiltFieldProps<I, O, P>) => (
       <Field<I, O>
         {...fieldProps}
-        {...props}
+        {...rest}
         path={fieldKey ? `${path}.${fieldKey}` : path}
       >
         {(cp) => <Component {...cp} {...baseInputProps} {...(inputProps as P)} />}

--- a/pluto/src/form/Form.tsx
+++ b/pluto/src/form/Form.tsx
@@ -748,5 +748,5 @@ export const use = <Z extends z.ZodTypeAny>({
 };
 
 export const Form = (props: PropsWithChildren<ContextValue>): ReactElement => (
-  <Context value={props}>{props.children}</Context>
+  <Context value={props} />
 );

--- a/pluto/src/form/synced.ts
+++ b/pluto/src/form/synced.ts
@@ -55,7 +55,7 @@ export const useSynced = <Z extends z.ZodTypeAny, O = Z>({
   openObservable,
   applyChanges,
   applyObservable,
-  ...props
+  ...rest
 }: UseSyncedProps<Z, O>): UseReturn<Z> => {
   const client = Synnax.use();
   const handleException = Status.useExceptionHandler();
@@ -63,7 +63,7 @@ export const useSynced = <Z extends z.ZodTypeAny, O = Z>({
 
   const methods = use({
     values: initialValues,
-    ...props,
+    ...rest,
     sync: false,
     onChange: (props) => {
       if (client == null) return;

--- a/pluto/src/generic/Generic.tsx
+++ b/pluto/src/generic/Generic.tsx
@@ -30,5 +30,5 @@ export type ElementProps<E extends JSXElementType> = ComponentPropsWithRef<E> & 
 export const Element = <E extends JSXElementType>({
   el,
   children,
-  ...props
-}: ElementProps<E>): ReactElement => createElement(el, props, children);
+  ...rest
+}: ElementProps<E>): ReactElement => createElement(el, rest, children);

--- a/pluto/src/hardware/device/Select.tsx
+++ b/pluto/src/hardware/device/Select.tsx
@@ -41,7 +41,7 @@ export interface SelectSingleProps
 
 export const SelectSingle = ({
   searchOptions,
-  ...props
+  ...rest
 }: SelectSingleProps): ReactElement => {
   const client = Synnax.use();
   let searcher: AsyncTermSearcher<string, device.Key, device.Device> | undefined =
@@ -53,7 +53,7 @@ export const SelectSingle = ({
       columns={deviceColumns}
       searcher={searcher}
       entryRenderKey="name"
-      {...props}
+      {...rest}
     />
   );
 };

--- a/pluto/src/haul/Haul.tsx
+++ b/pluto/src/haul/Haul.tsx
@@ -291,12 +291,12 @@ export interface UseDragAndDropReturn extends UseDragReturn, UseDropReturn {}
 export const useDragAndDrop = ({
   type,
   key,
-  ...props
+  ...rest
 }: UseDragAndDropProps): UseDragAndDropReturn => {
   const key_ = key ?? useId();
   const sourceAndTarget: Item = useMemo(() => ({ key: key_, type }), [key_, type]);
   const dragProps = useDrag(sourceAndTarget);
-  const dropProps = useDrop({ ...props, ...sourceAndTarget });
+  const dropProps = useDrop({ ...rest, ...sourceAndTarget });
   return { ...dragProps, ...dropProps };
 };
 

--- a/pluto/src/header/Actions.tsx
+++ b/pluto/src/header/Actions.tsx
@@ -60,7 +60,7 @@ interface ActionProps {
 const Action = ({ index, level, children, divided }: ActionProps): ReactElement => {
   let content: ReactElement = children as ReactElement;
   if (!isValidElement(children)) {
-    const { onClick, key, ...props } = children;
+    const { onClick, key, ...rest } = children;
     content = (
       <Button.Icon
         key={key ?? index}
@@ -70,7 +70,7 @@ const Action = ({ index, level, children, divided }: ActionProps): ReactElement 
           onClick?.(e);
         }}
         size={Text.LevelComponentSizes[level]}
-        {...props}
+        {...rest}
       />
     );
   }

--- a/pluto/src/header/ButtonTitle.tsx
+++ b/pluto/src/header/ButtonTitle.tsx
@@ -29,7 +29,7 @@ export const ButtonTitle = ({
   children = "",
   className,
   onClick,
-  ...props
+  ...rest
 }: ButtonTitleProps): ReactElement => {
   const { level } = useContext();
   return (
@@ -39,7 +39,7 @@ export const ButtonTitle = ({
       onClick={onClick}
       className={CSS(CSS.B("header-button-title"), className)}
       sharp
-      {...props}
+      {...rest}
     >
       {children}
     </Button.Button>

--- a/pluto/src/header/Header.tsx
+++ b/pluto/src/header/Header.tsx
@@ -41,11 +41,10 @@ export const useContext = () => use(Context);
  * and each action. Default is false.
  */
 export const Header = ({
-  children,
   className,
   level = "h1",
   divided = false,
-  ...props
+  ...rest
 }: HeaderProps): ReactElement => (
   <Context value={{ level, divided }}>
     <Align.Space
@@ -58,9 +57,7 @@ export const Header = ({
         divided && CSS.BM("header", "divided"),
         className,
       )}
-      {...props}
-    >
-      {children}
-    </Align.Space>
+      {...rest}
+    />
   </Context>
 );

--- a/pluto/src/header/Title.tsx
+++ b/pluto/src/header/Title.tsx
@@ -27,7 +27,7 @@ export interface TitleProps extends Omit<Text.WithIconProps, "divided" | "level"
 export const Title = ({
   className,
   level: propsLevel,
-  ...props
+  ...rest
 }: TitleProps): ReactElement => {
   const { level, divided } = useContext();
   return (
@@ -36,7 +36,7 @@ export const Title = ({
       level={propsLevel ?? level}
       divided={divided}
       size={1.5}
-      {...props}
+      {...rest}
     />
   );
 };

--- a/pluto/src/icon/Icon.tsx
+++ b/pluto/src/icon/Icon.tsx
@@ -48,9 +48,9 @@ export const Icon = ({
   bottomRight,
   children,
   className,
-  ...props
+  ...rest
 }: IconProps) => (
-  <div className={CSS(className, CSS.B("icon"))} {...props}>
+  <div className={CSS(className, CSS.B("icon"))} {...rest}>
     {topRight && clone(topRight, "topRight")}
     {topLeft && clone(topLeft, "topLeft")}
     {bottomLeft && clone(bottomLeft, "bottomLeft")}

--- a/pluto/src/input/Date.tsx
+++ b/pluto/src/input/Date.tsx
@@ -99,7 +99,7 @@ export const Date = ({
   className,
   showDragHandle = true,
   children,
-  ...props
+  ...rest
 }: DateProps): ReactElement => {
   const { value: inputValue, onChange: handleChange } = useDate({ value, onChange });
   return (
@@ -109,7 +109,7 @@ export const Date = ({
       className={CSS(CSS.B("input-date"), className)}
       onChange={handleChange}
       type="date"
-      {...props}
+      {...rest}
     >
       {showDragHandle && (
         <DragButton value={value} onChange={handleChange} dragScale={DRAG_SCALE} />

--- a/pluto/src/input/DateTime.tsx
+++ b/pluto/src/input/DateTime.tsx
@@ -42,7 +42,7 @@ export const DateTime = ({
   onBlur,
   onlyChangeOnBlur,
   variant,
-  ...props
+  ...rest
 }: DateTimeProps): ReactElement => {
   const [tempValue, setTempValue] = useState<string | null>(null);
 
@@ -93,7 +93,7 @@ export const DateTime = ({
         value={tempValue ?? parsedValue}
         onChange={handleChange}
         step={0.00001}
-        {...props}
+        {...rest}
       >
         <Button.Icon
           onClick={dProps.toggle}

--- a/pluto/src/input/DragButton.tsx
+++ b/pluto/src/input/DragButton.tsx
@@ -76,7 +76,7 @@ export const DragButton = ({
   size,
   resetValue,
   onDragEnd,
-  ...props
+  ...rest
 }: DragButtonProps): ReactElement => {
   const vRef = useRef({
     dragging: false,
@@ -134,9 +134,9 @@ export const DragButton = ({
         vRef.current.dragging = false;
         Cursor.clearGlobalStyle();
         onDragEnd?.(value);
-        props.onBlur?.();
+        rest.onBlur?.();
       },
-      [props.onBlur, onDragEnd, normalDragScale, normalDragThreshold],
+      [rest.onBlur, onDragEnd, normalDragScale, normalDragThreshold],
     ),
   });
 
@@ -152,7 +152,7 @@ export const DragButton = ({
       className={CSS(CSS.BE("input", "drag-btn"), CSS.dir(direction), className)}
       onDoubleClick={handleDoubleClick}
       onClick={(e) => e.preventDefault()}
-      {...props}
+      {...rest}
     >
       <Icon.Drag />
     </Button.Icon>

--- a/pluto/src/input/HelpText.tsx
+++ b/pluto/src/input/HelpText.tsx
@@ -34,7 +34,7 @@ export interface HelpTextProps extends Omit<Text.TextProps<"small">, "level" | "
 export const HelpText = ({
   className,
   variant = "error",
-  ...props
+  ...rest
 }: HelpTextProps): ReactElement => (
   <Text.Text<"small">
     className={CSS(
@@ -43,6 +43,6 @@ export const HelpText = ({
       className,
     )}
     level="small"
-    {...props}
+    {...rest}
   />
 );

--- a/pluto/src/input/Item.tsx
+++ b/pluto/src/input/Item.tsx
@@ -49,7 +49,7 @@ export const Item = ({
   padHelpText = false,
   helpTextVariant,
   showHelpText = true,
-  ...props
+  ...rest
 }: ItemProps): ReactElement => {
   let inputAndHelp: ReactElement;
   const showHelpText_ = showHelpText && helpText != null && helpText.length > 0;
@@ -80,7 +80,7 @@ export const Item = ({
       direction={direction}
       size={size}
       align={maybeDefaultAlignment(align, direction)}
-      {...props}
+      {...rest}
     >
       {showLabel_ && <Label required={required}>{label}</Label>}
       {inputAndHelp}

--- a/pluto/src/input/Label.tsx
+++ b/pluto/src/input/Label.tsx
@@ -33,9 +33,9 @@ export const Label = ({
   className,
   required = false,
   children,
-  ...props
+  ...rest
 }: LabelProps): ReactElement => (
-  <label className={CSS(CSS.B("input-label"), className)} {...props}>
+  <label className={CSS(CSS.B("input-label"), className)} {...rest}>
     {children} {required && <span className={CSS.B("required-indicator")}>*</span>}
   </label>
 );

--- a/pluto/src/input/Numeric.tsx
+++ b/pluto/src/input/Numeric.tsx
@@ -64,7 +64,7 @@ export const Numeric = ({
   disabled,
   onBlur,
   units,
-  ...props
+  ...rest
 }: NumericProps): ReactElement => {
   // We need to keep the actual value as a valid number, but we need to let the user
   // input an invalid value that may eventually be valid, so we need to keep the
@@ -149,7 +149,7 @@ export const Numeric = ({
         onBlur?.();
       }}
       onBlur={handleBlur}
-      {...props}
+      {...rest}
     >
       {showDragHandle && (
         <DragButton

--- a/pluto/src/input/Switch.tsx
+++ b/pluto/src/input/Switch.tsx
@@ -36,7 +36,7 @@ export const Switch = ({
   onChange,
   size = "medium",
   variant,
-  ...props
+  ...rest
 }: SwitchProps): ReactElement => {
   if (variant === "preview") disabled = true;
   return (
@@ -52,7 +52,7 @@ export const Switch = ({
           onChange={(e) => onChange(e.target.checked)}
           value=""
           disabled={disabled}
-          {...props}
+          {...rest}
         />
         <span className="pluto-input-switch__slider" />
       </label>

--- a/pluto/src/input/Text.tsx
+++ b/pluto/src/input/Text.tsx
@@ -73,7 +73,7 @@ export const Text = ({
   borderWidth,
   borderShade = 4,
   disabledOverlay,
-  ...props
+  ...rest
 }: TextProps): ReactElement => {
   const cachedFocusRef = useRef("");
   const [tempValue, setTempValue] = useState<string | null>(null);
@@ -180,7 +180,7 @@ export const Text = ({
           disabled={disabled}
           placeholder={typeof placeholder === "string" ? placeholder : undefined}
           style={{ fontWeight: weight, color: Color.cssString(color) }}
-          {...props}
+          {...rest}
         />
         {endContent != null && (
           <div className={CSS.BE("input", "end-content")}>

--- a/pluto/src/input/TextArea.tsx
+++ b/pluto/src/input/TextArea.tsx
@@ -46,7 +46,7 @@ export const TextArea = ({
   variant = "outlined",
   sharp = false,
   children,
-  ...props
+  ...rest
 }: TextAreaProps): ReactElement => (
   <textarea
     style={style}
@@ -65,6 +65,6 @@ export const TextArea = ({
       onFocus?.(e);
     }}
     placeholder={placeholder as string}
-    {...props}
+    {...rest}
   />
 );

--- a/pluto/src/input/Time.tsx
+++ b/pluto/src/input/Time.tsx
@@ -98,7 +98,7 @@ export const Time = ({
   showDragHandle = true,
   className,
   children,
-  ...props
+  ...rest
 }: TimeProps) => {
   const { inputValue, ts, handleChange } = useTime({ value, onChange, tzInfo });
   return (
@@ -109,7 +109,7 @@ export const Time = ({
       type="time"
       step="1"
       onChange={handleChange}
-      {...props}
+      {...rest}
     >
       {showDragHandle && (
         <DragButton

--- a/pluto/src/label/Select.tsx
+++ b/pluto/src/label/Select.tsx
@@ -61,9 +61,9 @@ const RenderTag: FC<Select.MultipleTagProps<label.Key, label.Label>> = ({
   loading,
   entryKey: _,
   entryRenderKey: __,
-  ...props
+  ...rest
 }) => (
-  <Tag.Tag color={entry?.color} {...props}>
+  <Tag.Tag color={entry?.color} {...rest}>
     {entry?.name}
   </Tag.Tag>
 );
@@ -74,7 +74,7 @@ export const SelectMultiple = ({
   onChange,
   className,
   value,
-  ...props
+  ...rest
 }: SelectMultipleProps): ReactElement => {
   const client = Synnax.use();
   const emptyContent =
@@ -136,7 +136,7 @@ export const SelectMultiple = ({
       renderTag={renderTag}
       addPlaceholder="Label"
       {...dropProps}
-      {...props}
+      {...rest}
     />
   );
 };
@@ -206,7 +206,7 @@ export const SelectSingle = ({
   value,
   className,
   data,
-  ...props
+  ...rest
 }: SelectSingleProps): ReactElement => {
   const { dragging, ...dragProps } = useSingle({ value, onChange });
   return (
@@ -218,7 +218,7 @@ export const SelectSingle = ({
       columns={rangeCols}
       entryRenderKey="name"
       {...dragProps}
-      {...props}
+      {...rest}
     />
   );
 };
@@ -227,7 +227,7 @@ export const SelectButton = ({
   data,
   value,
   onChange,
-  ...props
+  ...rest
 }: SelectSingleProps): ReactElement => {
   const { dragging, ...dragProps } = useSingle({ value, onChange });
   return (
@@ -238,7 +238,7 @@ export const SelectButton = ({
       columns={rangeCols}
       entryRenderKey="name"
       {...dragProps}
-      {...props}
+      {...rest}
     />
   );
 };

--- a/pluto/src/list/Column.tsx
+++ b/pluto/src/list/Column.tsx
@@ -169,10 +169,10 @@ const Item = <K extends Key = Key, E extends Keyed<K> = Keyed<K>>({
   entry,
   onSelect,
   className,
-  ...props
+  ...rest
 }: ItemProps<K, E> & ItemFrameProps<K, E>): ReactElement => {
   const { columns } = useColumnContext<K, E>();
-  const { index } = props;
+  const { index } = rest;
   return (
     <ItemFrame<K, E>
       key={entry.key.toString()}
@@ -185,7 +185,7 @@ const Item = <K extends Key = Key, E extends Keyed<K> = Keyed<K>>({
       )}
       align="center"
       size="medium"
-      {...props}
+      {...rest}
     >
       {columns
         .filter(({ visible = true }) => visible)

--- a/pluto/src/list/Core.tsx
+++ b/pluto/src/list/Core.tsx
@@ -58,7 +58,7 @@ const VirtualCore = <K extends Key = Key, E extends Keyed<K> = Keyed<K>>({
   children,
   overscan = 0,
   className,
-  ...props
+  ...rest
 }: VirtualCoreProps<K, E>): ReactElement => {
   const { hasMore, onFetchMore } = useInfiniteContext();
   const { hover: hoverValue, setHover } = useHoverContext();
@@ -117,7 +117,7 @@ const VirtualCore = <K extends Key = Key, E extends Keyed<K> = Keyed<K>>({
         CSS.BE("list", "container"),
         empty && CSS.BM("list", "empty"),
       )}
-      {...props}
+      {...rest}
     >
       {empty ? (
         emptyContent
@@ -151,7 +151,7 @@ const VirtualCore = <K extends Key = Key, E extends Keyed<K> = Keyed<K>>({
 export const Core = <K extends Key = Key, E extends Keyed<K> = Keyed<K>>({
   itemHeight = 50,
   className,
-  ...props
+  ...rest
 }: Omit<Align.SpaceProps, "children"> & {
   children: ItemRenderProp<K, E>;
   itemHeight?: number;
@@ -183,7 +183,7 @@ export const Core = <K extends Key = Key, E extends Keyed<K> = Keyed<K>>({
       className={CSS(className, CSS.BE("list", "container"))}
       ref={ref}
       size={0}
-      {...props}
+      {...rest}
     >
       {data.length === 0 ? (
         emptyContent
@@ -193,7 +193,7 @@ export const Core = <K extends Key = Key, E extends Keyed<K> = Keyed<K>>({
             let sourceIndex = index;
             if (transformed)
               sourceIndex = sourceData.findIndex((e) => e.key === entry.key);
-            return props.children({
+            return rest.children({
               key: entry.key,
               index,
               sourceIndex,

--- a/pluto/src/list/Filter.tsx
+++ b/pluto/src/list/Filter.tsx
@@ -68,8 +68,8 @@ export const useFilter = <K extends Key = Key, E extends Keyed<K> = Keyed<K>>({
  */
 export const Filter = <K extends Key = Key, E extends Keyed<K> = Keyed<K>>({
   children = (props) => <Input.Text placeholder="Filter" {...props} />,
-  ...props
-}: FilterProps): ReactElement | null => children(useFilter<K, E>(props));
+  ...rest
+}: FilterProps): ReactElement | null => children(useFilter<K, E>(rest));
 
 export interface Searcher<K extends Key = Key, E extends Keyed<K> = Keyed<K>> {
   search: (term: string) => E[];

--- a/pluto/src/list/Item.tsx
+++ b/pluto/src/list/Item.tsx
@@ -39,7 +39,7 @@ export const ItemFrame = <K extends Key, E extends Keyed<K>>({
   translate,
   style,
   sourceIndex: _,
-  ...props
+  ...rest
 }: ItemFrameProps<K, E>): ReactElement => (
   <Align.Space
     id={entry.key.toString()}
@@ -62,6 +62,6 @@ export const ItemFrame = <K extends Key, E extends Keyed<K>>({
       transform: `translateY(${translate}px)`,
       ...style,
     }}
-    {...props}
+    {...rest}
   />
 );

--- a/pluto/src/list/List.spec.tsx
+++ b/pluto/src/list/List.spec.tsx
@@ -40,7 +40,7 @@ const TestList = (): ReactElement => {
         <List.Selector value={selected} onChange={setSelected}>
           <List.Column.Header columns={cols}>
             <List.Core.Virtual<string> itemHeight={30}>
-              {({ key, ...props }) => <List.Column.Item key={key} {...props} />}
+              {({ key, ...rest }) => <List.Column.Item key={key} {...rest} />}
             </List.Core.Virtual>
           </List.Column.Header>
         </List.Selector>

--- a/pluto/src/list/Search.tsx
+++ b/pluto/src/list/Search.tsx
@@ -177,5 +177,5 @@ const searchInput = (props: Input.Control<string>): ReactElement => (
 
 export const Search = <K extends Key = Key, E extends Keyed<K> = Keyed<K>>({
   children = searchInput,
-  ...props
-}: SearchProps<K, E>): ReactElement | null => children(useSearch(props));
+  ...rest
+}: SearchProps<K, E>): ReactElement | null => children(useSearch(rest));

--- a/pluto/src/list/Selector.tsx
+++ b/pluto/src/list/Selector.tsx
@@ -63,11 +63,11 @@ const Base = memo(
   <K extends Key = Key, E extends Keyed<K> = Keyed<K>>({
     value,
     children,
-    ...props
+    ...rest
   }: SelectorProps<K, E>): ReactElement => {
     const getData = useGetTransformedData<K, E>();
     const { onSelect, clear } = useSelect<K, E>({
-      ...props,
+      ...rest,
       value,
       data: getData,
     } as const as UseSelectProps<K, E>);

--- a/pluto/src/menu/ContextMenu.tsx
+++ b/pluto/src/menu/ContextMenu.tsx
@@ -201,14 +201,14 @@ export const ContextMenu = ({
   keys,
   className,
   cursor: _,
-  ...props
+  ...rest
 }: ContextMenuProps): ReactElement => {
   const menuC = visible ? menu?.({ keys }) : null;
   return (
     <div
       className={CSS(CONTEXT_MENU_CONTAINER, className, CSS.inheritDims())}
       onContextMenu={open}
-      {...props}
+      {...rest}
     >
       {children}
       {menuC != null &&

--- a/pluto/src/modal/Modal.tsx
+++ b/pluto/src/modal/Modal.tsx
@@ -35,7 +35,7 @@ export const Dialog = ({
   enabled = true,
   close,
   style,
-  ...props
+  ...rest
 }: ModalProps): ReactElement => {
   const dialogRef = useRef<HTMLDivElement>(null);
   const visibleRef = useRef(visible);
@@ -76,7 +76,7 @@ export const Dialog = ({
         role="dialog"
         empty
         ref={dialogRef}
-        {...props}
+        {...rest}
         style={{ zIndex: enabled ? 11 : undefined, ...style }}
       >
         <Align.Space className={CSS(CSS.BE("modal", "content"))} empty>
@@ -87,5 +87,5 @@ export const Dialog = ({
   );
 };
 
-export const Modal = ({ root, ...props }: ModalProps): ReactElement =>
-  createPortal(<Dialog {...props} />, getRootElement(root));
+export const Modal = ({ root, ...rest }: ModalProps): ReactElement =>
+  createPortal(<Dialog {...rest} />, getRootElement(root));

--- a/pluto/src/mosaic/Mosaic.tsx
+++ b/pluto/src/mosaic/Mosaic.tsx
@@ -138,7 +138,7 @@ const TabLeaf = memo(
     activeTab,
     children,
     onFileDrop,
-    ...props
+    ...rest
   }: TabLeafProps): ReactElement => {
     const { key, tabs } = node as Omit<Node, "tabs"> & { tabs: Tabs.Tab[] };
 
@@ -218,7 +218,7 @@ const TabLeaf = memo(
           selectedAltColor={activeTab === node.selected}
           onDragStart={handleDragStart}
           onCreate={handleTabCreate}
-          {...props}
+          {...rest}
           {...haulProps}
         >
           {node.selected != null &&

--- a/pluto/src/nav/Bar.tsx
+++ b/pluto/src/nav/Bar.tsx
@@ -25,7 +25,7 @@ const CoreBar = ({
   size = "9rem",
   className,
   style,
-  ...props
+  ...rest
 }: BarProps): ReactElement => {
   const loc = location.construct(location_);
   const dir = location.direction(loc);
@@ -46,7 +46,7 @@ const CoreBar = ({
       }}
       align="center"
       empty
-      {...props}
+      {...rest}
     />
   );
 };
@@ -61,7 +61,7 @@ const contentFactory =
     pos: spatial.Alignment | "" | "absolute-center",
   ): FunctionComponent<BarContentProps> =>
   // eslint-disable-next-line react/display-name
-  ({ bordered = false, className, ...props }: BarContentProps): ReactElement => (
+  ({ bordered = false, className, ...rest }: BarContentProps): ReactElement => (
     <Align.Space
       className={CSS(
         CSS.BE("navbar", "content"),
@@ -70,7 +70,7 @@ const contentFactory =
         className,
       )}
       align="center"
-      {...props}
+      {...rest}
     />
   );
 

--- a/pluto/src/nav/Drawer.tsx
+++ b/pluto/src/nav/Drawer.tsx
@@ -56,7 +56,7 @@ export const Drawer = ({
   collapseThreshold = 0.65,
   className,
   onResize,
-  ...props
+  ...rest
 }: DrawerProps): ReactElement | null => {
   const dir = location.direction(loc_);
   const handleCollapse = useCallback(
@@ -87,7 +87,7 @@ export const Drawer = ({
       minSize={minSize}
       maxSize={maxSize}
       initialSize={initialSize}
-      {...props}
+      {...rest}
     >
       {content}
     </Resize.Single>

--- a/pluto/src/notation/Select.tsx
+++ b/pluto/src/notation/Select.tsx
@@ -25,6 +25,6 @@ export interface SelectNotationProps
     "data" | "entryRenderKey"
   > {}
 
-export const Select = ({ ...props }: SelectNotationProps): ReactElement => (
+export const Select = (props: SelectNotationProps): ReactElement => (
   <Button {...props} entryRenderKey="name" data={DATA} />
 );

--- a/pluto/src/note/Note.tsx
+++ b/pluto/src/note/Note.tsx
@@ -19,18 +19,11 @@ export interface NoteProps extends Align.SpaceProps<"div"> {
   variant: Status.Variant;
 }
 
-export const Note = ({
-  variant,
-  className,
-  children,
-  ...props
-}: NoteProps): ReactElement => (
+export const Note = ({ variant, className, ...rest }: NoteProps): ReactElement => (
   <Align.Space
     className={CSS(className, CSS.B("note"), CSS.M(variant))}
     align="stretch"
     empty
-    {...props}
-  >
-    {children}
-  </Align.Space>
+    {...rest}
+  />
 );

--- a/pluto/src/observe/use.ts
+++ b/pluto/src/observe/use.ts
@@ -36,11 +36,11 @@ export interface UseStateProps<D> extends UseListenerProps<D> {
 
 interface UseState {}
 
-export const useState = (<D>({ fetchInitialValue, ...props }: UseStateProps<D>) => {
+export const useState = (<D>({ fetchInitialValue, ...rest }: UseStateProps<D>) => {
   const [v, setV] = reactUseState<D | undefined>(undefined);
   useAsyncEffect(async () => {
     setV(await fetchInitialValue());
   }, [fetchInitialValue]);
-  useListener({ ...props, onChange: setV });
+  useListener({ ...rest, onChange: setV });
   return v;
 }) as UseState;

--- a/pluto/src/os/Controls/Controls.tsx
+++ b/pluto/src/os/Controls/Controls.tsx
@@ -24,10 +24,10 @@ export interface ControlsProps extends InternalControlsProps {
 export const Controls = ({
   forceOS,
   visibleIfOS,
-  ...props
+  ...rest
 }: ControlsProps): ReactElement | null => {
   const os = use({ force: forceOS, default: DEFAULT_OS });
   if (visibleIfOS != null && visibleIfOS !== os) return null;
   const C = os === "macOS" ? MacOS : Windows;
-  return <C {...props} />;
+  return <C {...rest} />;
 };

--- a/pluto/src/os/Controls/Mac.tsx
+++ b/pluto/src/os/Controls/Mac.tsx
@@ -83,7 +83,7 @@ export const MacOS = ({
   onMaximize,
   onFullscreen,
   onClose,
-  ...props
+  ...rest
 }: InternalControlsProps): ReactElement => (
   <Align.Space
     size={1.5}
@@ -93,7 +93,7 @@ export const MacOS = ({
       !focused && CSS.BM("macos-controls", "blurred"),
       className,
     )}
-    {...props}
+    {...rest}
   >
     <TrafficLight
       onClick={onClose}
@@ -125,13 +125,13 @@ const TrafficLight = ({
   className,
   disabled,
   color: _,
-  ...props
+  ...rest
 }: TrafficLightProps): ReactElement => (
   <button
     className={CSS(CSS.B("macos-control"), CSS.disabled(disabled), className)}
     tabIndex={-1}
     disabled={disabled}
     size={"" as ComponentSize}
-    {...props}
+    {...rest}
   />
 );

--- a/pluto/src/os/Controls/Windows.tsx
+++ b/pluto/src/os/Controls/Windows.tsx
@@ -25,9 +25,9 @@ export const Windows = ({
   // no-ops on windows
   onFullscreen: _,
   focused: __,
-  ...props
+  ...rest
 }: InternalControlsProps): ReactElement => (
-  <Align.Pack {...props}>
+  <Align.Pack {...rest}>
     <Button
       className={CSS.BM("windows-control", "minimize")}
       onClick={onMinimize}
@@ -55,12 +55,12 @@ export const Windows = ({
 const Button = ({
   disabled = false,
   className,
-  ...props
+  ...rest
 }: CoreButton.IconProps): ReactElement | null =>
   !disabled ? (
     <CoreButton.Icon
       className={CSS(CSS.B("windows-control"), className)}
       tabIndex={-1}
-      {...props}
+      {...rest}
     />
   ) : null;

--- a/pluto/src/ranger/Select.tsx
+++ b/pluto/src/ranger/Select.tsx
@@ -42,7 +42,7 @@ export const SelectMultiple = ({
   onChange,
   className,
   value,
-  ...props
+  ...rest
 }: SelectMultipleProps): ReactElement => {
   const client = Synnax.use();
   const emptyContent =
@@ -111,7 +111,7 @@ export const SelectMultiple = ({
       emptyContent={emptyContent}
       entryRenderKey="name"
       {...dropProps}
-      {...props}
+      {...rest}
     />
   );
 };
@@ -181,7 +181,7 @@ export const SelectSingle = ({
   value,
   className,
   data,
-  ...props
+  ...rest
 }: SelectSingleProps): ReactElement => {
   const { dragging, ...dragProps } = useSingle({ value, onChange });
   return (
@@ -193,7 +193,7 @@ export const SelectSingle = ({
       columns={rangeCols}
       entryRenderKey="name"
       {...dragProps}
-      {...props}
+      {...rest}
     />
   );
 };
@@ -202,7 +202,7 @@ export const SelectButton = ({
   data,
   value,
   onChange,
-  ...props
+  ...rest
 }: SelectSingleProps): ReactElement => {
   const { dragging, ...dragProps } = useSingle({ value, onChange });
   return (
@@ -213,7 +213,7 @@ export const SelectButton = ({
       columns={rangeCols}
       entryRenderKey="name"
       {...dragProps}
-      {...props}
+      {...rest}
     />
   );
 };

--- a/pluto/src/ranger/TimeRangeChip.tsx
+++ b/pluto/src/ranger/TimeRangeChip.tsx
@@ -29,7 +29,7 @@ export const TimeRangeChip = ({
   level = "p",
   shade = 7,
   showSpan = false,
-  ...props
+  ...rest
 }: TimeRangeChipProps): ReactElement => {
   const startTS = new TimeStamp(timeRange.start);
   const startFormat = startTS.isToday ? "time" : "dateTime";
@@ -44,7 +44,7 @@ export const TimeRangeChip = ({
       size="small"
       className={CSS(CSS.B("time-range-chip"))}
       align="center"
-      {...props}
+      {...rest}
     >
       {startTS.isToday && (
         <Text.Text level={level} shade={shade} weight={450}>

--- a/pluto/src/resize/Core.tsx
+++ b/pluto/src/resize/Core.tsx
@@ -34,7 +34,7 @@ export const Core = ({
   onDragStart,
   sizeUnits = "px",
   showHandle = true,
-  ...props
+  ...rest
 }: CoreProps): ReactElement => {
   const loc_ = location.construct(cloc);
   const dir = location.direction(loc_);
@@ -44,7 +44,7 @@ export const Core = ({
       className={CSS(CSS.B("resize"), CSS.loc(loc_), CSS.dir(dir), className)}
       style={{ [dim]: `${size}${sizeUnits}`, ...style }}
       ref={ref}
-      {...props}
+      {...rest}
     >
       {children}
       {showHandle && (

--- a/pluto/src/resize/Multiple.tsx
+++ b/pluto/src/resize/Multiple.tsx
@@ -150,7 +150,7 @@ export const Multiple = ({
   sizeDistribution,
   onDragHandle: onDrag,
   className,
-  ...props
+  ...rest
 }: MultipleProps) => {
   const dir = direction.construct(direction_);
   const children = Children.toArray(_children);
@@ -166,7 +166,7 @@ export const Multiple = ({
 
   return (
     <Align.Space
-      {...props}
+      {...rest}
       ref={ref}
       direction={dir}
       className={CSS(CSS.B("resize-multiple"), className)}

--- a/pluto/src/resize/Single.tsx
+++ b/pluto/src/resize/Single.tsx
@@ -47,7 +47,7 @@ export const Single = ({
   initialSize = 200,
   collapseThreshold = Infinity,
   className,
-  ...props
+  ...rest
 }: SingleProps): ReactElement => {
   const [size, setSize] = useState(clamp(initialSize, minSize, maxSize));
   const marker = useRef<number | null>(null);
@@ -116,7 +116,7 @@ export const Single = ({
       size={size}
       onDragStart={handleDragStart}
       className={clsx(className, CSS.expanded(size !== COLLAPSED_SIZE))}
-      {...props}
+      {...rest}
     />
   );
 };

--- a/pluto/src/select/Alignment.tsx
+++ b/pluto/src/select/Alignment.tsx
@@ -49,9 +49,9 @@ const defaultSelectTextAlignmentButton = ({
 
 export const TextAlignment = ({
   children = defaultSelectTextAlignmentButton,
-  ...props
+  ...rest
 }: AlignmentProps): ReactElement => (
-  <Button {...props} allowMultiple={false} data={DATA}>
+  <Button {...rest} allowMultiple={false} data={DATA}>
     {children}
   </Button>
 );

--- a/pluto/src/select/Button.tsx
+++ b/pluto/src/select/Button.tsx
@@ -70,7 +70,7 @@ export const Button = <K extends Key = Key, E extends Keyed<K> = Keyed<K>>({
   actions,
   pack = true,
   variant,
-  ...props
+  ...rest
 }: ButtonProps<K, E>): ReactElement => {
   const { onSelect } = useSelect<K, E>({
     allowMultiple,
@@ -104,7 +104,7 @@ export const Button = <K extends Key = Key, E extends Keyed<K> = Keyed<K>>({
       borderShade={4}
       className={CSS(CSS.B("select-button"), className)}
       size={size}
-      {...props}
+      {...rest}
     >
       {mapped}
       {actions}
@@ -160,7 +160,7 @@ export const BaseButton = ({
   toggle,
   visible,
   children,
-  ...props
+  ...rest
 }: DropdownButtonButtonProps<any, any>): ReactElement => (
   <CoreButton.Button
     className={CSS.B("select-dropdown-button")}
@@ -169,7 +169,7 @@ export const BaseButton = ({
     endIcon={
       <Caret.Animated enabledLoc="bottom" disabledLoc="left" enabled={visible} />
     }
-    {...props}
+    {...rest}
   >
     {children ?? selected?.[renderKey]}
   </CoreButton.Button>
@@ -190,7 +190,7 @@ export const DropdownButton = <K extends Key = Key, E extends Keyed<K> = Keyed<K
   hideColumnHeader = true,
   variant,
   dropdownVariant,
-  ...props
+  ...rest
 }: DropdownButtonProps<K, E>): ReactElement => {
   const { close, visible, toggle } = Dropdown.use();
   const [selected, setSelected] = useState<E | null>(
@@ -237,7 +237,7 @@ export const DropdownButton = <K extends Key = Key, E extends Keyed<K> = Keyed<K
       hideColumnHeader={hideColumnHeader}
       variant={dropdownVariant}
       trigger={<>{children(childrenProps)}</>}
-      {...props}
+      {...rest}
     />
   );
 };

--- a/pluto/src/select/ComponentSize.tsx
+++ b/pluto/src/select/ComponentSize.tsx
@@ -26,11 +26,6 @@ const SIZE_DATA: SizeEntry[] = [
 export interface SelectComponentSizeProps
   extends Omit<ButtonProps<BaseComponentSize, SizeEntry>, "data" | "entryRenderKey"> {}
 
-export const ComponentSize = ({
-  children,
-  ...props
-}: SelectComponentSizeProps): ReactElement => (
-  <Button {...props} data={SIZE_DATA} entryRenderKey="label">
-    {children}
-  </Button>
+export const ComponentSize = (props: SelectComponentSizeProps): ReactElement => (
+  <Button {...props} data={SIZE_DATA} entryRenderKey="label" />
 );

--- a/pluto/src/select/DataType.tsx
+++ b/pluto/src/select/DataType.tsx
@@ -43,10 +43,10 @@ export interface DataTypeProps
 
 export const DataType = ({
   hideVariableDensity = false,
-  ...props
+  ...rest
 }: DataTypeProps): ReactElement => (
   <DropdownButton<string, ListEntry>
-    {...props}
+    {...rest}
     data={hideVariableDensity ? FIXED_DENSITY_DATA : DATA}
     columns={COLUMNS}
     entryRenderKey="name"

--- a/pluto/src/select/Direction.tsx
+++ b/pluto/src/select/Direction.tsx
@@ -56,10 +56,10 @@ const defaultSelectDirectionButton = ({
 export const Direction = ({
   children = defaultSelectDirectionButton,
   yDirection = "up",
-  ...props
+  ...rest
 }: DirectionProps): ReactElement => (
   <Button
-    {...props}
+    {...rest}
     allowMultiple={false}
     data={yDirection === "up" ? DATA : ALTERNATE_DATA}
   >

--- a/pluto/src/select/List.tsx
+++ b/pluto/src/select/List.tsx
@@ -55,7 +55,7 @@ export const Core = <K extends Key, E extends Keyed<K>>({
   trigger,
   extraDialogContent,
   variant = "connected",
-  ...props
+  ...rest
 }: SelectListProps<K, E>): ReactElement => {
   let dialogContent = (
     <CoreList.Hover<K, E> disabled={!visible}>
@@ -98,7 +98,7 @@ export const Core = <K extends Key, E extends Keyed<K>>({
           className={CSS.B("select")}
           keepMounted={false}
           variant={variant}
-          {...props}
+          {...rest}
         >
           {trigger}
           {dialogContent}

--- a/pluto/src/select/Multiple.tsx
+++ b/pluto/src/select/Multiple.tsx
@@ -85,7 +85,7 @@ export const MultipleTag = <K extends Key, E extends Keyed<K>>({
   entryRenderKey,
   entry,
   loading,
-  ...props
+  ...rest
 }: MultipleTagProps<K, E>): ReactElement => {
   let v: RenderableValue = entryKey;
   if (entry != null)
@@ -101,7 +101,7 @@ export const MultipleTag = <K extends Key, E extends Keyed<K>>({
         entry == null && !loading && CSS.BEM("select-multiple", "tag", "invalid"),
       )}
       draggable
-      {...props}
+      {...rest}
       key={entryKey.toString()}
     >
       {convertRenderV(v)}
@@ -151,7 +151,7 @@ export const Multiple = <K extends Key = Key, E extends Keyed<K> = Keyed<K>>({
   children,
   dropdownVariant = "connected",
   actions,
-  ...props
+  ...rest
 }: MultipleProps<K, E>): ReactElement => {
   const { visible, open, close } = Dropdown.use();
   const [selected, setSelected] = useState<readonly E[]>([]);
@@ -289,7 +289,7 @@ export const Multiple = <K extends Key = Key, E extends Keyed<K> = Keyed<K>>({
       trigger={trigger}
       extraDialogContent={searchInput}
       variant={dropdownVariant}
-      {...props}
+      {...rest}
     />
   );
 };
@@ -324,7 +324,7 @@ const MultipleInput = <K extends Key, E extends Keyed<K>>({
   className,
   children,
   dropdownVariant,
-  ...props
+  ...rest
 }: SelectMultipleInputProps<K, E>): ReactElement => {
   const { onSelect, clear } = CoreList.useSelectionUtils();
   const ref = useRef<HTMLInputElement>(null);
@@ -373,7 +373,7 @@ const MultipleInput = <K extends Key, E extends Keyed<K>>({
       onClick={handleClick}
       endContent={endContent}
       variant="button"
-      {...props}
+      {...rest}
     >
       <Align.Space
         direction="x"

--- a/pluto/src/select/Select.spec.tsx
+++ b/pluto/src/select/Select.spec.tsx
@@ -69,7 +69,7 @@ export interface SelectSingleProps
 const SelectSingle = ({
   onChange,
   value: propsValue,
-  ...props
+  ...rest
 }: SelectSingleProps): ReactElement => {
   const [value, setValue] = useState<string | null>(null);
 
@@ -89,7 +89,7 @@ const SelectSingle = ({
         entryRenderKey="name"
         value={propsValue ?? value}
         onChange={handleChange}
-        {...props}
+        {...rest}
       />
     </Triggers.Provider>
   );

--- a/pluto/src/select/Single.tsx
+++ b/pluto/src/select/Single.tsx
@@ -103,7 +103,7 @@ export const Single = <K extends Key = Key, E extends Keyed<K> = Keyed<K>>({
   dropdownZIndex,
   filter,
   actions,
-  ...props
+  ...rest
 }: SingleProps<K, E>): ReactElement => {
   const { visible, open, close, toggle } = Dropdown.use();
   const [selected, setSelected] = useState<E | null>(null);
@@ -194,7 +194,7 @@ export const Single = <K extends Key = Key, E extends Keyed<K> = Keyed<K>>({
       trigger={dropdownVariant !== "modal" ? searchInput : buttonTrigger}
       extraDialogContent={dropdownVariant === "modal" ? searchInput : undefined}
       keepMounted={false}
-      {...props}
+      {...rest}
     />
   );
 };
@@ -234,7 +234,7 @@ const SingleInput = <K extends Key, E extends Keyed<K>>({
   disabled,
   dropdownVariant,
   children,
-  ...props
+  ...rest
 }: SelectInputProps<K, E>): ReactElement => {
   const { clear } = CoreList.useSelectionUtils();
   // We maintain our own value state for two reasons:
@@ -299,7 +299,7 @@ const SingleInput = <K extends Key, E extends Keyed<K>>({
       onClick={handleClick}
       placeholder={placeholder}
       disabled={disabled}
-      {...props}
+      {...rest}
     >
       {children}
       {allowNone && <ClearButton onClick={handleClear} disabled={disabled} />}

--- a/pluto/src/status/Circle.tsx
+++ b/pluto/src/status/Circle.tsx
@@ -17,6 +17,6 @@ export interface CircleProps extends IconProps {
   variant?: status.Variant;
 }
 
-export const Circle = ({ variant = "info", ...props }: CircleProps): ReactElement => (
-  <Icon.Circle color={variantColors[variant]} {...props} />
+export const Circle = ({ variant = "info", ...rest }: CircleProps): ReactElement => (
+  <Icon.Circle color={variantColors[variant]} {...rest} />
 );

--- a/pluto/src/status/Notification.tsx
+++ b/pluto/src/status/Notification.tsx
@@ -39,14 +39,14 @@ export const Notification = ({
   actions,
   className,
   children,
-  ...props
+  ...rest
 }: NotificationProps): ReactElement => (
   <Align.Space
     className={CSS(CSS.B("notification"), className)}
     direction="y"
     key={time.toString()}
     empty
-    {...props}
+    {...rest}
   >
     <Align.Space direction="x" justify="spaceBetween" grow style={{ width: "100%" }}>
       <Align.Space direction="x" align="center" size="small">

--- a/pluto/src/status/Text.tsx
+++ b/pluto/src/status/Text.tsx
@@ -29,7 +29,7 @@ const Core = ({
   level = "p",
   hideIcon = false,
   className,
-  ...props
+  ...rest
 }: TextProps): ReactElement => {
   let icon: PIcon.Element | undefined;
   if (!hideIcon) icon = variant === "loading" ? <Icon.Loading /> : <Icon.Circle />;
@@ -39,16 +39,16 @@ const Core = ({
       className={CSS(className, CSS.B("status-text"))}
       level={level}
       startIcon={icon}
-      {...props}
+      {...rest}
     />
   );
 };
 
 export interface TextCenteredProps extends TextProps {}
 
-const Centered = ({ style, ...props }: TextCenteredProps): ReactElement => (
+const Centered = ({ style, ...rest }: TextCenteredProps): ReactElement => (
   <Align.Center style={style} grow>
-    <Core {...props} />
+    <Core {...rest} />
   </Align.Center>
 );
 

--- a/pluto/src/steps/Steps.tsx
+++ b/pluto/src/steps/Steps.tsx
@@ -30,11 +30,11 @@ export const Steps = ({
   steps,
   value,
   onChange,
-  ...props
+  ...rest
 }: StepsProps): ReactElement => {
   const selectedIdx = steps.findIndex((step) => step.key === value);
   return (
-    <Align.Space direction="x" align="center" className={CSS.B("steps")} {...props}>
+    <Align.Space direction="x" align="center" className={CSS.B("steps")} {...rest}>
       {steps.map((step, i) => (
         <Fragment key={step.key}>
           <Button.Button

--- a/pluto/src/table/Table.tsx
+++ b/pluto/src/table/Table.tsx
@@ -37,7 +37,7 @@ export const Table = ({
   children,
   className,
   visible,
-  ...props
+  ...rest
 }: TableProps): ReactElement => {
   const [{ path }, , setState] = Aether.use({
     type: table.Table.TYPE,
@@ -63,7 +63,7 @@ export const Table = ({
           left: 6,
         }}
       />
-      <table className={CSS(CSS.B("table"), className)} {...props}>
+      <table className={CSS(CSS.B("table"), className)} {...rest}>
         <tbody>
           <Aether.Composite path={path}>{children}</Aether.Composite>
         </tbody>
@@ -89,9 +89,9 @@ export const Row = ({
   onResize,
   onSelect,
   position,
-  ...props
+  ...rest
 }: RowProps): ReactElement => (
-  <tr className={CSS(CSS.BE("table", "row"), className)} {...props}>
+  <tr className={CSS(CSS.BE("table", "row"), className)} {...rest}>
     {onResize != null && (
       <Indicator
         onSelect={onSelect}
@@ -115,11 +115,11 @@ export const Cell = ({
   children,
   className,
   selected = false,
-  ...props
+  ...rest
 }: CellProps): ReactElement => (
   <td
     ref={ref}
-    {...props}
+    {...rest}
     className={CSS(CSS.BE("table", "cell"), CSS.selected(selected), className)}
   >
     {children}

--- a/pluto/src/table/cells/Forms.tsx
+++ b/pluto/src/table/cells/Forms.tsx
@@ -54,11 +54,11 @@ export const ValueForm = ({ onVariantChange }: FormProps) => {
                 padHelpText={false}
                 path="color"
               >
-                {({ value, onChange, variant: _, ...props }) => (
+                {({ value, onChange, variant: _, ...rest }) => (
                   <Color.Swatch
                     value={value ?? Color.ZERO.setAlpha(1).rgba255}
                     onChange={(v) => onChange(v.rgba255)}
-                    {...props}
+                    {...rest}
                     bordered
                   />
                 )}

--- a/pluto/src/tabs/Selector.tsx
+++ b/pluto/src/tabs/Selector.tsx
@@ -40,7 +40,7 @@ export const Selector = ({
   size = "medium",
   direction = "x",
   contextMenu,
-  ...props
+  ...rest
 }: SelectorProps): ReactElement | null => {
   const {
     tabs,
@@ -63,7 +63,7 @@ export const Selector = ({
       onDrop={onDrop}
       empty
       direction={direction}
-      {...props}
+      {...rest}
     >
       <Align.Space direction={direction} className={CSS.BE(CLS, "tabs")} empty>
         {tabs.map((tab) => (
@@ -218,11 +218,11 @@ const Name = ({
   name,
   tabKey,
   editable = true,
-  ...props
+  ...rest
 }: NameProps): ReactElement => {
   if (onRename == null || !editable)
     return (
-      <Text.Text className={NAME_CLS} noWrap {...props}>
+      <Text.Text className={NAME_CLS} noWrap {...rest}>
         {name}
       </Text.Text>
     );
@@ -233,7 +233,7 @@ const Name = ({
         onChange={(newText: string) => onRename(tabKey, newText)}
         value={name}
         noWrap
-        {...props}
+        {...rest}
       />
     </div>
   );

--- a/pluto/src/tabs/Tabs.spec.tsx
+++ b/pluto/src/tabs/Tabs.spec.tsx
@@ -13,9 +13,9 @@ import { describe, expect, it, vi } from "vitest";
 
 import { Tabs } from "@/tabs";
 
-const StaticTabs = ({ tabs, ...tProps }: Tabs.TabsProps): ReactElement => {
+const StaticTabs = ({ tabs, ...rest }: Tabs.TabsProps): ReactElement => {
   const props = Tabs.useStatic({ tabs });
-  return <Tabs.Tabs {...tProps} {...props} />;
+  return <Tabs.Tabs {...rest} {...props} />;
 };
 
 describe("Tabs", () => {

--- a/pluto/src/tabs/Tabs.tsx
+++ b/pluto/src/tabs/Tabs.tsx
@@ -257,7 +257,7 @@ export const Tabs = ({
   contextMenu,
   size = "medium",
   direction: dir = "y",
-  ...props
+  ...rest
 }: TabsProps): ReactElement => (
   <Align.Space
     id={id}
@@ -266,7 +266,7 @@ export const Tabs = ({
     onDragOver={onDragOver}
     onDrop={onDrop}
     direction={dir}
-    {...props}
+    {...rest}
   >
     <Provider
       value={{

--- a/pluto/src/tag/Tag.tsx
+++ b/pluto/src/tag/Tag.tsx
@@ -37,7 +37,7 @@ export const Tag = ({
   onClose,
   className,
   onDragStart,
-  ...props
+  ...rest
 }: TagProps): ReactElement => {
   const cssColor = Color.cssString(color);
   if (icon == null && color != null) icon = <Icon.Circle fill={cssColor} />;
@@ -69,7 +69,7 @@ export const Tag = ({
       noWrap
       align="center"
       onDragStart={onDragStart}
-      {...props}
+      {...rest}
     >
       {children}
     </Text.WithIcon>

--- a/pluto/src/telem/control/Chip.tsx
+++ b/pluto/src/telem/control/Chip.tsx
@@ -72,12 +72,7 @@ const tooltipMessage = (status: Status.Spec): ChipStyle => {
   }
 };
 
-export const Chip = ({
-  source,
-  sink,
-  className,
-  ...props
-}: ChipProps): ReactElement => {
+export const Chip = ({ source, sink, className, ...rest }: ChipProps): ReactElement => {
   const memoProps = useMemoDeepEqualProps({ source, sink });
   const [, { status }, setState] = Aether.use({
     type: control.Chip.TYPE,
@@ -113,7 +108,7 @@ export const Chip = ({
       onClick={handleToggle}
       tooltip={<Text.Text level="small">{message}</Text.Text>}
       style={buttonStyle}
-      {...props}
+      {...rest}
     >
       <Icon.Circle color={chipColor} />
     </Button.Icon>

--- a/pluto/src/telem/control/Legend.tsx
+++ b/pluto/src/telem/control/Legend.tsx
@@ -18,7 +18,7 @@ import { Legend as Core } from "@/vis/legend";
 
 export interface LegendProps extends Core.SimpleProps {}
 
-export const Legend = ({ ...props }: LegendProps): ReactElement => {
+export const Legend = (props: LegendProps): ReactElement => {
   const { needsControlOf } = useContext();
   const [, { states }, setState] = Aether.use({
     type: control.Legend.TYPE,

--- a/pluto/src/text/DateTime.tsx
+++ b/pluto/src/text/DateTime.tsx
@@ -34,10 +34,10 @@ export const DateTime = <L extends text.Level = "h1">({
   suppliedTZ = "UTC",
   displayTZ = "local",
   children,
-  ...props
+  ...rest
 }: DateTimeProps<L>): ReactElement => (
   // @ts-expect-error - generic component errors
-  <Text<L> ref={ref} {...props}>
+  <Text<L> ref={ref} {...rest}>
     {new TimeStamp(children, suppliedTZ).fString(format, displayTZ)}
   </Text>
 );

--- a/pluto/src/text/Editable.tsx
+++ b/pluto/src/text/Editable.tsx
@@ -100,7 +100,7 @@ export const Editable = <L extends text.Level = text.Level>({
   allowEmpty = false,
   style,
   outline = true,
-  ...props
+  ...rest
 }: EditableProps<L>): ReactElement => {
   const [editable, setEditable] = useEditableState(false);
   const ref = useRef<HTMLElement>(null);
@@ -213,7 +213,7 @@ export const Editable = <L extends text.Level = text.Level>({
       contentEditable={editable}
       suppressContentEditableWarning
       style={style}
-      {...props}
+      {...rest}
     >
       {value}
     </Text>
@@ -233,11 +233,11 @@ export const MaybeEditable = <L extends text.Level = text.Level>({
   disabled = false,
   value,
   allowDoubleClick,
-  ...props
+  ...rest
 }: MaybeEditableProps<L>): ReactElement => {
   if (disabled || onChange == null || typeof onChange === "boolean")
     // @ts-expect-error - generic component errors
-    return <Text<L> {...props}>{value}</Text>;
+    return <Text<L> {...rest}>{value}</Text>;
 
   return (
     <>
@@ -246,7 +246,7 @@ export const MaybeEditable = <L extends text.Level = text.Level>({
         allowDoubleClick={allowDoubleClick}
         onChange={onChange}
         value={value}
-        {...props}
+        {...rest}
       />
     </>
   );

--- a/pluto/src/text/Keyboard.tsx
+++ b/pluto/src/text/Keyboard.tsx
@@ -22,7 +22,7 @@ export const Keyboard = <L extends text.Level = "p">({
   level,
   children,
   style,
-  ...props
+  ...rest
 }: KeyboardProps<L>): ReactElement => {
   const iStyle: CSSProperties = {
     height: `calc(var(--pluto-${level}-size) * 1.7)`,
@@ -40,7 +40,7 @@ export const Keyboard = <L extends text.Level = "p">({
       className={CSS(className, CSS.BM("text", "keyboard"), rect && CSS.M("rect"))}
       level={level}
       style={{ ...style, ...iStyle }}
-      {...props}
+      {...rest}
     >
       {children}
     </Text>

--- a/pluto/src/text/Link.tsx
+++ b/pluto/src/text/Link.tsx
@@ -29,7 +29,7 @@ export const Link = <L extends text.Level = "h1">({
   target,
   rel,
   className,
-  ...props
+  ...rest
 }: LinkProps<L>): ReactElement => (
   // @ts-expect-error - generic component errors
   <Text<L>
@@ -40,6 +40,6 @@ export const Link = <L extends text.Level = "h1">({
     target={target}
     rel={rel}
     className={CSS(className, CSS.B("text-link"))}
-    {...props}
+    {...rest}
   />
 );

--- a/pluto/src/text/Select.tsx
+++ b/pluto/src/text/Select.tsx
@@ -28,10 +28,8 @@ const DATA: LevelEntry[] = [
   { key: "small", label: "XS" },
 ];
 
-export const SelectLevel = ({ children, ...props }: SelectLevelProps): ReactElement => (
-  <Button {...props} data={DATA} entryRenderKey="label">
-    {children}
-  </Button>
+export const SelectLevel = (props: SelectLevelProps): ReactElement => (
+  <Button {...props} data={DATA} entryRenderKey="label" />
 );
 
 interface WeightEntry {
@@ -49,11 +47,6 @@ const WEIGHT_DATA: WeightEntry[] = [
 export interface SelectWeightProps
   extends Omit<ButtonProps<text.Weight, WeightEntry>, "data" | "entryRenderKey"> {}
 
-export const SelectWeight = ({
-  children,
-  ...props
-}: SelectWeightProps): ReactElement => (
-  <Button {...props} data={WEIGHT_DATA} entryRenderKey="label">
-    {children}
-  </Button>
+export const SelectWeight = (props: SelectWeightProps): ReactElement => (
+  <Button {...props} data={WEIGHT_DATA} entryRenderKey="label" />
 );

--- a/pluto/src/text/Text.tsx
+++ b/pluto/src/text/Text.tsx
@@ -42,11 +42,10 @@ export const Text = <L extends text.Level = text.Level>({
   color,
   className,
   style,
-  children,
   noWrap = false,
   shade,
   weight,
-  ...props
+  ...rest
 }: TextProps<L>): ReactElement => (
   // @ts-expect-error - TODO: Generic Elements are weird
   <Generic.Element<L>
@@ -54,10 +53,8 @@ export const Text = <L extends text.Level = text.Level>({
     ref={ref}
     style={{ color: evalColor(color, shade), fontWeight: weight, ...style }}
     className={CSS(CSS.B("text"), CSS.BM("text", level), CSS.noWrap(noWrap), className)}
-    {...props}
-  >
-    {children}
-  </Generic.Element>
+    {...rest}
+  />
 );
 
 export const evalColor = (

--- a/pluto/src/text/WithIcon.tsx
+++ b/pluto/src/text/WithIcon.tsx
@@ -52,7 +52,7 @@ export const WithIcon = <
   noWrap = false,
   shade,
   weight,
-  ...props
+  ...rest
 }: WithIconProps<E, L>): ReactElement => {
   const color = evalColor(crudeColor, shade);
   const startIcons = Children.toArray(startIcon);
@@ -70,8 +70,8 @@ export const WithIcon = <
       direction="x"
       size="small"
       align="center"
-      {...props}
-      style={{ ...props.style, color }}
+      {...rest}
+      style={{ ...rest.style, color }}
     >
       {startIcons}
       {divided && startIcon != null && <Divider.Divider direction="y" />}

--- a/pluto/src/theming/Provider.tsx
+++ b/pluto/src/theming/Provider.tsx
@@ -130,9 +130,9 @@ const setThemeClass = (el: HTMLElement, theme: theming.Theme): void => {
 export const Provider = ({
   children,
   applyCSSVars = true,
-  ...props
+  ...rest
 }: ProviderProps): ReactElement => {
-  const ret = useProvider(props);
+  const ret = useProvider(rest);
   const [{ path }, , setAetherTheme] = Aether.use({
     type: theming.Provider.TYPE,
     schema: theming.Provider.z,
@@ -165,9 +165,9 @@ export const Provider = ({
   );
 };
 
-export const Switch = ({
-  ...props
-}: Omit<SwitchProps, "onChange" | "value">): ReactElement => {
+export const Switch = (
+  props: Omit<SwitchProps, "onChange" | "value">,
+): ReactElement => {
   const { toggleTheme } = useContext();
   const [checked, setChecked] = useState(false);
   return (

--- a/pluto/src/tooltip/wrap.tsx
+++ b/pluto/src/tooltip/wrap.tsx
@@ -43,9 +43,9 @@ export const wrap = <P extends {} = {}>(Component: FC<P>): FC<P & WrapProps> => 
     tooltipDelay,
     tooltip,
     tooltipLocation,
-    ...props
+    ...rest
   }: P & WrapProps): ReactElement => {
-    const c = <Component {...(props as unknown as P)} />;
+    const c = <Component {...(rest as unknown as P)} />;
     if (tooltip == null) return c;
     return (
       <Dialog delay={tooltipDelay} location={tooltipLocation}>

--- a/pluto/src/tree/Tree.tsx
+++ b/pluto/src/tree/Tree.tsx
@@ -373,7 +373,7 @@ export const Tree = ({
   contract: _,
   emptyContent,
   loading,
-  ...props
+  ...rest
 }: TreeProps): ReactElement => {
   const Core = virtual ? List.Core.Virtual : List.Core;
   return (
@@ -387,11 +387,11 @@ export const Tree = ({
         <Core<string, FlattenedNode>
           itemHeight={itemHeight}
           className={CSS(className, CSS.B("tree"), showRules && CSS.M("rules"))}
-          {...props}
+          {...rest}
         >
-          {({ key, ...props }) =>
+          {({ key, ...rest }) =>
             children({
-              ...props,
+              ...rest,
               key,
               loading: loading === key,
               useMargin,

--- a/pluto/src/triggers/Text.tsx
+++ b/pluto/src/triggers/Text.tsx
@@ -41,12 +41,12 @@ export const Text = <L extends Core.Level>({
   style,
   trigger,
   children,
-  ...props
+  ...rest
 }: TextProps<L>): ReactElement => (
   <>
     {trigger.map((t) => (
       // @ts-expect-error - issues with generic element types
-      <Core.Keyboard<L> key={t} {...props}>
+      <Core.Keyboard<L> key={t} {...rest}>
         {getCustomText(t)}
       </Core.Keyboard>
     ))}

--- a/pluto/src/util/canDisable.tsx
+++ b/pluto/src/util/canDisable.tsx
@@ -16,8 +16,8 @@ export type CanDisabledProps<T extends object & { children?: ReactNode }> = T & 
 export const canDisable = <T extends object & { children?: ReactNode }>(
   C: FC<T>,
 ): FC<CanDisabledProps<T>> => {
-  const O: FC<CanDisabledProps<T>> = ({ disabled = false, ...props }) =>
-    disabled ? props.children : <C {...(props as T)} />;
+  const O: FC<CanDisabledProps<T>> = ({ disabled = false, ...rest }) =>
+    disabled ? rest.children : <C {...(rest as T)} />;
   O.displayName = C.displayName;
   return O;
 };

--- a/pluto/src/util/renderProp.tsx
+++ b/pluto/src/util/renderProp.tsx
@@ -20,8 +20,8 @@ export const componentRenderProp =
   <P extends Record<string, any>, R = ReactElement | null>(
     Component: React.ComponentType<P>,
   ): RenderProp<P, R> =>
-  ({ key, ...props }) =>
-    (<Component key={key} {...(props as P)} />) as R;
+  ({ key, ...rest }) =>
+    (<Component key={key} {...(rest as P)} />) as R;
 
 export const isRenderProp = <P extends Record<string, any>>(
   children: React.ReactNode | RenderProp<P>,

--- a/pluto/src/video/Video.tsx
+++ b/pluto/src/video/Video.tsx
@@ -17,8 +17,8 @@ export interface VideoProps extends ComponentPropsWithoutRef<"video"> {
   href: string;
 }
 
-export const Video = ({ href, className, ...props }: VideoProps): ReactElement => (
-  <video className={CSS(CSS.B("video"), className)} {...props}>
+export const Video = ({ href, className, ...rest }: VideoProps): ReactElement => (
+  <video className={CSS(CSS.B("video"), className)} {...rest}>
     <source id={href} src={href} type="video/mp4" />
   </video>
 );

--- a/pluto/src/viewport/Mask.tsx
+++ b/pluto/src/viewport/Mask.tsx
@@ -38,7 +38,7 @@ export const Mask = ({
   maskBox,
   children,
   style,
-  ...props
+  ...rest
 }: MaskProps): ReactElement | null => (
   <div
     className={CSS(CSS.noSelect, CSS.BE("viewport-mask", "container"), className)}
@@ -46,7 +46,7 @@ export const Mask = ({
       cursor: MODE_CURSORS[mode],
       ...style,
     }}
-    {...props}
+    {...rest}
   >
     <div
       style={{

--- a/pluto/src/viewport/SelectMode.tsx
+++ b/pluto/src/viewport/SelectMode.tsx
@@ -56,7 +56,7 @@ export interface SelectModeProps extends Omit<Select.ButtonProps<Mode>, "data"> 
 export const SelectMode = ({
   triggers,
   disable = ["zoomReset", "click"],
-  ...props
+  ...rest
 }: SelectModeProps): ReactElement => {
   const data = Object.entries(triggers)
     .filter(([key]) => !disable.includes(key as Mode) && MODES.includes(key as Mode))
@@ -68,12 +68,12 @@ export const SelectMode = ({
     .sort((a, b) => MODES.indexOf(a.key) - MODES.indexOf(b.key)) as Entry[];
 
   return (
-    <Select.Button<Mode, Entry> {...props} data={data} entryRenderKey="icon">
-      {({ title: _, entry, ...props }) => (
+    <Select.Button<Mode, Entry> {...rest} data={data} entryRenderKey="icon">
+      {({ title: _, entry, ...rest }) => (
         <Button.Icon
-          {...props}
+          {...rest}
           key={entry.key}
-          variant={props.selected ? "filled" : "text"}
+          variant={rest.selected ? "filled" : "text"}
           size="medium"
           tooltip={entry.tooltip}
           tooltipLocation={{ x: "right", y: "top" }}

--- a/pluto/src/vis/canvas/Canvas.tsx
+++ b/pluto/src/vis/canvas/Canvas.tsx
@@ -58,7 +58,7 @@ export const Canvas = ({
   children,
   resizeDebounce: debounce = 100,
   className,
-  ...props
+  ...rest
 }: CanvasProps): ReactElement => {
   const [{ path }, { bootstrapped, dpr }, setState] = Aether.use({
     type: canvas.Canvas.TYPE,
@@ -171,7 +171,7 @@ export const Canvas = ({
     <div
       ref={combinedElRef}
       className={CSS(CSS.B("canvas-container"), className)}
-      {...props}
+      {...rest}
     >
       <canvas
         ref={refCallback}

--- a/pluto/src/vis/diagram/Diagram.tsx
+++ b/pluto/src/vis/diagram/Diagram.tsx
@@ -216,7 +216,6 @@ const DELETE_KEY_CODES: Triggers.Trigger = ["Backspace", "Delete"];
 
 const Core = ({
   aetherKey,
-  children,
   onNodesChange,
   onEdgesChange,
   nodes,
@@ -229,7 +228,7 @@ const Core = ({
   fitViewOnResize,
   setFitViewOnResize,
   visible,
-  ...props
+  ...rest
 }: DiagramProps): ReactElement => {
   const memoProps = useMemoDeepEqualProps({ visible });
   const [{ path }, , setState] = Aether.use({
@@ -470,13 +469,11 @@ const Core = ({
             selectionMode={SelectionMode.Partial}
             proOptions={PRO_OPTIONS}
             deleteKeyCode={DELETE_KEY_CODES}
-            {...props}
-            style={{ [CSS.var("diagram-zoom")]: viewport.zoom, ...props.style }}
+            {...rest}
+            style={{ [CSS.var("diagram-zoom")]: viewport.zoom, ...rest.style }}
             {...editableProps}
             nodesDraggable={editable && !adjustable.held}
-          >
-            {children}
-          </ReactFlow>
+          />
         )}
       </Aether.Composite>
     </Context>
@@ -490,15 +487,13 @@ export const Background = (): ReactElement | null => {
 
 export interface ControlsProps extends Align.PackProps {}
 
-export const Controls = ({ children, ...props }: ControlsProps): ReactElement => (
+export const Controls = (props: ControlsProps): ReactElement => (
   <Align.Pack
     direction="y"
     borderShade={4}
     className={CSS.BE("diagram", "controls")}
     {...props}
-  >
-    {children}
-  </Align.Pack>
+  />
 );
 
 export interface ToggleEditControlProps
@@ -506,7 +501,7 @@ export interface ToggleEditControlProps
 
 export const ToggleEditControl = ({
   onClick,
-  ...props
+  ...rest
 }: ToggleEditControlProps): ReactElement => {
   const { editable, onEditableChange } = useContext();
   return (
@@ -523,7 +518,7 @@ export const ToggleEditControl = ({
           <Text.Text level="small">Enable edit mode</Text.Text>
         )
       }
-      {...props}
+      {...rest}
     >
       {editable ? <Icon.EditOff /> : <Icon.Edit />}
     </Button.ToggleIcon>
@@ -535,7 +530,7 @@ export interface FitViewControlProps
 
 export const FitViewControl = ({
   onClick,
-  ...props
+  ...rest
 }: FitViewControlProps): ReactElement => {
   const { fitView } = useReactFlow();
   const { fitViewOnResize, setFitViewOnResize } = useContext();
@@ -552,7 +547,7 @@ export const FitViewControl = ({
       tooltip={<Text.Text level="small">Fit view to contents</Text.Text>}
       tooltipLocation={location.RIGHT_CENTER}
       variant="outlined"
-      {...props}
+      {...rest}
     >
       <Icon.Expand />
     </Button.ToggleIcon>

--- a/pluto/src/vis/diagram/edge/Edge.tsx
+++ b/pluto/src/vis/diagram/edge/Edge.tsx
@@ -109,13 +109,13 @@ export const Edge = ({
   color = "var(--pluto-gray-l9)",
   selected = false,
   variant = "pipe",
-  ...props
+  ...rest
 }: EdgeProps): ReactElement => {
-  const sourcePos = xy.construct(props.sourceX, props.sourceY);
+  const sourcePos = xy.construct(rest.sourceX, rest.sourceY);
   const sourcePosRef = useRef(sourcePos);
   const sourcePosEq = xy.equals(sourcePos, sourcePosRef.current);
 
-  const targetPos = xy.construct(props.targetX, props.targetY);
+  const targetPos = xy.construct(rest.targetX, rest.targetY);
   const targetPosRef = useRef(targetPos);
   const targetPosEq = xy.equals(targetPos, targetPosRef.current);
 

--- a/pluto/src/vis/diagram/edge/paths.tsx
+++ b/pluto/src/vis/diagram/edge/paths.tsx
@@ -22,39 +22,39 @@ interface PathProps extends Omit<BaseEdgeProps, "path" | "color" | "points"> {
   color?: Color.Crude;
 }
 
-const Pipe = ({ points, color, ...props }: PathProps): ReactElement => (
+const Pipe = ({ points, color, ...rest }: PathProps): ReactElement => (
   <BaseEdge
     path={calcPath(points)}
     style={{
       stroke: Color.cssString(color),
     }}
-    {...props}
+    {...rest}
   />
 );
 
-const ElectricSignalPipe = ({ points, color, ...props }: PathProps): ReactElement => (
+const ElectricSignalPipe = ({ points, color, ...rest }: PathProps): ReactElement => (
   <BaseEdge
     path={calcPath(points)}
     style={{
       stroke: Color.cssString(color),
       strokeDasharray: "12,4",
     }}
-    {...props}
+    {...rest}
   />
 );
 
-const SecondaryPipe = ({ points, color, ...props }: PathProps): ReactElement => (
+const SecondaryPipe = ({ points, color, ...rest }: PathProps): ReactElement => (
   <BaseEdge
     path={calcPath(points)}
     style={{
       stroke: Color.cssString(color),
       strokeDasharray: "12,4,4",
     }}
-    {...props}
+    {...rest}
   />
 );
 
-const JackedPipe = ({ points, color, ...props }: PathProps): ReactElement => {
+const JackedPipe = ({ points, color, ...rest }: PathProps): ReactElement => {
   const miters = xy.calculateMiters(points, 6);
   const abovePath = points.map((p, i) => xy.translate(p, miters[i]));
   const belowPath = points.map((p, i) => xy.translate(p, xy.scale(miters[i], -1)));
@@ -62,9 +62,9 @@ const JackedPipe = ({ points, color, ...props }: PathProps): ReactElement => {
   const opacity = 0.7;
   return (
     <>
-      <BaseEdge path={calcPath(abovePath)} style={{ stroke, opacity }} {...props} />
-      <BaseEdge path={calcPath(points)} style={{ stroke }} {...props} />
-      <BaseEdge path={calcPath(belowPath)} style={{ stroke, opacity }} {...props} />
+      <BaseEdge path={calcPath(abovePath)} style={{ stroke, opacity }} {...rest} />
+      <BaseEdge path={calcPath(points)} style={{ stroke }} {...rest} />
+      <BaseEdge path={calcPath(belowPath)} style={{ stroke, opacity }} {...rest} />
     </>
   );
 };
@@ -183,12 +183,12 @@ const DataLinkSymbol = ({ color, position }: SymbolProps): ReactElement => (
 );
 
 const createSymbolLine = (C: FC<SymbolProps>) => {
-  const O = ({ points, color, ...props }: PathProps): ReactElement => {
+  const O = ({ points, color, ...rest }: PathProps): ReactElement => {
     const path = calcPath(points);
     const positions = computeSymbolPositions(points, 40); // Adjust the interval as needed
     return (
       <>
-        <BaseEdge path={path} {...props} style={{ stroke: Color.cssString(color) }} />
+        <BaseEdge path={path} {...rest} style={{ stroke: Color.cssString(color) }} />
         {positions.map(({ position, direction }, index) => (
           <C key={index} position={position} direction={direction} color={color} />
         ))}

--- a/pluto/src/vis/draw2d/index.ts
+++ b/pluto/src/vis/draw2d/index.ts
@@ -103,17 +103,17 @@ export class Draw2D {
     this.theme = theme;
   }
 
-  rule({ direction, region, position, ...props }: Draw2DRuleProps): void {
+  rule({ direction, region, position, ...rest }: Draw2DRuleProps): void {
     if (direction === "x")
       return this.line({
         start: xy.construct(box.left(region), position),
         end: xy.construct(box.right(region), position),
-        ...props,
+        ...rest,
       });
     return this.line({
       start: xy.construct(position, box.top(region)),
       end: xy.construct(position, box.bottom(region)),
-      ...props,
+      ...rest,
     });
   }
 

--- a/pluto/src/vis/legend/Container.tsx
+++ b/pluto/src/vis/legend/Container.tsx
@@ -125,7 +125,7 @@ export const Container = memo(
     onChange,
     style,
     draggable = true,
-    ...props
+    ...rest
   }: ContainerProps): ReactElement | null => {
     const [position, setPosition] = state.usePurePassthrough<StickyXY>({
       value,
@@ -194,7 +194,7 @@ export const Container = memo(
         onDragStart={handleCursorDragStart}
         draggable={draggable}
         ref={ref}
-        {...props}
+        {...rest}
         onDrag={preventDefault}
         onDragEnd={preventDefault}
         empty

--- a/pluto/src/vis/legend/Simple.tsx
+++ b/pluto/src/vis/legend/Simple.tsx
@@ -64,7 +64,7 @@ export const Simple = ({
   onEntryChange,
   position,
   onPositionChange,
-  ...props
+  ...rest
 }: SimpleProps): ReactElement | null => {
   const [pickerVisible, setPickerVisible] = useState<boolean>(false);
 
@@ -72,7 +72,7 @@ export const Simple = ({
 
   return (
     <Container
-      {...props}
+      {...rest}
       draggable={!pickerVisible}
       value={position}
       onChange={onPositionChange}

--- a/pluto/src/vis/line/Line.tsx
+++ b/pluto/src/vis/line/Line.tsx
@@ -17,12 +17,12 @@ export interface LineProps
   extends Optional<Omit<line.State, "key">, "strokeWidth">,
     Aether.CProps {}
 
-export const Line = memo(({ aetherKey, ...props }: LineProps): ReactElement | null => {
+export const Line = memo(({ aetherKey, ...rest }: LineProps): ReactElement | null => {
   Aether.useUnidirectional({
     aetherKey,
     type: line.Line.TYPE,
     schema: line.stateZ,
-    state: props,
+    state: rest,
   });
   return null;
 });

--- a/pluto/src/vis/lineplot/Axis.tsx
+++ b/pluto/src/vis/lineplot/Axis.tsx
@@ -69,7 +69,7 @@ export const axisFactory = (dir: direction.Direction): FC<AxisProps> => {
     autoBoundUpdateInterval,
     onAutoBoundsChange,
     style,
-    ...props
+    ...rest
   }: AxisProps): ReactElement => {
     const showLabel = (label?.length ?? 0) > 0;
     const cKey = useUniqueKey(aetherKey);
@@ -140,7 +140,7 @@ export const axisFactory = (dir: direction.Direction): FC<AxisProps> => {
           align="center"
           justify={location !== "left" ? "end" : "start"}
           direction={direction.swap(dir)}
-          {...props}
+          {...rest}
         >
           {showLabel && (
             <Text.MaybeEditable

--- a/pluto/src/vis/lineplot/Legend.tsx
+++ b/pluto/src/vis/lineplot/Legend.tsx
@@ -23,10 +23,10 @@ export interface LegendProps extends Omit<Core.SimpleProps, "data" | "onEntryCha
 }
 
 export const Floating = memo(
-  ({ className, style, onLineChange, ...props }: LegendProps): ReactElement | null => {
+  ({ className, style, onLineChange, ...rest }: LegendProps): ReactElement | null => {
     const { lines } = useContext("Legend");
     useContext("Legend");
-    return <Core.Simple data={lines} onEntryChange={onLineChange} {...props} />;
+    return <Core.Simple data={lines} onEntryChange={onLineChange} {...rest} />;
   },
 );
 Floating.displayName = "FloatingLegend";
@@ -59,6 +59,6 @@ const Fixed = ({ onLineChange }: LegendProps) => {
 
 export const Legend = ({
   variant = "floating",
-  ...props
+  ...rest
 }: LegendProps): ReactElement | null =>
-  variant === "floating" ? <Floating {...props} /> : <Fixed {...props} />;
+  variant === "floating" ? <Floating {...rest} /> : <Fixed {...rest} />;

--- a/pluto/src/vis/lineplot/Line.tsx
+++ b/pluto/src/vis/lineplot/Line.tsx
@@ -20,7 +20,7 @@ export const Line = ({
   aetherKey,
   color,
   label = "",
-  ...props
+  ...rest
 }: LineProps): ReactElement => {
   const cKey = useUniqueKey(aetherKey);
   const { setLine, removeLine } = useContext("Line");
@@ -28,5 +28,5 @@ export const Line = ({
     setLine({ key: cKey, color, label });
     return () => removeLine(cKey);
   }, [label, color]);
-  return <Core.Line aetherKey={cKey} color={color} label={label} {...props} />;
+  return <Core.Line aetherKey={cKey} color={color} label={label} {...rest} />;
 };

--- a/pluto/src/vis/lineplot/LinePlot.tsx
+++ b/pluto/src/vis/lineplot/LinePlot.tsx
@@ -116,7 +116,7 @@ export const LinePlot = ({
   hold = false,
   onHold,
   visible,
-  ...props
+  ...rest
 }: LinePlotProps): ReactElement => {
   const [lines, setLines] = useState<LineState>([]);
 
@@ -240,7 +240,7 @@ export const LinePlot = ({
       className={CSS.B("line-plot")}
       style={{ ...style, ...cssGrid }}
       ref={ref}
-      {...props}
+      {...rest}
     >
       <Context value={contextValue}>
         <Aether.Composite path={path}>{children}</Aether.Composite>

--- a/pluto/src/vis/lineplot/Title.tsx
+++ b/pluto/src/vis/lineplot/Title.tsx
@@ -19,7 +19,7 @@ export type TitleProps<L extends Text.Level = "h2"> = Text.MaybeEditableProps<L>
 
 export const Title = <L extends Text.Level = "h2">({
   level = "h2" as TitleProps<L>["level"],
-  ...props
+  ...rest
 }: TitleProps<L>): ReactElement => {
   const key = useUniqueKey();
   const font = Theming.useTypography(level);
@@ -30,7 +30,7 @@ export const Title = <L extends Text.Level = "h2">({
   return (
     <Align.Space justify="center" align="center" style={gridStyle}>
       {/* @ts-expect-error  - generic props issues */}
-      <Text.MaybeEditable<L> {...props} level={level} />
+      <Text.MaybeEditable<L> {...rest} level={level} />
     </Align.Space>
   );
 };

--- a/pluto/src/vis/lineplot/Viewport.tsx
+++ b/pluto/src/vis/lineplot/Viewport.tsx
@@ -31,7 +31,7 @@ export const Viewport = ({
   children,
   initial = box.DECIMAL,
   onChange,
-  ...props
+  ...rest
 }: ViewportProps): ReactElement => {
   const { setViewport } = useContext("Viewport");
 
@@ -47,7 +47,7 @@ export const Viewport = ({
     [onChange, setViewport],
   );
 
-  const maskProps = Core.use({ onChange: handleChange, initial, ref, ...props });
+  const maskProps = Core.use({ onChange: handleChange, initial, ref, ...rest });
 
   return (
     <Core.Mask className={CSS.BE("line-plot", "viewport")} {...maskProps}>

--- a/pluto/src/vis/lineplot/range/Annotation.tsx
+++ b/pluto/src/vis/lineplot/range/Annotation.tsx
@@ -16,12 +16,12 @@ interface AnnotationProps
   extends z.input<typeof range.annotationStateZ>,
     Aether.CProps {}
 
-export const Annotation = ({ aetherKey, ...props }: AnnotationProps): null => {
+export const Annotation = ({ aetherKey, ...rest }: AnnotationProps): null => {
   Aether.use({
     aetherKey,
     type: range.Annotation.TYPE,
     schema: range.annotationStateZ,
-    initialState: props,
+    initialState: rest,
   });
   return null;
 };

--- a/pluto/src/vis/lineplot/range/Provider.tsx
+++ b/pluto/src/vis/lineplot/range/Provider.tsx
@@ -23,18 +23,14 @@ export interface ProviderProps extends Aether.CProps {
   menu?: RenderProp<range.SelectedState>;
 }
 
-export const Provider = ({
-  aetherKey,
-  menu,
-  ...props
-}: ProviderProps): ReactElement => {
+export const Provider = ({ aetherKey, menu, ...rest }: ProviderProps): ReactElement => {
   const cKey = useUniqueKey(aetherKey);
   const { setViewport, setHold } = useContext("Range.Provider");
   const [, { hovered, count }, setState] = Aether.use({
     aetherKey: cKey,
     type: range.Provider.TYPE,
     schema: range.providerStateZ,
-    initialState: { ...props, cursor: null, hovered: null, count: 0 },
+    initialState: { ...rest, cursor: null, hovered: null, count: 0 },
   });
   const gridStyle = useGridEntry(
     { key: cKey, loc: "top", size: count > 0 ? 32 : 0, order: 3 },

--- a/pluto/src/vis/lineplot/tooltip/Tooltip.tsx
+++ b/pluto/src/vis/lineplot/tooltip/Tooltip.tsx
@@ -19,13 +19,13 @@ export interface TooltipProps
   extends Omit<z.input<typeof tooltip.tooltipStateZ>, "position">,
     Aether.CProps {}
 
-export const Tooltip = ({ aetherKey, ...props }: TooltipProps): ReactElement | null => {
+export const Tooltip = ({ aetherKey, ...rest }: TooltipProps): ReactElement | null => {
   const cKey = useUniqueKey(aetherKey);
   const [, , setState] = Aether.use({
     aetherKey: cKey,
     type: tooltip.Tooltip.TYPE,
     schema: tooltip.tooltipStateZ,
-    initialState: { position: null, ...props },
+    initialState: { position: null, ...rest },
   });
 
   const ref = useRef<HTMLSpanElement>(null);

--- a/pluto/src/vis/log/Log.tsx
+++ b/pluto/src/vis/log/Log.tsx
@@ -48,7 +48,7 @@ export const Log = ({
   ),
   color,
   telem,
-  ...props
+  ...rest
 }: LogProps): ReactElement | null => {
   const memoProps = useMemoDeepEqualProps({ font, color, telem, visible });
   const [, { scrolling, empty }, setState] = Aether.use({
@@ -82,7 +82,7 @@ export const Log = ({
           scrolling: s.scrolling ? s.scrolling : e.deltaY < 0,
         }));
       }}
-      {...props}
+      {...rest}
     >
       {empty ? (
         emptyContent

--- a/pluto/src/vis/rule/Rule.tsx
+++ b/pluto/src/vis/rule/Rule.tsx
@@ -52,7 +52,7 @@ export const Rule = ({
   className,
   onSelect,
   style,
-  ...props
+  ...rest
 }: RuleProps): ReactElement | null => {
   const [internalLabel, setInternalLabel] = state.usePurePassthrough({
     value: label,
@@ -145,7 +145,7 @@ export const Rule = ({
           backgroundColor: new Color.Color(color).setAlpha(0.7).hex,
           ...style,
         }}
-        {...props}
+        {...rest}
       >
         <Text.Editable
           className={CSS.B("label")}

--- a/pluto/src/vis/schematic/Forms.tsx
+++ b/pluto/src/vis/schematic/Forms.tsx
@@ -44,14 +44,14 @@ interface FormWrapperProps extends Align.SpaceProps {}
 const FormWrapper: FC<FormWrapperProps> = ({
   className,
   direction,
-  ...props
+  ...rest
 }): ReactElement => (
   <Align.Space
     direction={direction}
     align="stretch"
     className={CSS(CSS.B("symbol-form"), className)}
     size={direction === "x" ? "large" : "medium"}
-    {...props}
+    {...rest}
   />
 );
 
@@ -68,11 +68,11 @@ interface ShowOrientationProps {
 const OrientationControl = ({
   hideOuter,
   hideInner,
-  ...props
+  ...rest
 }: Form.FieldProps<SymbolOrientation> & ShowOrientationProps): ReactElement | null => {
   if (hideInner && hideOuter) return null;
   return (
-    <Form.Field<SymbolOrientation> label="Orientation" padHelpText={false} {...props}>
+    <Form.Field<SymbolOrientation> label="Orientation" padHelpText={false} {...rest}>
       {({ value, onChange }) => (
         <SelectOrientation
           value={{
@@ -145,11 +145,11 @@ const LabelControls = ({ path, omit = [] }: LabelControlsProps): ReactElement =>
 
 const ColorControl: Form.FieldT<Color.Crude> = (props): ReactElement => (
   <Form.Field hideIfNull label="Color" align="start" padHelpText={false} {...props}>
-    {({ value, onChange, variant: _, ...props }) => (
+    {({ value, onChange, variant: _, ...rest }) => (
       <Color.Swatch
         value={value ?? Color.ZERO.setAlpha(1).rgba255}
         onChange={(v) => onChange(v.rgba255)}
-        {...props}
+        {...rest}
         bordered
       />
     )}
@@ -336,9 +336,8 @@ export const TankForm = ({
           label="X Border Radius"
           grow
         >
-          {({ value, ...props }) => (
+          {(props) => (
             <Input.Numeric
-              value={value}
               dragScale={DIMENSIONS_DRAG_SCALE}
               bounds={BORDER_RADIUS_BOUNDS}
               endContent="%"
@@ -353,9 +352,8 @@ export const TankForm = ({
           label="Y Border Radius"
           grow
         >
-          {({ value, ...props }) => (
+          {(props) => (
             <Input.Numeric
-              value={value}
               dragScale={DIMENSIONS_DRAG_SCALE}
               bounds={BORDER_RADIUS_BOUNDS}
               endContent="%"
@@ -371,9 +369,8 @@ export const TankForm = ({
             label="Border Radius"
             grow
           >
-            {({ value, ...props }) => (
+            {(props) => (
               <Input.Numeric
-                value={value}
                 dragScale={DIMENSIONS_DRAG_SCALE}
                 bounds={DIMENSIONS_BOUNDS}
                 endContent="px"
@@ -383,24 +380,24 @@ export const TankForm = ({
           </Form.Field>
         )}
         <Form.Field<number> path="dimensions.width" label="Width" grow>
-          {({ value, ...props }) => (
+          {({ value, ...rest }) => (
             <Input.Numeric
               value={value ?? 200}
               dragScale={DIMENSIONS_DRAG_SCALE}
               bounds={DIMENSIONS_BOUNDS}
               endContent="px"
-              {...props}
+              {...rest}
             />
           )}
         </Form.Field>
         <Form.Field<number> path="dimensions.height" label="Height" grow>
-          {({ value, ...props }) => (
+          {({ value, ...rest }) => (
             <Input.Numeric
               value={value ?? 200}
               dragScale={DIMENSIONS_DRAG_SCALE}
               bounds={DIMENSIONS_BOUNDS}
               endContent="px"
-              {...props}
+              {...rest}
             />
           )}
         </Form.Field>
@@ -808,24 +805,24 @@ export const CylinderForm = (): ReactElement => (
         <ColorControl path="color" />
         <ColorControl path="backgroundColor" label="Background Color" />
         <Form.Field<number> path="dimensions.width" label="Width" grow>
-          {({ value, ...props }) => (
+          {({ value, ...rest }) => (
             <Input.Numeric
               value={value ?? 200}
               dragScale={DIMENSIONS_DRAG_SCALE}
               bounds={DIMENSIONS_BOUNDS}
               endContent="px"
-              {...props}
+              {...rest}
             />
           )}
         </Form.Field>
         <Form.Field<number> path="dimensions.height" label="Height" grow>
-          {({ value, ...props }) => (
+          {({ value, ...rest }) => (
             <Input.Numeric
               value={value ?? 200}
               dragScale={DIMENSIONS_DRAG_SCALE}
               bounds={DIMENSIONS_BOUNDS}
               endContent="px"
-              {...props}
+              {...rest}
             />
           )}
         </Form.Field>

--- a/pluto/src/vis/schematic/Grid.tsx
+++ b/pluto/src/vis/schematic/Grid.tsx
@@ -123,8 +123,8 @@ const createGridEl = (loc: location.Outer): FC<GridElProps> => {
     );
   };
 
-  const GridEl = ({ symbolKey, ...props }: GridElProps): ReactElement | null => {
-    const { editable, items: fItems } = props;
+  const GridEl = ({ symbolKey, ...rest }: GridElProps): ReactElement | null => {
+    const { editable, items: fItems } = rest;
 
     const prevEditable = useRef(editable);
     if (editable !== prevEditable.current && loc === "top") {
@@ -132,7 +132,7 @@ const createGridEl = (loc: location.Outer): FC<GridElProps> => {
       prevEditable.current = editable;
     }
 
-    if (editable) return <EditableGridEl symbolKey={symbolKey} {...props} />;
+    if (editable) return <EditableGridEl symbolKey={symbolKey} {...rest} />;
     const items = fItems.filter((i) => i.location === loc);
     if (items.length === 0) return null;
     return (
@@ -155,12 +155,12 @@ const LeftGridEl = createGridEl("left");
 const RightGridEl = createGridEl("right");
 const BottomGridEl = createGridEl("bottom");
 
-export const Grid = ({ editable, onRotate, children, ...props }: GridProps) => (
+export const Grid = ({ editable, onRotate, children, ...rest }: GridProps) => (
   <>
-    <TopGridEl editable={editable} {...props} />
-    <LeftGridEl editable={editable} {...props} />
-    <RightGridEl editable={editable} {...props} />
-    <BottomGridEl editable={editable} {...props} />
+    <TopGridEl editable={editable} {...rest} />
+    <LeftGridEl editable={editable} {...rest} />
+    <RightGridEl editable={editable} {...rest} />
+    <BottomGridEl editable={editable} {...rest} />
     {editable && (
       <Button.Icon
         className={CSS.BE("grid", "rotate")}

--- a/pluto/src/vis/schematic/SelectOrientation.tsx
+++ b/pluto/src/vis/schematic/SelectOrientation.tsx
@@ -77,7 +77,7 @@ const InternalOrientation = ({
   onChange,
   className,
   hideInner = false,
-  ...props
+  ...rest
 }: SelectOrientationProps): ReactElement => {
   const { inner } = value;
   const handleChange = (next: Partial<OrientationValue>) => () =>
@@ -92,7 +92,7 @@ const InternalOrientation = ({
       align="center"
       justify="center"
       empty
-      {...props}
+      {...rest}
     >
       <Button
         style={showStyle}
@@ -130,15 +130,11 @@ export interface ButtonProps extends Omit<CoreButton.IconProps, "children"> {
   selected: boolean;
 }
 
-export const Button = ({
-  selected,
-  className,
-  ...props
-}: ButtonProps): ReactElement => (
+export const Button = ({ selected, className, ...rest }: ButtonProps): ReactElement => (
   <CoreButton.Icon
     variant="text"
     className={CSS(className, CSS.selected(selected))}
-    {...props}
+    {...rest}
   >
     <div className="symbol"></div>
   </CoreButton.Icon>

--- a/pluto/src/vis/schematic/Symbols.tsx
+++ b/pluto/src/vis/schematic/Symbols.tsx
@@ -589,7 +589,7 @@ export const Setpoint = ({
 
 export const SetpointPreview = ({
   className,
-  ...props
+  ...rest
 }: SetpointProps): ReactElement => (
   <Primitives.Setpoint
     value={12}
@@ -598,7 +598,7 @@ export const SetpointPreview = ({
     style={{ width: 120, transform: "scale(0.95)" }}
     className={CSS(CSS.BM("setpoint", "preview"), className)}
     disabled
-    {...props}
+    {...rest}
   >
     <Text.Text level="p">10.0</Text.Text>
   </Primitives.Setpoint>
@@ -728,8 +728,8 @@ export const Button = ({
   );
 };
 
-export const ButtonPreview = ({ label: _, ...props }: ButtonProps): ReactElement => (
-  <Primitives.Button label="Button" {...props} />
+export const ButtonPreview = ({ label: _, ...rest }: ButtonProps): ReactElement => (
+  <Primitives.Button label="Button" {...rest} />
 );
 
 export interface LightProps
@@ -792,9 +792,9 @@ export const OffPageReference = ({
 
 export const OffPageReferencePreview = ({
   label: _,
-  ...props
+  ...rest
 }: OffPageReferenceProps) => (
-  <Primitives.OffPageReference label="Off Page" {...props} orientation="right" />
+  <Primitives.OffPageReference label="Off Page" {...rest} orientation="right" />
 );
 export const Cylinder = createLabeled<
   SymbolProps<Omit<Primitives.CylinderProps, "onChange">>

--- a/pluto/src/vis/schematic/primitives/Primitives.tsx
+++ b/pluto/src/vis/schematic/primitives/Primitives.tsx
@@ -184,16 +184,16 @@ const Handle = ({
   swap,
   top,
   style,
-  ...props
+  ...rest
 }: HandleProps): ReactElement => {
   const adjusted = adjustHandle(top, left, orientation, preventAutoAdjust);
   return (
     <RFHandle
       position={swapRF(smartPosition(location, orientation), !swap)}
-      {...props}
+      {...rest}
       type="source"
       onClick={(e) => e.stopPropagation()}
-      className={(CSS.B("handle"), CSS.BE("handle", props.id))}
+      className={(CSS.B("handle"), CSS.BE("handle", rest.id))}
       style={{
         left: `${adjusted.left}%`,
         top: `${adjusted.top}%`,
@@ -218,7 +218,7 @@ const Toggle = ({
   triggered = false,
   orientation = "left",
   color,
-  ...props
+  ...rest
 }: ToggleValveButtonProps): ReactElement => (
   <button
     className={CSS(
@@ -230,7 +230,7 @@ const Toggle = ({
       className,
     )}
     color={Color.cssString(color)}
-    {...props}
+    {...rest}
   />
 );
 
@@ -238,8 +238,8 @@ interface DivProps
   extends Omit<ComponentPropsWithoutRef<"div">, "color" | "onResize">,
     OrientableProps {}
 
-const Div = ({ className, ...props }: DivProps): ReactElement => (
-  <div className={CSS(CSS.B("symbol-primitive"), className)} {...props} />
+const Div = ({ className, ...rest }: DivProps): ReactElement => (
+  <div className={CSS(CSS.B("symbol-primitive"), className)} {...rest} />
 );
 
 interface SVGBasedPrimitiveProps extends OrientableProps {
@@ -266,7 +266,7 @@ const InternalSVG = ({
   color,
   style = {},
   scale = 1,
-  ...props
+  ...rest
 }: InternalSVGProps): ReactElement => {
   const dir = direction.construct(orientation);
   dims = dir === "y" ? dimensions.swap(dims) : dims;
@@ -288,7 +288,7 @@ const InternalSVG = ({
       className={CSS(CSS.loc(orientation), className)}
       fill={colorStr}
       stroke={colorStr}
-      {...props}
+      {...rest}
       style={{
         aspectRatio: `${dims.width} / ${dims.height}`,
         width: dimensions.scale(dims, scale * BASE_SCALE).width,
@@ -307,10 +307,10 @@ export const FourWayValve = ({
   orientation = "left",
   scale,
   color,
-  ...props
+  ...rest
 }: FourWayValveProps): ReactElement => (
   <Toggle
-    {...props}
+    {...rest}
     orientation={orientation}
     className={CSS(CSS.B("four-way-valve"), className)}
   >
@@ -333,13 +333,9 @@ export const ThreeWayValve = ({
   color,
   orientation = "left",
   scale,
-  ...props
+  ...rest
 }: ThreeWayValveProps): ReactElement => (
-  <Toggle
-    {...props}
-    className={CSS(CSS.B("three-way-valve"))}
-    orientation={orientation}
-  >
+  <Toggle {...rest} className={CSS(CSS.B("three-way-valve"))} orientation={orientation}>
     <HandleBoundary orientation={orientation}>
       <Handle
         location="bottom"
@@ -381,9 +377,9 @@ export const Valve = ({
   orientation = "left",
   color,
   scale,
-  ...props
+  ...rest
 }: ValveProps): ReactElement => (
-  <Toggle {...props}>
+  <Toggle {...rest}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={2.2989} top={50} id="1" />
       <Handle
@@ -415,7 +411,7 @@ export const SolenoidValve = ({
   orientation = "left",
   normallyOpen = false,
   scale,
-  ...props
+  ...rest
 }: SolenoidValveProps): ReactElement => (
   <Toggle
     className={CSS(
@@ -423,7 +419,7 @@ export const SolenoidValve = ({
       normallyOpen && CSS.M("normally-open"),
       className,
     )}
-    {...props}
+    {...rest}
   >
     <HandleBoundary orientation={orientation}>
       <Handle
@@ -480,13 +476,9 @@ export const ReliefValve = ({
   color,
   scale,
   enabled = false,
-  ...props
+  ...rest
 }: ReliefValveProps): ReactElement => (
-  <Toggle
-    className={CSS(CSS.B("relief-valve"), className)}
-    enabled={enabled}
-    {...props}
-  >
+  <Toggle className={CSS(CSS.B("relief-valve"), className)} enabled={enabled} {...rest}>
     <HandleBoundary orientation={orientation}>
       <Handle
         location="left"
@@ -525,12 +517,12 @@ export const CheckValve = ({
   orientation = "left",
   color,
   scale,
-  ...props
+  ...rest
 }: CheckValveProps): ReactElement => (
   <Div
     orientation={orientation}
     className={CSS(CSS.B("check-valve"), className)}
-    {...props}
+    {...rest}
   >
     <HandleBoundary orientation={orientation}>
       <Handle
@@ -567,11 +559,11 @@ export const ISOCheckValve = ({
   orientation = "left",
   color,
   scale,
-  ...props
+  ...rest
 }: ISOCheckValveProps): ReactElement => {
   const colorStr = Color.cssString(color);
   return (
-    <Div {...props} orientation={orientation}>
+    <Div {...rest} orientation={orientation}>
       <HandleBoundary orientation={orientation}>
         <Handle
           location="left"
@@ -611,10 +603,10 @@ export const AngledValve = ({
   className,
   orientation = "left",
   scale,
-  ...props
+  ...rest
 }: AngledValveProps): ReactElement => (
   <Toggle
-    {...props}
+    {...rest}
     orientation={orientation}
     className={CSS(CSS.B("angled-valve"), className)}
   >
@@ -654,10 +646,10 @@ export const BallValve = ({
   orientation = "left",
   scale,
   enabled = false,
-  ...props
+  ...rest
 }: BallValveProps): ReactElement => (
   <Toggle
-    {...props}
+    {...rest}
     orientation={orientation}
     className={CSS(CSS.B("ball-valve"), className)}
     enabled={enabled}
@@ -693,10 +685,10 @@ export const ThreeWayBallValve = ({
   orientation = "left",
   scale,
   enabled = false,
-  ...props
+  ...rest
 }: ThreeWayBallValveProps): ReactElement => (
   <Toggle
-    {...props}
+    {...rest}
     orientation={orientation}
     className={CSS(CSS.B("three-way-ball-valve"), className)}
     enabled={enabled}
@@ -740,10 +732,10 @@ export const GateValve = ({
   orientation = "left",
   scale,
   enabled = false,
-  ...props
+  ...rest
 }: GateValveProps): ReactElement => (
   <Toggle
-    {...props}
+    {...rest}
     orientation={orientation}
     className={CSS(CSS.B("gate-valve"), className)}
     enabled={enabled}
@@ -778,10 +770,10 @@ export const ButterflyValveOne = ({
   orientation = "left",
   scale,
   enabled = false,
-  ...props
+  ...rest
 }: ButterflyValveOneProps): ReactElement => (
   <Toggle
-    {...props}
+    {...rest}
     orientation={orientation}
     className={CSS(CSS.B("butterfly-valve-one"), className)}
     enabled={enabled}
@@ -817,10 +809,10 @@ export const ButterflyValveTwo = ({
   orientation = "left",
   scale,
   enabled = false,
-  ...props
+  ...rest
 }: ButterflyValveTwoProps): ReactElement => (
   <Toggle
-    {...props}
+    {...rest}
     orientation={orientation}
     className={CSS(CSS.B("butterfly-valve-two"), className)}
     enabled={enabled}
@@ -856,10 +848,10 @@ export const BreatherValve = ({
   orientation = "left",
   scale,
   enabled = false,
-  ...props
+  ...rest
 }: BreatherValveProps): ReactElement => (
   <Toggle
-    {...props}
+    {...rest}
     orientation={orientation}
     className={CSS(CSS.B("breather-valve"), className)}
     enabled={enabled}
@@ -894,13 +886,9 @@ export const Pump = ({
   className,
   orientation = "left",
   scale,
-  ...props
+  ...rest
 }: PumpProps): ReactElement => (
-  <Toggle
-    {...props}
-    className={CSS(CSS.B("pump"), className)}
-    orientation={orientation}
-  >
+  <Toggle {...rest} className={CSS(CSS.B("pump"), className)} orientation={orientation}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={3.125} top={50} id="1" />
       <Handle
@@ -951,11 +939,11 @@ export const BurstDisc = ({
   color,
   orientation = "left",
   scale,
-  ...props
+  ...rest
 }: BurstDiscProps): ReactElement => {
   const colorStr = Color.cssString(color);
   return (
-    <Div {...props} className={CSS(CSS.B("symbol"), className)}>
+    <Div {...rest} className={CSS(CSS.B("symbol"), className)}>
       <HandleBoundary orientation={orientation}>
         <Handle location="left" orientation={orientation} left={5} top={50} id="1" />
       </HandleBoundary>
@@ -985,9 +973,9 @@ export const ISOBurstDisc = ({
   color,
   orientation = "left",
   scale,
-  ...props
+  ...rest
 }: ISOBurstDiscProps): ReactElement => (
-  <Div {...props} className={CSS(CSS.B("symbol"), className)}>
+  <Div {...rest} className={CSS(CSS.B("symbol"), className)}>
     <HandleBoundary orientation={orientation}>
       <Handle
         location="left"
@@ -1019,9 +1007,9 @@ export const Cap = ({
   orientation = "left",
   color,
   scale,
-  ...props
+  ...rest
 }: CapProps): ReactElement => (
-  <Div className={CSS(CSS.B("cap"), className)} {...props}>
+  <Div className={CSS(CSS.B("cap"), className)} {...rest}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={7.6923} top={50} id="1" />
     </HandleBoundary>
@@ -1043,9 +1031,9 @@ export const ISOCap = ({
   orientation = "left",
   color,
   scale = 1,
-  ...props
+  ...rest
 }: ISOCapProps): ReactElement => (
-  <Div className={CSS(CSS.B("cap"), className)} {...props}>
+  <Div className={CSS(CSS.B("cap"), className)} {...rest}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={50} top={50} id="1" />
     </HandleBoundary>
@@ -1071,10 +1059,10 @@ export const ManualValve = ({
   color,
   scale,
   enabled = false,
-  ...props
+  ...rest
 }: ManualValveProps): ReactElement => (
   <Toggle
-    {...props}
+    {...rest}
     orientation={orientation}
     className={CSS(CSS.B("manual-valve"), className)}
     enabled={enabled}
@@ -1115,9 +1103,9 @@ export const OrificePlate = ({
   orientation = "left",
   color,
   scale,
-  ...props
+  ...rest
 }: OrificePlateProps): ReactElement => (
-  <Div className={CSS(CSS.B("orifice_plate"), className)} {...props}>
+  <Div className={CSS(CSS.B("orifice_plate"), className)} {...rest}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={3.125} top={50} id="1" />
       <Handle
@@ -1150,9 +1138,9 @@ export const Filter = ({
   orientation = "left",
   color,
   scale,
-  ...props
+  ...rest
 }: FilterProps): ReactElement => (
-  <Div className={CSS(CSS.B("filter"), className)} {...props}>
+  <Div className={CSS(CSS.B("filter"), className)} {...rest}>
     <HandleBoundary orientation={orientation}>
       <Handle
         location="left"
@@ -1237,7 +1225,7 @@ export const Tank = ({
   boxBorderRadius,
   color,
   backgroundColor,
-  ...props
+  ...rest
 }: TankProps): ReactElement => {
   const detailedRadius = parseBorderRadius(borderRadius);
   const hasCornerBoundaries = boxBorderRadius == null;
@@ -1267,7 +1255,7 @@ export const Tank = ({
         borderColor: Color.cssString(color ?? t.colors.gray.l9),
         backgroundColor: Color.cssString(backgroundColor),
       }}
-      {...props}
+      {...rest}
     >
       <HandleBoundary refreshDeps={refreshDeps} orientation="left">
         <Handle location="top" orientation="left" left={50} top={topOffset} id="1" />
@@ -1334,9 +1322,9 @@ export const Regulator = ({
   orientation = "left",
   color,
   scale,
-  ...props
+  ...rest
 }: RegulatorProps): ReactElement => (
-  <Div className={CSS(className, CSS.B("regulator"))} {...props}>
+  <Div className={CSS(className, CSS.B("regulator"))} {...rest}>
     <HandleBoundary orientation={orientation}>
       <Handle
         location="left"
@@ -1381,9 +1369,9 @@ export const Orifice = ({
   orientation = "left",
   scale,
   color,
-  ...props
+  ...rest
 }: OrificeProps): ReactElement => (
-  <Div className={CSS(CSS.B("orifice"), className)} {...props}>
+  <Div className={CSS(CSS.B("orifice"), className)} {...rest}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={2.8571} top={50} id="1" />
       <Handle
@@ -1414,10 +1402,10 @@ export const NeedleValve = ({
   color,
   scale,
   enabled = false,
-  ...props
+  ...rest
 }: NeedleValveProps): ReactElement => (
   <Toggle
-    {...props}
+    {...rest}
     orientation={orientation}
     className={CSS(CSS.B("needle-valve"), className)}
     enabled={enabled}
@@ -1461,10 +1449,10 @@ export const AngledReliefValve = ({
   orientation = "left",
   scale,
   enabled = false,
-  ...props
+  ...rest
 }: AngledReliefValveProps): ReactElement => (
   <Toggle
-    {...props}
+    {...rest}
     orientation={orientation}
     className={CSS(CSS.B("angled-relief-valve"), className)}
     enabled={enabled}
@@ -1518,7 +1506,7 @@ export const Value = ({
   unitsLevel = "small",
   children,
   inlineSize = 80,
-  ...props
+  ...rest
 }: ValueProps): ReactElement => {
   const borderColor = Color.cssString(color);
   const theme = Theming.use();
@@ -1534,7 +1522,7 @@ export const Value = ({
   return (
     <Div
       className={CSS(CSS.B("value"), className)}
-      {...props}
+      {...rest}
       style={{
         borderColor,
         height: dimensions?.height,
@@ -1679,14 +1667,14 @@ export const Setpoint = ({
   onChange,
   size = "small",
   disabled,
-  ...props
+  ...rest
 }: SetpointProps): ReactElement => {
   const [currValue, setCurrValue] = useState(value);
   return (
     <Div
       className={CSS(CSS.B("setpoint"), className)}
       orientation={orientation}
-      {...props}
+      {...rest}
     >
       <HandleBoundary orientation={orientation}>
         <Handle location="left" orientation={orientation} left={0.5} top={50} id="1" />
@@ -1739,10 +1727,10 @@ export const ScrewPump = ({
   className,
   orientation = "left",
   scale,
-  ...props
+  ...rest
 }: ScrewPumpProps): ReactElement => (
   <Toggle
-    {...props}
+    {...rest}
     className={CSS(CSS.B("screw-pump"), className)}
     orientation={orientation}
   >
@@ -1808,10 +1796,10 @@ export const VacuumPump = ({
   className,
   orientation = "left",
   scale,
-  ...props
+  ...rest
 }: VacuumPumpProps): ReactElement => (
   <Toggle
-    {...props}
+    {...rest}
     className={CSS(CSS.B("vacuum-pump"), className)}
     orientation={orientation}
   >
@@ -1851,10 +1839,10 @@ export const CavityPump = ({
   className,
   orientation = "left",
   scale,
-  ...props
+  ...rest
 }: CavityPumpProps): ReactElement => (
   <Toggle
-    {...props}
+    {...rest}
     className={CSS(CSS.B("cavity-pump"), className)}
     orientation={orientation}
   >
@@ -1914,10 +1902,10 @@ export const PistonPump = ({
   className,
   orientation = "left",
   scale,
-  ...props
+  ...rest
 }: PistonPumpProps): ReactElement => (
   <Toggle
-    {...props}
+    {...rest}
     className={CSS(CSS.B("piston-pump"), className)}
     orientation={orientation}
   >
@@ -1976,10 +1964,10 @@ export const StaticMixer = ({
   className,
   orientation = "left",
   scale,
-  ...props
+  ...rest
 }: StaticMixerProps): ReactElement => (
   <Div
-    {...props}
+    {...rest}
     className={CSS(CSS.B("static-mixer"), className)}
     orientation={orientation}
   >
@@ -2021,10 +2009,10 @@ export const RotaryMixer = ({
   className,
   orientation = "left",
   scale,
-  ...props
+  ...rest
 }: RotaryMixerProps): ReactElement => (
   <Toggle
-    {...props}
+    {...rest}
     className={CSS(CSS.B("rotary-mixer"), className)}
     orientation={orientation}
   >
@@ -2083,10 +2071,10 @@ export const Light = ({
   orientation = "left",
   enabled,
   scale,
-  ...props
+  ...rest
 }: LightProps): ReactElement => (
   <Div
-    {...props}
+    {...rest}
     orientation={orientation}
     className={CSS(CSS.B("light"), enabled && CSS.M("enabled"), className)}
   >
@@ -2126,9 +2114,9 @@ export const ElectricRegulator = ({
   orientation = "left",
   color,
   scale,
-  ...props
+  ...rest
 }: ElectricRegulatorProps): ReactElement => (
-  <Div className={CSS(className, CSS.B("regulator"))} {...props}>
+  <Div className={CSS(className, CSS.B("regulator"))} {...rest}>
     <HandleBoundary orientation={orientation}>
       <Handle
         location="left"
@@ -2183,9 +2171,9 @@ export const Agitator = ({
   orientation = "left",
   color,
   scale,
-  ...props
+  ...rest
 }: AgitatorProps): ReactElement => (
-  <Toggle {...props} className={CSS(CSS.B("agitator"))}>
+  <Toggle {...rest} className={CSS(CSS.B("agitator"))}>
     <HandleBoundary orientation={orientation}>
       <Handle
         location="top"
@@ -2214,9 +2202,9 @@ export const PropellerAgitator = ({
   orientation = "left",
   color,
   scale,
-  ...props
+  ...rest
 }: PropellerAgitatorProps): ReactElement => (
-  <Toggle {...props} className={CSS(CSS.B("agitator"))}>
+  <Toggle {...rest} className={CSS(CSS.B("agitator"))}>
     <HandleBoundary orientation={orientation}>
       <Handle
         location="top"
@@ -2245,9 +2233,9 @@ export const FlatBladeAgitator = ({
   orientation = "left",
   color,
   scale,
-  ...props
+  ...rest
 }: FlatBladeAgitatorProps): ReactElement => (
-  <Toggle {...props} className={CSS(CSS.B("agitator"))}>
+  <Toggle {...rest} className={CSS(CSS.B("agitator"))}>
     <HandleBoundary orientation={orientation}>
       <Handle
         location="top"
@@ -2277,9 +2265,9 @@ export const PaddleAgitator = ({
   orientation = "left",
   color,
   scale,
-  ...props
+  ...rest
 }: PaddleAgitatorProps): ReactElement => (
-  <Toggle {...props} className={CSS(CSS.B("agitator"))}>
+  <Toggle {...rest} className={CSS(CSS.B("agitator"))}>
     <HandleBoundary orientation={orientation}>
       <Handle
         location="top"
@@ -2333,9 +2321,9 @@ export const CrossBeamAgitator = ({
   orientation = "left",
   color,
   scale,
-  ...props
+  ...rest
 }: CrossBeamAgitatorProps): ReactElement => (
-  <Toggle {...props} className={CSS(CSS.B("agitator"))}>
+  <Toggle {...rest} className={CSS(CSS.B("agitator"))}>
     <HandleBoundary orientation={orientation}>
       <Handle
         location="top"
@@ -2369,9 +2357,9 @@ export const HelicalAgitator = ({
   orientation = "left",
   color,
   scale,
-  ...props
+  ...rest
 }: HelicalAgitatorProps): ReactElement => (
-  <Toggle {...props} className={CSS(CSS.B("agitator"))}>
+  <Toggle {...rest} className={CSS(CSS.B("agitator"))}>
     <HandleBoundary orientation={orientation}>
       <Handle
         location="top"
@@ -2411,7 +2399,7 @@ export const OffPageReference: React.FC<OffPageReferenceProps> = ({
   color = "black",
   level = "p",
   onLabelChange,
-  ...props
+  ...rest
 }) => {
   const element = document.querySelector(`[data-id="${id}"]`);
   // add the orientation to the class list
@@ -2423,7 +2411,7 @@ export const OffPageReference: React.FC<OffPageReferenceProps> = ({
     <Div
       className={CSS(CSS.B("arrow"), CSS.loc(orientation), className)}
       orientation={orientation}
-      {...props}
+      {...rest}
     >
       <div className="wrapper">
         <div className="outline" style={{ backgroundColor: Color.cssString(color) }}>
@@ -2488,9 +2476,9 @@ export const Vent = ({
   orientation = "left",
   color,
   scale,
-  ...props
+  ...rest
 }: VentProps): ReactElement => (
-  <Div className={CSS(CSS.B("vent"), className)} {...props}>
+  <Div className={CSS(CSS.B("vent"), className)} {...rest}>
     <HandleBoundary orientation={orientation}>
       <Handle
         location="left"
@@ -2522,9 +2510,9 @@ export const ISOFilter = ({
   orientation = "left",
   color,
   scale,
-  ...props
+  ...rest
 }: ISOFilterProps): ReactElement => (
-  <Div className={CSS(CSS.B("iso-filter"), className)} {...props}>
+  <Div className={CSS(CSS.B("iso-filter"), className)} {...rest}>
     <HandleBoundary orientation={orientation}>
       <Handle location="right" orientation={orientation} left={95} top={50} id="1" />
       <Handle location="left" orientation={orientation} left={5} top={50} id="2" />
@@ -2559,7 +2547,7 @@ export const Cylinder = ({
   boxBorderRadius,
   color,
   backgroundColor,
-  ...props
+  ...rest
 }: CylinderProps): ReactElement => {
   const detailedRadius = parseBorderRadius(borderRadius);
   const t = Theming.use();
@@ -2587,7 +2575,7 @@ export const Cylinder = ({
       style={{
         ...dimensions,
       }}
-      {...props}
+      {...rest}
     >
       <svg
         width="100%"
@@ -2635,12 +2623,12 @@ export const SpringLoadedReliefValve = ({
   color,
   scale,
   enabled = false,
-  ...props
+  ...rest
 }: SpringLoadedReliefValveProps): ReactElement => {
   const colorStr = Color.cssString(color);
   return (
     <Toggle
-      {...props}
+      {...rest}
       orientation={orientation}
       className={CSS(CSS.B("spring-loaded-relief-valve"), className)}
       enabled={enabled}
@@ -2702,12 +2690,12 @@ export const AngledSpringLoadedReliefValve = ({
   color,
   scale,
   enabled = false,
-  ...props
+  ...rest
 }: AngledSpringLoadedReliefValveProps): ReactElement => {
   const colorStr = Color.cssString(color);
   return (
     <Toggle
-      {...props}
+      {...rest}
       orientation={orientation}
       className={CSS(CSS.B("spring-loaded-relief-valve"), className)}
       enabled={enabled}
@@ -2755,9 +2743,9 @@ export const TJunction = ({
   orientation = "left",
   color,
   scale,
-  ...props
+  ...rest
 }: TJunctionProps): ReactElement => (
-  <Div className={CSS(CSS.B("t-junction"), className)} {...props}>
+  <Div className={CSS(CSS.B("t-junction"), className)} {...rest}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={1.6667} top={20} id="1" />
       <Handle
@@ -2791,9 +2779,9 @@ export const CrossJunction = ({
   orientation = "left",
   color,
   scale,
-  ...props
+  ...rest
 }: CrossJunctionProps): ReactElement => (
-  <Div className={CSS(CSS.B("t-junction"), className)} {...props}>
+  <Div className={CSS(CSS.B("t-junction"), className)} {...rest}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={5} top={49} id="1" />
       <Handle location="right" orientation={orientation} left={95} top={49} id="2" />
@@ -2839,9 +2827,9 @@ export const FlowmeterGeneral = ({
   orientation = "right",
   color = "black",
   scale = 1,
-  ...props
+  ...rest
 }: FlowmeterGeneralProps) => (
-  <Div {...props} className={CSS(CSS.B("flowmeter-general"), className)}>
+  <Div {...rest} className={CSS(CSS.B("flowmeter-general"), className)}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={1.6667} top={50} id="1" />
       <Handle
@@ -2882,9 +2870,9 @@ export const FlowmeterElectromagnetic = ({
   orientation = "right",
   color = "black",
   scale = 1,
-  ...props
+  ...rest
 }: FlowmeterElectromagneticProps) => (
-  <Div {...props} className={CSS(CSS.B("flowmeter-Electromagnetic"), className)}>
+  <Div {...rest} className={CSS(CSS.B("flowmeter-Electromagnetic"), className)}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={1.6667} top={50} id="1" />
       <Handle
@@ -2937,9 +2925,9 @@ export const FlowmeterVariableArea = ({
   orientation = "right",
   color = "black",
   scale = 1,
-  ...props
+  ...rest
 }: FlowmeterVariableAreaProps) => (
-  <Div {...props} className={CSS(CSS.B("flowmeter-VariableArea"), className)}>
+  <Div {...rest} className={CSS(CSS.B("flowmeter-VariableArea"), className)}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={1.6667} top={50} id="1" />
       <Handle
@@ -2982,9 +2970,9 @@ export const FlowmeterCoriolis = ({
   orientation = "right",
   color = "black",
   scale = 1,
-  ...props
+  ...rest
 }: FlowmeterCoriolisProps): ReactElement => (
-  <Div {...props} className={CSS(CSS.B("flowmeter-Coriolis"), className)}>
+  <Div {...rest} className={CSS(CSS.B("flowmeter-Coriolis"), className)}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={1.6667} top={50} id="1" />
       <Handle
@@ -3031,9 +3019,9 @@ export const FlowmeterNozzle = ({
   orientation = "right",
   color = "black",
   scale = 1,
-  ...props
+  ...rest
 }: FlowmeterNozzleProps): ReactElement => (
-  <Div {...props} className={CSS(CSS.B("flowmeter-Nozzle"), className)}>
+  <Div {...rest} className={CSS(CSS.B("flowmeter-Nozzle"), className)}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={1.6667} top={50} id="1" />
       <Handle
@@ -3076,9 +3064,9 @@ export const FlowmeterVenturi = ({
   orientation = "right",
   color = "black",
   scale = 1,
-  ...props
+  ...rest
 }: FlowmeterVenturiProps): ReactElement => (
-  <Div {...props} className={CSS(CSS.B("flowmeter-Venturi"), className)}>
+  <Div {...rest} className={CSS(CSS.B("flowmeter-Venturi"), className)}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={1.6667} top={50} id="1" />
       <Handle
@@ -3121,9 +3109,9 @@ export const FlowmeterRingPiston = ({
   orientation = "right",
   color = "black",
   scale = 1,
-  ...props
+  ...rest
 }: FlowmeterRingPistonProps): ReactElement => (
-  <Div {...props} className={CSS(CSS.B("flowmeter-RingPiston"), className)}>
+  <Div {...rest} className={CSS(CSS.B("flowmeter-RingPiston"), className)}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={1.6667} top={50} id="1" />
       <Handle
@@ -3166,9 +3154,9 @@ export const FlowmeterPositiveDisplacement = ({
   orientation = "right",
   color = "black",
   scale = 1,
-  ...props
+  ...rest
 }: FlowmeterPositiveDisplacementProps): ReactElement => (
-  <Div {...props} className={CSS(CSS.B("flowmeter-PositiveDisplacement"), className)}>
+  <Div {...rest} className={CSS(CSS.B("flowmeter-PositiveDisplacement"), className)}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={1.6667} top={50} id="1" />
       <Handle
@@ -3215,9 +3203,9 @@ export const FlowmeterTurbine = ({
   orientation = "right",
   color = "black",
   scale = 1,
-  ...props
+  ...rest
 }: FlowmeterTurbineProps): ReactElement => (
-  <Div {...props} className={CSS(CSS.B("flowmeter-Turbine"), className)}>
+  <Div {...rest} className={CSS(CSS.B("flowmeter-Turbine"), className)}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={1.6667} top={50} id="1" />
       <Handle
@@ -3269,9 +3257,9 @@ export const FlowmeterPulse = ({
   orientation = "right",
   color = "black",
   scale = 1,
-  ...props
+  ...rest
 }: FlowmeterPulseProps): ReactElement => (
-  <Div {...props} className={CSS(CSS.B("flowmeter-Pulse"), className)}>
+  <Div {...rest} className={CSS(CSS.B("flowmeter-Pulse"), className)}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={1.6667} top={50} id="1" />
       <Handle
@@ -3315,9 +3303,9 @@ export const FlowmeterFloatSensor = ({
   orientation = "right",
   color = "black",
   scale = 1,
-  ...props
+  ...rest
 }: FlowmeterFloatSensorProps): ReactElement => (
-  <Div {...props} className={CSS(CSS.B("flowmeter-FloatSensor"), className)}>
+  <Div {...rest} className={CSS(CSS.B("flowmeter-FloatSensor"), className)}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={1.6667} top={50} id="1" />
       <Handle
@@ -3352,9 +3340,9 @@ export const HeatExchangerGeneral = ({
   orientation = "right",
   color = "black",
   scale = 1,
-  ...props
+  ...rest
 }: HeatExchangerGeneralProps): ReactElement => (
-  <Div {...props} className={CSS(CSS.B("heat-exchanger-general"), className)}>
+  <Div {...rest} className={CSS(CSS.B("heat-exchanger-general"), className)}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={4.545} top={50} id="1" />
       <Handle
@@ -3393,9 +3381,9 @@ export const HeatExchangerM = ({
   orientation = "right",
   color = "black",
   scale = 1,
-  ...props
+  ...rest
 }: HeatExchangerMProps): ReactElement => (
-  <Div {...props} className={CSS(CSS.B("heat-exchanger-M"), className)}>
+  <Div {...rest} className={CSS(CSS.B("heat-exchanger-M"), className)}>
     <HandleBoundary orientation={orientation}>
       <Handle location="right" orientation={orientation} left={89} top={27.27} id="1" />
       <Handle location="right" orientation={orientation} left={89} top={72.73} id="2" />
@@ -3431,9 +3419,9 @@ export const HeatExchangerStraightTube = ({
   orientation = "right",
   color = "black",
   scale = 1,
-  ...props
+  ...rest
 }: HeatExchangerStraightTubeProps): ReactElement => (
-  <Div {...props} className={CSS(CSS.B("heat-exchanger-M"), className)}>
+  <Div {...rest} className={CSS(CSS.B("heat-exchanger-M"), className)}>
     <HandleBoundary orientation={orientation}>
       <Handle location="top" orientation={orientation} left={9} top={6.25} id="1" />
       <Handle
@@ -3481,13 +3469,9 @@ export const DiaphragmPump = ({
   className,
   orientation = "left",
   scale,
-  ...props
+  ...rest
 }: DiaphragmPumpProps): ReactElement => (
-  <Toggle
-    {...props}
-    className={CSS(CSS.B("pump"), className)}
-    orientation={orientation}
-  >
+  <Toggle {...rest} className={CSS(CSS.B("pump"), className)} orientation={orientation}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={3.125} top={50} id="1" />
       <Handle
@@ -3531,13 +3515,9 @@ export const EjectionPump = ({
   className,
   orientation = "left",
   scale,
-  ...props
+  ...rest
 }: EjectionPumpProps): ReactElement => (
-  <Toggle
-    {...props}
-    className={CSS(CSS.B("pump"), className)}
-    orientation={orientation}
-  >
+  <Toggle {...rest} className={CSS(CSS.B("pump"), className)} orientation={orientation}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={3.125} top={50} id="1" />
       <Handle
@@ -3581,10 +3561,10 @@ export const Compressor = ({
   className,
   orientation = "left",
   scale,
-  ...props
+  ...rest
 }: CompressorProps): ReactElement => (
   <Toggle
-    {...props}
+    {...rest}
     className={CSS(CSS.B("compressor"), className)}
     orientation={orientation}
   >
@@ -3621,13 +3601,9 @@ export const TurboCompressor = ({
   className,
   orientation = "left",
   scale,
-  ...props
+  ...rest
 }: TurboCompressorProps): ReactElement => (
-  <Toggle
-    {...props}
-    className={CSS(CSS.B("pump"), className)}
-    orientation={orientation}
-  >
+  <Toggle {...rest} className={CSS(CSS.B("pump"), className)} orientation={orientation}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={4.55} top={50} id="1" />
       <Handle location="right" orientation={orientation} left={95.45} top={50} id="2" />
@@ -3661,13 +3637,9 @@ export const RollerVaneCompressor = ({
   className,
   orientation = "left",
   scale,
-  ...props
+  ...rest
 }: RollerVaneCompressorProps): ReactElement => (
-  <Toggle
-    {...props}
-    className={CSS(CSS.B("pump"), className)}
-    orientation={orientation}
-  >
+  <Toggle {...rest} className={CSS(CSS.B("pump"), className)} orientation={orientation}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={4.55} top={50} id="1" />
       <Handle location="right" orientation={orientation} left={95.45} top={50} id="2" />
@@ -3703,13 +3675,9 @@ export const LiquidRingCompressor = ({
   className,
   orientation = "left",
   scale,
-  ...props
+  ...rest
 }: LiquidRingCompressorProps): ReactElement => (
-  <Toggle
-    {...props}
-    className={CSS(CSS.B("pump"), className)}
-    orientation={orientation}
-  >
+  <Toggle {...rest} className={CSS(CSS.B("pump"), className)} orientation={orientation}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={4.55} top={50} id="1" />
       <Handle location="right" orientation={orientation} left={95.45} top={50} id="2" />
@@ -3747,13 +3715,9 @@ export const EjectorCompressor = ({
   className,
   orientation = "left",
   scale,
-  ...props
+  ...rest
 }: EjectorCompressorProps): ReactElement => (
-  <Toggle
-    {...props}
-    className={CSS(CSS.B("pump"), className)}
-    orientation={orientation}
-  >
+  <Toggle {...rest} className={CSS(CSS.B("pump"), className)} orientation={orientation}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={4.55} top={50} id="1" />
       <Handle location="right" orientation={orientation} left={95.45} top={50} id="2" />
@@ -3787,13 +3751,9 @@ export const CentrifugalCompressor = ({
   className,
   orientation = "left",
   scale,
-  ...props
+  ...rest
 }: CentrifugalCompressorProps): ReactElement => (
-  <Toggle
-    {...props}
-    className={CSS(CSS.B("pump"), className)}
-    orientation={orientation}
-  >
+  <Toggle {...rest} className={CSS(CSS.B("pump"), className)} orientation={orientation}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={4.55} top={50} id="1" />
       <Handle location="right" orientation={orientation} left={95.45} top={50} id="2" />
@@ -3825,9 +3785,9 @@ export const FlameArrestor = ({
   className,
   orientation = "left",
   scale,
-  ...props
+  ...rest
 }: FlameArrestorProps): ReactElement => (
-  <Div {...props} className={CSS(CSS.B("flame-arrestor"), className)}>
+  <Div {...rest} className={CSS(CSS.B("flame-arrestor"), className)}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={7.575} top={50} id="1" />
       <Handle
@@ -3861,9 +3821,9 @@ export const FlameArrestorDetonation = ({
   className,
   orientation = "left",
   scale,
-  ...props
+  ...rest
 }: FlameArrestorDetonationProps): ReactElement => (
-  <Div {...props} className={CSS(CSS.B("flame-arrestor"), className)}>
+  <Div {...rest} className={CSS(CSS.B("flame-arrestor"), className)}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={3.333} top={50} id="1" />
       <Handle
@@ -3898,9 +3858,9 @@ export const FlameArrestorExplosion = ({
   className,
   orientation = "left",
   scale,
-  ...props
+  ...rest
 }: FlameArrestorExplosionProps): ReactElement => (
-  <Div {...props} className={CSS(CSS.B("flame-arrestor"), className)}>
+  <Div {...rest} className={CSS(CSS.B("flame-arrestor"), className)}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={3.333} top={50} id="1" />
       <Handle
@@ -3934,9 +3894,9 @@ export const FlameArrestorFireRes = ({
   className,
   orientation = "left",
   scale,
-  ...props
+  ...rest
 }: FlameArrestorFireResProps): ReactElement => (
-  <Div {...props} className={CSS(CSS.B("flame-arrestor"), className)}>
+  <Div {...rest} className={CSS(CSS.B("flame-arrestor"), className)}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={3.333} top={50} id="1" />
       <Handle
@@ -3977,9 +3937,9 @@ export const FlameArrestorFireResDetonation = ({
   className,
   orientation = "left",
   scale,
-  ...props
+  ...rest
 }: FlameArrestorFireResDetonationProps): ReactElement => (
-  <Div {...props} className={CSS(CSS.B("flame-arrestor"), className)}>
+  <Div {...rest} className={CSS(CSS.B("flame-arrestor"), className)}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={3.333} top={50} id="1" />
       <Handle
@@ -4017,9 +3977,9 @@ export const Thruster = ({
   className,
   orientation = "left",
   scale,
-  ...props
+  ...rest
 }: ThrusterProps): ReactElement => (
-  <Div {...props} className={CSS(CSS.B("thruster"), className)}>
+  <Div {...rest} className={CSS(CSS.B("thruster"), className)}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={3.125} top={50} id="1" />
       <Handle
@@ -4061,9 +4021,9 @@ export const Strainer = ({
   className,
   orientation = "left",
   scale,
-  ...props
+  ...rest
 }: StrainerProps): ReactElement => (
-  <Div {...props} className={CSS(CSS.B("strainer"), className)}>
+  <Div {...rest} className={CSS(CSS.B("strainer"), className)}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={6.06} top={50} id="1" />
       <Handle location="right" orientation={orientation} left={93.04} top={50} id="2" />
@@ -4087,9 +4047,9 @@ export const StrainerCone = ({
   className,
   orientation = "left",
   scale,
-  ...props
+  ...rest
 }: StrainerConeProps): ReactElement => (
-  <Div {...props} className={CSS(CSS.B("strainer"), className)}>
+  <Div {...rest} className={CSS(CSS.B("strainer"), className)}>
     <HandleBoundary orientation={orientation}>
       <Handle location="left" orientation={orientation} left={6.06} top={50} id="1" />
       <Handle location="right" orientation={orientation} left={93.04} top={50} id="2" />

--- a/x/media/src/Icon/index.tsx
+++ b/x/media/src/Icon/index.tsx
@@ -199,12 +199,12 @@ const NI: IconFC = (props) => (
   </svg>
 );
 
-const OPC: IconFC = ({ className, style, ...props }) => (
+const OPC: IconFC = ({ className, style, ...rest }) => (
   <svg
     xmlns="http://www.w3.org/2000/svg"
     version="1.1"
     className={clsx(className, "logo")}
-    {...props}
+    {...rest}
     stroke="currentColor"
     fill="currentColor"
     viewBox="0 0 512 325.74567"

--- a/x/media/src/Logo/Logo.tsx
+++ b/x/media/src/Logo/Logo.tsx
@@ -136,7 +136,7 @@ export const Logo = ({
   variant = "icon",
   color = "auto",
   className,
-  ...props
+  ...rest
 }: LogoProps): ReactElement => {
   const Internal = VARIANTS[variant];
   return (
@@ -147,7 +147,7 @@ export const Logo = ({
         `synnax-logo--${variant}`,
         className,
       )}
-      {...props}
+      {...rest}
     />
   );
 };

--- a/x/ts/src/telem/series.ts
+++ b/x/ts/src/telem/series.ts
@@ -277,14 +277,14 @@ export class Series<T extends TelemValue = TelemValue> {
     };
   }
 
-  static alloc({ capacity: length, dataType, ...props }: SeriesAllocProps): Series {
+  static alloc({ capacity: length, dataType, ...rest }: SeriesAllocProps): Series {
     if (length === 0)
       throw new Error("[Series] - cannot allocate an array of length 0");
     const data = new new DataType(dataType).Array(length);
     const arr = new Series({
       data: data.buffer,
       dataType,
-      ...props,
+      ...rest,
     });
     arr.writePos = 0;
     return arr;


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2023](https://linear.app/synnax/issue/SY-2023/replace-props-with-rest)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

- Replace `...props` with `...rest`
- Remove unneeded children destructuring

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
