### PR TITLE
SY-2188 - Fix Named Parameter Convention in Range Docs

### DIFF
--- a/client/py/synnax/ranger/client.py
+++ b/client/py/synnax/ranger/client.py
@@ -58,6 +58,7 @@ from synnax.telem import (
 )
 from synnax.util.interop import overload_comparison_operators
 from synnax.util.normalize import check_for_none, normalize
+from synnax.util.params import require_named_params
 
 RANGE_SET_CHANNEL = "sy_range_set"
 
@@ -447,6 +448,9 @@ class Range(RangePayload):
         return self._tasks.retrieve(keys=[t.id.key for t in tasks])
 
 
+
+
+
 class RangeClient:
     _frame_client: Client
     _channels: ChannelRetriever
@@ -589,18 +593,7 @@ class RangeClient:
             res.extend(self.__sugar(self._writer.create(to_create, parent=parent)))
         return res if not is_single else res[0]
 
-    @overload
-    def retrieve(self, *, key: RangeKey) -> Range: ...
-
-    @overload
-    def retrieve(self, *, name: RangeName) -> Range: ...
-
-    @overload
-    def retrieve(self, *, names: RangeNames) -> list[Range]: ...
-
-    @overload
-    def retrieve(self, *, keys: RangeKeys) -> list[Range]: ...
-
+    @require_named_params(example_params=("name", "My Range"))
     def retrieve(
         self,
         *,

--- a/client/py/synnax/ranger/client.py
+++ b/client/py/synnax/ranger/client.py
@@ -448,9 +448,6 @@ class Range(RangePayload):
         return self._tasks.retrieve(keys=[t.id.key for t in tasks])
 
 
-
-
-
 class RangeClient:
     _frame_client: Client
     _channels: ChannelRetriever

--- a/client/py/synnax/user/client.py
+++ b/client/py/synnax/user/client.py
@@ -14,6 +14,7 @@ from freighter import Empty, Payload, UnaryClient, send_required
 
 from synnax.user.payload import NewUser, User
 from synnax.util.normalize import normalize
+from synnax.util.params import require_named_params
 
 
 class _CreateRequest(Payload):
@@ -78,6 +79,7 @@ class Client:
     @overload
     def create(self, *, users: list[NewUser]) -> list[User]: ...
 
+    @require_named_params(example_params=("user", "NewUser(username='synnax')"))
     def create(
         self,
         *,
@@ -144,6 +146,7 @@ class Client:
     @overload
     def retrieve(self, *, usernames: list[str]) -> list[User]: ...
 
+    @require_named_params(example_params=("username", "synnax"))
     def retrieve(
         self,
         *,

--- a/client/py/synnax/util/params.py
+++ b/client/py/synnax/util/params.py
@@ -1,0 +1,63 @@
+import functools
+from typing import Callable, Optional, Tuple, TypeVar, Any, cast
+
+# Define a generic type variable for the function
+F = TypeVar('F', bound=Callable[..., Any])
+
+class RequiresNamedParams(TypeError):
+    """
+    Custom exception raised when a function is called with positional arguments
+    instead of named arguments.
+    """
+    pass
+
+def require_named_params(
+    func: Optional[F] = None,
+    *,
+    example_params: Optional[Tuple[str, str]] = None
+) -> Callable[[F], F]:
+    """
+    Decorator that catches TypeError exceptions related to positional arguments
+    and re-raises them with a more helpful error message.
+
+    Args:
+        func: The function to decorate
+        example_params: Optional tuple of (param_name, param_value) to show in the error message
+                        Example: example_params=("user_id", "12345")
+
+    Returns:
+        The decorated function with improved error messages for positional arguments
+    """
+    def decorator(func: F) -> F:
+        @functools.wraps(func)
+        def wrapper(*args: Any, **kwargs: Any) -> Any:
+            try:
+                return func(*args, **kwargs)
+            except TypeError as e:
+                # Check if this is the "takes X positional arguments but Y were given" error
+                if "positional argument" in str(e) and "were given" in str(e):
+                    func_name = func.__qualname__
+
+                    # Use custom example if provided, otherwise use generic example
+                    if example_params:
+                        param_name, param_value = example_params
+                        param_example = f"{func_name}({param_name}='{param_value}')"
+                        value_example = f"'{param_value}'"
+                    else:
+                        param_example = f"{func_name}(name='value')"
+                        value_example = "'value'"
+
+                    message = (
+                        f"{str(e)}. '{func_name}' only accepts named parameters.\n"
+                        f"Try using named parameters like: {param_example} instead of {func_name}({value_example})"
+                    )
+                    raise RequiresNamedParams(message) from None
+                # Re-raise other TypeErrors unchanged
+                raise
+
+        return cast(F, wrapper)
+
+    # Handle both @require_named_params and @require_named_params(example_params="...")
+    if func is None:
+        return decorator
+    return decorator(func)

--- a/client/py/synnax/util/params.py
+++ b/client/py/synnax/util/params.py
@@ -2,19 +2,20 @@ import functools
 from typing import Callable, Optional, Tuple, TypeVar, Any, cast
 
 # Define a generic type variable for the function
-F = TypeVar('F', bound=Callable[..., Any])
+F = TypeVar("F", bound=Callable[..., Any])
+
 
 class RequiresNamedParams(TypeError):
     """
     Custom exception raised when a function is called with positional arguments
     instead of named arguments.
     """
+
     pass
 
+
 def require_named_params(
-    func: Optional[F] = None,
-    *,
-    example_params: Optional[Tuple[str, str]] = None
+    func: Optional[F] = None, *, example_params: Optional[Tuple[str, str]] = None
 ) -> Callable[[F], F]:
     """
     Decorator that catches TypeError exceptions related to positional arguments
@@ -28,6 +29,7 @@ def require_named_params(
     Returns:
         The decorated function with improved error messages for positional arguments
     """
+
     def decorator(func: F) -> F:
         @functools.wraps(func)
         def wrapper(*args: Any, **kwargs: Any) -> Any:

--- a/client/py/tests/test_ranger.py
+++ b/client/py/tests/test_ranger.py
@@ -14,6 +14,7 @@ import numpy as np
 import pytest
 
 import synnax as sy
+from synnax.util.params import RequiresNamedParams
 
 
 @pytest.mark.ranger
@@ -61,6 +62,11 @@ class TestRangeClient:
         """Should retrieve a range by name"""
         rng = client.ranges.retrieve(name=two_ranges[0].name)
         assert rng.name == two_ranges[0].name
+
+    def test_retrieve_unnamed_parameter(self, client: sy.Synnax):
+        """Should raise an error when unnamed parameters are passed in"""
+        with pytest.raises(RequiresNamedParams):
+            client.ranges.retrieve("cat")
 
     def test_retrieve_by_name_not_found(
         self, two_ranges: list[sy.Range], client: sy.Synnax

--- a/docs/site/src/pages/reference/python-client/ranges.mdx
+++ b/docs/site/src/pages/reference/python-client/ranges.mdx
@@ -71,15 +71,21 @@ We can retrieve a range by its name or key:
 
 ```python
 # By name
-my_range = client.ranges.retrieve("My Range")
+my_range = client.ranges.retrieve(name="My Range")
 
 # By key
-my_range = client.ranges.retrieve(my_range.key)
+my_range = client.ranges.retrieve(key=my_range.key)
 ```
 
 Synnax will raise a `NotFoundError` if the range does not exist, and a
 `MultipleFoundError` if multiple ranges with the given name exist. If you'd like to
 accept multiple or no results, provide a list to the `retrieve` method as shown below.
+
+<Note.Note variant="info">
+  The `retrieve` method only supports passing in named parameters i.e. `name`, `key`,
+  `names`, `keys`. If you try to pass in unnamed parameters, Synnax will raise a
+  `TypeError`.
+</Note.Note>
 
 ### Retrieving Multiple Ranges
 
@@ -88,13 +94,13 @@ method:
 
 ```python
 # By name
-my_ranges = client.ranges.retrieve(["My Range", "My Other Range"])
+my_ranges = client.ranges.retrieve(names=["My Range", "My Other Range"])
 
 # By key
-my_ranges = client.ranges.retrieve([my_range.key, my_other_range.key])
+my_ranges = client.ranges.retrieve(keys=[my_range.key, my_other_range.key])
 
 # This won't work!
-my_ranges = client.ranges.retrieve(["My Range", my_other_range.key])
+my_ranges = client.ranges.retrieve(names=["My Range", my_other_range.key])
 ```
 
 In these examples, Synnax will not raise an error if a range cannot be found. Instead,
@@ -110,7 +116,7 @@ We can access the channels on a range as if they were class properties or dictio
 keys:
 
 ```python
-my_range = client.ranges.retrieve("My Range")
+my_range = client.ranges.retrieve(name="My Range")
 
 # Using a property accessor
 my_pressure_channel = my_range.pressure_2
@@ -124,7 +130,7 @@ We can also access multiple channels on the range by passing a regular expressio
 property accessor:
 
 ```python
-my_range = client.ranges.retrieve("My Range")
+my_range = client.ranges.retrieve(name="My Range")
 
 # Returns an iterable object containing matching channels
 my_pressure_channels = my_range["^pressure"]
@@ -155,7 +161,7 @@ Imagine we have a channel named `daq_analog_input_1` that we'd like to refer to 
 `tank_pressure` for a tank burst test. We can do this by aliasing the channel:
 
 ```python
-burst_test = client.ranges.retrieve("Oct 10 Burst Test")
+burst_test = client.ranges.retrieve(name="Oct 10 Burst Test")
 
 # Set our alias
 burst_test.daq_analog_input_1.set_alias("tank_pressure")
@@ -188,7 +194,7 @@ as test configuration parameters, numeric results, part numbers, etc. We can att
 metadata to a range using the `meta_data` property:
 
 ```python
-burst_test = client.ranges.retrieve("Oct 10 Burst Test")
+burst_test = client.ranges.retrieve(name="Oct 10 Burst Test")
 
 # Set a single key/value pair
 burst_test.meta_data.set("part_number", "12345")
@@ -214,7 +220,7 @@ burst_test.meta_data.set({
 Getting metadata is as easy as setting it:
 
 ```python
-burst_test = client.ranges.retrieve("Oct 10 Burst Test")
+burst_test = client.ranges.retrieve(name="Oct 10 Burst Test")
 
 # Retrieve a single key
 part_number = burst_test.meta_data.get("part_number")
@@ -228,7 +234,7 @@ part_number = burst_test.meta_data["part_number"]
 We can delete metadata using the `delete` method:
 
 ```python
-burst_test = client.ranges.retrieve("Oct 10 Burst Test")
+burst_test = client.ranges.retrieve(name="Oct 10 Burst Test")
 
 # Delete a single key
 burst_test.meta_data.delete("part_number")
@@ -247,8 +253,8 @@ burst_test.meta_data.delete(["part_number", "test_configuration"])
 Deleting a range is as simple as passing in its name or key to the `delete` method:
 
 ```python
-client.ranges.delete("My Range")
-client.ranges.delete(my_range.key)
+client.ranges.delete(name="My Range")
+client.ranges.delete(key=my_range.key)
 ```
 
 <Note.Note variant="info">
@@ -258,6 +264,6 @@ client.ranges.delete(my_range.key)
 We can delete multiple ranges by passing a list of names or keys to the `delete` method:
 
 ```python
-client.ranges.delete(["My Range", "My Other Range"])
-client.ranges.delete([my_range.key, my_other_range.key])
+client.ranges.delete(names=["My Range", "My Other Range"])
+client.ranges.delete(keys=[my_range.key, my_other_range.key])
 ```


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2188](https://linear.app/synnax/issue/SY-2188)

## Description

Current docs don't reflect the fact that `ranges.retrieve` requires you to pass in named parameters with `key` or `name`. This fixes the docs and improves the errors thrown. 

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
