### PR TITLE
SY-2885: Remove `dataSaving` from OPC UA Write Task

### DIFF
--- a/console/src/hardware/common/task/types.ts
+++ b/console/src/hardware/common/task/types.ts
@@ -119,14 +119,21 @@ export const validateWriteChannels = (ctx: z.core.ParsePayload<WriteChannel[]>) 
 
 export const baseConfigZ = z.object({
   autoStart: z.boolean().default(false),
-  dataSaving: z.boolean(),
   device: Device.keyZ,
 });
 export interface BaseConfig extends z.infer<typeof baseConfigZ> {}
 export const ZERO_BASE_CONFIG: BaseConfig = {
   autoStart: false,
-  dataSaving: true,
   device: "",
+};
+
+export const baseReadConfigZ = baseConfigZ.extend({
+  dataSaving: z.boolean().default(true),
+});
+export interface BaseReadConfig extends z.infer<typeof baseReadConfigZ> {}
+export const ZERO_BASE_READ_CONFIG: BaseReadConfig = {
+  ...ZERO_BASE_CONFIG,
+  dataSaving: true,
 };
 
 interface ConfigWithSampleRateAndStreamRate {

--- a/console/src/hardware/labjack/task/types.spec.ts
+++ b/console/src/hardware/labjack/task/types.spec.ts
@@ -196,6 +196,7 @@ describe("readConfigZ", () => {
       ],
       sampleRate: 1000,
       streamRate: 500,
+      dataSaving: true,
     };
 
     const result = readConfigZ.safeParse(configWithLinearScale);

--- a/console/src/hardware/labjack/task/types.ts
+++ b/console/src/hardware/labjack/task/types.ts
@@ -246,7 +246,7 @@ export interface BaseStateDetails {
   running: boolean;
 }
 
-export const readConfigZ = Common.Task.baseConfigZ
+export const readConfigZ = Common.Task.baseReadConfigZ
   .extend({
     channels: z
       .array(inputChannelZ)
@@ -258,7 +258,7 @@ export const readConfigZ = Common.Task.baseConfigZ
   .check(Common.Task.validateStreamRate);
 export interface ReadConfig extends z.infer<typeof readConfigZ> {}
 const ZERO_READ_CONFIG: ReadConfig = {
-  ...Common.Task.ZERO_BASE_CONFIG,
+  ...Common.Task.ZERO_BASE_READ_CONFIG,
   channels: [],
   sampleRate: 10,
   streamRate: 5,
@@ -313,11 +313,13 @@ export const writeConfigZ = Common.Task.baseConfigZ.extend({
     .check(Common.Task.validateWriteChannels)
     .check(validateUniquePorts),
   stateRate: z.number().positive().max(50000),
+  dataSaving: z.boolean().default(true),
 });
 export interface WriteConfig extends z.infer<typeof writeConfigZ> {}
 const ZERO_WRITE_CONFIG: WriteConfig = {
   ...Common.Task.ZERO_BASE_CONFIG,
   channels: [],
+  dataSaving: true,
   stateRate: 10,
 };
 

--- a/console/src/hardware/ni/task/types/v0.tsx
+++ b/console/src/hardware/ni/task/types/v0.tsx
@@ -1086,23 +1086,25 @@ export const ZERO_DO_CHANNEL: DOChannel = {
 
 export type DigitalChannel = DIChannel | DOChannel;
 
-const baseReadConfigZ = Common.Task.baseConfigZ.extend({
+const baseReadConfigZ = Common.Task.baseReadConfigZ.extend({
   sampleRate: z.number().positive().max(100000),
   streamRate: z.number().positive().max(20000),
 });
 interface BaseReadConfig extends z.infer<typeof baseReadConfigZ> {}
 const ZERO_BASE_READ_CONFIG: BaseReadConfig = {
-  ...Common.Task.ZERO_BASE_CONFIG,
+  ...Common.Task.ZERO_BASE_READ_CONFIG,
   sampleRate: 10,
   streamRate: 5,
 };
 
 const baseWriteConfigZ = Common.Task.baseConfigZ.extend({
+  dataSaving: z.boolean().default(true),
   stateRate: z.number().positive().max(50000),
 });
 interface BaseWriteConfig extends z.infer<typeof baseWriteConfigZ> {}
 const ZERO_BASE_WRITE_CONFIG: BaseWriteConfig = {
   ...Common.Task.ZERO_BASE_CONFIG,
+  dataSaving: true,
   stateRate: 10,
 };
 

--- a/console/src/hardware/opc/task/Write.tsx
+++ b/console/src/hardware/opc/task/Write.tsx
@@ -43,7 +43,6 @@ export const WRITE_SELECTABLE: Selector.Selectable = {
 const Properties = () => (
   <>
     <Device.Select />
-    <Common.Task.Fields.DataSaving />
     <Common.Task.Fields.AutoStart />
   </>
 );

--- a/console/src/hardware/opc/task/types.spec.ts
+++ b/console/src/hardware/opc/task/types.spec.ts
@@ -27,7 +27,6 @@ describe("OPC Write Task Types", () => {
           nodeName: "test",
         } as WriteChannel,
       ],
-      dataSaving: true,
       device: "1",
     };
     const result = writeConfigZ.safeParse(config);

--- a/console/src/hardware/opc/task/types.ts
+++ b/console/src/hardware/opc/task/types.ts
@@ -57,7 +57,7 @@ const validateNodeIDs = ({
   });
 };
 
-const baseReadConfigZ = Common.Task.baseConfigZ.extend({
+const baseReadConfigZ = Common.Task.baseReadConfigZ.extend({
   channels: z
     .array(readChannelZ)
     .check(Common.Task.validateReadChannels)
@@ -100,7 +100,7 @@ const arraySamplingConfigZ = baseReadConfigZ
 export const readConfigZ = z.union([nonArraySamplingConfigZ, arraySamplingConfigZ]);
 export type ReadConfig = z.infer<typeof readConfigZ>;
 const ZERO_READ_CONFIG: ReadConfig = {
-  ...Common.Task.ZERO_BASE_CONFIG,
+  ...Common.Task.ZERO_BASE_READ_CONFIG,
   arrayMode: false,
   channels: [],
   sampleRate: 50,


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2885](https://linear.app/synnax/issue/SY-2885/remove-data-saving-from-opc-write-field)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Remove `dataSaving` from OPC UA Write Task Form.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.
