### PR TITLE
SY-1845: Fix Summary & Details Code on Documentation Site

### DIFF
--- a/docs/site/src/components/Diagram.astro
+++ b/docs/site/src/components/Diagram.astro
@@ -1,5 +1,4 @@
 ---
-import { Icon } from "@synnaxlabs/media";
 const { preview, variant, ...rest } = Astro.props;
 ---
 

--- a/docs/site/src/components/NextPrev.astro
+++ b/docs/site/src/components/NextPrev.astro
@@ -1,6 +1,6 @@
 ---
 import { Icon } from "@synnaxlabs/media";
-import { Align, Button, Divider, Text } from "@synnaxlabs/pluto";
+import { Align, Divider, Text } from "@synnaxlabs/pluto";
 const { next, prev, nextURL, prevURL } = Astro.props;
 ---
 

--- a/docs/site/src/components/Rule.astro
+++ b/docs/site/src/components/Rule.astro
@@ -1,5 +1,4 @@
 ---
-const { title } = Astro.props;
 ---
 
 <div class="rule magicpattern">

--- a/docs/site/src/components/Table.tsx
+++ b/docs/site/src/components/Table.tsx
@@ -7,13 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import {
-  bounds,
-  convertRenderV,
-  type direction,
-  type Key,
-  type Keyed,
-} from "@synnaxlabs/x";
+import { bounds, convertRenderV, type direction, type record } from "@synnaxlabs/x";
 import { type ReactElement } from "react";
 
 export interface TableColumn<K extends record.Key, E extends record.Keyed<K>> {
@@ -40,7 +34,7 @@ export const Table = <K extends record.Key, E extends record.Keyed<K>>({
   columns,
   data,
   highlights = [],
-}: TableProps<Key, E>): ReactElement => (
+}: TableProps<record.Key, E>): ReactElement => (
   <div style={{ overflowX: "auto", paddingLeft: 2 }}>
     <table>
       <thead>

--- a/docs/site/src/components/details/Summary.astro
+++ b/docs/site/src/components/details/Summary.astro
@@ -1,8 +1,0 @@
----
-import { Icon } from "@synnaxlabs/media";
----
-
-<summary>
-    <Icon.Caret.Left className="indicator" />
-    <slot />
-</summary>

--- a/docs/site/src/components/mdxOverrides.tsx
+++ b/docs/site/src/components/mdxOverrides.tsx
@@ -13,7 +13,6 @@ import { type FC } from "react";
 
 import pre from "@/components/code/Code.astro";
 import Details from "@/components/details/Details.astro";
-import Summary from "@/components/details/Summary.astro";
 import table from "@/components/Table.astro";
 
 interface TextFactoryProps {
@@ -48,5 +47,4 @@ export const mdxOverrides = {
   h2: textFactory({ level: "h2", includeAnchor: true }),
   h3: textFactory({ level: "h3", includeAnchor: true }),
   details: Details,
-  summary: Summary,
 };

--- a/docs/site/src/components/releases/Release.astro
+++ b/docs/site/src/components/releases/Release.astro
@@ -1,8 +1,7 @@
 ---
 import { Icon } from "@synnaxlabs/media";
-import { Align, Button, Text } from "@synnaxlabs/pluto";
+import { Align, Text } from "@synnaxlabs/pluto";
 const { date, version, title, breakingChanges } = Astro.props;
-const id = version.split(".").join("-");
 const firstPart = version.split(".").slice(0, 2).join(".");
 ---
 

--- a/docs/site/src/middleware.ts
+++ b/docs/site/src/middleware.ts
@@ -1,6 +1,6 @@
 import type { MiddlewareHandler } from "astro";
 
-export const onRequest: MiddlewareHandler = async (context, next) => {
+export const onRequest: MiddlewareHandler = async (_, next) => {
   const response = await next();
 
   response.headers.set(

--- a/docs/site/src/pages/guides/comparison/performance/one-billion-rows/index.mdx
+++ b/docs/site/src/pages/guides/comparison/performance/one-billion-rows/index.mdx
@@ -12,7 +12,6 @@ import { Image } from "@/components/Media";
 import { Tabs } from "@/components/Tabs";
 import StepText from "@/components/StepText.astro";
 import Details from "@/components/details/Details.astro";
-import Summary from "@/components/details/Summary.astro";
 import { Icon } from "@synnaxlabs/media";
 import { mdxOverrides } from "@/components/mdxOverrides";
 export const components = mdxOverrides;

--- a/docs/site/src/pages/guides/operations/automated-control.mdx
+++ b/docs/site/src/pages/guides/operations/automated-control.mdx
@@ -7,7 +7,6 @@ description: "Write a control sequence for pressurizing a tank."
 
 import { Divider, Note } from "@synnaxlabs/pluto";
 import Details from "@/components/details/Details.astro";
-import Summary from "@/components/details/Summary.astro";
 import { Image, Video } from "@/components/Media";
 import { mdxOverrides } from "@/components/mdxOverrides";
 export const components = mdxOverrides;
@@ -182,7 +181,7 @@ This range is now saved and can be referenced later to view this test.
 The full file can be viewed below:
 
 <Details>
-<Summary>`control_sequence.py`</Summary>
+<span slot="summary">`control_sequence.py`</span>
 
 ```python
 import synnax as sy

--- a/docs/site/src/pages/reference/python-client/device-driver.mdx
+++ b/docs/site/src/pages/reference/python-client/device-driver.mdx
@@ -9,7 +9,6 @@ import { Image, Video } from "@/components/Media";
 import StepText from "@/components/StepText.astro";
 import Code from "@/components/code/Code.astro";
 import Details from "@/components/details/Details.astro";
-import Summary from "@/components/details/Summary.astro";
 export const components = { pre: Code };
 
 While our [pre-built drivers](/reference/device-drivers) are great for the devices we
@@ -335,7 +334,7 @@ Once we've finished these modifications, we can run the script and see the value
 pouring in from the Arduino. Here's the entire script for reference:
 
 <Details>
-<Summary>`driver.py`</Summary>
+<span slot="summary">`driver.py`</span>
 
 ```python
 import synnax as sy
@@ -520,7 +519,7 @@ script before we move into setting up the console. Here's the entire `driver_wri
 script for reference:
 
 <Details>
-<Summary>`driver_write.py`</Summary>
+<span slot="summary">`driver_write.py`</span>
 
 ```python
 import synnax as sy
@@ -730,7 +729,7 @@ script before we move into setting up the console. Here's the entire
 `driver_readwrite.py` script for reference:
 
 <Details>
-<Summary>`driver_readwrite.py`</Summary>
+<span slot="summary">`driver_readwrite.py`</span>
 
 ```python
 import synnax as sy

--- a/docs/site/src/pages/releases/Thumbnail0370.astro
+++ b/docs/site/src/pages/releases/Thumbnail0370.astro
@@ -1,5 +1,4 @@
 ---
-import { Logo } from "@synnaxlabs/media";
 import { Align, Text } from "@synnaxlabs/pluto";
 ---
 


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-1845](https://linear.app/synnax/issue/SY-1845/fix-dropdown-code-on-documentation-site)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

- Fix some Astro linting issues with the documentation site
- Remove the custom `<Summary />` component

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.
