### PR TITLE
Verify form in OPC UA server before testing connection

### DIFF
--- a/console/src/hardware/opc/device/Connect.tsx
+++ b/console/src/hardware/opc/device/Connect.tsx
@@ -68,7 +68,7 @@ export const CONNECT_LAYOUT: Layout.BaseState = {
 
 const formSchema = z.object({
   name: Common.Device.nameZ,
-  rack: rack.keyZ,
+  rack: rack.keyZ.refine((k) => k > 0, "Must select a location to connect from"),
   connection: connectionConfigZ,
 });
 interface FormSchema extends z.infer<typeof formSchema> {}
@@ -87,7 +87,8 @@ const Internal = ({ initialValues, layoutKey, onClose, properties }: InternalPro
     onError: (e) => handleError(e, "Failed to test connection"),
     mutationFn: async () => {
       if (client == null) throw NULL_CLIENT_ERROR;
-      if (!methods.validate("connection")) throw new Error("Invalid configuration");
+      if (!methods.validate("connection") || !methods.validate("rack"))
+        throw new Error("Invalid configuration");
       const rack = await client.hardware.racks.retrieve(
         methods.get<rack.Key>("rack").value,
       );


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2555](https://linear.app/synnax/issue/SY-2555/verify-form-in-opc-ua-server-test-connection-before-running-query)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Verify rack location before testing for OPC UA server connection.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.
