### PR TITLE
SY-2432 - Added Device Tooltips on Toolbar

### DIFF
--- a/console/src/hardware/device/ontology.tsx
+++ b/console/src/hardware/device/ontology.tsx
@@ -11,7 +11,7 @@ import "@/hardware/device/ontology.css";
 
 import { device, ontology } from "@synnaxlabs/client";
 import { Icon } from "@synnaxlabs/media";
-import { Align, Menu as PMenu, Status, Text, Tree } from "@synnaxlabs/pluto";
+import { Align, Menu as PMenu, Status, Text, Tooltip, Tree } from "@synnaxlabs/pluto";
 import { errors } from "@synnaxlabs/x";
 import { useMutation } from "@tanstack/react-query";
 
@@ -176,6 +176,7 @@ const icon = (resource: ontology.Resource) => getIcon(getMake(resource.data?.mak
 const Item: Tree.Item = ({ entry, ...rest }: Tree.ItemProps) => {
   const id = new ontology.ID(entry.key);
   const devState = useState(id.key);
+  console.log(devState);
   return (
     <Tree.DefaultItem {...rest} className={CSS.B("device-ontology-item")} entry={entry}>
       {({ entry, onRename, key }) => (
@@ -194,9 +195,19 @@ const Item: Tree.Item = ({ entry, ...rest }: Tree.ItemProps) => {
               {entry.extraData?.location as string}
             </Text.Text>
           </Align.Space>
-          <Status.Circle
-            variant={(devState?.variant ?? "disabled") as Status.Variant}
-          />
+          <Tooltip.Dialog location="right">
+            <Status.Text
+              variant={(devState?.variant ?? "error") as Status.Variant}
+              hideIcon
+              level="small"
+              weight={450}
+            >
+              {(devState?.details?.message ?? "Device State Unknown") as string}
+            </Status.Text>
+            <Status.Circle
+              variant={(devState?.variant ?? "disabled") as Status.Variant}
+            />
+          </Tooltip.Dialog>
         </>
       )}
     </Tree.DefaultItem>


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2434](https://linear.app/synnax/issue/SY-2434)

## Description

Added status tooltips to devices in the ontology toolbar. 
## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
