### PR TITLE
SY-1116 - Fix Bleve Race Condition on Server Startup

### DIFF
--- a/synnax/pkg/distribution/channel/channel_suite_test.go
+++ b/synnax/pkg/distribution/channel/channel_suite_test.go
@@ -55,7 +55,7 @@ func provisionServices() (*mock.CoreBuilder, map[core.NodeKey]channel.Service, i
 		DB: core1.Storage.Gorpify(),
 	}))
 	builder.AttachCloser(otg1)
-	g1 := MustSucceed(group.OpenService(group.Config{
+	g1 := MustSucceed(group.OpenService(ctx, group.Config{
 		DB:       core1.Storage.Gorpify(),
 		Ontology: otg1,
 	}))
@@ -64,7 +64,7 @@ func provisionServices() (*mock.CoreBuilder, map[core.NodeKey]channel.Service, i
 		DB: core2.Storage.Gorpify(),
 	}))
 	builder.AttachCloser(otg2)
-	g2 := MustSucceed(group.OpenService(group.Config{
+	g2 := MustSucceed(group.OpenService(ctx, group.Config{
 		DB:       core2.Storage.Gorpify(),
 		Ontology: otg2,
 	}))
@@ -73,7 +73,7 @@ func provisionServices() (*mock.CoreBuilder, map[core.NodeKey]channel.Service, i
 		DB: core3.Storage.Gorpify(),
 	}))
 	builder2.AttachCloser(otg3)
-	g3 := MustSucceed(group.OpenService(group.Config{
+	g3 := MustSucceed(group.OpenService(ctx, group.Config{
 		DB:       core3.Storage.Gorpify(),
 		Ontology: otg3,
 	}))

--- a/synnax/pkg/distribution/channel/service.go
+++ b/synnax/pkg/distribution/channel/service.go
@@ -118,7 +118,7 @@ func New(ctx context.Context, configs ...ServiceConfig) (Service, error) {
 	}
 	s.Writer = s.NewWriter(nil)
 	if cfg.Ontology != nil {
-		cfg.Ontology.RegisterService(s)
+		cfg.Ontology.RegisterService(ctx, s)
 	}
 	return s, nil
 }

--- a/synnax/pkg/distribution/distribution.go
+++ b/synnax/pkg/distribution/distribution.go
@@ -134,6 +134,7 @@ func Open(ctx context.Context, cfg Config) (d Distribution, err error) {
 		return d, err
 	}
 	if d.Group, err = group.OpenService(
+		ctx,
 		cfg.Group,
 		group.Config{
 			DB:       gorpDB,
@@ -148,8 +149,8 @@ func Open(ctx context.Context, cfg Config) (d Distribution, err error) {
 		Cluster:  d.Cluster,
 	}
 	clusterOntologySvc := &cluster.OntologyService{Cluster: d.Cluster}
-	d.Ontology.RegisterService(clusterOntologySvc)
-	d.Ontology.RegisterService(nodeOntologySvc)
+	d.Ontology.RegisterService(ctx, clusterOntologySvc)
+	d.Ontology.RegisterService(ctx, nodeOntologySvc)
 
 	nodeOntologySvc.ListenForChanges(ctx)
 

--- a/synnax/pkg/distribution/mock/builder.go
+++ b/synnax/pkg/distribution/mock/builder.go
@@ -71,7 +71,7 @@ func (b *Builder) New(ctx context.Context) distribution.Distribution {
 	}
 
 	d.Ontology = lo.Must(ontology.Open(ctx, b.cfg.Ontology, ontology.Config{DB: d.Storage.Gorpify()}))
-	d.Group = lo.Must(group.OpenService(b.cfg.Group, group.Config{Ontology: d.Ontology, DB: d.Storage.Gorpify()}))
+	d.Group = lo.Must(group.OpenService(ctx, b.cfg.Group, group.Config{Ontology: d.Ontology, DB: d.Storage.Gorpify()}))
 
 	nodeOntologySvc := &cluster.NodeOntologyService{
 		Cluster:  d.Cluster,

--- a/synnax/pkg/distribution/mock/builder.go
+++ b/synnax/pkg/distribution/mock/builder.go
@@ -78,8 +78,8 @@ func (b *Builder) New(ctx context.Context) distribution.Distribution {
 		Ontology: d.Ontology,
 	}
 	clusterOntologySvc := &cluster.OntologyService{Cluster: d.Cluster}
-	d.Ontology.RegisterService(nodeOntologySvc)
-	d.Ontology.RegisterService(clusterOntologySvc)
+	d.Ontology.RegisterService(ctx, nodeOntologySvc)
+	d.Ontology.RegisterService(ctx, clusterOntologySvc)
 	nodeOntologySvc.ListenForChanges(ctx)
 
 	d.Channel = lo.Must(channel.New(ctx, b.cfg.Channel, channel.ServiceConfig{

--- a/synnax/pkg/distribution/ontology/group/group_test.go
+++ b/synnax/pkg/distribution/ontology/group/group_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Group", Ordered, func() {
 	BeforeAll(func() {
 		db = gorp.Wrap(memkv.New())
 		otg = MustSucceed(ontology.Open(ctx, ontology.Config{DB: db}))
-		svc = MustSucceed(group.OpenService(group.Config{DB: db, Ontology: otg}))
+		svc = MustSucceed(group.OpenService(ctx, group.Config{DB: db, Ontology: otg}))
 		w = svc.NewWriter(nil)
 	})
 

--- a/synnax/pkg/distribution/ontology/group/service.go
+++ b/synnax/pkg/distribution/ontology/group/service.go
@@ -52,13 +52,13 @@ type Service struct {
 	signals io.Closer
 }
 
-func OpenService(configs ...Config) (*Service, error) {
+func OpenService(ctx context.Context, configs ...Config) (*Service, error) {
 	cfg, err := config.New(DefaultConfig, configs...)
 	if err != nil {
 		return nil, err
 	}
 	s := &Service{Config: cfg}
-	cfg.Ontology.RegisterService(s)
+	cfg.Ontology.RegisterService(ctx, s)
 	return s, nil
 }
 

--- a/synnax/pkg/distribution/ontology/ontology.go
+++ b/synnax/pkg/distribution/ontology/ontology.go
@@ -26,8 +26,6 @@ package ontology
 
 import (
 	"context"
-	"io"
-
 	"github.com/synnaxlabs/alamos"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology/schema"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology/search"
@@ -59,8 +57,6 @@ type Ontology struct {
 	ResourceObserver     observe.Observer[iter.Nexter[schema.Change]]
 	RelationshipObserver observe.Observable[gorp.TxReader[[]byte, Relationship]]
 	search               struct {
-		signal.Go
-		io.Closer
 		*search.Index
 	}
 	registrar           serviceRegistrar
@@ -100,6 +96,9 @@ func (c Config) Override(other Config) Config {
 // exist, it will be created.
 func Open(ctx context.Context, configs ...Config) (*Ontology, error) {
 	cfg, err := config.New(DefaultConfig, configs...)
+	if err != nil {
+		return nil, err
+	}
 	o := &Ontology{
 		Config:               cfg,
 		ResourceObserver:     observe.New[iter.Nexter[schema.Change]](),
@@ -116,9 +115,6 @@ func Open(ctx context.Context, configs ...Config) (*Ontology, error) {
 
 	if *o.Config.EnableSearch {
 		o.search.Index, err = search.New(search.Config{Instrumentation: cfg.Instrumentation})
-		sCtx, cancel := signal.Isolated(signal.WithInstrumentation(cfg.Instrumentation))
-		o.search.Go = sCtx
-		o.search.Closer = signal.NewHardShutdown(sCtx, cancel)
 	}
 
 	return o, err
@@ -200,17 +196,16 @@ func (o *Ontology) NewWriter(tx gorp.Tx) Writer {
 // Ontology will execute queries for Entity information for the given Type using the
 // provided Service. RegisterService panics if a Service is already registered for
 // the given Type.
-func (o *Ontology) RegisterService(s Service) {
+func (o *Ontology) RegisterService(ctx context.Context, s Service) {
 	o.L.Debug("registering service", zap.Stringer("type", s.Schema().Type))
 	o.registrar.register(s)
 
 	if !*o.Config.EnableSearch {
 		return
 	}
-	o.search.Register(context.TODO(), *s.Schema())
+	o.search.Register(ctx, *s.Schema())
 
 	d1 := s.OnChange(o.ResourceObserver.Notify)
-
 	// SetKV up a change handler to index new resources.
 	d2 := s.OnChange(func(ctx context.Context, i iter.Nexter[schema.Change]) {
 		err := o.search.Index.WithTx(func(tx search.Tx) error {
@@ -234,32 +229,42 @@ func (o *Ontology) RegisterService(s Service) {
 			)
 		}
 	})
-
-	o.search.Go.Go(func(ctx context.Context) error {
-		n, err := s.OpenNexter()
-		if err != nil {
-			return err
-		}
-		err = o.search.Index.WithTx(func(tx search.Tx) error {
-			for r, ok := n.Next(ctx); ok; r, ok = n.Next(ctx) {
-				if err := tx.Index(r); err != nil {
-					return err
-				}
-			}
-			return nil
-		})
-		return errors.Combine(err, n.Close())
-	}, signal.WithKeyf("startup-indexing-%s", s.Schema().Type))
-
 	o.disconnectObservers = append(o.disconnectObservers, d1, d2)
+}
+
+// RunStartupSearchIndexing indexes all resources from registered services into the search
+// index (if search is enabled). This method should be called AFTER all necessary services
+// have been registered. This method will block until all resources have been indexed,
+// so it should probably be run in a separate goroutine.
+func (o *Ontology) RunStartupSearchIndexing(ctx context.Context) error {
+	if !*o.EnableSearch {
+		return nil
+	}
+	oCtx, cancel := signal.WithCancel(ctx)
+	defer cancel()
+	for _, svc := range o.registrar {
+		oCtx.Go(func(ctx context.Context) error {
+			n, err := svc.OpenNexter()
+			if err != nil {
+				return err
+			}
+			err = o.search.Index.WithTx(func(tx search.Tx) error {
+				for r, ok := n.Next(ctx); ok; r, ok = n.Next(ctx) {
+					if err := tx.Index(r); err != nil {
+						return err
+					}
+				}
+				return nil
+			})
+			return errors.Combine(err, n.Close())
+		}, signal.WithKeyf("startup-indexing-%s", svc.Schema().Type))
+	}
+	return oCtx.Wait()
 }
 
 func (o *Ontology) Close() error {
 	for _, d := range o.disconnectObservers {
 		d()
-	}
-	if *o.EnableSearch {
-		return o.search.Close()
 	}
 	return nil
 }

--- a/synnax/pkg/distribution/ontology/ontology.go
+++ b/synnax/pkg/distribution/ontology/ontology.go
@@ -106,10 +106,10 @@ func Open(ctx context.Context, configs ...Config) (*Ontology, error) {
 		registrar:            serviceRegistrar{BuiltIn: &builtinService{}},
 	}
 
-	err = o.NewRetrieve().WhereIDs(RootID).Exec(ctx, cfg.DB)
-	if errors.Is(err, query.NotFound) {
+	if err = o.NewRetrieve().WhereIDs(RootID).Exec(ctx, cfg.DB); errors.Is(err, query.NotFound) {
 		err = o.NewWriter(cfg.DB).DefineResource(ctx, RootID)
-	} else if err != nil {
+	}
+	if err != nil {
 		return nil, err
 	}
 

--- a/synnax/pkg/distribution/ontology/ontology_suite_test.go
+++ b/synnax/pkg/distribution/ontology/ontology_suite_test.go
@@ -71,7 +71,7 @@ var (
 var _ = BeforeSuite(func() {
 	db = gorp.Wrap(memkv.New())
 	otg = MustSucceed(ontology.Open(ctx, ontology.Config{DB: db}))
-	otg.RegisterService(&emptyService{})
+	otg.RegisterService(ctx, &emptyService{})
 })
 
 var _ = AfterSuite(func() {

--- a/synnax/pkg/distribution/ontology/search_indexing_test.go
+++ b/synnax/pkg/distribution/ontology/search_indexing_test.go
@@ -1,0 +1,145 @@
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+package ontology
+
+import (
+	"context"
+	"github.com/synnaxlabs/x/kv/memkv"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/synnaxlabs/alamos"
+	"github.com/synnaxlabs/synnax/pkg/distribution/ontology/schema"
+	"github.com/synnaxlabs/synnax/pkg/distribution/ontology/search"
+	"github.com/synnaxlabs/x/config"
+	"github.com/synnaxlabs/x/gorp"
+	"github.com/synnaxlabs/x/iter"
+	"github.com/synnaxlabs/x/observe"
+)
+
+// mockIndexingService implements the Service interface for testing startup indexing
+type mockIndexingService struct {
+	observe.Observer[iter.Nexter[schema.Change]]
+	resources []Resource
+	schema_   *Schema
+}
+
+var _ Service = (*mockIndexingService)(nil)
+
+func newMockIndexingService(schema_ *Schema, resources []Resource) *mockIndexingService {
+	return &mockIndexingService{
+		Observer:  observe.New[iter.Nexter[schema.Change]](),
+		resources: resources,
+		schema_:   schema_,
+	}
+}
+
+func (s *mockIndexingService) Schema() *Schema {
+	return s.schema_
+}
+
+func (s *mockIndexingService) OpenNexter() (iter.NexterCloser[Resource], error) {
+	return iter.NexterNopCloser[Resource](iter.All[Resource](s.resources)), nil
+}
+
+func (s *mockIndexingService) RetrieveResource(ctx context.Context, key string, tx gorp.Tx) (Resource, error) {
+	for _, r := range s.resources {
+		if r.ID.Key == key {
+			return r, nil
+		}
+	}
+	return Resource{}, nil
+}
+
+var _ = Describe("Search Indexing", func() {
+	var (
+		ctx       = context.Background()
+		ontology_ *Ontology
+		db        *gorp.DB
+		mockSvc   *mockIndexingService
+	)
+
+	const testType Type = "test-type"
+
+	BeforeEach(func() {
+		var err error
+		db = gorp.Wrap(memkv.New())
+		ontology_, err = Open(ctx, Config{
+			Instrumentation: alamos.New("test"),
+			DB:              db,
+			EnableSearch:    config.True(),
+		})
+		Expect(err).NotTo(HaveOccurred())
+
+		// Create a schema with searchable fields
+		schema_ := &Schema{
+			Type:   testType,
+			Fields: map[string]schema.Field{},
+		}
+
+		// Create test resources
+		resources := []Resource{
+			{
+				ID:     ID{Type: testType, Key: "1"},
+				Name:   "cat",
+				Schema: schema_,
+				Data:   map[string]interface{}{},
+			},
+			{
+				ID:     ID{Type: testType, Key: "2"},
+				Name:   "Test Resource Two",
+				Schema: schema_,
+				Data:   map[string]interface{}{},
+			},
+			{
+				ID:     ID{Type: testType, Key: "3"},
+				Name:   "Special_Resource_Three",
+				Schema: schema_,
+				Data:   map[string]interface{}{},
+			},
+			{
+				ID:     ID{Type: testType, Key: "4"},
+				Name:   "UPPERCASE RESOURCE",
+				Schema: schema_,
+				Data:   map[string]interface{}{},
+			},
+		}
+
+		// Create and register the mock service
+		mockSvc = newMockIndexingService(schema_, resources)
+		tx := db.OpenTx()
+		w := ontology_.NewWriter(tx)
+		for _, r := range resources {
+			Expect(w.DefineResource(ctx, r.ID)).To(Succeed())
+		}
+		Expect(tx.Commit(ctx)).To(Succeed())
+		ontology_.RegisterService(ctx, mockSvc)
+	})
+
+	AfterEach(func() {
+		Expect(ontology_.Close()).To(Succeed())
+		Expect(db.Close()).To(Succeed())
+	})
+
+	It("should index all resources during startup", func() {
+		// Run the startup indexing
+		err := ontology_.RunStartupSearchIndexing(ctx)
+		Expect(err).NotTo(HaveOccurred())
+
+		// Test exact name search
+		results, err := ontology_.Search(ctx, search.Request{
+			Type: testType,
+			Term: "cat",
+		})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(results).To(HaveLen(1))
+		Expect(results[0].ID.Key).To(Equal("1"))
+	})
+})

--- a/synnax/pkg/distribution/ontology/signals/signals_test.go
+++ b/synnax/pkg/distribution/ontology/signals/signals_test.go
@@ -72,7 +72,7 @@ var _ = Describe("Signals", Ordered, func() {
 		builder = mock.NewBuilder()
 		dist = builder.New(ctx)
 		svc = &changeService{Observer: observe.New[iter.Nexter[schema.Change]]()}
-		dist.Ontology.RegisterService(svc)
+		dist.Ontology.RegisterService(ctx, svc)
 	})
 	AfterAll(func() {
 		Expect(builder.Close()).To(Succeed())

--- a/synnax/pkg/service/hardware/device/device_test.go
+++ b/synnax/pkg/service/hardware/device/device_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Device", Ordered, func() {
 	BeforeAll(func() {
 		db = gorp.Wrap(memkv.New())
 		otg = MustSucceed(ontology.Open(ctx, ontology.Config{DB: db}))
-		g = MustSucceed(group.OpenService(group.Config{DB: db, Ontology: otg}))
+		g = MustSucceed(group.OpenService(ctx, group.Config{DB: db, Ontology: otg}))
 		rackSvc = MustSucceed(rack.OpenService(ctx, rack.Config{
 			DB:           db,
 			Ontology:     otg,

--- a/synnax/pkg/service/hardware/device/service.go
+++ b/synnax/pkg/service/hardware/device/service.go
@@ -70,7 +70,7 @@ func OpenService(ctx context.Context, configs ...Config) (s *Service, err error)
 		return
 	}
 	s = &Service{Config: cfg, group: g}
-	cfg.Ontology.RegisterService(s)
+	cfg.Ontology.RegisterService(ctx, s)
 	if cfg.Signals == nil {
 		return s, nil
 	}

--- a/synnax/pkg/service/hardware/rack/rack_test.go
+++ b/synnax/pkg/service/hardware/rack/rack_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Rack", Ordered, func() {
 	BeforeAll(func() {
 		db = gorp.Wrap(memkv.New())
 		otg := MustSucceed(ontology.Open(ctx, ontology.Config{DB: db}))
-		g := MustSucceed(group.OpenService(group.Config{DB: db, Ontology: otg}))
+		g := MustSucceed(group.OpenService(ctx, group.Config{DB: db, Ontology: otg}))
 		svc = MustSucceed(rack.OpenService(ctx, rack.Config{
 			DB:           db,
 			Ontology:     otg,
@@ -120,7 +120,7 @@ var _ = Describe("Migration", func() {
 	It("Should correctly migrate a v1 rack to a v2 rack", func() {
 		db := gorp.Wrap(memkv.New())
 		otg := MustSucceed(ontology.Open(ctx, ontology.Config{DB: db}))
-		g := MustSucceed(group.OpenService(group.Config{DB: db, Ontology: otg}))
+		g := MustSucceed(group.OpenService(ctx, group.Config{DB: db, Ontology: otg}))
 
 		v1EmbeddedRack := rack.Rack{
 			Key:  65538,

--- a/synnax/pkg/service/hardware/rack/service.go
+++ b/synnax/pkg/service/hardware/rack/service.go
@@ -111,7 +111,7 @@ func OpenService(ctx context.Context, configs ...Config) (s *Service, err error)
 	if err = s.loadEmbeddedRack(ctx); err != nil {
 		return nil, err
 	}
-	cfg.Ontology.RegisterService(s)
+	cfg.Ontology.RegisterService(ctx, s)
 
 	if cfg.Signals != nil {
 		cdcS, err := signals.PublishFromGorp[Key](

--- a/synnax/pkg/service/hardware/task/service.go
+++ b/synnax/pkg/service/hardware/task/service.go
@@ -87,7 +87,7 @@ func OpenService(ctx context.Context, configs ...Config) (s *Service, err error)
 		return
 	}
 	s = &Service{cfg: cfg, group: g}
-	cfg.Ontology.RegisterService(s)
+	cfg.Ontology.RegisterService(ctx, s)
 	s.cleanupInternalOntologyResources(ctx)
 	if cfg.Signals == nil {
 		return

--- a/synnax/pkg/service/hardware/task/task_test.go
+++ b/synnax/pkg/service/hardware/task/task_test.go
@@ -36,7 +36,7 @@ var _ = Describe("Task", Ordered, func() {
 	BeforeAll(func() {
 		db = gorp.Wrap(memkv.New())
 		otg = MustSucceed(ontology.Open(ctx, ontology.Config{DB: db}))
-		g := MustSucceed(group.OpenService(group.Config{DB: db, Ontology: otg}))
+		g := MustSucceed(group.OpenService(ctx, group.Config{DB: db, Ontology: otg}))
 		rackSvc := MustSucceed(rack.OpenService(ctx, rack.Config{DB: db, Ontology: otg, Group: g, HostProvider: mock.StaticHostKeyProvider(1)}))
 		svc = MustSucceed(task.OpenService(ctx, task.Config{
 			DB:           db,

--- a/synnax/pkg/service/label/label_test.go
+++ b/synnax/pkg/service/label/label_test.go
@@ -34,7 +34,7 @@ var _ = Describe("Label", Ordered, func() {
 	BeforeAll(func() {
 		db = gorp.Wrap(memkv.New())
 		otg = MustSucceed(ontology.Open(ctx, ontology.Config{DB: db}))
-		g := MustSucceed(group.OpenService(group.Config{DB: db, Ontology: otg}))
+		g := MustSucceed(group.OpenService(ctx, group.Config{DB: db, Ontology: otg}))
 		svc = MustSucceed(label.OpenService(ctx, label.Config{
 			DB:       db,
 			Ontology: otg,

--- a/synnax/pkg/service/label/service.go
+++ b/synnax/pkg/service/label/service.go
@@ -84,7 +84,7 @@ func OpenService(ctx context.Context, cfgs ...Config) (*Service, error) {
 		return nil, err
 	}
 	s := &Service{Config: cfg}
-	cfg.Ontology.RegisterService(s)
+	cfg.Ontology.RegisterService(ctx, s)
 	if cfg.Signals != nil {
 		s.signals, err = signals.PublishFromGorp(ctx, cfg.Signals, signals.GorpPublisherConfigUUID[Label](cfg.DB))
 		if err != nil {

--- a/synnax/pkg/service/ranger/ranger_test.go
+++ b/synnax/pkg/service/ranger/ranger_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Ranger", Ordered, func() {
 			DB:           db,
 			EnableSearch: config.True(),
 		}))
-		g := MustSucceed(group.OpenService(group.Config{DB: db, Ontology: otg}))
+		g := MustSucceed(group.OpenService(ctx, group.Config{DB: db, Ontology: otg}))
 		svc = MustSucceed(ranger.OpenService(ctx, ranger.Config{DB: db, Ontology: otg, Group: g}))
 		closer = xio.MultiCloser{db, otg, g, svc}
 	})

--- a/synnax/pkg/service/ranger/service.go
+++ b/synnax/pkg/service/ranger/service.go
@@ -89,8 +89,8 @@ func OpenService(ctx context.Context, cfgs ...Config) (s *Service, err error) {
 		return nil, err
 	}
 	s = &Service{Config: cfg, group: g}
-	cfg.Ontology.RegisterService(s)
-	cfg.Ontology.RegisterService(&aliasOntologyService{db: cfg.DB})
+	cfg.Ontology.RegisterService(ctx, s)
+	cfg.Ontology.RegisterService(ctx, &aliasOntologyService{db: cfg.DB})
 	if cfg.Signals == nil {
 		return
 	}

--- a/synnax/pkg/service/user/ontology_test.go
+++ b/synnax/pkg/service/user/ontology_test.go
@@ -33,7 +33,7 @@ var _ = Describe("Ontology", Ordered, func() {
 		userKey = uuid.New()
 		db = gorp.Wrap(memkv.New())
 		otg = MustSucceed(ontology.Open(ctx, ontology.Config{DB: db}))
-		g := MustSucceed(group.OpenService(group.Config{DB: db, Ontology: otg}))
+		g := MustSucceed(group.OpenService(ctx, group.Config{DB: db, Ontology: otg}))
 		svc = MustSucceed(user.NewService(ctx, user.Config{DB: db, Ontology: otg, Group: g}))
 	})
 	AfterAll(func() {

--- a/synnax/pkg/service/user/service.go
+++ b/synnax/pkg/service/user/service.go
@@ -75,7 +75,7 @@ func NewService(ctx context.Context, configs ...Config) (*Service, error) {
 		return nil, err
 	}
 	s := &Service{Config: cfg, group: g}
-	cfg.Ontology.RegisterService(s)
+	cfg.Ontology.RegisterService(ctx, s)
 	return s, nil
 }
 

--- a/synnax/pkg/service/user/service_test.go
+++ b/synnax/pkg/service/user/service_test.go
@@ -34,7 +34,7 @@ var _ = Describe("User", Ordered, func() {
 	BeforeAll(func() {
 		db = gorp.Wrap(memkv.New())
 		otg = MustSucceed(ontology.Open(ctx, ontology.Config{DB: db}))
-		g := MustSucceed(group.OpenService(group.Config{DB: db, Ontology: otg}))
+		g := MustSucceed(group.OpenService(ctx, group.Config{DB: db, Ontology: otg}))
 		_, err := user.NewService(ctx, user.Config{})
 		Expect(err).To(HaveOccurred())
 		svc = MustSucceed(user.NewService(ctx, user.Config{DB: db, Ontology: otg, Group: g}))

--- a/synnax/pkg/service/workspace/lineplot/lineplot_suite_test.go
+++ b/synnax/pkg/service/workspace/lineplot/lineplot_suite_test.go
@@ -49,7 +49,7 @@ var _ = BeforeSuite(func() {
 		EnableSearch: config.False(),
 		DB:           db,
 	}))
-	g := MustSucceed(group.OpenService(group.Config{
+	g := MustSucceed(group.OpenService(ctx, group.Config{
 		DB:       db,
 		Ontology: otg,
 	}))
@@ -68,7 +68,7 @@ var _ = BeforeSuite(func() {
 	Expect(userSvc.NewWriter(nil).Create(ctx, &author)).To(Succeed())
 	ws.Author = author.Key
 	Expect(workspaceSvc.NewWriter(nil).Create(ctx, &ws)).To(Succeed())
-	svc = MustSucceed(schematic.NewService(schematic.Config{
+	svc = MustSucceed(schematic.NewService(ctx, schematic.Config{
 		DB:       db,
 		Ontology: otg,
 	}))

--- a/synnax/pkg/service/workspace/lineplot/service.go
+++ b/synnax/pkg/service/workspace/lineplot/service.go
@@ -10,6 +10,7 @@
 package lineplot
 
 import (
+	"context"
 	"github.com/google/uuid"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
 	"github.com/synnaxlabs/x/config"
@@ -56,13 +57,13 @@ type Service struct{ Config }
 // NewService instantiates a new line plot service using the provided configurations. Each
 // configuration will be used as an override for the previous configuration in the list.
 // See the Config struct for information on which fields should be set.
-func NewService(configs ...Config) (*Service, error) {
+func NewService(ctx context.Context, configs ...Config) (*Service, error) {
 	cfg, err := config.New(DefaultConfig, configs...)
 	if err != nil {
 		return nil, err
 	}
 	s := &Service{Config: cfg}
-	cfg.Ontology.RegisterService(s)
+	cfg.Ontology.RegisterService(ctx, s)
 	return s, nil
 }
 

--- a/synnax/pkg/service/workspace/log/log_suite_test.go
+++ b/synnax/pkg/service/workspace/log/log_suite_test.go
@@ -50,7 +50,7 @@ var _ = BeforeSuite(func() {
 		EnableSearch: config.False(),
 		DB:           db,
 	}))
-	g := MustSucceed(group.OpenService(group.Config{
+	g := MustSucceed(group.OpenService(ctx, group.Config{
 		DB:       db,
 		Ontology: otg,
 	}))
@@ -69,7 +69,7 @@ var _ = BeforeSuite(func() {
 	Expect(userSvc.NewWriter(nil).Create(ctx, &author)).To(Succeed())
 	ws.Author = author.Key
 	Expect(workspaceSvc.NewWriter(nil).Create(ctx, &ws)).To(Succeed())
-	svc = MustSucceed(log.NewService(log.Config{
+	svc = MustSucceed(log.NewService(ctx, log.Config{
 		DB:       db,
 		Ontology: otg,
 	}))

--- a/synnax/pkg/service/workspace/log/service.go
+++ b/synnax/pkg/service/workspace/log/service.go
@@ -10,6 +10,7 @@
 package log
 
 import (
+	"context"
 	"github.com/google/uuid"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
 	"github.com/synnaxlabs/x/config"
@@ -55,13 +56,13 @@ type Service struct{ Config }
 // NewService instantiates a new log service using the provided configurations. Each
 // configuration will be used as an override for the previous configuration in the list.
 // See the Config struct for information on which fields should be set.
-func NewService(configs ...Config) (*Service, error) {
+func NewService(ctx context.Context, configs ...Config) (*Service, error) {
 	cfg, err := config.New(DefaultConfig, configs...)
 	if err != nil {
 		return nil, err
 	}
 	s := &Service{Config: cfg}
-	cfg.Ontology.RegisterService(s)
+	cfg.Ontology.RegisterService(ctx, s)
 	return s, nil
 }
 

--- a/synnax/pkg/service/workspace/schematic/schematic_suite_test.go
+++ b/synnax/pkg/service/workspace/schematic/schematic_suite_test.go
@@ -50,7 +50,7 @@ var _ = BeforeSuite(func() {
 		EnableSearch: config.False(),
 		DB:           db,
 	}))
-	g := MustSucceed(group.OpenService(group.Config{
+	g := MustSucceed(group.OpenService(ctx, group.Config{
 		DB:       db,
 		Ontology: otg,
 	}))
@@ -69,7 +69,7 @@ var _ = BeforeSuite(func() {
 	Expect(userSvc.NewWriter(nil).Create(ctx, &author)).To(Succeed())
 	ws.Author = author.Key
 	Expect(workspaceSvc.NewWriter(nil).Create(ctx, &ws)).To(Succeed())
-	svc = MustSucceed(schematic.NewService(schematic.Config{
+	svc = MustSucceed(schematic.NewService(ctx, schematic.Config{
 		DB:       db,
 		Ontology: otg,
 	}))

--- a/synnax/pkg/service/workspace/schematic/service.go
+++ b/synnax/pkg/service/workspace/schematic/service.go
@@ -10,6 +10,7 @@
 package schematic
 
 import (
+	"context"
 	"github.com/google/uuid"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
 	"github.com/synnaxlabs/x/config"
@@ -56,13 +57,13 @@ type Service struct{ Config }
 // NewService instantiates a new schematic service using the provided configurations. Each
 // configuration will be used as an override for the previous configuration in the list.
 // See the Config struct for information on which fields should be set.
-func NewService(configs ...Config) (*Service, error) {
+func NewService(ctx context.Context, configs ...Config) (*Service, error) {
 	cfg, err := config.New(DefaultConfig, configs...)
 	if err != nil {
 		return nil, err
 	}
 	s := &Service{Config: cfg}
-	cfg.Ontology.RegisterService(s)
+	cfg.Ontology.RegisterService(ctx, s)
 	return s, nil
 }
 

--- a/synnax/pkg/service/workspace/service.go
+++ b/synnax/pkg/service/workspace/service.go
@@ -66,7 +66,7 @@ func NewService(ctx context.Context, configs ...Config) (*Service, error) {
 		return nil, err
 	}
 	s := &Service{Config: cfg, group: g}
-	cfg.Ontology.RegisterService(s)
+	cfg.Ontology.RegisterService(ctx, s)
 	return s, nil
 }
 

--- a/synnax/pkg/service/workspace/table/service.go
+++ b/synnax/pkg/service/workspace/table/service.go
@@ -10,6 +10,7 @@
 package table
 
 import (
+	"context"
 	"github.com/google/uuid"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
 	"github.com/synnaxlabs/x/config"
@@ -55,13 +56,13 @@ type Service struct{ Config }
 // NewService instantiates a new table service using the provided configurations. Each
 // configuration will be used as an override for the previous configuration in the list.
 // See the Config struct for information on which fields should be set.
-func NewService(configs ...Config) (*Service, error) {
+func NewService(ctx context.Context, configs ...Config) (*Service, error) {
 	cfg, err := config.New(DefaultConfig, configs...)
 	if err != nil {
 		return nil, err
 	}
 	s := &Service{Config: cfg}
-	cfg.Ontology.RegisterService(s)
+	cfg.Ontology.RegisterService(ctx, s)
 	return s, nil
 }
 

--- a/synnax/pkg/service/workspace/table/table_suite_test.go
+++ b/synnax/pkg/service/workspace/table/table_suite_test.go
@@ -50,7 +50,7 @@ var _ = BeforeSuite(func() {
 		EnableSearch: config.False(),
 		DB:           db,
 	}))
-	g := MustSucceed(group.OpenService(group.Config{
+	g := MustSucceed(group.OpenService(ctx, group.Config{
 		DB:       db,
 		Ontology: otg,
 	}))
@@ -69,7 +69,7 @@ var _ = BeforeSuite(func() {
 	Expect(userSvc.NewWriter(nil).Create(ctx, &author)).To(Succeed())
 	ws.Author = author.Key
 	Expect(workspaceSvc.NewWriter(nil).Create(ctx, &ws)).To(Succeed())
-	svc = MustSucceed(table.NewService(table.Config{
+	svc = MustSucceed(table.NewService(ctx, table.Config{
 		DB:       db,
 		Ontology: otg,
 	}))

--- a/synnax/pkg/service/workspace/workspace_suite_test.go
+++ b/synnax/pkg/service/workspace/workspace_suite_test.go
@@ -48,7 +48,7 @@ var _ = BeforeSuite(func() {
 		EnableSearch: config.False(),
 		DB:           db,
 	}))
-	g := MustSucceed(group.OpenService(group.Config{
+	g := MustSucceed(group.OpenService(ctx, group.Config{
 		DB:       db,
 		Ontology: otg,
 	}))


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-1116](https://linear.app/synnax/issue/SY-1116)

## Description

Fixes an issue where bleve would panic due to a concurrent map read and write on startup. This fixes the issue by indexing all resources after services have been indexed in the ontology. See issue for more details. 

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
