### PR TITLE
SY-2096 - Raise Error on Calls to Set With Empty `write_to` field

### DIFF
--- a/driver/sequence/plugins/channel_write.cpp
+++ b/driver/sequence/plugins/channel_write.cpp
@@ -215,3 +215,17 @@ xerrors::Error plugins::ChannelWrite::after_next(lua_State *L) {
         frame.emplace(index, telem::Series(now));
     return this->sink->write(this->frame);
 }
+
+xerrors::Error plugins::ChannelWriteNoop::before_all(lua_State *L) {
+    lua_pushcclosure(L, [](lua_State *cL) -> int {
+        luaL_error(cL, "set() was called but no channels were passed to the write list in the sequence!");
+        return 0;
+    }, 0);
+    lua_setglobal(L, "set");
+    lua_pushcclosure(L, [](lua_State *cL) -> int {
+        luaL_error(cL, "set_authority() was called but no channels were passed to the write list in the sequence!");
+        return 0;
+    }, 0);
+    lua_setglobal(L, "set_authority");
+    return xerrors::NIL;
+}

--- a/driver/sequence/plugins/channel_write_test.cpp
+++ b/driver/sequence/plugins/channel_write_test.cpp
@@ -325,3 +325,32 @@ TEST_F(SetAuthorityTest, InvalidArguments) {
     ASSERT_NE(luaL_dostring(L, "set_authority('channel1', 'not_a_number')"), 0);
     EXPECT_EQ(sink->authority_calls.size(), 0);
 }
+
+class ChannelWriteNoopTest : public testing::Test {
+protected:
+    void SetUp() override {
+        op = std::make_unique<plugins::ChannelWriteNoop>();
+        L = luaL_newstate();
+        luaL_openlibs(L);
+        op->before_all(L);
+    }
+
+    void TearDown() override {
+        lua_close(L);
+    }
+
+    std::unique_ptr<plugins::ChannelWriteNoop> op;
+    lua_State *L{};
+};
+
+TEST_F(ChannelWriteNoopTest, SetShouldError) {
+    ASSERT_NE(luaL_dostring(L, "set('channel', 42)"), 0);
+    const char* error_msg = lua_tostring(L, -1);
+    EXPECT_TRUE(std::string(error_msg).find("set() was called but no channels were passed to the write list in the sequence!") != std::string::npos);
+}
+
+TEST_F(ChannelWriteNoopTest, SetAuthorityShouldError) {
+    ASSERT_NE(luaL_dostring(L, "set_authority('channel', 42)"), 0);
+    const char* error_msg = lua_tostring(L, -1);
+    EXPECT_TRUE(std::string(error_msg).find("set_authority() was called but no channels were passed to the write list in the sequence!") != std::string::npos);
+}

--- a/driver/sequence/plugins/plugins.h
+++ b/driver/sequence/plugins/plugins.h
@@ -173,6 +173,11 @@ public:
     xerrors::Error after_next(lua_State *L) override;
 };
 
+class ChannelWriteNoop final : public Plugin {
+public:
+    xerrors::Error before_all(lua_State *L) override;
+};
+
 struct LatestValue {
     telem::SampleValue value;
     bool changed;


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2096](https://linear.app/synnax/issue/SY-2096)

## Description

Makes it so that when you attempt to make calls to `set` on a sequence with no channels in the `write_to` field, that an error is raised.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
