### PR TITLE
Sy-2526-actually-fix-opc-ua-read-task-pydantic-model-validation

### DIFF
--- a/client/py/pyproject.toml
+++ b/client/py/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "synnax"
-version = "0.42.1"
+version = "0.42.2"
 description = "Synnax Client Library"
 keywords = ["Synnax", "Synnax Python Client"]
 authors = [{ name = "Emiliano Bonilla", email = "ebonilla@synnaxlabs.com" }]

--- a/client/py/synnax/hardware/opcua/types.py
+++ b/client/py/synnax/hardware/opcua/types.py
@@ -7,7 +7,8 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-from typing import Annotated, Literal, Union
+import json
+from typing import Literal, Union
 from uuid import uuid4
 
 from pydantic import BaseModel, Field
@@ -121,8 +122,8 @@ class ReadTask(StarterStopperMixin, JSONConfigMixin, MetaTask):
     ):
         if internal is not None:
             self._internal = internal
-            self.config = WrappedReadTaskConfig.model_validate_json(
-                internal.config
+            self.config = WrappedReadTaskConfig.model_validate(
+                {"config": json.loads(internal.config)}
             ).config
             return
         self._internal = Task(name=name, type=self.TYPE)

--- a/client/py/synnax/hardware/task/client.py
+++ b/client/py/synnax/hardware/task/client.py
@@ -17,7 +17,7 @@ from uuid import uuid4
 
 from alamos import NOOP, Instrumentation
 from freighter import Empty, Payload, UnaryClient, send_required
-from pydantic import ValidationError
+from pydantic import BaseModel, ValidationError
 
 from synnax import UnexpectedError
 from synnax.exceptions import ConfigurationError
@@ -204,7 +204,7 @@ class StarterStopperMixin:
 
 class JSONConfigMixin(MetaTask):
     _internal: Task
-    config: Any
+    config: BaseModel
 
     @property
     def name(self) -> str:

--- a/client/py/tests/test_opcua.py
+++ b/client/py/tests/test_opcua.py
@@ -9,7 +9,8 @@
 
 import pytest
 
-from synnax.hardware.opcua import WrappedReadTaskConfig
+import synnax as sy
+from synnax.hardware.opcua import Channel, ReadTask, WrappedReadTaskConfig
 
 
 @pytest.mark.opcua
@@ -83,3 +84,27 @@ class TestOPCUATask:
         """Test that ReadTaskConfig can parse various configurations correctly."""
         input_data = test_data["data"]
         WrappedReadTaskConfig(config=input_data)
+
+    def test_create_and_retrieve_task(self, client: sy.Synnax):
+        """Test that ReadTask can be created and retrieved from the database."""
+        task = ReadTask(
+            name="test-task",
+            device="some-device-key",
+            sample_rate=10,
+            stream_rate=5,
+            array_mode=False,
+            array_size=1,
+            channels=[
+                Channel(
+                    key="k09AWoiyLxN",
+                    node_id="NS=2;I=8",
+                    channel=1234,
+                )
+            ],
+        )
+        createdTask = client.hardware.tasks.create(
+            name="test-task",
+            type="opc_read",
+            config=task.config.model_dump_json(),
+        )
+        ReadTask(createdTask)


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2526](https://linear.app/synnax/issue/SY-2526/actually-fix-opc-ua-read-task-pydantic-model-validation)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Actually fix the opc ua read task pydantic model validation when retrieving a task

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.
