### PR TITLE
Standardize "Device is not configured" error

### DIFF
--- a/console/src/hardware/common/device/checkConfigured.ts
+++ b/console/src/hardware/common/device/checkConfigured.ts
@@ -7,9 +7,8 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-export * from "@/hardware/common/device/checkConfigured";
-export * from "@/hardware/common/device/Configure";
-export * from "@/hardware/common/device/Provider";
-export * from "@/hardware/common/device/Select";
-export * from "@/hardware/common/device/types";
-export * from "@/hardware/common/device/use";
+import { type device } from "@synnaxlabs/client";
+
+export const checkConfigured = (device: device.Device): void => {
+  if (!device.configured) throw new Error(`${device.name} is not configured.`);
+};

--- a/console/src/hardware/labjack/task/Read.tsx
+++ b/console/src/hardware/labjack/task/Read.tsx
@@ -272,7 +272,7 @@ const getInitialPayload: Common.Task.GetInitialPayload<
 
 const onConfigure: Common.Task.OnConfigure<ReadConfig> = async (client, config) => {
   const dev = await client.hardware.devices.retrieve<Device.Properties>(config.device);
-  if (!dev.configured) throw new Error(`${dev.name} is not configured`);
+  Common.Device.checkConfigured(dev);
   let shouldCreateIndex = false;
   if (dev.properties.readIndex)
     try {

--- a/console/src/hardware/labjack/task/Write.tsx
+++ b/console/src/hardware/labjack/task/Write.tsx
@@ -217,7 +217,7 @@ const getInitialPayload: Common.Task.GetInitialPayload<
 
 const onConfigure: Common.Task.OnConfigure<WriteConfig> = async (client, config) => {
   const dev = await client.hardware.devices.retrieve<Device.Properties>(config.device);
-  if (!dev.configured) throw new Error(`${dev.name} is not configured`);
+  Common.Device.checkConfigured(dev);
   let modified = false;
   let shouldCreateStateIndex = primitiveIsZero(dev.properties.writeStateIndex);
   if (!shouldCreateStateIndex)

--- a/console/src/hardware/ni/task/AnalogRead.tsx
+++ b/console/src/hardware/ni/task/AnalogRead.tsx
@@ -148,11 +148,10 @@ const onConfigure: Common.Task.OnConfigure<AnalogReadConfig> = async (
   config,
 ) => {
   const devices = unique.unique(config.channels.map((c) => c.device));
-  // TODO: check that multiple devices are not being configured at once.
   let rackKey: rack.Key | undefined;
   for (const devKey of devices) {
     const dev = await client.hardware.devices.retrieve<Device.Properties>(devKey);
-    if (!dev.configured) throw new Error(`${dev.name} is not configured`);
+    Common.Device.checkConfigured(dev);
     dev.properties = Device.enrich(dev.model, dev.properties);
     if (rackKey != null && dev.rack !== rackKey)
       throw new Error("All devices must be on the same rack");

--- a/console/src/hardware/ni/task/AnalogWrite.tsx
+++ b/console/src/hardware/ni/task/AnalogWrite.tsx
@@ -120,7 +120,7 @@ const onConfigure: Common.Task.OnConfigure<AnalogWriteConfig> = async (
   const dev = await client.hardware.devices.retrieve<Device.Properties, Device.Make>(
     config.device,
   );
-  if (!dev.configured) throw new Error(`${dev.name} is not configured`);
+  Common.Device.checkConfigured(dev);
   dev.properties = Device.enrich(dev.model, dev.properties);
   let modified = false;
   let shouldCreateStateIndex = primitiveIsZero(dev.properties.analogOutput.stateIndex);

--- a/console/src/hardware/ni/task/DigitalRead.tsx
+++ b/console/src/hardware/ni/task/DigitalRead.tsx
@@ -90,7 +90,7 @@ const onConfigure: Common.Task.OnConfigure<DigitalReadConfig> = async (
   config,
 ) => {
   const dev = await client.hardware.devices.retrieve<Device.Properties>(config.device);
-  if (!dev.configured) throw new Error(`${dev.name} is not configured`);
+  Common.Device.checkConfigured(dev);
   dev.properties = Device.enrich(dev.model, dev.properties);
   let modified = false;
   let shouldCreateIndex = primitiveIsZero(dev.properties.digitalInput.index);

--- a/console/src/hardware/ni/task/DigitalWrite.tsx
+++ b/console/src/hardware/ni/task/DigitalWrite.tsx
@@ -89,7 +89,7 @@ const onConfigure: Common.Task.OnConfigure<DigitalWriteConfig> = async (
   const dev = await client.hardware.devices.retrieve<Device.Properties, Device.Make>(
     config.device,
   );
-  if (!dev.configured) throw new Error(`${dev.name} is not configured`);
+  Common.Device.checkConfigured(dev);
   dev.properties = Device.enrich(dev.model, dev.properties);
   let modified = false;
   let shouldCreateStateIndex = primitiveIsZero(dev.properties.digitalOutput.stateIndex);


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2238](https://linear.app/synnax/issue/SY-2238/standardize-device-is-not-configured-errors)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Standardize code for "Device is not configured" error.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
