### PR TITLE
SY-2653 - Fix Task Config Initial Values

### DIFF
--- a/console/src/hardware/common/task/Form.tsx
+++ b/console/src/hardware/common/task/Form.tsx
@@ -136,10 +136,10 @@ export const useForm = <
   );
   const methods = PForm.use<FormSchema<Config>>({
     schema,
-    values: schema.parse({
+    values: {
       name: initialTask.name,
       config: initialTask.config,
-    }) as z.infer<FormSchema<Config>>,
+    } as z.infer<FormSchema<Config>>,
     onHasTouched: handleUnsavedChanges,
   });
   const create = useCreate<Type, Config, StatusData>(layoutKey, schemas);


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2653](https://linear.app/synnax/issue/SY-2653/fix-task-config-parsing)

## Description

We were parsing schemas for tasks too early, which caused validation errors before fields were specified (such as devices not having a length greater than 1).

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.
