### PR TITLE
SY-2472 - Fix Display of Scientific and Exponential Engineering Units with Text Atlas

### DIFF
--- a/pluto/src/vis/text/atlas.ts
+++ b/pluto/src/vis/text/atlas.ts
@@ -25,7 +25,7 @@ export class MonospacedAtlas {
   // A map of characters to their index in the atlas.
   private readonly charMap: Map<string, number>;
   // The default characters to include in the atlas.
-  private static readonly DEFAULT_CHARS = "0123456789.:-ums";
+  private static readonly DEFAULT_CHARS = "0123456789.:-umsNa∞ᴇ";
 
   constructor(props: AtlasProps) {
     const { font, dpr, characters = MonospacedAtlas.DEFAULT_CHARS, textColor } = props;


### PR DESCRIPTION
…tlas

# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2472](https://linear.app/synnax/issue/SY-2472)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
