### PR TITLE
SY-2160: Add Duplicate Channels to Task Channel List Context Menu

### DIFF
--- a/console/src/hardware/common/task/ChannelList.tsx
+++ b/console/src/hardware/common/task/ChannelList.tsx
@@ -20,6 +20,7 @@ interface ContextMenuProps<C extends Channel> {
   channels: C[];
   isSnapshot: boolean;
   keys: string[];
+  onDuplicate?: (channels: C[], indices: number[]) => void;
   onSelect: (keys: string[], index: number) => void;
   onTare?: (keys: string[], channels: C[]) => void;
   path: string;
@@ -31,6 +32,7 @@ const ContextMenu = <C extends Channel>({
   channels,
   isSnapshot,
   keys,
+  onDuplicate,
   onSelect,
   onTare,
   path,
@@ -47,6 +49,7 @@ const ContextMenu = <C extends Channel>({
     else onSelect([], -1);
   };
   const { set } = Form.useContext();
+  const handleDuplicate = () => onDuplicate?.(channels, indices);
   const handleDisable = () =>
     indices.forEach((index) => set(`${path}.${index}.enabled`, false));
   const handleEnable = () =>
@@ -60,7 +63,9 @@ const ContextMenu = <C extends Channel>({
     disable: handleDisable,
     enable: handleEnable,
     tare: handleTare,
+    duplicate: handleDuplicate,
   };
+  const canDuplicate = onDuplicate != null && indices.length > 0;
   const canRemove = indices.length > 0;
   const canDisable = indices.some((i) => channels[i].enabled);
   const canEnable = indices.some((i) => !channels[i].enabled);
@@ -69,14 +74,19 @@ const ContextMenu = <C extends Channel>({
     <PMenu.Menu onChange={handleSelect} level="small">
       {!isSnapshot && (
         <>
+          {canDuplicate && (
+            <PMenu.Item itemKey="duplicate" startIcon={<Icon.Copy />}>
+              Duplicate
+            </PMenu.Item>
+          )}
           {canRemove && (
             <>
               <PMenu.Item itemKey="remove" startIcon={<Icon.Close />}>
                 Remove
               </PMenu.Item>
-              <PMenu.Divider />
             </>
           )}
+          {canDuplicate || (canRemove && <PMenu.Divider />)}
           {canDisable && (
             <PMenu.Item itemKey="disable" startIcon={<Icon.Disable />}>
               Disable

--- a/console/src/hardware/common/task/layouts/ChannelList.tsx
+++ b/console/src/hardware/common/task/layouts/ChannelList.tsx
@@ -9,7 +9,7 @@
 
 import { Icon } from "@synnaxlabs/media";
 import { Align, Form, Header as PHeader, Text } from "@synnaxlabs/pluto";
-import { useCallback } from "react";
+import { useCallback, useMemo } from "react";
 
 import {
   ChannelList as Core,
@@ -56,17 +56,20 @@ const EmptyContent = ({ isSnapshot, onAdd }: EmptyContentProps) => (
   </Align.Center>
 );
 
-export type ChannelListProps<C extends Channel> = Omit<
-  CoreProps<C>,
-  "channels" | "header" | "emptyContent" | "path" | "remove"
-> & {
+export interface ChannelListProps<C extends Channel>
+  extends Omit<
+    CoreProps<C>,
+    "channels" | "header" | "emptyContent" | "path" | "remove"
+  > {
   createChannel: (channels: C[]) => C | null;
+  createChannels?: (channels: C[], indices: number[]) => C[];
   path?: string;
-};
+}
 
 export const ChannelList = <C extends Channel>({
   isSnapshot,
   createChannel,
+  createChannels,
   onSelect,
   path = "config.channels",
   ...rest
@@ -82,6 +85,14 @@ export const ChannelList = <C extends Channel>({
     push(channel);
     onSelect([channel.key], channels.length);
   }, [push, channels, createChannel, onSelect]);
+  const handleDuplicate = useMemo(() => {
+    if (createChannels == null) return undefined;
+    return (chs: C[], indices: number[]) => {
+      const duplicated = createChannels(chs, indices);
+      push(duplicated);
+      onSelect([...rest.selected, ...duplicated.map((c) => c.key)], channels.length);
+    };
+  }, [createChannels, channels, onSelect, rest.selected]);
   return (
     <Core
       header={<Header isSnapshot={isSnapshot} onAdd={handleAdd} />}
@@ -91,6 +102,7 @@ export const ChannelList = <C extends Channel>({
       path={path}
       remove={remove}
       onSelect={onSelect}
+      onDuplicate={handleDuplicate}
       {...rest}
     />
   );

--- a/console/src/hardware/common/task/layouts/ChannelList.tsx
+++ b/console/src/hardware/common/task/layouts/ChannelList.tsx
@@ -89,10 +89,17 @@ export const ChannelList = <C extends Channel>({
     if (createChannels == null) return undefined;
     return (chs: C[], indices: number[]) => {
       const duplicated = createChannels(chs, indices);
+      if (duplicated.length === 0) {
+        onSelect([], -1);
+        return;
+      }
       push(duplicated);
-      onSelect([...rest.selected, ...duplicated.map((c) => c.key)], channels.length);
+      onSelect(
+        duplicated.map(({ key }) => key),
+        chs.length + duplicated.length - 1,
+      );
     };
-  }, [createChannels, channels, onSelect, rest.selected]);
+  }, [createChannels, onSelect, push]);
   return (
     <Core
       header={<Header isSnapshot={isSnapshot} onAdd={handleAdd} />}

--- a/console/src/hardware/common/task/layouts/ListAndDetails.tsx
+++ b/console/src/hardware/common/task/layouts/ListAndDetails.tsx
@@ -27,7 +27,7 @@ import {
 import { type Channel } from "@/hardware/common/task/types";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 
-export interface createChannel<C extends Channel> {
+export interface CreateChannel<C extends Channel> {
   (channels: C[], index: number): C | null;
 }
 
@@ -41,7 +41,7 @@ export interface ListAndDetailsProps<C extends Channel>
     "onTare" | "allowTare" | "isSnapshot" | "listItem"
   > {
   details: RenderProp<DetailsProps>;
-  createChannel: createChannel<C>;
+  createChannel: CreateChannel<C>;
   initialChannels: C[];
 }
 
@@ -65,9 +65,20 @@ export const ListAndDetails = <C extends Channel>({
     },
     [setSelected, setSelectedIndex],
   );
-  const handlecreateChannel = useCallback(
+  const handleCreateChannel = useCallback(
     (channels: C[]) => createChannel(channels, selectedIndex),
     [selectedIndex],
+  );
+  const handleDuplicateChannels = useCallback(
+    (allChannels: C[], indices: number[]) => {
+      const newlyMade: C[] = [];
+      indices.forEach((index) => {
+        const newlyMadeChannel = createChannel([...allChannels, ...newlyMade], index);
+        if (newlyMadeChannel != null) newlyMade.push(newlyMadeChannel);
+      });
+      return newlyMade;
+    },
+    [createChannel],
   );
   const copy = useCopyToClipboard();
   const handleCopyChannelDetails = useCallback(() => {
@@ -83,7 +94,8 @@ export const ListAndDetails = <C extends Channel>({
         {...rest}
         selected={selected}
         onSelect={handleSelect}
-        createChannel={handlecreateChannel}
+        createChannel={handleCreateChannel}
+        createChannels={handleDuplicateChannels}
       />
       <Divider.Divider direction="y" />
       <Align.Space direction="y" grow empty className={CSS.B("details")}>


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2160](https://linear.app/synnax/issue/SY-2160/add-duplicate-channels-to-task-channel-list-context-menu)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Added a "Duplicate Channel" to the context menu for NI Analog Read, NI Analog Write, and LabJack Read tasks.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
