### PR TITLE
SY-2716: Rename the name of the nominal sequence in abort example

### DIFF
--- a/client/py/examples/control/abort/nominal_sequence.py
+++ b/client/py/examples/control/abort/nominal_sequence.py
@@ -23,7 +23,7 @@ PRESSURE = "pressure"
 # Open a control sequence under a context manager, so that the control is released when
 # the block exits
 with client.control.acquire(
-    name="Press Sequence",
+    name="Nominal Press Sequence",
     # Defines the authorities at which the sequence controls the valve channels.
     #
     # Notice that we take a higher control authority here than we do at the start of the


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2716](https://linear.app/synnax/issue/SY-2716/rename-the-name-of-the-nominal-sequence-from-press-sequence-to-nominal)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Rename the name of the nominal sequence in the abort example.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.
