### PR TITLE
SY-2241: Allow for Changing Device Identifier

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synnaxlabs/console",
   "private": true,
-  "version": "0.39.4",
+  "version": "0.39.5",
   "type": "module",
   "scripts": {
     "dev": "tauri dev",

--- a/console/src/hardware/device/make.tsx
+++ b/console/src/hardware/device/make.tsx
@@ -24,6 +24,22 @@ export type Make = z.infer<typeof makeZ>;
 export const getMake = (make: unknown): Make | null =>
   makeZ.safeParse(make).data ?? null;
 
+export const getIconString = (make: Make | null): string => {
+  switch (make) {
+    case LabJack.Device.MAKE:
+      return "Logo.LabJack";
+    case NI.Device.MAKE:
+      return "Logo.NI";
+    case OPC.Device.MAKE:
+      return "Logo.OPC";
+    default:
+      return "Device";
+  }
+};
+
+export const hasIdentifier = (make: Make | null): boolean =>
+  make === LabJack.Device.MAKE || make === NI.Device.MAKE;
+
 const MAKE_ICONS: Record<Make, PIcon.Element> = {
   [LabJack.Device.MAKE]: <Icon.Logo.LabJack />,
   [NI.Device.MAKE]: <Icon.Logo.NI />,

--- a/console/src/modals/Rename.tsx
+++ b/console/src/modals/Rename.tsx
@@ -15,8 +15,9 @@ import { ModalContentLayout } from "@/modals/layout";
 import { Triggers } from "@/triggers";
 
 export interface PromptRenameLayoutArgs extends BaseArgs<string> {
-  result?: string;
   allowEmpty?: boolean;
+  initialValue?: string;
+  label?: string;
 }
 
 export const RENAME_LAYOUT_TYPE = "rename";
@@ -28,10 +29,12 @@ const SAVE_TRIGGER: PTrigger.Trigger = ["Enter"];
 export const [useRename, Rename] = createBase<string, PromptRenameLayoutArgs>(
   "Name",
   RENAME_LAYOUT_TYPE,
-  ({ value: { result, allowEmpty = false }, onFinish }) => {
-    const [name, setName] = useState(result ?? "");
+  ({
+    value: { result, allowEmpty = false, label = "Name", initialValue },
+    onFinish,
+  }) => {
+    const [name, setName] = useState(result ?? initialValue ?? "");
     const [error, setError] = useState<string | undefined>(undefined);
-
     const footer = (
       <>
         <Triggers.SaveHelpText action="Save" trigger={SAVE_TRIGGER} />
@@ -41,7 +44,8 @@ export const [useRename, Rename] = createBase<string, PromptRenameLayoutArgs>(
             disabled={!allowEmpty && name.length === 0}
             onClick={() => {
               if (allowEmpty && name.length === 0) return onFinish(null);
-              if (!allowEmpty && name.length === 0) return setError("Name is required");
+              if (!allowEmpty && name.length === 0)
+                return setError(`${label} is required`);
               return onFinish(name);
             }}
             triggers={SAVE_TRIGGER}
@@ -55,7 +59,7 @@ export const [useRename, Rename] = createBase<string, PromptRenameLayoutArgs>(
     return (
       <ModalContentLayout footer={footer}>
         <Input.Item
-          label="Name"
+          label={label}
           required={!allowEmpty}
           helpText={error}
           helpTextVariant={error != null ? "error" : "success"}
@@ -63,7 +67,7 @@ export const [useRename, Rename] = createBase<string, PromptRenameLayoutArgs>(
         >
           <Input.Text
             autoFocus
-            placeholder="Name"
+            placeholder={label}
             level="h2"
             variant="natural"
             value={name}


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2241](https://linear.app/synnax/issue/SY-2241/add-device-identifier-changing)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Added an option for the context menu in the device ontology to change the identifier of NI and LabJack devices.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
