### PR TITLE
SY-2156 - Properly Handle Disabled Channels in Scale Transform

### DIFF
--- a/driver/transform/transform_test.cpp
+++ b/driver/transform/transform_test.cpp
@@ -17,8 +17,7 @@
 
 using namespace transform;
 
-/// Mock transform for testing
-class MockTransform : public Transform {
+class MockTransform final : public Transform {
 public:
     explicit MockTransform(bool should_fail = false) : should_fail_(should_fail) {
     }
@@ -37,7 +36,7 @@ private:
     bool should_fail_;
 };
 
-/// @brief it should correctly execute a chaint transform.
+/// @brief it should correctly execute a chain transform.
 TEST(TransformTests, ChainTransform) {
     Chain chain;
     const auto mock1 = std::make_shared<MockTransform>();
@@ -58,7 +57,8 @@ TEST(TransformTests, ChainTransformFailure) {
     Chain chain;
     const auto mock1 = std::make_shared<MockTransform>();
     const auto mock2 = std::make_shared<MockTransform>(true); // This one will fail
-    const auto mock3 = std::make_shared<MockTransform>(); // This one shouldn't be called
+    const auto mock3 = std::make_shared<MockTransform>();
+    // This one shouldn't be called
 
     chain.add(mock1);
     chain.add(mock2);
@@ -170,11 +170,11 @@ TEST_F(TareTests, InvalidChannelKey) {
     ASSERT_NIL(tare.transform(frame));
 
     json tare_args = {{"keys", {999}}};
-    auto err = tare.tare(tare_args);
+    const auto err = tare.tare(tare_args);
     ASSERT_TRUE(err);
 }
 
-/// @brief it should correclty apply a linear scale to a channel
+/// @brief it should correctly apply a linear scale to a channel
 TEST(ScaleTests, LinearScale) {
     json config = {
         {
@@ -203,23 +203,20 @@ TEST(ScaleTests, LinearScale) {
     xjson::Parser parser(config);
     Scale scale(parser, channels);
 
-    // Create a frame with test data
     Frame frame(1);
     auto series = telem::Series(telem::FLOAT64_T, 2);
     series.write(10.0);
     series.write(20.0);
     frame.emplace(1, std::move(series));
 
-    // Apply the scale transform
     ASSERT_NIL(scale.transform(frame));
 
-    // Check the scaled values: value * slope + offset
     ASSERT_EQ(frame.at<double>(1, 0), 25.0); // 10 * 2 + 5
     ASSERT_EQ(frame.at<double>(1, 1), 45.0); // 20 * 2 + 5
 }
 
+/// @brief it should properly apply a map scale to a channel.
 TEST(ScaleTests, MapScale) {
-    // Create a scale config with map scaling
     json config = {
         {
             "channels", {
@@ -239,7 +236,6 @@ TEST(ScaleTests, MapScale) {
         }
     };
 
-    // Create channel map
     std::unordered_map<synnax::ChannelKey, synnax::Channel> channels;
     synnax::Channel ch1;
     ch1.key = 1;
@@ -249,7 +245,6 @@ TEST(ScaleTests, MapScale) {
     xjson::Parser parser(config);
     Scale scale(parser, channels);
 
-    // Create a frame with test data
     Frame frame(1);
     auto series = telem::Series(telem::FLOAT64_T, 3);
     series.write(0.0);
@@ -257,17 +252,15 @@ TEST(ScaleTests, MapScale) {
     series.write(100.0);
     frame.emplace(1, std::move(series));
 
-    // Apply the scale transform
     ASSERT_NIL(scale.transform(frame));
 
-    // Check the scaled values: (value - pre_min) / (pre_max - pre_min) * (scaled_max - scaled_min) + scaled_min
     ASSERT_NEAR(frame.at<double>(1, 0), 0.0, 0.001);
     ASSERT_NEAR(frame.at<double>(1, 1), 0.5, 0.001);
     ASSERT_NEAR(frame.at<double>(1, 2), 1.0, 0.001);
 }
 
+/// @brief it should correctly apply a scale to multiple channels.
 TEST(ScaleTests, MultipleChannels) {
-    // Create a scale config with multiple channels
     json config = {
         {
             "channels", {
@@ -297,13 +290,12 @@ TEST(ScaleTests, MultipleChannels) {
         }
     };
 
-    // Create channel map
     std::unordered_map<synnax::ChannelKey, synnax::Channel> channels;
     synnax::Channel ch1;
     ch1.key = 1;
     ch1.data_type = telem::FLOAT64_T;
     channels[1] = ch1;
-    
+
     synnax::Channel ch2;
     ch2.key = 2;
     ch2.data_type = telem::FLOAT64_T;
@@ -312,27 +304,20 @@ TEST(ScaleTests, MultipleChannels) {
     xjson::Parser parser(config);
     Scale scale(parser, channels);
 
-    // Create a frame with test data
     Frame frame(2);
-
     auto series1 = telem::Series(telem::FLOAT64_T, 1);
     series1.write(5.0);
     frame.emplace(1, std::move(series1));
-
     auto series2 = telem::Series(telem::FLOAT64_T, 1);
     series2.write(5.0);
     frame.emplace(2, std::move(series2));
-
-    // Apply the scale transform
     ASSERT_NIL(scale.transform(frame));
-
-    // Check the scaled values
     ASSERT_EQ(frame.at<double>(1, 0), 10.0); // Linear: 5 * 2 + 0
     ASSERT_EQ(frame.at<double>(2, 0), 50.0); // Map: (5 - 0) / (10 - 0) * (100 - 0) + 0
 }
 
+/// @brief it should correctly ignore channels that are not configured for scaling.
 TEST(ScaleTests, IgnoreUnknownChannels) {
-    // Create a scale config
     json config = {
         {
             "channels", {
@@ -350,7 +335,6 @@ TEST(ScaleTests, IgnoreUnknownChannels) {
         }
     };
 
-    // Create channel map
     std::unordered_map<synnax::ChannelKey, synnax::Channel> channels;
     synnax::Channel ch1;
     ch1.key = 1;
@@ -360,7 +344,6 @@ TEST(ScaleTests, IgnoreUnknownChannels) {
     xjson::Parser parser(config);
     Scale scale(parser, channels);
 
-    // Create a frame with test data including an unconfigured channel
     Frame frame(2);
 
     auto series1 = telem::Series(telem::FLOAT64_T, 1);
@@ -371,225 +354,14 @@ TEST(ScaleTests, IgnoreUnknownChannels) {
     series2.write(5.0);
     frame.emplace(2, std::move(series2));
 
-    // Apply the scale transform
     ASSERT_NIL(scale.transform(frame));
 
-    // Check that only configured channel is scaled
     ASSERT_EQ(frame.at<double>(1, 0), 10.0); // Scaled: 5 * 2 + 0
     ASSERT_EQ(frame.at<double>(2, 0), 5.0); // Unchanged
 }
 
-TEST(ScaleTests, TransformInplaceUsage) {
-    // Test that the transform_inplace method is correctly used in Scale
-
-    // Create a simple linear scale config
-    json config = {
-        {
-            "channels", {
-                {
-                    {"channel", 1},
-                    {
-                        "scale", {
-                            {"type", "linear"},
-                            {"slope", 3.0},
-                            {"offset", 2.0}
-                        }
-                    }
-                }
-            }
-        }
-    };
-
-    // Create channel map
-    std::unordered_map<synnax::ChannelKey, synnax::Channel> channels;
-    synnax::Channel ch1;
-    ch1.key = 1;
-    ch1.data_type = telem::FLOAT64_T;
-    channels[1] = ch1;
-
-    xjson::Parser parser(config);
-    Scale scale(parser, channels);
-
-    // Create a frame with various numeric types
-    Frame frame(3);
-
-    // Float64 series
-    auto series1 = telem::Series(telem::FLOAT64_T, 2);
-    series1.write(1.0);
-    series1.write(2.0);
-    frame.emplace(1, std::move(series1));
-
-    // Int32 series (not configured for scaling)
-    auto series2 = telem::Series(telem::INT32_T, 2);
-    series2.write(10);
-    series2.write(20);
-    frame.emplace(2, std::move(series2));
-
-    // Float32 series (not configured for scaling)
-    auto series3 = telem::Series(telem::FLOAT32_T, 2);
-    series3.write(1.5f);
-    series3.write(2.5f);
-    frame.emplace(3, std::move(series3));
-
-    // Apply the scale transform
-    ASSERT_NIL(scale.transform(frame));
-
-    // Check that the float64 series was scaled correctly
-    ASSERT_EQ(frame.at<double>(1, 0), 5.0); // 1.0 * 3.0 + 2.0
-    ASSERT_EQ(frame.at<double>(1, 1), 8.0); // 2.0 * 3.0 + 2.0
-
-    // Check that the other series were not modified
-    ASSERT_EQ(frame.at<int32_t>(2, 0), 10);
-    ASSERT_EQ(frame.at<int32_t>(2, 1), 20);
-    ASSERT_EQ(frame.at<float>(3, 0), 1.5f);
-    ASSERT_EQ(frame.at<float>(3, 1), 2.5f);
-}
-
-TEST_F(TareTests, TareWithDifferentDataTypes) {
-    // Create test channels with different data types
-    std::vector<synnax::Channel> channels;
-    
-    synnax::Channel ch1;
-    ch1.key = 1;
-    ch1.name = "int32";
-    ch1.data_type = telem::INT32_T;
-    
-    synnax::Channel ch2;
-    ch2.key = 2;
-    ch2.name = "float32";
-    ch2.data_type = telem::FLOAT32_T;
-    
-    synnax::Channel ch3;
-    ch3.key = 3;
-    ch3.name = "float64";
-    ch3.data_type = telem::FLOAT64_T;
-    
-    channels = {ch1, ch2, ch3};
-
-    Tare tare(channels);
-
-    // Create frame with sample data of different types
-    Frame frame(3);
-
-    auto series1 = telem::Series(telem::INT32_T, 2);
-    series1.write(100);
-    series1.write(200);
-    frame.emplace(1, std::move(series1));
-
-    auto series2 = telem::Series(telem::FLOAT32_T, 2);
-    series2.write(10.5f);
-    series2.write(20.5f);
-    frame.emplace(2, std::move(series2));
-
-    auto series3 = telem::Series(telem::FLOAT64_T, 2);
-    series3.write(1000.25);
-    series3.write(2000.25);
-    frame.emplace(3, std::move(series3));
-
-    // First transform should store the last values
-    ASSERT_NIL(tare.transform(frame));
-
-    // Tare all channels
-    json tare_args = json::object();
-    ASSERT_NIL(tare.tare(tare_args));
-
-    // Create new frame with more data
-    Frame new_frame(3);
-
-    auto new_series1 = telem::Series(telem::INT32_T, 2);
-    new_series1.write(300);
-    new_series1.write(400);
-    new_frame.emplace(1, std::move(new_series1));
-
-    auto new_series2 = telem::Series(telem::FLOAT32_T, 2);
-    new_series2.write(30.5f);
-    new_series2.write(40.5f);
-    new_frame.emplace(2, std::move(new_series2));
-
-    auto new_series3 = telem::Series(telem::FLOAT64_T, 2);
-    new_series3.write(3000.25);
-    new_series3.write(4000.25);
-    new_frame.emplace(3, std::move(new_series3));
-
-    // Transform should subtract the tare values
-    ASSERT_NIL(tare.transform(new_frame));
-
-    // Check that values are tared correctly for each data type
-    ASSERT_EQ(new_frame.at<int32_t>(1, 0), 100); // 300 - 200
-    ASSERT_EQ(new_frame.at<int32_t>(1, 1), 200); // 400 - 200
-    ASSERT_EQ(new_frame.at<float>(2, 0), 10.0f); // 30.5 - 20.5
-    ASSERT_EQ(new_frame.at<float>(2, 1), 20.0f); // 40.5 - 20.5
-    ASSERT_EQ(new_frame.at<double>(3, 0), 1000.0); // 3000.25 - 2000.25
-    ASSERT_EQ(new_frame.at<double>(3, 1), 2000.0); // 4000.25 - 2000.25
-}
-
-TEST(ChainTests, ComplexTransformChain) {
-    // Test a chain of multiple transforms working together
-
-    std::vector<synnax::Channel> channels;
-    
-    synnax::Channel ch1;
-    ch1.key = 1;
-    ch1.name = "test";
-    ch1.data_type = telem::FLOAT64_T;
-    
-    channels = {ch1};
-
-    auto tare = std::make_shared<Tare>(channels);
-
-    json config = {
-        {
-            "channels", {
-                {
-                    {"channel", 1},
-                    {
-                        "scale", {
-                            {"type", "linear"},
-                            {"slope", 2.0},
-                            {"offset", 10.0}
-                        }
-                    }
-                }
-            }
-        }
-    };
-    
-    std::unordered_map<synnax::ChannelKey, synnax::Channel> channel_map;
-    channel_map[1] = ch1;
-    
-    xjson::Parser parser(config);
-    auto scale = std::make_shared<Scale>(parser, channel_map);
-
-    Chain chain;
-    chain.add(tare);
-    chain.add(scale);
-
-    Frame frame(1);
-    auto series = telem::Series(telem::FLOAT64_T, 1);
-    series.write(50.0);
-    frame.emplace(1, std::move(series));
-
-    ASSERT_NIL(chain.transform(frame));
-
-    json tare_args = json::object();
-    ASSERT_NIL(tare->tare(tare_args));
-
-    // Create second frame
-    Frame frame2(1);
-    auto series2 = telem::Series(telem::FLOAT64_T, 1);
-    series2.write(70.0);
-    frame2.emplace(1, std::move(series2));
-
-    // Second pass through the chain
-    // First tare will subtract 50, then scale will multiply by 2 and add 10
-    ASSERT_NIL(chain.transform(frame2));
-
-    // Check the result: (70 - 50) * 2 + 10 = 50
-    ASSERT_EQ(frame2.at<double>(1, 0), 50.0);
-}
-
+/// @brief it should correctly ignore disabled channels.
 TEST(ScaleTests, DisabledChannel) {
-    // Create a scale config with one enabled and one disabled channel
     json config = {
         {
             "channels", {
@@ -620,12 +392,12 @@ TEST(ScaleTests, DisabledChannel) {
     };
 
     std::unordered_map<synnax::ChannelKey, synnax::Channel> channels;
-    
+
     synnax::Channel ch1;
     ch1.key = 1;
     ch1.data_type = telem::FLOAT64_T;
     channels[1] = ch1;
-    
+
     xjson::Parser parser(config);
     Scale scale(parser, channels);
 
@@ -643,4 +415,195 @@ TEST(ScaleTests, DisabledChannel) {
 
     ASSERT_EQ(frame.at<double>(1, 0), 25.0); // Enabled: 10 * 2 + 5
     ASSERT_EQ(frame.at<double>(2, 0), 10.0); // Disabled: unchanged
+}
+
+/// @brief it should apply transformations directly to the frame.
+TEST(ScaleTests, TransformInplaceUsage) {
+    json config = {
+        {
+            "channels", {
+                {
+                    {"channel", 1},
+                    {
+                        "scale", {
+                            {"type", "linear"},
+                            {"slope", 3.0},
+                            {"offset", 2.0}
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+    std::unordered_map<synnax::ChannelKey, synnax::Channel> channels;
+    synnax::Channel ch1;
+    ch1.key = 1;
+    ch1.data_type = telem::FLOAT64_T;
+    channels[1] = ch1;
+
+    xjson::Parser parser(config);
+    Scale scale(parser, channels);
+
+    Frame frame(3);
+
+    auto series1 = telem::Series(telem::FLOAT64_T, 2);
+    series1.write(1.0);
+    series1.write(2.0);
+    frame.emplace(1, std::move(series1));
+
+    auto series2 = telem::Series(telem::INT32_T, 2);
+    series2.write(10);
+    series2.write(20);
+    frame.emplace(2, std::move(series2));
+
+    auto series3 = telem::Series(telem::FLOAT32_T, 2);
+    series3.write(1.5f);
+    series3.write(2.5f);
+    frame.emplace(3, std::move(series3));
+
+    ASSERT_NIL(scale.transform(frame));
+    ASSERT_EQ(frame.at<double>(1, 0), 5.0); // 1.0 * 3.0 + 2.0
+    ASSERT_EQ(frame.at<double>(1, 1), 8.0); // 2.0 * 3.0 + 2.0
+
+    ASSERT_EQ(frame.at<int32_t>(2, 0), 10);
+    ASSERT_EQ(frame.at<int32_t>(2, 1), 20);
+    ASSERT_EQ(frame.at<float>(3, 0), 1.5f);
+    ASSERT_EQ(frame.at<float>(3, 1), 2.5f);
+}
+
+// @brief it should correctly tare channels with different data types.
+TEST_F(TareTests, TareWithDifferentDataTypes) {
+    std::vector<synnax::Channel> channels;
+
+    synnax::Channel ch1;
+    ch1.key = 1;
+    ch1.name = "int32";
+    ch1.data_type = telem::INT32_T;
+
+    synnax::Channel ch2;
+    ch2.key = 2;
+    ch2.name = "float32";
+    ch2.data_type = telem::FLOAT32_T;
+
+    synnax::Channel ch3;
+    ch3.key = 3;
+    ch3.name = "float64";
+    ch3.data_type = telem::FLOAT64_T;
+
+    channels = {ch1, ch2, ch3};
+
+    Tare tare(channels);
+
+    Frame frame(3);
+
+    auto series1 = telem::Series(telem::INT32_T, 2);
+    series1.write(100);
+    series1.write(200);
+    frame.emplace(1, std::move(series1));
+
+    auto series2 = telem::Series(telem::FLOAT32_T, 2);
+    series2.write(10.5f);
+    series2.write(20.5f);
+    frame.emplace(2, std::move(series2));
+
+    auto series3 = telem::Series(telem::FLOAT64_T, 2);
+    series3.write(1000.25);
+    series3.write(2000.25);
+    frame.emplace(3, std::move(series3));
+
+    ASSERT_NIL(tare.transform(frame));
+
+    json tare_args = json::object();
+    ASSERT_NIL(tare.tare(tare_args));
+
+    Frame new_frame(3);
+
+    auto new_series1 = telem::Series(telem::INT32_T, 2);
+    new_series1.write(300);
+    new_series1.write(400);
+    new_frame.emplace(1, std::move(new_series1));
+
+    auto new_series2 = telem::Series(telem::FLOAT32_T, 2);
+    new_series2.write(30.5f);
+    new_series2.write(40.5f);
+    new_frame.emplace(2, std::move(new_series2));
+
+    auto new_series3 = telem::Series(telem::FLOAT64_T, 2);
+    new_series3.write(3000.25);
+    new_series3.write(4000.25);
+    new_frame.emplace(3, std::move(new_series3));
+
+    ASSERT_NIL(tare.transform(new_frame));
+
+    ASSERT_EQ(new_frame.at<int32_t>(1, 0), 100); // 300 - 200
+    ASSERT_EQ(new_frame.at<int32_t>(1, 1), 200); // 400 - 200
+    ASSERT_EQ(new_frame.at<float>(2, 0), 10.0f); // 30.5 - 20.5
+    ASSERT_EQ(new_frame.at<float>(2, 1), 20.0f); // 40.5 - 20.5
+    ASSERT_EQ(new_frame.at<double>(3, 0), 1000.0); // 3000.25 - 2000.25
+    ASSERT_EQ(new_frame.at<double>(3, 1), 2000.0); // 4000.25 - 2000.25
+}
+
+/// @brief it should correctly execute a chain with a tare and scale transform.
+TEST(ChainTests, ComplexTransformChain) {
+    std::vector<synnax::Channel> channels;
+
+    synnax::Channel ch1;
+    ch1.key = 1;
+    ch1.name = "test";
+    ch1.data_type = telem::FLOAT64_T;
+
+    channels = {ch1};
+
+    auto tare = std::make_shared<Tare>(channels);
+
+    json config = {
+        {
+            "channels", {
+                {
+                    {"channel", 1},
+                    {
+                        "scale", {
+                            {"type", "linear"},
+                            {"slope", 2.0},
+                            {"offset", 10.0}
+                        }
+                    }
+                }
+            }
+        }
+    };
+
+    std::unordered_map<synnax::ChannelKey, synnax::Channel> channel_map;
+    channel_map[1] = ch1;
+
+    xjson::Parser parser(config);
+    auto scale = std::make_shared<Scale>(parser, channel_map);
+
+    Chain chain;
+    chain.add(tare);
+    chain.add(scale);
+
+    Frame frame(1);
+    auto series = telem::Series(telem::FLOAT64_T, 1);
+    series.write(50.0);
+    frame.emplace(1, std::move(series));
+
+    ASSERT_NIL(chain.transform(frame));
+
+    json tare_args = json::object();
+    ASSERT_NIL(tare->tare(tare_args));
+
+    // Create second frame
+    Frame frame2(1);
+    auto series2 = telem::Series(telem::FLOAT64_T, 1);
+    series2.write(70.0);
+    frame2.emplace(1, std::move(series2));
+
+    // Second pass through the chain
+    // First tare will subtract 50, then scale will multiply by 2 and add 10
+    ASSERT_NIL(chain.transform(frame2));
+
+    // Check the result: (70 - 50) * 2 + 10 = 50
+    ASSERT_EQ(frame2.at<double>(1, 0), 50.0);
 }


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2156](https://linear.app/synnax/issue/SY-2156)

## Description

Properly handle disabled channels in scale transform.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
