### PR TITLE
Update Unit Tests for expected NaN values

### DIFF
--- a/pluto/src/telem/aether/remote.spec.ts
+++ b/pluto/src/telem/aether/remote.spec.ts
@@ -88,21 +88,21 @@ describe("remote", () => {
       vi.resetAllMocks();
     });
 
-    it("should return a zero value when no channel has been set", async () => {
+    it("should return a NaN value when no channel has been set", async () => {
       const props: StreamChannelValueProps = {
         channel: 0,
       };
       const scv = new StreamChannelValue(c, props);
-      expect(scv.value()).toBe(0);
+      expect(scv.value()).toBe(NaN);
       expect(scv.testingOnlyValid).toBe(false);
     });
 
-    it("should return a zero value when no leading buffer has been set", async () => {
+    it("should return a NaN value when no leading buffer has been set", async () => {
       const props: StreamChannelValueProps = {
         channel: 0,
       };
       const scv = new StreamChannelValue(c, props);
-      expect(scv.value()).toBe(0);
+      expect(scv.value()).toBe(NaN);
       expect(scv.testingOnlyLeadingBuffer).toBeNull();
     });
 
@@ -153,7 +153,7 @@ describe("remote", () => {
       const scv = new StreamChannelValue(c, props);
       const handleChange = vi.fn();
       scv.onChange(handleChange);
-      expect(scv.value()).toBe(0);
+      expect(scv.value()).toBe(NaN);
       await expect.poll(() => handleChange.mock.calls.length === 1).toBe(true);
       const series = Series.alloc({ dataType: DataType.FLOAT32, capacity: 3 });
 


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue


[SY-2743](https://linear.app/synnax/issue/SY-2743/add-staleness-to-schematic-values)

## Description

remote.ts now returns NaN when a channel primitive isZero, the leading buffer is null, or the leading buffer length is 0. remote.spec.ts must be updated.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [ ] ~I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.~
- [ ] ~I have updated in-code documentation to reflect the changes.~
- [ ] ~I have updated user-facing documentation to reflect the changes.~
