### PR TITLE
Remove `setState` call during Schematic rendering

### DIFF
--- a/console/src/schematic/Schematic.tsx
+++ b/console/src/schematic/Schematic.tsx
@@ -47,6 +47,7 @@ import {
   select,
   selectHasPermission,
   useSelect,
+  useSelectEditable,
   useSelectHasPermission,
   useSelectNodeProps,
   useSelectVersion,
@@ -188,9 +189,12 @@ export const Loaded: Layout.Renderer = ({ layoutKey, visible }) => {
     if (prevName !== name) dispatch(Layout.rename({ key: layoutKey, name }));
   }, [name, prevName, layoutKey, dispatch]);
 
+  const isEditable = useSelectEditable(layoutKey);
   const canBeEditable = useSelectHasPermission();
-  if (!canBeEditable && schematic.editable)
-    dispatch(setEditable({ key: layoutKey, editable: false }));
+  useEffect(() => {
+    if (!canBeEditable && isEditable)
+      dispatch(setEditable({ key: layoutKey, editable: false }));
+  }, [canBeEditable, isEditable, layoutKey, dispatch]);
 
   const handleEdgesChange: Diagram.DiagramProps["onEdgesChange"] = useCallback(
     (edges) => undoableDispatch(setEdges({ key: layoutKey, edges })),


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2573](https://linear.app/synnax/issue/SY-2573/remove-setstate-during-render-call-in-schematictsx)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Remove `setState` call during Schematic rendering.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.
