### PR TITLE
SY-2906: Rename `synnax` to `core` in integration build scripts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,8 +66,7 @@ python_install
 
 synnax-data/**
 
-synnax/pkg/service/hardware/embedded/assets/**
-!synnax/pkg/service/hardware/embedded/assets/.gitkeep
+core/pkg/service/hardware/embedded/assets/**
 
 # |||||| BAZEL ||||||
 # Ignore all bazel-* symlinks. There is no full list since this can change

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,10 +1,12 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in
+this repository.
 
 ## Common Development Commands
 
 ### Building the Project
+
 - `pnpm build` - Build all packages using Turbo
 - `pnpm build:console` - Build only the Console application
 - `pnpm build:pluto` - Build only the Pluto component library
@@ -13,6 +15,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `pnpm check-types:console` - Type check only Console
 
 ### Development & Testing
+
 - `pnpm dev:console` - Start Console in development mode (Tauri)
 - `pnpm dev:console-vite` - Start Console Vite dev server only
 - `pnpm dev:pluto` - Start Pluto development server
@@ -22,74 +25,98 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - `pnpm watch` - Watch mode for all packages
 
 ### Code Quality
+
 - `pnpm lint` - Lint all packages with ESLint
 - `pnpm fix` - Auto-fix linting issues across packages
 - `pnpm lint:console` - Lint only Console package
 - `pnpm fix:console` - Fix linting issues in Console
 
 ### Integration Tests
+
 The repository includes comprehensive integration testing:
+
 - Integration tests are located in `/integration/` directory
 - Tests cover read, write, streaming, and delete operations across all client languages
 - Run with configurable parameters for stress testing and performance measurement
-- Tests validate the entire system from Python/TypeScript/C++ clients through Synnax server to Cesium storage
+- Tests validate the entire system from Python/TypeScript/C++ clients through Synnax
+  server to Cesium storage
 
 ### Go Development
-- Individual Go modules: `/synnax/`, `/aspen/`, `/cesium/`, `/freighter/go/`
+
+- Individual Go modules: `/core/`, `/aspen/`, `/cesium/`, `/freighter/go/`
 - Use standard `go test`, `go build` commands within each module
 - Integration tests available via scripts in `/integration/`
 
 ## High-Level Architecture
 
 ### Core Philosophy
-Synnax is a **horizontally-scalable observability and control platform** built around a strict **4-layer architecture** with unidirectional dependencies. The system prioritizes **real-time performance** and **distributed reliability** for hardware telemetry systems.
+
+Synnax is a **horizontally-scalable observability and control platform** built around a
+strict **4-layer architecture** with unidirectional dependencies. The system prioritizes
+**real-time performance** and **distributed reliability** for hardware telemetry
+systems.
 
 ### Key Components
 
-#### 1. Synnax Server (Go) - `/synnax/`
+#### 1. Synnax Server (Go) - `/core/`
+
 The core time-series engine with 4-layer architecture:
+
 - **Storage Layer**: Cesium (time-series) + Pebble (key-value) for disk persistence
-- **Distribution Layer**: Aspen-based clustering with gossip protocols for horizontal scaling
+- **Distribution Layer**: Aspen-based clustering with gossip protocols for horizontal
+  scaling
 - **Service Layer**: Business logic for channels, users, authentication, ranges
 - **Interface Layer**: HTTP/WebSocket APIs via Freighter transport abstraction
 
 #### 2. Cesium - `/cesium/` (Go)
+
 High-performance embedded time-series database:
+
 - **Columnar storage** with automatic compression and domain-based indexing
 - **Transactional writers** with conflict detection for data integrity
 - **Memory-efficient iterators** for streaming large datasets
 - Optimized for high-frequency (>1kHz) sensor data with microsecond precision
 
 #### 3. Aspen - `/aspen/` (Go)
+
 Distributed key-value store and cluster management:
+
 - **SI gossip protocol** for cluster membership and failure detection
 - **SIR gossip protocol** for eventually consistent metadata synchronization
 - **Dynamic node joining** with distributed counter assignment
 - Read-optimized design suitable for metadata that's frequently accessed
 
 #### 4. Freighter - `/freighter/` (Multi-language)
+
 Protocol-agnostic transport layer:
+
 - **Unary and streaming** communication patterns
 - Support for **gRPC, HTTP, WebSockets** with middleware architecture
 - **Cross-language consistency** across Go, TypeScript, Python, C++
 - Error handling and authentication standardization
 
 #### 5. Pluto - `/pluto/` (TypeScript/React)
+
 High-performance visualization component library:
+
 - **Aether framework** with worker-thread rendering to maintain 60fps
 - **GPU-accelerated** visualization for real-time telemetry streams
 - **Modular components** with incremental update patterns
 - Generic architecture independent of Synnax-specific APIs
 
 #### 6. Console - `/console/` (Tauri + React + TypeScript)
+
 Cross-platform desktop application:
+
 - **Tauri (Rust) + React** for native performance with web UI
 - **Redux Toolkit** for complex state management with persistence
 - **Drag-and-drop layout system** for custom interface building
 - **Embedded Synnax server** capability for standalone deployments
 
 #### 7. Driver - `/driver/` (C++)
+
 Real-time hardware integration system:
+
 - **Task-based architecture** with separate acquisition and control pipelines
 - **Device abstraction** supporting LabJack, National Instruments, OPC UA
 - **Real-time OS support** including NI Linux RT
@@ -98,16 +125,19 @@ Real-time hardware integration system:
 ### Data Flow Patterns
 
 #### Telemetry Ingestion
+
 ```
 Hardware → Driver (C++) → Synnax Server (Go) → Cesium Storage → Distribution → Clients
 ```
 
 #### Control Commands
+
 ```
 Client → Synnax Server → Validation → Distribution → Driver → Hardware (with feedback)
 ```
 
 #### Cluster Communication
+
 ```
 Node A ←→ Aspen Gossip ←→ Node B (metadata sync)
        ↓                    ↓
@@ -115,6 +145,7 @@ Node A ←→ Aspen Gossip ←→ Node B (metadata sync)
 ```
 
 ### Build System & Monorepo
+
 - **PNPM workspaces** with catalog dependencies for TypeScript packages
 - **Turbo** for build orchestration and caching across packages
 - **Poetry** for Python package management
@@ -122,6 +153,7 @@ Node A ←→ Aspen Gossip ←→ Node B (metadata sync)
 - **Bazel** for C++ components with complex dependencies
 
 ### Key Architectural Patterns
+
 - **Dependency Injection** throughout Go services for testability
 - **Interface Segregation** with clear layer boundaries and abstractions
 - **Command Pattern** for control operations with validation pipelines
@@ -129,32 +161,51 @@ Node A ←→ Aspen Gossip ←→ Node B (metadata sync)
 - **Strategy Pattern** for pluggable transports and storage backends
 
 ### Testing Strategy
-- **Unit tests** per component using language-specific frameworks (Vitest, Ginkgo/Gomega, pytest)
-- **Integration tests** in `/integration/` covering full system with configurable parameters
+
+- **Unit tests** per component using language-specific frameworks (Vitest,
+  Ginkgo/Gomega, pytest)
+- **Integration tests** in `/integration/` covering full system with configurable
+  parameters
 - **Performance benchmarking** built into integration test framework
 - **Cross-language validation** ensuring API consistency across client libraries
 
 ### Development Guidelines
-- **Strict layering** - dependencies only flow downward in the 4-layer server architecture
+
+- **Strict layering** - dependencies only flow downward in the 4-layer server
+  architecture
 - **Protocol agnostic** - use Freighter abstractions rather than direct HTTP/gRPC
 - **Real-time focus** - optimize for low-latency, high-frequency data streams
-- **Multi-language consistency** - maintain API parity across Go, TypeScript, Python, C++
+- **Multi-language consistency** - maintain API parity across Go, TypeScript, Python,
+  C++
 - **Horizontal scalability** - design with distributed deployment in mind
-- **Safety-critical reliability** - prefer availability over consistency for metadata, strong consistency for telemetry
-- **Absolute imports** - always prefer absolute imports over relative imports in TypeScript projects (e.g., `@/components/Button` instead of `../../../components/Button`)
-- **Vitest for testing** - always use Vitest APIs in TypeScript test files (e.g., `import { describe, it, expect } from "vitest"` instead of Jest or other testing frameworks)
-- **Dependency injection & composition** - prefer dependency injection and composition over singletons, mocking, and inheritance across all languages (Go interfaces, TypeScript composition, etc.)
-- **Cross-platform C++** - always consider cross-platform compatibility when writing C++ code (Windows, macOS, Linux, NI Linux RT); avoid platform-specific APIs unless absolutely necessary
+- **Safety-critical reliability** - prefer availability over consistency for metadata,
+  strong consistency for telemetry
+- **Absolute imports** - always prefer absolute imports over relative imports in
+  TypeScript projects (e.g., `@/components/Button` instead of
+  `../../../components/Button`)
+- **Vitest for testing** - always use Vitest APIs in TypeScript test files (e.g.,
+  `import { describe, it, expect } from "vitest"` instead of Jest or other testing
+  frameworks)
+- **Dependency injection & composition** - prefer dependency injection and composition
+  over singletons, mocking, and inheritance across all languages (Go interfaces,
+  TypeScript composition, etc.)
+- **Cross-platform C++** - always consider cross-platform compatibility when writing C++
+  code (Windows, macOS, Linux, NI Linux RT); avoid platform-specific APIs unless
+  absolutely necessary
 
 ### Common Gotchas
+
 - Console has both Tauri (dev) and Vite-only (dev-vite) development modes
 - Cesium requires careful handling of overlapping time ranges to prevent write conflicts
-- Aspen's eventual consistency means metadata updates may take up to 1 second to propagate
-- Driver components require specific hardware SDKs (LabJack LJM, NI DAQmx) for compilation
+- Aspen's eventual consistency means metadata updates may take up to 1 second to
+  propagate
+- Driver components require specific hardware SDKs (LabJack LJM, NI DAQmx) for
+  compilation
 - Pluto components use worker threads - ensure proper serialization for data passing
 - Integration tests require running Synnax server instances - check for port conflicts
 
 ### Performance Considerations
+
 - Cesium is optimized for columnar reads - structure queries to take advantage of this
 - Pluto uses incremental rendering - avoid full component re-renders on data updates
 - Freighter connection pooling - reuse clients rather than creating new instances
@@ -162,4 +213,5 @@ Node A ←→ Aspen Gossip ←→ Node B (metadata sync)
 - Driver tasks should minimize blocking operations in real-time acquisition loops
 
 ### Code Style Guidelines
+
 - All lines in our codebase are 88 characters

--- a/integration/test/py/framework/utils.py
+++ b/integration/test/py/framework/utils.py
@@ -195,7 +195,7 @@ def get_synnax_version():
     """Get the current Synnax version from the VERSION file."""
     try:
         # Try to read from the VERSION file in the synnax package
-        version_file = "../../../synnax/pkg/version/VERSION"
+        version_file = "../../../core/pkg/version/VERSION"
         with open(version_file, "r") as f:
             version = f.read().strip()
             return version

--- a/scripts/integration/build-macos-latest.sh
+++ b/scripts/integration/build-macos-latest.sh
@@ -19,12 +19,12 @@ bazel build --enable_platform_specific_config -c opt --config=hide_symbols --ann
 
 # Move Driver to Assets
 echo "Moving driver to assets..."
-mkdir -p synnax/pkg/service/hardware/embedded/assets
-cp bazel-bin/driver/driver synnax/pkg/service/hardware/embedded/assets/driver
+mkdir -p core/pkg/service/hardware/embedded/assets
+cp bazel-bin/driver/driver core/pkg/service/hardware/embedded/assets/driver
 
 # Get Version
 echo "Getting version..."
-cd synnax
+cd core
 VERSION=$(cat pkg/version/VERSION)
 echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 echo "Building version: $VERSION"
@@ -32,7 +32,7 @@ cd ..
 
 # Download Go Dependencies
 echo "Downloading Go dependencies..."
-cd synnax
+cd core
 go mod download
 
 # Build Server
@@ -42,10 +42,10 @@ cd ..
 
 # Test Binary Execution
 echo "Testing binary execution..."
-./synnax/synnax-v${VERSION}-macos version || echo "WARNING: Server binary check failed"
+./core/synnax-v${VERSION}-macos version || echo "WARNING: Server binary check failed"
 bazel-bin/driver/driver --help || echo "WARNING: Driver binary check failed"
 
 echo "macOS build completed successfully!"
 echo "Built artifacts:"
 echo "  - Driver: bazel-bin/driver/driver"
-echo "  - Server: synnax/synnax-v${VERSION}-macos"
+echo "  - Server: core/synnax-v${VERSION}-macos"

--- a/scripts/integration/build-ubuntu-22-04.sh
+++ b/scripts/integration/build-ubuntu-22-04.sh
@@ -22,12 +22,12 @@ bazel build --enable_platform_specific_config -c opt --define=platform=nilinuxrt
 
 # Move Driver to Assets
 echo "Moving driver to assets..."
-mkdir -p synnax/pkg/service/hardware/embedded/assets
-cp bazel-bin/driver/driver synnax/pkg/service/hardware/embedded/assets/driver
+mkdir -p core/pkg/service/hardware/embedded/assets
+cp bazel-bin/driver/driver core/pkg/service/hardware/embedded/assets/driver
 
 # Get Version
 echo "Getting version..."
-cd synnax
+cd core
 VERSION=$(cat pkg/version/VERSION)
 echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 echo "Building version: $VERSION"
@@ -43,10 +43,10 @@ cd ..
 
 # Test Binary Execution
 echo "Testing binary execution..."
-./synnax/synnax-v${VERSION}-nilinuxrt version || echo "WARNING: Server binary check failed"
+./core/synnax-v${VERSION}-nilinuxrt version || echo "WARNING: Server binary check failed"
 bazel-bin/driver/driver --help || echo "WARNING: Driver binary check failed"
 
 echo "Ubuntu 22.04 (NI Linux RT) build completed successfully!"
 echo "Built artifacts:"
 echo "  - Driver: bazel-bin/driver/driver"
-echo "  - Server: synnax/synnax-v${VERSION}-nilinuxrt"
+echo "  - Server: core/synnax-v${VERSION}-nilinuxrt"

--- a/scripts/integration/build-ubuntu-latest.sh
+++ b/scripts/integration/build-ubuntu-latest.sh
@@ -28,12 +28,12 @@ bazel build --enable_platform_specific_config -c opt --config=hide_symbols --ann
 
 # Move Driver to Assets
 echo "Moving driver to assets..."
-mkdir -p synnax/pkg/service/hardware/embedded/assets
-cp bazel-bin/driver/driver synnax/pkg/service/hardware/embedded/assets/driver
+mkdir -p core/pkg/service/hardware/embedded/assets
+cp bazel-bin/driver/driver core/pkg/service/hardware/embedded/assets/driver
 
 # Get Version
 echo "Getting version..."
-cd synnax
+cd core
 VERSION=$(cat pkg/version/VERSION)
 echo "VERSION=$VERSION" >> $GITHUB_OUTPUT
 echo "Building version: $VERSION"
@@ -49,10 +49,10 @@ cd ..
 
 # Test Binary Execution
 echo "Testing binary execution..."
-./synnax/synnax-v${VERSION}-linux version || echo "WARNING: Server binary check failed"
+./core/synnax-v${VERSION}-linux version || echo "WARNING: Server binary check failed"
 bazel-bin/driver/driver --help || echo "WARNING: Driver binary check failed"
 
 echo "Ubuntu Latest build completed successfully!"
 echo "Built artifacts:"
 echo "  - Driver: bazel-bin/driver/driver"
-echo "  - Server: synnax/synnax-v${VERSION}-linux"
+echo "  - Server: core/synnax-v${VERSION}-linux"

--- a/scripts/integration/build-windows-latest.cmd
+++ b/scripts/integration/build-windows-latest.cmd
@@ -21,12 +21,12 @@ bazel --output_user_root=C:/tmp build --enable_platform_specific_config -c opt -
 
 rem Move Driver to Assets
 echo Moving driver to assets...
-if not exist synnax\pkg\service\hardware\embedded\assets mkdir synnax\pkg\service\hardware\embedded\assets
-copy bazel-bin\driver\driver.exe synnax\pkg\service\hardware\embedded\assets\driver.exe
+if not exist core\pkg\service\hardware\embedded\assets mkdir core\pkg\service\hardware\embedded\assets
+copy bazel-bin\driver\driver.exe core\pkg\service\hardware\embedded\assets\driver.exe
 
 rem Get Version
 echo 📋 Getting version...
-cd synnax
+cd core
 for /f "tokens=*" %%i in (pkg\version\VERSION) do set VERSION=%%i
 echo VERSION=%VERSION%>> %GITHUB_OUTPUT%
 echo Building version: %VERSION%
@@ -43,10 +43,10 @@ cd ..
 rem Test Binary Execution
 echo Testing binary execution...
 echo Testing binary execution...
-synnax\synnax-v%VERSION%-windows.exe version || echo ⚠️ Server binary check failed
+core\synnax-v%VERSION%-windows.exe version || echo ⚠️ Server binary check failed
 bazel-bin\driver\driver.exe --help || echo ⚠️ Driver binary check failed
 
 echo ✅ Windows Latest build completed successfully!
 echo 📁 Built artifacts:
 echo   - Driver: bazel-bin\driver\driver.exe
-echo   - Server: synnax\synnax-v%VERSION%-windows.exe
+echo   - Server: core\synnax-v%VERSION%-windows.exe


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2906](https://linear.app/synnax/issue/SY-2906/fix-integration-build-scripts)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Fix integration build scripts by renaming `synnax` to `core`.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.
