### PR TITLE
SY-2307: Temporarily Use Default Font In Code Editor on Windows

### DIFF
--- a/console/src/code/Editor.css
+++ b/console/src/code/Editor.css
@@ -14,6 +14,8 @@
     --editor-token-delimiter-parenthesis: #cc255f;
 }
 
+/* Monaco editor on windows does a bad job of dealing with custom fonts, so we're just
+using the default for now.  */
 .console-main--macos .monaco-editor *:not(.codicon) {
     font-family: "Geist Mono" !important;
 }

--- a/console/src/code/Editor.css
+++ b/console/src/code/Editor.css
@@ -14,18 +14,10 @@
     --editor-token-delimiter-parenthesis: #cc255f;
 }
 
-/* 
-Monaco does some fancy stuff with web workers to move the cursor around, and 
-Geist Mono runs a bit larger than the standard monospace font on Windows, so we need
-to manually downsize a tad. 
-*/
-.console-main--windows .monaco-editor *:not(.codicon) {
-    font-size: 13px !important;
-}
-
-.monaco-editor *:not(.codicon) {
+.console-main--macos .monaco-editor *:not(.codicon) {
     font-family: "Geist Mono" !important;
 }
+
 .mtk1 {
     color: var(--pluto-gray-l9) !important;
 }


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2307](https://linear.app/synnax/issue/SY-2307)

## Description

Using geist mono for editor font on windows caused cursor offset problems. This is a temporary fix to just switch back to default font.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
