### PR TITLE
SY-2552: Fix typo in NI digital write task documentation

### DIFF
--- a/docs/site/src/pages/reference/device-drivers/ni/digital-write-task.mdx
+++ b/docs/site/src/pages/reference/device-drivers/ni/digital-write-task.mdx
@@ -86,7 +86,7 @@ running task.
 
 To create a digital write task from the resources toolbar, open the Synnax Console and
 click on the resources (<Icon.Resources />) toolbar in the left sidebar. Find the device
-you'd like to create the task for, right-click on it, and select "Create Digital write
+you'd like to create the task for, right-click on it, and select "Create Digital Write
 Task".
 
 <Video
@@ -101,7 +101,7 @@ click on the Quick Search & Command Palette at the top. You can also open this p
 with `Ctrl+Shift+P` on Windows and `Cmd+Shift+P` on macOS.
 
 In command mode (enabled when the first character in the input is ">"), type "NI".
-You'll see an option called "Create a New Digital write Task". Select this option to
+You'll see an option called "Create a New Digital Write Task". Select this option to
 open the read task configuration dialog.
 
 <Video


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2552](https://linear.app/synnax/issue/SY-2552/fix-typo-on-ni-digital-write-documentation-site)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Fix typo on NI digital write task documentation site.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.
