### PR TITLE
SY-2094 - Sequence Error on Data Type Mismatch

### DIFF
--- a/driver/sequence/plugins/channel_write.cpp
+++ b/driver/sequence/plugins/channel_write.cpp
@@ -215,3 +215,17 @@ xerrors::Error plugins::ChannelWrite::after_next(lua_State *L) {
         frame.emplace(index, telem::Series(now));
     return this->sink->write(this->frame);
 }
+
+xerrors::Error plugins::ChannelWriteNoop::before_all(lua_State *L) {
+    lua_pushcclosure(L, [](lua_State *cL) -> int {
+        luaL_error(cL, "set() was called but no channels were passed to the write list in the sequence!");
+        return 0;
+    }, 0);
+    lua_setglobal(L, "set");
+    lua_pushcclosure(L, [](lua_State *cL) -> int {
+        luaL_error(cL, "set_authority() was called but no channels were passed to the write list in the sequence!");
+        return 0;
+    }, 0);
+    lua_setglobal(L, "set_authority");
+    return xerrors::NIL;
+}

--- a/driver/sequence/plugins/channel_write_test.cpp
+++ b/driver/sequence/plugins/channel_write_test.cpp
@@ -100,7 +100,7 @@ TEST_F(SetOperatorTest, Int32Value) {
 
 TEST_F(SetOperatorTest, Int64Value) {
     SetupChannel(telem::INT64_T);
-    RunTest<int64_t>("9223372036854775807", 9223372036854775807L);
+    RunTest<int64_t>("9223372036854775807", 9223372036854775807LL);
 }
 
 TEST_F(SetOperatorTest, Uint8NumberValue) {

--- a/driver/sequence/plugins/channel_write_test.cpp
+++ b/driver/sequence/plugins/channel_write_test.cpp
@@ -138,6 +138,29 @@ TEST_F(SetOperatorTest, StringValue) {
     RunStringTest("'hello'", "hello");
 }
 
+TEST_F(SetOperatorTest, StringTypeMismatch) {
+    SetupChannel(telem::STRING_T);
+    RunStringTest("123", "123.000000");
+}
+
+TEST_F(SetOperatorTest, Float32TypeMismatch) {
+    SetupChannel(telem::FLOAT32_T);
+    ASSERT_NE(luaL_dostring(L, "set('my_channel', 'not a number')"), 0);
+    EXPECT_EQ(sink->writes->size(), 0);
+}
+
+TEST_F(SetOperatorTest, Int32TypeMismatch) {
+    SetupChannel(telem::INT32_T);
+    ASSERT_NE(luaL_dostring(L, "set('my_channel', 'not an integer')"), 0);
+    EXPECT_EQ(sink->writes->size(), 0);
+}
+
+TEST_F(SetOperatorTest, BooleanTypeMismatch) {
+    SetupChannel(telem::UINT8_T);
+    ASSERT_NE(luaL_dostring(L, "set('my_channel', 'not a boolean')"), 0);
+    EXPECT_EQ(sink->writes->size(), 0);
+}
+
 class SetOperatorWithIndexTest : public testing::Test {
 protected:
     void SetupChannels(telem::DataType data_type) {

--- a/driver/sequence/plugins/channel_write_test.cpp
+++ b/driver/sequence/plugins/channel_write_test.cpp
@@ -325,3 +325,32 @@ TEST_F(SetAuthorityTest, InvalidArguments) {
     ASSERT_NE(luaL_dostring(L, "set_authority('channel1', 'not_a_number')"), 0);
     EXPECT_EQ(sink->authority_calls.size(), 0);
 }
+
+class ChannelWriteNoopTest : public testing::Test {
+protected:
+    void SetUp() override {
+        op = std::make_unique<plugins::ChannelWriteNoop>();
+        L = luaL_newstate();
+        luaL_openlibs(L);
+        op->before_all(L);
+    }
+
+    void TearDown() override {
+        lua_close(L);
+    }
+
+    std::unique_ptr<plugins::ChannelWriteNoop> op;
+    lua_State *L{};
+};
+
+TEST_F(ChannelWriteNoopTest, SetShouldError) {
+    ASSERT_NE(luaL_dostring(L, "set('channel', 42)"), 0);
+    const char* error_msg = lua_tostring(L, -1);
+    EXPECT_TRUE(std::string(error_msg).find("set() was called but no channels were passed to the write list in the sequence!") != std::string::npos);
+}
+
+TEST_F(ChannelWriteNoopTest, SetAuthorityShouldError) {
+    ASSERT_NE(luaL_dostring(L, "set_authority('channel', 42)"), 0);
+    const char* error_msg = lua_tostring(L, -1);
+    EXPECT_TRUE(std::string(error_msg).find("set_authority() was called but no channels were passed to the write list in the sequence!") != std::string::npos);
+}

--- a/driver/sequence/plugins/plugins.h
+++ b/driver/sequence/plugins/plugins.h
@@ -173,6 +173,11 @@ public:
     xerrors::Error after_next(lua_State *L) override;
 };
 
+class ChannelWriteNoop final : public Plugin {
+public:
+    xerrors::Error before_all(lua_State *L) override;
+};
+
 struct LatestValue {
     telem::SampleValue value;
     bool changed;

--- a/driver/sequence/sequence.h
+++ b/driver/sequence/sequence.h
@@ -145,6 +145,9 @@ public:
         const breaker::Config &breaker_config
     );
 
+    /// @brief returns the name of the task for logging.
+    std::string name() override { return this->task.name; }
+
     /// @brief main run loop that will execute in a separate thread.
     void run();
 

--- a/driver/sequence/task.cpp
+++ b/driver/sequence/task.cpp
@@ -49,7 +49,12 @@ void sequence::Task::run() {
             this->state.details["message"] = next_err.message();
             break;
         }
-        timer.wait(this->breaker);
+        auto [elapsed, ok] = timer.wait(this->breaker);
+        if (!ok) {
+            this->state.variant = "warning";
+            this->state.details["message"] = "Sequence script is executing too slowly for the configured loop rate. Last execution took " + elapsed.to_string();
+            this->ctx->set_state(this->state);
+        }
     }
     if (const auto end_err = this->seq->end()) {
         this->state.variant = "error";

--- a/x/cpp/telem/series.h
+++ b/x/cpp/telem/series.h
@@ -149,7 +149,7 @@ public:
     template<typename NumericType>
     explicit Series(
         const std::vector<NumericType> &d,
-        const DataType dt = DATA_TYPE_UNKNOWN
+        const DataType& dt = DATA_TYPE_UNKNOWN
     ):
         data_type(telem::DataType::infer<NumericType>(dt)),
         cap(d.size()),
@@ -182,7 +182,7 @@ public:
     template<typename NumericType>
     explicit Series(
         NumericType v,
-        const DataType override_dt = DATA_TYPE_UNKNOWN
+        const DataType& override_dt = DATA_TYPE_UNKNOWN
     ) :
         data_type(telem::DataType::infer<NumericType>(override_dt)),
         cap(1),

--- a/x/cpp/telem/telem.h
+++ b/x/cpp/telem/telem.h
@@ -99,6 +99,7 @@ public:
             throw std::runtime_error("failed to infer data type for " + std::string(typeid(T).name()));
         return DataType(TYPE_INDEXES[type_index]);
     }
+    
 
     /// @property Gets type name.
     [[nodiscard]] std::string name() const { return value; }
@@ -134,6 +135,8 @@ public:
         for (const auto &other: others) if (matches(other)) return true;
         return false;
     }
+
+    
 
     /////////////////////////////////// COMPARISON ///////////////////////////////////
 

--- a/x/cpp/telem/telem.h
+++ b/x/cpp/telem/telem.h
@@ -443,29 +443,38 @@ public:
 
     ////////////////////////////////// OSTREAM /////////////////////////////////
 
-    friend std::ostream &operator<<(std::ostream &os, const TimeSpan &ts) {
-        const auto total_days = ts.truncate(TimeSpan(_priv::DAY));
-        const auto total_hours = ts.truncate(TimeSpan(_priv::HOUR));
-        const auto total_minutes = ts.truncate(TimeSpan(_priv::MINUTE));
-        const auto total_seconds = ts.truncate(TimeSpan(_priv::SECOND));
-        const auto total_milliseconds = ts.truncate(TimeSpan(_priv::MILLISECOND));
-        const auto total_microseconds = ts.truncate(TimeSpan(_priv::MICROSECOND));
-        const auto total_nanoseconds = ts;
-        const auto days = total_days;
-        const auto hours = total_hours - total_days;
-        const auto minutes = total_minutes - total_hours;
-        const auto seconds = total_seconds - total_minutes;
-        const auto milliseconds = total_milliseconds - total_seconds;
-        const auto microseconds = total_microseconds - total_milliseconds;
-        const auto nanoseconds = total_nanoseconds - total_microseconds;
+    [[nodiscard]] std::string to_string() const {
+        const auto total_days = this->truncate(TimeSpan(_priv::DAY));
+        const auto total_hours = this->truncate(TimeSpan(_priv::HOUR));
+        const auto total_minutes = this->truncate(TimeSpan(_priv::MINUTE));
+        const auto total_seconds = this->truncate(TimeSpan(_priv::SECOND));
+        const auto total_milliseconds = this->truncate(TimeSpan(_priv::MILLISECOND));
+        const auto total_microseconds = this->truncate(TimeSpan(_priv::MICROSECOND));
+        const auto total_nanoseconds = this->value;
 
-        if (total_days != 0) os << days.days() << "d ";
-        if (total_hours != 0) os << hours.hours() << "h ";
-        if (total_minutes != 0) os << minutes.minutes() << "m ";
-        if (total_seconds != 0) os << seconds.seconds() << "s ";
-        if (total_milliseconds != 0) os << milliseconds.milliseconds() << "ms ";
-        if (total_microseconds != 0) os << microseconds.microseconds() << "us ";
-        if (total_nanoseconds != 0) os << nanoseconds.value << "ns";
+        const auto days = total_days.value / _priv::DAY;
+        const auto hours = (total_hours.value - total_days.value) / _priv::HOUR;
+        const auto minutes = (total_minutes.value - total_hours.value) / _priv::MINUTE;
+        const auto seconds = (total_seconds.value - total_minutes.value) / _priv::SECOND;
+        const auto milliseconds = (total_milliseconds.value - total_seconds.value) / _priv::MILLISECOND;
+        const auto microseconds = (total_microseconds.value - total_milliseconds.value) / _priv::MICROSECOND;
+        const auto nanoseconds = total_nanoseconds - total_microseconds.value;
+
+        std::string out;
+        if (days != 0) out += std::to_string(days) + "d ";
+        if (hours != 0) out += std::to_string(hours) + "h ";
+        if (minutes != 0) out += std::to_string(minutes) + "m ";
+        if (seconds != 0) out += std::to_string(seconds) + "s ";
+        if (milliseconds != 0) out += std::to_string(milliseconds) + "ms ";
+        if (microseconds != 0) out += std::to_string(microseconds) + "us ";
+        if (nanoseconds != 0) out += std::to_string(nanoseconds) + "ns";
+        if (out.empty()) return "0ns";
+        if (out.back() == ' ') out.pop_back();
+        return out;
+    }
+
+    friend std::ostream &operator<<(std::ostream &os, const TimeSpan &ts) {
+        os << ts.to_string();
         return os;
     }
 

--- a/x/cpp/telem/telem_test.cpp
+++ b/x/cpp/telem/telem_test.cpp
@@ -13,140 +13,14 @@
 
 using namespace telem;
 
+////////////////////////////////////////////////////////////
+// TimeStamp Tests
+////////////////////////////////////////////////////////////
+
 /// @brief - it should initialize a timestamp from a long.
-TEST(TimeStampTests, testContructor) {
+TEST(TimeStampTests, testConstructor) {
     const auto ts = TimeStamp(5);
     ASSERT_EQ(ts.value, 5);
-}
-
-TEST(TimeSpanTests, testPeriod) {
-    const auto r = Rate(1);
-    ASSERT_EQ(r.period().value, telem::SECOND.value);
-    const auto r2 = Rate(2);
-    ASSERT_EQ(r2.period().value, telem::SECOND.value / 2);
-}
-
-TEST(TimeSpanTests, testConstructor) {
-    const auto ts = TimeSpan(5);
-    ASSERT_EQ(ts.value, 5);
-}
-
-TEST(TimeSpanTests, testAddition) {
-    const auto ts = TimeSpan(5);
-    const auto ts2 = TimeSpan(5);
-    const auto ts3 = ts + ts2;
-    ASSERT_EQ(ts3.value, 10);
-}
-
-TEST(TimeSpanTests, testSubtraction) {
-    const auto ts = TimeSpan(5);
-    const auto ts2 = TimeSpan(5);
-    const auto ts3 = ts - ts2;
-    ASSERT_EQ(ts3.value, 0);
-}
-
-TEST(TimeSpanTests, testMultiplication) {
-    const auto ts = TimeSpan(5);
-    const auto ts2 = TimeSpan(5);
-    const auto ts3 = ts * ts2;
-    ASSERT_EQ(ts3.value, 25);
-
-    const auto ts4 = TimeSpan(5);
-    const auto ts5 = ts4 * 5;
-    ASSERT_EQ(ts5.value, 25);
-
-    const auto ts6 = TimeSpan(5);
-    const auto ts7 = 5 * ts6;
-    ASSERT_EQ(ts7.value, 25);
-
-    const auto ts8 = TimeSpan(5);
-    const auto ts9 = ts8 * 5.0;
-    ASSERT_EQ(ts9.value, 25);
-
-    const auto ts10 = TimeSpan(5);
-    const auto ts11 = ts10 * 5.0f;
-    ASSERT_EQ(ts11.value, 25);
-}
-
-TEST(TimeSpanTests, testDivision) {
-    const auto ts = TimeSpan(5);
-    const auto ts2 = TimeSpan(5);
-    const auto ts3 = ts / ts2;
-    ASSERT_EQ(ts3.value, 1);
-
-    const auto ts4 = TimeSpan(5);
-    const auto ts5 = ts4 / 5;
-    ASSERT_EQ(ts5.value, 1);
-
-    const auto ts6 = TimeSpan(5);
-    const auto ts7 = 5 / ts6;
-    ASSERT_EQ(ts7.value, 1);
-}
-
-
-TEST(TimeSpanTests, testEquality) {
-    const auto ts = TimeSpan(5);
-    const auto ts2 = TimeSpan(5);
-    ASSERT_TRUE(ts == ts2);
-}
-
-TEST(TimeSpanTests, testInequality) {
-    const auto ts = TimeSpan(5);
-    const auto ts2 = TimeSpan(6);
-    ASSERT_TRUE(ts != ts2);
-}
-
-TEST(TimeSpanTests, testLessThan) {
-    const auto ts = TimeSpan(5);
-    const auto ts2 = TimeSpan(6);
-    ASSERT_TRUE(ts < ts2);
-}
-
-TEST(TimeSpanTests, testLessThanEqual) {
-    const auto ts = TimeSpan(5);
-    const auto ts2 = TimeSpan(5);
-    ASSERT_TRUE(ts <= ts2);
-}
-
-TEST(TimeSpanTests, testGreaterThan) {
-    const auto ts = TimeSpan(6);
-    const auto ts2 = TimeSpan(5);
-    ASSERT_TRUE(ts > ts2);
-}
-
-TEST(TimeSpanTests, testGreaterThanEqual) {
-    const auto ts = TimeSpan(5);
-    const auto ts2 = TimeSpan(5);
-    ASSERT_TRUE(ts >= ts2);
-}
-
-TEST(TimeSpanTests, testModulo) {
-    const auto ts = TimeSpan(5);
-    const auto ts2 = TimeSpan(2);
-    const auto ts3 = ts % ts2;
-    ASSERT_EQ(ts3.value, 1);
-
-    const auto ts4 = TimeSpan(5);
-    const auto ts5 = 2 % ts4;
-    ASSERT_EQ(ts5.value, 2);
-
-    const auto ts6 = TimeSpan(5);
-    const auto ts7 = ts6 % 2;
-    ASSERT_EQ(ts7.value, 1);
-}
-
-TEST(TimeSpanTests, testTruncate) {
-    const auto ts = TimeSpan(5);
-    const auto ts2 = TimeSpan(2);
-    const auto ts3 = ts.truncate(ts2);
-    ASSERT_EQ(ts3.value, 4);
-}
-
-TEST(TimeSpanTests, testDelta) {
-    const auto ts = TimeSpan(5);
-    const auto ts2 = TimeSpan(2);
-    const auto ts3 = ts.delta(ts2);
-    ASSERT_EQ(ts3.value, 3);
 }
 
 TEST(TimeStampTests, testAddition) {
@@ -220,8 +94,6 @@ TEST(TimeStampTests, testModulo) {
     ASSERT_EQ(ts3.value, 1);
 }
 
-// Test assignment compound operators like +=, -=, *=, and /=.
-
 TEST(TimeStampTests, testAdditionAssignment) {
     auto ts = TimeStamp(5);
     const auto ts2 = TimeStamp(5);
@@ -257,35 +129,168 @@ TEST(TimeStampTests, testModuloAssignment) {
     ASSERT_EQ(ts.value, 1);
 }
 
+////////////////////////////////////////////////////////////
+// TimeSpan Tests
+////////////////////////////////////////////////////////////
+
+TEST(TimeSpanTests, testConstructor) {
+    const auto ts = TimeSpan(5);
+    ASSERT_EQ(ts.value, 5);
+}
+
+TEST(TimeSpanTests, testAddition) {
+    const auto ts = TimeSpan(5);
+    const auto ts2 = TimeSpan(5);
+    const auto ts3 = ts + ts2;
+    ASSERT_EQ(ts3.value, 10);
+}
+
+TEST(TimeSpanTests, testSubtraction) {
+    const auto ts = TimeSpan(5);
+    const auto ts2 = TimeSpan(5);
+    const auto ts3 = ts - ts2;
+    ASSERT_EQ(ts3.value, 0);
+}
+
+TEST(TimeSpanTests, testMultiplication) {
+    const auto ts = TimeSpan(5);
+    const auto ts2 = TimeSpan(5);
+    const auto ts3 = ts * ts2;
+    ASSERT_EQ(ts3.value, 25);
+
+    const auto ts4 = TimeSpan(5);
+    const auto ts5 = ts4 * 5;
+    ASSERT_EQ(ts5.value, 25);
+
+    const auto ts6 = TimeSpan(5);
+    const auto ts7 = 5 * ts6;
+    ASSERT_EQ(ts7.value, 25);
+
+    const auto ts8 = TimeSpan(5);
+    const auto ts9 = ts8 * 5.0;
+    ASSERT_EQ(ts9.value, 25);
+
+    const auto ts10 = TimeSpan(5);
+    const auto ts11 = ts10 * 5.0f;
+    ASSERT_EQ(ts11.value, 25);
+}
+
+TEST(TimeSpanTests, testDivision) {
+    const auto ts = TimeSpan(5);
+    const auto ts2 = TimeSpan(5);
+    const auto ts3 = ts / ts2;
+    ASSERT_EQ(ts3.value, 1);
+
+    const auto ts4 = TimeSpan(5);
+    const auto ts5 = ts4 / 5;
+    ASSERT_EQ(ts5.value, 1);
+
+    const auto ts6 = TimeSpan(5);
+    const auto ts7 = 5 / ts6;
+    ASSERT_EQ(ts7.value, 1);
+}
+
+TEST(TimeSpanTests, testEquality) {
+    const auto ts = TimeSpan(5);
+    const auto ts2 = TimeSpan(5);
+    ASSERT_TRUE(ts == ts2);
+}
+
+TEST(TimeSpanTests, testInequality) {
+    const auto ts = TimeSpan(5);
+    const auto ts2 = TimeSpan(6);
+    ASSERT_TRUE(ts != ts2);
+}
+
+TEST(TimeSpanTests, testLessThan) {
+    const auto ts = TimeSpan(5);
+    const auto ts2 = TimeSpan(6);
+    ASSERT_TRUE(ts < ts2);
+}
+
+TEST(TimeSpanTests, testLessThanEqual) {
+    const auto ts = TimeSpan(5);
+    const auto ts2 = TimeSpan(5);
+    ASSERT_TRUE(ts <= ts2);
+}
+
+TEST(TimeSpanTests, testGreaterThan) {
+    const auto ts = TimeSpan(6);
+    const auto ts2 = TimeSpan(5);
+    ASSERT_TRUE(ts > ts2);
+}
+
+TEST(TimeSpanTests, testGreaterThanEqual) {
+    const auto ts = TimeSpan(5);
+    const auto ts2 = TimeSpan(5);
+    ASSERT_TRUE(ts >= ts2);
+}
+
+TEST(TimeSpanTests, testModulo) {
+    const auto ts = TimeSpan(5);
+    const auto ts2 = TimeSpan(2);
+    const auto ts3 = ts % ts2;
+    ASSERT_EQ(ts3.value, 1);
+
+    const auto ts4 = TimeSpan(5);
+    const auto ts5 = 2 % ts4;
+    ASSERT_EQ(ts5.value, 2);
+
+    const auto ts6 = TimeSpan(5);
+    const auto ts7 = ts6 % 2;
+    ASSERT_EQ(ts7.value, 1);
+}
+
+TEST(TimeSpanTests, testTruncate) {
+    const auto ts = TimeSpan(5);
+    const auto ts2 = TimeSpan(2);
+    const auto ts3 = ts.truncate(ts2);
+    ASSERT_EQ(ts3.value, 4);
+}
+
+TEST(TimeSpanTests, testDelta) {
+    const auto ts = TimeSpan(5);
+    const auto ts2 = TimeSpan(2);
+    const auto ts3 = ts.delta(ts2);
+    ASSERT_EQ(ts3.value, 3);
+}
+
+////////////////////////////////////////////////////////////
+// TimeRange Tests
+////////////////////////////////////////////////////////////
 
 TEST(TimeRangeTests, testContains) {
-    auto tr = TimeRange(5, 10);
+    const auto tr = TimeRange(5, 10);
     const auto ts = TimeStamp(7);
     ASSERT_TRUE(tr.contains(ts));
 }
 
 TEST(TimeRangeTests, testContainsRange) {
-    auto tr = TimeRange(5, 10);
-    auto tr2 = TimeRange(6, 9);
+    const auto tr = TimeRange(5, 10);
+    const auto tr2 = TimeRange(6, 9);
     ASSERT_TRUE(tr.contains(tr2));
 }
 
 TEST(TimeRangeTests, testEquality) {
-    auto tr = TimeRange(5, 10);
-    auto tr2 = TimeRange(5, 10);
+    const auto tr = TimeRange(5, 10);
+    const auto tr2 = TimeRange(5, 10);
     ASSERT_TRUE(tr == tr2);
 }
 
-TEST(RateTests, testContructor) {
-    const auto r = Rate(5);
-    ASSERT_EQ(r.value, 5);
-}
+////////////////////////////////////////////////////////////
+// Rate Tests
+////////////////////////////////////////////////////////////
 
 TEST(RateTests, testPeriod) {
     const auto r = Rate(1);
     ASSERT_EQ(r.period().value, telem::SECOND.value);
     const auto r2 = Rate(2);
     ASSERT_EQ(r2.period().value, telem::SECOND.value / 2);
+}
+
+TEST(RateTests, testContructor) {
+    const auto r = Rate(5);
+    ASSERT_EQ(r.value, 5);
 }
 
 TEST(RateTests, testAddition) {
@@ -375,3 +380,121 @@ TEST(RateTests, testGreaterThanEqual) {
     const auto r2 = Rate(5);
     ASSERT_TRUE(r >= r2);
 }
+
+////////////////////////////////////////////////////////////
+// DataType Tests
+////////////////////////////////////////////////////////////
+
+class DataTypeTests : public ::testing::Test {};
+
+struct TypeTestCase {
+    std::string expected;
+    std::function<DataType()> inferFn;
+};
+
+class DataTypeInferTest : public testing::TestWithParam<TypeTestCase> {};
+
+TEST_P(DataTypeInferTest, testInferBuiltInTypes) {
+    const auto& param = GetParam();
+    const auto dt = param.inferFn();
+    ASSERT_EQ(dt.value, param.expected);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    DataTypes,
+    DataTypeInferTest,
+    testing::Values(
+        TypeTestCase{"int8", []() { return DataType::infer<int8_t>(); }},
+        TypeTestCase{"uint8", []() { return DataType::infer<uint8_t>(); }},
+        TypeTestCase{"int16", []() { return DataType::infer<int16_t>(); }},
+        TypeTestCase{"uint16", []() { return DataType::infer<uint16_t>(); }},
+        TypeTestCase{"int32", []() { return DataType::infer<int32_t>(); }},
+        TypeTestCase{"uint32", []() { return DataType::infer<uint32_t>(); }},
+        TypeTestCase{"int64", []() { return DataType::infer<int64_t>(); }},
+        TypeTestCase{"uint64", []() { return DataType::infer<uint64_t>(); }},
+        TypeTestCase{"float32", []() { return DataType::infer<float>(); }},
+        TypeTestCase{"float64", []() { return DataType::infer<double>(); }}
+    ));
+
+TEST(DataTypeTests, testName) {
+    const auto dt = DataType("float32");
+    ASSERT_EQ(dt.name(), "float32");
+}
+
+TEST(DataTypeTests, testDensity) {
+    ASSERT_EQ(DataType("").density(), 0);
+    ASSERT_EQ(DataType("float64").density(), 8);
+    ASSERT_EQ(DataType("float32").density(), 4);
+    ASSERT_EQ(DataType("int8").density(), 1);
+    ASSERT_EQ(DataType("int16").density(), 2);
+    ASSERT_EQ(DataType("int32").density(), 4);
+    ASSERT_EQ(DataType("int64").density(), 8);
+    ASSERT_EQ(DataType("uint8").density(), 1);
+    ASSERT_EQ(DataType("uint16").density(), 2);
+    ASSERT_EQ(DataType("uint32").density(), 4);
+    ASSERT_EQ(DataType("uint64").density(), 8);
+    ASSERT_EQ(DataType("uint128").density(), 16);
+    ASSERT_EQ(DataType("timestamp").density(), 8);
+    ASSERT_EQ(DataType("uuid").density(), 16);
+    ASSERT_EQ(DataType("string").density(), 0);
+    ASSERT_EQ(DataType("json").density(), 0);
+}
+
+TEST(DataTypeTests, testIsVariable) {
+    ASSERT_TRUE(DataType("string").is_variable());
+    ASSERT_TRUE(DataType("json").is_variable());
+    ASSERT_FALSE(DataType("float32").is_variable());
+    ASSERT_FALSE(DataType("int64").is_variable());
+}
+
+TEST(DataTypeTests, testMatches) {
+    // Test empty data type matches anything
+    const auto empty = DataType("");
+    ASSERT_TRUE(empty.matches(DataType("float32")));
+    ASSERT_TRUE(empty.matches("float32"));
+    
+    // Test exact matches
+    const auto dt = DataType("float32");
+    ASSERT_TRUE(dt.matches(DataType("float32")));
+    ASSERT_TRUE(dt.matches("float32"));
+    ASSERT_FALSE(dt.matches(DataType("float64")));
+    ASSERT_FALSE(dt.matches("float64"));
+    
+    // Test vector matches
+    std::vector<DataType> types = {DataType("float32"), DataType("float64")};
+    ASSERT_TRUE(dt.matches(types));
+    
+    std::vector<DataType> non_matching = {DataType("int32"), DataType("int64")};
+    ASSERT_FALSE(dt.matches(non_matching));
+}
+
+TEST(DataTypeTests, testEquality) {
+    const auto dt1 = DataType("float32");
+    const auto dt2 = DataType("float32");
+    const auto dt3 = DataType("float64");
+    
+    ASSERT_TRUE(dt1 == dt2);
+    ASSERT_FALSE(dt1 == dt3);
+}
+
+TEST(DataTypeTests, testInequality) {
+    const auto dt1 = DataType("float32");
+    const auto dt2 = DataType("float32");
+    const auto dt3 = DataType("float64");
+    
+    ASSERT_FALSE(dt1 != dt2);
+    ASSERT_TRUE(dt1 != dt3);
+}
+
+TEST(DataTypeTests, testStreamOperator) {
+    const auto dt = DataType("float32");
+    std::stringstream ss;
+    ss << dt;
+    ASSERT_EQ(ss.str(), "float32");
+}
+
+TEST(DataTypeTests, testInvalidConstruction) {
+    ASSERT_THROW(DataType("invalid_type"), std::runtime_error);
+}
+
+

--- a/x/cpp/xlua/xlua.h
+++ b/x/cpp/xlua/xlua.h
@@ -21,6 +21,7 @@ extern "C" {
 
 /// internal
 #include "x/cpp/telem/telem.h"
+#include "x/cpp/telem/series.h"
 #include "x/cpp/xerrors/errors.h"
 
 using json = nlohmann::json;
@@ -28,7 +29,6 @@ using json = nlohmann::json;
 /// @brief The xlua namespace provides utilities for interacting between C++ and Lua,
 /// specifically focusing on converting between JSON/telemetry data and Lua values.
 namespace xlua {
-
 /// @brief Pushes a JSON value onto the Lua stack, converting it to the appropriate Lua type
 /// @param L The Lua state
 /// @param value The JSON value to push
@@ -129,33 +129,195 @@ inline xerrors::Error set_globals_from_json_object(lua_State *L, const json &obj
             lua_pushstring(L, std::get<std::string>(value).c_str());
         else if (data_type == telem::JSON_T) {
             try {
-                const auto& str_val = std::get<std::string>(value);
+                const auto &str_val = std::get<std::string>(value);
                 const auto parsed = json::parse(str_val);
                 const auto err = push_json_value(L, parsed);
                 if (!err.ok()) {
                     lua_pushnil(L);
-                    return xerrors::Error(xerrors::VALIDATION_ERROR, 
-                        "failed to push JSON value for '" + name + "': " + err.message());
+                    return xerrors::Error(xerrors::VALIDATION_ERROR,
+                                          "failed to push JSON value for '" + name +
+                                          "': " + err.message());
                 }
-            } catch (const json::parse_error& e) {
+            } catch (const json::parse_error &e) {
                 lua_pushnil(L);
-                return xerrors::Error(xerrors::VALIDATION_ERROR, 
-                    "invalid JSON format for '" + name + "': " + std::string(e.what()));
+                return xerrors::Error(xerrors::VALIDATION_ERROR,
+                                      "invalid JSON format for '" + name + "': " +
+                                      std::string(e.what()));
             }
         } else {
             lua_pushnil(L);
-            return xerrors::Error(xerrors::VALIDATION_ERROR, 
-                "unsupported data type for '" + name + "'");
+            return xerrors::Error(xerrors::VALIDATION_ERROR,
+                                  "unsupported data type for '" + name + "'");
         }
-        
+
         lua_setglobal(L, name.c_str());
         return xerrors::NIL;
-        
-    } catch (const std::bad_variant_access&) {
+    } catch (const std::bad_variant_access &) {
         lua_pushnil(L);
         lua_setglobal(L, name.c_str());
-        return xerrors::Error(xerrors::VALIDATION_ERROR, 
-            "type mismatch between data_type and value for '" + name + "'");
+        return xerrors::Error(xerrors::VALIDATION_ERROR,
+                              "type mismatch between data_type and value for '" + name +
+                              "'");
     }
+}
+
+/// @brief Converts a Lua value at the given stack index to a telemetry Series
+/// based on the specified channel's data type
+/// @param L The Lua state
+/// @param index The stack index of the Lua value
+/// @param data_type The target data type for the Series
+/// @return The converted Series
+[[nodiscard]] inline std::pair<telem::Series, xerrors::Error> to_series(
+    lua_State *L,
+    const int index,
+    const telem::DataType &data_type
+) {
+    // Check if the index contains any value (even nil)
+    if (lua_isnone(L, index)) {
+        return {
+            telem::Series(telem::DATA_TYPE_UNKNOWN, 0),
+            xerrors::Error(xerrors::VALIDATION_ERROR, "Invalid stack index")
+        };
+    }
+
+    if (lua_isnil(L, index)) {
+        return {
+            telem::Series(telem::DATA_TYPE_UNKNOWN, 0),
+            xerrors::Error(xerrors::VALIDATION_ERROR, "Expected value but received nil")
+        };
+    }
+
+    const bool is_numeric = lua_isnumber(L, index) || lua_isinteger(L, index);
+    const bool is_boolean = lua_isboolean(L, index);
+    const bool is_string = lua_isstring(L, index);
+
+    // Helper to get numeric value, handling both numbers and booleans
+    auto get_numeric_value = [L, is_boolean](const int idx) -> lua_Number {
+        if (is_boolean) return lua_toboolean(L, idx);
+        return lua_tonumber(L, idx);
+    };
+
+    if (!data_type.is_variable() && !is_numeric && !is_boolean) {
+        return {
+            telem::Series(telem::DATA_TYPE_UNKNOWN, 0),
+            xerrors::Error(
+                xerrors::VALIDATION_ERROR,
+                "unsupported data type: " + data_type.value
+            )
+        };
+    }
+
+    if (data_type == telem::STRING_T) {
+        if (is_boolean) {
+            const auto val = lua_toboolean(L, index);
+            const std::string value = val ? "true" : "false";
+            return {telem::Series(value), xerrors::NIL};
+        }
+        if (is_numeric) {
+            return {
+                telem::Series(std::to_string(get_numeric_value(index)), data_type),
+                xerrors::NIL
+            };
+        }
+        if (is_string) {
+            return {
+                telem::Series(std::string(lua_tostring(L, index)), data_type),
+                xerrors::NIL
+            };
+        }
+        return {
+            telem::Series(telem::DATA_TYPE_UNKNOWN, 0),
+            xerrors::Error(
+                xerrors::VALIDATION_ERROR,
+                "expected string value but received different type"
+            )
+        };
+    }
+
+    if (data_type == telem::FLOAT32_T)
+        return {
+            telem::Series(
+                static_cast<float>(get_numeric_value(index)),
+                data_type
+            ),
+            xerrors::NIL
+        };
+    if (data_type == telem::FLOAT64_T)
+        return {
+            telem::Series(
+                get_numeric_value(index),
+                data_type
+            ),
+            xerrors::NIL
+        };
+    if (data_type == telem::INT8_T)
+        return {
+            telem::Series(
+                static_cast<int8_t>(get_numeric_value(index)),
+                data_type
+            ),
+            xerrors::NIL
+        };
+    if (data_type == telem::INT16_T)
+        return {
+            telem::Series(
+                static_cast<int16_t>(get_numeric_value(index)),
+                data_type
+            ),
+            xerrors::NIL
+        };
+    if (data_type == telem::INT32_T)
+        return {
+            telem::Series(
+                static_cast<int32_t>(get_numeric_value(index)),
+                data_type
+            ),
+            xerrors::NIL
+        };
+    if (data_type == telem::INT64_T)
+        return {
+            telem::Series(
+                static_cast<int64_t>(get_numeric_value(index)),
+                data_type
+            ),
+            xerrors::NIL
+        };
+    if (data_type == telem::UINT8_T)
+        return {
+            telem::Series(
+                static_cast<uint8_t>(get_numeric_value(index)),
+                data_type
+            ),
+            xerrors::NIL
+        };
+    if (data_type == telem::UINT16_T)
+        return {
+            telem::Series(
+                static_cast<uint16_t>(get_numeric_value(index)),
+                data_type
+            ),
+            xerrors::NIL
+        };
+    if (data_type == telem::UINT32_T)
+        return {
+            telem::Series(
+                static_cast<uint32_t>(get_numeric_value(index)),
+                data_type
+            ),
+            xerrors::NIL
+        };
+    if (data_type == telem::UINT64_T)
+        return {
+            telem::Series(
+                static_cast<uint64_t>(get_numeric_value(index)),
+                data_type
+            ),
+            xerrors::NIL
+        };
+    return {
+        telem::Series(telem::DATA_TYPE_UNKNOWN, 0),
+        xerrors::Error(xerrors::VALIDATION_ERROR,
+                       "Unsupported data type: " + data_type.value)
+    };
 }
 }

--- a/x/cpp/xlua/xlua.h
+++ b/x/cpp/xlua/xlua.h
@@ -198,12 +198,16 @@ inline xerrors::Error set_globals_from_json_object(lua_State *L, const json &obj
     };
 
     if (!data_type.is_variable() && !is_numeric && !is_boolean) {
+        std::string error_msg;
+        if (is_string) 
+            error_msg = "cannot convert string value '" + 
+            std::string(lua_tostring(L, index)) + "' to " + data_type.value;
+        else 
+            error_msg = "cannot convert Lua type '" + 
+            std::string(lua_typename(L, lua_type(L, index))) + "' to " + data_type.value;
         return {
             telem::Series(telem::DATA_TYPE_UNKNOWN, 0),
-            xerrors::Error(
-                xerrors::VALIDATION_ERROR,
-                "unsupported data type: " + data_type.value
-            )
+            xerrors::Error(xerrors::VALIDATION_ERROR, error_msg)
         };
     }
 
@@ -229,7 +233,8 @@ inline xerrors::Error set_globals_from_json_object(lua_State *L, const json &obj
             telem::Series(telem::DATA_TYPE_UNKNOWN, 0),
             xerrors::Error(
                 xerrors::VALIDATION_ERROR,
-                "expected string value but received different type"
+                "expected string value but received type '" + 
+                std::string(lua_typename(L, lua_type(L, index))) + "'"
             )
         };
     }

--- a/x/cpp/xlua/xlua.h
+++ b/x/cpp/xlua/xlua.h
@@ -197,6 +197,11 @@ inline xerrors::Error set_globals_from_json_object(lua_State *L, const json &obj
         return lua_tonumber(L, idx);
     };
 
+    auto get_integer_value = [L, is_boolean](const int idx) -> lua_Integer {
+        if (is_boolean) return lua_toboolean(L, idx);
+        return lua_tointeger(L, idx);
+    };
+
     if (!data_type.is_variable() && !is_numeric && !is_boolean) {
         std::string error_msg;
         if (is_string) 
@@ -282,7 +287,7 @@ inline xerrors::Error set_globals_from_json_object(lua_State *L, const json &obj
     if (data_type == telem::INT64_T)
         return {
             telem::Series(
-                static_cast<int64_t>(get_numeric_value(index)),
+                static_cast<int64_t>(get_integer_value(index)),
                 data_type
             ),
             xerrors::NIL

--- a/x/cpp/xlua/xlua_test.cpp
+++ b/x/cpp/xlua/xlua_test.cpp
@@ -811,3 +811,11 @@ TEST_F(XLuaTest, ToSeriesUnsupportedTypes) {
     EXPECT_EQ(err3, xerrors::VALIDATION_ERROR);
     lua_pop(L, 1);
 }
+
+TEST_F(XLuaTest, Int64Max) {
+    lua_pushinteger(L, 9223372036854775807);
+    auto [series1, err1] = xlua::to_series(L, -1, telem::INT64_T);
+    EXPECT_FALSE(err1) << err1;
+    EXPECT_EQ(series1.at<int64_t>(0), 9223372036854775807LL);
+
+}

--- a/x/cpp/xlua/xlua_test.cpp
+++ b/x/cpp/xlua/xlua_test.cpp
@@ -521,3 +521,293 @@ TEST_F(XLuaTest, SetGlobalTelemJsonInvalid) {
     EXPECT_TRUE(lua_isnil(L, -1));
     lua_pop(L, 1);
 }
+
+TEST_F(XLuaTest, ToSeriesBooleanCoercion) {
+    // Set up a boolean value in Lua
+    lua_pushboolean(L, true);
+    
+    // Test coercion to various numeric types
+    {
+        auto [series, err] = xlua::to_series(L, -1, telem::FLOAT64_T);
+        EXPECT_FALSE(err) << err;
+        EXPECT_EQ(series.data_type, telem::FLOAT64_T);
+        EXPECT_DOUBLE_EQ(series.at<double>(0), 1.0);
+    }
+    
+    {
+        auto [series, err] = xlua::to_series(L, -1, telem::FLOAT32_T);
+        EXPECT_FALSE(err) << err;
+        EXPECT_EQ(series.data_type, telem::FLOAT32_T);
+        EXPECT_FLOAT_EQ(series.at<float>(0), 1.0f);
+    }
+    
+    {
+        auto [series, err] = xlua::to_series(L, -1, telem::INT64_T);
+        EXPECT_FALSE(err) << err;
+        EXPECT_EQ(series.data_type, telem::INT64_T);
+        EXPECT_EQ(series.at<int64_t>(0), 1);
+    }
+    
+    {
+        auto [series, err] = xlua::to_series(L, -1, telem::INT32_T);
+        EXPECT_FALSE(err) << err;
+        EXPECT_EQ(series.data_type, telem::INT32_T);
+        EXPECT_EQ(series.at<int32_t>(0), 1);
+    }
+    
+    {
+        auto [series, err] = xlua::to_series(L, -1, telem::INT16_T);
+        EXPECT_FALSE(err) << err;
+        EXPECT_EQ(series.data_type, telem::INT16_T);
+        EXPECT_EQ(series.at<int16_t>(0), 1);
+    }
+    
+    {
+        auto [series, err] = xlua::to_series(L, -1, telem::INT8_T);
+        EXPECT_FALSE(err) << err;
+        EXPECT_EQ(series.data_type, telem::INT8_T);
+        EXPECT_EQ(series.at<int8_t>(0), 1);
+    }
+    
+    {
+        auto [series, err] = xlua::to_series(L, -1, telem::UINT64_T);
+        EXPECT_FALSE(err) << err;
+        EXPECT_EQ(series.data_type, telem::UINT64_T);
+        EXPECT_EQ(series.at<uint64_t>(0), 1);
+    }
+    
+    {
+        auto [series, err] = xlua::to_series(L, -1, telem::UINT32_T);
+        EXPECT_FALSE(err) << err;
+        EXPECT_EQ(series.data_type, telem::UINT32_T);
+        EXPECT_EQ(series.at<uint32_t>(0), 1);
+    }
+    
+    {
+        auto [series, err] = xlua::to_series(L, -1, telem::UINT16_T);
+        EXPECT_FALSE(err) << err;
+        EXPECT_EQ(series.data_type, telem::UINT16_T);
+        EXPECT_EQ(series.at<uint16_t>(0), 1);
+    }
+    
+    {
+        auto [series, err] = xlua::to_series(L, -1, telem::UINT8_T);
+        EXPECT_FALSE(err) << err;
+        EXPECT_EQ(series.data_type, telem::UINT8_T);
+        EXPECT_EQ(series.at<uint8_t>(0), 1);
+    }
+    
+    lua_pop(L, 1);
+
+    // Test false value
+    lua_pushboolean(L, false);
+    
+    {
+        auto [series, err] = xlua::to_series(L, -1, telem::FLOAT64_T);
+        EXPECT_FALSE(err) << err;
+        EXPECT_EQ(series.data_type, telem::FLOAT64_T);
+        EXPECT_DOUBLE_EQ(series.at<double>(0), 0.0);
+    }
+    
+    {
+        auto [series, err] = xlua::to_series(L, -1, telem::INT32_T);
+        EXPECT_FALSE(err) << err;
+        EXPECT_EQ(series.data_type, telem::INT32_T);
+        EXPECT_EQ(series.at<int32_t>(0), 0);
+    }
+    
+    lua_pop(L, 1);
+}
+
+TEST_F(XLuaTest, ToSeriesNumberCoercion) {
+    // Test integer to various numeric types
+    lua_pushinteger(L, 42);
+    
+    {
+        auto [series, err] = xlua::to_series(L, -1, telem::FLOAT64_T);
+        EXPECT_FALSE(err) << err;
+        EXPECT_EQ(series.data_type, telem::FLOAT64_T);
+        EXPECT_DOUBLE_EQ(series.at<double>(0), 42.0);
+    }
+    
+    {
+        auto [series, err] = xlua::to_series(L, -1, telem::INT32_T);
+        EXPECT_FALSE(err) << err;
+        EXPECT_EQ(series.data_type, telem::INT32_T);
+        EXPECT_EQ(series.at<int32_t>(0), 42);
+    }
+    
+    lua_pop(L, 1);
+
+    // Test float to various numeric types
+    lua_pushnumber(L, 3.14159);
+    
+    {
+        auto [series, err] = xlua::to_series(L, -1, telem::FLOAT64_T);
+        EXPECT_FALSE(err) << err;
+        EXPECT_EQ(series.data_type, telem::FLOAT64_T);
+        EXPECT_DOUBLE_EQ(series.at<double>(0), 3.14159);
+    }
+    
+    {
+        auto [series, err] = xlua::to_series(L, -1, telem::FLOAT32_T);
+        EXPECT_FALSE(err) << err;
+        EXPECT_EQ(series.data_type, telem::FLOAT32_T);
+        EXPECT_FLOAT_EQ(series.at<float>(0), 3.14159f);
+    }
+    
+    lua_pop(L, 1);
+}
+
+TEST_F(XLuaTest, ToSeriesStringHandling) {
+    // Test string to string type
+    lua_pushstring(L, "test string");
+    
+    {
+        auto [series, err] = xlua::to_series(L, -1, telem::STRING_T);
+        EXPECT_FALSE(err) << err;
+        EXPECT_EQ(series.data_type, telem::STRING_T);
+        EXPECT_EQ(series.at<std::string>(0), "test string");
+    }
+    
+    lua_pop(L, 1);
+
+    // Test empty string
+    lua_pushstring(L, "");
+    
+    {
+        auto [series, err] = xlua::to_series(L, -1, telem::STRING_T);
+        EXPECT_FALSE(err) << err;
+        EXPECT_EQ(series.data_type, telem::STRING_T);
+        EXPECT_EQ(series.at<std::string>(0), "");
+    }
+    
+    lua_pop(L, 1);
+}
+
+TEST_F(XLuaTest, booleanToString) {
+    // Test true
+    lua_pushboolean(L, true);
+    auto [series1, err1] = xlua::to_series(L, -1, telem::STRING_T);
+    EXPECT_FALSE(err1) << err1;
+    EXPECT_EQ(series1.data_type, telem::STRING_T);
+    EXPECT_EQ(series1.at<std::string>(0), "true");
+    lua_pop(L, 1);
+
+    // Test false
+    lua_pushboolean(L, false);
+    auto [series2, err2] = xlua::to_series(L, -1, telem::STRING_T);
+    EXPECT_FALSE(err2) << err2;
+    EXPECT_EQ(series2.data_type, telem::STRING_T);
+    EXPECT_EQ(series2.at<std::string>(0), "false");
+    lua_pop(L, 1);
+}
+
+TEST_F(XLuaTest, ToSeriesTypeMismatch) {
+    // Test string to numeric type
+    lua_pushstring(L, "not a number");
+    auto [series, err] = xlua::to_series(L, -1, telem::FLOAT64_T);
+    EXPECT_TRUE(err) << err;
+    EXPECT_EQ(err, xerrors::VALIDATION_ERROR);
+    lua_pop(L, 1);
+
+    lua_pushstring(L, "not a number");
+    auto [series2, err2] = xlua::to_series(L, -1, telem::INT32_T);
+    EXPECT_TRUE(err2) << err2;
+}
+
+TEST_F(XLuaTest, ToSeriesNilHandling) {
+    lua_pushnil(L);
+    
+    // Test nil to various types
+    auto [series1, err1] = xlua::to_series(L, -1, telem::FLOAT64_T);
+    EXPECT_TRUE(err1);
+    EXPECT_EQ(err1, xerrors::VALIDATION_ERROR);
+    auto [series2, err2] = xlua::to_series(L, -1, telem::INT32_T);
+    EXPECT_TRUE(err2);
+    EXPECT_EQ(err2, xerrors::VALIDATION_ERROR);
+    auto [series3, err3] = xlua::to_series(L, -1, telem::STRING_T);
+    EXPECT_TRUE(err3);
+    EXPECT_EQ(err3, xerrors::VALIDATION_ERROR);
+    
+    lua_pop(L, 1);
+}
+
+TEST_F(XLuaTest, ToSeriesNumericRanges) {
+    // Test integer bounds
+    {
+        lua_pushinteger(L, std::numeric_limits<int16_t>::max());
+        auto [series, err] = xlua::to_series(L, -1, telem::INT16_T);
+        EXPECT_FALSE(err) << err;
+        EXPECT_EQ(series.at<int16_t>(0), std::numeric_limits<int16_t>::max());
+        lua_pop(L, 1);
+    }
+    
+    {
+        lua_pushinteger(L, std::numeric_limits<int16_t>::min());
+        auto [series, err] = xlua::to_series(L, -1, telem::INT16_T);
+        EXPECT_FALSE(err) << err;
+        EXPECT_EQ(series.at<int16_t>(0), std::numeric_limits<int16_t>::min());
+        lua_pop(L, 1);
+    }
+
+    // Test floating point special values
+    {
+        lua_pushnumber(L, std::numeric_limits<double>::infinity());
+        auto [series, err] = xlua::to_series(L, -1, telem::FLOAT64_T);
+        EXPECT_FALSE(err) << err;
+        EXPECT_TRUE(std::isinf(series.at<double>(0)));
+        lua_pop(L, 1);
+    }
+    
+    {
+        lua_pushnumber(L, -std::numeric_limits<double>::infinity());
+        auto [series, err] = xlua::to_series(L, -1, telem::FLOAT64_T);
+        EXPECT_FALSE(err) << err;
+        EXPECT_TRUE(std::isinf(series.at<double>(0)));
+        EXPECT_LT(series.at<double>(0), 0);
+        lua_pop(L, 1);
+    }
+    
+    {
+        lua_pushnumber(L, std::numeric_limits<double>::quiet_NaN());
+        auto [series, err] = xlua::to_series(L, -1, telem::FLOAT64_T);
+        EXPECT_FALSE(err) << err;
+        EXPECT_TRUE(std::isnan(series.at<double>(0)));
+        lua_pop(L, 1);
+    }
+}
+
+TEST_F(XLuaTest, ToSeriesInvalidIndex) {
+    // Test with invalid stack index
+    auto [series1, err1] = xlua::to_series(L, 999, telem::FLOAT64_T);
+    EXPECT_TRUE(err1);
+    EXPECT_EQ(err1, xerrors::VALIDATION_ERROR);
+
+    auto [series2, err2] = xlua::to_series(L, -999, telem::FLOAT64_T);
+    EXPECT_TRUE(err2);
+    EXPECT_EQ(err2, xerrors::VALIDATION_ERROR);
+}
+
+TEST_F(XLuaTest, ToSeriesUnsupportedTypes) {
+    // Test with table
+    lua_newtable(L);
+    auto [series1, err1] = xlua::to_series(L, -1, telem::FLOAT64_T);
+    EXPECT_TRUE(err1);
+    EXPECT_EQ(err1, xerrors::VALIDATION_ERROR);
+    lua_pop(L, 1);
+
+    // Test with function
+    lua_pushcfunction(L, [](lua_State*) -> int { return 0; });
+    auto [series2, err2] = xlua::to_series(L, -1, telem::FLOAT64_T);
+    EXPECT_TRUE(err2);
+    EXPECT_EQ(err2, xerrors::VALIDATION_ERROR);
+    lua_pop(L, 1);
+
+    // Test with userdata
+    lua_newuserdata(L, sizeof(int));
+    auto [series3, err3] = xlua::to_series(L, -1, telem::FLOAT64_T);
+    EXPECT_TRUE(err3);
+    EXPECT_EQ(err3, xerrors::VALIDATION_ERROR);
+    lua_pop(L, 1);
+}


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2094](https://linear.app/synnax/issue/SY-2094)

## Description

Make it so that the sequence returns an error when you call `set` with an invalid data type.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
