### PR TITLE
SY-2742: Add onDoubleClick method to delete stop-line component

### DIFF
--- a/pluto/src/color/GradientPicker.tsx
+++ b/pluto/src/color/GradientPicker.tsx
@@ -173,7 +173,13 @@ const StopSwatch = ({ stop, onChange, nextStop, onDelete, scale }: StopSwatchPro
         onDragStart={onDragStart}
         empty
       >
-        <div className={CSS.BE("gradient-picker", "stop-line")} />
+        <div 
+          className={CSS.BE("gradient-picker", "stop-line")} 
+          onDoubleClick={(e) => {
+            e.stopPropagation();
+            onDelete(stop.key);
+          }}
+        />
         <Text.Editable
           level="small"
           value={scale.pos(stop.position).toFixed(2)}


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-2742](https://linear.app/synnax/issue/SY-2742/enable-deletion-of-redlines)

## Description

There is no currently way to delete the redline limit selectors. This can lead to many being accidentally created and a headache for users to deal with. This change implements a quick fix to delete the limit selectors when double-clicked.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [ ] ~I have added relevant tests to cover the changes to CI.~
- [ ] ~I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.~
- [ ] ~I have updated in-code documentation to reflect the changes.~
- [ ] ~I have updated user-facing documentation to reflect the changes.~
