### PR TITLE
SY-2840 - Add Tooltips To Stroke and Fill Icons on Schematic Symbol Edit Dialog

### DIFF
--- a/console/src/schematic/symbols/edit/RegionList.tsx
+++ b/console/src/schematic/symbols/edit/RegionList.tsx
@@ -19,6 +19,7 @@ import {
   List,
   Select,
   Text,
+  Tooltip,
 } from "@synnaxlabs/pluto";
 import { color } from "@synnaxlabs/x";
 
@@ -105,8 +106,18 @@ export const RegionList = ({
         </Header.Title>
         <Header.Actions>
           <Text.Text level="p" color={7} gap={3}>
-            <Icon.StrokeColor />
-            <Icon.FillColor />
+            <Tooltip.Dialog>
+              <Text.Text level="small">Stroke Color</Text.Text>
+              <Flex.Box>
+                <Icon.StrokeColor />
+              </Flex.Box>
+            </Tooltip.Dialog>
+            <Tooltip.Dialog>
+              <Text.Text level="small">Fill Color</Text.Text>
+              <Flex.Box>
+                <Icon.FillColor />
+              </Flex.Box>
+            </Tooltip.Dialog>
           </Text.Text>
           <Button.Button onClick={onAddRegion} size="small" variant="outlined">
             <Icon.Add />

--- a/pluto/src/color/Swatch.css
+++ b/pluto/src/color/Swatch.css
@@ -13,7 +13,11 @@
     border-radius: 1rem;
     background:
         linear-gradient(var(--pluto-swatch-color), var(--pluto-swatch-color)),
-        repeating-conic-gradient(#e0e0e0 0% 25%, white 0% 50%) 50% / 1rem 1rem;
+        repeating-conic-gradient(
+                var(--pluto-gray-l2) 0% 25%,
+                var(--pluto-gray-l5) 0% 50%
+            )
+            50% / 1rem 1rem;
 
     &.pluto--no-border {
         border-color: transparent;


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2840](https://linear.app/synnax/issue/SY-2840/add-tooltips-to-stroke-and-fill-color-symbols-on-schematic-symbol)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.
