### PR TITLE
Trigger unmount / mount of table toolbar for different cells.

### DIFF
--- a/console/src/table/Toolbar.tsx
+++ b/console/src/table/Toolbar.tsx
@@ -105,6 +105,8 @@ export const Toolbar = ({ layoutKey }: ToolbarProps): ReactElement => {
           <CellForm
             tableKey={layoutKey}
             cell={firstCell}
+            // trigger re-render if you select a different cell
+            key={firstCell.key}
             onVariantChange={(variant) => handleVariantChange(variant, firstCell.key)}
           />
         )}


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2270](https://linear.app/synnax/issue/SY-2270/fix-table-cell-selection-in-console)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Trigger a unmount->mount of the table toolbar whenever a different cell is selected. This is to prevent an issue where two different cells with the same property were selected consecutively, and then changing the cell type from value to text would change the previously selected cell's value instead of the current one.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [x] Server
- [x] Console

### API Changes

The following projects have backwards-compatible APIs:

- [x] Python Client
- [x] Server
- [x] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
