### PR TITLE
[console] - fixed device name styling in ontology tree when shrunk

### DIFF
--- a/console/src/hardware/device/ontology.css
+++ b/console/src/hardware/device/ontology.css
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2025 Synnax Labs, Inc.
+ *
+ * Use of this software is governed by the Business Source License included in the file
+ * licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source
+ * License, use of this software will be governed by the Apache License, Version 2.0,
+ * included in the file licenses/APL.txt.
+ */
+
+.console-device-ontology-item {
+    .console-name {
+        text-overflow: ellipsis;
+        width: 0;
+        overflow: hidden;
+        flex-grow: 1;
+    }
+    .console-location {
+        line-height: 100%;
+        margin-top: 0.25rem;
+        text-overflow: ellipsis;
+        width: 0;
+        overflow: hidden;
+        flex-grow: 1;
+    }
+}

--- a/console/src/hardware/device/ontology.tsx
+++ b/console/src/hardware/device/ontology.tsx
@@ -7,6 +7,8 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+import "@/hardware/device/ontology.css";
+
 import { device, ontology } from "@synnaxlabs/client";
 import { Icon } from "@synnaxlabs/media";
 import { Align, Menu as PMenu, Status, Text, Tree } from "@synnaxlabs/pluto";
@@ -14,6 +16,7 @@ import { errors } from "@synnaxlabs/x";
 import { useMutation } from "@tanstack/react-query";
 
 import { Menu } from "@/components";
+import { CSS } from "@/css";
 import { Group } from "@/group";
 import {
   CONFIGURE_LAYOUTS,
@@ -174,23 +177,20 @@ const Item: Tree.Item = ({ entry, ...rest }: Tree.ItemProps) => {
   const id = new ontology.ID(entry.key);
   const devState = useState(id.key);
   return (
-    <Tree.DefaultItem {...rest} entry={entry}>
+    <Tree.DefaultItem {...rest} className={CSS.B("device-ontology-item")} entry={entry}>
       {({ entry, onRename, key }) => (
         <>
           <Align.Space x grow align="center">
             <Text.MaybeEditable
               id={`text-${key}`}
               level="p"
+              className={CSS.B("name")}
               allowDoubleClick={false}
               value={entry.name}
               disabled={!entry.allowRename}
               onChange={(name) => onRename?.(entry.key, name)}
             />
-            <Text.Text
-              level="small"
-              shade={9}
-              style={{ lineHeight: "100%", marginTop: "0.25rem" }}
-            >
+            <Text.Text level="small" shade={9} className={CSS.B("location")}>
               {entry.extraData?.location as string}
             </Text.Text>
           </Align.Space>


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2434](https://linear.app/synnax/issue/SY-2434)

## Description

Fixes device name and location styling in device toolbar when shrunk.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
