### PR TITLE
SY - 2187 - Fix Rack Renaming

### DIFF
--- a/client/ts/src/hardware/rack/payload.ts
+++ b/client/ts/src/hardware/rack/payload.ts
@@ -16,7 +16,9 @@ export type Key = z.infer<typeof keyZ>;
 export const rackZ = z.object({ key: keyZ, name: z.string() });
 export interface Payload extends z.infer<typeof rackZ> {}
 
-export const newZ = rackZ.omit({ key: true });
+export const newZ = rackZ.omit({ key: true }).extend({
+  key: keyZ.optional(),
+});
 export interface New extends z.input<typeof newZ> {}
 
 export const ONTOLOGY_TYPE = "rack";

--- a/client/ts/src/hardware/rack/payload.ts
+++ b/client/ts/src/hardware/rack/payload.ts
@@ -16,8 +16,6 @@ export type Key = z.infer<typeof keyZ>;
 export const rackZ = z.object({ key: keyZ, name: z.string() });
 export interface Payload extends z.infer<typeof rackZ> {}
 
-export const newZ = rackZ.omit({ key: true }).extend({
-  key: keyZ.optional(),
 export const newZ = rackZ.partial({ key: true });
 export interface New extends z.input<typeof newZ> {}
 

--- a/client/ts/src/hardware/rack/payload.ts
+++ b/client/ts/src/hardware/rack/payload.ts
@@ -18,7 +18,7 @@ export interface Payload extends z.infer<typeof rackZ> {}
 
 export const newZ = rackZ.omit({ key: true }).extend({
   key: keyZ.optional(),
-});
+export const newZ = rackZ.partial({ key: true });
 export interface New extends z.input<typeof newZ> {}
 
 export const ONTOLOGY_TYPE = "rack";

--- a/client/ts/src/hardware/rack/rack.spec.ts
+++ b/client/ts/src/hardware/rack/rack.spec.ts
@@ -26,6 +26,18 @@ describe("Rack", () => {
       await expect(client.hardware.racks.create({})).rejects.toThrow(ZodError);
     });
   });
+  describe("update", () => {
+    it("should update a rack if the key is provided", async () => {
+      const r = await client.hardware.racks.create({ name: "test" });
+      const updated = await client.hardware.racks.create({
+        key: r.key,
+        name: "updated",
+      });
+      expect(updated.name).toBe("updated");
+      const retrieved = await client.hardware.racks.retrieve(r.key);
+      expect(retrieved.name).toBe("updated");
+    });
+  });
   describe("retrieve", () => {
     it("should retrieve a rack by its key", async () => {
       const r = await client.hardware.racks.create({ name: "test" });

--- a/client/ts/src/hardware/task/task.spec.ts
+++ b/client/ts/src/hardware/task/task.spec.ts
@@ -45,6 +45,22 @@ describe("Task", async () => {
       expect(m.config).toStrictEqual(config);
     });
   });
+  describe("update", () => {
+    it("should update a task if the key is provided", async () => {
+      const m = await testRack.createTask({
+        name: "test",
+        config: { a: "dog" },
+        type: "ni",
+      });
+      const updated = await client.hardware.tasks.create({
+        ...m,
+        name: "updated",
+      });
+      expect(updated.name).toBe("updated");
+      const retrieved = await client.hardware.tasks.retrieve(m.key);
+      expect(retrieved.name).toBe("updated");
+    });
+  });
   describe("retrieve", () => {
     it("should retrieve a task by its key", async () => {
       const m = await testRack.createTask({


### PR DESCRIPTION
# Issue Pull Request

## Key Information

- **Linear Issue**: [SY-2187](https://linear.app/synnax/issue/SY-2187)

## Description

Fixes an issue where a rack would just get re-created if you try to rename it. Also adds tests. 

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
