### PR TITLE
SY-2049 - Fix Labjack Port Override

### DIFF
--- a/console/src/hardware/labjack/task/Read.tsx
+++ b/console/src/hardware/labjack/task/Read.tsx
@@ -132,16 +132,13 @@ const ChannelDetails = ({ path, device }: ChannelDetailsProps) => {
           }}
         />
         <PForm.Field<string> path={`${path}.port`}>
-          {(p) => {
-            console.log(p);
-            return (
-              <Device.SelectPort
-                {...p}
-                model={model}
-                portType={convertChannelTypeToPortType(channel.type)}
-              />
-            );
-          }}
+          {(p) => (
+            <Device.SelectPort
+              {...p}
+              model={model}
+              portType={convertChannelTypeToPortType(channel.type)}
+            />
+          )}
         </PForm.Field>
       </Align.Space>
       <Form deviceModel={device.model} path={path} />

--- a/console/src/hardware/labjack/task/Read.tsx
+++ b/console/src/hardware/labjack/task/Read.tsx
@@ -116,24 +116,32 @@ const ChannelDetails = ({ path, device }: ChannelDetailsProps) => {
             const parentPath = path.slice(0, path.lastIndexOf("."));
             const prevParent = get<InputChannel>(parentPath).value;
             const schema = INPUT_CHANNEL_SCHEMAS[value];
-            const port =
-              Device.DEVICES[model].ports[convertChannelTypeToPortType(value)][0].key;
+            const nextParent = deep.overrideValidItems(next, prevParent, schema);
+            const prevPortType = convertChannelTypeToPortType(prevType);
+            const nextPortType = convertChannelTypeToPortType(value);
+            let nextPort = nextParent.port;
+            if (prevPortType !== nextPortType)
+              nextPort =
+                Device.DEVICES[model].ports[convertChannelTypeToPortType(value)][0].key;
             set(parentPath, {
-              ...deep.overrideValidItems(next, prevParent, schema),
+              ...nextParent,
               type: next.type,
             });
             // Need to explicitly set port to cause select port field to rerender
-            set(`${parentPath}.port`, port);
+            set(`${parentPath}.port`, nextPort);
           }}
         />
         <PForm.Field<string> path={`${path}.port`}>
-          {(p) => (
-            <Device.SelectPort
-              {...p}
-              model={model}
-              portType={convertChannelTypeToPortType(channel.type)}
-            />
-          )}
+          {(p) => {
+            console.log(p);
+            return (
+              <Device.SelectPort
+                {...p}
+                model={model}
+                portType={convertChannelTypeToPortType(channel.type)}
+              />
+            );
+          }}
         </PForm.Field>
       </Align.Space>
       <Form deviceModel={device.model} path={path} />


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2049](https://linear.app/synnax/issue/SY-2049)

## Description

Turns out the `overrideValidSchemas` implementation is totally fine, and it was an issue in the LabJack read task type change handler.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
