### PR TITLE
SY-2681 -  Exclude Context Menus from Closing Dropdowns

### DIFF
--- a/pluto/src/dialog/Frame.tsx
+++ b/pluto/src/dialog/Frame.tsx
@@ -32,6 +32,7 @@ import {
   useResize,
   useSyncedRef,
 } from "@/hooks";
+import { Menu } from "@/menu";
 import { state } from "@/state";
 import { Triggers } from "@/triggers";
 
@@ -183,6 +184,8 @@ export const Frame = ({
           const isTrigger = parentRef.current.contains(e.target as Node);
           exclude = isTrigger;
         }
+        const contextMenus = document.getElementsByClassName(Menu.CONTEXT_MENU_CLASS);
+        if (contextMenus.length > 0) exclude = true;
         if (!exclude) e.stopImmediatePropagation();
         return exclude;
       }

--- a/pluto/src/menu/ContextMenu.tsx
+++ b/pluto/src/menu/ContextMenu.tsx
@@ -56,6 +56,7 @@ const INITIAL_STATE: ContextMenuState = {
 
 export const CONTEXT_SELECTED = CSS.BM("context", "selected");
 export const CONTEXT_TARGET = CSS.BE("context", "target");
+export const CONTEXT_MENU_CLASS = CSS.B("menu-context");
 const CONTEXT_MENU_CONTAINER = CSS.BE("menu-context", "container");
 
 const findTarget = (target: HTMLElement): HTMLElement | null => {
@@ -162,7 +163,7 @@ const Internal = ({
   if (!visible) return null;
   return createPortal(
     <Flex.Box
-      className={CSS(CSS.B("menu-context"), CSS.bordered())}
+      className={CSS(CONTEXT_MENU_CLASS, CSS.bordered())}
       ref={ref}
       style={{ ...xy.css(position), ...style }}
       onClick={close}


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-2681](https://linear.app/synnax/issue/SY-2681/prevent-clicking-outside-context-menu-from-closing-dropdown-dialogs)

## Description

Clicking on a context menu that was opened inside of a dropdown (such as cluster select) would result in the dialog being closed if the button on the context menu was outside of the dropdown. This fixes that issue.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.
