### PR TITLE
SY-2194 - Fix At() Support for Timestamps

### DIFF
--- a/x/cpp/telem/series.h
+++ b/x/cpp/telem/series.h
@@ -593,9 +593,10 @@ public:
         if (dt == UINT32_T) return this->at<uint32_t>(index);
         if (dt == UINT16_T) return this->at<uint16_t>(index);
         if (dt == UINT8_T) return this->at<uint8_t>(index);
+        if (dt == TIMESTAMP_T) return this->at<TimeStamp>(index);
         if (dt == STRING_T || dt == JSON_T) return this->at<std::string>(index);
         throw std::runtime_error(
-            "unsupported data type for value_at: " + dt.name()
+            "unsupported data type for at: " + dt.name()
         );
     }
 

--- a/x/cpp/telem/series_test.cpp
+++ b/x/cpp/telem/series_test.cpp
@@ -429,6 +429,17 @@ TEST_F(SeriesAtTest, testAtFloat64) {
     validateAt(s, vals, telem::FLOAT64_T);
 }
 
+TEST_F(SeriesAtTest, testAtTimestamp) {
+    const std::vector<telem::TimeStamp> vals = {
+        telem::TimeStamp(1000),
+        telem::TimeStamp(2000),
+        telem::TimeStamp(3000)
+    };
+    const auto s = telem::Series(vals);
+    telem::SampleValue sample = s.at(0);
+    ASSERT_EQ(std::get<telem::TimeStamp>(sample).nanoseconds(), 1000);
+}
+
 TEST(TestSeries, testJSONValueConstruction) {
     // Test with a simple JSON object
     json obj = {{"key", "value"}};


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2194](https://linear.app/synnax/issue/SY-2194)

## Description

Fixed and added regression test for SampleValue at() with timestamps.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
