### PR TITLE
SY-2481 - Fix Pluto Telem Backloading of Calculated Channels in Streaming Scenarios

### DIFF
--- a/pluto/src/telem/aether/remote.ts
+++ b/pluto/src/telem/aether/remote.ts
@@ -225,7 +225,6 @@ export class ChannelData
         useIndexOfChannel,
       );
       const series = await this.client.read(timeRange, this.channel.key);
-      if (series == null) return;
       series.acquire();
       this.data = series;
       this.notify();
@@ -292,14 +291,14 @@ export class StreamChannelData
     try {
       this.valid = true;
       this.onStatusChange?.(LOADING_STATUS);
-      const { channel, useIndexOfChannel } = this.props;
+      const { channel, useIndexOfChannel, timeSpan } = this.props;
       this.channel = await fetchChannelProperties(
         this.client,
         channel,
         useIndexOfChannel,
       );
-      const tr = this.now().spanRange(-this.props.timeSpan);
-      if (!this.channel.virtual && !this.channel.isCalculated) {
+      const tr = this.now().spanRange(-timeSpan);
+      if (!this.channel.virtual || this.channel.isCalculated) {
         const res = await this.client.read(tr, this.channel.key);
         res.acquire();
         this.data.push(res);


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2481](https://linear.app/synnax/issue/SY-2481)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
