### PR TITLE
SY-2788 - Fixed Calculated Channels Across Domains

### DIFF
--- a/synnax/pkg/service/framer/calculation/calculator.go
+++ b/synnax/pkg/service/framer/calculation/calculator.go
@@ -33,7 +33,7 @@ type Calculator struct {
 		alignment telem.Alignment
 		timestamp telem.TimeStamp
 	}
-	// cache is a map of cache channels and an accumulated buffer of data. Data
+	// cache is a map of required channels and an accumulated buffer of data. Data
 	// is accumulated for each channel until a calculation can be performed, and is
 	// then flushed.
 	cache map[channel.Key]cacheEntry

--- a/synnax/pkg/service/framer/calculation/calculator.go
+++ b/synnax/pkg/service/framer/calculation/calculator.go
@@ -82,7 +82,7 @@ func (c *Calculator) Next(fr framer.Frame) (telem.Series, error) {
 		if v, ok := c.required[k]; ok {
 			v.data = v.data.Append(s).FilterGreaterThanOrEqualTo(c.highWaterMark.alignment)
 			c.required[k] = v
-			if c.highWaterMark.alignment == 0 {
+			if c.highWaterMark.alignment == 0 || c.highWaterMark.alignment.DomainIndex() != v.data.AlignmentBounds().Lower.DomainIndex() {
 				c.highWaterMark.alignment = v.data.AlignmentBounds().Lower
 				c.highWaterMark.timestamp = v.data.TimeRange().Start
 			}

--- a/synnax/pkg/service/framer/calculation/calculator_test.go
+++ b/synnax/pkg/service/framer/calculation/calculator_test.go
@@ -143,6 +143,261 @@ var _ = Describe("Calculator", func() {
 		})
 	})
 
+	Describe("High Water Mark Behavior", func() {
+		var (
+			inCh1 = channel.Channel{
+				Leaseholder: 1,
+				LocalKey:    1,
+				Name:        "in_ch_1",
+				DataType:    telem.Float32T,
+			}
+			inCh2 = channel.Channel{
+				Leaseholder: 1,
+				LocalKey:    2,
+				Name:        "in_ch_2",
+				DataType:    telem.Float32T,
+			}
+			out = channel.Channel{
+				Leaseholder: 1,
+				LocalKey:    3,
+				Name:        "out",
+				DataType:    telem.Float32T,
+				Expression:  "return in_ch_1 + in_ch_2",
+			}
+			calc *calculation.Calculator
+		)
+
+		BeforeEach(func() {
+			calc = MustSucceed(calculation.OpenCalculator(
+				out,
+				[]channel.Channel{inCh1, inCh2},
+			))
+		})
+
+		AfterEach(func() {
+			calc.Close()
+		})
+
+		It("Should maintain high water mark across multiple frames", func() {
+			// First frame: send data for both channels
+			inSeries1 := telem.NewSeriesV[float32](1, 2, 3)
+			inSeries1.Alignment = 0
+			inSeries1.TimeRange = telem.NewRangeSeconds(0, 3)
+
+			inSeries2 := telem.NewSeriesV[float32](10, 20, 30)
+			inSeries2.Alignment = 0
+			inSeries2.TimeRange = telem.NewRangeSeconds(0, 3)
+
+			outSeries := MustSucceed(calc.Next(core.MultiFrame(
+				[]channel.Key{inCh1.Key(), inCh2.Key()},
+				[]telem.Series{inSeries1, inSeries2},
+			)))
+
+			// Should calculate all 3 samples
+			Expect(outSeries.Len()).To(Equal(int64(3)))
+			Expect(outSeries.Alignment).To(Equal(telem.Alignment(0)))
+			Expect(outSeries).To(telem.MatchSeriesDataV[float32](11, 22, 33))
+
+			// Second frame: send more data with alignment starting after high water mark
+			inSeries1 = telem.NewSeriesV[float32](4, 5, 6)
+			inSeries1.Alignment = 3
+			inSeries1.TimeRange = telem.NewRangeSeconds(3, 6)
+
+			inSeries2 = telem.NewSeriesV[float32](40, 50, 60)
+			inSeries2.Alignment = 3
+			inSeries2.TimeRange = telem.NewRangeSeconds(3, 6)
+
+			outSeries = MustSucceed(calc.Next(core.MultiFrame(
+				[]channel.Key{inCh1.Key(), inCh2.Key()},
+				[]telem.Series{inSeries1, inSeries2},
+			)))
+
+			// Should calculate 3 more samples
+			Expect(outSeries.Len()).To(Equal(int64(3)))
+			Expect(outSeries.Alignment).To(Equal(telem.Alignment(3)))
+			Expect(outSeries).To(telem.MatchSeriesDataV[float32](44, 55, 66))
+		})
+
+		It("Should not recalculate data before high water mark", func() {
+			// First frame
+			inSeries1 := telem.NewSeriesV[float32](1, 2, 3, 4, 5)
+			inSeries1.Alignment = 0
+			inSeries1.TimeRange = telem.NewRangeSeconds(0, 5)
+
+			inSeries2 := telem.NewSeriesV[float32](10, 20, 30, 40, 50)
+			inSeries2.Alignment = 0
+			inSeries2.TimeRange = telem.NewRangeSeconds(0, 5)
+
+			outSeries := MustSucceed(calc.Next(core.MultiFrame(
+				[]channel.Key{inCh1.Key(), inCh2.Key()},
+				[]telem.Series{inSeries1, inSeries2},
+			)))
+
+			Expect(outSeries.Len()).To(Equal(int64(5)))
+			Expect(outSeries).To(telem.MatchSeriesDataV[float32](11, 22, 33, 44, 55))
+
+			// Second frame: send overlapping data
+			// Data with alignment 2-6 (overlapping with 2-4 from previous)
+			inSeries1 = telem.NewSeriesV[float32](3, 4, 5, 6, 7)
+			inSeries1.Alignment = 2
+			inSeries1.TimeRange = telem.NewRangeSeconds(2, 7)
+
+			inSeries2 = telem.NewSeriesV[float32](30, 40, 50, 60, 70)
+			inSeries2.Alignment = 2
+			inSeries2.TimeRange = telem.NewRangeSeconds(2, 7)
+
+			outSeries = MustSucceed(calc.Next(core.MultiFrame(
+				[]channel.Key{inCh1.Key(), inCh2.Key()},
+				[]telem.Series{inSeries1, inSeries2},
+			)))
+
+			// Should only calculate new data (alignment 5-6)
+			Expect(outSeries.Len()).To(Equal(int64(2)))
+			Expect(outSeries.Alignment).To(Equal(telem.Alignment(5)))
+			Expect(outSeries).To(telem.MatchSeriesDataV[float32](66, 77))
+		})
+
+		It("Should handle gaps in data with high water mark", func() {
+			// First frame: ch1 only
+			inSeries1 := telem.NewSeriesV[float32](1, 2, 3)
+			inSeries1.Alignment = 0
+			inSeries1.TimeRange = telem.NewRangeSeconds(0, 3)
+
+			outSeries := MustSucceed(calc.Next(core.UnaryFrame(
+				inCh1.Key(),
+				inSeries1,
+			)))
+
+			// No output yet, waiting for ch2
+			Expect(outSeries.Len()).To(Equal(int64(0)))
+
+			// Second frame: ch2 with partial overlap
+			inSeries2 := telem.NewSeriesV[float32](10, 20)
+			inSeries2.Alignment = 0
+			inSeries2.TimeRange = telem.NewRangeSeconds(0, 2)
+
+			outSeries = MustSucceed(calc.Next(core.UnaryFrame(
+				inCh2.Key(),
+				inSeries2,
+			)))
+
+			// Should calculate first 2 samples
+			Expect(outSeries.Len()).To(Equal(int64(2)))
+			Expect(outSeries.Alignment).To(Equal(telem.Alignment(0)))
+			Expect(outSeries).To(telem.MatchSeriesDataV[float32](11, 22))
+
+			// Third frame: more ch2 data
+			inSeries2 = telem.NewSeriesV[float32](30, 40, 50)
+			inSeries2.Alignment = 2
+			inSeries2.TimeRange = telem.NewRangeSeconds(2, 5)
+
+			outSeries = MustSucceed(calc.Next(core.UnaryFrame(
+				inCh2.Key(),
+				inSeries2,
+			)))
+
+			// Should calculate third sample (alignment 2)
+			Expect(outSeries.Len()).To(Equal(int64(1)))
+			Expect(outSeries.Alignment).To(Equal(telem.Alignment(2)))
+			Expect(outSeries).To(telem.MatchSeriesDataV[float32](33))
+
+			// Fourth frame: more ch1 data
+			inSeries1 = telem.NewSeriesV[float32](4, 5, 6)
+			inSeries1.Alignment = 3
+			inSeries1.TimeRange = telem.NewRangeSeconds(3, 6)
+
+			outSeries = MustSucceed(calc.Next(core.UnaryFrame(
+				inCh1.Key(),
+				inSeries1,
+			)))
+
+			// Should calculate alignment 3-4
+			Expect(outSeries.Len()).To(Equal(int64(2)))
+			Expect(outSeries.Alignment).To(Equal(telem.Alignment(3)))
+			Expect(outSeries).To(telem.MatchSeriesDataV[float32](44, 55))
+		})
+
+		It("Should correctly update high water mark with different domain indices", func() {
+			// First frame with domain index 0
+			inSeries1 := telem.NewSeriesV[float32](1, 2, 3)
+			inSeries1.Alignment = 0
+			inSeries1.TimeRange = telem.NewRangeSeconds(0, 3)
+
+			inSeries2 := telem.NewSeriesV[float32](10, 20, 30)
+			inSeries2.Alignment = 0
+			inSeries2.TimeRange = telem.NewRangeSeconds(0, 3)
+
+			outSeries := MustSucceed(calc.Next(core.MultiFrame(
+				[]channel.Key{inCh1.Key(), inCh2.Key()},
+				[]telem.Series{inSeries1, inSeries2},
+			)))
+
+			Expect(outSeries.Len()).To(Equal(int64(3)))
+
+			// Second frame with new domain index (simulating time jump)
+			inSeries1 = telem.NewSeriesV[float32](4, 5, 6)
+			inSeries1.Alignment = telem.Alignment(1 << 32) // Different domain index
+			inSeries1.TimeRange = telem.NewRangeSeconds(100, 103)
+
+			inSeries2 = telem.NewSeriesV[float32](40, 50, 60)
+			inSeries2.Alignment = telem.Alignment(1 << 32)
+			inSeries2.TimeRange = telem.NewRangeSeconds(100, 103)
+
+			outSeries = MustSucceed(calc.Next(core.MultiFrame(
+				[]channel.Key{inCh1.Key(), inCh2.Key()},
+				[]telem.Series{inSeries1, inSeries2},
+			)))
+
+			// Should calculate all 3 samples with new domain
+			Expect(outSeries.Len()).To(Equal(int64(3)))
+			Expect(outSeries.Alignment.DomainIndex()).To(Equal(uint32(1)))
+			Expect(outSeries).To(telem.MatchSeriesDataV[float32](44, 55, 66))
+		})
+
+		It("Should handle single channel with high water mark", func() {
+			singleOut := channel.Channel{
+				Leaseholder: 1,
+				LocalKey:    4,
+				Name:        "single_out",
+				DataType:    telem.Float32T,
+				Expression:  "return in_ch_1 * 3",
+			}
+			singleCalc := MustSucceed(calculation.OpenCalculator(
+				singleOut,
+				[]channel.Channel{inCh1},
+			))
+			defer singleCalc.Close()
+
+			// First frame
+			inSeries := telem.NewSeriesV[float32](1, 2, 3)
+			inSeries.Alignment = 0
+			inSeries.TimeRange = telem.NewRangeSeconds(0, 3)
+
+			outSeries := MustSucceed(singleCalc.Next(core.UnaryFrame(
+				inCh1.Key(),
+				inSeries,
+			)))
+
+			Expect(outSeries.Len()).To(Equal(int64(3)))
+			Expect(outSeries).To(telem.MatchSeriesDataV[float32](3, 6, 9))
+
+			// Second frame with overlap
+			inSeries = telem.NewSeriesV[float32](2, 3, 4, 5)
+			inSeries.Alignment = 1
+			inSeries.TimeRange = telem.NewRangeSeconds(1, 5)
+
+			outSeries = MustSucceed(singleCalc.Next(core.UnaryFrame(
+				inCh1.Key(),
+				inSeries,
+			)))
+
+			// Should only calculate new data (alignment 3-4)
+			Expect(outSeries.Len()).To(Equal(int64(2)))
+			Expect(outSeries.Alignment).To(Equal(telem.Alignment(3)))
+			Expect(outSeries).To(telem.MatchSeriesDataV[float32](12, 15))
+		})
+	})
+
 	Describe("Error Handling", func() {
 		It("Should return an error if the calculation fails to compile", func() {
 			out := channel.Channel{

--- a/synnax/pkg/service/framer/calculation/calculator_test.go
+++ b/synnax/pkg/service/framer/calculation/calculator_test.go
@@ -336,11 +336,11 @@ var _ = Describe("Calculator", func() {
 
 			// Second frame with new domain index (simulating time jump)
 			inSeries1 = telem.NewSeriesV[float32](4, 5, 6)
-			inSeries1.Alignment = telem.Alignment(1 << 32) // Different domain index
+			inSeries1.Alignment = telem.NewAlignment(1, 0)
 			inSeries1.TimeRange = telem.NewRangeSeconds(100, 103)
 
 			inSeries2 = telem.NewSeriesV[float32](40, 50, 60)
-			inSeries2.Alignment = telem.Alignment(1 << 32)
+			inSeries2.Alignment = telem.NewAlignment(1, 0)
 			inSeries2.TimeRange = telem.NewRangeSeconds(100, 103)
 
 			outSeries = MustSucceed(calc.Next(core.MultiFrame(
@@ -556,7 +556,7 @@ var _ = Describe("Calculator", func() {
 			Expect(outSeries).To(telem.MatchSeriesDataV[float32](11, 22))
 
 			// Second frame with huge alignment jump (different domain)
-			largeAlignment := telem.Alignment(1) << 32 // Different domain index
+			largeAlignment := telem.NewAlignment(1, 0)
 			inSeries1 = telem.NewSeriesV[float32](3, 4)
 			inSeries1.Alignment = largeAlignment
 			inSeries1.TimeRange = telem.NewRangeSeconds(1000000, 1000002)

--- a/synnax/pkg/service/framer/calculation/service.go
+++ b/synnax/pkg/service/framer/calculation/service.go
@@ -343,7 +343,7 @@ func (s *Service) startCalculation(
 			calculation: streamerRequests,
 			shutdown:    signal.NewHardShutdown(sCtx, cancel),
 		}
-		p.Flow(sCtx, confluence.CloseOutputInletsOnExit())
+		p.Flow(sCtx, confluence.CloseOutputInletsOnExit(), confluence.WithRetryOnPanic())
 		s.cfg.L.Debug("started calculated channel", zap.Stringer("key", key))
 		return s.releaseEntryCloser(key), nil
 	}()

--- a/synnax/pkg/service/framer/calculation/service.go
+++ b/synnax/pkg/service/framer/calculation/service.go
@@ -43,7 +43,7 @@ import (
 // ServiceConfig is the configuration for opening the calculation service.
 type ServiceConfig struct {
 	alamos.Instrumentation
-	// Framer is the underlying frame service to stream required channel values and write
+	// Framer is the underlying frame service to stream cache channel values and write
 	// calculated samples.
 	// [REQUIRED]
 	Framer *framer.Service


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2788](https://linear.app/synnax/issue/SY-2788/fix-calculated-channel-server-panic)

## Description

Fixes an issue where calculated channels whose series crossed domains would result in a panic.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.
