### PR TITLE
SY-2322 - Place Labels in Center Of Schematic Tank and Box

### DIFF
--- a/pluto/src/vis/schematic/Forms.tsx
+++ b/pluto/src/vis/schematic/Forms.tsx
@@ -69,11 +69,13 @@ interface SymbolOrientation {
 interface ShowOrientationProps {
   hideOuter?: boolean;
   hideInner?: boolean;
+  showOuterCenter?: boolean;
 }
 
 const OrientationControl = ({
   hideOuter,
   hideInner,
+  showOuterCenter,
   ...rest
 }: Form.FieldProps<SymbolOrientation> & ShowOrientationProps): ReactElement | null => {
   if (hideInner && hideOuter) return null;
@@ -87,6 +89,7 @@ const OrientationControl = ({
           }}
           hideInner={hideInner}
           hideOuter={hideOuter}
+          showOuterCenter={showOuterCenter}
           onChange={(v) =>
             onChange({
               ...value,
@@ -429,7 +432,7 @@ export const TankForm = ({
         </Form.Field>
       </Align.Space>
     </Align.Space>
-    <OrientationControl path="" hideInner />
+    <OrientationControl path="" hideInner showOuterCenter label="Label Location" />
   </FormWrapper>
 );
 

--- a/pluto/src/vis/schematic/Grid.tsx
+++ b/pluto/src/vis/schematic/Grid.tsx
@@ -38,14 +38,14 @@ export interface GridItem {
     onDragStart?: (e: DragEvent<HTMLElement>) => void;
     onDragEnd?: (e: DragEvent<HTMLElement>) => void;
   }>;
-  location: location.Outer;
+  location: location.Location;
 }
 
 export interface GridProps extends PropsWithChildren<{}> {
   editable: boolean;
   symbolKey: string;
   items: GridItem[];
-  onLocationChange: (key: string, loc: location.Outer) => void;
+  onLocationChange: (key: string, loc: location.Location) => void;
   onRotate?: () => void;
 }
 
@@ -53,7 +53,7 @@ interface GridElProps {
   editable: boolean;
   symbolKey: string;
   items: GridItem[];
-  onLocationChange: (key: string, loc: location.Outer) => void;
+  onLocationChange: (key: string, loc: location.Location) => void;
 }
 
 const HAUL_TYPE = "Schematic.Grid";
@@ -64,7 +64,7 @@ const reflowPane = (symbolKey: string) => {
   if (nearestDiagram != null) triggerReflow(nearestDiagram as HTMLElement);
 };
 
-const createGridEl = (loc: location.Outer): FC<GridElProps> => {
+const createGridEl = (loc: location.Location): FC<GridElProps> => {
   const EditableGridEl = ({
     symbolKey,
     items: fItems,
@@ -154,6 +154,7 @@ const TopGridEl = createGridEl("top");
 const LeftGridEl = createGridEl("left");
 const RightGridEl = createGridEl("right");
 const BottomGridEl = createGridEl("bottom");
+const CenterGridEl = createGridEl("center");
 
 export const Grid = ({ editable, onRotate, children, ...rest }: GridProps) => (
   <>
@@ -161,6 +162,7 @@ export const Grid = ({ editable, onRotate, children, ...rest }: GridProps) => (
     <LeftGridEl editable={editable} {...rest} />
     <RightGridEl editable={editable} {...rest} />
     <BottomGridEl editable={editable} {...rest} />
+    <CenterGridEl editable={editable} {...rest} />
     {editable && (
       <Button.Icon
         className={CSS.BE("grid", "rotate")}

--- a/pluto/src/vis/schematic/OrientationControl.css
+++ b/pluto/src/vis/schematic/OrientationControl.css
@@ -28,6 +28,9 @@
         border: var(--pluto-border);
         border-radius: var(--pluto-border-radius);
         padding: 0.5rem;
+        &.pluto--show-outer-center {
+            padding: 1.5rem;
+        }
     }
 
     & button {

--- a/pluto/src/vis/schematic/SelectOrientation.tsx
+++ b/pluto/src/vis/schematic/SelectOrientation.tsx
@@ -19,19 +19,21 @@ import { type Input } from "@/input";
 
 export interface OrientationValue {
   inner: location.Outer;
-  outer: location.Outer;
+  outer: location.Location;
 }
 
 export interface SelectOrientationProps
   extends Input.Control<OrientationValue>,
     Omit<Align.SpaceProps, "value" | "onChange"> {
   hideOuter?: boolean;
+  showOuterCenter?: boolean;
   hideInner?: boolean;
 }
 
 export const SelectOrientation = ({
   value,
   hideOuter = false,
+  showOuterCenter = false,
   hideInner,
   onChange,
 }: SelectOrientationProps): ReactElement => {
@@ -58,7 +60,12 @@ export const SelectOrientation = ({
       <Button selected={outer === "top"} onClick={handleChange({ outer: "top" })} />
       <Align.Space x align="center" justify="center" size="tiny">
         <Button selected={outer === "left"} onClick={handleChange({ outer: "left" })} />
-        <InternalOrientation hideInner={hideInner} value={value} onChange={onChange} />
+        <InternalOrientation
+          hideInner={hideInner}
+          value={value}
+          onChange={onChange}
+          showOuterCenter={showOuterCenter}
+        />
         <Button
           selected={outer === "right"}
           onClick={handleChange({ outer: "right" })}
@@ -77,6 +84,7 @@ const InternalOrientation = ({
   onChange,
   className,
   hideInner = false,
+  showOuterCenter = true,
   ...rest
 }: SelectOrientationProps): ReactElement => {
   const { inner } = value;
@@ -85,43 +93,61 @@ const InternalOrientation = ({
   let showStyle: CSSProperties = {};
   if (hideInner)
     showStyle = { opacity: 0, userSelect: "none", width: "1.5rem", height: "1.5rem" };
+  let content: ReactElement | null = null;
+  if (showOuterCenter)
+    content = (
+      <Button
+        selected={value.outer === "center"}
+        onClick={handleChange({ outer: "center" })}
+      />
+    );
+  else
+    content = (
+      <>
+        <Button
+          style={showStyle}
+          disabled={hideInner}
+          className={CSS(CSS.dir("y"))}
+          selected={inner === "top"}
+          onClick={handleChange({ inner: "top" })}
+        />
+        <Align.Space x align="center" justify="center">
+          <Button
+            style={showStyle}
+            disabled={hideInner}
+            selected={inner === "left"}
+            onClick={handleChange({ inner: "left" })}
+          />
+          <Button
+            style={showStyle}
+            disabled={hideInner}
+            selected={inner === "right"}
+            onClick={handleChange({ inner: "right" })}
+          />
+        </Align.Space>
+        <Button
+          style={showStyle}
+          disabled={hideInner}
+          className={CSS(CSS.dir("y"))}
+          selected={inner === "bottom"}
+          onClick={handleChange({ inner: "bottom" })}
+        />
+      </>
+    );
   return (
     <Align.Space
-      className={CSS(className, CSS.B("value"))}
+      className={CSS(
+        className,
+        CSS.B("value"),
+        showOuterCenter && CSS.M("show-outer-center"),
+      )}
       y
       align="center"
       justify="center"
       empty
       {...rest}
     >
-      <Button
-        style={showStyle}
-        disabled={hideInner}
-        className={CSS(CSS.dir("y"))}
-        selected={inner === "top"}
-        onClick={handleChange({ inner: "top" })}
-      />
-      <Align.Space x align="center" justify="center">
-        <Button
-          style={showStyle}
-          disabled={hideInner}
-          selected={inner === "left"}
-          onClick={handleChange({ inner: "left" })}
-        />
-        <Button
-          style={showStyle}
-          disabled={hideInner}
-          selected={inner === "right"}
-          onClick={handleChange({ inner: "right" })}
-        />
-      </Align.Space>
-      <Button
-        style={showStyle}
-        disabled={hideInner}
-        className={CSS(CSS.dir("y"))}
-        selected={inner === "bottom"}
-        onClick={handleChange({ inner: "bottom" })}
-      />
+      {content}
     </Align.Space>
   );
 };

--- a/pluto/src/vis/schematic/Symbols.css
+++ b/pluto/src/vis/schematic/Symbols.css
@@ -68,6 +68,11 @@
         top: 50%;
         transform: translate(calc(100% + var(--offset)), -50%);
     }
+    &.pluto--center {
+        left: 50%;
+        top: 50%;
+        transform: translate(-50%, -50%);
+    }
 }
 
 .pluto-symbol__label {

--- a/pluto/src/vis/schematic/Symbols.tsx
+++ b/pluto/src/vis/schematic/Symbols.tsx
@@ -38,13 +38,13 @@ export interface ControlStateProps extends Omit<Align.SpaceProps, "direction"> {
   showIndicator?: boolean;
   chip?: Control.ChipProps;
   indicator?: Control.IndicatorProps;
-  orientation?: location.Outer;
+  orientation?: location.Location;
 }
 
 export interface LabelExtensionProps {
   label?: string;
   level?: Text.Level;
-  orientation?: location.Outer;
+  orientation?: location.Location;
   direction?: direction.Direction;
   maxInlineSize?: number;
   align?: Align.Alignment;


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2322](https://linear.app/synnax/issue/SY-2322/place-labels-in-center-of-schematic-symbols)

## Description

Implementation is not particularly beautiful, but it gets the job done and doesn't introduce any liability.  My take is we'll eventually refactor the entire orientation control, so it's fine that this is quick and dirty

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.
