### PR TITLE
SY-2550: Match icon color in NI analog tasks

### DIFF
--- a/console/src/hardware/ni/task/AnalogRead.tsx
+++ b/console/src/hardware/ni/task/AnalogRead.tsx
@@ -86,10 +86,7 @@ const ChannelListItem = ({
       path={path}
       hasTareButton={hasTareButton}
       channel={channel}
-      icon={{
-        name: AI_CHANNEL_TYPE_NAMES[type],
-        icon: <Icon style={{ color: "var(--pluto-gray-l9)" }} />,
-      }}
+      icon={{ icon: <Icon />, name: AI_CHANNEL_TYPE_NAMES[type] }}
       portMaxChars={2}
     />
   );

--- a/console/src/hardware/ni/task/AnalogWrite.tsx
+++ b/console/src/hardware/ni/task/AnalogWrite.tsx
@@ -63,6 +63,7 @@ const ChannelListItem = ({ path, isSnapshot, ...rest }: ChannelListItemProps) =>
   const {
     entry: { port, cmdChannel, stateChannel, type },
   } = rest;
+  const Icon = AO_CHANNEL_TYPE_ICONS[type];
   return (
     <Common.Task.Layouts.ListAndDetailsChannelItem
       {...rest}
@@ -74,10 +75,7 @@ const ChannelListItem = ({ path, isSnapshot, ...rest }: ChannelListItemProps) =>
       canTare={false}
       isSnapshot={isSnapshot}
       path={path}
-      icon={{
-        name: AO_CHANNEL_TYPE_NAMES[type],
-        icon: AO_CHANNEL_TYPE_ICONS[type],
-      }}
+      icon={{ icon: <Icon />, name: AO_CHANNEL_TYPE_NAMES[type] }}
     />
   );
 };

--- a/console/src/hardware/ni/task/SelectAIChannelTypeField.tsx
+++ b/console/src/hardware/ni/task/SelectAIChannelTypeField.tsx
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { Form, Text } from "@synnaxlabs/pluto";
+import { Align, Form, Text } from "@synnaxlabs/pluto";
 import { deep, type Keyed } from "@synnaxlabs/x";
 import { type ReactElement } from "react";
 
@@ -31,14 +31,14 @@ interface ChannelTypeProps {
 const ChannelType = ({ type }: ChannelTypeProps) => {
   const Icon = AI_CHANNEL_TYPE_ICONS[type];
   return (
-    <Text.WithIcon
-      level="p"
-      startIcon={
-        <Icon style={{ transform: "scale(0.9)", color: "var(--pluto-gray-l9)" }} />
-      }
-    >
-      {AI_CHANNEL_TYPE_NAMES[type]}
-    </Text.WithIcon>
+    <Align.Space direction="x" size="small">
+      <Text.WithIcon
+        level="p"
+        shade={7}
+        startIcon={<Icon style={{ transform: "scale(0.9)" }} />}
+      />
+      <Text.Text level="p">{AI_CHANNEL_TYPE_NAMES[type]}</Text.Text>
+    </Align.Space>
   );
 };
 

--- a/console/src/hardware/ni/task/SelectAIChannelTypeField.tsx
+++ b/console/src/hardware/ni/task/SelectAIChannelTypeField.tsx
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { Align, Form, Text } from "@synnaxlabs/pluto";
+import { Form, Text } from "@synnaxlabs/pluto";
 import { deep, type Keyed } from "@synnaxlabs/x";
 import { type ReactElement } from "react";
 
@@ -31,14 +31,14 @@ interface ChannelTypeProps {
 const ChannelType = ({ type }: ChannelTypeProps) => {
   const Icon = AI_CHANNEL_TYPE_ICONS[type];
   return (
-    <Align.Space direction="x" size="small">
-      <Text.WithIcon
-        level="p"
-        shade={7}
-        startIcon={<Icon style={{ transform: "scale(0.9)" }} />}
-      />
-      <Text.Text level="p">{AI_CHANNEL_TYPE_NAMES[type]}</Text.Text>
-    </Align.Space>
+    <Text.WithIcon
+      level="p"
+      startIcon={
+        <Icon style={{ transform: "scale(0.9)", color: "var(--pluto-gray-l7)" }} />
+      }
+    >
+      {AI_CHANNEL_TYPE_NAMES[type]}
+    </Text.WithIcon>
   );
 };
 

--- a/console/src/hardware/ni/task/SelectAOChannelTypeField.tsx
+++ b/console/src/hardware/ni/task/SelectAOChannelTypeField.tsx
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { Align, Form, Text } from "@synnaxlabs/pluto";
+import { Form, Text } from "@synnaxlabs/pluto";
 import { deep, type Keyed } from "@synnaxlabs/x";
 import { type ReactElement } from "react";
 
@@ -28,12 +28,17 @@ interface ChannelTypeProps {
   type: AOChannelType;
 }
 
-const ChannelType = ({ type }: ChannelTypeProps) => (
-  <Align.Space direction="x" size="small">
-    <Text.WithIcon startIcon={AO_CHANNEL_TYPE_ICONS[type]} level="p" shade={7} />
-    <Text.Text level="p">{AO_CHANNEL_TYPE_NAMES[type]}</Text.Text>
-  </Align.Space>
-);
+const ChannelType = ({ type }: ChannelTypeProps) => {
+  const Icon = AO_CHANNEL_TYPE_ICONS[type];
+  return (
+    <Text.WithIcon
+      level="p"
+      startIcon={<Icon style={{ color: "var(--pluto-gray-l7)" }} />}
+    >
+      {AO_CHANNEL_TYPE_NAMES[type]}
+    </Text.WithIcon>
+  );
+};
 
 export type SelectAOChannelTypeFieldProps = Form.DropdownButtonFieldProps<
   AOChannelType,

--- a/console/src/hardware/ni/task/types/v0.tsx
+++ b/console/src/hardware/ni/task/types/v0.tsx
@@ -9,7 +9,7 @@
 
 import { type task } from "@synnaxlabs/client";
 import { Icon, type IconProps } from "@synnaxlabs/media";
-import { type FC, type JSX } from "react";
+import { type FC } from "react";
 import { z } from "zod/v4";
 
 import { Common } from "@/hardware/common";
@@ -1042,10 +1042,10 @@ export const AO_CHANNEL_TYPE_NAMES: Record<AOChannelType, string> = {
   [AO_VOLTAGE_CHAN_TYPE]: "Voltage",
 };
 
-export const AO_CHANNEL_TYPE_ICONS: Record<AOChannelType, JSX.Element> = {
-  [AO_CURRENT_CHAN_TYPE]: <Icon.Units.Current />,
-  [AO_FUNC_GEN_CHAN_TYPE]: <Icon.Function />,
-  [AO_VOLTAGE_CHAN_TYPE]: <Icon.Units.Voltage />,
+export const AO_CHANNEL_TYPE_ICONS: Record<AOChannelType, FC<IconProps>> = {
+  [AO_CURRENT_CHAN_TYPE]: Icon.Units.Current,
+  [AO_FUNC_GEN_CHAN_TYPE]: Icon.Function,
+  [AO_VOLTAGE_CHAN_TYPE]: Icon.Units.Voltage,
 };
 
 export const ZERO_AO_CHANNELS: Record<AOChannelType, AOChannel> = {


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2550](https://linear.app/synnax/issue/SY-2550/match-icon-color-in-ni-analog-tasks)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Match icon colors in NI analog read and write tasks.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.
