### PR TITLE
SY-2860 - Fix Remote Search In Schematic Symbols Toolbar

### DIFF
--- a/console/src/schematic/toolbar/Symbols.tsx
+++ b/console/src/schematic/toolbar/Symbols.tsx
@@ -9,7 +9,7 @@
 
 import "@/schematic/toolbar/Symbols.css";
 
-import { group, type ontology, type schematic } from "@synnaxlabs/client";
+import { group, type ontology, schematic } from "@synnaxlabs/client";
 import {
   Button,
   Component,
@@ -527,7 +527,7 @@ const SearchListItem = (props: List.ItemProps<string>): ReactElement | null => {
     itemKey,
   );
   if (item == null) return null;
-  const isRemote = "specKey" in item;
+  const isRemote = schematic.symbol.keyZ.safeParse(itemKey).success;
   if (isRemote) return <RemoteListItem {...props} />;
   return <StaticListItem {...props} />;
 };
@@ -552,15 +552,16 @@ const SearchSymbolList = ({
     second: remote,
   });
   const { search } = List.usePager({
-    retrieve: (args) => {
-      remote.retrieve(args);
-      staticData.retrieve(args);
-    },
+    retrieve: useCallback(
+      (args) => {
+        remote.retrieve(args);
+        staticData.retrieve(args);
+      },
+      [remote.retrieve, staticData.retrieve],
+    ),
   });
 
-  useEffect(() => {
-    search(searchTerm);
-  }, [search, searchTerm]);
+  useEffect(() => search(searchTerm), [search, searchTerm]);
   return (
     <Select.Frame<string, Schematic.Symbol.Spec | schematic.symbol.Symbol>
       data={data}

--- a/core/pkg/service/workspace/schematic/symbol/service.go
+++ b/core/pkg/service/workspace/schematic/symbol/service.go
@@ -119,6 +119,7 @@ func (s *Service) NewRetrieve() Retrieve {
 	return Retrieve{
 		gorp:   gorp.NewRetrieve[uuid.UUID, Symbol](),
 		baseTX: s.DB,
+		otg:    s.Ontology,
 	}
 }
 

--- a/pluto/src/schematic/symbol/queries.ts
+++ b/pluto/src/schematic/symbol/queries.ts
@@ -121,7 +121,9 @@ export const useList = Flux.createList<
       });
       return symbols;
     }
-    return await client.workspaces.schematic.symbols.retrieve(rest);
+    const res = await client.workspaces.schematic.symbols.retrieve(rest);
+    store.schematicSymbols.set(res);
+    return res;
   },
   retrieveByKey: async ({ client, key, store }) =>
     await retrieveByKey(client, key, store),


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2860](https://linear.app/synnax/issue/SY-2860/search-symbols-in-schematic-toolbar-should-search-across-groups)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.
