### PR TITLE
SY-2300: Fix Sequencing Shutdown Mechanics

### DIFF
--- a/client/cpp/transport.h
+++ b/client/cpp/transport.h
@@ -15,6 +15,7 @@
 #include "client/cpp/framer/framer.h"
 #include "client/cpp/hardware/hardware.h"
 #include "client/cpp/ranger/ranger.h"
+#include "freighter/cpp/fgrpc/fgrpc.h"
 
 namespace synnax {
 struct Transport {

--- a/driver/pipeline/acquisition_test.cpp
+++ b/driver/pipeline/acquisition_test.cpp
@@ -221,3 +221,17 @@ TEST(AcquisitionPipeline, testErrorCommunicationOnReadCriticalHardwareError) {
     ASSERT_EQ(writes->size(), 0);
     pipeline.stop();
 }
+
+/// @brief it should not stop the pipeline if it was never started.
+TEST(AcquisitionPipeline, testStopNeverStartedPipeline) {
+    auto writes = std::make_shared<std::vector<synnax::Frame> >();
+    const auto mock_factory = std::make_shared<pipeline::mock::WriterFactory>(writes);
+    const auto source = std::make_shared<MockSource>(telem::TimeStamp::now());
+    auto pipeline = pipeline::Acquisition(
+        mock_factory,
+        synnax::WriterConfig(),
+        source,
+        breaker::Config()
+    );
+    ASSERT_FALSE(pipeline.stop());
+}

--- a/driver/sequence/plugins/BUILD.bazel
+++ b/driver/sequence/plugins/BUILD.bazel
@@ -29,6 +29,7 @@ cc_test(
         "channel_receive_test.cpp",
         "channel_write_test.cpp",
         "json_test.cpp",
+        "multi_test.cpp",
         "time_test.cpp",
     ],
     copts = select({

--- a/driver/sequence/plugins/channel_receive_test.cpp
+++ b/driver/sequence/plugins/channel_receive_test.cpp
@@ -42,3 +42,49 @@ TEST(ChannelReceive, Basic) {
     lua_close(L);
     plugin.after_all(L);
 }
+
+TEST(ChannelReceive, StopBeforeStart) {
+    synnax::Channel ch;
+    ch.key = 1;
+    ch.name = "my_channel";
+    ch.data_type = telem::FLOAT64_T;
+    const auto factory = pipeline::mock::simple_streamer_factory({ch.key}, std::make_shared<std::vector<synnax::Frame>>());
+    auto plugin = plugins::ChannelReceive(factory, std::vector{ch});
+    const auto L = luaL_newstate();
+    luaL_openlibs(L);
+    // Stopping before starting should be safe
+    plugin.after_all(L);
+    lua_close(L);
+}
+
+TEST(ChannelReceive, DoubleStart) {
+    synnax::Channel ch;
+    ch.key = 1;
+    ch.name = "my_channel";
+    ch.data_type = telem::FLOAT64_T;
+    const auto factory = pipeline::mock::simple_streamer_factory({ch.key}, std::make_shared<std::vector<synnax::Frame>>());
+    auto plugin = plugins::ChannelReceive(factory, std::vector{ch});
+    const auto L = luaL_newstate();
+    luaL_openlibs(L);
+    // Starting twice should be safe
+    plugin.before_all(L);
+    plugin.before_all(L);
+    plugin.after_all(L);
+    lua_close(L);
+}
+
+TEST(ChannelReceive, DoubleStop) {
+    synnax::Channel ch;
+    ch.key = 1;
+    ch.name = "my_channel";
+    ch.data_type = telem::FLOAT64_T;
+    const auto factory = pipeline::mock::simple_streamer_factory({ch.key}, std::make_shared<std::vector<synnax::Frame>>());
+    auto plugin = plugins::ChannelReceive(factory, std::vector{ch});
+    const auto L = luaL_newstate();
+    luaL_openlibs(L);
+    plugin.before_all(L);
+    // Stopping twice should be safe
+    plugin.after_all(L);
+    plugin.after_all(L);
+    lua_close(L);
+}

--- a/driver/sequence/plugins/channel_write.cpp
+++ b/driver/sequence/plugins/channel_write.cpp
@@ -14,13 +14,11 @@
 plugins::SynnaxFrameSink::SynnaxFrameSink(
     const std::shared_ptr<synnax::Synnax> &client,
     synnax::WriterConfig cfg
-)
-    : client(client), cfg(std::move(cfg)) {
+): client(client), cfg(std::move(cfg)) {
 }
 
 xerrors::Error plugins::SynnaxFrameSink::open() {
-    if (this->writer != nullptr)
-        throw std::runtime_error("sink already open");
+    if (this->writer != nullptr) return xerrors::NIL;
     auto [w, err] = this->client->telem.open_writer(this->cfg);
     if (err) return err;
     this->writer = std::make_unique<synnax::Writer>(std::move(w));
@@ -44,8 +42,7 @@ xerrors::Error plugins::SynnaxFrameSink::set_authority(
 }
 
 xerrors::Error plugins::SynnaxFrameSink::close() {
-    if (this->writer == nullptr)
-        throw std::runtime_error("sink already closed");
+    if (this->writer == nullptr) return xerrors::NIL;
     const auto err = this->writer->close();
     this->writer = nullptr;
     return err;

--- a/driver/sequence/plugins/json.cpp
+++ b/driver/sequence/plugins/json.cpp
@@ -18,7 +18,6 @@
 plugins::JSON::JSON(json source_data): data(std::move(source_data)) {
 }
 
-
 xerrors::Error plugins::JSON::before_all(lua_State *L) {
     return xlua::set_globals_from_json_object(L, this->data);
 }

--- a/driver/sequence/plugins/multi_test.cpp
+++ b/driver/sequence/plugins/multi_test.cpp
@@ -1,0 +1,152 @@
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+#include "gtest/gtest.h"
+#include "driver/sequence/plugins/plugins.h"
+
+class MockPlugin : public plugins::Plugin {
+public:
+    std::vector<std::string> calls;
+    bool should_error = false;
+    std::string error_on;
+
+    xerrors::Error before_all(lua_State *L) override {
+        calls.emplace_back("before_all");
+        if (should_error && error_on == "before_all") 
+            return xerrors::Error("mock error");
+        return xerrors::NIL;
+    }
+
+    xerrors::Error after_all(lua_State *L) override {
+        calls.emplace_back("after_all");
+        if (should_error && error_on == "after_all") 
+            return xerrors::Error("mock error");
+        return xerrors::NIL;
+    }
+
+    xerrors::Error before_next(lua_State *L) override {
+        calls.emplace_back("before_next");
+        if (should_error && error_on == "before_next") 
+            return xerrors::Error("mock error");
+        return xerrors::NIL;
+    }
+
+    xerrors::Error after_next(lua_State *L) override {
+        calls.emplace_back("after_next");
+        if (should_error && error_on == "after_next") 
+            return xerrors::Error("mock error");
+        return xerrors::NIL;
+    }
+};
+
+TEST(MultiPlugin, testCallOrder) {
+    auto plugin1 = std::make_shared<MockPlugin>();
+    auto plugin2 = std::make_shared<MockPlugin>();
+    std::vector<std::shared_ptr<plugins::Plugin>> plugins = {plugin1, plugin2};
+    
+    auto multi = plugins::MultiPlugin(plugins);
+    
+    ASSERT_EQ(multi.before_all(nullptr), xerrors::NIL);
+    ASSERT_EQ(multi.before_next(nullptr), xerrors::NIL);
+    ASSERT_EQ(multi.after_next(nullptr), xerrors::NIL);
+    ASSERT_EQ(multi.after_all(nullptr), xerrors::NIL);
+
+    std::vector<std::string> expected = {
+        "before_all", "before_next", "after_next", "after_all"
+    };
+    ASSERT_EQ(plugin1->calls, expected);
+    ASSERT_EQ(plugin2->calls, expected);
+}
+
+TEST(MultiPlugin, testErrorPropagationBeforeAll) {
+    auto plugin1 = std::make_shared<MockPlugin>();
+    auto plugin2 = std::make_shared<MockPlugin>();
+    plugin2->should_error = true;
+    plugin2->error_on = "before_all";
+    
+    std::vector<std::shared_ptr<plugins::Plugin>> plugins = {plugin1, plugin2};
+    auto multi = plugins::MultiPlugin(plugins);
+    
+    auto err = multi.before_all(nullptr);
+    ASSERT_NE(err, xerrors::NIL);
+    ASSERT_EQ(plugin1->calls.size(), 1);
+    ASSERT_EQ(plugin2->calls.size(), 1);
+}
+
+TEST(MultiPlugin, testErrorPropagationAfterAll) {
+    auto plugin1 = std::make_shared<MockPlugin>();
+    auto plugin2 = std::make_shared<MockPlugin>();
+    plugin2->should_error = true;
+    plugin2->error_on = "after_all";
+    
+    std::vector<std::shared_ptr<plugins::Plugin>> plugins = {plugin1, plugin2};
+    auto multi = plugins::MultiPlugin(plugins);
+    
+    auto err = multi.after_all(nullptr);
+    ASSERT_NE(err, xerrors::NIL);
+    ASSERT_EQ(plugin1->calls.size(), 1);
+    ASSERT_EQ(plugin2->calls.size(), 1);
+}
+
+TEST(MultiPlugin, testErrorPropagationBeforeNext) {
+    auto plugin1 = std::make_shared<MockPlugin>();
+    auto plugin2 = std::make_shared<MockPlugin>();
+    plugin2->should_error = true;
+    plugin2->error_on = "before_next";
+    
+    std::vector<std::shared_ptr<plugins::Plugin>> plugins = {plugin1, plugin2};
+    auto multi = plugins::MultiPlugin(plugins);
+    
+    auto err = multi.before_next(nullptr);
+    ASSERT_NE(err, xerrors::NIL);
+    ASSERT_EQ(plugin1->calls.size(), 1);
+    ASSERT_EQ(plugin2->calls.size(), 1);
+}
+
+TEST(MultiPlugin, testErrorPropagationAfterNext) {
+    auto plugin1 = std::make_shared<MockPlugin>();
+    auto plugin2 = std::make_shared<MockPlugin>();
+    plugin2->should_error = true;
+    plugin2->error_on = "after_next";
+    
+    std::vector<std::shared_ptr<plugins::Plugin>> plugins = {plugin1, plugin2};
+    auto multi = plugins::MultiPlugin(plugins);
+    
+    auto err = multi.after_next(nullptr);
+    ASSERT_NE(err, xerrors::NIL);
+    ASSERT_EQ(plugin1->calls.size(), 1);
+    ASSERT_EQ(plugin2->calls.size(), 1);
+}
+
+/// @brief it should call after_all on all plugins even if one returns an error
+TEST(MultiPlugin, testAfterAllCallsAllPlugins) {
+    auto plugin1 = std::make_shared<MockPlugin>();
+    auto plugin2 = std::make_shared<MockPlugin>();
+    auto plugin3 = std::make_shared<MockPlugin>();
+    
+    // Make the middle plugin return an error
+    plugin2->should_error = true;
+    plugin2->error_on = "after_all";
+    
+    std::vector<std::shared_ptr<plugins::Plugin>> plugins = {plugin1, plugin2, plugin3};
+    auto multi = plugins::MultiPlugin(plugins);
+    
+    auto err = multi.after_all(nullptr);
+    ASSERT_NE(err, xerrors::NIL);
+    
+    // Verify that all plugins had after_all called
+    ASSERT_EQ(plugin1->calls.size(), 1);
+    ASSERT_EQ(plugin1->calls[0], "after_all");
+    
+    ASSERT_EQ(plugin2->calls.size(), 1);
+    ASSERT_EQ(plugin2->calls[0], "after_all");
+    
+    ASSERT_EQ(plugin3->calls.size(), 1);
+    ASSERT_EQ(plugin3->calls[0], "after_all");
+}

--- a/driver/sequence/plugins/plugins.h
+++ b/driver/sequence/plugins/plugins.h
@@ -69,8 +69,8 @@ class MultiPlugin final : public Plugin {
     std::vector<std::shared_ptr<Plugin> > plugins;
 
 public:
-    explicit
-    MultiPlugin(std::vector<std::shared_ptr<Plugin> > ops): plugins(std::move(ops)) {
+    explicit MultiPlugin(std::vector<std::shared_ptr<Plugin> > ops):
+        plugins(std::move(ops)) {
     }
 
     /// @brief implements Plugin::before_all.
@@ -82,9 +82,10 @@ public:
 
     /// @brief implements Plugin::after_all.
     xerrors::Error after_all(lua_State *L) override {
+        auto err = xerrors::NIL;
         for (const auto &op: plugins)
-            if (auto err = op->after_all(L)) return err;
-        return xerrors::NIL;
+            if (const auto t_err = op->after_all(L)) err = t_err;
+        return err;
     }
 
     /// @brief implements Plugin::before_next.
@@ -161,7 +162,8 @@ class ChannelWrite final : public Plugin {
     std::unordered_map<std::string, synnax::ChannelKey> names_to_keys;
 
 public:
-    ChannelWrite(std::shared_ptr<FrameSink> sink, const std::vector<synnax::Channel> &channels);
+    ChannelWrite(std::shared_ptr<FrameSink> sink,
+                 const std::vector<synnax::Channel> &channels);
 
     std::pair<synnax::Channel, xerrors::Error> resolve(const std::string &name);
 

--- a/driver/sequence/task.cpp
+++ b/driver/sequence/task.cpp
@@ -33,6 +33,8 @@ sequence::Task::Task(
 
 void sequence::Task::run() {
     if (const auto err = this->seq->begin(); err) {
+        if (const auto end_err = this->seq->end())
+            LOG(ERROR) << "[sequence] failed to end after failed start:" << end_err;
         this->state.variant = "error";
         this->state.details["running"] = false;
         this->state.details["message"] = err.message();

--- a/freighter/cpp/fgrpc/fgrpc.h
+++ b/freighter/cpp/fgrpc/fgrpc.h
@@ -177,7 +177,7 @@ public:
             grpc_ctx.AddMetadata(k, v);
 
         // Execute request.
-        auto channel = this->pool->get_channel(req_ctx.target);
+        auto channel = this->pool->get_channel(this->base_target.to_string());
         auto stub = RPC::NewStub(channel);
         auto res = RS();
 
@@ -326,7 +326,7 @@ public:
         freighter::Context req_ctx,
         std::nullptr_t &_
     ) override {
-        auto channel = this->pool->get_channel(req_ctx.target);
+        auto channel = this->pool->get_channel(this->base_target.to_string());
         auto res_ctx = freighter::Context(
             req_ctx.protocol,
             req_ctx.target,


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2300](https://linear.app/synnax/issue/SY-2300)

## Description

Makes it so that sequences shutdown gracefully even after failed startup.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
