### PR TITLE
SY-2133 - Fix Cmd+Enter in Configure Device Modals

### DIFF
--- a/console/src/layout/hooks.spec.tsx
+++ b/console/src/layout/hooks.spec.tsx
@@ -14,81 +14,173 @@ import { act, type PropsWithChildren } from "react";
 import { Provider, useStore } from "react-redux";
 import { describe, expect, it } from "vitest";
 
+import { Layout } from "@/layout";
 import { select } from "@/layout/selectors";
 import { reducer } from "@/layout/slice";
-import { usePlacer } from "@/layout/usePlacer";
-import { useRemover } from "@/layout/useRemover";
 
-describe("placing & removing", () => {
-  it("should place a layout within the store", () => {
-    const store = configureStore({
-      reducer: combineReducers({
-        layout: reducer,
-        drift: Drift.reducer,
-      }),
-    });
-    const wrapper = ({ children }: PropsWithChildren) => (
-      <Provider store={store}>{children}</Provider>
-    );
-    const { result } = renderHook(
-      () => ({
-        placer: usePlacer(),
-        store: useStore(),
-      }),
-      { wrapper },
-    );
-    act(() => {
-      result.current.placer({
-        key: "test",
-        location: "mosaic",
-        type: "cat",
-        name: "test",
-        window: {
-          title: "test",
-        },
+describe("layout hooks", () => {
+  describe("placing & removing", () => {
+    it("should place a layout within the store", () => {
+      const store = configureStore({
+        reducer: combineReducers({
+          layout: reducer,
+          drift: Drift.reducer,
+        }),
       });
+      const wrapper = ({ children }: PropsWithChildren) => (
+        <Provider store={store}>{children}</Provider>
+      );
+      const { result } = renderHook(
+        () => ({
+          placer: Layout.usePlacer(),
+          store: useStore(),
+        }),
+        { wrapper },
+      );
+      act(() => {
+        result.current.placer({
+          key: "test",
+          location: "mosaic",
+          type: "cat",
+          name: "test",
+          window: {
+            title: "test",
+          },
+        });
+      });
+      const state = select(store.getState(), "test");
+      expect(state).toBeDefined();
+      expect(state?.key).toBe("test");
+      expect(state?.location).toBe("mosaic");
+      expect(state?.type).toBe("cat");
+      expect(state?.name).toBe("test");
     });
-    const state = select(store.getState(), "test");
-    expect(state).toBeDefined();
-    expect(state?.key).toBe("test");
-    expect(state?.location).toBe("mosaic");
-    expect(state?.type).toBe("cat");
-    expect(state?.name).toBe("test");
+
+    it("should remove a layout from the store", () => {
+      const store = configureStore({
+        reducer: combineReducers({
+          layout: reducer,
+          drift: Drift.reducer,
+        }),
+      });
+      const wrapper = ({ children }: PropsWithChildren) => (
+        <Provider store={store}>{children}</Provider>
+      );
+      const { result } = renderHook(
+        () => ({
+          placer: Layout.usePlacer(),
+          store: useStore(),
+          remover: Layout.useRemover(),
+        }),
+        { wrapper },
+      );
+      act(() => {
+        result.current.placer({
+          key: "test",
+          location: "mosaic",
+          type: "cat",
+          name: "test",
+          window: {
+            title: "test",
+          },
+        });
+      });
+      act(() => {
+        result.current.remover("test");
+      });
+      const state = select(store.getState(), "test");
+      expect(state).toBeUndefined();
+    });
   });
-
-  it("should remove a layout from the store", () => {
-    const store = configureStore({
-      reducer: combineReducers({
-        layout: reducer,
-        drift: Drift.reducer,
-      }),
-    });
-    const wrapper = ({ children }: PropsWithChildren) => (
-      <Provider store={store}>{children}</Provider>
-    );
-    const { result } = renderHook(
-      () => ({
-        placer: usePlacer(),
-        store: useStore(),
-        remover: useRemover(),
-      }),
-      { wrapper },
-    );
-    act(() => {
-      result.current.placer({
-        key: "test",
-        location: "mosaic",
-        type: "cat",
-        name: "test",
-        window: {
-          title: "test",
-        },
+  describe("useSelectActiveMosaicTab", () => {
+    it("should select the active mosaic tab", () => {
+      const store = configureStore({
+        reducer: combineReducers({
+          layout: reducer,
+          drift: Drift.reducer,
+        }),
       });
+      const wrapper = ({ children }: PropsWithChildren) => (
+        <Provider store={store}>{children}</Provider>
+      );
+      const { result } = renderHook(
+        () => ({
+          placer: Layout.usePlacer(),
+          store: useStore(),
+          activeTab: Layout.useSelectActiveMosaicTabKey(),
+        }),
+        { wrapper },
+      );
+
+      // Initially there should be no active tab
+      expect(result.current.activeTab).toBeNull();
+
+      // Place a layout in the mosaic
+      act(() => {
+        result.current.placer({
+          key: "test-tab",
+          location: "mosaic",
+          type: "cat",
+          name: "Test Tab",
+          window: {
+            title: "test",
+          },
+        });
+      });
+
+      // Now the active tab should be the one we just placed
+      expect(result.current.activeTab).toBe("test-tab");
     });
-    act(() => {
-      result.current.remover("test");
+    it("should return null if there is a modal open", () => {
+      const store = configureStore({
+        reducer: combineReducers({
+          layout: reducer,
+          drift: Drift.reducer,
+        }),
+      });
+      const wrapper = ({ children }: PropsWithChildren) => (
+        <Provider store={store}>{children}</Provider>
+      );
+      const { result } = renderHook(
+        () => ({
+          placer: Layout.usePlacer(),
+          store: useStore(),
+          activeTab: Layout.useSelectActiveMosaicTabKey(),
+        }),
+        { wrapper },
+      );
+
+      // Place a layout in the mosaic
+      act(() => {
+        result.current.placer({
+          key: "test-tab",
+          location: "mosaic",
+          type: "cat",
+          name: "Test Tab",
+          window: {
+            title: "test",
+          },
+        });
+      });
+
+      // Verify the tab is active
+      expect(result.current.activeTab).toBe("test-tab");
+
+      // Place a modal
+      act(() => {
+        result.current.placer({
+          key: "test-modal",
+          location: "modal",
+          type: "dog",
+          name: "Test Modal",
+          window: {
+            title: "modal",
+          },
+        });
+      });
+
+      // Now the active tab should be null because a modal is open
+      expect(result.current.activeTab).toBeNull();
     });
-    const state = select(store.getState(), "test");
-    expect(state).toBeUndefined();
   });
 });

--- a/console/src/layout/selectors.ts
+++ b/console/src/layout/selectors.ts
@@ -217,7 +217,12 @@ export const selectActiveMosaicTabKey = (
 ): string | null => {
   const winKey = selectWindowKey(state, windowKey);
   if (winKey == null) return null;
-  return selectSliceState(state).mosaics[winKey].activeTab;
+  const sliceState = selectSliceState(state);
+  const hasModals = Object.values(sliceState.layouts).some(
+    (l) => l.location === "modal" && l.windowKey === winKey,
+  );
+  if (hasModals) return null;
+  return sliceState.mosaics[winKey].activeTab;
 };
 
 export const useSelectActiveMosaicTabKey = (): string | null =>


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2133](https://linear.app/synnax/issue/SY-2133)

## Description

Makes it so that triggers on mosaic windows do not work when a modal is focused.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
