### PR TITLE
SY-2854 - Improve Schematic Symbol Group Rename Modal

### DIFF
--- a/console/src/modals/Rename.tsx
+++ b/console/src/modals/Rename.tsx
@@ -49,7 +49,7 @@ export const [useRename, Rename] = createBase<string, PromptRenameLayoutArgs>(
             }}
             trigger={Triggers.SAVE}
           >
-            Create
+            Save
           </Button.Button>
         </Nav.Bar.End>
       </>

--- a/console/src/schematic/toolbar/Symbols.tsx
+++ b/console/src/schematic/toolbar/Symbols.tsx
@@ -455,7 +455,13 @@ const GroupListContextMenu = ({
     params: { key: item?.key ?? "" },
     beforeUpdate: async ({ value }) => {
       if (item == null) return false;
-      const newName = await renameModal({ initialValue: value });
+      const newName = await renameModal(
+        { initialValue: value, allowEmpty: false, label: "Gorup Name" },
+        {
+          name: "Schematic.Symbols.Rename Group",
+          icon: "Group",
+        },
+      );
       if (newName == null) return false;
       return newName;
     },


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2854](https://linear.app/synnax/issue/SY-2854/schematic-symbol-group-name-modal-doesnt-have-an-icon-and-text-save)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.
