### PR TITLE
SY-2463 - Improve Handling of Errors Thrown in the Aether Tree

### DIFF
--- a/alamos/ts/src/instrumentation.ts
+++ b/alamos/ts/src/instrumentation.ts
@@ -40,7 +40,6 @@ export class Instrumentation {
   }
 
   child(key: string): Instrumentation {
-
     const __meta = this.meta.child(key);
     return new Instrumentation({ __meta, tracer: this.T, logger: this.L });
   }

--- a/alamos/ts/src/meta.ts
+++ b/alamos/ts/src/meta.ts
@@ -37,5 +37,9 @@ export class Meta {
     return this._noop;
   }
 
+  copy(): Meta {
+    return new Meta(this.key, this.path, this.serviceName, this.noop);
+  }
+
   static readonly NOOP = new Meta("", "", "");
 }

--- a/alamos/ts/src/meta.ts
+++ b/alamos/ts/src/meta.ts
@@ -37,9 +37,5 @@ export class Meta {
     return this._noop;
   }
 
-  copy(): Meta {
-    return new Meta(this.key, this.path, this.serviceName, this.noop);
-  }
-
   static readonly NOOP = new Meta("", "", "");
 }

--- a/alamos/ts/src/trace.ts
+++ b/alamos/ts/src/trace.ts
@@ -49,7 +49,7 @@ export class Tracer {
 
   child(meta: Meta): Tracer {
     const t = new Tracer(this.otelTracer, this.filter);
-    t.meta = meta.copy();
+    t.meta = meta;
     return t;
   }
 

--- a/alamos/ts/src/trace.ts
+++ b/alamos/ts/src/trace.ts
@@ -36,20 +36,20 @@ export type SpanF = (span: Span) => unknown;
  */
 export class Tracer {
   private meta: Meta = Meta.NOOP;
-  private readonly tracer: OtelTracer;
+  private readonly otelTracer?: OtelTracer;
   private readonly filter: EnvironmentFilter;
 
   constructor(
     tracer?: OtelTracer,
     filter: EnvironmentFilter = envThresholdFilter("debug"),
   ) {
-    this.tracer = tracer as OtelTracer;
+    this.otelTracer = tracer;
     this.filter = filter;
   }
 
   child(meta: Meta): Tracer {
-    const t = new Tracer(this.tracer, this.filter);
-    t.meta = meta;
+    const t = new Tracer(this.otelTracer, this.filter);
+    t.meta = meta.copy();
     return t;
   }
 
@@ -128,15 +128,16 @@ export class Tracer {
     f?: F,
   ): ReturnType<F> | Destructor {
     if (f == null) {
-      if (this.meta.noop || !this.filter(env)) return () => {};
-      const span = new _Span(key, this.tracer.startSpan(key));
+      if (this.meta.noop || !this.filter(env) || this.otelTracer == null)
+        return () => {};
+      const span = new _Span(key, this.otelTracer.startSpan(key));
       span.start();
       return () => span.end();
     }
 
-    if (this.meta.noop || !this.filter(env))
+    if (this.meta.noop || !this.filter(env) || this.otelTracer == null)
       return f(new NoopSpan(key)) as ReturnType<F>;
-    return this.tracer.startActiveSpan(key, (otelSpan) => {
+    return this.otelTracer.startActiveSpan(key, (otelSpan) => {
       const span = new _Span(key, otelSpan);
       const result = f(span);
       return result as ReturnType<F>;

--- a/client/ts/src/channel/channel.spec.ts
+++ b/client/ts/src/channel/channel.spec.ts
@@ -11,7 +11,7 @@ import { DataType, TimeStamp } from "@synnaxlabs/x/telem";
 import { beforeAll, describe, expect, it, test } from "vitest";
 
 import { Channel } from "@/channel/client";
-import { NotFoundError, QueryError } from "@/errors";
+import { NotFoundError } from "@/errors";
 import { newClient } from "@/setupspecs";
 
 const client = newClient();
@@ -194,7 +194,7 @@ describe("Channel", () => {
     test("retrieve by key - not found", async () => {
       await expect(
         async () => await client.channels.retrieve("1-1000"),
-      ).rejects.toThrow(QueryError);
+      ).rejects.toThrow(NotFoundError);
     });
     test("retrieve by name", async () => {
       const retrieved = await client.channels.retrieve(["test"]);
@@ -224,7 +224,7 @@ describe("Channel", () => {
       await client.channels.delete(channel.key);
       await expect(
         async () => await client.channels.retrieve(channel.key),
-      ).rejects.toThrow(QueryError);
+      ).rejects.toThrow(NotFoundError);
     });
     test("delete by name", async () => {
       const channel = await client.channels.create({
@@ -236,7 +236,7 @@ describe("Channel", () => {
       await client.channels.delete(["test"]);
       await expect(
         async () => await client.channels.retrieve(channel.key),
-      ).rejects.toThrow(QueryError);
+      ).rejects.toThrow(NotFoundError);
     });
   });
   describe("rename", async () => {

--- a/client/ts/src/errors.spec.ts
+++ b/client/ts/src/errors.spec.ts
@@ -7,8 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { type MatchableErrorType } from "@synnaxlabs/freighter/src/errors";
-import { id } from "@synnaxlabs/x";
+import { type errors, id } from "@synnaxlabs/x";
 import { v4 as uuid } from "uuid";
 import { describe, expect, test } from "vitest";
 
@@ -30,7 +29,7 @@ import { newClient } from "@/setupspecs";
 
 describe("error", () => {
   describe("type matching", () => {
-    const ERRORS: [string, Error, MatchableErrorType][] = [
+    const ERRORS: [string, Error, errors.Matchable][] = [
       [ValidationError.TYPE, new ValidationError(), ValidationError],
       [FieldError.TYPE, new FieldError("field", "message"), FieldError],
       [AuthError.TYPE, new AuthError(), AuthError],
@@ -45,7 +44,9 @@ describe("error", () => {
       [ContiguityError.TYPE, new ContiguityError("message"), ContiguityError],
     ];
     ERRORS.forEach(([typeName, error, type]) =>
-      test(`matches ${typeName}`, () => expect(type.matches(error)).toBeTruthy()),
+      test(`matches ${typeName}`, () => {
+        expect(type.matches(error)).toBeTruthy();
+      }),
     );
   });
 });

--- a/client/ts/src/framer/iterator.ts
+++ b/client/ts/src/framer/iterator.ts
@@ -7,7 +7,8 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { errorZ, type Stream, type StreamClient } from "@synnaxlabs/freighter";
+import { type Stream, type StreamClient } from "@synnaxlabs/freighter";
+import { errors } from "@synnaxlabs/x";
 import {
   type CrudeTimeRange,
   type CrudeTimeSpan,
@@ -57,7 +58,7 @@ const resZ = z.object({
   variant: z.nativeEnum(ResponseVariant),
   ack: z.boolean(),
   command: z.nativeEnum(Command),
-  error: errorZ.optional().nullable(),
+  error: errors.payloadZ.optional().nullable(),
   frame: frameZ.optional(),
 });
 

--- a/client/ts/src/ontology/group/group.spec.ts
+++ b/client/ts/src/ontology/group/group.spec.ts
@@ -34,7 +34,7 @@ describe("Group", () => {
     });
   });
   describe("delete", () => {
-    it.only("should correctly delete the group", async () => {
+    it("should correctly delete the group", async () => {
       const name = `group-${Math.random()}`;
       const g = await client.ontology.groups.create(ontology.ROOT_ID, name);
       await client.ontology.groups.delete(g.key);

--- a/client/ts/src/ontology/group/group.spec.ts
+++ b/client/ts/src/ontology/group/group.spec.ts
@@ -9,7 +9,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { QueryError } from "@/errors";
+import { NotFoundError } from "@/errors";
 import { ontology } from "@/ontology";
 import { newClient } from "@/setupspecs";
 
@@ -34,13 +34,13 @@ describe("Group", () => {
     });
   });
   describe("delete", () => {
-    it("should correctly delete the group", async () => {
+    it.only("should correctly delete the group", async () => {
       const name = `group-${Math.random()}`;
       const g = await client.ontology.groups.create(ontology.ROOT_ID, name);
       await client.ontology.groups.delete(g.key);
       await expect(
         async () => await client.ontology.retrieve(g.ontologyID),
-      ).rejects.toThrow(QueryError);
+      ).rejects.toThrowError(NotFoundError);
     });
   });
 });

--- a/client/ts/src/ranger/ranger.spec.ts
+++ b/client/ts/src/ranger/ranger.spec.ts
@@ -11,7 +11,7 @@ import { type change } from "@synnaxlabs/x";
 import { DataType, TimeSpan, TimeStamp } from "@synnaxlabs/x/telem";
 import { describe, expect, it } from "vitest";
 
-import { QueryError } from "@/errors";
+import { NotFoundError } from "@/errors";
 import { type ranger } from "@/ranger";
 import { newClient } from "@/setupspecs";
 
@@ -74,7 +74,7 @@ describe("Ranger", () => {
       });
       await client.ranges.delete(range.key);
       await expect(async () => await client.ranges.retrieve(range.key)).rejects.toThrow(
-        QueryError,
+        NotFoundError,
       );
     });
   });
@@ -172,7 +172,9 @@ describe("Ranger", () => {
       const val = await rng.kv.get("foo");
       expect(val).toEqual("bar");
       await rng.kv.delete("foo");
-      await expect(async () => await rng.kv.get("foo")).rejects.toThrow(QueryError);
+      await expect(async () => await rng.kv.get("foo")).rejects.toThrowError(
+        NotFoundError,
+      );
     });
 
     it("should set and get multiple keys", async () => {

--- a/console/src/Console.tsx
+++ b/console/src/Console.tsx
@@ -142,7 +142,7 @@ const MainUnderContext = (): ReactElement => {
         triggers={TRIGGERS_PROVIDER_PROPS}
         haul={{ useState: useHaulState }}
         color={{ useState: useColorContextState }}
-        alamos={{ level: "debug", include: [] }}
+        alamos={{ level: "info" }}
       >
         <Code.Provider importExtensions={Lua.EXTENSIONS} initServices={Lua.SERVICES}>
           <Vis.Canvas>

--- a/console/src/channel/services/ontology.tsx
+++ b/console/src/channel/services/ontology.tsx
@@ -113,7 +113,7 @@ export const useDelete = (): ((props: Ontology.TreeContextMenuProps) => void) =>
   return useMutation<void, Error, Ontology.TreeContextMenuProps, Tree.Node[]>({
     onMutate: async ({ state: { nodes, setNodes }, selection: { resources } }) => {
       const prevNodes = Tree.deepCopy(nodes);
-      if (!(await confirm(resources))) throw errors.CANCELED;
+      if (!(await confirm(resources))) throw new errors.Canceled();
       setNodes([
         ...Tree.removeNode({
           tree: nodes,
@@ -129,7 +129,7 @@ export const useDelete = (): ((props: Ontology.TreeContextMenuProps) => void) =>
       { selection: { resources }, handleError, state: { setNodes } },
       prevNodes,
     ) => {
-      if (errors.CANCELED.matches(e)) return;
+      if (errors.Canceled.matches(e)) return;
       if (prevNodes != null) setNodes(prevNodes);
       let message = "Failed to delete channels";
       if (resources.length === 1)

--- a/console/src/error/Overlay.tsx
+++ b/console/src/error/Overlay.tsx
@@ -29,10 +29,10 @@ import {
 } from "react-error-boundary";
 import { useDispatch } from "react-redux";
 
-import { getCurrentWindow } from "@/tauriShim";
 import { CSS } from "@/css";
 import { Persist } from "@/persist";
 import { CLEAR_STATE, REVERT_STATE } from "@/persist/state";
+import { getCurrentWindow } from "@/tauriShim";
 
 export interface OverlayProps extends PropsWithChildren {}
 
@@ -90,7 +90,13 @@ const FallBackRenderContent = ({
   }, []);
   return (
     <Align.Space y className={CSS.B("error-overlay")}>
-      <Nav.Bar location="top" size="6.5rem" className="console-main-nav-top" bordered>
+      <Nav.Bar
+        location="top"
+        size="6.5rem"
+        className="console-main-nav-top"
+        bordered
+        data-tauri-drag-region
+      >
         <Nav.Bar.Start className="console-main-nav-top__start">
           <OS.Controls
             className="console-controls--macos"
@@ -135,7 +141,7 @@ const FallBackRenderContent = ({
           <Align.Space y align="start" className={CSS.B("details")}>
             <Text.Text level="h1">Something went wrong</Text.Text>
             <Status.Text variant="error" hideIcon level="h3">
-              {messageTranslation[error.message] ?? error.message}
+              {error.name} - {messageTranslation[error.message] ?? error.message}
             </Status.Text>
             <Text.Text className={CSS.B("stack")} level="p">
               {error.stack}

--- a/console/src/group/services/ontology.tsx
+++ b/console/src/group/services/ontology.tsx
@@ -157,7 +157,7 @@ const useCreateEmpty = (): ((
     mutationFn: async ({ client, selection: { resources }, newID }) => {
       const resource = resources[resources.length - 1];
       const [name, renamed] = await Tree.asyncRename(newID.toString());
-      if (!renamed) throw errors.CANCELED;
+      if (!renamed) throw new errors.Canceled();
       await client.ontology.groups.create(resource.id, name, newID.key);
     },
     onError: async (
@@ -165,7 +165,7 @@ const useCreateEmpty = (): ((
       { state: { nodes, setNodes }, handleError, selection, newID },
     ) => {
       if (selection.resources.length === 0) return;
-      if (!errors.CANCELED.matches(e)) handleError(e, "Failed to create group");
+      if (!errors.Canceled.matches(e)) handleError(e, "Failed to create group");
       setNodes([...Tree.removeNode({ tree: nodes, keys: newID.toString() })]);
     },
   });

--- a/console/src/group/useCreateFromSelection.tsx
+++ b/console/src/group/useCreateFromSelection.tsx
@@ -62,7 +62,7 @@ export const useCreateFromSelection = (): CreateFromSelection => {
     mutationFn: async ({ client, selection, newID }: CreateArgs) => {
       if (selection.parentID == null) return;
       const [groupName, renamed] = await Tree.asyncRename(newID.toString());
-      if (!renamed) throw errors.CANCELED;
+      if (!renamed) throw new errors.Canceled();
       const resourcesToGroup = getResourcesToGroup(selection);
       const parentID = new ontology.ID(selection.parentID.toString());
       await client.ontology.groups.create(parentID, groupName, newID.key);
@@ -70,7 +70,7 @@ export const useCreateFromSelection = (): CreateFromSelection => {
     },
     onError: async (e, { state: { setNodes }, handleError }, prevNodes) => {
       if (prevNodes != null) setNodes(prevNodes);
-      if (errors.CANCELED.matches(e.message)) return;
+      if (errors.Canceled.matches(e.message)) return;
       handleError(e, "Failed to group resources");
     },
   }).mutate;

--- a/console/src/hardware/device/ontology.tsx
+++ b/console/src/hardware/device/ontology.tsx
@@ -77,7 +77,7 @@ const useHandleChangeIdentifier = () => {
           properties: { ...device.properties, identifier: newIdentifier },
         });
       } catch (e) {
-        if (e instanceof Error && errors.CANCELED.matches(e)) return;
+        if (e instanceof Error && errors.Canceled.matches(e)) return;
         throw e;
       }
     }, "Failed to change identifier");
@@ -89,7 +89,7 @@ const useDelete = () => {
   return useMutation<void, Error, Ontology.TreeContextMenuProps, Tree.Node[]>({
     onMutate: async ({ state: { nodes, setNodes }, selection: { resources } }) => {
       const prevNodes = Tree.deepCopy(nodes);
-      if (!(await confirm(resources))) throw errors.CANCELED;
+      if (!(await confirm(resources))) throw new errors.Canceled();
       setNodes([
         ...Tree.removeNode({
           tree: nodes,
@@ -101,7 +101,7 @@ const useDelete = () => {
     mutationFn: async ({ selection, client }) =>
       await client.hardware.devices.delete(selection.resources.map((r) => r.id.key)),
     onError: (e, { handleError, state: { setNodes } }, prevNodes) => {
-      if (errors.CANCELED.matches(e)) return;
+      if (errors.Canceled.matches(e)) return;
       if (prevNodes != null) setNodes(prevNodes);
       handleError(e, `Failed to delete devices`);
     },

--- a/console/src/hardware/rack/ontology.tsx
+++ b/console/src/hardware/rack/ontology.tsx
@@ -36,7 +36,7 @@ const useDelete = (): ((props: Ontology.TreeContextMenuProps) => void) => {
   const confirm = Ontology.useConfirmDelete({ type: "Rack" });
   return useMutation<void, Error, Ontology.TreeContextMenuProps, Tree.Node[]>({
     onMutate: async ({ state: { nodes, setNodes }, selection: { resources } }) => {
-      if (!(await confirm(resources))) throw errors.CANCELED;
+      if (!(await confirm(resources))) throw new errors.Canceled();
       const prevNodes = Tree.deepCopy(nodes);
       setNodes([
         ...Tree.removeNode({
@@ -50,7 +50,7 @@ const useDelete = (): ((props: Ontology.TreeContextMenuProps) => void) => {
       await client.hardware.racks.delete(resources.map(({ id }) => Number(id.key))),
     onError: (e, { handleError, state: { setNodes } }, prevNodes) => {
       if (prevNodes != null) setNodes(prevNodes);
-      if (errors.CANCELED.matches(e)) return;
+      if (errors.Canceled.matches(e)) return;
       handleError(e, "Failed to delete racks");
     },
   }).mutate;

--- a/console/src/hardware/task/Toolbar.tsx
+++ b/console/src/hardware/task/Toolbar.tsx
@@ -265,7 +265,7 @@ const Content = () => {
       setTasks((prev) => prev.filter(({ key }) => !keys.includes(key)));
     },
     onError: (e) => {
-      if (errors.CANCELED.matches(e)) return;
+      if (errors.Canceled.matches(e)) return;
       handleError(e, "Failed to delete tasks");
     },
   }).mutate;

--- a/console/src/hardware/task/ontology.tsx
+++ b/console/src/hardware/task/ontology.tsx
@@ -43,7 +43,7 @@ const useDelete = () => {
   return useMutation({
     onMutate: async ({ state: { nodes, setNodes }, selection: { resources } }) => {
       const prevNodes = Tree.deepCopy(nodes);
-      if (!(await confirm(resources))) throw errors.CANCELED;
+      if (!(await confirm(resources))) throw new errors.Canceled();
       setNodes([
         ...Tree.removeNode({
           tree: nodes,
@@ -65,7 +65,7 @@ const useDelete = () => {
       let message = "Failed to delete tasks";
       if (resources.length === 1)
         message = `Failed to delete task ${resources[0].name}`;
-      if (errors.CANCELED.matches(e)) return;
+      if (errors.Canceled.matches(e)) return;
       handleError(e, message);
     },
   }).mutate;

--- a/console/src/lineplot/services/ontology.tsx
+++ b/console/src/lineplot/services/ontology.tsx
@@ -27,7 +27,7 @@ const useDelete = (): ((props: Ontology.TreeContextMenuProps) => void) => {
   const confirm = useConfirmDelete({ type: "LinePlot" });
   return useMutation<void, Error, Ontology.TreeContextMenuProps, Tree.Node[]>({
     onMutate: async ({ selection, removeLayout, state: { nodes, setNodes } }) => {
-      if (!(await confirm(selection.resources))) throw errors.CANCELED;
+      if (!(await confirm(selection.resources))) throw new errors.Canceled();
       const ids = selection.resources.map((res) => new ontology.ID(res.key));
       const keys = ids.map((id) => id.key);
       removeLayout(...keys);
@@ -46,7 +46,7 @@ const useDelete = (): ((props: Ontology.TreeContextMenuProps) => void) => {
     },
     onError: (err, { state: { setNodes }, handleError }, prevNodes) => {
       if (prevNodes != null) setNodes(prevNodes);
-      if (errors.CANCELED.matches(err)) return;
+      if (errors.Canceled.matches(err)) return;
       handleError(err, "Failed to delete line plot");
     },
   }).mutate;

--- a/console/src/log/services/ontology.tsx
+++ b/console/src/log/services/ontology.tsx
@@ -28,7 +28,7 @@ const useDelete = (): ((props: Ontology.TreeContextMenuProps) => void) => {
   const confirm = useConfirmDelete({ type: "Log" });
   return useMutation<void, Error, Ontology.TreeContextMenuProps, Tree.Node[]>({
     onMutate: async ({ selection, removeLayout, state: { nodes, setNodes } }) => {
-      if (!(await confirm(selection.resources))) throw errors.CANCELED;
+      if (!(await confirm(selection.resources))) throw new errors.Canceled();
       const ids = selection.resources.map((res) => new ontology.ID(res.key));
       const keys = ids.map((id) => id.key);
       removeLayout(...keys);
@@ -47,7 +47,7 @@ const useDelete = (): ((props: Ontology.TreeContextMenuProps) => void) => {
     },
     onError: (err, { state: { setNodes }, handleError }, prevNodes) => {
       if (prevNodes != null) setNodes(prevNodes);
-      if (errors.CANCELED.matches(err)) return;
+      if (errors.Canceled.matches(err)) return;
       handleError(err, "Failed to delete log");
     },
   }).mutate;

--- a/console/src/range/ContextMenu.tsx
+++ b/console/src/range/ContextMenu.tsx
@@ -254,14 +254,14 @@ export const useDelete = (name?: string) => {
           confirm: { label: "Delete", variant: "error" },
         }))
       )
-        throw errors.CANCELED;
+        throw new errors.Canceled();
       handleRemove([key]);
       remover(key);
       return rng;
     },
     mutationFn: async (key: string) => await client?.ranges.delete(key),
     onError: (e, _, range) => {
-      if (errors.CANCELED.matches(e)) return;
+      if (errors.Canceled.matches(e)) return;
       handleError(e, "Failed to delete range");
       dispatch(add({ ranges: [range as Range] }));
     },

--- a/console/src/range/services/ontology.tsx
+++ b/console/src/range/services/ontology.tsx
@@ -167,7 +167,7 @@ const useDelete = (): ((props: Ontology.TreeContextMenuProps) => void) => {
       store,
       removeLayout,
     }) => {
-      if (!(await confirm(resources))) throw errors.CANCELED;
+      if (!(await confirm(resources))) throw new errors.Canceled();
       const prevNodes = Tree.deepCopy(nodes);
       const minDepth = Math.min(...selectedNodes.map((n) => n.depth));
       const nodesOfMinDepth = selectedNodes.filter((n) => n.depth === minDepth);
@@ -194,7 +194,7 @@ const useDelete = (): ((props: Ontology.TreeContextMenuProps) => void) => {
       { handleError, selection: { resources }, state: { setNodes }, store },
       prevNodes,
     ) => {
-      if (errors.CANCELED.matches(e)) return;
+      if (errors.Canceled.matches(e)) return;
       if (prevNodes != null) {
         setNodes(prevNodes);
         const ranges = fromClientRange(

--- a/console/src/schematic/services/ontology.tsx
+++ b/console/src/schematic/services/ontology.tsx
@@ -29,7 +29,7 @@ const useDelete = (): ((props: Ontology.TreeContextMenuProps) => void) => {
   const confirm = useConfirmDelete({ type: "Schematic" });
   return useMutation<void, Error, Ontology.TreeContextMenuProps, Tree.Node[]>({
     onMutate: async ({ selection, removeLayout, state: { nodes, setNodes } }) => {
-      if (!(await confirm(selection.resources))) throw errors.CANCELED;
+      if (!(await confirm(selection.resources))) throw new errors.Canceled();
       const ids = selection.resources.map((res) => new ontology.ID(res.key));
       const keys = ids.map((id) => id.key);
       removeLayout(...keys);
@@ -48,7 +48,7 @@ const useDelete = (): ((props: Ontology.TreeContextMenuProps) => void) => {
     },
     onError: (err, { state: { setNodes }, handleError }, prevNodes) => {
       if (prevNodes != null) setNodes(prevNodes);
-      if (errors.CANCELED.matches(err)) return;
+      if (errors.Canceled.matches(err)) return;
       handleError(err, "Failed to delete schematic");
     },
   }).mutate;

--- a/console/src/table/services/ontology.tsx
+++ b/console/src/table/services/ontology.tsx
@@ -28,7 +28,7 @@ const useDelete = (): ((props: Ontology.TreeContextMenuProps) => void) => {
   const confirm = useConfirmDelete({ type: "Table" });
   return useMutation<void, Error, Ontology.TreeContextMenuProps, Tree.Node[]>({
     onMutate: async ({ selection, removeLayout, state: { nodes, setNodes } }) => {
-      if (!(await confirm(selection.resources))) throw errors.CANCELED;
+      if (!(await confirm(selection.resources))) throw new errors.Canceled();
       const ids = selection.resources.map((res) => new ontology.ID(res.key));
       const keys = ids.map((id) => id.key);
       removeLayout(...keys);
@@ -47,7 +47,7 @@ const useDelete = (): ((props: Ontology.TreeContextMenuProps) => void) => {
     },
     onError: (e, { state: { setNodes }, handleError }, prevNodes) => {
       if (prevNodes != null) setNodes(prevNodes);
-      if (errors.CANCELED.matches(e)) return;
+      if (errors.Canceled.matches(e)) return;
       handleError(e, "Failed to delete table");
     },
   }).mutate;

--- a/console/src/user/services/ontology.tsx
+++ b/console/src/user/services/ontology.tsx
@@ -31,7 +31,7 @@ const useDelete = (): ((props: Ontology.TreeContextMenuProps) => void) => {
   const confirm = Ontology.useConfirmDelete({ type: "User" });
   return useMutation<void, Error, Ontology.TreeContextMenuProps, Tree.Node[]>({
     onMutate: async ({ state: { nodes, setNodes }, selection: { resources } }) => {
-      if (!(await confirm(resources))) throw errors.CANCELED;
+      if (!(await confirm(resources))) throw new errors.Canceled();
       const prevNodes = Tree.deepCopy(nodes);
       setNodes([
         ...Tree.removeNode({
@@ -45,7 +45,7 @@ const useDelete = (): ((props: Ontology.TreeContextMenuProps) => void) => {
       await client.user.delete(resources.map(({ id }) => id.key)),
     onError: (e, { handleError, state: { setNodes } }, prevNodes) => {
       if (prevNodes != null) setNodes(prevNodes);
-      if (errors.CANCELED.matches(e)) return;
+      if (errors.Canceled.matches(e)) return;
       handleError(e, "Failed to delete users");
     },
   }).mutate;

--- a/console/src/workspace/services/ontology.tsx
+++ b/console/src/workspace/services/ontology.tsx
@@ -48,7 +48,7 @@ const useDelete = (): ((props: Ontology.TreeContextMenuProps) => void) => {
   const confirm = useConfirmDelete({ type: "Workspace" });
   return useMutation<void, Error, Ontology.TreeContextMenuProps, Tree.Node[]>({
     onMutate: async ({ state: { nodes, setNodes }, selection: { resources } }) => {
-      if (!(await confirm(resources))) throw errors.CANCELED;
+      if (!(await confirm(resources))) throw new errors.Canceled();
       const prevNodes = Tree.deepCopy(nodes);
       setNodes([
         ...Tree.removeNode({
@@ -70,7 +70,7 @@ const useDelete = (): ((props: Ontology.TreeContextMenuProps) => void) => {
     },
     onError: (e, { handleError, state: { setNodes } }, prevNodes) => {
       if (prevNodes != null) setNodes(prevNodes);
-      if (errors.CANCELED.matches(e)) return;
+      if (errors.Canceled.matches(e)) return;
       handleError(e, "Failed to delete workspace");
     },
   }).mutate;

--- a/freighter/ts/package.json
+++ b/freighter/ts/package.json
@@ -32,6 +32,7 @@
     "@synnaxlabs/tsconfig": "workspace:*",
     "@synnaxlabs/vite-plugin": "workspace:*",
     "@types/node": "^22.13.10",
+    "@vitest/coverage-v8": "^3.1.3",
     "eslint": "^9.24.0",
     "eslint-config-synnaxlabs": "workspace:*",
     "madge": "^8.0.0",

--- a/freighter/ts/src/errors.ts
+++ b/freighter/ts/src/errors.ts
@@ -7,191 +7,41 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { URL } from "@synnaxlabs/x";
-import { z } from "zod";
-
-/** Basic interface for an error or error type that can be matched against a candidate error */
-export interface MatchableErrorType {
-  /**
-   * @returns a function that matches errors of the given type. Returns true if
-   * the provided instance of Error or a string message contains the provided error type.
-   */
-  matches: (e: string | Error | unknown) => boolean;
-}
-
-export interface TypedError extends Error {
-  discriminator: "FreighterError";
-  /**
-   * @description Returns a unique type identifier for the error. Freighter uses this to
-   * determine the correct decoder to use on the other end of the freighter.
-   */
-  type: string;
-}
+import { errors, URL } from "@synnaxlabs/x";
 
 /**
- * @param type - the error type to match
- * @returns a function that matches errors of the given type. Returns true if
- * the provided instance of Error or a string message contains the provided error type.
+ * @description Base class for all freighter-specific errors
  */
-export const errorMatcher =
-  (type: string) =>
-  (e: string | Error | unknown): boolean => {
-    if (e != null && typeof e === "object" && "type" in e && typeof e.type === "string")
-      return e.type.includes(type);
-    if (e instanceof Error) return e.message.includes(type);
-    if (typeof e !== "string") return false;
-    return e.includes(type);
-  };
-
-export class BaseTypedError extends Error implements TypedError {
-  readonly discriminator = "FreighterError";
-  type: string = "";
-}
-
-type ErrorDecoder = (encoded: ErrorPayload) => Error | null;
-type ErrorEncoder = (error: TypedError) => ErrorPayload | null;
-
-export const isTypedError = (error: unknown): error is TypedError => {
-  if (error == null || typeof error !== "object") return false;
-  const typedError = error as TypedError;
-  if (typedError.discriminator !== "FreighterError") return false;
-  if (!("type" in typedError))
-    throw new Error(
-      `Freighter error is missing its type property: ${JSON.stringify(typedError)}`,
-    );
-  return true;
-};
-
-export const assertErrorType = <T>(type: string, error?: Error | null): T => {
-  if (error == null)
-    throw new Error(`Expected error of type ${type} but got nothing instead`);
-  if (!isTypedError(error))
-    throw new Error(`Expected a typed error, got: ${error.message}`);
-  if (error.type !== type)
-    throw new Error(
-      `Expected error of type ${type}, got ${error.type}: ${error.message}`,
-    );
-  return error as T;
-};
-
-export const UNKNOWN = "unknown";
-export const NONE = "nil";
-export const FREIGHTER = "freighter";
-
-export const errorZ = z.object({ type: z.string(), data: z.string() });
-
-export type ErrorPayload = z.infer<typeof errorZ>;
-
-interface errorProvider {
-  encode: ErrorEncoder;
-  decode: ErrorDecoder;
-}
-
-class Registry {
-  private readonly providers: errorProvider[] = [];
-
-  register(provider: errorProvider): void {
-    this.providers.push(provider);
-  }
-
-  encode(error: unknown): ErrorPayload {
-    if (error == null) return { type: NONE, data: "" };
-    if (isTypedError(error))
-      for (const provider of this.providers) {
-        const payload = provider.encode(error);
-        if (payload != null) return payload;
-      }
-    return { type: UNKNOWN, data: JSON.stringify(error) };
-  }
-
-  decode(payload?: ErrorPayload | null): Error | null {
-    if (payload == null || payload.type === NONE) return null;
-    if (payload.type === UNKNOWN) return new UnknownError(payload.data);
-    for (const provider of this.providers) {
-      const error = provider.decode(payload);
-      if (error != null) return error;
-    }
-    return new UnknownError(payload.data);
-  }
-}
-
-const REGISTRY = new Registry();
+export class FreighterError extends errors.createTyped("freighter") {}
 
 /**
- * Registers a custom error type with the error registry, which allows it to be
- * encoded/decoded and sent over the network.
- *
- * @param type - A unique string identifier for the error type.
- * @param encode - A function that encodes the error into a string.
- * @param decode - A function that decodes the error from a string.
+ * @description Error thrown when reaching the end of a file or stream
  */
-export const registerError = ({
-  encode,
-  decode,
-}: {
-  encode: ErrorEncoder;
-  decode: ErrorDecoder;
-}): void => REGISTRY.register({ encode, decode });
-
-/**
- * Encodes an error into a payload that can be sent between a freighter server
- * and client.
- * @param error - The error to encode.
- * @returns The encoded error.
- */
-export const encodeError = (error: unknown): ErrorPayload => REGISTRY.encode(error);
-
-/**
- * Decodes an error payload into an exception. If a custom decoder can be found
- * for the error type, it will be used. Otherwise, a generic Error containing
- * the error data is returned.
- *
- * @param payload - The encoded error payload.
- * @returns The decoded error.
- */
-export const decodeError = (payload?: ErrorPayload | null): Error | null => {
-  if (payload == null) return null;
-  return REGISTRY.decode(payload);
-};
-
-export class UnknownError extends BaseTypedError implements TypedError {
-  type = "unknown";
-}
-
-const FREIGHTER_ERROR_TYPE = "freighter.";
-
-/** Thrown/returned when a stream closed normally. */
-export class EOF extends BaseTypedError implements TypedError {
-  static readonly TYPE = `${FREIGHTER_ERROR_TYPE}eof`;
-  type = EOF.TYPE;
-  static readonly matches = errorMatcher(EOF.TYPE);
-
+export class EOF extends FreighterError.sub("eof") {
   constructor() {
     super("EOF");
   }
 }
 
-/** Thrown/returned when a stream is closed abnormally. */
-export class StreamClosed extends BaseTypedError implements TypedError {
-  static readonly TYPE = `${FREIGHTER_ERROR_TYPE}stream_closed`;
-  static readonly matches = errorMatcher(StreamClosed.TYPE);
-  type = StreamClosed.TYPE;
-
+/**
+ * @description Error thrown when attempting to operate on a closed stream
+ */
+export class StreamClosed extends FreighterError.sub("stream_closed") {
   constructor() {
     super("StreamClosed");
   }
 }
 
+/**
+ * @description Arguments for constructing an Unreachable error
+ */
 export interface UnreachableArgs {
   message?: string;
   url?: URL;
 }
 
-/** Thrown when a target is unreachable. */
-export class Unreachable extends BaseTypedError implements TypedError {
-  static readonly TYPE = `${FREIGHTER_ERROR_TYPE}unreachable`;
-  type = Unreachable.TYPE;
-  static readonly matches = errorMatcher(Unreachable.TYPE);
+/** @description Thrown when a network target is unreachable. */
+export class Unreachable extends FreighterError.sub("unreachable") {
   url: URL;
 
   constructor(args: UnreachableArgs = {}) {
@@ -201,8 +51,8 @@ export class Unreachable extends BaseTypedError implements TypedError {
   }
 }
 
-const freighterErrorEncoder: ErrorEncoder = (error: TypedError) => {
-  if (!error.type.startsWith(FREIGHTER)) return null;
+const freighterErrorEncoder: errors.Encoder = (error: errors.Typed) => {
+  if (!error.type.startsWith(FreighterError.TYPE)) return null;
   if (EOF.matches(error)) return { type: EOF.TYPE, data: "EOF" };
   if (StreamClosed.matches(error))
     return { type: StreamClosed.TYPE, data: "StreamClosed" };
@@ -211,8 +61,8 @@ const freighterErrorEncoder: ErrorEncoder = (error: TypedError) => {
   throw new Error(`Unknown error type: ${error.type}: ${error.message}`);
 };
 
-const freighterErrorDecoder: ErrorDecoder = (encoded: ErrorPayload) => {
-  if (!encoded.type.startsWith(FREIGHTER_ERROR_TYPE)) return null;
+const freighterErrorDecoder: errors.Decoder = (encoded: errors.Payload) => {
+  if (!encoded.type.startsWith(FreighterError.TYPE)) return null;
   switch (encoded.type) {
     case EOF.TYPE:
       return new EOF();
@@ -221,11 +71,11 @@ const freighterErrorDecoder: ErrorDecoder = (encoded: ErrorPayload) => {
     case Unreachable.TYPE:
       return new Unreachable();
     default:
-      throw new Error(`Unknown error type: ${encoded.data}`);
+      throw new errors.Unknown(`Unknown error type: ${encoded.data}`);
   }
 };
 
-registerError({
+errors.register({
   encode: freighterErrorEncoder,
   decode: freighterErrorDecoder,
 });

--- a/freighter/ts/src/http.ts
+++ b/freighter/ts/src/http.ts
@@ -7,10 +7,10 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { type binary, runtime, type URL } from "@synnaxlabs/x";
+import { type binary, errors, runtime, type URL } from "@synnaxlabs/x";
 import { type z } from "zod";
 
-import { decodeError, errorZ, Unreachable } from "@/errors";
+import { Unreachable } from "@/errors";
 import { type Context, MiddlewareCollector } from "@/middleware";
 import { type UnaryClient } from "@/unary";
 
@@ -27,6 +27,12 @@ const resolveFetchAPI = (protocol: "http" | "https"): typeof fetch => {
   // @ts-expect-error - TS doesn't know about qhis option
   return async (info, init) => await _fetch(info, { ...init, agent });
 };
+
+const shouldCastToUnreachable = (err: Error): boolean =>
+  ("code" in err && err.code === "ECONNREFUSED") ||
+  err.message.toLowerCase().includes("load failed");
+
+const HTTP_STATUS_BAD_REQUEST = 400;
 
 /**
  * HTTPClientFactory provides a POST and GET implementation of the Unary
@@ -91,11 +97,7 @@ export class HTTPClient extends MiddlewareCollector implements UnaryClient {
           httpRes = await f(ctx.target, request);
         } catch (err_) {
           let err = err_ as Error;
-          if (
-            ("code" in err && err.code === "ECONNREFUSED") ||
-            err.message == "Load Failed"
-          )
-            err = new Unreachable({ url });
+          if (shouldCastToUnreachable(err)) err = new Unreachable({ url });
           return [outCtx, err];
         }
         const data = new Uint8Array(await (await httpRes.blob()).arrayBuffer());
@@ -104,9 +106,10 @@ export class HTTPClient extends MiddlewareCollector implements UnaryClient {
           return [outCtx, null];
         }
         try {
-          if (httpRes.status !== 400) return [outCtx, new Error(httpRes.statusText)];
-          const err = this.encoder.decode(data, errorZ);
-          const decoded = decodeError(err);
+          if (httpRes.status !== HTTP_STATUS_BAD_REQUEST)
+            return [outCtx, new Error(httpRes.statusText)];
+          const err = this.encoder.decode(data, errors.payloadZ);
+          const decoded = errors.decode(err);
           return [outCtx, decoded];
         } catch (e) {
           return [

--- a/freighter/ts/src/index.ts
+++ b/freighter/ts/src/index.ts
@@ -7,20 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-export {
-  BaseTypedError,
-  decodeError,
-  encodeError,
-  EOF,
-  errorMatcher,
-  type ErrorPayload,
-  errorZ,
-  type MatchableErrorType,
-  registerError,
-  StreamClosed,
-  type TypedError,
-  Unreachable,
-} from "@/errors";
+export { EOF, StreamClosed, Unreachable } from "@/errors";
 export { HTTPClient } from "@/http";
 export { type Context, type Middleware, type Next } from "@/middleware";
 export { type Stream, type StreamClient } from "@/stream";

--- a/freighter/ts/src/websocket.spec.ts
+++ b/freighter/ts/src/websocket.spec.ts
@@ -7,17 +7,11 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { binary, URL } from "@synnaxlabs/x";
+import { binary, errors, URL } from "@synnaxlabs/x";
 import { describe, expect, test } from "vitest";
 import { z } from "zod";
 
-import {
-  BaseTypedError,
-  EOF,
-  type ErrorPayload,
-  registerError,
-  type TypedError,
-} from "@/errors";
+import { EOF } from "@/errors";
 import { type Context } from "@/middleware";
 import { WebSocketClient } from "@/websocket";
 
@@ -33,29 +27,27 @@ const MessageSchema = z.object({
 
 const client = new WebSocketClient(url, new binary.JSONCodec());
 
-class MyCustomError extends BaseTypedError {
+class MyCustomError extends errors.createTyped("integration.error") {
   code: number;
-  type = "integration.error";
-
   constructor(message: string, code: number) {
     super(message);
     this.code = code;
   }
 }
 
-const encodeTestError = (err: TypedError): ErrorPayload => {
+const encodeTestError = (err: errors.Typed): errors.Payload => {
   if (!(err instanceof MyCustomError)) throw new Error("Unexpected error type");
 
   return { type: "integration.error", data: `${err.code},${err.message}` };
 };
 
-const decodeTestError = (encoded: ErrorPayload): TypedError | null => {
+const decodeTestError = (encoded: errors.Payload): errors.Typed | null => {
   if (encoded.type !== "integration.error") return null;
   const [code, message] = encoded.data.split(",");
   return new MyCustomError(message, parseInt(code));
 };
 
-registerError({
+errors.register({
   encode: encodeTestError,
   decode: decodeTestError,
 });
@@ -72,7 +64,7 @@ describe("websocket", () => {
     }
     stream.closeSend();
     const [response, error] = await stream.receive();
-    expect(error).toEqual(new EOF());
+    expect(EOF.matches(error)).toBeTruthy();
     expect(response).toBeNull();
   });
 
@@ -88,7 +80,7 @@ describe("websocket", () => {
     expect(response?.id).toEqual(0);
     expect(response?.message).toEqual("Close Acknowledged");
     const [, recvError] = await stream.receive();
-    expect(recvError).toEqual(new EOF());
+    expect(EOF.matches(recvError)).toBeTruthy();
   });
 
   test("receive error", async () => {
@@ -99,7 +91,7 @@ describe("websocket", () => {
     );
     stream.send({ id: 0, message: "hello" });
     const [response, error] = await stream.receive();
-    expect(error).toEqual(new MyCustomError("unexpected error", 1));
+    expect(MyCustomError.matches(error)).toBeTruthy();
     expect(response).toBeNull();
   });
 

--- a/freighter/ts/src/websocket.ts
+++ b/freighter/ts/src/websocket.ts
@@ -7,10 +7,16 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { type binary, buildQueryString, runtime, type URL } from "@synnaxlabs/x";
+import {
+  type binary,
+  buildQueryString,
+  errors,
+  runtime,
+  type URL,
+} from "@synnaxlabs/x";
 import { z } from "zod";
 
-import { decodeError, EOF, type ErrorPayload, errorZ, StreamClosed } from "@/errors";
+import { EOF, StreamClosed } from "@/errors";
 import { CONTENT_TYPE_HEADER_KEY } from "@/http";
 import { type Context, MiddlewareCollector } from "@/middleware";
 import { type Stream, type StreamClient } from "@/stream";
@@ -24,12 +30,12 @@ const resolveWebSocketConstructor = (): ((target: string) => WebSocket) => {
 const wsMessageZ = z.object({
   type: z.enum(["data", "close", "open"]),
   payload: z.unknown(),
-  error: z.optional(errorZ),
+  error: z.optional(errors.payloadZ),
 });
 
 export type WebsocketMessage<P = unknown> = {
   type: "data" | "close" | "open";
-  error?: ErrorPayload;
+  error?: errors.Payload;
   payload?: P;
 };
 
@@ -65,7 +71,7 @@ class WebSocketStream<RQ extends z.ZodTypeAny, RS extends z.ZodTypeAny = RQ>
     const msg = await this.receiveMsg();
     if (msg.type !== "open") {
       if (msg.error == null) throw new Error("Message error must be defined");
-      return decodeError(msg.error);
+      return errors.decode(msg.error);
     }
     return null;
   }
@@ -84,7 +90,7 @@ class WebSocketStream<RQ extends z.ZodTypeAny, RS extends z.ZodTypeAny = RQ>
     const msg = await this.receiveMsg();
     if (msg.type === "close") {
       if (msg.error == null) throw new Error("Message error must be defined");
-      this.serverClosed = decodeError(msg.error);
+      this.serverClosed = errors.decode(msg.error);
       return [null, this.serverClosed];
     }
     return [this.resSchema.parse(msg.payload), null];

--- a/pluto/package.json
+++ b/pluto/package.json
@@ -21,7 +21,6 @@
     "@synnaxlabs/alamos": "workspace:*",
     "@synnaxlabs/client": "workspace:*",
     "@synnaxlabs/media": "workspace:*",
-    "@synnaxlabs/x": "workspace:*",
     "@tanstack/react-virtual": "^3.13.6",
     "@xyflow/react": "^12.5.5",
     "async-mutex": "^0.5.0",
@@ -34,7 +33,8 @@
     "proxy-memoize": "2.0.3",
     "react": "^19.1.0",
     "react-color": "^2.19.3",
-    "zod": "^4.0.0-beta"
+    "zod": "^4.0.0-beta",
+    "@synnaxlabs/x": "workspace:*"
   },
   "devDependencies": {
     "@juggle/resize-observer": "^3.4.0",

--- a/pluto/package.json
+++ b/pluto/package.json
@@ -21,6 +21,7 @@
     "@synnaxlabs/alamos": "workspace:*",
     "@synnaxlabs/client": "workspace:*",
     "@synnaxlabs/media": "workspace:*",
+    "@synnaxlabs/x": "workspace:*",
     "@tanstack/react-virtual": "^3.13.6",
     "@xyflow/react": "^12.5.5",
     "async-mutex": "^0.5.0",
@@ -33,8 +34,7 @@
     "proxy-memoize": "2.0.3",
     "react": "^19.1.0",
     "react-color": "^2.19.3",
-    "zod": "^4.0.0-beta",
-    "@synnaxlabs/x": "workspace:*"
+    "zod": "^4.0.0-beta"
   },
   "devDependencies": {
     "@juggle/resize-observer": "^3.4.0",

--- a/pluto/src/aether/aether/aether.ts
+++ b/pluto/src/aether/aether/aether.ts
@@ -27,7 +27,7 @@ import {
 import { state } from "@/state";
 import { prettyParse } from "@/util/zod";
 
-const transformError = (e: unknown, message?: string): Error => {
+const newTreeError = (e: unknown, message?: string): Error => {
   if (e instanceof Error) {
     e.message = `[${message}] - ${e.message}`;
     return e;
@@ -291,7 +291,7 @@ export abstract class Leaf<
       await this.afterUpdate(this.ctx);
       endSpan();
     } catch (e) {
-      throw transformError(e, `${this.type}.${this.key}.updateState`);
+      throw newTreeError(e, `${this.type}.${this.key}.updateState`);
     }
   }
 
@@ -304,7 +304,7 @@ export abstract class Leaf<
       await this.afterUpdate(this.ctx);
       endSpan();
     } catch (e) {
-      throw transformError(e, `${this.type}.${this.key}.updateContext`);
+      throw newTreeError(e, `${this.type}.${this.key}.updateContext`);
     }
   }
 
@@ -320,7 +320,7 @@ export abstract class Leaf<
       await this.afterDelete(this.ctx);
       endSpan();
     } catch (e) {
-      throw transformError(e, `[${this.type}:${this.key}:delete]`);
+      throw newTreeError(e, `[${this.type}:${this.key}:delete]`);
     }
   }
 

--- a/pluto/src/aether/aether/aether.ts
+++ b/pluto/src/aether/aether/aether.ts
@@ -19,9 +19,21 @@ import { deep } from "@synnaxlabs/x/deep";
 import { Mutex } from "async-mutex";
 import { z } from "zod";
 
-import { type MainMessage, type WorkerMessage } from "@/aether/message";
+import {
+  type ErrorObject,
+  type MainMessage,
+  type WorkerMessage,
+} from "@/aether/message";
 import { state } from "@/state";
 import { prettyParse } from "@/util/zod";
+
+const transformError = (e: unknown, message?: string): Error => {
+  if (e instanceof Error) {
+    e.message = `[${message}] - ${e.message}`;
+    return e;
+  }
+  return new Error(message ?? "unknown error", { cause: e });
+};
 
 /**
  * A selected subset of the Map interface used for efficiently propagating context
@@ -215,7 +227,7 @@ export abstract class Leaf<
     const nextState: z.input<StateSchema> = state.executeSetter(next, this._state);
     this._prevState = shallowCopy(this._state);
     this._state = prettyParse(this._schema, nextState, `${this.type}:${this.key}`);
-    this.sender.send({ key: this.key, state: nextState });
+    this.sender.send({ variant: "update", key: this.key, state: nextState });
   }
 
   /** @returns the current state of the component. */
@@ -263,29 +275,37 @@ export abstract class Leaf<
     _: CreateComponent,
   ): Promise<void> {
     if (this.deleted) return;
-    const endSpan = this.instrumentation.T.debug(
-      `${this.type}:${this.key}:updateState`,
-    );
-    this.validatePath(path);
-    const state_ = prettyParse(this._schema, state, `${this.type}:${this.key}`);
-    if (this._state != null)
-      this.instrumentation.L.debug("updating state", () => ({
-        diff: deep.difference(this.state as UnknownRecord, state_ as UnknownRecord),
-      }));
-    else this.instrumentation.L.debug("setting initial state", { state });
-    this._prevState = this._state ?? state_;
-    this._state = state_;
-    await this.afterUpdate(this.ctx);
-    endSpan();
+    try {
+      const endSpan = this.instrumentation.T.debug(
+        `${this.type}:${this.key}:updateState`,
+      );
+      this.validatePath(path);
+      const state_ = prettyParse(this._schema, state, `${this.type}:${this.key}`);
+      if (this._state != null)
+        this.instrumentation.L.debug("updating state", () => ({
+          diff: deep.difference(this.state as UnknownRecord, state_ as UnknownRecord),
+        }));
+      else this.instrumentation.L.debug("setting initial state", { state });
+      this._prevState = this._state ?? state_;
+      this._state = state_;
+      await this.afterUpdate(this.ctx);
+      endSpan();
+    } catch (e) {
+      throw transformError(e, `${this.type}.${this.key}.updateState`);
+    }
   }
 
   async _updateContext(values: ContextMap): Promise<void> {
-    const endSpan = this.instrumentation.T.debug(
-      `${this.type}:${this.key}:updateContext`,
-    );
-    values.forEach((value, key) => this.parentCtxValues.set(key, value));
-    await this.afterUpdate(this.ctx);
-    endSpan();
+    try {
+      const endSpan = this.instrumentation.T.debug(
+        `${this.type}:${this.key}:updateContext`,
+      );
+      values.forEach((value, key) => this.parentCtxValues.set(key, value));
+      await this.afterUpdate(this.ctx);
+      endSpan();
+    } catch (e) {
+      throw transformError(e, `${this.type}.${this.key}.updateContext`);
+    }
   }
 
   /**
@@ -293,11 +313,15 @@ export abstract class Leaf<
    * AetherComposite.
    */
   async _delete(path: string[]): Promise<void> {
-    const endSpan = this.instrumentation.T.debug(`${this.type}:${this.key}:delete`);
-    this.validatePath(path);
-    this._deleted = true;
-    await this.afterDelete(this.ctx);
-    endSpan();
+    try {
+      const endSpan = this.instrumentation.T.debug(`${this.type}:${this.key}:delete`);
+      this.validatePath(path);
+      this._deleted = true;
+      await this.afterDelete(this.ctx);
+      endSpan();
+    } catch (e) {
+      throw transformError(e, `[${this.type}:${this.key}:delete]`);
+    }
   }
 
   /**
@@ -398,7 +422,7 @@ export abstract class Composite<
 
     const childKey = subPath[0];
     const child = this.getChild(childKey);
-    if (child != null) return child._updateState(subPath, state, create);
+    if (child != null) return await child._updateState(subPath, state, create);
     if (subPath.length > 1)
       throw new UnexpectedError(
         `[Composite.update] - ${this.type}:${this.key} received a subPath ${subPath.join(
@@ -529,7 +553,21 @@ export class Root extends Composite<typeof aetherRootState> {
      */
     root.comms.handle((msg) => {
       void root.mu.runExclusive(async () => {
-        await root.handle(msg);
+        try {
+          await root.handle(msg);
+        } catch (e) {
+          const errorObj: ErrorObject = {
+            name: "unknown",
+            message: JSON.stringify(e),
+            stack: "unknown",
+          };
+          if (e instanceof Error) {
+            errorObj.name = e.name;
+            errorObj.message = e.message;
+            errorObj.stack = e.stack;
+          }
+          root.comms.send({ variant: "error", error: errorObj });
+        }
       });
     });
     return root;

--- a/pluto/src/aether/main.tsx
+++ b/pluto/src/aether/main.tsx
@@ -93,8 +93,22 @@ export const Provider = ({
     [worker, registry],
   );
 
+  const [error, setError] = useState<Error | null>(null);
+  if (error != null) throw error;
+
   useEffect(() => {
     worker?.handle((msg) => {
+      const { variant } = msg;
+      if (variant == "error") {
+        const {
+          error: { message, stack, name },
+        } = msg;
+        const err = new Error(message);
+        err.stack = stack;
+        err.name = name;
+        setError(err);
+        return;
+      }
       const { key, state } = msg;
       const component = registry.current.get(key);
       if (component == null)

--- a/pluto/src/aether/message.ts
+++ b/pluto/src/aether/message.ts
@@ -21,9 +21,21 @@ export interface MainDelete {
 }
 
 export interface WorkerUpdate {
+  variant: "update";
   key: string;
   state: any;
 }
 
-export type WorkerMessage = WorkerUpdate;
+export interface ErrorObject {
+  name: string;
+  message: string;
+  stack?: string;
+}
+
+export interface WorkerError {
+  variant: "error";
+  error: ErrorObject;
+}
+
+export type WorkerMessage = WorkerUpdate | WorkerError;
 export type MainMessage = MainUpdate | MainDelete;

--- a/pluto/src/pluto/aether/pluto.ts
+++ b/pluto/src/pluto/aether/pluto.ts
@@ -7,6 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+import { Instrumentation, Logger, logThresholdFilter } from "@synnaxlabs/alamos";
 import { RoutedWorker } from "@synnaxlabs/x";
 
 import { aether } from "@/aether/aether";
@@ -65,5 +66,11 @@ export const render = (): void => {
     ...performance.REGISTRY,
   };
 
-  void aether.render({ comms: w.route("vis"), registry: REGISTRY });
+  void aether.render({
+    comms: w.route("vis"),
+    registry: REGISTRY,
+    instrumentation: new Instrumentation({
+      logger: new Logger({ filters: [logThresholdFilter("info")] }),
+    }),
+  });
 };

--- a/pluto/src/vis/performance/aether/performance.ts
+++ b/pluto/src/vis/performance/aether/performance.ts
@@ -20,7 +20,7 @@ export class Performance extends aether.Leaf<typeof performanceStateZ> {
   schema = performanceStateZ;
   interval: ReturnType<typeof setInterval> | null = null;
 
-  async afterUpdate(ctx: aether.Context): Promise<void> {
+  async afterUpdate(): Promise<void> {
     // Convert duration to FPS (1000ms / avgDuration)
     if (this.interval != null) clearInterval(this.interval);
     this.interval = setInterval(() => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -578,6 +578,9 @@ importers:
       '@types/node':
         specifier: ^22.13.10
         version: 22.14.0
+      '@vitest/coverage-v8':
+        specifier: ^3.1.3
+        version: 3.1.3(vitest@3.1.1(@types/debug@4.1.12)(@types/node@22.14.0)(jsdom@26.0.0)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.1))
       eslint:
         specifier: ^9.24.0
         version: 9.24.0

--- a/x/ts/src/errors/errors.spec.ts
+++ b/x/ts/src/errors/errors.spec.ts
@@ -1,0 +1,152 @@
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { describe, expect, it, test } from "vitest";
+
+import { errors } from "@/errors";
+
+class ErrorOne extends errors.createTyped("one") {}
+
+class ErrorTwo extends errors.createTyped("two") {}
+
+class SubError extends ErrorOne.sub("child") {}
+
+const myCustomErrorEncoder = (error: errors.Typed): errors.Payload | null => {
+  if (error.type !== "one") return null;
+  return { type: "one", data: error.message };
+};
+
+const myCustomErrorDecoder = (encoded: errors.Payload): errors.Typed =>
+  new ErrorOne(encoded.data);
+
+describe("errors", () => {
+  describe("isTypedError", () => {
+    it("should return true if the error implements the TypedError interface", () => {
+      const error = new ErrorOne("test");
+      const fError = errors.isTyped(error);
+      expect(fError).toBeTruthy();
+      expect(error.type).toEqual("one");
+    });
+
+    it("should return false if the error does not implement the TypedError interface", () => {
+      const error = new Error("rando");
+      const fError = errors.isTyped(error);
+      expect(fError).toBeFalsy();
+    });
+  });
+
+  describe("encoding/decoding", () => {
+    it("should encode and decode a custom error through the registry", () => {
+      errors.register({
+        encode: myCustomErrorEncoder,
+        decode: myCustomErrorDecoder,
+      });
+      const error = new ErrorOne("test");
+      const encoded = errors.encode(error);
+      const decoded = errors.decode(encoded);
+      expect(ErrorOne.matches(decoded)).toBeTruthy();
+    });
+
+    test("should correctly encode/decode a null error", () => {
+      const encoded = errors.encode(null);
+      expect(encoded.type).toEqual(errors.NONE);
+      expect(encoded.data).toEqual("");
+      const decoded = errors.decode(encoded);
+      expect(decoded).toBeNull();
+    });
+
+    it("should correctly encode/decode an undefined error", () => {
+      const encoded = errors.encode(undefined);
+      expect(encoded.type).toEqual(errors.NONE);
+      expect(encoded.data).toEqual("");
+      const decoded = errors.decode(encoded);
+      expect(decoded).toBeNull();
+    });
+
+    it("should correctly encode/decode a generic error", () => {
+      const error = new Error("test");
+      const encoded = errors.encode(error);
+      expect(encoded.type).toEqual(errors.UNKNOWN);
+      expect(encoded.data).toEqual("test");
+      const decoded = errors.decode(encoded);
+      expect(decoded).toBeInstanceOf(Error);
+      expect((decoded as Error).message).toEqual(error.message);
+    });
+
+    it("should correctly encode/decode a string that is not an error", () => {
+      const error = "test";
+      const encoded = errors.encode(error);
+      expect(encoded.type).toEqual(errors.UNKNOWN);
+      expect(encoded.data).toEqual("test");
+      const decoded = errors.decode(encoded);
+      expect(errors.Unknown.matches(decoded)).toBeTruthy();
+    });
+
+    it("should correctly encode/decode a random object", () => {
+      const error = { foo: "bar" };
+      const encoded = errors.encode(error);
+      expect(encoded.type).toEqual(errors.UNKNOWN);
+      expect(encoded.data).toEqual(JSON.stringify(error));
+      const decoded = errors.decode(encoded);
+      expect(errors.Unknown.matches(decoded)).toBeTruthy();
+    });
+  });
+
+  describe("matches", () => {
+    it("should return true if the errors are exactly the same", () => {
+      const v = new ErrorOne("test");
+      expect(ErrorOne.matches(v)).toBeTruthy();
+      const v2 = new ErrorOne("test");
+      expect(v2.matches(v)).toBeTruthy();
+    });
+
+    it("should return false if the errors are typed and clearly different", () => {
+      const e1 = new ErrorOne("test");
+      const e2 = new ErrorTwo("test");
+      expect(e1.matches(e2)).toBeFalsy();
+      expect(ErrorOne.matches(e2)).toBeFalsy();
+      expect(ErrorTwo.matches(e1)).toBeFalsy();
+    });
+
+    it("should return false if the error is not typed", () => {
+      const e1 = new ErrorOne("test");
+      const e2 = new Error("rando");
+      expect(e1.matches(e2)).toBeFalsy();
+      expect(ErrorOne.matches(e2)).toBeFalsy();
+    });
+
+    it("should return false if the error is not actually an error", () => {
+      const e1 = new ErrorOne("test");
+      const e2 = "rando";
+      expect(e1.matches(e2)).toBeFalsy();
+      expect(ErrorOne.matches(e2)).toBeFalsy();
+    });
+
+    it("should return false if hte error is undefined", () => {
+      const e1 = new ErrorOne("test");
+      const e2 = undefined;
+      expect(e1.matches(e2)).toBeFalsy();
+      expect(ErrorOne.matches(e2)).toBeFalsy();
+    });
+
+    it("should return true if the the matching error is a parent", () => {
+      const e1 = new ErrorOne("rando");
+      const e2 = new SubError("rando");
+      expect(e1.matches(e2)).toBeTruthy();
+      expect(ErrorOne.matches(e1)).toBeTruthy();
+    });
+
+    it("should return false if the matching error is a sub-error", () => {
+      const e1 = new ErrorOne("random");
+      const e2 = new SubError("random");
+      expect(e2.matches(e1)).toBeFalsy();
+      expect(SubError.matches(e1)).toBeFalsy();
+    });
+  });
+});

--- a/x/ts/src/errors/errors.ts
+++ b/x/ts/src/errors/errors.ts
@@ -7,20 +7,233 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-class Canceled extends Error {
-  static readonly MESSAGE = "canceled";
-  constructor() {
-    super(Canceled.MESSAGE);
-  }
+import { z } from "zod";
 
-  /** Returns true if the error or message is a cancellation error" */
-  matches(e: Error | string): boolean {
-    if (typeof e === "string") return e.includes(Canceled.MESSAGE);
-    return e instanceof Canceled || e.message.includes(Canceled.MESSAGE);
-  }
+import { singleton } from "@/singleton";
+
+/**
+ * @returns general function that returns true if an error matches a set of
+ * abstracted criteria
+ */
+export type Matcher = (e: string | Error | unknown) => boolean;
+
+/** @description an error type that can match against other errors. */
+export interface Matchable {
+  /**
+   * @returns a function that matches errors of the given type. Returns true if
+   * the provided instance of Error or a string message contains the provided error type.
+   */
+  matches: Matcher;
 }
 
 /**
- * CANCELED should be thrown to indicate the cancellation of an operation.
+ * @description an error that has a network-portable type, allowing it to be encoded/
+ * decoded by freighter. Also allows for simpler matching using @method matches instead
+ * of using instanceof, which has a number of caveats.
  */
-export const CANCELED = new Canceled();
+export interface Typed extends Error, Matchable {
+  discriminator: "FreighterError";
+  /**
+   * @description Returns a unique type identifier for the error. Freighter uses this to
+   * determine the correct decoder to use on the other end of the freighter.
+   */
+  type: string;
+}
+
+/**
+ * @description a class that, when constructed, implements the TypedError interface.
+ * Also provides utilities for matching and creating subclasses.
+ */
+export interface TypedClass extends Matchable {
+  /**
+   * @description constructs a new TypedError. Identical to the Error constructor.
+   * @param message - the error message.
+   * @param options - the error options.
+   * @returns a new TypedError.
+   */
+  new (message?: string, options?: ErrorOptions): Typed;
+  /**
+   * @description the type of the error.
+   */
+  TYPE: string;
+  /**
+   * @description creates a new subclass of the error that extends its type. So if
+   * the type of this class is `dog` and subType is `labrador`, the type of the new
+   * class will be `dog.labrador`.
+   * @param subType - the type of the new error.
+   * @returns a new TypedErrorClass.
+   */
+  sub: (subType: string) => TypedClass;
+}
+
+/**
+ * @param type - the error type to match
+ * @returns a function that matches errors of the given type. Returns true if
+ * the provided instance of Error or a string message contains the provided error type.
+ */
+const createTypeMatcher =
+  (type: string): Matcher =>
+  (e) => {
+    if (e != null && typeof e === "object" && "type" in e && typeof e.type === "string")
+      return e.type.startsWith(type);
+    if (e instanceof Error) return e.message.startsWith(type);
+    if (typeof e !== "string") return false;
+    return e.startsWith(type);
+  };
+
+/**
+ * Creates a new class definition that implements the TypedErrorClass interface.
+ * @param type - the type of the error.
+ * @returns a new TypedErrorClass.
+ * @example
+ * ```ts
+ * class MyError extends createTypedError("my_error") {}
+ * ```
+ */
+export const createTyped = (type: string): TypedClass =>
+  class Internal extends Error implements Typed {
+    static readonly discriminator = "FreighterError";
+    readonly discriminator = Internal.discriminator;
+
+    static readonly TYPE = type;
+    readonly type: string = Internal.TYPE;
+
+    static readonly matches = createTypeMatcher(type);
+    readonly matches: Matcher = Internal.matches;
+
+    constructor(message?: string, options?: ErrorOptions) {
+      super(message, options);
+      this.name = Internal.TYPE;
+    }
+    static sub(subType: string): TypedClass {
+      return createTyped(`${type}.${subType}`);
+    }
+  };
+
+/**
+ * @description Function that decodes an encoded error payload back into an error object
+ * @param encoded - The encoded error payload to decode
+ * @returns The decoded error object or null if the decoder cannot handle this error type
+ */
+export type Decoder = (encoded: Payload) => Error | null;
+
+/**
+ * @description Function that encodes a typed error into a network-portable payload
+ * @param error - The typed error to encode
+ * @returns The encoded error payload or null if the encoder cannot handle this error type
+ */
+export type Encoder = (error: Typed) => Payload | null;
+
+/**
+ * @description Checks if an unknown value is a TypedError
+ * @param error - The value to check
+ * @returns True if the value is a TypedError, false otherwise
+ */
+export const isTyped = (error: unknown): error is Typed => {
+  if (error == null || typeof error !== "object") return false;
+  const typedError = error as Typed;
+  if (typedError.discriminator !== "FreighterError") return false;
+  if (!("type" in typedError))
+    throw new Error(
+      `Freighter error is missing its type property: ${JSON.stringify(typedError)}`,
+    );
+  return true;
+};
+
+/** @description Constant representing an unknown error type */
+export const UNKNOWN = "unknown";
+
+/** @description Constant representing no error (null) */
+export const NONE = "nil";
+
+interface provider {
+  encode: Encoder;
+  decode: Decoder;
+}
+
+class Registry {
+  private readonly providers: provider[] = [];
+
+  register(provider: provider): void {
+    this.providers.push(provider);
+  }
+
+  encode(error: unknown): Payload {
+    if (error == null) return { type: NONE, data: "" };
+    if (isTyped(error))
+      for (const provider of this.providers) {
+        const payload = provider.encode(error);
+        if (payload != null) return payload;
+      }
+    if (error instanceof Error) return { type: UNKNOWN, data: error.message };
+    if (typeof error === "string") return { type: UNKNOWN, data: error };
+    try {
+      return { type: UNKNOWN, data: JSON.stringify(error) };
+    } catch {
+      return { type: UNKNOWN, data: "unable to encode error information" };
+    }
+  }
+
+  decode(payload?: Payload | null): Error | null {
+    if (payload == null || payload.type === NONE) return null;
+    if (payload.type === UNKNOWN) return new Unknown(payload.data);
+    for (const provider of this.providers) {
+      const error = provider.decode(payload);
+      if (error != null) return error;
+    }
+    return new Unknown(payload.data);
+  }
+}
+
+const getRegistry = singleton.define("synnax-error-registry", () => new Registry());
+
+/**
+ * Registers a custom error type with the error registry, which allows it to be
+ * encoded/decoded and sent over the network.
+ *
+ * @param type - A unique string identifier for the error type.
+ * @param encode - A function that encodes the error into a string.
+ * @param decode - A function that decodes the error from a string.
+ */
+export const register = ({
+  encode,
+  decode,
+}: {
+  encode: Encoder;
+  decode: Decoder;
+}): void => getRegistry().register({ encode, decode });
+
+/**
+ * Encodes an error into a payload that can be sent between a freighter server
+ * and client.
+ * @param error - The error to encode.
+ * @returns The encoded error.
+ */
+export const encode = (error: unknown): Payload => getRegistry().encode(error);
+
+/**
+ * Decodes an error payload into an exception. If a custom decoder can be found
+ * for the error type, it will be used. Otherwise, a generic Error containing
+ * the error data is returned.
+ *
+ * @param payload - The encoded error payload.
+ * @returns The decoded error.
+ */
+export const decode = (payload?: Payload | null): Error | null => {
+  if (payload == null) return null;
+  return getRegistry().decode(payload);
+};
+
+/**
+ * @description Generic error for representing unknown errors
+ */
+export class Unknown extends createTyped("unknown") {}
+
+/** @description Zod schema for validating error payloads */
+export const payloadZ = z.object({ type: z.string(), data: z.string() });
+
+/** @description Network-portable representation of an error */
+export type Payload = z.infer<typeof payloadZ>;
+
+/** @description Error for representing the cancellation of an operation */
+export class Canceled extends createTyped("canceled") {}

--- a/x/ts/src/singleton/define.spec.ts
+++ b/x/ts/src/singleton/define.spec.ts
@@ -1,0 +1,93 @@
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { describe, expect, it } from "vitest";
+
+import { define } from "@/singleton/define";
+
+describe("define", () => {
+  it("should create and return a singleton instance", () => {
+    const key = "test-singleton-1";
+    let constructorCallCount = 0;
+
+    const createInstance = () => {
+      constructorCallCount++;
+      return { value: "singleton-value" };
+    };
+
+    const getInstance = define(key, createInstance);
+    const instance1 = getInstance();
+
+    expect(constructorCallCount).toBe(1);
+    expect(instance1).toEqual({ value: "singleton-value" });
+
+    const instance2 = getInstance();
+    expect(constructorCallCount).toBe(1);
+    expect(instance2).toBe(instance1); // Same instance reference
+  });
+
+  it("should maintain separate singletons for different keys", () => {
+    const key1 = "test-singleton-2";
+    const key2 = "test-singleton-3";
+
+    const getInstance1 = define(key1, () => ({ id: 1 }));
+    const getInstance2 = define(key2, () => ({ id: 2 }));
+
+    const instance1 = getInstance1();
+    const instance2 = getInstance2();
+
+    expect(instance1).toEqual({ id: 1 });
+    expect(instance2).toEqual({ id: 2 });
+    expect(instance1).not.toBe(instance2);
+  });
+
+  it("should retrieve the same singleton when defining with the same key multiple times", () => {
+    const key = "test-singleton-4";
+    let constructorCallCount = 0;
+
+    const createInstance1 = () => {
+      constructorCallCount++;
+      return { id: constructorCallCount };
+    };
+
+    const getInstance1 = define(key, createInstance1);
+    const firstInstance = getInstance1();
+    expect(firstInstance).toEqual({ id: 1 });
+    expect(constructorCallCount).toBe(1);
+
+    // Second definition with the same key but different factory
+    const createInstance2 = () => {
+      constructorCallCount++;
+      return { id: 999 }; // Different value
+    };
+
+    const getInstance2 = define(key, createInstance2);
+    const secondInstance = getInstance2();
+
+    expect(secondInstance).toBe(firstInstance);
+    expect(secondInstance).toEqual({ id: 1 });
+    expect(constructorCallCount).toBe(1); // Still 1, not 2
+  });
+
+  it("should handle object instances as singleton values", () => {
+    class TestClass {
+      public value: number;
+      constructor(value: number) {
+        this.value = value;
+      }
+    }
+
+    const key = "test-singleton-5";
+    const getInstance = define(key, () => new TestClass(42));
+
+    const instance = getInstance();
+    expect(instance).toBeInstanceOf(TestClass);
+    expect(instance.value).toBe(42);
+  });
+});

--- a/x/ts/src/singleton/define.ts
+++ b/x/ts/src/singleton/define.ts
@@ -1,0 +1,18 @@
+const isDefined = (key: symbol): boolean =>
+  Object.getOwnPropertySymbols(globalThis).includes(key);
+
+/**
+ * Defines a new global singleton instance of a value.
+ *
+ * @param key - The unique identifier for the singleton.
+ * @param value - A function that returns the singleton instance.
+ * @returns A function that returns the singleton instance.
+ */
+export const define = <T>(key: string, value: () => T): (() => T) => {
+  const symbol = Symbol.for(key);
+  if (!isDefined(symbol)) {
+    const singleton = value();
+    Object.defineProperty(globalThis, symbol, { value: singleton });
+  }
+  return () => (globalThis as any)[symbol] as T;
+};

--- a/x/ts/src/singleton/define.ts
+++ b/x/ts/src/singleton/define.ts
@@ -1,3 +1,12 @@
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
 const isDefined = (key: symbol): boolean =>
   Object.getOwnPropertySymbols(globalThis).includes(key);
 

--- a/x/ts/src/singleton/index.ts
+++ b/x/ts/src/singleton/index.ts
@@ -1,0 +1,1 @@
+export * as singleton from "@/singleton/define";

--- a/x/ts/src/singleton/index.ts
+++ b/x/ts/src/singleton/index.ts
@@ -1,1 +1,10 @@
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
 export * as singleton from "@/singleton/define";


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2463](https://linear.app/synnax/issue/SY-2463)

## Description

1. Creates a new `x/errors` package that gets rid of the freighter errors file. Improves error subclassing and matching.
2. Adds exception catching, handling, and rethrowing in the aether tree that makes errors that occur in aether components behave the same as in react components.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
