### PR TITLE
Fix Workspaces Failing to Save Visualizations from bad UUIDs

### DIFF
--- a/console/src/layouts/GetStarted.tsx
+++ b/console/src/layouts/GetStarted.tsx
@@ -45,7 +45,7 @@ const NoCluster = (): ReactElement => {
   const handleVisualize = useCallback<NonNullable<Button.ButtonProps["onClick"]>>(
     (e) => {
       e.stopPropagation();
-      placeLayout(Vis.SELECTOR_LAYOUT);
+      placeLayout(Vis.createSelectorLayout());
       dispatch(
         Layout.setNavDrawerVisible({ windowKey, key: Vis.TOOLBAR.key, value: true }),
       );

--- a/console/src/layouts/Mosaic.tsx
+++ b/console/src/layouts/Mosaic.tsx
@@ -33,7 +33,7 @@ import { Import } from "@/import";
 import { INGESTORS } from "@/ingestors";
 import { Layout } from "@/layout";
 import { Nav } from "@/layouts/nav";
-import { SELECTOR_LAYOUT } from "@/layouts/Selector";
+import { createSelectorLayout } from "@/layouts/Selector";
 import { LinePlot } from "@/lineplot";
 import { SERVICES } from "@/services";
 import { type RootState, type RootStore } from "@/store";
@@ -155,7 +155,7 @@ const Internal = ({ windowKey, mosaic }: MosaicProps): ReactElement => {
   const handleCreate = useCallback(
     (mosaicKey: number, location: location.Location, tabKeys?: string[]) => {
       if (tabKeys == null) {
-        placeLayout({ ...SELECTOR_LAYOUT, tab: { mosaicKey, location } });
+        placeLayout(createSelectorLayout({ tab: { mosaicKey, location } }));
         return;
       }
       tabKeys.forEach((tabKey) => {
@@ -173,7 +173,7 @@ const Internal = ({ windowKey, mosaic }: MosaicProps): ReactElement => {
             addStatus,
             handleException,
           });
-        } else placeLayout({ ...SELECTOR_LAYOUT, tab: { mosaicKey, location } });
+        } else placeLayout(createSelectorLayout({ tab: { mosaicKey, location } }));
       });
     },
     [placeLayout, store, client, addStatus],

--- a/console/src/layouts/Selector.tsx
+++ b/console/src/layouts/Selector.tsx
@@ -8,6 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { useStore } from "react-redux";
+import { v4 as uuid } from "uuid";
 
 import { Hardware } from "@/hardware";
 import { type Layout } from "@/layout";
@@ -17,12 +18,19 @@ import { Vis } from "@/vis";
 
 export const SELECTOR_LAYOUT_TYPE = "layoutSelector";
 
-export const SELECTOR_LAYOUT: Layout.BaseState = {
+export interface CreateSelectorLayoutArgs
+  extends Omit<Layout.BaseState, "type" | "icon" | "location" | "name" | "key"> {}
+
+export const createSelectorLayout = (
+  args: CreateSelectorLayoutArgs = {},
+): Layout.BaseState => ({
+  ...args,
   type: SELECTOR_LAYOUT_TYPE,
   icon: "Visualize",
   location: "mosaic",
   name: "New Component",
-};
+  key: uuid(),
+});
 
 export const Selector: Layout.Renderer = (props) => {
   const store = useStore<RootState>();

--- a/console/src/lineplot/LinePlot.tsx
+++ b/console/src/lineplot/LinePlot.tsx
@@ -521,5 +521,5 @@ export const SELECTABLE: Selector.Selectable = {
   key: LAYOUT_TYPE,
   title: "Line Plot",
   icon: <Icon.LinePlot />,
-  create: async ({ layoutKey }) => create({ key: layoutKey }),
+  create: async () => create(),
 };

--- a/console/src/lineplot/LinePlot.tsx
+++ b/console/src/lineplot/LinePlot.tsx
@@ -521,5 +521,5 @@ export const SELECTABLE: Selector.Selectable = {
   key: LAYOUT_TYPE,
   title: "Line Plot",
   icon: <Icon.LinePlot />,
-  create: async () => create(),
+  create: async ({ layoutKey }) => create({ key: layoutKey }),
 };

--- a/console/src/lineplot/layout.ts
+++ b/console/src/lineplot/layout.ts
@@ -7,7 +7,8 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { deep, primitiveIsZero } from "@synnaxlabs/x";
+import { linePlot } from "@synnaxlabs/client";
+import { deep } from "@synnaxlabs/x";
 import { v4 as uuid } from "uuid";
 
 import { type Layout } from "@/layout";
@@ -16,11 +17,13 @@ import { internalCreate, type State, ZERO_STATE } from "@/lineplot/slice";
 export const LAYOUT_TYPE = "lineplot";
 export type LayoutType = typeof LAYOUT_TYPE;
 
+export type CreateArg = Partial<State> & Omit<Partial<Layout.BaseState>, "type">;
+
 export const create =
-  (initial: Partial<State> & Omit<Partial<Layout.BaseState>, "type">): Layout.Creator =>
+  (initial: CreateArg = {}): Layout.Creator =>
   ({ dispatch }) => {
     const { name = "Line Plot", location = "mosaic", window, tab, ...rest } = initial;
-    const key: string = primitiveIsZero(initial.key) ? uuid() : (initial.key as string);
+    const key = linePlot.keyZ.safeParse(initial.key).data ?? uuid();
     dispatch(internalCreate({ ...deep.copy(ZERO_STATE), ...rest, key }));
     return { key, name, location, type: LAYOUT_TYPE, icon: "Visualize", window, tab };
   };

--- a/console/src/lineplot/services/palette.tsx
+++ b/console/src/lineplot/services/palette.tsx
@@ -19,7 +19,7 @@ const CREATE_COMMAND: Palette.Command = {
   key: "create-line-plot",
   name: "Create Line Plot",
   icon: <Icon.LinePlot />,
-  onSelect: ({ placeLayout }) => placeLayout(LinePlot.create({})),
+  onSelect: ({ placeLayout }) => placeLayout(LinePlot.create()),
 };
 
 const IMPORT_COMMAND: Palette.Command = {

--- a/console/src/log/Log.tsx
+++ b/console/src/log/Log.tsx
@@ -133,7 +133,7 @@ export const SELECTABLE: Selector.Selectable = {
   key: LAYOUT_TYPE,
   title: "Log",
   icon: <Icon.Log />,
-  create: async () => create(),
+  create: async ({ layoutKey }) => create({ key: layoutKey }),
 };
 
 export type CreateArg = Partial<State> & Omit<Partial<Layout.BaseState>, "type">;

--- a/console/src/log/Log.tsx
+++ b/console/src/log/Log.tsx
@@ -8,6 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { type Dispatch, type PayloadAction } from "@reduxjs/toolkit";
+import { log } from "@synnaxlabs/client";
 import { useSelectWindowKey } from "@synnaxlabs/drift/react";
 import { Icon } from "@synnaxlabs/media";
 import { Align, Log as Core, telem, Text, usePrevious } from "@synnaxlabs/pluto";
@@ -132,14 +133,16 @@ export const SELECTABLE: Selector.Selectable = {
   key: LAYOUT_TYPE,
   title: "Log",
   icon: <Icon.Log />,
-  create: async ({ layoutKey }) => create({ key: layoutKey }),
+  create: async () => create(),
 };
 
+export type CreateArg = Partial<State> & Omit<Partial<Layout.BaseState>, "type">;
+
 export const create =
-  (initial: Partial<State> & Omit<Partial<Layout.BaseState>, "type">): Layout.Creator =>
+  (initial: CreateArg = {}): Layout.Creator =>
   ({ dispatch }) => {
     const { name = "Log", location = "mosaic", window, tab, ...rest } = initial;
-    const key: string = primitiveIsZero(initial.key) ? uuid() : (initial.key as string);
+    const key = log.keyZ.safeParse(initial.key).data ?? uuid();
     dispatch(internalCreate({ ...deep.copy(ZERO_STATE), ...rest, key }));
     return {
       key,

--- a/console/src/log/services/palette.tsx
+++ b/console/src/log/services/palette.tsx
@@ -19,7 +19,7 @@ const CREATE_COMMAND: Palette.Command = {
   key: "create-log",
   name: "Create Log",
   icon: <Icon.Log />,
-  onSelect: ({ placeLayout }) => placeLayout(Log.create({})),
+  onSelect: ({ placeLayout }) => placeLayout(Log.create()),
 };
 
 const IMPORT_COMMAND: Palette.Command = {

--- a/console/src/schematic/Schematic.tsx
+++ b/console/src/schematic/Schematic.tsx
@@ -12,6 +12,7 @@ import {
   type PayloadAction,
   type UnknownAction,
 } from "@reduxjs/toolkit";
+import { schematic } from "@synnaxlabs/client";
 import { useSelectWindowKey } from "@synnaxlabs/drift/react";
 import { Icon } from "@synnaxlabs/media";
 import {
@@ -29,7 +30,7 @@ import {
   useSyncedRef,
   Viewport,
 } from "@synnaxlabs/pluto";
-import { box, deep, id, primitiveIsZero, xy } from "@synnaxlabs/x";
+import { box, deep, id, xy } from "@synnaxlabs/x";
 import {
   type ReactElement,
   useCallback,
@@ -441,18 +442,18 @@ export const SELECTABLE: Selector.Selectable = {
   key: LAYOUT_TYPE,
   title: "Schematic",
   icon: <Icon.Schematic />,
-  create: async ({ layoutKey }) => create({ key: layoutKey }),
+  create: async () => create(),
 };
 
 export type CreateArg = Partial<State> & Partial<Layout.BaseState>;
 
 export const create =
-  (initial: CreateArg): Layout.Creator =>
+  (initial: CreateArg = {}): Layout.Creator =>
   ({ dispatch, store }) => {
     const canEditSchematic = selectHasPermission(store.getState());
     const { name = "Schematic", location = "mosaic", window, tab, ...rest } = initial;
     if (!canEditSchematic && tab?.editable) tab.editable = false;
-    const key: string = primitiveIsZero(initial.key) ? uuid() : (initial.key as string);
+    const key = schematic.keyZ.safeParse(initial.key).data ?? uuid();
     dispatch(internalCreate({ ...deep.copy(ZERO_STATE), ...rest, key }));
     return {
       key,

--- a/console/src/schematic/Schematic.tsx
+++ b/console/src/schematic/Schematic.tsx
@@ -442,7 +442,7 @@ export const SELECTABLE: Selector.Selectable = {
   key: LAYOUT_TYPE,
   title: "Schematic",
   icon: <Icon.Schematic />,
-  create: async () => create(),
+  create: async ({ layoutKey }) => create({ key: layoutKey }),
 };
 
 export type CreateArg = Partial<State> & Partial<Layout.BaseState>;

--- a/console/src/schematic/services/palette.tsx
+++ b/console/src/schematic/services/palette.tsx
@@ -19,7 +19,7 @@ const CREATE_COMMAND: Palette.Command = {
   key: "create-schematic",
   name: "Create Schematic",
   icon: <Icon.Schematic />,
-  onSelect: ({ placeLayout }) => placeLayout(Schematic.create({})),
+  onSelect: ({ placeLayout }) => placeLayout(Schematic.create()),
   visible: (state) => Schematic.selectHasPermission(state),
 };
 

--- a/console/src/selector/Selector.tsx
+++ b/console/src/selector/Selector.tsx
@@ -64,13 +64,12 @@ export const Selector = ({
             <Button.Button
               key={key}
               variant="outlined"
-              onClick={() => {
-                create({ layoutKey, rename })
-                  .then((layout) => {
-                    if (layout != null) place(layout);
-                  })
-                  .catch((e) => handleException(e, "Failed to select layout"));
-              }}
+              onClick={() =>
+                handleException(async () => {
+                  const layout = await create({ layoutKey, rename });
+                  if (layout != null) place(layout);
+                }, `Failed to create ${title}`)
+              }
               startIcon={icon}
               style={{ flexBasis: "185px" }}
             >

--- a/console/src/table/Table.tsx
+++ b/console/src/table/Table.tsx
@@ -10,6 +10,7 @@
 import "@/table/Table.css";
 
 import { type Dispatch, type PayloadAction } from "@reduxjs/toolkit";
+import { table } from "@synnaxlabs/client";
 import { useSelectWindowKey } from "@synnaxlabs/drift/react";
 import { Icon } from "@synnaxlabs/media";
 import {
@@ -26,7 +27,6 @@ import {
   clamp,
   dimensions,
   type location,
-  primitiveIsZero,
   type UnknownRecord,
   xy,
 } from "@synnaxlabs/x";
@@ -365,11 +365,13 @@ interface CellContainerProps {
   cellKey: string;
 }
 
+export type CreateArg = Partial<State> & Omit<Partial<Layout.BaseState>, "type">;
+
 export const create =
-  (initial: Partial<State> & Omit<Partial<Layout.BaseState>, "type">): Layout.Creator =>
+  (initial: CreateArg = {}): Layout.Creator =>
   ({ dispatch }) => {
     const { name = "Table", location = "mosaic", window, tab, ...rest } = initial;
-    const key: string = primitiveIsZero(initial.key) ? uuid() : (initial.key as string);
+    const key = table.keyZ.safeParse(initial.key).data ?? uuid();
     dispatch(internalCreate({ ...ZERO_STATE, ...rest, key }));
     return {
       key,
@@ -386,7 +388,7 @@ export const SELECTABLE: Selector.Selectable = {
   key: LAYOUT_TYPE,
   title: "Table",
   icon: <Icon.Table />,
-  create: async ({ layoutKey }) => create({ key: layoutKey }),
+  create: async () => create(),
 };
 
 interface ColResizerProps {

--- a/console/src/table/Table.tsx
+++ b/console/src/table/Table.tsx
@@ -388,7 +388,7 @@ export const SELECTABLE: Selector.Selectable = {
   key: LAYOUT_TYPE,
   title: "Table",
   icon: <Icon.Table />,
-  create: async () => create(),
+  create: async ({ layoutKey }) => create({ key: layoutKey }),
 };
 
 interface ColResizerProps {

--- a/console/src/table/services/palette.tsx
+++ b/console/src/table/services/palette.tsx
@@ -19,7 +19,7 @@ const CREATE_COMMAND: Palette.Command = {
   key: "create-table",
   name: "Create Table",
   icon: <Icon.Table />,
-  onSelect: ({ placeLayout }) => placeLayout(Table.create({})),
+  onSelect: ({ placeLayout }) => placeLayout(Table.create()),
 };
 
 const IMPORT_COMMAND: Palette.Command = {

--- a/console/src/vis/Selector.tsx
+++ b/console/src/vis/Selector.tsx
@@ -8,6 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { useStore } from "react-redux";
+import { v4 as uuid } from "uuid";
 
 import { type Layout } from "@/layout";
 import { LinePlot } from "@/lineplot";
@@ -26,12 +27,13 @@ const SELECTABLES: CoreSelector.Selectable[] = [
 
 export const SELECTOR_LAYOUT_TYPE = "visualizationSelector";
 
-export const SELECTOR_LAYOUT: Layout.BaseState = {
+export const createSelectorLayout = (): Layout.BaseState => ({
   type: SELECTOR_LAYOUT_TYPE,
   icon: "Visualize",
   location: "mosaic",
   name: "New Visualization",
-};
+  key: uuid(),
+});
 
 export const getSelectables = (storeState: RootState): CoreSelector.Selectable[] => {
   const canCreateSchematic = Schematic.selectHasPermission(storeState);

--- a/console/src/vis/Toolbar.tsx
+++ b/console/src/vis/Toolbar.tsx
@@ -17,7 +17,7 @@ import { LinePlot } from "@/lineplot";
 import { Log } from "@/log";
 import { Schematic } from "@/schematic";
 import { Table } from "@/table";
-import { SELECTOR_LAYOUT } from "@/vis/Selector";
+import { createSelectorLayout } from "@/vis/Selector";
 import { type LayoutType } from "@/vis/types";
 
 interface ToolbarProps {
@@ -33,6 +33,9 @@ const TOOLBARS: Record<LayoutType, FC<ToolbarProps>> = {
 
 const NoVis = (): ReactElement => {
   const placeLayout = Layout.usePlacer();
+  const handleCreateNewVisualization = () => {
+    placeLayout(createSelectorLayout());
+  };
   return (
     <Align.Space justify="spaceBetween" style={{ height: "100%" }} empty>
       <Toolbar.Header>
@@ -42,7 +45,7 @@ const NoVis = (): ReactElement => {
         <Status.Text level="p" variant="disabled" hideIcon>
           No visualization selected. Select a visualization or
         </Status.Text>
-        <Text.Link level="p" onClick={() => placeLayout(SELECTOR_LAYOUT)}>
+        <Text.Link level="p" onClick={handleCreateNewVisualization}>
           create a new one.
         </Text.Link>
       </Align.Center>


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2093](https://linear.app/synnax/issue/SY-2093/workspace-failing-to-save-visualizations-on-reopen)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Made sure that when new visualizations are created in the console, the keys are all UUIDs. This prevents some issue where a workspace has a layout key that is not a UUID, so the workspace saves properly but the visualizations do not.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
