### PR TITLE
SY-2229: Fixed Null Rack in OPC Connect & Color Swatch D&D

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synnaxlabs/console",
   "private": true,
-  "version": "0.39.2",
+  "version": "0.39.3",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/console/src/hardware/opc/device/Connect.tsx
+++ b/console/src/hardware/opc/device/Connect.tsx
@@ -150,7 +150,7 @@ const Internal = ({ initialValues, layoutKey, onClose, properties }: InternalPro
             path="name"
           />
           <Form.Field<rack.Key> path="rack" label="Connect From Location" required>
-            {(p) => <Rack.SelectSingle {...p}></Rack.SelectSingle>}
+            {(p) => <Rack.SelectSingle {...p} allowNone={false} />}
           </Form.Field>
           <Form.Field<string> path="connection.endpoint">
             {(p) => (

--- a/pluto/package.json
+++ b/pluto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synnaxlabs/pluto",
-  "version": "0.39.0",
+  "version": "0.39.1",
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit && vite build",

--- a/pluto/src/color/Swatch.tsx
+++ b/pluto/src/color/Swatch.tsx
@@ -50,6 +50,7 @@ export const Swatch = ({
     <BaseSwatch
       disabled={!canPick && onClick == null}
       onClick={handleClick}
+      onChange={onChange}
       value={value}
       style={style}
       tooltip={tooltip}


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2229](https://linear.app/synnax/issue/SY-2229)

## Description

Fix color swatch drag and drop and made it so you cannot clear the location when connecting an OPC UA server. 

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
