### PR TITLE
SY-2180 - Fix NI Scan Task Ignore

### DIFF
--- a/driver/ni/BUILD.bazel
+++ b/driver/ni/BUILD.bazel
@@ -35,6 +35,7 @@ cc_test(
     name = "ni_test",
     srcs = [
         "read_task_test.cpp",
+        "scan_task_test.cpp",
         "write_task_test.cpp",
     ],
     copts = select({

--- a/driver/ni/scan_task.cpp
+++ b/driver/ni/scan_task.cpp
@@ -82,11 +82,10 @@ std::pair<ni::Device, xerrors::Error> ni::Scanner::parse_device(
             1, dev.resource_name.size() - 2);
     if (is_simulated) dev.key = dev.resource_name;
 
-    for (const auto &pattern: this->cfg.ignored_models)
-        if (std::regex_match(dev.model, pattern))
-            return {dev, xerrors::NIL};
-
-    return {dev, xerrors::NIL};
+    auto err = xerrors::NIL;
+    if (this->cfg.should_ignore(dev.model))
+        err = SKIP_DEVICE_ERR;
+    return {dev, err};
 }
 
 std::pair<std::vector<synnax::Device>, xerrors::Error> ni::Scanner::scan(
@@ -108,9 +107,7 @@ std::pair<std::vector<synnax::Device>, xerrors::Error> ni::Scanner::scan(
             this->session,
             resources,
             &curr_resource
-        )) {
-            break;
-        }
+        )) break;
         auto [dev, parse_err] = this->parse_device(curr_resource);
         err = parse_err;
         if (err) continue;

--- a/driver/ni/scan_task.h
+++ b/driver/ni/scan_task.h
@@ -102,6 +102,13 @@ struct ScanTaskConfig {
         );
         for (const auto &pattern: i) ignored_models.emplace_back(pattern);
     }
+
+    /// @brief returns if the device with the given model should be ignored.
+    bool should_ignore(const std::string &model) const {
+        for (const auto &pattern: this->ignored_models)
+            if (std::regex_match(model, pattern)) return true;
+        return false;
+    }
 };
 
 /// @brief a task that scans for NI devices.

--- a/driver/ni/scan_task_test.cpp
+++ b/driver/ni/scan_task_test.cpp
@@ -1,0 +1,76 @@
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+/// external
+#include "gtest/gtest.h"
+
+/// module
+#include "x/cpp/xjson/xjson.h"
+
+/// internal
+#include "driver/ni/scan_task.h"
+
+TEST(ScanTaskTest, testConfigParse) {
+    // Test default configuration
+    json j = {
+        {"enabled", true}
+    };
+    auto p = xjson::Parser(j);
+    ni::ScanTaskConfig cfg(p);
+    
+    EXPECT_TRUE(cfg.enabled);
+    EXPECT_EQ(cfg.rate.hz(), ni::DEFAULT_SCAN_RATE.hz());
+    EXPECT_EQ(cfg.ignored_models.size(), ni::DEFAULT_IGNORED_MODELS.size());
+    
+    // Test custom configuration
+    json j2 = {
+        {"enabled", false},
+        {"rate", 10.0},
+        {"ignored_models", json::array({"^Test.*", "^Mock.*"})}
+    };
+    auto p2 = xjson::Parser(j2);
+    ni::ScanTaskConfig cfg2(p2);
+    
+    EXPECT_FALSE(cfg2.enabled);
+    EXPECT_EQ(cfg2.rate.hz(), 10.0);
+    EXPECT_EQ(cfg2.ignored_models.size(), 2);
+}
+
+TEST(ScanTaskTest, testConfigShouldIgnore) {
+    json j = {
+        {"ignored_models", json::array({"^Test.*", "^Mock.*", "PXI-.*"})}
+    };
+    auto p = xjson::Parser(j);
+    ni::ScanTaskConfig cfg(p);
+    
+    // Should ignore models matching the patterns
+    EXPECT_TRUE(cfg.should_ignore("TestDevice"));
+    EXPECT_TRUE(cfg.should_ignore("MockDevice123"));
+    EXPECT_TRUE(cfg.should_ignore("PXI-6255"));
+    
+    // Should not ignore models not matching the patterns
+    EXPECT_FALSE(cfg.should_ignore("NI-DAQ"));
+    EXPECT_FALSE(cfg.should_ignore("Regular-Device"));
+    EXPECT_FALSE(cfg.should_ignore("cDAQ-9178"));
+    
+    // Test with default configuration
+    json j2 = {};
+    auto p2 = xjson::Parser(j2);
+    ni::ScanTaskConfig cfg2(p2);
+    
+    // Should ignore models matching default patterns
+    EXPECT_TRUE(cfg2.should_ignore("O-PXI-123"));
+    EXPECT_TRUE(cfg2.should_ignore("cRIO-9068"));
+    EXPECT_TRUE(cfg2.should_ignore("nownDevice"));
+    
+    // Should not ignore models not matching default patterns
+    EXPECT_FALSE(cfg2.should_ignore("PXI-6255"));
+    EXPECT_FALSE(cfg2.should_ignore("NI-DAQ"));
+}
+


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2180](https://linear.app/synnax/issue/SY-2180)

## Description

Fixes an issue where the NI scan task fails to ignore devices that should be ignored. Also adds regression tests.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
