### PR TITLE
SY-2155 - Bound Schematic Control Authority Selector

### DIFF
--- a/client/ts/src/framer/writer.ts
+++ b/client/ts/src/framer/writer.ts
@@ -170,7 +170,7 @@ export class Writer {
     {
       channels,
       start = TimeStamp.now(),
-      authorities = control.Authority.Absolute,
+      authorities = control.Authority.ABSOLUTE,
       controlSubject: subject,
       mode = WriterMode.PersistStream,
       errOnUnauthorized = false,

--- a/console/src/schematic/toolbar/Control.tsx
+++ b/console/src/schematic/toolbar/Control.tsx
@@ -15,7 +15,7 @@ export const Control = ({ layoutKey }: { layoutKey: string }) => {
         <Input.Numeric
           value={authority}
           onChange={(v) => dispatch(setAuthority({ key: layoutKey, authority: v }))}
-          bounds={control.AUTHORITY_BOUNDS}
+          bounds={control.Authority.BOUNDS}
         />
       </Input.Item>
     </Align.Space>

--- a/console/src/schematic/toolbar/Control.tsx
+++ b/console/src/schematic/toolbar/Control.tsx
@@ -1,4 +1,5 @@
 import { Align, Input } from "@synnaxlabs/pluto";
+import { control } from "@synnaxlabs/x";
 import { useDispatch } from "react-redux";
 
 import { useSelectAuthority } from "@/schematic/selectors";
@@ -14,6 +15,7 @@ export const Control = ({ layoutKey }: { layoutKey: string }) => {
         <Input.Numeric
           value={authority}
           onChange={(v) => dispatch(setAuthority({ key: layoutKey, authority: v }))}
+          bounds={control.AUTHORITY_BOUNDS}
         />
       </Input.Item>
     </Align.Space>

--- a/pluto/src/telem/control/Chip.tsx
+++ b/pluto/src/telem/control/Chip.tsx
@@ -52,7 +52,7 @@ const tooltipMessage = (status: Status.Spec): ChipStyle => {
         chipColor: "var(--pluto-error-z)",
       };
     case "success":
-      if (status.data?.authority === clientControl.Authority.Absolute.valueOf())
+      if (status.data?.authority === clientControl.Authority.ABSOLUTE.valueOf())
         return {
           message: "You have absolute control. Click to release.",
           chipColor: "var(--pluto-secondary-z)",

--- a/pluto/src/telem/control/Chip.tsx
+++ b/pluto/src/telem/control/Chip.tsx
@@ -52,7 +52,7 @@ const tooltipMessage = (status: Status.Spec): ChipStyle => {
         chipColor: "var(--pluto-error-z)",
       };
     case "success":
-      if (status.data?.authority === clientControl.Authority.ABSOLUTE.valueOf())
+      if (status.data?.authority === clientControl.Authority.ABSOLUTE)
         return {
           message: "You have absolute control. Click to release.",
           chipColor: "var(--pluto-secondary-z)",

--- a/pluto/src/telem/control/aether/chip.ts
+++ b/pluto/src/telem/control/aether/chip.ts
@@ -44,7 +44,7 @@ export class Chip extends aether.Leaf<typeof chipStateZ, InternalState> {
 
     if (this.state.triggered && !this.prevState.triggered)
       await this.internal.sink.set(
-        this.state.status.data?.authority !== Authority.ABSOLUTE.valueOf(),
+        this.state.status.data?.authority !== Authority.ABSOLUTE,
       );
 
     await this.updateEnabledState();

--- a/pluto/src/telem/control/aether/chip.ts
+++ b/pluto/src/telem/control/aether/chip.ts
@@ -44,7 +44,7 @@ export class Chip extends aether.Leaf<typeof chipStateZ, InternalState> {
 
     if (this.state.triggered && !this.prevState.triggered)
       await this.internal.sink.set(
-        this.state.status.data?.authority !== Authority.Absolute.valueOf(),
+        this.state.status.data?.authority !== Authority.ABSOLUTE.valueOf(),
       );
 
     await this.updateEnabledState();

--- a/pluto/src/telem/control/aether/controller.ts
+++ b/pluto/src/telem/control/aether/controller.ts
@@ -290,7 +290,7 @@ export const setChannelValue = (props: SetChannelValueProps): telem.NumberSinkSp
 });
 
 export const acquireChannelControlPropsZ = z.object({
-  authority: z.number().default(control.Authority.ABSOLUTE.valueOf()),
+  authority: z.number().default(control.Authority.ABSOLUTE),
   channel: z.number(),
 });
 

--- a/pluto/src/telem/control/aether/controller.ts
+++ b/pluto/src/telem/control/aether/controller.ts
@@ -290,7 +290,7 @@ export const setChannelValue = (props: SetChannelValueProps): telem.NumberSinkSp
 });
 
 export const acquireChannelControlPropsZ = z.object({
-  authority: z.number().default(control.Authority.Absolute.valueOf()),
+  authority: z.number().default(control.Authority.ABSOLUTE.valueOf()),
   channel: z.number(),
 });
 

--- a/x/ts/src/control/control.ts
+++ b/x/ts/src/control/control.ts
@@ -15,6 +15,12 @@ export class Authority extends Number {
   static readonly ABSOLUTE = 255;
   static readonly MINIMUM = 0;
 
+  static readonly BOUNDS: bounds.Bounds<number> = {
+    lower: Authority.MINIMUM,
+    // upper bound is exclusive, so we add 1
+    upper: Authority.ABSOLUTE + 1,
+  };
+
   static readonly z = z.union([
     z.instanceof(Authority),
     z
@@ -26,12 +32,6 @@ export class Authority extends Number {
     z.instanceof(Number).transform((n) => new Authority(n)),
   ]);
 }
-
-export const AUTHORITY_BOUNDS: bounds.Bounds<number> = {
-  lower: Authority.MINIMUM,
-  // upper bound is exclusive, so we add 1
-  upper: Authority.ABSOLUTE + 1,
-};
 
 export const subjectZ = z.object({
   name: z.string(),

--- a/x/ts/src/control/control.ts
+++ b/x/ts/src/control/control.ts
@@ -9,9 +9,11 @@
 
 import { z } from "zod";
 
+import { type bounds } from "@/spatial";
+
 export class Authority extends Number {
-  static readonly Absolute = 255;
-  static readonly Default = 1;
+  static readonly ABSOLUTE = 255;
+  static readonly MINIMUM = 0;
 
   static readonly z = z.union([
     z.instanceof(Authority),
@@ -24,6 +26,12 @@ export class Authority extends Number {
     z.instanceof(Number).transform((n) => new Authority(n)),
   ]);
 }
+
+export const AUTHORITY_BOUNDS: bounds.Bounds<number> = {
+  lower: Authority.MINIMUM,
+  // upper bound is exclusive, so we add 1
+  upper: Authority.ABSOLUTE + 1,
+};
 
 export const subjectZ = z.object({
   name: z.string(),


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2155](https://linear.app/synnax/issue/SY-2155)

## Description

Bounds the schematic control authority selector from 0 to 255.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
