### PR TITLE
SY-2849: Remove "Create Symbol" command from command palette

### DIFF
--- a/console/src/schematic/services/palette.tsx
+++ b/console/src/schematic/services/palette.tsx
@@ -11,7 +11,6 @@ import { type Palette } from "@/palette";
 import { Schematic } from "@/schematic";
 import { CreateIcon, ImportIcon } from "@/schematic/services/Icon";
 import { import_ } from "@/schematic/services/import";
-import { createEditLayout } from "@/schematic/symbols/edit/Edit";
 
 const CREATE_COMMAND: Palette.Command = {
   key: "create-schematic",
@@ -30,12 +29,4 @@ const IMPORT_COMMAND: Palette.Command = {
   visible: Schematic.selectHasPermission,
 };
 
-const CREATE_SYMBOL_COMMAND: Palette.Command = {
-  key: "create-symbol",
-  name: "Create Symbol",
-  icon: <CreateIcon />,
-  onSelect: ({ placeLayout }) => placeLayout(createEditLayout()),
-  visible: Schematic.selectHasPermission,
-};
-
-export const COMMANDS = [CREATE_COMMAND, IMPORT_COMMAND, CREATE_SYMBOL_COMMAND];
+export const COMMANDS = [CREATE_COMMAND, IMPORT_COMMAND];


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2849](https://linear.app/synnax/issue/SY-2849/remove-schematic-symbol-from-command-palette)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Remove the create schematic symbol command from the command palette.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.
