### PR TITLE
SY-2200 - Change DAQmx Default Sampling Mode

### DIFF
--- a/driver/ni/daqmx/api.h
+++ b/driver/ni/daqmx/api.h
@@ -409,5 +409,8 @@ public:
     virtual int32 WriteRaw(TaskHandle task, int32 numSamps, bool32 autoStart, float64 timeout, const uInt8 writeArray[], int32* sampsPerChanWritten, bool32* reserved) = 0;
     virtual int32 WriteToTEDSFromArray(const char physicalChannel[], const uInt8 bitStream[], uInt32 arraySize, int32 basicTEDSOptions) = 0;
     virtual int32 WriteToTEDSFromFile(const char physicalChannel[], const char filePath[], int32 basicTEDSOptions) = 0;
+    virtual int32 SetReadRelativeTo(TaskHandle taskHandle, int32 data) = 0;
+    virtual int32 SetReadOffset(TaskHandle taskHandle, int32 data) = 0;
+    virtual int32 SetReadOverWrite(TaskHandle taskHandle, int32 data) = 0;
 };
 }

--- a/driver/ni/daqmx/prod.cpp
+++ b/driver/ni/daqmx/prod.cpp
@@ -1856,6 +1856,15 @@ ProdAPI::ProdAPI(std::unique_ptr<xlib::SharedLib> &lib_): lib(std::move(lib_)) {
     function_pointers_.WriteToTEDSFromFile = reinterpret_cast<WriteToTEDSFromFilePtr>(
         const_cast<void *>(lib->get_func_ptr(
             "DAQmxWriteToTEDSFromFile")));
+    function_pointers_.SetReadRelativeTo = reinterpret_cast<SetReadRelativeToPtr>(
+        const_cast<void *>(lib->get_func_ptr(
+            "DAQmxSetReadRelativeTo")));
+    function_pointers_.SetReadOffset = reinterpret_cast<SetReadOffsetPtr>(
+        const_cast<void *>(lib->get_func_ptr(
+            "DAQmxSetReadOffset")));
+    function_pointers_.SetReadOverWrite = reinterpret_cast<SetReadOverWritePtr>(
+        const_cast<void *>(lib->get_func_ptr(
+            "DAQmxSetReadOverWrite")));
 }
 
 ProdAPI::~ProdAPI() {
@@ -5980,4 +5989,14 @@ int32 ProdAPI::WriteToTEDSFromFile(const char physicalChannel[],
     return function_pointers_.WriteToTEDSFromFile(physicalChannel, filePath,
                                                   basicTEDSOptions);
 }
+
+int32 ProdAPI::SetReadRelativeTo(TaskHandle taskHandle, int32 data) {
+    return function_pointers_.SetReadRelativeTo(taskHandle, data);
+};
+int32 ProdAPI::SetReadOffset(TaskHandle taskHandle, int32 data) {
+    return function_pointers_.SetReadOffset(taskHandle, data);
+};
+int32 ProdAPI::SetReadOverWrite(TaskHandle taskHandle, int32 data) {
+    return function_pointers_.SetReadOverWrite(taskHandle, data);
+};
 }

--- a/driver/ni/daqmx/prod.h
+++ b/driver/ni/daqmx/prod.h
@@ -2371,7 +2371,9 @@ public:
 
     int32 WriteToTEDSFromFile(const char physicalChannel[], const char filePath[],
                               int32 basicTEDSOptions) override;
-
+    int32 SetReadRelativeTo(TaskHandle taskHandle, int32 data) override;
+    int32 SetReadOffset(TaskHandle taskHandle, int32 data) override;
+    int32 SetReadOverWrite(TaskHandle taskHandle, int32 data) override;
 private:
     using AddCDAQSyncConnectionPtr = decltype(&DAQmxAddCDAQSyncConnection);
     using AddGlobalChansToTaskPtr = decltype(&DAQmxAddGlobalChansToTask);
@@ -2821,6 +2823,9 @@ private:
     using WriteRawPtr = decltype(&DAQmxWriteRaw);
     using WriteToTEDSFromArrayPtr = decltype(&DAQmxWriteToTEDSFromArray);
     using WriteToTEDSFromFilePtr = decltype(&DAQmxWriteToTEDSFromFile);
+    using SetReadRelativeToPtr = decltype(&DAQmxSetReadRelativeTo);
+    using SetReadOffsetPtr = decltype(&DAQmxSetReadOffset);
+    using SetReadOverWritePtr = decltype(&DAQmxSetReadOverWrite);
 
     typedef struct FunctionPointers {
         AddCDAQSyncConnectionPtr AddCDAQSyncConnection;
@@ -3220,6 +3225,9 @@ private:
         WriteRawPtr WriteRaw;
         WriteToTEDSFromArrayPtr WriteToTEDSFromArray;
         WriteToTEDSFromFilePtr WriteToTEDSFromFile;
+        SetReadRelativeToPtr SetReadRelativeTo;
+        SetReadOffsetPtr SetReadOffset;
+        SetReadOverWritePtr SetReadOverWrite;
     } FunctionLoadStatus;
 
     FunctionPointers function_pointers_{};

--- a/driver/ni/daqmx/sugared.cpp
+++ b/driver/ni/daqmx/sugared.cpp
@@ -1099,9 +1099,21 @@ xerrors::Error SugaredAPI::WriteToTEDSFromFile(const char physicalChannel[],
         dmx->WriteToTEDSFromFile(physicalChannel, filePath, basicTEDSOptions));
 }
 
+xerrors::Error SugaredAPI::SetReadRelativeTo(TaskHandle taskHandle, int32 data) {
+    return process_error(dmx->SetReadRelativeTo(taskHandle, data));
+}
+
+xerrors::Error SugaredAPI::SetReadOffset(TaskHandle taskHandle, int32 data) {
+    return process_error(dmx->SetReadOffset(taskHandle, data));
+}
+
+xerrors::Error SugaredAPI::SetReadOverWrite(TaskHandle taskHandle, int32 data) {
+    return process_error(dmx->SetReadOverWrite(taskHandle, data));
+}
+
 xerrors::Error SugaredAPI::CreateLinScale(const char scaleName[], float64 slope,
-                                            float64 yIntercept, int32 preScaledUnits,
-                                            const char customScaleName[]) {
+                                          float64 yIntercept, int32 preScaledUnits,
+                                          const char customScaleName[]) {
     return process_error(dmx->CreateLinScale(scaleName, slope, yIntercept,
                                              preScaledUnits, customScaleName));
 }

--- a/driver/ni/daqmx/sugared.h
+++ b/driver/ni/daqmx/sugared.h
@@ -429,6 +429,8 @@ class SugaredAPI {
   xerrors::Error WriteRaw(TaskHandle task, int32 numSamps, bool32 autoStart, float64 timeout, const uInt8 writeArray[], int32* sampsPerChanWritten, bool32* reserved);
   xerrors::Error WriteToTEDSFromArray(const char physicalChannel[], const uInt8 bitStream[], uInt32 arraySize, int32 basicTEDSOptions);
   xerrors::Error WriteToTEDSFromFile(const char physicalChannel[], const char filePath[], int32 basicTEDSOptions);
-
+  xerrors::Error SetReadRelativeTo(TaskHandle taskHandle, int32 data);
+  xerrors::Error SetReadOffset(TaskHandle taskHandle, int32 data);
+  xerrors::Error SetReadOverWrite(TaskHandle taskHandle, int32 data);
 };
 }

--- a/driver/ni/hardware/daqmx.cpp
+++ b/driver/ni/hardware/daqmx.cpp
@@ -116,4 +116,11 @@ std::pair<size_t, xerrors::Error> AnalogReader::read(
     );
     return {static_cast<size_t>(samples_read), err};
 }
+
+xerrors::Error AnalogReader::start() {
+    if (const auto err = this->dmx->SetReadRelativeTo(this->task_handle, DAQmx_Val_MostRecentSamp)) return err;
+    if (const auto err  = this->dmx->SetReadOffset(this->task_handle, 0)) return err;
+    if (const auto err = this->dmx->SetReadOverWrite(this->task_handle, DAQmx_Val_OverwriteUnreadSamps)) return err;
+    return Base::start();
+}
 }

--- a/driver/ni/hardware/hardware.h
+++ b/driver/ni/hardware/hardware.h
@@ -120,6 +120,8 @@ struct AnalogReader final : Base, Reader<double> {
         size_t samples_per_channel,
         std::vector<double> &data
     ) override;
+
+    xerrors::Error start() override;
 };
 }
 


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2200](https://linear.app/synnax/issue/SY-2200)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
