### PR TITLE
Remove TS-Expect-Error from CSS Variable Typing

### DIFF
--- a/pluto/src/align/Pack.tsx
+++ b/pluto/src/align/Pack.tsx
@@ -57,13 +57,15 @@ export const Pack = <E extends ElementType = "div">({
   ...rest
 }: PackProps<E>): ReactElement => {
   const dir = parseDirection(direction, x, y, "x");
-  const pStyle = {
+  let pStyle = {
     [CSS.var("pack-border-shade")]: CSS.shadeVar(borderShade),
     ...style,
   };
   if (borderWidth != null)
-    // @ts-expect-error - generic element issues
-    pStyle[CSS.var("pack-border-width")] = `${borderWidth}px`;
+    pStyle = {
+      ...pStyle,
+      [CSS.var("pack-border-width")]: `${borderWidth}px`,
+    };
 
   return (
     // @ts-expect-error - generic element issues

--- a/pluto/src/button/Button.tsx
+++ b/pluto/src/button/Button.tsx
@@ -156,23 +156,26 @@ export const Button = Tooltip.wrap(
       ),
     });
 
-    const pStyle = { ...style };
+    let pStyle = style;
     const res = color.colorZ.safeParse(colorVal);
     const hasCustomColor =
       res.success && (variant === "filled" || variant === "outlined");
     if (hasCustomColor) {
       const theme = Theming.use();
-      // @ts-expect-error - css variable
-      pStyle[CSS.var("btn-color")] = color.rgbString(res.data);
-      // @ts-expect-error - css variable
-      pStyle[CSS.var("btn-text-color")] = color.rgbCSS(
-        color.pickByContrast(res.data, theme.colors.text, theme.colors.textInverted),
-      );
+      pStyle = {
+        ...pStyle,
+        [CSS.var("btn-color")]: color.rgbString(res.data),
+        [CSS.var("btn-text-color")]: color.rgbCSS(
+          color.pickByContrast(res.data, theme.colors.text, theme.colors.textInverted),
+        ),
+      };
     }
 
     if (!parsedDelay.isZero)
-      // @ts-expect-error - css variable
-      pStyle[CSS.var("btn-delay")] = `${parsedDelay.seconds.toString()}s`;
+      pStyle = {
+        ...pStyle,
+        [CSS.var("btn-delay")]: `${parsedDelay.seconds.toString()}s`,
+      };
 
     if (size == null && level != null) size = Text.LevelComponentSizes[level];
     else if (size != null && level == null) level = Text.ComponentSizeLevels[size];

--- a/pluto/src/dropdown/Dropdown.tsx
+++ b/pluto/src/dropdown/Dropdown.tsx
@@ -152,11 +152,12 @@ export const Dialog = ({
   } else if (variant === "modal") dialogStyle = { top: `${modalOffset}%` };
 
   if (typeof maxHeight === "number") dialogStyle.maxHeight = maxHeight;
-  if (visible) {
-    dialogStyle.zIndex = zIndex;
-    // @ts-expect-error - css variable
-    dialogStyle[Z_INDEX_VARIABLE] = zIndex;
-  }
+  if (visible)
+    dialogStyle = {
+      ...dialogStyle,
+      zIndex,
+      [Z_INDEX_VARIABLE]: zIndex,
+    } as CSSProperties;
 
   const C = variant === "connected" ? Align.Pack : Align.Space;
 
@@ -203,8 +204,7 @@ export const Dialog = ({
         role="dialog"
         empty
         align="center"
-        // @ts-expect-error - css variable
-        style={{ zIndex, [Z_INDEX_VARIABLE]: zIndex }}
+        style={{ zIndex, [Z_INDEX_VARIABLE]: zIndex } as CSSProperties}
         visible={visible}
       >
         {child}
@@ -228,11 +228,7 @@ export const Dialog = ({
         )}
         y
         reverse={dialogLoc.y === "top"}
-        style={{
-          ...rest.style,
-          // @ts-expect-error - css variable
-          [Z_INDEX_VARIABLE]: zIndex,
-        }}
+        style={{ ...rest.style, [Z_INDEX_VARIABLE]: zIndex } as CSSProperties}
       >
         {children[0]}
         {child}

--- a/pluto/src/tooltip/Dialog.css
+++ b/pluto/src/tooltip/Dialog.css
@@ -42,42 +42,50 @@
 
     &.pluto--center {
         &.pluto--top {
-            --transform-x: calc(var(--pos-x) - 50%);
-            --transform-y: calc(var(--pos-y) + calc(-100% - var(--translate-amount)));
+            --transform-x: calc(var(--pluto-pos-x) - 50%);
+            --transform-y: calc(
+                var(--pluto-pos-y) + calc(-100% - var(--translate-amount))
+            );
         }
         &.pluto--bottom {
-            --transform-x: calc(var(--pos-x) - 50%);
-            --transform-y: calc(var(--pos-y) + var(--translate-amount));
+            --transform-x: calc(var(--pluto-pos-x) - 50%);
+            --transform-y: calc(var(--pluto-pos-y) + var(--translate-amount));
         }
         &.pluto--left {
-            --transform-x: calc(var(--pos-x) + calc(-100% - var(--translate-amount)));
-            --transform-y: calc(var(--pos-y) - 50%);
+            --transform-x: calc(
+                var(--pluto-pos-x) + calc(-100% - var(--translate-amount))
+            );
+            --transform-y: calc(var(--pluto-pos-y) - 50%);
         }
         &.pluto--right {
-            --transform-x: calc(var(--pos-x) + var(--translate-amount));
-            --transform-y: calc(var(--pos-y) - 50%);
+            --transform-x: calc(var(--pluto-pos-x) + var(--translate-amount));
+            --transform-y: calc(var(--pluto-pos-y) - 50%);
         }
     }
 
     &.pluto--top {
         &.pluto--right {
-            --transform-x: var(--pos-x);
-            --transform-y: calc(var(--pos-y) + calc(-100% - var(--translate-amount)));
+            --transform-x: var(--pluto-pos-x);
+            --transform-y: calc(
+                var(--pluto-pos-y) + calc(-100% - var(--translate-amount))
+            );
         }
         &.pluto--left {
-            --transform-x: calc(var(--pos-x) - 100%);
-            --transform-y: calc(var(--pos-y) + calc(-100% - var(--translate-amount)));
+            --transform-x: calc(var(--pluto-pos-x) - 100%);
+            --transform-y: calc(
+                var(--pluto-pos-y) + calc(-100% - var(--translate-amount))
+            );
         }
     }
 
     &.pluto--bottom {
         &.pluto--right {
-            --transform-x: var(--pos-x);
-            --transform-y: calc(var(--pos-y) - var(--translate-amount));
+            --transform-x: var(--pluto-pos-x);
+            --transform-y: calc(var(--pluto-pos-y) - var(--translate-amount));
         }
         &.pluto--left {
-            --transform-x: calc(var(--pos-x) - 100%);
-            --transform-y: calc(var(--pos-y) + var(--translate-amount));
+            --transform-x: calc(var(--pluto-pos-x) - 100%);
+            --transform-y: calc(var(--pluto-pos-y) + var(--translate-amount));
         }
     }
 }

--- a/pluto/src/tooltip/Dialog.tsx
+++ b/pluto/src/tooltip/Dialog.tsx
@@ -277,10 +277,8 @@ export const Dialog = ({
               loadCLS,
             )}
             style={{
-              // @ts-expect-error - css
-              "--pos-x": CSS.px(state.position.x),
-              "--pos-y": CSS.px(state.position.y),
-              "--el-width": CSS.px(state.triggerDims.width),
+              [CSS.var("pos-x")]: CSS.px(state.position.x),
+              [CSS.var("pos-y")]: CSS.px(state.position.y),
             }}
           >
             {isRenderProp(tip) ? tip(state) : formatTip(tip)}

--- a/pluto/src/tree/Tree.tsx
+++ b/pluto/src/tree/Tree.tsx
@@ -304,8 +304,7 @@ export const DefaultItem = memo(
         position: translate != null ? "absolute" : "relative",
         transform: `translateY(${translate}px)`,
         [offsetKey]: `${offset}rem`,
-        // @ts-expect-error - CSS variable
-        "--pluto-tree-indicator-offset": `${offset - 1.5}rem`,
+        [CSS.var("tree-indicator-offset")]: `${offset - 1.5}rem`,
       },
       startIcon: startIcons,
       iconSpacing: "small",

--- a/pluto/src/vis/schematic/primitives/Primitives.tsx
+++ b/pluto/src/vis/schematic/primitives/Primitives.tsx
@@ -271,14 +271,20 @@ const InternalSVG = ({
   dims = dir === "y" ? dimensions.swap(dims) : dims;
   const colorStr = color.cssString(colorVal);
   const theme = Theming.use();
-  if (colorVal != null) {
-    // @ts-expect-error - css variables
-    style[CSS.var("symbol-color")] = color.rgbString(colorVal);
-    // @ts-expect-error - css variables
-    style[CSS.var("symbol-color-contrast")] = color.rgbString(
-      color.pickByContrast(colorVal, theme.colors.gray.l0, theme.colors.gray.l11),
-    );
-  }
+  let pStyle = {
+    ...style,
+    aspectRatio: `${dims.width} / ${dims.height}`,
+    width: dimensions.scale(dims, scale * BASE_SCALE).width,
+  };
+  if (colorVal != null)
+    pStyle = {
+      ...pStyle,
+      [CSS.var("symbol-color")]: color.rgbString(colorVal),
+      [CSS.var("symbol-color-contrast")]: color.rgbString(
+        color.pickByContrast(colorVal, theme.colors.gray.l0, theme.colors.gray.l11),
+      ),
+    };
+
   return (
     <svg
       xmlns="http://www.w3.org/2000/svg"
@@ -287,11 +293,7 @@ const InternalSVG = ({
       fill={colorStr}
       stroke={colorStr}
       {...rest}
-      style={{
-        aspectRatio: `${dims.width} / ${dims.height}`,
-        width: dimensions.scale(dims, scale * BASE_SCALE).width,
-        ...style,
-      }}
+      style={pStyle}
     >
       <g>{children}</g>
     </svg>


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2426](https://linear.app/synnax/issue/SY-2525/fix-expect-error-on-css-variables)

## Description

Getting some nasty issues by blatantly ignoring an entire line of TS code when using CSS variables. This fixes that issue by using spread operators and `as CSSProperties` where necessary. 

Read through this stack overflow thread and didn't find anything particularly ideal, so just went a more standard route: https://stackoverflow.com/questions/52005083/how-to-define-css-variables-in-style-attribute-in-react-and-typescript

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.
