### PR TITLE
SY-2206: Fix OPC UA Read Task channel renaming

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synnaxlabs/console",
   "private": true,
-  "version": "0.39.0",
+  "version": "0.39.1",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/console/src/hardware/opc/task/Read.tsx
+++ b/console/src/hardware/opc/task/Read.tsx
@@ -241,7 +241,7 @@ const onConfigure: Common.Task.OnConfigure<ReadConfig> = async (
         throw new Error(
           `Channel ${ch.name} already exists as ${rCh.name}. Please move all channels from ${name} to the OPC UA Read Task that reads for ${rCh.name}.`,
         );
-      if (rCh.name !== ch.name) await client.channels.rename(exKey, ch.name);
+      if (rCh.name !== ch.name) ch.name = rCh.name;
     } catch (e) {
       if (NotFoundError.matches(e)) toCreate.push(ch);
       else throw e;


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2206](https://linear.app/synnax/issue/SY-2206/fix-opc-ua-task-renaming)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Make sure that configuring the OPC UA Read Task does not rename channels.



## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
