### PR TITLE
SY-2879: Improve sizing of channel names in task forms

### DIFF
--- a/console/src/hardware/ni/task/DigitalRead.tsx
+++ b/console/src/hardware/ni/task/DigitalRead.tsx
@@ -55,7 +55,11 @@ const Properties = () => (
 );
 
 const NameComponent = ({ channel, key }: DIChannel) => (
-  <Common.Task.ChannelName channel={channel} id={Common.Task.getChannelNameID(key)} />
+  <Common.Task.ChannelName
+    channel={channel}
+    id={Common.Task.getChannelNameID(key)}
+    level="p"
+  />
 );
 
 const name = Component.renderProp(NameComponent);

--- a/console/src/hardware/opc/task/Form.tsx
+++ b/console/src/hardware/opc/task/Form.tsx
@@ -57,7 +57,7 @@ const ChannelListItem = <C extends Channel>({
   return (
     <Select.ListItem {...rest} justify="between" align="center" rightAligned>
       <Flex.Box direction="y" gap="small">
-        <ChannelName weight={500} color={10} channel={channel} id={id} />
+        <ChannelName weight={500} color={10} level="p" channel={channel} id={id} />
         <Text.Text level="small" weight={350} color={opcNodeColor ?? 9} gap="small">
           <Icon.Variable style={{ color: "var(--pluto-gray-l7)" }} />
           {nodeName} {opcNode}


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2879](https://linear.app/synnax/issue/SY-2879/make-channel-names-bigger-on-opc-read-task)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Improve channel name sizing in NI Digital Read and OPC UA Tasks.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.
