### PR TITLE
SY 2129 Fix BigInt Setpoints, Better Communicate Setpoint Errors, and Make Window Default Hidden

### DIFF
--- a/client/ts/src/framer/adapter.spec.ts
+++ b/client/ts/src/framer/adapter.spec.ts
@@ -148,12 +148,26 @@ describe("WriteFrameAdapter", () => {
     expect(res.get(jsonChannel.key).at(0)).toEqual({ dog: "blue" });
   });
 
-  it("should correctly adapt generic object keys", async () => {
-    const res = await adapter.adaptObjectKeys({
-      [timeCh.name]: 532,
-      [dataCh.name]: 123,
+  it("should correctly adapt a numeric value to a BigInt keyed by key", async () => {
+    const bigIntCh = await client.channels.create({
+      name: `bigint-${Math.random()}-${TimeStamp.now().toString()}`,
+      dataType: DataType.INT64,
+      virtual: true,
     });
-    expect(res).toHaveProperty(timeCh.key.toString());
-    expect(res).toHaveProperty(dataCh.key.toString());
+    const res = await adapter.adapt({
+      [bigIntCh.key]: 12,
+    });
+    expect(res.get(bigIntCh.key).at(0)).toEqual(12n);
+  });
+
+  describe("adaptObjectKeys", () => {
+    it("should correctly adapt generic object keys", async () => {
+      const res = await adapter.adaptObjectKeys({
+        [timeCh.name]: 532,
+        [dataCh.name]: 123,
+      });
+      expect(res).toHaveProperty(timeCh.key.toString());
+      expect(res).toHaveProperty(dataCh.key.toString());
+    });
   });
 });

--- a/console/src-tauri/tauri.conf.json
+++ b/console/src-tauri/tauri.conf.json
@@ -57,7 +57,7 @@
         "width": 1080,
         "minWidth": 625,
         "minHeight": 375,
-        "visible": true,
+        "visible": false,
         "acceptFirstMouse": true,
         "titleBarStyle": "Overlay",
         "hiddenTitle": true,

--- a/console/vite.config.ts
+++ b/console/vite.config.ts
@@ -40,7 +40,6 @@ export default defineConfig({
     esbuildOptions: {
       plugins: [importMetaUrlPlugin],
     },
-    include: ["vscode-textmate", "vscode-oniguruma"],
   },
   build: {
     target: process.env.TAURI_PLATFORM === "windows" ? "chrome105" : "safari16",

--- a/pluto/src/status/Aggregator.tsx
+++ b/pluto/src/status/Aggregator.tsx
@@ -63,26 +63,11 @@ export const Aggregator = ({ children, maxHistory = 500 }: AggregatorProps) => {
 
 export const useAdder = () => use(AdderContext);
 
-export interface ExceptionHandler extends status.ExceptionHandler {
-  (func: () => Promise<void>, message?: string): void;
-}
+export interface ExceptionHandler extends status.ExceptionHandler {}
 
 export const useExceptionHandler = (): ExceptionHandler => {
   const add = useAdder();
-  return useCallback(
-    (excOrFunc: unknown | (() => Promise<void>), message?: string): void => {
-      if (typeof excOrFunc !== "function")
-        return add(status.fromException(excOrFunc, message));
-      void (async () => {
-        try {
-          await excOrFunc();
-        } catch (exc) {
-          add(status.fromException(exc, message));
-        }
-      })();
-    },
-    [add],
-  );
+  return useMemo(() => status.createExceptionHandler(add), [add]);
 };
 
 export interface NotificationSpec extends status.Spec {

--- a/x/ts/src/telem/series.spec.ts
+++ b/x/ts/src/telem/series.spec.ts
@@ -146,6 +146,48 @@ describe("Series", () => {
       expect(a.dataType.toString()).toBe(DataType.JSON.toString());
     });
 
+    it("should convert a numeric value to a BigInt when data type is int64, timestamp, or uint64", () => {
+      const a = new Series({ data: 12, dataType: DataType.INT64 });
+      expect(a.dataType.toString()).toBe(DataType.INT64.toString());
+      expect(a.data).toEqual(new BigInt64Array([BigInt(12)]));
+      const b = new Series({ data: 12, dataType: DataType.TIMESTAMP });
+      expect(b.dataType.toString()).toBe(DataType.TIMESTAMP.toString());
+      expect(b.data).toEqual(new BigInt64Array([BigInt(12)]));
+      const c = new Series({ data: 12, dataType: DataType.UINT64 });
+      expect(c.dataType.toString()).toBe(DataType.UINT64.toString());
+      expect(c.data).toEqual(new BigUint64Array([BigInt(12)]));
+    });
+
+    it("should convert an array of numeric values to a BigInt when data type is int64, timestamp, or uint64", () => {
+      const a = new Series({ data: [12, 13, 14], dataType: DataType.INT64 });
+      expect(a.dataType.toString()).toBe(DataType.INT64.toString());
+      expect(a.data).toEqual(new BigInt64Array([BigInt(12), BigInt(13), BigInt(14)]));
+      const b = new Series({ data: [12, 13, 14], dataType: DataType.TIMESTAMP });
+      expect(b.dataType.toString()).toBe(DataType.TIMESTAMP.toString());
+      expect(b.data).toEqual(new BigInt64Array([BigInt(12), BigInt(13), BigInt(14)]));
+      const c = new Series({ data: [12, 13, 14], dataType: DataType.UINT64 });
+      expect(c.dataType.toString()).toBe(DataType.UINT64.toString());
+      expect(c.data).toEqual(new BigUint64Array([BigInt(12), BigInt(13), BigInt(14)]));
+    });
+
+    it("should convert bigints to numbers when data type does not use bigints", () => {
+      const a = new Series({ data: [12n, 13n, 14n], dataType: DataType.FLOAT32 });
+      expect(a.dataType.toString()).toBe(DataType.FLOAT32.toString());
+      expect(a.data).toEqual(new Float32Array([12, 13, 14]));
+    });
+
+    it("should correctly convert a mix of bigints and numbers", () => {
+      const a = new Series({ data: [12n, 13], dataType: DataType.FLOAT32 });
+      expect(a.dataType.toString()).toBe(DataType.FLOAT32.toString());
+      expect(a.data).toEqual(new Float32Array([12, 13]));
+    });
+
+    it("should convert a floating point numeric value to a BigInt when data type is int64, timestamp, or uint64", () => {
+      const a = new Series({ data: 12.5, dataType: DataType.INT64 });
+      expect(a.dataType.toString()).toBe(DataType.INT64.toString());
+      expect(a.data).toEqual(new BigInt64Array([BigInt(13)]));
+    });
+
     it("should convert encoded keys to snake_case", () => {
       const a = new Series({ data: [{ aB: 1, bC: "apple" }], dataType: DataType.JSON });
       const strContent = new TextDecoder().decode(a.data);

--- a/x/ts/src/telem/series.ts
+++ b/x/ts/src/telem/series.ts
@@ -262,7 +262,15 @@ export class Series<T extends TelemValue = TelemValue> {
         this._data = new TextEncoder().encode(
           `${data_.map((d) => binary.JSON_CODEC.encodeString(d)).join("\n")}\n`,
         ).buffer as ArrayBuffer;
-      } else this._data = new this.dataType.Array(data_ as number[] & bigint[]).buffer;
+      } else if (this.dataType.usesBigInt && typeof first === "number")
+        this._data = new this.dataType.Array(
+          data_.map((v) => BigInt(Math.round(v as number))),
+        ).buffer;
+      else if (!this.dataType.usesBigInt && typeof first === "bigint")
+        this._data = new this.dataType.Array(
+          data_.map((v) => Number(v)) as number[] & bigint[],
+        ).buffer;
+      else this._data = new this.dataType.Array(data_ as number[] & bigint[]).buffer;
     }
 
     this.key = key;


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2129](https://linear.app/synnax/issue/SY-2129)

## Description

Fixes a few important things:

- Fixes using setpoints with channels that require using bigints as their data.
- Modifies status aggregator to consolidate some code and add an async exception handler in aether.
- Makes the window default hidden to avoid blankscreening in tauri.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
