### PR TITLE
SY-2183 - Fix Channel Null Pointers  When Configuring Read Tasks

### DIFF
--- a/console/src/hardware/ni/task/types/v0.ts
+++ b/console/src/hardware/ni/task/types/v0.ts
@@ -22,7 +22,10 @@ interface AnalogChannelExtension
   extends z.infer<z.ZodObject<typeof analogChannelExtensionShape>> {}
 const ZERO_ANALOG_CHANNEL_EXTENSION: AnalogChannelExtension = { port: 0 };
 
-const digitalChannelExtensionShape = { port: portZ, line: lineZ };
+const digitalChannelExtensionShape = {
+  port: portZ,
+  line: lineZ,
+};
 interface DigitalChannelExtension
   extends z.infer<z.ZodObject<typeof digitalChannelExtensionShape>> {}
 const ZERO_DIGITAL_CHANNEL_EXTENSION: DigitalChannelExtension = { port: 0, line: 0 };
@@ -1022,18 +1025,31 @@ export const ZERO_AO_CHANNELS: Record<AOChannelType, AOChannel> = {
 };
 export const ZERO_AO_CHANNEL = ZERO_AO_CHANNELS[AO_VOLTAGE_CHAN_TYPE];
 
-const diChannelZ = Common.Task.readChannelZ.extend(digitalChannelExtensionShape);
+const DIGITAL_INPUT_TYPE = "digital_input";
+const DIGITAL_OUTPUT_TYPE = "digital_output";
+
+const diChannelZ = Common.Task.readChannelZ
+  .extend(digitalChannelExtensionShape)
+  .extend({
+    type: z.literal(DIGITAL_INPUT_TYPE),
+  });
 export interface DIChannel extends z.infer<typeof diChannelZ> {}
 export const ZERO_DI_CHANNEL: DIChannel = {
   ...Common.Task.ZERO_READ_CHANNEL,
   ...ZERO_DIGITAL_CHANNEL_EXTENSION,
+  type: DIGITAL_INPUT_TYPE,
 };
 
-const doChannelZ = Common.Task.writeChannelZ.extend(digitalChannelExtensionShape);
+const doChannelZ = Common.Task.writeChannelZ
+  .extend(digitalChannelExtensionShape)
+  .extend({
+    type: z.literal(DIGITAL_OUTPUT_TYPE),
+  });
 export interface DOChannel extends z.infer<typeof doChannelZ> {}
 export const ZERO_DO_CHANNEL: DOChannel = {
   ...Common.Task.ZERO_WRITE_CHANNEL,
   ...ZERO_DIGITAL_CHANNEL_EXTENSION,
+  type: DIGITAL_OUTPUT_TYPE,
 };
 
 export type DigitalChannel = DIChannel | DOChannel;

--- a/driver/labjack/read_task_test.cpp
+++ b/driver/labjack/read_task_test.cpp
@@ -106,6 +106,27 @@ TEST(TestInputChannelParse, testTCChan) {
     ASSERT_EQ(tc_chan->cjc_offset, 0);
 }
 
+TEST(TestInputChannelParse, testInvalidChannelType) {
+    const json cfg{
+        {"port", "AIN0"},
+        {"enabled", true},
+        {"key", "8hYJO9zt6eS"},
+        {"channel", 1},
+        {"type", "INVALID_TYPE"}, // Invalid channel type
+        {"range", 5},
+        {
+            "scale", {
+                {"type", "linear"},
+                {"slope", 1},
+                {"offset", 2}
+            }
+        }
+    };
+    auto p = xjson::Parser(cfg);
+    const auto chan = labjack::parse_input_chan(p);
+    ASSERT_OCCURRED_AS(p.error(), xerrors::VALIDATION);
+}
+
 json basic_read_task_config() {
     return {
         {"device", "230227d9-02aa-47e4-b370-0d590add1bc1"},
@@ -220,4 +241,41 @@ TEST(TestReadTaskConfigParse, testBasicReadTaskConfigParse) {
     ASSERT_EQ(ai_chan->enabled, true);
     ASSERT_EQ(ai_chan->synnax_key, ai_ch.key);
     ASSERT_EQ(ai_chan->range, 0);
+}
+
+TEST(TestReadTaskConfigParse, testInvalidChannelTypeInConfig) {
+    auto sy = std::make_shared<synnax::Synnax>(new_test_client());
+    auto rack = ASSERT_NIL_P(sy->hardware.create_rack("cat"));
+    auto dev = synnax::Device(
+        "230227d9-02aa-47e4-b370-0d590add1bc1",
+        "my_device",
+        rack.key,
+        "dev1",
+        "dev1",
+        "labjack",
+        "T7",
+        ""
+    );
+    ASSERT_NIL(sy->hardware.create_device(dev));
+
+    // Create a channel
+    auto ch = ASSERT_NIL_P(sy->channels.create("test_channel", telem::FLOAT64_T, true));
+
+    // Create a config with an invalid channel type
+    auto j = basic_read_task_config();
+    j["channels"] = json::array({
+        {
+            {"port", "AIN0"},
+            {"enabled", true},
+            {"key", "8hYJO9zt6eS"},
+            {"channel", ch.key},
+            {"type", "UNKNOWN_CHANNEL_TYPE"}, // Invalid channel type
+            {"range", 5}
+        }
+    });
+
+    auto p = xjson::Parser(j);
+    auto cfg = std::make_unique<labjack::ReadTaskConfig>(sy, p);
+    
+    ASSERT_OCCURRED_AS(p.error(), xerrors::VALIDATION);
 }

--- a/driver/ni/read_task.h
+++ b/driver/ni/read_task.h
@@ -30,17 +30,11 @@
 
 namespace ni {
 /// @brief the configuration for a read task.
-struct ReadTaskConfig {
-    /// @brief whether data saving is enabled for the task.
-    const bool data_saving;
+struct ReadTaskConfig: common::BaseReadTaskConfig {
     /// @brief the device key that will be used for the channels in the task. Analog
     /// read tasks can specify multiple devices. In this case, the device key field
     /// is empty and automatically set to "cross-device".
     const std::string device_key;
-    /// @brief sets the sample rate for the task.
-    const telem::Rate sample_rate;
-    /// @brief sets the stream rate for the task.
-    const telem::Rate stream_rate;
     /// @brief sets the timing source for the task. If not provided, the task will
     /// use software timing on digital tasks and the sample clock on analog tasks.
     const std::string timing_source;
@@ -55,10 +49,8 @@ struct ReadTaskConfig {
 
     /// @brief Move constructor to allow transfer of ownership
     ReadTaskConfig(ReadTaskConfig &&other) noexcept:
-        data_saving(other.data_saving),
+        common::BaseReadTaskConfig(std::move(other)),
         device_key(other.device_key),
-        sample_rate(other.sample_rate),
-        stream_rate(other.stream_rate),
         timing_source(other.timing_source),
         samples_per_chan(other.samples_per_chan),
         software_timed(other.software_timed),
@@ -75,10 +67,8 @@ struct ReadTaskConfig {
         std::shared_ptr<synnax::Synnax> &client,
         xjson::Parser &cfg,
         const std::string &task_type
-    ): data_saving(cfg.optional<bool>("data_saving", false)),
+    ): BaseReadTaskConfig(cfg),
        device_key(cfg.optional<std::string>("device", "cross-device")),
-       sample_rate(telem::Rate(cfg.required<float>("sample_rate"))),
-       stream_rate(telem::Rate(cfg.required<float>("stream_rate"))),
        timing_source(cfg.optional<std::string>("timing_source", "")),
        samples_per_chan(sample_rate / stream_rate),
        software_timed(this->timing_source.empty() && task_type == "ni_digital_read"),

--- a/driver/ni/read_task.h
+++ b/driver/ni/read_task.h
@@ -84,9 +84,10 @@ struct ReadTaskConfig {
        software_timed(this->timing_source.empty() && task_type == "ni_digital_read"),
        channels(cfg.map<std::unique_ptr<channel::Input>>(
            "channels",
-           [&](xjson::Parser &ch_cfg) -> std::pair<std::unique_ptr<channel::Input>,
+           [](xjson::Parser &ch_cfg) -> std::pair<std::unique_ptr<channel::Input>,
        bool> {
                auto ch = channel::parse_input(ch_cfg);
+               if (ch == nullptr) return {nullptr, false};
                return {std::move(ch), ch->enabled};
            })) {
         if (this->channels.empty()) {

--- a/driver/ni/read_task_test.cpp
+++ b/driver/ni/read_task_test.cpp
@@ -155,6 +155,56 @@ TEST(ReadTaskConfigTest, testSampleRateLessThanStreamRate) {
 
 /// @brief it should return a validation error if no channels in the task are enabled.
 TEST(ReadTaskConfigTest, testNoEnabledChannels) {
+    auto sy = std::make_shared<synnax::Synnax>(new_test_client());
+    auto rack = ASSERT_NIL_P(sy->hardware.create_rack("cat"));
+    auto dev = synnax::Device(
+        "abc123",
+        "my_device",
+        rack.key,
+        "dev1",
+        "dev1",
+        "ni",
+        "PXI-6255",
+        ""
+    );
+    ASSERT_NIL(sy->hardware.create_device(dev));
+    auto ch = ASSERT_NIL_P(sy->channels.create("virtual", telem::FLOAT64_T, true));
+
+    auto j = base_analog_config();
+    j["channels"][0]["device"] = dev.key;
+    j["channels"][0]["channel"] = ch.key;
+    j["channels"][0]["enabled"] = false;
+
+    auto p = xjson::Parser(j);
+    auto cfg = std::make_unique<ni::ReadTaskConfig>(sy, p, "ni_analog_read");
+    ASSERT_OCCURRED_AS(p.error(), xerrors::VALIDATION);
+}
+
+/// @brief it should return a validation error if a channel has an unknown type.
+TEST(ReadTaskConfigTest, testUnknownChannelType) {
+    auto sy = std::make_shared<synnax::Synnax>(new_test_client());
+    auto rack = ASSERT_NIL_P(sy->hardware.create_rack("cat"));
+    auto dev = synnax::Device(
+        "abc123",
+        "my_device",
+        rack.key,
+        "dev1",
+        "dev1",
+        "ni",
+        "PXI-6255",
+        ""
+    );
+    ASSERT_NIL(sy->hardware.create_device(dev));
+    auto ch = ASSERT_NIL_P(sy->channels.create("virtual", telem::FLOAT64_T, true));
+
+    auto j = base_analog_config();
+    j["channels"][0]["device"] = dev.key;
+    j["channels"][0]["channel"] = ch.key;
+    j["channels"][0]["type"] = "unknown_channel_type";  // Set an invalid channel type
+
+    auto p = xjson::Parser(j);
+    auto cfg = std::make_unique<ni::ReadTaskConfig>(sy, p, "ni_analog_read");
+    ASSERT_OCCURRED_AS(p.error(), xerrors::VALIDATION);
 }
 
 class AnalogReadTest : public ::testing::Test {

--- a/driver/ni/write_task.h
+++ b/driver/ni/write_task.h
@@ -79,7 +79,7 @@ struct WriteTaskConfig {
        data_saving(cfg.optional<bool>("data_saving", false)) {
         cfg.iter("channels", [&](xjson::Parser &ch_cfg) {
             auto ch = channel::parse_output(ch_cfg);
-            if (ch->enabled) this->channels[ch->cmd_ch_key] = std::move(ch);
+            if (ch != nullptr && ch->enabled) this->channels[ch->cmd_ch_key] = std::move(ch);
         });
         if (channels.empty()) {
             cfg.field_err("channels", "task must have at least one enabled channel");

--- a/driver/opc/factory.cpp
+++ b/driver/opc/factory.cpp
@@ -26,9 +26,9 @@ std::pair<std::unique_ptr<task::Task>, xerrors::Error> configure_read(
     if (c_err) return {nullptr, err};
     std::unique_ptr<common::Source> s;
     if (cfg.array_size > 1)
-        s = std::make_unique<opc::ArrayReadTaskSource>(client, cfg);
+        s = std::make_unique<opc::ArrayReadTaskSource>(client, std::move(cfg));
     else
-        s = std::make_unique<opc::UnaryReadTaskSource>(client, cfg);
+        s = std::make_unique<opc::UnaryReadTaskSource>(client, std::move(cfg));
     return {
         std::make_unique<common::ReadTask>(
             task,

--- a/driver/task/common/read_task_test.cpp
+++ b/driver/task/common/read_task_test.cpp
@@ -450,3 +450,104 @@ TEST(TestCommonReadTask, testTemporaryErrorWarning) {
     EXPECT_EQ(stop_state.variant, "success");
     EXPECT_EQ(stop_state.details["message"], "Task stopped successfully");
 }
+
+/// @brief Tests for BaseReadTaskConfig parsing
+TEST(BaseReadTaskConfigTest, testValidConfig) {
+    json j{
+        {"data_saving", true},
+        {"sample_rate", 100.0},
+        {"stream_rate", 50.0}
+    };
+
+    auto p = xjson::Parser(j);
+    auto cfg = common::BaseReadTaskConfig(p);
+    ASSERT_FALSE(p.error()) << p.error();
+    EXPECT_TRUE(cfg.data_saving);
+    EXPECT_EQ(cfg.sample_rate, telem::Rate(100.0));
+    EXPECT_EQ(cfg.stream_rate, telem::Rate(50.0));
+}
+
+TEST(BaseReadTaskConfigTest, testDefaultDataSaving) {
+    json j{
+        {"sample_rate", 100.0},
+        {"stream_rate", 50.0}
+    };
+
+    auto p = xjson::Parser(j);
+    auto cfg = common::BaseReadTaskConfig(p);
+    ASSERT_FALSE(p.error()) << p.error();
+    EXPECT_FALSE(cfg.data_saving); // Default should be false
+    EXPECT_EQ(cfg.sample_rate, telem::Rate(100.0));
+    EXPECT_EQ(cfg.stream_rate, telem::Rate(50.0));
+}
+
+TEST(BaseReadTaskConfigTest, testEqualRates) {
+    json j{
+        {"sample_rate", 100.0},
+        {"stream_rate", 100.0}
+    };
+
+    auto p = xjson::Parser(j);
+    auto cfg = common::BaseReadTaskConfig(p);
+    ASSERT_FALSE(p.error()) << p.error();
+    EXPECT_EQ(cfg.sample_rate, telem::Rate(100.0));
+    EXPECT_EQ(cfg.stream_rate, telem::Rate(100.0));
+}
+
+TEST(BaseReadTaskConfigTest, testMissingSampleRate) {
+    json j{
+        {"stream_rate", 50.0}
+    };
+
+    auto p = xjson::Parser(j);
+    auto cfg = common::BaseReadTaskConfig(p);
+    ASSERT_TRUE(p.error());
+    EXPECT_TRUE(p.error().matches(xerrors::VALIDATION));
+}
+
+TEST(BaseReadTaskConfigTest, testMissingStreamRate) {
+    json j{
+        {"sample_rate", 100.0}
+    };
+
+    auto p = xjson::Parser(j);
+    auto cfg = common::BaseReadTaskConfig(p);
+    ASSERT_TRUE(p.error());
+    EXPECT_TRUE(p.error().matches(xerrors::VALIDATION));
+}
+
+TEST(BaseReadTaskConfigTest, testNegativeSampleRate) {
+    json j{
+        {"sample_rate", -100.0},
+        {"stream_rate", 50.0}
+    };
+
+    auto p = xjson::Parser(j);
+    auto cfg = common::BaseReadTaskConfig(p);
+    ASSERT_TRUE(p.error());
+    EXPECT_TRUE(p.error().matches(xerrors::VALIDATION));
+}
+
+TEST(BaseReadTaskConfigTest, testNegativeStreamRate) {
+    json j{
+        {"sample_rate", 100.0},
+        {"stream_rate", -50.0}
+    };
+
+    auto p = xjson::Parser(j);
+    auto cfg = common::BaseReadTaskConfig(p);
+    ASSERT_TRUE(p.error());
+    EXPECT_TRUE(p.error().matches(xerrors::VALIDATION));
+}
+
+TEST(BaseReadTaskConfigTest, testSampleRateLessThanStreamRate) {
+    json j{
+        {"sample_rate", 25.0},
+        {"stream_rate", 50.0}
+    };
+
+    auto p = xjson::Parser(j);
+    auto cfg = common::BaseReadTaskConfig(p);
+    ASSERT_TRUE(p.error());
+    EXPECT_TRUE(p.error().matches(xerrors::VALIDATION));
+}


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2183](https://linear.app/synnax/issue/SY-2183)

## Description

Fixed missing channel types in Digital Input/Output channels in NI schemas, and made driver task parsing more resillient to unknown channel types.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
