### PR TITLE
SY-2605: Add Individual Visualization Mode Control

### DIFF
--- a/console/src/lineplot/LinePlot.tsx
+++ b/console/src/lineplot/LinePlot.tsx
@@ -333,8 +333,8 @@ const Loaded: Layout.Renderer = ({ layoutKey, focused, visible }) => {
     [storeLegendPosition],
   );
 
-  const { enableTooltip, clickMode, hold } = useSelectControlState();
-  const mode = useSelectViewportMode();
+  const { enableTooltip, clickMode, hold } = useSelectControlState(layoutKey);
+  const mode = useSelectViewportMode(layoutKey);
   const triggers = useMemo(() => Viewport.DEFAULT_TRIGGERS[mode], [mode]);
 
   const initialViewport = useMemo(
@@ -350,7 +350,7 @@ const Loaded: Layout.Renderer = ({ layoutKey, focused, visible }) => {
     dispatch(
       Layout.setNavDrawerVisible({ windowKey, key: "visualization", value: true }),
     );
-    dispatch(setActiveToolbarTab({ tab: "data" }));
+    dispatch(setActiveToolbarTab({ key: layoutKey, tab: "data" }));
   }, [windowKey, dispatch]);
 
   const props = PMenu.useContextMenu();
@@ -477,14 +477,16 @@ const Loaded: Layout.Renderer = ({ layoutKey, focused, visible }) => {
           onSelectRule={(ruleKey) =>
             dispatch(setSelectedRule({ key: layoutKey, ruleKey }))
           }
-          onHold={(hold) => dispatch(setControlState({ state: { hold } }))}
+          onHold={(hold) =>
+            dispatch(setControlState({ key: layoutKey, state: { hold } }))
+          }
           rangeAnnotationProvider={rangeAnnotationProvider}
         >
-          {!focused && <NavControls />}
+          {!focused && <NavControls layoutKey={layoutKey} />}
           <Core.BoundsQuerier ref={boundsQuerierRef} />
         </Channel.LinePlot>
       </PMenu.ContextMenu>
-      {focused && <NavControls />}
+      {focused && <NavControls layoutKey={layoutKey} />}
     </div>
   );
 };

--- a/console/src/lineplot/LinePlot.tsx
+++ b/console/src/lineplot/LinePlot.tsx
@@ -351,7 +351,7 @@ const Loaded: Layout.Renderer = ({ layoutKey, focused, visible }) => {
       Layout.setNavDrawerVisible({ windowKey, key: "visualization", value: true }),
     );
     dispatch(setActiveToolbarTab({ key: layoutKey, tab: "data" }));
-  }, [windowKey, dispatch]);
+  }, [windowKey, dispatch, layoutKey]);
 
   const props = PMenu.useContextMenu();
 

--- a/console/src/lineplot/NavControls.tsx
+++ b/console/src/lineplot/NavControls.tsx
@@ -27,22 +27,28 @@ const TOOLTIP_LOCATION: location.XY = {
   y: "bottom",
 };
 
-export const NavControls = (): ReactElement => {
-  const control = useSelectControlState();
+const style = { zIndex: 500 };
+
+export interface NavControlsProps {
+  layoutKey: string;
+}
+
+export const NavControls = ({ layoutKey }: NavControlsProps): ReactElement => {
+  const control = useSelectControlState(layoutKey);
   const vis = Layout.useSelectActiveMosaicTabKey();
-  const mode = useSelectViewportMode();
+  const mode = useSelectViewportMode(layoutKey);
   const dispatch = useDispatch();
 
   const handleModeChange = (mode: Viewport.Mode): void => {
-    dispatch(setViewportMode({ mode }));
+    dispatch(setViewportMode({ key: layoutKey, mode }));
   };
 
   const handleClickModeChange = (clickMode: ClickMode | null): void => {
-    dispatch(setControlState({ state: { clickMode } }));
+    dispatch(setControlState({ key: layoutKey, state: { clickMode } }));
   };
 
   const handleTooltipChange = (tooltip: boolean): void => {
-    dispatch(setControlState({ state: { enableTooltip: tooltip } }));
+    dispatch(setControlState({ key: layoutKey, state: { enableTooltip: tooltip } }));
   };
 
   const handleZoomReset = (): void => {
@@ -50,7 +56,7 @@ export const NavControls = (): ReactElement => {
   };
 
   const handleHoldChange = (hold: boolean): void => {
-    dispatch(setControlState({ state: { hold } }));
+    dispatch(setControlState({ key: layoutKey, state: { hold } }));
   };
 
   const triggers = useMemo(() => Viewport.DEFAULT_TRIGGERS[mode], [mode]);
@@ -60,7 +66,7 @@ export const NavControls = (): ReactElement => {
       className={CSS.BE("line-plot", "nav-controls")}
       x
       gap="small"
-      style={{ zIndex: 500 }}
+      style={style}
     >
       <Viewport.SelectMode
         value={mode}
@@ -97,9 +103,9 @@ export const NavControls = (): ReactElement => {
         value={control.clickMode != null}
         tooltip={<Text.Text level="small">Slope</Text.Text>}
         tooltipLocation={TOOLTIP_LOCATION}
-        onChange={() => {
-          handleClickModeChange(control.clickMode != null ? null : "measure");
-        }}
+        onChange={() =>
+          handleClickModeChange(control.clickMode != null ? null : "measure")
+        }
         size="small"
       >
         <Icon.Rule />

--- a/console/src/lineplot/selectors.ts
+++ b/console/src/lineplot/selectors.ts
@@ -56,22 +56,31 @@ export const useSelectRanges = (key: string): XAxisRecord<Range.Range[]> =>
     [key],
   );
 
-export const selectToolbar = (state: StoreState): ToolbarState =>
-  selectSliceState(state).toolbar;
+export const selectToolbar = (state: StoreState, key: string): ToolbarState =>
+  select(state, key).toolbar;
 
-export const useSelectToolbar = (): ToolbarState => useMemoSelect(selectToolbar, []);
+export const useSelectToolbar = (key: string): ToolbarState =>
+  useMemoSelect((state: StoreState) => selectToolbar(state, key), [key]);
 
-export const selectControlState = (state: StoreState): ControlState =>
-  selectSliceState(state).control;
+export const selectControlState = (state: StoreState, key: string): ControlState =>
+  select(state, key).control;
 
-export const useSelectControlState = (): ControlState =>
-  useMemoSelect(selectControlState, []);
+export const useSelectControlState = (key: string): ControlState =>
+  useMemoSelect((state: StoreState) => selectControlState(state, key), [key]);
 
-export const selectViewportMode = (state: StoreState): Viewport.Mode =>
-  selectSliceState(state).mode;
+export const selectControlStateOptional = (
+  state: StoreState,
+  key: string,
+): ControlState | undefined => selectOptional(state, key)?.control;
 
-export const useSelectViewportMode = (): Viewport.Mode =>
-  useMemoSelect(selectViewportMode, []);
+export const useSelectControlStateOptional = (key: string): ControlState | undefined =>
+  useMemoSelect((state: StoreState) => selectControlStateOptional(state, key), [key]);
+
+export const selectViewportMode = (state: StoreState, key: string): Viewport.Mode =>
+  select(state, key).mode;
+
+export const useSelectViewportMode = (key: string): Viewport.Mode =>
+  useMemoSelect((state: StoreState) => selectViewportMode(state, key), [key]);
 
 export const selectSelection = (state: StoreState, key: string): SelectionState =>
   select(state, key).selection;

--- a/console/src/lineplot/slice.ts
+++ b/console/src/lineplot/slice.ts
@@ -14,7 +14,6 @@ import { array, deep, record, unique } from "@synnaxlabs/x";
 
 import {
   type AxisKey,
-  type MultiXAxisRecord,
   X_AXIS_KEYS,
   type XAxisKey,
   type YAxisKey,
@@ -40,7 +39,6 @@ export type RuleState = latest.RuleState;
 export type RulesState = latest.RulesState;
 export type ChannelsState = latest.ChannelsState;
 export type RangesState = latest.RangesState;
-export type SugaredRangesState = MultiXAxisRecord<Range>;
 export type State = latest.State;
 export type ToolbarTab = latest.ToolbarTab;
 export type ToolbarState = latest.ToolbarState;
@@ -136,14 +134,17 @@ export interface RemoveRulePayload {
 }
 
 export interface SetActiveToolbarTabPayload {
+  key: string;
   tab: ToolbarTab;
 }
 
 export interface SetControlStatePayload {
+  key: string;
   state: Partial<ControlState>;
 }
 
 export interface SetViewportModePayload {
+  key: string;
   mode: Viewport.Mode;
 }
 
@@ -334,16 +335,19 @@ export const { actions, reducer } = createSlice({
       state,
       { payload }: PayloadAction<SetActiveToolbarTabPayload>,
     ) => {
-      state.toolbar.activeTab = payload.tab;
+      state.plots[payload.key].toolbar.activeTab = payload.tab;
     },
     setControlState: (state, { payload }: PayloadAction<SetControlStatePayload>) => {
-      state.control = { ...state.control, ...payload.state };
+      state.plots[payload.key].control = {
+        ...state.plots[payload.key].control,
+        ...payload.state,
+      };
     },
     setViewportMode: (
       state,
-      { payload: { mode } }: PayloadAction<SetViewportModePayload>,
+      { payload: { key, mode } }: PayloadAction<SetViewportModePayload>,
     ) => {
-      state.mode = mode;
+      state.plots[key].mode = mode;
     },
     setRemoteCreated: (state, { payload }: PayloadAction<SetRemoteCreatedPayload>) => {
       state.plots[payload.key].remoteCreated = true;
@@ -358,7 +362,7 @@ export const { actions, reducer } = createSlice({
         ...rule,
         selected: keys.includes(rule.key),
       }));
-      state.toolbar.activeTab = "annotations";
+      state.plots[payload.key].toolbar.activeTab = "annotations";
     },
   },
 });

--- a/console/src/lineplot/toolbar/Toolbar.tsx
+++ b/console/src/lineplot/toolbar/Toolbar.tsx
@@ -48,7 +48,7 @@ export interface ToolbarProps {
 export const Toolbar = ({ layoutKey }: ToolbarProps): ReactElement | null => {
   const { name } = Layout.useSelectRequired(layoutKey);
   const dispatch = useDispatch();
-  const toolbar = useSelectToolbar();
+  const toolbar = useSelectToolbar(layoutKey);
   const state = useSelect(layoutKey);
   const handleExport = useExport();
   const content = useCallback(
@@ -70,7 +70,7 @@ export const Toolbar = ({ layoutKey }: ToolbarProps): ReactElement | null => {
   );
   const handleTabSelect = useCallback(
     (tabKey: string): void => {
-      dispatch(setActiveToolbarTab({ tab: tabKey as ToolbarTab }));
+      dispatch(setActiveToolbarTab({ key: layoutKey, tab: tabKey as ToolbarTab }));
     },
     [dispatch],
   );

--- a/console/src/lineplot/toolbar/Toolbar.tsx
+++ b/console/src/lineplot/toolbar/Toolbar.tsx
@@ -72,7 +72,7 @@ export const Toolbar = ({ layoutKey }: ToolbarProps): ReactElement | null => {
     (tabKey: string): void => {
       dispatch(setActiveToolbarTab({ key: layoutKey, tab: tabKey as ToolbarTab }));
     },
-    [dispatch],
+    [dispatch, layoutKey],
   );
   if (state == null) return null;
   return (

--- a/console/src/lineplot/types/index.ts
+++ b/console/src/lineplot/types/index.ts
@@ -97,7 +97,7 @@ export const STATE_MIGRATIONS: migrate.Migrations = {
 };
 
 export const migrateState = migrate.migrator<AnyState, State>({
-  name: "lineplot.state",
+  name: v1.STATE_MIGRATION_NAME,
   migrations: STATE_MIGRATIONS,
   def: ZERO_STATE,
 });
@@ -109,7 +109,7 @@ export const SLICE_MIGRATIONS: migrate.Migrations = {
 };
 
 export const migrateSlice = migrate.migrator<AnySliceState, SliceState>({
-  name: "lineplot.slice",
+  name: v1.SLICE_MIGRATION_NAME,
   migrations: SLICE_MIGRATIONS,
   def: ZERO_SLICE_STATE,
 });

--- a/console/src/lineplot/types/index.ts
+++ b/console/src/lineplot/types/index.ts
@@ -13,6 +13,7 @@ import { z } from "zod";
 import * as v0 from "@/lineplot/types/v0";
 import * as v1 from "@/lineplot/types/v1";
 import * as v2 from "@/lineplot/types/v2";
+import * as v3 from "@/lineplot/types/v3";
 
 export const titleStateZ = v0.titleStateZ;
 export type TitleState = v0.TitleState;
@@ -32,6 +33,7 @@ export const ZERO_SELECTION_STATE = v0.ZERO_SELECTION_STATE;
 
 export type AxisState = v2.AxisState;
 export const ZERO_AXIS_STATE = v2.ZERO_AXIS_STATE;
+
 export type AxesState = v2.AxesState;
 export const ZERO_AXES_STATE = v2.ZERO_AXES_STATE;
 
@@ -59,9 +61,9 @@ export const rangesStateZ = v0.rangesStateZ;
 export type RangesState = v0.RangesState;
 export const ZERO_RANGES_STATE = v0.ZERO_RANGES_STATE;
 
-export const stateZ = v2.stateZ;
-export type State = v2.State;
-export const ZERO_STATE = v2.ZERO_STATE;
+export const stateZ = v3.stateZ;
+export type State = v3.State;
+export const ZERO_STATE = v3.ZERO_STATE;
 
 export const toolbarTabZ = v0.toolbarTabZ;
 export type ToolbarTab = v0.ToolbarTab;
@@ -77,35 +79,41 @@ export const controlStateZ = v0.controlStateZ;
 export type ControlState = v0.ControlState;
 export const ZERO_CONTROL_STATE = v0.ZERO_CONTROL_SATE;
 
-export const sliceStateZ = v2.sliceStateZ;
-export type SliceState = v2.SliceState;
-export const ZERO_SLICE_STATE = v2.ZERO_SLICE_STATE;
+export const sliceStateZ = v3.sliceStateZ;
+export type SliceState = v3.SliceState;
+export const ZERO_SLICE_STATE = v3.ZERO_SLICE_STATE;
 
-export type AnyState = v0.State | v1.State | v2.State;
-export type AnySliceState = v0.SliceState | v1.SliceState | v2.SliceState;
+export type AnyState = v0.State | v1.State | v2.State | v3.State;
+export type AnySliceState =
+  | v0.SliceState
+  | v1.SliceState
+  | v2.SliceState
+  | v3.SliceState;
 
 export const STATE_MIGRATIONS: migrate.Migrations = {
-  "0.0.0": v1.stateMigration,
-  "1.0.0": v2.stateMigration,
+  [v0.VERSION]: v1.stateMigration,
+  [v1.VERSION]: v2.stateMigration,
+  [v2.VERSION]: v3.stateMigration,
 };
 
-export const migrateState = migrate.migrator<AnyState, v2.State>({
+export const migrateState = migrate.migrator<AnyState, State>({
   name: "lineplot.state",
   migrations: STATE_MIGRATIONS,
-  def: v2.ZERO_STATE,
+  def: ZERO_STATE,
 });
 
 export const SLICE_MIGRATIONS: migrate.Migrations = {
-  "0.0.0": v1.sliceMigration,
-  "1.0.0": v2.sliceMigration,
+  [v0.VERSION]: v1.sliceMigration,
+  [v1.VERSION]: v2.sliceMigration,
+  [v2.VERSION]: v3.sliceMigration,
 };
 
-export const migrateSlice = migrate.migrator<AnySliceState, v2.SliceState>({
+export const migrateSlice = migrate.migrator<AnySliceState, SliceState>({
   name: "lineplot.slice",
   migrations: SLICE_MIGRATIONS,
   def: ZERO_SLICE_STATE,
 });
 
 export const anyStateZ = z
-  .union([v2.stateZ, v1.stateZ, v0.stateZ])
+  .union([v3.stateZ, v2.stateZ, v1.stateZ, v0.stateZ])
   .transform((state) => migrateState(state));

--- a/console/src/lineplot/types/migrations.spec.ts
+++ b/console/src/lineplot/types/migrations.spec.ts
@@ -18,23 +18,27 @@ import {
 import * as v0 from "@/lineplot/types/v0";
 import * as v1 from "@/lineplot/types/v1";
 import * as v2 from "@/lineplot/types/v2";
+import * as v3 from "@/lineplot/types/v3";
 
 describe("migrations", () => {
   describe("state", () => {
-    const STATES = [v0.ZERO_STATE, v1.ZERO_STATE, v2.ZERO_STATE];
+    const STATES = [v0.ZERO_STATE, v1.ZERO_STATE, v2.ZERO_STATE, v3.ZERO_STATE];
     STATES.forEach((state) => {
       it(`should migrate state from ${state.version} to latest`, () => {
-        const migrated = migrateState(state);
-        expect(migrated).toEqual(ZERO_STATE);
+        expect(migrateState(state)).toEqual(ZERO_STATE);
       });
     });
   });
   describe("slice", () => {
-    const STATES = [v0.ZERO_SLICE_STATE, v1.ZERO_SLICE_STATE, v2.ZERO_SLICE_STATE];
+    const STATES = [
+      v0.ZERO_SLICE_STATE,
+      v1.ZERO_SLICE_STATE,
+      v2.ZERO_SLICE_STATE,
+      v3.ZERO_SLICE_STATE,
+    ];
     STATES.forEach((state) => {
       it(`should migrate slice from ${state.version} to latest`, () => {
-        const migrated = migrateSlice(state);
-        expect(migrated).toEqual(ZERO_SLICE_STATE);
+        expect(migrateSlice(state)).toEqual(ZERO_SLICE_STATE);
       });
     });
   });

--- a/console/src/lineplot/types/v0.ts
+++ b/console/src/lineplot/types/v0.ts
@@ -11,55 +11,33 @@ import { telem, Text, Viewport } from "@synnaxlabs/pluto";
 import { bounds, box, dimensions, direction, xy } from "@synnaxlabs/x";
 import { z } from "zod";
 
-import {
-  type AxisKey,
-  axisKeyZ,
-  type MultiXAxisRecord,
-  type MultiYAxisRecord,
-  type XAxisRecord,
-} from "@/lineplot/axis";
+import { axisKeyZ } from "@/lineplot/axis";
 
-// |||||| TITLE ||||||
+export const VERSION = "0.0.0";
 
 export const titleStateZ = z.object({ level: Text.levelZ, visible: z.boolean() });
-
-export type TitleState = z.infer<typeof titleStateZ>;
-
+export interface TitleState extends z.infer<typeof titleStateZ> {}
 export const ZERO_TITLE_STATE: TitleState = { level: "h4", visible: false };
 
-// |||||| LEGEND ||||||
-
 export const legendStateZ = z.object({ visible: z.boolean() });
-
-export type LegendState = z.infer<typeof legendStateZ>;
-
-const ZERO_LEGEND_STATE = { visible: true };
-
-// |||||| VIEWPORT ||||||
+export interface LegendState extends z.infer<typeof legendStateZ> {}
+export const ZERO_LEGEND_STATE: LegendState = { visible: true };
 
 export const viewportStateZ = z.object({
   renderTrigger: z.number(),
   zoom: dimensions.dimensions,
   pan: xy.xy,
 });
-
-export type ViewportState = z.infer<typeof viewportStateZ>;
-
+export interface ViewportState extends z.infer<typeof viewportStateZ> {}
 export const ZERO_VIEWPORT_STATE: ViewportState = {
   renderTrigger: 0,
   zoom: dimensions.DECIMAL,
   pan: xy.ZERO,
 };
 
-// ||||||| SELECTION |||||||
-
 export const selectionStateZ = z.object({ box: box.box });
-
-export type SelectionState = z.infer<typeof selectionStateZ>;
-
+export interface SelectionState extends z.infer<typeof selectionStateZ> {}
 export const ZERO_SELECTION_STATE: SelectionState = { box: box.ZERO };
-
-// |||||| AXES ||||||
 
 export const axisStateZ = z.object({
   key: axisKeyZ,
@@ -70,8 +48,16 @@ export const axisStateZ = z.object({
   tickSpacing: z.number(),
   labelLevel: Text.levelZ,
 });
-
-export type AxisState = z.infer<typeof axisStateZ>;
+export interface AxisState extends z.infer<typeof axisStateZ> {}
+export const ZERO_AXIS_STATE: AxisState = {
+  key: "x1",
+  label: "",
+  labelDirection: "x",
+  labelLevel: "small",
+  bounds: bounds.ZERO,
+  autoBounds: { lower: true, upper: true },
+  tickSpacing: 75,
+};
 
 export const axesStateZ = z.object({
   renderTrigger: z.number(),
@@ -85,137 +71,7 @@ export const axesStateZ = z.object({
     x2: axisStateZ,
   }),
 });
-
-// Zod uses partial records so we need to
-export type AxesState = z.infer<typeof axesStateZ>;
-
-// |||| LINE ||||||
-
-export const lineStateZ = z.object({
-  key: z.string(),
-  label: z.string().optional(),
-  color: z.string(),
-  strokeWidth: z.number(),
-  downsample: z.number(),
-  downsampleMode: telem.downsampleModeZ.default("decimate"),
-});
-
-export type LineState = z.infer<typeof lineStateZ>;
-
-export const linesStateZ = z.array(lineStateZ);
-
-export type LinesState = z.infer<typeof linesStateZ>;
-
-export const ZERO_LINE_STATE: Omit<LineState, "key"> = {
-  color: "",
-  strokeWidth: 2,
-  downsample: 1,
-  downsampleMode: "decimate",
-};
-
-export const ZERO_LINES_STATE: LinesState = [];
-
-// |||||| RULES ||||||
-
-export const ruleStateZ = z.object({
-  selected: z.boolean().optional(),
-  key: z.string(),
-  label: z.string(),
-  color: z.string(),
-  axis: axisKeyZ,
-  lineWidth: z.number(),
-  lineDash: z.number(),
-  units: z.string(),
-  position: z.number(),
-});
-
-export type RuleState = z.infer<typeof ruleStateZ>;
-
-export const rulesStateZ = z.array(ruleStateZ);
-
-export type RulesState = z.infer<typeof rulesStateZ>;
-
-export const ZERO_RULE_STATE: Omit<RuleState, "key"> = {
-  color: "#3774D0",
-  label: "",
-  axis: "y1",
-  lineWidth: 1,
-  lineDash: 0,
-  units: "",
-  position: 0,
-};
-
-export const ZERO_RULES_STATE: RulesState = [];
-
-// |||||| CHANNELS |||||
-
-export const channelsStateZ = z.object({
-  x1: z.number(),
-  x2: z.number(),
-  y1: z.array(z.number()),
-  y2: z.array(z.number()),
-  y3: z.array(z.number()),
-  y4: z.array(z.number()),
-});
-
-export type ChannelsState = MultiYAxisRecord<number[]> & XAxisRecord<number>;
-
-export const ZERO_CHANNELS_STATE: z.infer<typeof channelsStateZ> = {
-  x1: 0,
-  x2: 0,
-  y1: [],
-  y2: [],
-  y3: [],
-  y4: [],
-};
-
-export const shouldDisplayAxis = (key: AxisKey, state: State): boolean => {
-  if (["x1", "y1"].includes(key)) return true;
-  const channels = state.channels[key];
-  if (Array.isArray(channels)) return channels.length > 0;
-  return channels !== 0;
-};
-
-// |||||| RANGES ||||||
-
-export const rangesStateZ = z.object({
-  x1: z.array(z.string()),
-  x2: z.array(z.string()),
-});
-
-export type RangesState = z.infer<typeof rangesStateZ>;
-
-export const ZERO_RANGES_STATE: RangesState = { x1: [], x2: [] };
-
-export type SugaredRangesState = MultiXAxisRecord<Range>;
-
-export const stateZ = z.object({
-  version: z.literal("0.0.0"),
-  key: z.string(),
-  remoteCreated: z.boolean(),
-  title: titleStateZ,
-  legend: legendStateZ,
-  channels: channelsStateZ,
-  ranges: rangesStateZ,
-  viewport: viewportStateZ,
-  axes: axesStateZ,
-  lines: linesStateZ,
-  rules: rulesStateZ,
-  selection: selectionStateZ,
-});
-
-export type State = z.infer<typeof stateZ>;
-
-export const ZERO_AXIS_STATE: AxisState = {
-  key: "x1",
-  label: "",
-  labelDirection: "x",
-  labelLevel: "small",
-  bounds: bounds.ZERO,
-  autoBounds: { lower: true, upper: true },
-  tickSpacing: 75,
-};
-
+export interface AxesState extends z.infer<typeof axesStateZ> {}
 export const ZERO_AXES_STATE: AxesState = {
   renderTrigger: 0,
   hasHadChannelSet: false,
@@ -229,8 +85,94 @@ export const ZERO_AXES_STATE: AxesState = {
   },
 };
 
+export const lineStateZ = z.object({
+  key: z.string(),
+  label: z.string().optional(),
+  color: z.string(),
+  strokeWidth: z.number(),
+  downsample: z.number(),
+  downsampleMode: telem.downsampleModeZ.default("decimate"),
+});
+export interface LineState extends z.infer<typeof lineStateZ> {}
+export const ZERO_LINE_STATE: Omit<LineState, "key"> = {
+  color: "",
+  strokeWidth: 2,
+  downsample: 1,
+  downsampleMode: "decimate",
+};
+
+export const linesStateZ = z.array(lineStateZ);
+export interface LinesState extends z.infer<typeof linesStateZ> {}
+export const ZERO_LINES_STATE: LinesState = [];
+
+export const ruleStateZ = z.object({
+  selected: z.boolean().optional(),
+  key: z.string(),
+  label: z.string(),
+  color: z.string(),
+  axis: axisKeyZ,
+  lineWidth: z.number(),
+  lineDash: z.number(),
+  units: z.string(),
+  position: z.number(),
+});
+export interface RuleState extends z.infer<typeof ruleStateZ> {}
+export const ZERO_RULE_STATE: Omit<RuleState, "key"> = {
+  color: "#3774D0",
+  label: "",
+  axis: "y1",
+  lineWidth: 1,
+  lineDash: 0,
+  units: "",
+  position: 0,
+};
+
+export const rulesStateZ = z.array(ruleStateZ);
+export interface RulesState extends z.infer<typeof rulesStateZ> {}
+export const ZERO_RULES_STATE: RulesState = [];
+
+export const channelsStateZ = z.object({
+  x1: z.number(),
+  x2: z.number(),
+  y1: z.array(z.number()),
+  y2: z.array(z.number()),
+  y3: z.array(z.number()),
+  y4: z.array(z.number()),
+});
+export interface ChannelsState extends z.infer<typeof channelsStateZ> {}
+export const ZERO_CHANNELS_STATE: ChannelsState = {
+  x1: 0,
+  x2: 0,
+  y1: [],
+  y2: [],
+  y3: [],
+  y4: [],
+};
+
+export const rangesStateZ = z.object({
+  x1: z.array(z.string()),
+  x2: z.array(z.string()),
+});
+export interface RangesState extends z.infer<typeof rangesStateZ> {}
+export const ZERO_RANGES_STATE: RangesState = { x1: [], x2: [] };
+
+export const stateZ = z.object({
+  version: z.literal(VERSION),
+  key: z.string(),
+  remoteCreated: z.boolean(),
+  title: titleStateZ,
+  legend: legendStateZ,
+  channels: channelsStateZ,
+  ranges: rangesStateZ,
+  viewport: viewportStateZ,
+  axes: axesStateZ,
+  lines: linesStateZ,
+  rules: rulesStateZ,
+  selection: selectionStateZ,
+});
+export interface State extends z.infer<typeof stateZ> {}
 export const ZERO_STATE: State = {
-  version: "0.0.0",
+  version: VERSION,
   key: "",
   remoteCreated: false,
   title: ZERO_TITLE_STATE,
@@ -244,24 +186,20 @@ export const ZERO_STATE: State = {
   selection: ZERO_SELECTION_STATE,
 };
 
-// |||||| TOOLBAR ||||||
-
-const LINE_TOOLBAR_TABS = [
+export const toolbarTabZ = z.enum([
   "data",
   "lines",
   "axes",
   "annotations",
   "properties",
-] as const;
-export const toolbarTabZ = z.enum(LINE_TOOLBAR_TABS);
+]);
 export type ToolbarTab = z.infer<typeof toolbarTabZ>;
 
 export const toolbarStateZ = z.object({ activeTab: toolbarTabZ });
-export type ToolbarState = z.infer<typeof toolbarStateZ>;
+export interface ToolbarState extends z.infer<typeof toolbarStateZ> {}
 export const ZERO_TOOLBAR_STATE: ToolbarState = { activeTab: "data" };
 
-export const CLICK_MODES = ["annotate", "measure"] as const;
-export const clickModeZ = z.enum(CLICK_MODES);
+export const clickModeZ = z.enum(["annotate", "measure"]);
 export type ClickMode = z.infer<typeof clickModeZ>;
 
 export const controlStateZ = z.object({
@@ -269,9 +207,7 @@ export const controlStateZ = z.object({
   clickMode: clickModeZ.nullable(),
   enableTooltip: z.boolean(),
 });
-
-export type ControlState = z.infer<typeof controlStateZ>;
-
+export interface ControlState extends z.infer<typeof controlStateZ> {}
 export const ZERO_CONTROL_SATE: ControlState = {
   clickMode: null,
   hold: false,
@@ -279,23 +215,15 @@ export const ZERO_CONTROL_SATE: ControlState = {
 };
 
 export const sliceStateZ = z.object({
-  version: z.literal("0.0.0"),
+  version: z.literal(VERSION),
   mode: Viewport.modeZ,
   control: controlStateZ,
   toolbar: toolbarStateZ,
   plots: z.record(z.string(), stateZ),
 });
-
-export type SliceState = z.infer<typeof sliceStateZ>;
-
-export const SLICE_NAME = "line";
-
-export interface StoreState {
-  [SLICE_NAME]: SliceState;
-}
-
+export interface SliceState extends z.infer<typeof sliceStateZ> {}
 export const ZERO_SLICE_STATE: SliceState = {
-  version: "0.0.0",
+  version: VERSION,
   mode: "zoom",
   control: ZERO_CONTROL_SATE,
   toolbar: ZERO_TOOLBAR_STATE,

--- a/console/src/lineplot/types/v1.ts
+++ b/console/src/lineplot/types/v1.ts
@@ -47,13 +47,16 @@ export const ZERO_SLICE_STATE: SliceState = {
   plots: {},
 };
 
+export const STATE_MIGRATION_NAME = "lineplot.state";
+export const SLICE_MIGRATION_NAME = "lineplot.slice";
+
 export const stateMigration = migrate.createMigration<v0.State, State>({
-  name: "lineplot.state",
-  migrate: (s) => ({ ...s, version: VERSION, legend: ZERO_LEGEND_STATE }),
+  name: STATE_MIGRATION_NAME,
+  migrate: (state) => ({ ...state, version: VERSION, legend: ZERO_LEGEND_STATE }),
 });
 
 export const sliceMigration = migrate.createMigration<v0.SliceState, SliceState>({
-  name: "lineplot.slice",
+  name: SLICE_MIGRATION_NAME,
   migrate: ({ plots, ...rest }) => ({
     ...rest,
     version: VERSION,

--- a/console/src/lineplot/types/v2.ts
+++ b/console/src/lineplot/types/v2.ts
@@ -8,20 +8,17 @@
 // included in the file licenses/APL.txt.
 
 import { axis } from "@synnaxlabs/pluto";
-import { bounds, migrate } from "@synnaxlabs/x";
+import { migrate } from "@synnaxlabs/x";
 import { z } from "zod";
 
-import { X_AXIS_KEYS, type XAxisKey } from "@/lineplot/axis";
 import * as v0 from "@/lineplot/types/v0";
 import * as v1 from "@/lineplot/types/v1";
 
-// V2 IS DEFINED FOR SYNNAX V0.25
+export const VERSION = "2.0.0";
 
-export const axisStateZ = v0.axisStateZ.extend({
-  type: axis.tickType.optional(),
-});
-
-export type AxisState = z.infer<typeof axisStateZ>;
+export const axisStateZ = v0.axisStateZ.extend({ type: axis.tickType.optional() });
+export interface AxisState extends z.infer<typeof axisStateZ> {}
+export const ZERO_AXIS_STATE: AxisState = { ...v0.ZERO_AXIS_STATE };
 
 export const axesStateZ = v0.axesStateZ.omit({ axes: true }).extend({
   axes: z.object({
@@ -33,93 +30,63 @@ export const axesStateZ = v0.axesStateZ.omit({ axes: true }).extend({
     x2: axisStateZ,
   }),
 });
-
-export type AxesState = z.infer<typeof axesStateZ>;
-
-export const ZERO_AXIS_STATE: AxisState = {
-  key: "x1",
-  label: "",
-  labelDirection: "x",
-  labelLevel: "small",
-  bounds: bounds.ZERO,
-  autoBounds: { lower: true, upper: true },
-  tickSpacing: 75,
-};
-
+export interface AxesState extends z.infer<typeof axesStateZ> {}
 export const ZERO_AXES_STATE: AxesState = {
-  renderTrigger: 0,
-  hasHadChannelSet: false,
+  ...v0.ZERO_AXES_STATE,
   axes: {
-    y1: { ...ZERO_AXIS_STATE, key: "y1", labelDirection: "y" },
-    y2: { ...ZERO_AXIS_STATE, key: "y2", labelDirection: "y" },
-    y3: { ...ZERO_AXIS_STATE, key: "y3", labelDirection: "y" },
-    y4: { ...ZERO_AXIS_STATE, key: "y4", labelDirection: "y" },
-    x1: { ...ZERO_AXIS_STATE, key: "x1", type: "time" },
-    x2: { ...ZERO_AXIS_STATE, key: "x2", type: "time" },
+    y1: { ...v0.ZERO_AXES_STATE.axes.y1, labelDirection: "y" },
+    y2: { ...v0.ZERO_AXES_STATE.axes.y2, labelDirection: "y" },
+    y3: { ...v0.ZERO_AXES_STATE.axes.y3, labelDirection: "y" },
+    y4: { ...v0.ZERO_AXES_STATE.axes.y4, labelDirection: "y" },
+    x1: { ...v0.ZERO_AXES_STATE.axes.x1, type: "time" },
+    x2: { ...v0.ZERO_AXES_STATE.axes.x2, type: "time" },
   },
 };
 
 export const stateZ = v1.stateZ
-  .omit({
-    axes: true,
-    version: true,
-  })
-  .extend({
-    version: z.literal("2.0.0"),
-    axes: axesStateZ,
-  });
-
-export type State = z.infer<typeof stateZ>;
-
+  .omit({ axes: true, version: true })
+  .extend({ version: z.literal(VERSION), axes: axesStateZ });
+export interface State extends z.infer<typeof stateZ> {}
 export const ZERO_STATE: State = {
   ...v1.ZERO_STATE,
-  version: "2.0.0",
+  version: VERSION,
   axes: ZERO_AXES_STATE,
 };
 
 export const sliceStateZ = v1.sliceStateZ
-  .omit({
-    plots: true,
-    version: true,
-  })
-  .extend({
-    version: z.literal("2.0.0"),
-    plots: z.record(z.string(), stateZ),
-  });
-
-export type SliceState = z.infer<typeof sliceStateZ>;
-
+  .omit({ plots: true, version: true })
+  .extend({ version: z.literal(VERSION), plots: z.record(z.string(), stateZ) });
+export interface SliceState extends z.infer<typeof sliceStateZ> {}
 export const ZERO_SLICE_STATE: SliceState = {
   ...v1.ZERO_SLICE_STATE,
-  version: "2.0.0",
+  version: VERSION,
   plots: {},
 };
 
 export const stateMigration = migrate.createMigration<v1.State, State>({
   name: "lineplot.state",
-  migrate: (s) => ({
-    ...s,
-    version: "2.0.0",
+  migrate: ({ axes, ...rest }) => ({
+    ...rest,
+    version: VERSION,
     axes: {
-      ...s.axes,
+      ...axes,
       axes: Object.fromEntries(
-        Object.entries(s.axes.axes).map(([key, value]) => {
-          if (!X_AXIS_KEYS.includes(key as XAxisKey))
-            return [key, { ...value, labelDirection: "y" }];
-          return [key, { ...value, type: "time" }];
+        Object.entries(axes.axes).map(([key, axis]) => {
+          if (key.startsWith("x")) return [key, { ...axis, type: "time" }];
+          return [key, { ...axis, labelDirection: "y" }];
         }),
-      ) as AxesState["axes"],
+      ),
     },
   }),
 });
 
 export const sliceMigration = migrate.createMigration<v1.SliceState, SliceState>({
   name: "lineplot.slice",
-  migrate: (s) => ({
-    ...s,
-    version: "2.0.0",
+  migrate: ({ plots, ...rest }) => ({
+    ...rest,
+    version: VERSION,
     plots: Object.fromEntries(
-      Object.entries(s.plots).map(([key, value]) => [key, stateMigration(value)]),
+      Object.entries(plots).map(([key, plot]) => [key, stateMigration(plot)]),
     ),
   }),
 });

--- a/console/src/lineplot/types/v2.ts
+++ b/console/src/lineplot/types/v2.ts
@@ -64,7 +64,7 @@ export const ZERO_SLICE_STATE: SliceState = {
 };
 
 export const stateMigration = migrate.createMigration<v1.State, State>({
-  name: "lineplot.state",
+  name: v1.STATE_MIGRATION_NAME,
   migrate: ({ axes, ...rest }) => ({
     ...rest,
     version: VERSION,
@@ -81,7 +81,7 @@ export const stateMigration = migrate.createMigration<v1.State, State>({
 });
 
 export const sliceMigration = migrate.createMigration<v1.SliceState, SliceState>({
-  name: "lineplot.slice",
+  name: v1.SLICE_MIGRATION_NAME,
   migrate: ({ plots, ...rest }) => ({
     ...rest,
     version: VERSION,

--- a/console/src/lineplot/types/v3.ts
+++ b/console/src/lineplot/types/v3.ts
@@ -12,6 +12,7 @@ import { migrate } from "@synnaxlabs/x";
 import { z } from "zod";
 
 import * as v0 from "@/lineplot/types/v0";
+import * as v1 from "@/lineplot/types/v1";
 import * as v2 from "@/lineplot/types/v2";
 
 export const VERSION = "3.0.0";
@@ -41,9 +42,9 @@ export const ZERO_SLICE_STATE: SliceState = {
 };
 
 export const stateMigration = migrate.createMigration<v2.State, State>({
-  name: "lineplot.state",
-  migrate: (s) => ({
-    ...s,
+  name: v1.STATE_MIGRATION_NAME,
+  migrate: (state) => ({
+    ...state,
     version: VERSION,
     mode: v2.ZERO_SLICE_STATE.mode,
     control: v2.ZERO_SLICE_STATE.control,
@@ -52,7 +53,7 @@ export const stateMigration = migrate.createMigration<v2.State, State>({
 });
 
 export const sliceMigration = migrate.createMigration<v2.SliceState, SliceState>({
-  name: "lineplot.slice",
+  name: v1.SLICE_MIGRATION_NAME,
   migrate: ({ plots, mode, control, toolbar }) => ({
     version: VERSION,
     plots: Object.fromEntries(

--- a/console/src/lineplot/types/v3.ts
+++ b/console/src/lineplot/types/v3.ts
@@ -1,0 +1,65 @@
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { Viewport } from "@synnaxlabs/pluto";
+import { migrate } from "@synnaxlabs/x";
+import { z } from "zod";
+
+import * as v0 from "@/lineplot/types/v0";
+import * as v2 from "@/lineplot/types/v2";
+
+export const VERSION = "3.0.0";
+
+export const stateZ = v2.stateZ.omit({ version: true }).extend({
+  version: z.literal(VERSION),
+  mode: Viewport.modeZ,
+  control: v0.controlStateZ,
+  toolbar: v0.toolbarStateZ,
+});
+export interface State extends z.infer<typeof stateZ> {}
+export const ZERO_STATE: State = {
+  ...v2.ZERO_STATE,
+  version: VERSION,
+  mode: v2.ZERO_SLICE_STATE.mode,
+  control: v2.ZERO_SLICE_STATE.control,
+  toolbar: v2.ZERO_SLICE_STATE.toolbar,
+};
+
+export const sliceStateZ = v2.sliceStateZ
+  .omit({ plots: true, version: true, mode: true, control: true, toolbar: true })
+  .extend({ version: z.literal(VERSION), plots: z.record(z.string(), stateZ) });
+export interface SliceState extends z.infer<typeof sliceStateZ> {}
+export const ZERO_SLICE_STATE: SliceState = {
+  version: VERSION,
+  plots: {},
+};
+
+export const stateMigration = migrate.createMigration<v2.State, State>({
+  name: "lineplot.state",
+  migrate: (s) => ({
+    ...s,
+    version: VERSION,
+    mode: v2.ZERO_SLICE_STATE.mode,
+    control: v2.ZERO_SLICE_STATE.control,
+    toolbar: v2.ZERO_SLICE_STATE.toolbar,
+  }),
+});
+
+export const sliceMigration = migrate.createMigration<v2.SliceState, SliceState>({
+  name: "lineplot.slice",
+  migrate: ({ plots, mode, control, toolbar }) => ({
+    version: VERSION,
+    plots: Object.fromEntries(
+      Object.entries(plots).map(([key, plot]) => [
+        key,
+        { ...stateMigration(plot), mode, control, toolbar },
+      ]),
+    ),
+  }),
+});

--- a/console/src/lineplot/useTriggerHold.ts
+++ b/console/src/lineplot/useTriggerHold.ts
@@ -11,14 +11,16 @@ import { Triggers, useSyncedRef } from "@synnaxlabs/pluto";
 import { useCallback } from "react";
 import { useDispatch } from "react-redux";
 
-import { useSelectControlState } from "@/lineplot/selectors";
+import { Layout } from "@/layout";
+import { useSelectControlStateOptional } from "@/lineplot/selectors";
 import { setControlState } from "@/lineplot/slice";
 
 export type Config = Triggers.ModeConfig<"toggle">;
 
 export const useTriggerHold = (triggers: Config): void => {
-  const { hold } = useSelectControlState();
-  const ref = useSyncedRef(hold);
+  const activeTab = Layout.useSelectActiveMosaicTabKey();
+  const controlState = useSelectControlStateOptional(activeTab ?? "");
+  const ref = useSyncedRef(controlState?.hold);
   const dispatch = useDispatch();
   const flat = Triggers.useFlattenedMemoConfig(triggers);
   Triggers.use({
@@ -26,10 +28,10 @@ export const useTriggerHold = (triggers: Config): void => {
     loose: true,
     callback: useCallback(
       (e: Triggers.UseEvent) => {
-        if (e.stage !== "start") return;
-        dispatch(setControlState({ state: { hold: !ref.current } }));
+        if (e.stage !== "start" || activeTab == null || ref.current == null) return;
+        dispatch(setControlState({ key: activeTab, state: { hold: !ref.current } }));
       },
-      [dispatch],
+      [dispatch, activeTab, flat, ref],
     ),
   });
 };

--- a/console/src/schematic/Schematic.tsx
+++ b/console/src/schematic/Schematic.tsx
@@ -53,8 +53,8 @@ import {
   useSelectHasPermission,
   useSelectNodeProps,
   useSelectRequired,
+  useSelectRequiredViewportMode,
   useSelectVersion,
-  useSelectViewportMode,
 } from "@/schematic/selectors";
 import {
   addElement,
@@ -292,7 +292,7 @@ export const Loaded: Layout.Renderer = ({ layoutKey, visible }) => {
     onDrop: handleDrop,
   });
 
-  const mode = useSelectViewportMode();
+  const mode = useSelectRequiredViewportMode(layoutKey);
   const triggers = useMemo(() => Viewport.DEFAULT_TRIGGERS[mode], [mode]);
 
   Triggers.use({
@@ -361,8 +361,8 @@ export const Loaded: Layout.Renderer = ({ layoutKey, visible }) => {
   const canEditSchematic = useSelectHasPermission() && !schematic.snapshot;
 
   const handleViewportModeChange = useCallback(
-    (mode: Viewport.Mode) => dispatch(setViewportMode({ mode })),
-    [dispatch],
+    (mode: Viewport.Mode) => dispatch(setViewportMode({ key: layoutKey, mode })),
+    [dispatch, layoutKey],
   );
 
   return (

--- a/console/src/schematic/selectors.ts
+++ b/console/src/schematic/selectors.ts
@@ -155,7 +155,15 @@ export const selectSelectedElementNames = (
 ): (string | null)[] => {
   const elements = selectSelectedElementsProps(state, layoutKey);
   return elements.map((element) => {
-    if (element.type === "node") return element.props.label?.label ?? null;
+    if (
+      element.type === "node" &&
+      "label" in element.props &&
+      typeof element.props.label === "object" &&
+      element.props.label != null &&
+      "label" in element.props.label &&
+      typeof element.props.label.label === "string"
+    )
+      return element.props.label.label;
     return null;
   });
 };
@@ -197,10 +205,11 @@ export const useSelectRequiredNodeProps = (layoutKey: string, key: string): Node
     [layoutKey, key],
   );
 
-export const selectToolbar = (state: StoreState): ToolbarState =>
-  selectSliceState(state).toolbar;
+export const selectRequiredToolbar = (state: StoreState, key: string): ToolbarState =>
+  selectRequired(state, key).toolbar;
 
-export const useSelectToolbar = (): ToolbarState => useMemoSelect(selectToolbar, []);
+export const useSelectRequiredToolbar = (key: string): ToolbarState =>
+  useMemoSelect((state: StoreState) => selectRequiredToolbar(state, key), [key]);
 
 export const selectEditable = (state: StoreState, key: string): boolean | undefined =>
   selectOptional(state, key)?.editable;
@@ -208,11 +217,13 @@ export const selectEditable = (state: StoreState, key: string): boolean | undefi
 export const useSelectEditable = (key: string): boolean | undefined =>
   useMemoSelect((state: StoreState) => selectEditable(state, key), [key]);
 
-export const selectViewportMode = (state: StoreState): Viewport.Mode =>
-  selectSliceState(state).mode;
+export const selectRequiredViewportMode = (
+  state: StoreState,
+  key: string,
+): Viewport.Mode => selectRequired(state, key).mode;
 
-export const useSelectViewportMode = (): Viewport.Mode =>
-  useMemoSelect(selectViewportMode, []);
+export const useSelectRequiredViewportMode = (key: string): Viewport.Mode =>
+  useMemoSelect((state: StoreState) => selectRequiredViewportMode(state, key), [key]);
 
 export const selectViewport = (
   state: StoreState,

--- a/console/src/schematic/slice.ts
+++ b/console/src/schematic/slice.ts
@@ -121,6 +121,7 @@ export interface ToggleControlPayload {
 }
 
 export interface SetActiveToolbarTabPayload {
+  key: string;
   tab: ToolbarTab;
 }
 
@@ -136,6 +137,7 @@ export interface ClearSelectionPayload {
 }
 
 export interface SetViewportModePayload {
+  key: string;
   mode: Viewport.Mode;
 }
 
@@ -257,7 +259,7 @@ export const { actions, reducer } = createSlice({
         clearSelections(schematic);
       }
       state.schematics[layoutKey] = schematic;
-      state.toolbar.activeTab = "symbols";
+      state.schematics[layoutKey].toolbar.activeTab = "symbols";
     },
     clearSelection: (state, { payload }: PayloadAction<ClearSelectionPayload>) => {
       const { key: layoutKey } = payload;
@@ -268,7 +270,7 @@ export const { actions, reducer } = createSlice({
       schematic.edges.forEach((edge) => {
         edge.selected = false;
       });
-      state.toolbar.activeTab = "symbols";
+      state.schematics[layoutKey].toolbar.activeTab = "symbols";
     },
     remove: (state, { payload }: PayloadAction<RemovePayload>) => {
       const { keys: layoutKeys } = payload;
@@ -316,10 +318,10 @@ export const { actions, reducer } = createSlice({
         nodes.some((node) => node.selected) ||
         schematic.edges.some((edge) => edge.selected);
       if (anySelected) {
-        if (state.toolbar.activeTab !== "properties")
+        if (state.schematics[layoutKey].toolbar.activeTab !== "properties")
           clearOtherSelections(state, layoutKey);
-        state.toolbar.activeTab = "properties";
-      } else state.toolbar.activeTab = "symbols";
+        state.schematics[layoutKey].toolbar.activeTab = "properties";
+      } else state.schematics[layoutKey].toolbar.activeTab = "symbols";
     },
     setNodePositions: (state, { payload }: PayloadAction<SetNodePositionsPayload>) => {
       const { key: layoutKey, positions } = payload;
@@ -350,17 +352,17 @@ export const { actions, reducer } = createSlice({
         edges.some((edge) => edge.selected) ||
         schematic.nodes.some((node) => node.selected);
       if (anySelected) {
-        if (state.toolbar.activeTab !== "properties")
+        if (state.schematics[layoutKey].toolbar.activeTab !== "properties")
           clearOtherSelections(state, layoutKey);
-        state.toolbar.activeTab = "properties";
-      } else state.toolbar.activeTab = "symbols";
+        state.schematics[layoutKey].toolbar.activeTab = "properties";
+      } else state.schematics[layoutKey].toolbar.activeTab = "symbols";
     },
     setActiveToolbarTab: (
       state,
       { payload }: PayloadAction<SetActiveToolbarTabPayload>,
     ) => {
-      const { tab } = payload;
-      state.toolbar.activeTab = tab;
+      const { key, tab } = payload;
+      state.schematics[key].toolbar.activeTab = tab;
     },
     setViewport: (state, { payload }: PayloadAction<SetViewportPayload>) => {
       const { key: layoutKey, viewport } = payload;
@@ -403,9 +405,9 @@ export const { actions, reducer } = createSlice({
     },
     setViewportMode: (
       state,
-      { payload: { mode } }: PayloadAction<SetViewportModePayload>,
+      { payload: { key, mode } }: PayloadAction<SetViewportModePayload>,
     ) => {
-      state.mode = mode;
+      state.schematics[key].mode = mode;
     },
     setRemoteCreated: (state, { payload }: PayloadAction<SetRemoteCreatedPayload>) => {
       const { key: layoutKey } = payload;

--- a/console/src/schematic/toolbar/Toolbar.tsx
+++ b/console/src/schematic/toolbar/Toolbar.tsx
@@ -22,8 +22,8 @@ import {
   useSelectEditable,
   useSelectHasPermission,
   useSelectIsSnapshot,
+  useSelectRequiredToolbar,
   useSelectSelectedElementNames,
-  useSelectToolbar,
 } from "@/schematic/selectors";
 import { setActiveToolbarTab, setEditable, type ToolbarTab } from "@/schematic/slice";
 import { Control } from "@/schematic/toolbar/Control";
@@ -68,7 +68,7 @@ export interface ToolbarProps {
 export const Toolbar = ({ layoutKey }: ToolbarProps): ReactElement | null => {
   const { name } = Layout.useSelectRequired(layoutKey);
   const dispatch = useDispatch();
-  const toolbar = useSelectToolbar();
+  const toolbar = useSelectRequiredToolbar(layoutKey);
   const isEditable = useSelectEditable(layoutKey) === true;
   const handleExport = useExport();
   const selectedNames = useSelectSelectedElementNames(layoutKey);
@@ -88,9 +88,9 @@ export const Toolbar = ({ layoutKey }: ToolbarProps): ReactElement | null => {
   );
   const handleTabSelect = useCallback(
     (tabKey: string): void => {
-      dispatch(setActiveToolbarTab({ tab: tabKey as ToolbarTab }));
+      dispatch(setActiveToolbarTab({ key: layoutKey, tab: tabKey as ToolbarTab }));
     },
-    [dispatch],
+    [dispatch, layoutKey],
   );
   const canEdit = useSelectHasPermission();
   return (

--- a/console/src/schematic/types/index.ts
+++ b/console/src/schematic/types/index.ts
@@ -15,31 +15,34 @@ import * as v1 from "@/schematic/types/v1";
 import * as v2 from "@/schematic/types/v2";
 import * as v3 from "@/schematic/types/v3";
 import * as v4 from "@/schematic/types/v4";
+import * as v5 from "@/schematic/types/v5";
 
 export type NodeProps = v0.NodeProps;
 export type EdgeProps = v0.EdgeProps;
-export type State = v4.State;
-export type SliceState = v4.SliceState;
+export type State = v5.State;
+export type SliceState = v5.SliceState;
 export type ToolbarTab = v0.ToolbarTab;
 export type ToolbarState = v0.ToolbarState;
 export type LegendState = v1.LegendState;
 export type CopyBuffer = v0.CopyBuffer;
-export type AnyState = v0.State | v1.State | v2.State | v3.State | v4.State;
+export type AnyState = v0.State | v1.State | v2.State | v3.State | v4.State | v5.State;
 export type AnySliceState =
   | v0.SliceState
   | v1.SliceState
   | v2.SliceState
   | v3.SliceState
-  | v4.SliceState;
+  | v4.SliceState
+  | v5.SliceState;
 
-export const ZERO_STATE = v4.ZERO_STATE;
-export const ZERO_SLICE_STATE = v4.ZERO_SLICE_STATE;
+export const ZERO_STATE = v5.ZERO_STATE;
+export const ZERO_SLICE_STATE = v5.ZERO_SLICE_STATE;
 
 const STATE_MIGRATIONS: migrate.Migrations = {
   [v0.VERSION]: v1.stateMigration,
   [v1.VERSION]: v2.stateMigration,
   [v2.VERSION]: v3.stateMigration,
   [v3.VERSION]: v4.stateMigration,
+  [v4.VERSION]: v5.stateMigration,
 };
 
 const SLICE_MIGRATIONS: migrate.Migrations = {
@@ -47,20 +50,21 @@ const SLICE_MIGRATIONS: migrate.Migrations = {
   [v1.VERSION]: v2.sliceMigration,
   [v2.VERSION]: v3.sliceMigration,
   [v3.VERSION]: v4.sliceMigration,
+  [v4.VERSION]: v5.sliceMigration,
 };
 
 export const migrateState = migrate.migrator<AnyState, State>({
-  name: "schematic.state",
+  name: v1.STATE_MIGRATION_NAME,
   migrations: STATE_MIGRATIONS,
   def: ZERO_STATE,
 });
 
 export const migrateSlice = migrate.migrator<AnySliceState, SliceState>({
-  name: "schematic.slice",
+  name: v1.SLICE_MIGRATION_NAME,
   migrations: SLICE_MIGRATIONS,
   def: ZERO_SLICE_STATE,
 });
 
 export const anyStateZ = z
-  .union([v3.stateZ, v2.stateZ, v1.stateZ, v0.stateZ, v4.stateZ])
+  .union([v5.stateZ, v4.stateZ, v3.stateZ, v2.stateZ, v1.stateZ, v0.stateZ])
   .transform((state) => migrateState(state));

--- a/console/src/schematic/types/migrations.spec.ts
+++ b/console/src/schematic/types/migrations.spec.ts
@@ -20,6 +20,7 @@ import * as v1 from "@/schematic/types/v1";
 import * as v2 from "@/schematic/types/v2";
 import * as v3 from "@/schematic/types/v3";
 import * as v4 from "@/schematic/types/v4";
+import * as v5 from "@/schematic/types/v5";
 
 describe("migrations", () => {
   describe("state", () => {
@@ -29,6 +30,7 @@ describe("migrations", () => {
       v2.ZERO_STATE,
       v3.ZERO_STATE,
       v4.ZERO_STATE,
+      v5.ZERO_STATE,
     ];
     STATES.forEach((state) => {
       it(`should migrate state from ${state.version} to latest`, () => {
@@ -44,6 +46,7 @@ describe("migrations", () => {
       v2.ZERO_SLICE_STATE,
       v3.ZERO_SLICE_STATE,
       v4.ZERO_SLICE_STATE,
+      v5.ZERO_SLICE_STATE,
     ];
     STATES.forEach((state) => {
       it(`should migrate slice from ${state.version} to latest`, () => {

--- a/console/src/schematic/types/v0.ts
+++ b/console/src/schematic/types/v0.ts
@@ -7,32 +7,20 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import {
-  type Control,
-  control,
-  Diagram,
-  Schematic,
-  Value,
-  Viewport,
-} from "@synnaxlabs/pluto";
-import { color, type migrate, xy } from "@synnaxlabs/x";
+import { control, Diagram, Schematic, Value, Viewport } from "@synnaxlabs/pluto";
+import { color, xy } from "@synnaxlabs/x";
 import { z } from "zod";
 
 export const VERSION = "0.0.0";
-export type Version = typeof VERSION;
-
-export type NodeProps = {
-  key: Schematic.Variant;
-  color?: color.Crude;
-  label?: { label?: string };
-};
 
 export const nodePropsZ = z.looseObject({
   key: Schematic.variantZ,
   color: color.crudeZ.optional(),
 });
+export interface NodeProps extends z.infer<typeof nodePropsZ> {}
 
-export interface EdgeProps extends Pick<Diagram.Edge, "color" | "variant"> {}
+export const edgePropsZ = Diagram.edgeZ.pick({ color: true, variant: true });
+export interface EdgeProps extends z.infer<typeof edgePropsZ> {}
 
 export const stateZ = z.object({
   version: z.literal(VERSION),
@@ -42,11 +30,11 @@ export const stateZ = z.object({
   remoteCreated: z.boolean(),
   viewport: Diagram.viewportZ,
   nodes: z
-    .array(z.any())
+    .array(z.unknown())
     .transform((nodes) => nodes.filter((node) => Diagram.nodeZ.safeParse(node).success))
     .pipe(z.array(Diagram.nodeZ)),
   edges: z
-    .array(z.any())
+    .array(z.unknown())
     .transform((edges) => edges.filter((edge) => Diagram.edgeZ.safeParse(edge).success))
     .pipe(z.array(Diagram.edgeZ)),
   props: z.record(z.string(), nodePropsZ).transform((p) => {
@@ -57,60 +45,7 @@ export const stateZ = z.object({
   control: control.statusZ,
   controlAcquireTrigger: z.number(),
 });
-
-export interface State extends migrate.Migratable<Version> {
-  editable: boolean;
-  fitViewOnResize: boolean;
-  snapshot: boolean;
-  remoteCreated: boolean;
-  viewport: Diagram.Viewport;
-  nodes: Diagram.Node[];
-  edges: Diagram.Edge[];
-  props: Record<string, NodeProps>;
-  control: Control.Status;
-  controlAcquireTrigger: number;
-}
-
-export const copyBufferZ = z.object({
-  pos: xy.xy,
-  nodes: z.array(Diagram.nodeZ),
-  edges: z.array(z.unknown()),
-  props: z.record(z.string(), z.unknown()),
-});
-
-export interface CopyBuffer {
-  pos: xy.Crude;
-  nodes: Diagram.Node[];
-  edges: Diagram.Edge[];
-  props: Record<string, NodeProps>;
-}
-
-const ZERO_COPY_BUFFER: CopyBuffer = { pos: xy.ZERO, nodes: [], edges: [], props: {} };
-
-// ||||| TOOLBAR |||||
-
-const TOOLBAR_TABS = ["symbols", "properties"] as const;
-export const toolbarTabZ = z.enum(TOOLBAR_TABS);
-export type ToolbarTab = z.infer<typeof toolbarTabZ>;
-
-export const toolbarStateZ = z.object({ activeTab: toolbarTabZ });
-export type ToolbarState = z.infer<typeof toolbarStateZ>;
-
-export const sliceStateZ = z.object({
-  version: z.literal(VERSION),
-  mode: Viewport.modeZ,
-  copy: copyBufferZ,
-  toolbar: toolbarStateZ,
-  schematics: z.record(z.string(), stateZ),
-});
-
-export interface SliceState extends migrate.Migratable<Version> {
-  mode: Viewport.Mode;
-  copy: CopyBuffer;
-  toolbar: ToolbarState;
-  schematics: Record<string, State>;
-}
-
+export interface State extends z.infer<typeof stateZ> {}
 export const ZERO_STATE: State = {
   version: VERSION,
   snapshot: false,
@@ -125,10 +60,34 @@ export const ZERO_STATE: State = {
   fitViewOnResize: false,
 };
 
+export const copyBufferZ = z.object({
+  pos: xy.xy,
+  nodes: z.array(Diagram.nodeZ),
+  edges: z.array(Diagram.edgeZ),
+  props: z.record(z.string(), nodePropsZ),
+});
+export interface CopyBuffer extends z.infer<typeof copyBufferZ> {}
+const ZERO_COPY_BUFFER: CopyBuffer = { pos: xy.ZERO, nodes: [], edges: [], props: {} };
+
+export const toolbarTabZ = z.enum(["symbols", "properties"]);
+export type ToolbarTab = z.infer<typeof toolbarTabZ>;
+
+export const toolbarStateZ = z.object({ activeTab: toolbarTabZ });
+export interface ToolbarState extends z.infer<typeof toolbarStateZ> {}
+export const ZERO_TOOLBAR_STATE: ToolbarState = { activeTab: "symbols" };
+
+export const sliceStateZ = z.object({
+  version: z.literal(VERSION),
+  mode: Viewport.modeZ,
+  copy: copyBufferZ,
+  toolbar: toolbarStateZ,
+  schematics: z.record(z.string(), stateZ),
+});
+export interface SliceState extends z.infer<typeof sliceStateZ> {}
 export const ZERO_SLICE_STATE: SliceState = {
   version: VERSION,
   mode: "select",
-  copy: { ...ZERO_COPY_BUFFER },
-  toolbar: { activeTab: "symbols" },
+  copy: ZERO_COPY_BUFFER,
+  toolbar: ZERO_TOOLBAR_STATE,
   schematics: {},
 };

--- a/console/src/schematic/types/v1.ts
+++ b/console/src/schematic/types/v1.ts
@@ -14,14 +14,12 @@ import { z } from "zod";
 import * as v0 from "@/schematic/types/v0";
 
 export const VERSION = "1.0.0";
-export type Version = typeof VERSION;
 
 export const legendStateZ = z.object({
   visible: z.boolean(),
   position: Legend.stickyXYz,
 });
-export type LegendState = z.infer<typeof legendStateZ>;
-
+export interface LegendState extends z.infer<typeof legendStateZ> {}
 const ZERO_LEGEND_STATE: LegendState = {
   visible: false,
   position: { x: 50, y: 50, units: { x: "px", y: "px" } },
@@ -31,11 +29,7 @@ export const stateZ = v0.stateZ
   .omit({ version: true })
   .extend({ version: z.literal(VERSION), legend: legendStateZ });
 
-export interface State extends Omit<v0.State, "version"> {
-  version: Version;
-  legend: LegendState;
-}
-
+export interface State extends z.infer<typeof stateZ> {}
 export const ZERO_STATE: State = {
   ...v0.ZERO_STATE,
   version: VERSION,
@@ -45,30 +39,31 @@ export const ZERO_STATE: State = {
 export const sliceStateZ = v0.sliceStateZ
   .omit({ version: true, schematics: true })
   .extend({ version: z.literal(VERSION), schematics: z.record(z.string(), stateZ) });
-
-export interface SliceState extends Omit<v0.SliceState, "version" | "schematics"> {
-  version: Version;
-  schematics: Record<string, State>;
-}
-
-export const stateMigration = migrate.createMigration<v0.State, State>({
-  name: "schematic.state",
-  migrate: (input) => ({ ...input, legend: ZERO_LEGEND_STATE, version: VERSION }),
-});
-
-export const sliceMigration = migrate.createMigration<v0.SliceState, SliceState>({
-  name: "schematic.slice",
-  migrate: (input) => ({
-    ...input,
-    schematics: Object.fromEntries(
-      Object.entries(input.schematics).map(([k, v]) => [k, stateMigration(v)]),
-    ),
-    version: VERSION,
-  }),
-});
-
+export interface SliceState extends z.infer<typeof sliceStateZ> {}
 export const ZERO_SLICE_STATE: SliceState = {
   ...v0.ZERO_SLICE_STATE,
   version: VERSION,
   schematics: {},
 };
+
+export const STATE_MIGRATION_NAME = "schematic.state";
+export const SLICE_MIGRATION_NAME = "schematic.slice";
+
+export const stateMigration = migrate.createMigration<v0.State, State>({
+  name: STATE_MIGRATION_NAME,
+  migrate: (state) => ({ ...state, legend: ZERO_LEGEND_STATE, version: VERSION }),
+});
+
+export const sliceMigration = migrate.createMigration<v0.SliceState, SliceState>({
+  name: SLICE_MIGRATION_NAME,
+  migrate: ({ schematics, ...rest }) => ({
+    ...rest,
+    version: VERSION,
+    schematics: Object.fromEntries(
+      Object.entries(schematics).map(([key, schematic]) => [
+        key,
+        stateMigration(schematic),
+      ]),
+    ),
+  }),
+});

--- a/console/src/schematic/types/v3.ts
+++ b/console/src/schematic/types/v3.ts
@@ -10,59 +10,46 @@
 import { migrate } from "@synnaxlabs/x";
 import { z } from "zod";
 
+import * as v1 from "@/schematic/types/v1";
 import * as v2 from "@/schematic/types/v2";
 
-// This file is mostly pointless, as the state is exactly the same as the previous
-// version. But, customers have existing schematics and slices with the 'version' key
-// being 3.0.0, so we need to keep this file around for compatibility.
-
 export const VERSION = "3.0.0";
-export type Version = typeof VERSION;
 
 export const stateZ = v2.stateZ
   .omit({ version: true })
   .extend({ version: z.literal(VERSION) });
-
-export interface State extends Omit<v2.State, "version"> {
-  version: Version;
-}
-
+export interface State extends z.infer<typeof stateZ> {}
 export const ZERO_STATE: State = { ...v2.ZERO_STATE, version: VERSION };
 
 export const sliceStateZ = v2.sliceStateZ
-  .omit({ version: true })
-  .extend({ version: z.literal(VERSION) });
-
-export interface SliceState extends Omit<v2.SliceState, "version" | "schematics"> {
-  schematics: Record<string, State>;
-  version: Version;
-}
-
-export const stateMigration = migrate.createMigration<v2.State, State>({
-  name: "schematic.state",
-  migrate: (state) => ({
-    ...state,
-    edges: state.edges.map((edge) => ({ ...edge, segments: [] })),
-    version: VERSION,
-  }),
-});
-
-export const sliceMigration = migrate.createMigration<v2.SliceState, SliceState>({
-  name: "schematic.slice",
-  migrate: (sliceState) => ({
-    ...sliceState,
-    schematics: Object.fromEntries(
-      Object.entries(sliceState.schematics).map(([key, state]) => [
-        key,
-        { ...stateMigration(state) },
-      ]),
-    ),
-    version: VERSION,
-  }),
-});
-
+  .omit({ version: true, schematics: true })
+  .extend({ version: z.literal(VERSION), schematics: z.record(z.string(), stateZ) });
+export interface SliceState extends z.infer<typeof sliceStateZ> {}
 export const ZERO_SLICE_STATE: SliceState = {
   ...v2.ZERO_SLICE_STATE,
   version: VERSION,
   schematics: {},
 };
+
+export const stateMigration = migrate.createMigration<v2.State, State>({
+  name: v1.STATE_MIGRATION_NAME,
+  migrate: ({ edges, ...rest }) => ({
+    ...rest,
+    edges: edges.map((edge) => ({ ...edge, segments: [] })),
+    version: VERSION,
+  }),
+});
+
+export const sliceMigration = migrate.createMigration<v2.SliceState, SliceState>({
+  name: v1.SLICE_MIGRATION_NAME,
+  migrate: ({ schematics, ...rest }) => ({
+    ...rest,
+    schematics: Object.fromEntries(
+      Object.entries(schematics).map(([key, schematic]) => [
+        key,
+        stateMigration(schematic),
+      ]),
+    ),
+    version: VERSION,
+  }),
+});

--- a/console/src/schematic/types/v4.ts
+++ b/console/src/schematic/types/v4.ts
@@ -10,60 +10,42 @@
 import { migrate } from "@synnaxlabs/x";
 import { z } from "zod";
 
+import * as v1 from "@/schematic/types/v1";
 import * as v3 from "@/schematic/types/v3";
 
-// This file is mostly pointless, as the state is exactly the same as the previous
-// version. But, customers have existing schematics and slices with the 'version' key
-// being 3.0.0, so we need to keep this file around for compatibility.
-
 export const VERSION = "4.0.0";
-export type Version = typeof VERSION;
 
 export const stateZ = v3.stateZ
   .omit({ version: true })
   .extend({ version: z.literal(VERSION), authority: z.number() });
-
-export interface State extends Omit<v3.State, "version"> {
-  version: Version;
-  authority: number;
-}
-
+export interface State extends z.infer<typeof stateZ> {}
 export const ZERO_STATE: State = { ...v3.ZERO_STATE, version: VERSION, authority: 1 };
 
 export const sliceStateZ = v3.sliceStateZ
   .omit({ version: true, schematics: true })
   .extend({ version: z.literal(VERSION), schematics: z.record(z.string(), stateZ) });
-
-export interface SliceState extends Omit<v3.SliceState, "version" | "schematics"> {
-  schematics: Record<string, State>;
-  version: Version;
-}
-
-export const stateMigration = migrate.createMigration<v3.State, State>({
-  name: "schematic.state",
-  migrate: (state) => ({
-    ...state,
-    version: VERSION,
-    authority: 1,
-  }),
-});
-
-export const sliceMigration = migrate.createMigration<v3.SliceState, SliceState>({
-  name: "schematic.slice",
-  migrate: (sliceState) => ({
-    ...sliceState,
-    schematics: Object.fromEntries(
-      Object.entries(sliceState.schematics).map(([key, state]) => [
-        key,
-        { ...stateMigration(state) },
-      ]),
-    ),
-    version: VERSION,
-  }),
-});
-
+export interface SliceState extends z.infer<typeof sliceStateZ> {}
 export const ZERO_SLICE_STATE: SliceState = {
   ...v3.ZERO_SLICE_STATE,
   version: VERSION,
   schematics: {},
 };
+
+export const stateMigration = migrate.createMigration<v3.State, State>({
+  name: v1.STATE_MIGRATION_NAME,
+  migrate: (state) => ({ ...state, version: VERSION, authority: 1 }),
+});
+
+export const sliceMigration = migrate.createMigration<v3.SliceState, SliceState>({
+  name: v1.SLICE_MIGRATION_NAME,
+  migrate: ({ schematics, ...rest }) => ({
+    ...rest,
+    schematics: Object.fromEntries(
+      Object.entries(schematics).map(([key, schematic]) => [
+        key,
+        stateMigration(schematic),
+      ]),
+    ),
+    version: VERSION,
+  }),
+});

--- a/console/src/schematic/types/v5.ts
+++ b/console/src/schematic/types/v5.ts
@@ -8,57 +8,56 @@
 // included in the file licenses/APL.txt.
 
 import { Viewport } from "@synnaxlabs/pluto";
-import { migrate, uuid } from "@synnaxlabs/x";
+import { migrate, omit } from "@synnaxlabs/x";
 import { z } from "zod";
 
+import * as v0 from "@/schematic/types/v0";
 import * as v1 from "@/schematic/types/v1";
+import * as v4 from "@/schematic/types/v4";
 
-export const VERSION = "2.0.0";
+export const VERSION = "5.0.0";
 
-export const stateZ = v1.stateZ.omit({ version: true }).extend({
+export const stateZ = v4.stateZ.omit({ version: true, type: true }).extend({
   version: z.literal(VERSION),
-  key: z.string(),
-  type: z.literal("schematic"),
-  viewportMode: Viewport.modeZ.default("select"),
+  mode: Viewport.modeZ,
+  toolbar: v0.toolbarStateZ,
 });
 export interface State extends z.infer<typeof stateZ> {}
 export const ZERO_STATE: State = {
-  ...v1.ZERO_STATE,
+  ...omit(v4.ZERO_STATE, "type"),
   version: VERSION,
-  key: "",
-  type: "schematic",
-  viewportMode: "select",
+  mode: v4.ZERO_SLICE_STATE.mode,
+  toolbar: v0.ZERO_TOOLBAR_STATE,
 };
 
-export const sliceStateZ = v1.sliceStateZ
-  .omit({ version: true, schematics: true })
+export const sliceStateZ = v4.sliceStateZ
+  .omit({ version: true, schematics: true, mode: true, toolbar: true })
   .extend({ version: z.literal(VERSION), schematics: z.record(z.string(), stateZ) });
 export interface SliceState extends z.infer<typeof sliceStateZ> {}
 export const ZERO_SLICE_STATE: SliceState = {
-  ...v1.ZERO_SLICE_STATE,
+  copy: v4.ZERO_SLICE_STATE.copy,
   version: VERSION,
   schematics: {},
 };
 
-export const stateMigration = migrate.createMigration<v1.State, State>({
+export const stateMigration = migrate.createMigration<v4.State, State>({
   name: v1.STATE_MIGRATION_NAME,
   migrate: (state) => ({
-    ...state,
+    ...omit(state, "type"),
     version: VERSION,
-    key: uuid.create(),
-    type: "schematic",
-    viewportMode: "select",
+    mode: v4.ZERO_SLICE_STATE.mode,
+    toolbar: { ...v4.ZERO_SLICE_STATE.toolbar },
   }),
 });
 
-export const sliceMigration = migrate.createMigration<v1.SliceState, SliceState>({
+export const sliceMigration = migrate.createMigration<v4.SliceState, SliceState>({
   name: v1.SLICE_MIGRATION_NAME,
-  migrate: ({ schematics, ...rest }) => ({
+  migrate: ({ schematics, mode, toolbar, ...rest }) => ({
     ...rest,
     schematics: Object.fromEntries(
       Object.entries(schematics).map(([key, schematic]) => [
         key,
-        { ...stateMigration(schematic), key },
+        { ...stateMigration(schematic), mode, toolbar },
       ]),
     ),
     version: VERSION,

--- a/x/ts/src/index.ts
+++ b/x/ts/src/index.ts
@@ -33,6 +33,7 @@ export * from "@/math";
 export * from "@/migrate";
 export * from "@/notation";
 export * from "@/observe";
+export * from "@/omit";
 export * from "@/optional";
 export * from "@/primitive";
 export * from "@/record";

--- a/x/ts/src/omit.spec.ts
+++ b/x/ts/src/omit.spec.ts
@@ -1,0 +1,44 @@
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { describe, expect, it } from "vitest";
+
+import { omit } from "@/omit";
+
+type Object = { [key: string]: number };
+
+describe("omit", () => {
+  it("should return the object if no keys are provided", () =>
+    expect(omit({ a: 1, b: 2, c: 3 })).toEqual({ a: 1, b: 2, c: 3 }));
+
+  it("should return the object for a single key", () =>
+    expect(omit({ a: 1, b: 2, c: 3 }, "a")).toEqual({ b: 2, c: 3 }));
+
+  it("should return the object for multiple keys", () =>
+    expect(omit({ a: 1, b: 2, c: 3 }, "a", "b")).toEqual({ c: 3 }));
+
+  it("should not mutate the original object", () => {
+    const obj = { a: 1, b: 2, c: 3 };
+    const result = omit(obj, "a", "b");
+    expect(result).toEqual({ c: 3 });
+    expect(obj).toEqual({ a: 1, b: 2, c: 3 });
+  });
+
+  it("should be a no-op if the keys are not present", () => {
+    const obj: Object = { a: 1, b: 2, c: 3 };
+    const result = omit(obj, "d", "e");
+    expect(result).toEqual({ a: 1, b: 2, c: 3 });
+  });
+
+  it("should handle empty objects", () => {
+    const obj: Object = {};
+    const result = omit(obj, "a", "b", "c");
+    expect(result).toEqual({});
+  });
+});

--- a/x/ts/src/omit.ts
+++ b/x/ts/src/omit.ts
@@ -1,0 +1,14 @@
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+export const omit = <T, K extends keyof T>(obj: T, ...keys: K[]): Omit<T, K> => {
+  const result = { ...obj };
+  for (const key of keys) delete result[key];
+  return result;
+};


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2605](https://linear.app/synnax/issue/SY-2605/add-individual-line-plot-pausing)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

- clean up code for lineplot and schematic types files
- add omit utility to x/ts
- add individual pausing of line plots via moving state out of slice state and into individual plot state
- add individual select / pan mode of schematics via moving state out of slice state and into individual schematic state

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.
