### PR TITLE
SY-2893: Fix placing range overview layout from link

### DIFF
--- a/console/src/range/services/link.ts
+++ b/console/src/range/services/link.ts
@@ -19,5 +19,5 @@ export const handleLink: Link.Handler = async ({
   const range = await client.ranges.retrieve(key);
   dispatch(Range.add({ ranges: Range.fromClientRange(range) }));
   dispatch(Range.setActive(range.key));
-  placeLayout({ ...Range.OVERVIEW_LAYOUT, key });
+  placeLayout({ ...Range.OVERVIEW_LAYOUT, key, name: range.name });
 };


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2893](https://linear.app/synnax/issue/SY-2893/fix-layout-name-sync-problems-when-opening-ranges)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Fix placing the range overview layout name from the link.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.
