### PR TITLE
SY-2879: Fix drag and drop import of tasks

### DIFF
--- a/console/src/hardware/common/task/Form.tsx
+++ b/console/src/hardware/common/task/Form.tsx
@@ -179,8 +179,8 @@ export const wrapForm = <
           if (!confirmed) return false;
           await client.hardware.tasks.delete(taskKey);
         }
-        if ("channels" in (newConfig as { channels: any }))
-          form.set("config.channels", (newConfig as { channels: any }).channels);
+        form.set("rackKey", rackKey);
+        form.set("config", newConfig);
         return true;
       },
       afterSave: ({ client, ...form }) => {


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2879](https://linear.app/synnax/issue/SY-2878/drag-and-drop-import-of-ni-digital-read-task-does-not-allow-for)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Fix the drag and drop import of tasks.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.
