### PR TITLE
Add set_authority to control sequence editor global variables

### DIFF
--- a/console/src/hardware/task/sequence/globals.ts
+++ b/console/src/hardware/task/sequence/globals.ts
@@ -1,3 +1,12 @@
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
 import { type Variable } from "@/code/phantom";
 
 export const GLOBALS: Variable[] = [
@@ -33,7 +42,18 @@ export const GLOBALS: Variable[] = [
     key: "iteration",
     name: "iteration",
     value: "0",
-    docs: `The iteration number of the sequence. This is incremented each time the sequence is run, 
+    docs: `The iteration number of the sequence. This is incremented each time the sequence is run,
     and starts at 1.`,
+  },
+  {
+    key: "set_authority",
+    name: "set_authority",
+    value: `
+    --- Set the control authority of a channel
+    --- @param channel string The name of the channel to set the authority of
+    --- @param authority number The authority to set the channel to
+    --- @return void
+    function(channel, authority)
+    end`,
   },
 ];


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2303](https://linear.app/synnax/issue/SY-2303/add-set-authority-to-control-sequence-editor-global-variables)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Add set_authority to the global variables in the console for control sequences.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
