### PR TITLE
SY-2157: Remove Max Voltage Field from LabJack Read Task Thermocouple Channels

### DIFF
--- a/console/src/hardware/labjack/task/InputChannelForms.tsx
+++ b/console/src/hardware/labjack/task/InputChannelForms.tsx
@@ -186,8 +186,6 @@ export const FORMS: Record<InputChannelType, FC<FormProps>> = {
   [TC_CHANNEL_TYPE]: ({ path, deviceModel }) => (
     <>
       <Divider.Divider direction="x" padded="bottom" />
-      <MaxVoltageField path={path} />
-      <Divider.Divider direction="x" padded="bottom" />
       <Align.Space direction="x">
         <ThermocoupleTypeField path={path} grow />
         <TemperatureUnitsField path={path} grow />

--- a/console/src/hardware/labjack/task/Read.tsx
+++ b/console/src/hardware/labjack/task/Read.tsx
@@ -17,7 +17,7 @@ import { Common } from "@/hardware/common";
 import { Device } from "@/hardware/labjack/device";
 import { convertChannelTypeToPortType } from "@/hardware/labjack/task/convertChannelTypeToPortType";
 import { getOpenPort } from "@/hardware/labjack/task/getOpenPort";
-import { FORMS } from "@/hardware/labjack/task/OutputChannelForms";
+import { FORMS } from "@/hardware/labjack/task/InputChannelForms";
 import { SelectInputChannelTypeField } from "@/hardware/labjack/task/SelectInputChannelTypeField";
 import {
   AI_CHANNEL_TYPE,

--- a/console/src/hardware/labjack/task/types.ts
+++ b/console/src/hardware/labjack/task/types.ts
@@ -57,7 +57,7 @@ export type AIChannelType = typeof AI_CHANNEL_TYPE;
 
 const aiChannelZ = Common.Task.readChannelZ.extend({
   type: z.literal(AI_CHANNEL_TYPE),
-  range: z.number().finite().optional(),
+  range: z.number().positive().finite().optional(),
   scale: scaleZ,
   port: portZ.regex(
     Device.AIN_PORT_REGEX,
@@ -69,7 +69,7 @@ const ZERO_AI_CHANNEL: AIChannel = {
   ...Common.Task.ZERO_READ_CHANNEL,
   type: AI_CHANNEL_TYPE,
   port: "AIN0",
-  range: 0,
+  range: 10,
   scale: ZERO_SCALES[NO_SCALE_TYPE],
 };
 
@@ -121,7 +121,7 @@ export type ThermocoupleType = z.infer<typeof thermocoupleTypeZ>;
 export const DEVICE_CJC_SOURCE = "TEMPERATURE_DEVICE_K";
 export const AIR_CJC_SOURCE = "TEMPERATURE_AIR_K";
 
-const tcChannelZ = aiChannelZ.omit({ type: true }).extend({
+const tcChannelZ = aiChannelZ.omit({ type: true, range: true }).extend({
   type: z.literal(TC_CHANNEL_TYPE),
   thermocoupleType: thermocoupleTypeZ,
   posChan: z.number().int(),


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2157](https://linear.app/synnax/issue/SY-2157/remove-max-voltage-field-from-labjack-read-task-thermocouple-channel)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Removed the max voltage field from the LabJack TC channel form as it is not used. Set
the default range to 10V instead of 0V.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
