### PR TITLE
Fix Palette Switching and Update Pluto Dialog Hook

### DIFF
--- a/console/src/cluster/Dropdown.tsx
+++ b/console/src/cluster/Dropdown.tsx
@@ -244,17 +244,18 @@ export const NoneConnected = (): ReactElement => {
 };
 
 export const Dropdown = (): ReactElement => {
-  const dropProps = Core.use();
+  const { close, toggle, visible } = Core.use();
   const cluster = useSelect();
   return (
     <Core.Dialog
-      {...dropProps}
+      close={close}
+      visible={visible}
       variant="floating"
       bordered={false}
       className={CSS.B("cluster-dropdown")}
     >
       <Button.Button
-        onClick={dropProps.toggle}
+        onClick={toggle}
         variant="text"
         startIcon={<Icon.Cluster />}
         justify="center"

--- a/console/src/layout/slice.ts
+++ b/console/src/layout/slice.ts
@@ -524,7 +524,7 @@ export const createMosaicWindow = (window?: WindowProps): BaseState => ({
   window: {
     ...window,
     size: { width: 800, height: 600 },
-    navTop: false,
+    navTop: true,
     visible: true,
     showTitle: false,
   },

--- a/console/src/layouts/Mosaic.tsx
+++ b/console/src/layouts/Mosaic.tsx
@@ -288,9 +288,9 @@ export const MosaicWindow = memo<Layout.Renderer>(
         }),
       );
     }, [layoutKey]);
-    return windowKey == null || mosaic == null ? null : (
+    if (windowKey == null || mosaic == null) return null;
+    return (
       <>
-        <Nav.Top />
         <Internal windowKey={windowKey} mosaic={mosaic} />
         <Nav.Drawer location="bottom" />
         <PNav.Bar

--- a/console/src/layouts/nav/Top.tsx
+++ b/console/src/layouts/nav/Top.tsx
@@ -33,10 +33,10 @@ import { UserServices } from "@/user/services";
 import { Workspace } from "@/workspace";
 import { WorkspaceServices } from "@/workspace/services";
 
-const DEFAULT_TRIGGER: Palette.TriggerConfig = {
+const PALETTE_TRIGGER_CONFIG: Palette.TriggerConfig = {
   command: [["Control", "Shift", "P"]],
   defaultMode: "command",
-  resource: [["Control", "P"]],
+  search: [["Control", "P"]],
 };
 
 const COMMANDS: Palette.Command[] = [
@@ -61,7 +61,7 @@ const TopPalette = (): ReactElement => (
     commands={COMMANDS}
     commandSymbol=">"
     services={SERVICES}
-    triggers={DEFAULT_TRIGGER}
+    triggerConfig={PALETTE_TRIGGER_CONFIG}
   />
 );
 

--- a/console/src/palette/Palette.tsx
+++ b/console/src/palette/Palette.tsx
@@ -24,14 +24,7 @@ import {
   Tooltip,
   Triggers,
 } from "@synnaxlabs/pluto";
-import {
-  type FC,
-  type ReactElement,
-  useCallback,
-  useLayoutEffect,
-  useMemo,
-  useState,
-} from "react";
+import { type FC, type ReactElement, useCallback, useMemo, useState } from "react";
 import { useStore } from "react-redux";
 
 import { CSS } from "@/css";
@@ -50,37 +43,39 @@ import { TooltipContent } from "@/palette/Tooltip";
 import { type Mode, type TriggerConfig } from "@/palette/types";
 import { type RootAction, type RootState } from "@/store";
 
+type Key = string;
+type Entry = Command | ontology.Resource;
+
 export interface PaletteProps {
   commands: Command[];
-  services: Ontology.Services;
-  triggers: TriggerConfig;
   commandSymbol: string;
+  services: Ontology.Services;
+  triggerConfig: TriggerConfig;
 }
-
-type Entry = Command | ontology.Resource;
-type Key = string;
 
 export const Palette = ({
   commands,
-  services,
-  triggers: triggerConfig,
   commandSymbol,
+  services,
+  triggerConfig,
 }: PaletteProps): ReactElement => {
-  const dropdown = Dropdown.use();
+  const { close, open, visible } = Dropdown.use();
 
   const [value, setValue] = useState("");
   const store = useStore<RootState>();
 
-  const newCommands = commands.filter((c) => c.visible?.(store.getState()) ?? true);
+  const newCommands = commands.filter(
+    ({ visible }) => visible?.(store.getState()) ?? true,
+  );
 
   const handleTrigger = useCallback(
     ({ triggers, stage }: Triggers.UseEvent) => {
-      if (stage !== "start" || dropdown.visible) return;
+      if (stage !== "start" || visible) return;
       const mode = Triggers.determineMode(triggerConfig, triggers);
       setValue(mode === "command" ? commandSymbol : "");
-      dropdown.open();
+      open();
     },
-    [dropdown.visible, dropdown.open, triggerConfig.command, commandSymbol],
+    [visible, triggerConfig, commandSymbol, open],
   );
 
   const triggers = useMemo(
@@ -90,20 +85,22 @@ export const Palette = ({
 
   Triggers.use({ triggers, callback: handleTrigger });
 
+  const data = value.startsWith(commandSymbol) ? newCommands : [];
+
   return (
-    <List.List>
-      <Tooltip.Dialog location="bottom" hide={dropdown.visible}>
-        <TooltipContent triggers={triggerConfig} />
+    <List.List<Key, Entry> data={data}>
+      <Tooltip.Dialog location="bottom" hide={visible}>
+        <TooltipContent triggerConfig={triggerConfig} />
         <Dropdown.Dialog
-          {...dropdown}
+          close={close}
           keepMounted={false}
-          visible={dropdown.visible}
+          visible={visible}
           className={CSS.B("palette")}
           location="bottom"
           variant="modal"
         >
           <Button.Button
-            onClick={dropdown.open}
+            onClick={open}
             className={CSS(CSS.BE("palette", "btn"))}
             variant="outlined"
             align="center"
@@ -112,15 +109,14 @@ export const Palette = ({
             startIcon={<Icon.Search />}
             shade={7}
           >
-            Quick Search & Command
+            Quick Search & Command Palette
           </Button.Button>
           <PaletteDialog
             value={value}
             onChange={setValue}
-            commands={newCommands}
             services={services}
             commandSymbol={commandSymbol}
-            close={dropdown.close}
+            close={close}
           />
         </Dropdown.Dialog>
       </Tooltip.Dialog>
@@ -128,46 +124,22 @@ export const Palette = ({
   );
 };
 
-interface PaletteListProps {
-  mode: Mode;
-  services: Ontology.Services;
-  commandSelectionContext: CommandSelectionContext;
-}
+const transformBefore = (term: string): string => term.slice(1);
 
-const PaletteList = ({
-  mode,
-  services,
-  commandSelectionContext,
-}: PaletteListProps): ReactElement => {
-  const item = useMemo(() => {
-    const Item = (
-      mode === "command" ? CommandListItem : createResourceListItem(services)
-    ) as FC<List.ItemProps<string, ontology.Resource | Command>>;
-    return componentRenderProp(Item);
-  }, [commandSelectionContext, mode, services]);
-  return (
-    <List.Core className={CSS.BE("palette", "list")} itemHeight={27} grow>
-      {item}
-    </List.Core>
-  );
-};
-
-export interface PaletteDialogProps extends Input.Control<string> {
-  services: Ontology.Services;
+export interface PaletteDialogProps
+  extends Input.Control<string>,
+    Pick<Dropdown.DialogProps, "close"> {
   commandSymbol: string;
-  commands: Command[];
-  close: () => void;
+  services: Ontology.Services;
 }
 
 const PaletteDialog = ({
-  value,
-  onChange,
-  commands,
-  services,
-  commandSymbol,
   close,
+  commandSymbol,
+  onChange,
+  services,
+  value,
 }: PaletteDialogProps): ReactElement => {
-  const { setSourceData } = List.useDataUtils<Key, Entry>();
   const addStatus = Status.useAdder();
   const handleException = Status.useExceptionHandler();
   const client = Synnax.use();
@@ -175,26 +147,24 @@ const PaletteDialog = ({
   const placeLayout = Layout.usePlacer();
   const removeLayout = Layout.useRemover();
 
-  const mode = value.startsWith(commandSymbol) ? "command" : "resource";
-
-  useLayoutEffect(() => setSourceData(mode === "command" ? commands : []), [mode]);
+  const mode = value.startsWith(commandSymbol) ? "command" : "search";
 
   const confirm = Modals.useConfirm();
   const rename = Modals.useRename();
 
   const cmdSelectCtx = useMemo<CommandSelectionContext>(
     () => ({
-      store,
-      placeLayout,
-      confirm,
-      rename,
-      client,
       addStatus,
+      client,
+      confirm,
+      extractors: EXTRACTORS,
       handleException,
       ingestors: INGESTORS,
-      extractors: EXTRACTORS,
+      placeLayout,
+      rename,
+      store,
     }),
-    [store, placeLayout, confirm, client, addStatus, handleException, rename],
+    [addStatus, client, confirm, handleException, placeLayout, rename, store],
   );
 
   const handleSelect = useCallback(
@@ -205,9 +175,8 @@ const PaletteDialog = ({
         return;
       }
       if (client == null) return;
-      const id = new ontology.ID(key);
-      const t = services[id.type];
-      void t.onSelect?.({
+      const { type } = new ontology.ID(key);
+      services[type].onSelect?.({
         services,
         store,
         addStatus,
@@ -231,30 +200,30 @@ const PaletteDialog = ({
     ],
   );
 
-  const { value: searchValue, onChange: onSearchChange } = List.useSearch<
-    string,
-    ontology.Resource
-  >({ value, onChange, searcher: client?.ontology });
-
-  const { value: filterValue, onChange: onFilterChange } = List.useFilter({
-    value,
+  const { onChange: onSearchChange } = List.useSearch<string, ontology.Resource>({
     onChange,
-    transformBefore: (term) => term.slice(1),
+    searcher: client?.ontology,
+    value,
   });
 
-  const handleChange = useCallback(
-    (value: string) => {
-      if (mode === "command") onFilterChange(value);
-      else onSearchChange(value);
-    },
-    [mode, onFilterChange, onSearchChange],
-  );
+  const { onChange: onFilterChange } = List.useFilter({
+    onChange,
+    transformBefore,
+    value,
+  });
 
-  const actualValue = mode === "command" ? filterValue : searchValue;
+  const handleChange = useCallback(() => {
+    if (value.startsWith(commandSymbol)) onFilterChange(value);
+    else onSearchChange(value);
+  }, [onFilterChange, onSearchChange]);
 
   return (
-    <List.Selector value={null} onChange={handleSelect} allowMultiple={false}>
-      <List.Hover initialHover={0}>
+    <List.Selector<Key, Entry>
+      value={null}
+      onChange={handleSelect}
+      allowMultiple={false}
+    >
+      <List.Hover<Key, Entry> initialHover={0}>
         <Align.Pack
           className={CSS.BE("palette", "content")}
           direction="y"
@@ -270,16 +239,31 @@ const PaletteDialog = ({
             size="huge"
             autoFocus
             onChange={handleChange}
-            value={actualValue}
+            value={value}
             autoComplete="off"
           />
-          <PaletteList
-            mode={mode}
-            services={services}
-            commandSelectionContext={cmdSelectCtx}
-          />
+          <PaletteList mode={mode} services={services} />
         </Align.Pack>
       </List.Hover>
     </List.Selector>
+  );
+};
+
+interface PaletteListProps {
+  mode: Mode;
+  services: Ontology.Services;
+}
+
+const PaletteList = ({ mode, services }: PaletteListProps): ReactElement => {
+  const item = useMemo(() => {
+    const Item = (
+      mode === "command" ? CommandListItem : createResourceListItem(services)
+    ) as FC<List.ItemProps<Key, Entry>>;
+    return componentRenderProp(Item);
+  }, [mode, services]);
+  return (
+    <List.Core<Key, Entry> className={CSS.BE("palette", "list")} itemHeight={27} grow>
+      {item}
+    </List.Core>
   );
 };

--- a/console/src/palette/Palette.tsx
+++ b/console/src/palette/Palette.tsx
@@ -212,10 +212,13 @@ const PaletteDialog = ({
     value,
   });
 
-  const handleChange = useCallback(() => {
-    if (value.startsWith(commandSymbol)) onFilterChange(value);
-    else onSearchChange(value);
-  }, [onFilterChange, onSearchChange]);
+  const handleChange = useCallback(
+    (value: string) => {
+      if (value.startsWith(commandSymbol)) onFilterChange(value);
+      else onSearchChange(value);
+    },
+    [onFilterChange, onSearchChange],
+  );
 
   return (
     <List.Selector<Key, Entry>

--- a/console/src/palette/Tooltip.tsx
+++ b/console/src/palette/Tooltip.tsx
@@ -12,24 +12,24 @@ import { type ReactElement } from "react";
 
 import { type TriggerConfig } from "@/palette/types";
 
-const TOOLTIP_TEXT_LEVEL: Text.Level = "small";
-
 export interface TooltipContentProps {
-  triggers: TriggerConfig;
+  triggerConfig: TriggerConfig;
 }
 
-export const TooltipContent = ({ triggers }: TooltipContentProps): ReactElement => (
+export const TooltipContent = ({
+  triggerConfig: { command, search },
+}: TooltipContentProps): ReactElement => (
   <Align.Space size="small">
     <Align.Space direction="x" justify="spaceBetween" align="center">
-      <Text.Text level={TOOLTIP_TEXT_LEVEL}>Search</Text.Text>
+      <Text.Text level="small">Search</Text.Text>
       <Align.Space direction="x" empty size={0.5}>
-        <Triggers.Text trigger={triggers.resource[0]} level={TOOLTIP_TEXT_LEVEL} />
+        <Triggers.Text trigger={search[0]} level="small" />
       </Align.Space>
     </Align.Space>
     <Align.Space direction="x" justify="spaceBetween" align="center">
-      <Text.Text level={TOOLTIP_TEXT_LEVEL}>Command Palette</Text.Text>
+      <Text.Text level="small">Command Palette</Text.Text>
       <Align.Space direction="x" size={0.5}>
-        <Triggers.Text trigger={triggers.command[0]} level={TOOLTIP_TEXT_LEVEL} />
+        <Triggers.Text trigger={command[0]} level="small" />
       </Align.Space>
     </Align.Space>
   </Align.Space>

--- a/console/src/palette/command.tsx
+++ b/console/src/palette/command.tsx
@@ -17,9 +17,9 @@ import { type Layout } from "@/layout";
 import { type Modals } from "@/modals";
 import { type RootState, type RootStore } from "@/store";
 
-export const CommandListItem = (
-  props: List.ItemProps<string, Command>,
-): ReactElement => {
+export interface CommandListItemProps extends List.ItemProps<string, Command> {}
+
+export const CommandListItem = (props: CommandListItemProps): ReactElement => {
   const {
     entry: { icon, name, endContent },
   } = props;

--- a/console/src/palette/resource.tsx
+++ b/console/src/palette/resource.tsx
@@ -26,14 +26,12 @@ export const createResourceListItem = (
     // This null check is needed because sometimes when switching to search mode from command
     // mode, the commands are passed in as resources.
     if (id == null) return null;
-    const ontologyService = ontologyServices[id.type];
+    const { icon, onSelect, PaletteListItem } = ontologyServices[id.type];
     // return null if the ontology service does not have an onSelect method, that way we
     // don't show pointless items in the palette.
-    if (ontologyService?.onSelect == null) return null;
-    const ListItem = ontologyService?.PaletteListItem;
-    if (ListItem != null) return <ListItem {...props} />;
-    const { icon } = ontologyService;
-    return (
+    return onSelect == null ? null : PaletteListItem != null ? (
+      <PaletteListItem {...props} />
+    ) : (
       <List.ItemFrame style={{ padding: "1.5rem" }} highlightHovered {...props}>
         <Text.WithIcon
           startIcon={isValidElement(icon) ? icon : icon(entry)}

--- a/console/src/palette/types.ts
+++ b/console/src/palette/types.ts
@@ -9,6 +9,6 @@
 
 import { type Triggers } from "@synnaxlabs/pluto";
 
-export type Mode = "command" | "resource";
+export type Mode = "command" | "search";
 
 export interface TriggerConfig extends Triggers.ModeConfig<Mode> {}

--- a/console/src/workspace/Selector.tsx
+++ b/console/src/workspace/Selector.tsx
@@ -38,11 +38,11 @@ export const Selector = (): ReactElement => {
   const dispatch = useDispatch();
   const placeLayout = Layout.usePlacer();
   const active = useSelectActive();
-  const dProps = Dropdown.use();
+  const { close, toggle, visible } = Dropdown.use();
   const handleException = Status.useExceptionHandler();
   const handleChange = useCallback(
     (v: string | null) => {
-      dProps.close();
+      close();
       if (v === null) {
         dispatch(setActive(null));
         dispatch(Layout.clearWorkspace());
@@ -62,12 +62,13 @@ export const Selector = (): ReactElement => {
         })
         .catch((e) => handleException(e, "Failed to switch workspace"));
     },
-    [active, client, dispatch, dProps.close, handleException],
+    [active, client, dispatch, close, handleException],
   );
 
   return (
     <Dropdown.Dialog
-      {...dProps}
+      close={close}
+      visible={visible}
       keepMounted={false}
       variant="floating"
       className={CSS(CSS.BE("workspace", "selector"))}
@@ -75,14 +76,10 @@ export const Selector = (): ReactElement => {
       <Button.Button
         startIcon={<Icon.Workspace key="workspace" />}
         endIcon={
-          <Caret.Animated
-            enabledLoc="bottom"
-            disabledLoc="left"
-            enabled={dProps.visible}
-          />
+          <Caret.Animated enabledLoc="bottom" disabledLoc="left" enabled={visible} />
         }
         variant="text"
-        onClick={() => dProps.toggle()}
+        onClick={toggle}
         size="medium"
         className={CSS.B("trigger")}
         shade={8}
@@ -123,7 +120,7 @@ export const Selector = (): ReactElement => {
                       startIcon={<Icon.Add />}
                       variant="outlined"
                       onClick={() => {
-                        dProps.close();
+                        close();
                         placeLayout(CREATE_LAYOUT);
                       }}
                       iconSpacing="small"

--- a/docs/site/src/components/feedback/Feedback.tsx
+++ b/docs/site/src/components/feedback/Feedback.tsx
@@ -23,25 +23,26 @@ const formSchema = z.object({
 });
 
 export const FeedbackButton = (): ReactElement => {
-  const props = Dropdown.use();
+  const { close, toggle, visible } = Dropdown.use();
   return (
     <Dropdown.Dialog
       className="feedback-modal"
       variant="modal"
       keepMounted={false}
-      {...props}
+      close={close}
+      visible={visible}
     >
       <Button.Button
         className="feedback-button"
         variant="outlined"
         size="medium"
         iconSpacing="small"
-        onClick={props.toggle}
+        onClick={toggle}
         startIcon={<Icon.Feedback />}
       >
         Stuck? Let us know!
       </Button.Button>
-      <FeedbackForm close={props.close} />
+      <FeedbackForm close={close} />
     </Dropdown.Dialog>
   );
 };

--- a/docs/site/src/components/search/Search.tsx
+++ b/docs/site/src/components/search/Search.tsx
@@ -41,13 +41,13 @@ const ALGOLIA_HEADERS = {
 };
 
 export const Search = (): ReactElement => {
-  const d = Dropdown.use();
+  const { close, open, toggle, visible } = Dropdown.use();
   useEffect(() => {
     const handleKeyDown = (e: KeyboardEvent): void => {
-      if (e.key === "Escape") d.close();
+      if (e.key === "Escape") close();
       if (e.key === "k" && (e.metaKey || e.ctrlKey)) {
         e.preventDefault();
-        d.open();
+        open();
       }
     };
     window.addEventListener("keydown", handleKeyDown);
@@ -55,10 +55,15 @@ export const Search = (): ReactElement => {
   }, []);
   return (
     <Triggers.Provider>
-      <Dropdown.Dialog variant="modal" {...d} className="search-box">
+      <Dropdown.Dialog
+        variant="modal"
+        close={close}
+        visible={visible}
+        className="search-box"
+      >
         <Button.Button
           startIcon={<Icon.Search />}
-          onClick={d.toggle}
+          onClick={toggle}
           variant="outlined"
           justify="center"
           size="large"
@@ -66,15 +71,11 @@ export const Search = (): ReactElement => {
         >
           Search
         </Button.Button>
-        <SearchDialogContent d={d} />
+        <SearchDialogContent close={close} visible={visible} />
       </Dropdown.Dialog>
     </Triggers.Provider>
   );
 };
-
-interface SearchDialogContentProps {
-  d: Dropdown.DialogProps;
-}
 
 const ICONS: Record<string, ReactElement> = {
   "python-client": <Icon.Python />,
@@ -134,7 +135,10 @@ export const SearchListItem = (props: List.ItemProps<string, SearchResult>) => {
 
 const searchListItem = componentRenderProp(SearchListItem);
 
-const SearchDialogContent = ({ d }: SearchDialogContentProps) => {
+interface SearchDialogContentProps
+  extends Pick<Dropdown.DialogProps, "close" | "visible"> {}
+
+const SearchDialogContent = ({ close, visible }: SearchDialogContentProps) => {
   const [results, setResults] = useState<SearchResult[]>([]);
   const [value, setValue] = useState<string>("");
   const inputRef = useRef<HTMLInputElement>(null);
@@ -162,7 +166,7 @@ const SearchDialogContent = ({ d }: SearchDialogContentProps) => {
   useEffect(() => {
     handleSearch("");
     inputRef.current?.focus();
-  }, [d.visible]);
+  }, [visible]);
 
   return (
     <List.List
@@ -180,7 +184,7 @@ const SearchDialogContent = ({ d }: SearchDialogContentProps) => {
         allowMultiple={false}
         onChange={(k: string) => {
           document.getElementById(k)?.click();
-          d.close();
+          close();
         }}
       >
         <List.Hover>

--- a/pluto/src/dialog/use.ts
+++ b/pluto/src/dialog/use.ts
@@ -12,21 +12,43 @@ import {
   use as reactUse,
   useCallback,
   useEffect,
+  useMemo,
+  useRef,
   useState,
 } from "react";
 
 /** Props for the {@link use} hook. */
 export interface UseProps {
+  /**
+   * Whether the dialog should be visible on mount.
+   */
   initialVisible?: boolean;
-  onVisibleChange?: (vis: boolean) => void;
+  /**
+   * A callback invoked whenever the dialog's visibility changes.
+   *
+   * @param visible - The new visibility state.
+   */
+  onVisibleChange?: (visible: boolean) => void;
 }
 
 /** Return type for the {@link use} hook. */
 export interface UseReturn {
-  visible: boolean;
+  /**
+   * Function to close the dialog.
+   */
   close: () => void;
+  /**
+   * Function to open the dialog.
+   */
   open: () => void;
-  toggle: (vis?: boolean | unknown) => void;
+  /**
+   * Function to toggle the dialog.
+   */
+  toggle: () => void;
+  /**
+   * Whether the dialog is currently visible.
+   */
+  visible: boolean;
 }
 
 export interface ContextValue extends Pick<UseReturn, "close"> {}
@@ -39,34 +61,33 @@ const Context = createContext<ContextValue>({
 
 export const Provider = Context;
 
-export const useContext = () => reactUse(Context);
+export const useContext = (): ContextValue => reactUse(Context);
 
 /**
- * Implements basic dropdown behavior, and should be preferred when using
- * the {@link Dialog} component. Opens the dropdown whenever the 'open' function is
- * called, and closes it whenever the 'close' function is called OR the user clicks
- * outside of the dropdown parent wrapped,which includes the dropdown trigger (often
- * a button or input).
+ * Implements basic dialog behavior. Opens the dialog whenever the 'open' function is
+ * called, closes it whenever the 'close' function is called, and toggles it whenever
+ * the 'toggle' function is called.
  *
- * @param initialVisible - Whether the dropdown should be visible on mount.
- * @returns visible - Whether the dropdown is visible.
- * @returns close - A function to close the dropdown.
- * @returns open - A function to open the dropdown.
- * @returns toggle - A function to toggle the dropdown.
+ * @param initialVisible - Whether the dialog should be visible on mount.
+ * @param onVisibleChange - A function to call whenever the visibility of the dialog
+ * changes.
+ * @returns close - A function to close the dialog.
+ * @returns open - A function to open the dialog.
+ * @returns toggle - A function to toggle the dialog.
+ * @returns visible - Whether the dialog is visible.
  */
-export const use = (props?: UseProps): UseReturn => {
-  const { initialVisible = false, onVisibleChange } = props ?? {};
+export const use = ({
+  initialVisible = false,
+  onVisibleChange,
+}: UseProps = {}): UseReturn => {
   const [visible, setVisible] = useState(initialVisible);
-  useEffect(() => onVisibleChange?.(visible), [visible, onVisibleChange]);
-  const toggle = useCallback(
-    (vis?: boolean | unknown) =>
-      setVisible((v) => {
-        if (typeof vis === "boolean") return vis;
-        return !v;
-      }),
-    [setVisible, onVisibleChange],
-  );
-  const open = useCallback(() => toggle(true), [toggle]);
-  const close = useCallback(() => toggle(false), [toggle]);
-  return { visible, open, close, toggle };
+  const onVisibleChangeRef = useRef(onVisibleChange);
+  useEffect(() => {
+    onVisibleChangeRef.current = onVisibleChange;
+  }, [onVisibleChange]);
+  useEffect(() => onVisibleChangeRef.current?.(visible), [visible]);
+  const close = useCallback(() => setVisible(false), []);
+  const open = useCallback(() => setVisible(true), []);
+  const toggle = useCallback(() => setVisible((prevVisible) => !prevVisible), []);
+  return useMemo(() => ({ close, open, toggle, visible }), [visible]);
 };

--- a/pluto/src/dropdown/Dropdown.tsx
+++ b/pluto/src/dropdown/Dropdown.tsx
@@ -48,7 +48,6 @@ export type Variant = "connected" | "floating" | "modal";
 /** Props for the {@link Dialog} component. */
 export interface DialogProps
   extends Pick<CoreDialog.UseReturn, "visible" | "close">,
-    Partial<Omit<CoreDialog.UseReturn, "visible" | "ref" | "close">>,
     Omit<Align.PackProps, "ref" | "reverse" | "size" | "empty"> {
   location?: loc.Y | loc.XY;
   children: [ReactNode, ReactNode];
@@ -93,10 +92,6 @@ export const Dialog = ({
   variant = "connected",
   close,
   maxHeight,
-  // It's common to pass these in, so we'll destructure and ignore them so we don't
-  // get an invalid prop on div tag error.
-  open,
-  toggle,
   zIndex = 5,
   ...rest
 }: DialogProps): ReactElement => {

--- a/pluto/src/input/DateTime.tsx
+++ b/pluto/src/input/DateTime.tsx
@@ -80,10 +80,16 @@ export const DateTime = ({
   const tsValue = new TimeStamp(value, "UTC");
   const parsedValue = tsValue.fString("ISO", "local").slice(0, -1);
 
-  const dProps = Dropdown.use();
+  const { close, toggle, visible } = Dropdown.use();
 
   return (
-    <Dropdown.Dialog {...dProps} variant="modal" zIndex={500} keepMounted={false}>
+    <Dropdown.Dialog
+      close={close}
+      visible={visible}
+      variant="modal"
+      zIndex={500}
+      keepMounted={false}
+    >
       <InputText
         className={CSS.BE("input", "datetime")}
         variant={variant}
@@ -96,7 +102,7 @@ export const DateTime = ({
         {...rest}
       >
         <Button.Icon
-          onClick={dProps.toggle}
+          onClick={toggle}
           variant={variant === "natural" ? "text" : "outlined"}
         >
           <Icon.Calendar />
@@ -105,7 +111,7 @@ export const DateTime = ({
       <DateTimeModal
         value={tsValue}
         onChange={(next) => onChange(Number(next.valueOf()))}
-        close={dProps.close}
+        close={close}
       />
     </Dropdown.Dialog>
   );

--- a/pluto/src/select/Multiple.tsx
+++ b/pluto/src/select/Multiple.tsx
@@ -275,7 +275,6 @@ export const Multiple = <K extends Key = Key, E extends Keyed<K> = Keyed<K>>({
   return (
     <Core<K, E>
       close={close}
-      open={open}
       data={data}
       emptyContent={emptyContent}
       visible={visible}

--- a/pluto/src/select/Single.tsx
+++ b/pluto/src/select/Single.tsx
@@ -181,7 +181,6 @@ export const Single = <K extends Key = Key, E extends Keyed<K> = Keyed<K>>({
     <Core<K, E>
       close={close}
       zIndex={dropdownZIndex}
-      open={open}
       data={data}
       allowMultiple={false}
       visible={visible}


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1685](https://linear.app/synnax/issue/SY-1685/fix-palette-failing-to-switch-to-command-mode)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

- Minor performance improvements to increase memoization in the Pluto Dialog.use hook
- Fix Quick Search & Command Palette mode switching

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
