### PR TITLE
SY-2861: Make device location required in control sequence

### DIFF
--- a/console/src/hardware/task/sequence/Sequence.tsx
+++ b/console/src/hardware/task/sequence/Sequence.tsx
@@ -163,7 +163,6 @@ const Internal = ({
             <Form.Field<rack.Key>
               path="config.rack"
               label="Location"
-              required
               padHelpText={false}
               onChange={(v, { set }) => set("rackKey", v)}
               grow

--- a/console/src/hardware/task/sequence/Sequence.tsx
+++ b/console/src/hardware/task/sequence/Sequence.tsx
@@ -163,6 +163,7 @@ const Internal = ({
             <Form.Field<rack.Key>
               path="config.rack"
               label="Location"
+              required
               padHelpText={false}
               onChange={(v, { set }) => set("rackKey", v)}
               grow

--- a/console/src/hardware/task/sequence/types.ts
+++ b/console/src/hardware/task/sequence/types.ts
@@ -16,7 +16,7 @@ export type Type = z.infer<typeof typeZ>;
 
 export const configZ = z.object({
   rate: z.number().min(1),
-  rack: rack.keyZ.optional().default(0),
+  rack: rack.keyZ,
   read: z.array(channel.keyZ),
   write: z.array(channel.keyZ),
   script: z.string(),


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2861](https://linear.app/synnax/issue/SY-2861/control-sequence-does-not-require-a-deployment-location)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Make the device location required for a control sequence schema.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.
