### PR TITLE
allow synnax console to run in the browser

### DIFF
--- a/console/src/error/Overlay.tsx
+++ b/console/src/error/Overlay.tsx
@@ -21,7 +21,7 @@ import {
   Text,
   Theming,
 } from "@synnaxlabs/pluto";
-import { getCurrentWindow } from "@tauri-apps/api/window";
+import { getCurrentWindow } from "@/tauriShim";
 import { type PropsWithChildren, type ReactElement, useEffect } from "react";
 import {
   ErrorBoundary,

--- a/console/src/layout/Window.tsx
+++ b/console/src/layout/Window.tsx
@@ -12,7 +12,7 @@ import "@/layout/Window.css";
 import { MAIN_WINDOW, setWindowProps } from "@synnaxlabs/drift";
 import { useSelectWindowKey } from "@synnaxlabs/drift/react";
 import { Align, Haul, Menu as PMenu, OS } from "@synnaxlabs/pluto";
-import { getCurrentWindow } from "@tauri-apps/api/window";
+import { getCurrentWindow } from "@/tauriShim";
 import { memo, type ReactElement, useEffect } from "react";
 import { useDispatch } from "react-redux";
 

--- a/console/src/layout/useThemeProvider.ts
+++ b/console/src/layout/useThemeProvider.ts
@@ -10,7 +10,7 @@
 import { type UnknownAction } from "@reduxjs/toolkit";
 import { Drift } from "@synnaxlabs/drift";
 import { type AsyncDestructor, Theming, useAsyncEffect } from "@synnaxlabs/pluto";
-import { getCurrentWindow } from "@tauri-apps/api/window";
+import { getCurrentWindow } from "@/tauriShim";
 import { type Dispatch } from "react";
 import { useDispatch } from "react-redux";
 

--- a/console/src/persist/state.ts
+++ b/console/src/persist/state.ts
@@ -10,9 +10,9 @@
 import { type Action, type Middleware } from "@reduxjs/toolkit";
 import { MAIN_WINDOW } from "@synnaxlabs/drift";
 import { debounce, deep, TimeSpan, type UnknownRecord } from "@synnaxlabs/x";
-import { getCurrentWindow } from "@tauri-apps/api/window";
+import { getCurrentWindow } from "@/tauriShim";
 
-import { openTauriKV, type SugaredKV } from "@/persist/kv";
+import { openSugaredKV, type SugaredKV } from "@/persist/kv";
 import { type Version } from "@/version";
 
 export const PERSISTED_STATE_KEY = "console-persisted-state";
@@ -28,13 +28,13 @@ interface StateVersionValue {
   version: number;
 }
 
-export interface RequiredState extends Version.StoreState {}
+export interface RequiredState extends Version.StoreState { }
 
 export interface KVOpener {
   (base: string): Promise<SugaredKV>;
 }
 
-const openAndMigrateKV = async (openKV: KVOpener = openTauriKV): Promise<SugaredKV> => {
+const openAndMigrateKV = async (openKV: KVOpener = openSugaredKV): Promise<SugaredKV> => {
   // Open V2 store and check its length. If it's greater than 0, return it. Otherwise,
   // open V1 store and return it.
   const v2Store = await openKV(V2_STORE_PATH);

--- a/console/src/tauriShim.ts
+++ b/console/src/tauriShim.ts
@@ -1,0 +1,50 @@
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { MAIN_WINDOW } from "@synnaxlabs/drift";
+import { isTauri } from "@tauri-apps/api/core";
+import { EventCallback, UnlistenFn } from "@tauri-apps/api/event";
+import { getCurrentWindow as tauriGetCurrentWindow, Window, Theme } from "@tauri-apps/api/window";
+
+/**
+ * An object that looks like `Window` from `@tauri-apps/api/window`.
+ */
+export interface WindowLike {
+    label: string
+
+    show: () => Promise<void>
+    close: () => Promise<void>
+    minimize: () => Promise<void>
+    maximize: () => Promise<void>
+
+    onThemeChanged: (handler: EventCallback<Theme>) => Promise<UnlistenFn>;
+    theme(): Promise<Theme | null>;
+}
+
+/**
+ * Get the current Tauri window, or a similarly-shaped stub object if running in the browser.
+ */
+export const getCurrentWindow = (): Window | WindowLike => {
+    if (isTauri()) {
+        return tauriGetCurrentWindow();
+    } else {
+        return {
+            label: MAIN_WINDOW,
+            show: async () => { },
+            close: async () => { },
+            minimize: async () => { },
+            maximize: async () => { },
+            onThemeChanged: async (handler) => {
+                return () => { }
+            },
+            theme: async () => { return null; },
+
+        }
+    }
+};

--- a/drift/src/tauri/index.ts
+++ b/drift/src/tauri/index.ts
@@ -349,6 +349,47 @@ export class TauriRuntime<S extends StoreState, A extends Action = UnknownAction
   }
 }
 
+/** 
+ * In certain environments (such as the web browser), it is not really possible to
+ * spawn new windows. The `NoopRuntime` is intended to stand in for drift in these 
+ * environments.
+ */
+export class NoopRuntime<S extends StoreState, A extends Action = UnknownAction>
+  implements Runtime<S, A> {
+
+  async emit(event: Omit<Event<S, A>, "emitter">, to?: string): Promise<void> {
+    // TODO: maybe have an event emitter ??
+  }
+  async subscribe(lis: (event: Event<S, A>) => void): Promise<void> { }
+  isMain(): boolean { return true; }
+  label(): string { return MAIN_WINDOW; };
+  onCloseRequested(cb: () => void): void {
+    // TODO: consider implementing
+  };
+  async listLabels(): Promise<string[]> { return []; }
+  async getProps(): Promise<Omit<WindowProps, "key">> { return {}; }
+  async create(label: string, props: Omit<WindowProps, "key">): Promise<void> { };
+  async close(label: string): Promise<void> { };
+  async focus(): Promise<void> { };
+  async setMinimized(value: boolean): Promise<void> { };
+  async setMaximized(value: boolean): Promise<void> { };
+  async setVisible(value: boolean): Promise<void> { };
+  async setFullscreen(value: boolean): Promise<void> { };
+  async center(): Promise<void> { };
+  async setPosition(xy: xy.XY): Promise<void> { };
+  async setSize(dims: dimensions.Dimensions): Promise<void> { };
+  async setMinSize(dims: dimensions.Dimensions): Promise<void> { };
+  async setMaxSize(dims: dimensions.Dimensions): Promise<void> { };
+  async setResizable(value: boolean): Promise<void> { };
+  async setSkipTaskbar(value: boolean): Promise<void> { };
+  async setAlwaysOnTop(value: boolean): Promise<void> { };
+  async setDecorations(value: boolean): Promise<void> { };
+  async setTitle(title: string): Promise<void> { };
+  async configure(): Promise<void> {
+    // throw new Error("Method not implemented.");
+  }
+
+}
 interface HandlerEntry {
   key: TauriEventKey;
   debounce: number;


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-####](https://linear.app/synnax/issue/)

## Description

I'm trying to run the Synnax Console on Linux. Unfortunately, the Tauri backend for linux (`libwebkit2gtk`) does not support `webgl2` inside `OffscreenCanvas`, which breaks the renderer. The easiest workaround for me is to run the console inside Chrome. To achieve this, this PR adds web-compatible stubs for the few tauri-dependent bits of the console (kv store and drift runtime).

## Basic Readiness

- [x] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
