### PR TITLE
SY-2527 - Center Text In Schematic Valus

### DIFF
--- a/pluto/src/vis/draw2d/canvas.ts
+++ b/pluto/src/vis/draw2d/canvas.ts
@@ -600,11 +600,7 @@ export class SugaredOffscreenCanvasRenderingContext2D
   ): void {
     const [useAtlas, fillStyle] = this.checkAtlasFillStyle(options.useAtlas);
     if (useAtlas) {
-      const atlas = this.atlasRegistry.get({
-        font: this.font,
-        textColor: fillStyle,
-        dpr: this.dpr,
-      });
+      const atlas = this.atlasRegistry.get({ font: this.font, textColor: fillStyle });
       atlas.fillText(this, text, x, y);
       return;
     }
@@ -623,11 +619,7 @@ export class SugaredOffscreenCanvasRenderingContext2D
   textDimensions(text: string, options: FillTextOptions = {}): dimensions.Dimensions {
     const [useAtlas, fillStyle] = this.checkAtlasFillStyle(options.useAtlas);
     if (useAtlas) {
-      const atlas = this.atlasRegistry.get({
-        font: this.font,
-        textColor: fillStyle,
-        dpr: this.dpr,
-      });
+      const atlas = this.atlasRegistry.get({ font: this.font, textColor: fillStyle });
       return atlas.measureText(text);
     }
     return dimensionsFromMetrics(this.measureText(text));

--- a/pluto/src/vis/text/atlas.ts
+++ b/pluto/src/vis/text/atlas.ts
@@ -14,11 +14,11 @@ import { dimensionsFromMetrics } from "@/text/core/dimensions";
 export interface AtlasProps {
   font: string;
   textColor: color.Crude;
-  dpr: number;
   characters?: string;
 }
 
 const PADDING = 2;
+const SCALE_FACTOR = 2;
 
 /**
  * @desc a text atlas that allows for efficient caching and rendering of monospaced
@@ -29,16 +29,13 @@ export class MonospacedAtlas {
   private readonly atlas: OffscreenCanvas;
   // Cached dimensions of a character.
   private readonly charDims: dimensions.Dimensions;
-  // The device pixel ratio of the atlas.
-  private readonly dpr: number;
   // A map of characters to their index in the atlas.
   private readonly charMap: Map<string, number>;
   // The default characters to include in the atlas.
   private static readonly DEFAULT_CHARS = "0123456789.:-umsNa∞ᴇ";
 
   constructor(props: AtlasProps) {
-    const { font, dpr, characters = MonospacedAtlas.DEFAULT_CHARS, textColor } = props;
-    this.dpr = dpr;
+    const { font, characters = MonospacedAtlas.DEFAULT_CHARS, textColor } = props;
     this.charMap = new Map();
 
     const uniqueChars = unique.unique(Array.from(characters));
@@ -59,12 +56,12 @@ export class MonospacedAtlas {
     const rows = Math.ceil(totalChars / cols);
 
     this.atlas = new OffscreenCanvas(
-      atlasCharWidth * cols * this.dpr,
-      atlasCharHeight * (rows + 1) * this.dpr,
+      atlasCharWidth * cols * SCALE_FACTOR,
+      atlasCharHeight * (rows + 1) * SCALE_FACTOR,
     );
 
     const atlasCtx = this.atlas.getContext("2d") as OffscreenCanvasRenderingContext2D;
-    atlasCtx.scale(this.dpr, this.dpr);
+    atlasCtx.scale(SCALE_FACTOR, SCALE_FACTOR);
     atlasCtx.font = font;
     atlasCtx.textBaseline = "alphabetic";
     atlasCtx.textAlign = "left";
@@ -99,12 +96,12 @@ export class MonospacedAtlas {
       const row = Math.floor(index / cols);
       ctx.drawImage(
         this.atlas,
-        col * width * this.dpr,
-        row * height * this.dpr + PADDING,
-        width * this.dpr,
-        height * this.dpr,
+        col * width * SCALE_FACTOR,
+        row * height * SCALE_FACTOR + PADDING,
+        width * SCALE_FACTOR,
+        height * SCALE_FACTOR,
         x + i * width,
-        y - height - PADDING / this.dpr,
+        y - height - PADDING / SCALE_FACTOR,
         width,
         height,
       );
@@ -129,7 +126,7 @@ export class AtlasRegistry {
    * atlas does not exist in the registry, it is created and added to the registry.
    */
   get(props: AtlasProps): MonospacedAtlas {
-    const key = `${props.font}-${color.hex(props.textColor)}-${props.dpr}-${props.characters}`;
+    const key = `${props.font}-${color.hex(props.textColor)}-${props.characters}`;
     if (this.atlases.has(key)) return this.atlases.get(key)!;
     const atlas = new MonospacedAtlas(props);
     this.atlases.set(key, atlas);


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-2538](https://linear.app/synnax/issue/SY-2527/center-text-in-schematic-values)

## Description

Fixes issues with centering in text atlas. Turns out that DPI doesn't matter if we just upscale the atlas canvas.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.
