### PR TITLE
SY-2855: Fix Symbol Group Deletion Modal

### DIFF
--- a/console/src/schematic/symbols/useDeleteSymbolGroup.ts
+++ b/console/src/schematic/symbols/useDeleteSymbolGroup.ts
@@ -17,13 +17,12 @@ export const useDeleteSymbolGroup = (): ((group: group.Payload) => void) => {
   const client = Synnax.use();
   const handleError = Status.useErrorHandler();
   const addStatus = Status.useAdder();
-  const confirmDelete = useConfirmDelete({
-    type: "Group",
-  });
+  const confirmDelete = useConfirmDelete({ type: "Group" });
   return useCallback(
     (g: group.Payload) => {
       handleError(async () => {
-        await confirmDelete(g);
+        const confirmed = await confirmDelete(g);
+        if (!confirmed) return;
         if (client == null) throw new DisconnectedError();
         const children = await client.ontology.retrieveChildren(
           group.ontologyID(g.key),
@@ -43,6 +42,6 @@ export const useDeleteSymbolGroup = (): ((group: group.Payload) => void) => {
         });
       }, "Failed to delete symbol group");
     },
-    [client, handleError, addStatus],
+    [client, handleError, addStatus, confirmDelete],
   );
 };

--- a/console/src/schematic/toolbar/Symbols.tsx
+++ b/console/src/schematic/toolbar/Symbols.tsx
@@ -37,7 +37,6 @@ import { Modals } from "@/modals";
 import { useConfirmDelete } from "@/ontology/hooks";
 import { useSelectSelectedSymbolGroup } from "@/schematic/selectors";
 import { setSelectedSymbolGroup } from "@/schematic/slice";
-import { useDeleteSymbolGroup } from "@/schematic/symbols/deleteGroup";
 import { createEditLayout } from "@/schematic/symbols/edit/Edit";
 import {
   useExport as useExportSymbol,
@@ -48,6 +47,7 @@ import {
   useImportGroup,
 } from "@/schematic/symbols/import";
 import { useAddSymbol } from "@/schematic/symbols/useAddSymbol";
+import { useDeleteSymbolGroup } from "@/schematic/symbols/useDeleteSymbolGroup";
 
 const StaticListItem = (props: List.ItemProps<string>): ReactElement | null => {
   const { itemKey } = props;


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2855](https://linear.app/synnax/issue/SY-2855/escaping-out-of-the-delete-symbol-group-pop-up-deletes-the-symbol)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Fix an error where escaping from the symbol group deletion modal still caused the group to be deleted.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.
