### PR TITLE
SY-2585: Remove potential deadlock in cluster ontology service

### DIFF
--- a/synnax/pkg/distribution/cluster/ontology.go
+++ b/synnax/pkg/distribution/cluster/ontology.go
@@ -76,10 +76,6 @@ func (s *NodeOntologyService) ListenForChanges(ctx context.Context) {
 	if err := s.Ontology.NewWriter(nil).DefineResource(ctx, NodeOntologyID(core.Free)); err != nil {
 		s.L.Error("failed to define free node ontology resource", zap.Error(err))
 	}
-	s.update(ctx, s.Cluster.CopyState())
-	s.Cluster.OnChange(func(ctx context.Context, change core.ClusterChange) {
-		s.update(ctx, change.State)
-	})
 }
 
 func translateNodeChange(ch core.NodeChange, _ int) schema.Change {
@@ -107,31 +103,6 @@ func (s *NodeOntologyService) OpenNexter() (iter.NexterCloser[ontology.Resource]
 			return newNodeResource(n)
 		})),
 	), nil
-}
-
-func (s *NodeOntologyService) update(ctx context.Context, state core.ClusterState) {
-	if err := s.Ontology.DB.WithTx(ctx, func(txn gorp.Tx) error {
-		w := s.Ontology.NewWriter(txn)
-		clusterID := OntologyID(s.Cluster.Key())
-		if err := w.DefineResource(ctx, clusterID); err != nil {
-			return err
-		}
-		if err := w.DefineRelationship(ctx, ontology.RootID, ontology.ParentOf, clusterID); err != nil {
-			return err
-		}
-		for _, n := range state.Nodes {
-			nodeID := NodeOntologyID(n.Key)
-			if err := w.DefineResource(ctx, NodeOntologyID(n.Key)); err != nil {
-				return err
-			}
-			if err := w.DefineRelationship(ctx, clusterID, ontology.ParentOf, nodeID); err != nil {
-				return err
-			}
-		}
-		return nil
-	}); err != nil {
-		s.L.Error("failed to update node ontology", zap.Error(err))
-	}
 }
 
 // Schema implements ontology.Service.


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2585](https://linear.app/synnax/issue/SY-2585/check-for-cluster-ontology-service-deadlock-potential)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Remove a potential deadlock in the cluster ontology service.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.
