### PR TITLE
Fix LabJack T4 Ports

### DIFF
--- a/client/py/examples/dev/create_device.py
+++ b/client/py/examples/dev/create_device.py
@@ -13,7 +13,7 @@ import synnax as sy
 
 client = sy.Synnax()
 
-rack = client.hardware.racks.create(name="Rack 1")
+rack = client.hardware.racks.create(name="NI / LabJack Test Rack")
 
 client.hardware.devices.create(
     [
@@ -27,13 +27,31 @@ client.hardware.devices.create(
             identifier="dev1",
         ),
         sy.Device(
-            key="230227d9-02aa-47e4-b370-0d590add1bc1",
+            key="labjack-t4",
             rack=rack.key,
-            name="LJM dtT4",
+            name="LabJack T4",
             make="LabJack",
             model="LJM_dtT4",
             location="dev2",
             identifier="dev2",
+        ),
+        sy.Device(
+            key="labjack-t7",
+            rack=rack.key,
+            name="LabJack T7",
+            make="LabJack",
+            model="LJM_dtT7",
+            location="dev3",
+            identifier="dev3",
+        ),
+        sy.Device(
+            key="labjack-t8",
+            rack=rack.key,
+            name="LabJack T8",
+            make="LabJack",
+            model="LJM_dtT8",
+            location="dev4",
+            identifier="dev4",
         ),
         sy.Device(
             key="a0e37b26-5401-413e-8e65-c7ad9d9afd70",

--- a/console/src/hardware/labjack/device/SelectPort.tsx
+++ b/console/src/hardware/labjack/device/SelectPort.tsx
@@ -10,9 +10,9 @@
 import { type List, Select, Text } from "@synnaxlabs/pluto";
 
 import {
-  DEVICES,
   type Model,
   type Port,
+  PORTS,
   type PortType,
 } from "@/hardware/labjack/device/types";
 
@@ -46,7 +46,7 @@ export const SelectPort = ({ model, portType, ...rest }: SelectPortProps) => (
     allowNone={false}
     {...rest}
     columns={COLUMNS}
-    data={DEVICES[model].ports[portType]}
+    data={PORTS[model][portType]}
     entryRenderKey={getEntryRenderKey}
   />
 );

--- a/console/src/hardware/labjack/task/OutputChannelForms.tsx
+++ b/console/src/hardware/labjack/task/OutputChannelForms.tsx
@@ -156,7 +156,7 @@ const DEFAULT_CJC_SOURCE_ENTRIES: CJCSourceEntry[] = [
 ];
 
 const SelectCJCSourceField = ({ model, ...rest }: SelectCJCSourceFieldProps) => {
-  const ports: CJCSourceEntry[] = Device.DEVICES[model].ports[Device.AI_PORT_TYPE];
+  const ports: CJCSourceEntry[] = Device.PORTS[model][Device.AI_PORT_TYPE];
   const data = [...DEFAULT_CJC_SOURCE_ENTRIES, ...ports];
   return (
     <Select.Single<string, CJCSourceEntry>

--- a/console/src/hardware/labjack/task/Read.tsx
+++ b/console/src/hardware/labjack/task/Read.tsx
@@ -69,9 +69,7 @@ const getRenderedPort = (
   type: InputChannelType,
 ) => {
   const portType = convertChannelTypeToPortType(type);
-  const portInfo = Device.DEVICES[deviceModel].ports[portType].find(
-    ({ key }) => key === port,
-  );
+  const portInfo = Device.PORTS[deviceModel][portType].find(({ key }) => key === port);
   return portInfo == null ? port : (portInfo.alias ?? portInfo.key);
 };
 
@@ -135,14 +133,8 @@ const ChannelDetails = ({ path, deviceModel }: ChannelDetailsProps) => {
             const nextPortType = convertChannelTypeToPortType(value);
             let nextPort = nextParent.port;
             if (prevPortType !== nextPortType)
-              nextPort =
-                Device.DEVICES[deviceModel].ports[
-                  convertChannelTypeToPortType(value)
-                ][0].key;
-            set(parentPath, {
-              ...nextParent,
-              type: next.type,
-            });
+              nextPort = Device.PORTS[deviceModel][nextPortType][0].key;
+            set(parentPath, { ...nextParent, type: next.type });
             // Need to explicitly set port to cause select port field to rerender
             set(`${parentPath}.port`, nextPort);
           }}

--- a/console/src/hardware/labjack/task/Write.tsx
+++ b/console/src/hardware/labjack/task/Write.tsx
@@ -111,7 +111,7 @@ const ChannelListItem = ({
                   hideIfNull
                   onChange={(value) => {
                     if (type === value) return;
-                    const port = Device.DEVICES[device.model].ports[value][0].key;
+                    const port = Device.PORTS[device.model][value][0].key;
                     const existingCommandStatePair =
                       device.properties[value].channels[port] ??
                       Common.Device.ZERO_COMMAND_STATE_PAIR;

--- a/console/src/hardware/labjack/task/getOpenPort.spec.ts
+++ b/console/src/hardware/labjack/task/getOpenPort.spec.ts
@@ -31,13 +31,13 @@ describe("getOpenPort", () => {
     const port = getOpenPort(channels, model, [type]);
 
     // The expected port is the first port in the list for the given type.
-    const expectedPort = Device.DEVICES[model].ports[type][0];
+    const expectedPort = Device.PORTS[model][type][0];
     expect(port).toEqual(expectedPort);
   });
 
   it("skips ports that are already in use", () => {
     const type = Device.AI_PORT_TYPE;
-    const aiPorts = Device.DEVICES[model].ports[type];
+    const aiPorts = Device.PORTS[model][type];
     // Mark the first port as in use.
     const channels: Channel[] = [
       { ...ZERO_INPUT_CHANNELS[AI_CHANNEL_TYPE], port: aiPorts[0].key },
@@ -51,7 +51,7 @@ describe("getOpenPort", () => {
 
   it("returns null if all ports for the given type are in use", () => {
     const type = Device.AI_PORT_TYPE;
-    const aiPorts = Device.DEVICES[model].ports[type];
+    const aiPorts = Device.PORTS[model][type];
     // Mark every port for this type as in use.
     const channels: Channel[] = aiPorts.map(({ key }) => ({
       ...ZERO_INPUT_CHANNELS[AI_CHANNEL_TYPE],
@@ -66,7 +66,7 @@ describe("getOpenPort", () => {
     // Mark all DI ports as in use and leave AO ports free.
     const type1 = Device.DI_PORT_TYPE;
     const type2 = Device.AO_PORT_TYPE;
-    const diPorts = Device.DEVICES[model].ports[type1];
+    const diPorts = Device.PORTS[model][type1];
     const channels: Channel[] = diPorts.map(({ key }) => ({
       ...ZERO_INPUT_CHANNELS[DI_CHANNEL_TYPE],
       port: key,
@@ -74,15 +74,15 @@ describe("getOpenPort", () => {
 
     const port = getOpenPort(channels, model, [type1, type2]);
     // Since all DI ports are taken, we expect the first AO port.
-    const expectedPort = Device.DEVICES[model].ports[type2][0];
+    const expectedPort = Device.PORTS[model][type2][0];
     expect(port).toEqual(expectedPort);
   });
 
   it("returns null when multiple types are provided but all ports are in use", () => {
     const type1 = Device.AI_PORT_TYPE;
     const type2 = Device.AO_PORT_TYPE;
-    const aiPorts = Device.DEVICES[model].ports[type1];
-    const aoPorts = Device.DEVICES[model].ports[type2];
+    const aiPorts = Device.PORTS[model][type1];
+    const aoPorts = Device.PORTS[model][type2];
 
     // Mark all ports for both AI and AO as in use.
     const channels: Channel[] = [

--- a/console/src/hardware/labjack/task/getOpenPort.ts
+++ b/console/src/hardware/labjack/task/getOpenPort.ts
@@ -29,9 +29,7 @@ export const getOpenPort = <T extends Device.PortType>(
 ): Port<T> | null => {
   const portsInUse = new Set(channels.map(({ port }) => port));
   for (const type of types) {
-    const port = Device.DEVICES[model].ports[type].find(
-      ({ key }) => !portsInUse.has(key),
-    );
+    const port = Device.PORTS[model][type].find(({ key }) => !portsInUse.has(key));
     if (port != null) return port as Port<T>;
   }
   return null;


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2169](https://linear.app/synnax/issue/SY-2169/add-fio-ports-for-labjack-t4-analog-inputs)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Add in missing ports and port aliases for LabJack T4.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
