### PR TITLE
SY-2651: Remove Python 3.13 Syntax and fix default status initialization

### DIFF
--- a/client/py/synnax/status/status.py
+++ b/client/py/synnax/status/status.py
@@ -32,13 +32,13 @@ Variant = Literal[
 ]
 """Represents the variant of a status message."""
 
-D = TypeVar("D", bound=Payload, default=Payload)
+D = TypeVar("D", bound=Payload)
 
 
 class Status(Payload, Generic[D]):
     """A standardized payload used across Synnax."""
 
-    key: str = Field(default=str(uuid4()))
+    key: str = Field(default_factory=lambda: str(uuid4()))
     """A unique key for the status."""
     variant: Variant
     """The variant of the status."""
@@ -46,7 +46,7 @@ class Status(Payload, Generic[D]):
     """The message of the status."""
     description: str = ""
     """The description of the status."""
-    time: TimeStamp = Field(default=TimeStamp.now())
+    time: TimeStamp = Field(default_factory=TimeStamp.now)
     """The time the status was created."""
     details: D
     """The details are customizable details for component specific statuses."""


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2651](https://linear.app/synnax/issue/SY-2651/remove-python-313-syntax-from-python-client)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Remove the Python 3.13 syntax of the `default` arg in `TypeVar`. Also fixed the default initialization of `time` and `key` to be dynamically generated.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.
