### PR TITLE
SY-2226: Fix Unique Port Validation in NI Analog Input Task

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synnaxlabs/console",
   "private": true,
-  "version": "0.39.1",
+  "version": "0.39.2",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/console/src/hardware/ni/task/types/types.spec.ts
+++ b/console/src/hardware/ni/task/types/types.spec.ts
@@ -117,40 +117,70 @@ describe("analog read task", () => {
       }).success,
     ).toEqual(true);
   });
-});
 
-describe("analog write task", () => {
-  it("should be able to parse a valid task", () => {
-    expect(
-      analogWriteConfigZ.safeParse({
-        ...ZERO_ANALOG_WRITE_PAYLOAD.config,
-        device: "Dev1",
-        channels: [{ ...ZERO_AO_CHANNEL, key: "0" }],
-      }).success,
-    ).toEqual(true);
+  describe("should be able to parse a task on multiple devices", () => {
+    it("should properly parse a task with the same ports on different devices", () => {
+      expect(
+        analogReadConfigZ.safeParse({
+          ...ZERO_ANALOG_READ_PAYLOAD.config,
+          streamRate: 1000,
+          sampleRate: 2000,
+          channels: [
+            { ...ZERO_AI_CHANNEL, key: "0", device: "34", port: 0 },
+            { ...ZERO_AI_CHANNEL, key: "1", device: "35", port: 0 },
+          ],
+        }).success,
+      ).toEqual(true);
+    });
+
+    it("should properly parse a task with the same ports on the same device", () => {
+      expect(
+        analogReadConfigZ.safeParse({
+          ...ZERO_ANALOG_READ_PAYLOAD.config,
+          streamRate: 1000,
+          sampleRate: 2000,
+          channels: [
+            { ...ZERO_AI_CHANNEL, key: "0", device: "34", port: 0 },
+            { ...ZERO_AI_CHANNEL, key: "1", device: "34", port: 0 },
+          ],
+        }).success,
+      ).toEqual(false);
+    });
   });
-});
 
-describe("digital read task", () => {
-  it("should be able to parse a valid task", () => {
-    expect(
-      digitalReadConfigZ.safeParse({
-        ...ZERO_DIGITAL_READ_PAYLOAD.config,
-        device: "Dev1",
-        channels: [{ ...ZERO_DI_CHANNEL, key: "0" }],
-      }).success,
-    ).toEqual(true);
+  describe("analog write task", () => {
+    it("should be able to parse a valid task", () => {
+      expect(
+        analogWriteConfigZ.safeParse({
+          ...ZERO_ANALOG_WRITE_PAYLOAD.config,
+          device: "Dev1",
+          channels: [{ ...ZERO_AO_CHANNEL, key: "0" }],
+        }).success,
+      ).toEqual(true);
+    });
   });
-});
 
-describe("digital write task", () => {
-  it("should be able to parse a valid task", () => {
-    expect(
-      digitalWriteConfigZ.safeParse({
-        ...ZERO_DIGITAL_WRITE_PAYLOAD.config,
-        device: "Dev1",
-        channels: [{ ...ZERO_DO_CHANNEL, key: "0" }],
-      }).success,
-    ).toEqual(true);
+  describe("digital read task", () => {
+    it("should be able to parse a valid task", () => {
+      expect(
+        digitalReadConfigZ.safeParse({
+          ...ZERO_DIGITAL_READ_PAYLOAD.config,
+          device: "Dev1",
+          channels: [{ ...ZERO_DI_CHANNEL, key: "0" }],
+        }).success,
+      ).toEqual(true);
+    });
+  });
+
+  describe("digital write task", () => {
+    it("should be able to parse a valid task", () => {
+      expect(
+        digitalWriteConfigZ.safeParse({
+          ...ZERO_DIGITAL_WRITE_PAYLOAD.config,
+          device: "Dev1",
+          channels: [{ ...ZERO_DO_CHANNEL, key: "0" }],
+        }).success,
+      ).toEqual(true);
+    });
   });
 });

--- a/console/src/hardware/ni/task/types/v0.ts
+++ b/console/src/hardware/ni/task/types/v0.ts
@@ -1074,7 +1074,7 @@ const ZERO_BASE_WRITE_CONFIG: BaseWriteConfig = {
   stateRate: 10,
 };
 
-export const validateAnalogPorts = (
+const validateAnalogPorts = (
   channels: { port: number }[],
   { addIssue }: z.RefinementCtx,
 ) => {


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2227](https://linear.app/synnax/issue/SY-2227/fix-ni-analog-input-task-multi-device-unique-port-validation)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Fixed an issue in the NI Analog Input task where channels with the same port number on different device were thought to not be unique ports.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
