### PR TITLE
SY-2179 - Fix Shutdown Panic: Missing Cancel Error

### DIFF
--- a/freighter/go/fmock/unary.go
+++ b/freighter/go/fmock/unary.go
@@ -55,6 +55,7 @@ func (u *UnaryServer[RQ, RS]) exec(ctx freighter.Context, req RQ) (res RS, oMD f
 		freighter.FinalizerFunc(func(ctx freighter.Context) (oCtx freighter.Context, err error) {
 			res, err = u.Handler(ctx, req)
 			return freighter.Context{
+				Context:  ctx,
 				Target:   u.Address,
 				Protocol: u.Protocol,
 				Params:   make(freighter.Params),

--- a/synnax/pkg/service/hardware/embedded/enabled.go
+++ b/synnax/pkg/service/hardware/embedded/enabled.go
@@ -56,7 +56,7 @@ func (d *Driver) start() error {
 	}
 	d.cfg.L.Info("starting embedded driver")
 	sCtx, cancel := signal.Isolated(signal.WithInstrumentation(d.cfg.Instrumentation))
-	d.shutdown = signal.NewHardShutdown(sCtx, cancel)
+	d.shutdown = signal.NewGracefulShutdown(sCtx, cancel)
 	bre, err := breaker.NewBreaker(sCtx, breaker.Config{
 		BaseInterval: 1 * time.Second,
 		Scale:        1.1,


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2179](https://linear.app/synnax/issue/SY-2179)

## Description

There are some strange implementation details related to fiber websockets. The fiber request context provided is only valid for the lifetime of the http request before we upgrade it to a websocket. We were mistakenly using the context past it's available lifetime. This fix makes it so that we use the underlying server context that is valid throughout the lifetime of the socket. Also makes changes to prevent these sorts of lifecycle mistakes in the future.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
