### PR TITLE
SY-2467 - Fix Optional Field Checks in Pluto Forms

### DIFF
--- a/console/src/cluster/Connect.tsx
+++ b/console/src/cluster/Connect.tsx
@@ -55,7 +55,10 @@ export const Connect: Layout.Renderer = ({ onClose }) => {
   const [loading, setLoading] = useState<"test" | "submit" | null>(null);
   const names = useSelectAllNames();
   const formSchema = clusterZ.refine(({ name }) => !names.includes(name), {
-    error: ({ name }) => ({ message: `${name} is already in use.`, path: ["name"] }),
+    error: ({ input }) => ({
+      message: `${(input as { name: string }).name} is already in use.`,
+    }),
+    path: ["name"],
   });
   const handleError = Status.useErrorHandler();
   const methods = Form.use<typeof formSchema>({

--- a/pluto/src/form/Form.tsx
+++ b/pluto/src/form/Form.tsx
@@ -528,7 +528,8 @@ export const use = <Z extends z.ZodTypeAny>({
       const schema = schemaRef.current;
       const zField = zod.getFieldSchema(schema, path, { optional: true });
       if (zField == null) return fs;
-      fs.required = !zField.isOptional();
+      if ("isOptional" in zField && typeof zField.isOptional === "function")
+        fs.required = !zField.isOptional();
       return fs;
     },
     [],

--- a/x/ts/src/zod/util.spec.ts
+++ b/x/ts/src/zod/util.spec.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, test } from "vitest";
 import { z } from "zod";
 
 import { zod } from "@/zod";
@@ -95,6 +95,22 @@ describe("zod", () => {
         const v = zod.getFieldSchema(veryComplexSchema, "a.array.0.c");
         expect(v).not.toBeNull();
         expect(v).toBeInstanceOf(z.ZodNumber);
+      });
+    });
+
+    describe("regression", () => {
+      test("reg 1", () => {
+        const names = ["one"];
+        const schema = z
+          .object({
+            name: z.string(),
+          })
+          .refine(({ name }) => !names.includes(name), {
+            error: "Already in use",
+          });
+        const v = zod.getFieldSchema(schema, "name");
+        expect(v).toBeInstanceOf(z.ZodString);
+        expect(v.isOptional()).toBe(false);
       });
     });
   });


### PR DESCRIPTION
# Issue Pull Request

## Key Information

<!-- Edit the list below with the proper issue number and link -->

- **Linear Issue**: [SY-2467](https://linear.app/synnax/issue/SY-2467)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

## Backwards Compatibility

### Data Structures

I have ensured that previous versions of stored data structures are properly migrated to new formats in the following projects:

- [ ] Server
- [ ] Console

### API Changes

The following projects have backwards-compatible APIs:

- [ ] Python Client
- [ ] Server
- [ ] TypeScript Client

### Breaking Changes

<!-- If anything in this section is not true, list all breaking changes. -->
