### PR TITLE
SY-1185: Hide remove alias menu option when no alias exists

### DIFF
--- a/console/src/channel/services/ontology.tsx
+++ b/console/src/channel/services/ontology.tsx
@@ -221,6 +221,10 @@ const TreeContextMenu: Ontology.TreeContextMenu = (props) => {
   const activeRange = Range.useSelect();
   const groupFromSelection = Group.useCreateFromSelection();
   const setAlias = useSetAlias();
+  const aliases = PChannel.useAliases();
+  const showDeleteAlias = resources.some(
+    ({ id: { key } }) => aliases[Number(key)] != null,
+  );
   const delAlias = useDeleteAlias();
   const del = useDelete();
   const handleRename = useRename();
@@ -252,20 +256,24 @@ const TreeContextMenu: Ontology.TreeContextMenu = (props) => {
           </PMenu.Item>
         </>
       )}
-      {activeRange != null && activeRange.persisted && (
-        <>
-          <PMenu.Divider />
-          {singleResource && (
-            <PMenu.Item itemKey="alias" startIcon={<Icon.Rename />}>
-              Set Alias Under {activeRange.name}
-            </PMenu.Item>
-          )}
-          <PMenu.Item itemKey="deleteAlias" startIcon={<Icon.Delete />}>
-            Remove Alias Under {activeRange.name}
-          </PMenu.Item>
-          <PMenu.Divider />
-        </>
-      )}
+      {activeRange != null &&
+        activeRange.persisted &&
+        (singleResource || showDeleteAlias) && (
+          <>
+            <PMenu.Divider />
+            {singleResource && (
+              <PMenu.Item itemKey="alias" startIcon={<Icon.Rename />}>
+                Set Alias Under {activeRange.name}
+              </PMenu.Item>
+            )}
+            {showDeleteAlias && (
+              <PMenu.Item itemKey="deleteAlias" startIcon={<Icon.Delete />}>
+                Remove Alias Under {activeRange.name}
+              </PMenu.Item>
+            )}
+            <PMenu.Divider />
+          </>
+        )}
       <PMenu.Item itemKey="delete" startIcon={<Icon.Delete />}>
         Delete
       </PMenu.Item>


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-1185](https://linear.app/synnax/issue/SY-1185/hide-remove-alias-menu-option-when-no-alias-exists)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.
