### PR TITLE
SY-2554: Add "Connect From" field to OPC UA server documentation

### DIFF
--- a/console/src/hardware/opc/device/Connect.tsx
+++ b/console/src/hardware/opc/device/Connect.tsx
@@ -148,7 +148,7 @@ const Internal = ({ initialValues, layoutKey, onClose, properties }: InternalPro
             }}
             path="name"
           />
-          <Form.Field<rack.Key> path="rack" label="Connect From Location" required>
+          <Form.Field<rack.Key> path="rack" label="Connect From" required>
             {(p) => <Rack.SelectSingle {...p} allowNone={false} />}
           </Form.Field>
           <Form.Field<string> path="connection.endpoint">

--- a/docs/site/src/pages/reference/device-drivers/opc-ua/connect-server.mdx
+++ b/docs/site/src/pages/reference/device-drivers/opc-ua/connect-server.mdx
@@ -65,6 +65,12 @@ reference for each of the fields you'll need to fill:
       </td>
     </tr>
     <tr>
+      <td>Connect From</td>
+      <td>
+        The Synnax driver that will connect to the OPC UA server.
+      </td>
+    </tr>
+    <tr>
       <td>Endpoint</td>
       <td>
         The endpoint URL for your server. This should be it's reachable address on the


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2554](https://linear.app/synnax/issue/SY-2554/add-connect-from-field-to-opc-ua-server-documentation)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Add "Connect From" field to OPC UA server documentation

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.
