### PR TITLE
SY-2936: Improve Form Context Handling

### DIFF
--- a/pluto/src/form/Context.spec.tsx
+++ b/pluto/src/form/Context.spec.tsx
@@ -1,0 +1,295 @@
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { type status, TimeStamp } from "@synnaxlabs/x";
+import { render, renderHook } from "@testing-library/react";
+import { type PropsWithChildren, type ReactElement } from "react";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { Form } from "@/form";
+import { useContext } from "@/form/Context";
+
+const mockSchema = z.object({
+  name: z.string().min(1, "Name is required"),
+  age: z.number().min(0, "Age must be positive"),
+});
+
+const mockInitialValues = {
+  name: "John Doe",
+  age: 25,
+};
+
+// Wrapper that provides Form context
+const FormWrapper = ({ children }: PropsWithChildren): ReactElement => {
+  const methods = Form.use({
+    values: mockInitialValues,
+    schema: mockSchema,
+  });
+  return <Form.Form<typeof mockSchema> {...methods}>{children}</Form.Form>;
+};
+
+describe("useContext", () => {
+  describe("error handling when used outside Form context", () => {
+    it("should throw error with default function name when used outside context", () => {
+      expect(() => {
+        renderHook(() => useContext());
+      }).toThrow("useContext must be used within a Form context value");
+    });
+
+    it("should throw error with custom function name when used outside context", () => {
+      expect(() => {
+        renderHook(() => useContext(undefined, "CustomFunction"));
+      }).toThrow("CustomFunction must be used within a Form context value");
+    });
+
+    it("should throw error with Field component name when used outside context", () => {
+      expect(() => {
+        renderHook(() => useContext(undefined, "Field(user.name)"));
+      }).toThrow("Field(user.name) must be used within a Form context value");
+    });
+
+    it("should throw error with useField hook name when used outside context", () => {
+      expect(() => {
+        renderHook(() => useContext(undefined, "useField(user.email)"));
+      }).toThrow("useField(user.email) must be used within a Form context value");
+    });
+
+    it("should throw error with useFieldState hook name when used outside context", () => {
+      expect(() => {
+        renderHook(() => useContext(undefined, "useFieldState(profile.bio)"));
+      }).toThrow("useFieldState(profile.bio) must be used within a Form context value");
+    });
+
+    it("should throw error with useFieldValue hook name when used outside context", () => {
+      expect(() => {
+        renderHook(() => useContext(undefined, "useFieldValue(settings.theme)"));
+      }).toThrow(
+        "useFieldValue(settings.theme) must be used within a Form context value",
+      );
+    });
+  });
+
+  describe("successful context usage", () => {
+    it("should return context value when used within Form context", () => {
+      const { result } = renderHook(() => useContext(), {
+        wrapper: FormWrapper,
+      });
+
+      expect(result.current).toBeDefined();
+      expect(typeof result.current.get).toBe("function");
+      expect(typeof result.current.set).toBe("function");
+      expect(typeof result.current.bind).toBe("function");
+      expect(typeof result.current.validate).toBe("function");
+    });
+
+    it("should return context value with custom function name when used within Form context", () => {
+      const { result } = renderHook(() => useContext(undefined, "CustomFunction"), {
+        wrapper: FormWrapper,
+      });
+
+      expect(result.current).toBeDefined();
+      expect(typeof result.current.get).toBe("function");
+      expect(typeof result.current.set).toBe("function");
+    });
+
+    it("should return override context when provided", () => {
+      const status: status.Status = {
+        key: "test",
+        variant: "success",
+        message: "",
+        description: undefined,
+        time: TimeStamp.now(),
+      };
+      const mockOverride = {
+        mode: "normal" as const,
+        bind: () => () => {},
+        set: () => {},
+        get: () => ({
+          value: "override",
+          status,
+          touched: false,
+          required: false,
+        }),
+        reset: () => {},
+        remove: () => {},
+        value: () => ({}),
+        validate: () => true,
+        validateAsync: async () => true,
+        has: () => true,
+        setStatus: () => {},
+        clearStatuses: () => {},
+        setCurrentStateAsInitialValues: () => {},
+        getStatuses: () => [],
+      };
+
+      const { result } = renderHook(() => useContext(mockOverride, "TestFunction"), {
+        wrapper: FormWrapper,
+      });
+
+      expect(result.current).toBe(mockOverride);
+    });
+  });
+
+  describe("integration with actual Form components", () => {
+    it("should work properly when Field component calls useContext", () => {
+      const TestField = () => {
+        const ctx = useContext(undefined, `Field(name)`);
+        return <div>Field has context: {ctx ? "true" : "false"}</div>;
+      };
+
+      const { result } = renderHook(() => <TestField />, {
+        wrapper: FormWrapper,
+      });
+
+      // Should not throw any errors
+      expect(() => result.current).not.toThrow();
+    });
+
+    it("should work properly when useField hook calls useContext", () => {
+      const TestUseField = () => {
+        const ctx = useContext(undefined, `useField(name)`);
+        return ctx.get("name").value;
+      };
+
+      const { result } = renderHook(() => TestUseField(), {
+        wrapper: FormWrapper,
+      });
+
+      // Should not throw any errors and return the expected value
+      expect(() => result.current).not.toThrow();
+    });
+  });
+
+  describe("error message variations", () => {
+    it("should handle complex path expressions in function names", () => {
+      expect(() => {
+        renderHook(() =>
+          useContext(undefined, "Field(user.profile.settings[0].theme)"),
+        );
+      }).toThrow(
+        "Field(user.profile.settings[0].theme) must be used within a Form context value",
+      );
+    });
+
+    it("should handle function names with special characters", () => {
+      expect(() => {
+        renderHook(() =>
+          useContext(undefined, 'useField(data.items["complex-key"].value)'),
+        );
+      }).toThrow(
+        'useField(data.items["complex-key"].value) must be used within a Form context value',
+      );
+    });
+
+    it("should handle empty function name", () => {
+      expect(() => {
+        renderHook(() => useContext(undefined, ""));
+      }).toThrow(" must be used within a Form context value");
+    });
+
+    it("should handle very long function names", () => {
+      const longFunctionName =
+        "useField(very.long.nested.path.with.many.levels.and.properties.that.goes.on.and.on)";
+      expect(() => {
+        renderHook(() => useContext(undefined, longFunctionName));
+      }).toThrow(`${longFunctionName} must be used within a Form context value`);
+    });
+  });
+
+  describe("type safety", () => {
+    it("should preserve correct typing when context is available", () => {
+      const { result } = renderHook(
+        () => {
+          const ctx = useContext();
+          // These should be type-safe operations
+          const fieldState = ctx.get("name");
+          return {
+            hasGetMethod: typeof ctx.get === "function",
+            hasSetMethod: typeof ctx.set === "function",
+            hasValidateMethod: typeof ctx.validate === "function",
+            fieldValue: fieldState.value,
+          };
+        },
+        {
+          wrapper: FormWrapper,
+        },
+      );
+
+      expect(result.current.hasGetMethod).toBe(true);
+      expect(result.current.hasSetMethod).toBe(true);
+      expect(result.current.hasValidateMethod).toBe(true);
+      expect(result.current.fieldValue).toBe("John Doe");
+    });
+  });
+
+  describe("With field APIS", () => {
+    describe("Field component error messages", () => {
+      it("should throw error with Field path when used outside Form context", () => {
+        expect(() => {
+          render(<Form.Field path="user.name" />);
+        }).toThrow("Field(user.name) must be used within a Form context value");
+      });
+
+      it("should throw error with complex Field path when used outside Form context", () => {
+        expect(() => {
+          render(<Form.Field path="settings.appearance.theme.colors[0]" />);
+        }).toThrow(
+          "Field(settings.appearance.theme.colors[0]) must be used within a Form context value",
+        );
+      });
+    });
+
+    describe("useField hook error messages", () => {
+      it("should throw error with useField path when used outside Form context", () => {
+        expect(() => {
+          renderHook(() => Form.useField("profile.email"));
+        }).toThrow("useField(profile.email) must be used within a Form context value");
+      });
+
+      it("should throw error with complex useField path when used outside Form context", () => {
+        expect(() => {
+          renderHook(() => Form.useField("data.metrics.performance[0].value"));
+        }).toThrow(
+          "useField(data.metrics.performance[0].value) must be used within a Form context value",
+        );
+      });
+    });
+
+    describe("useFieldState hook error messages", () => {
+      it("should throw error with default function name when used outside Form context", () => {
+        expect(() => {
+          renderHook(() => Form.useFieldState("status"));
+        }).toThrow("useContext must be used within a Form context value");
+      });
+    });
+
+    describe("useFieldValue hook error messages", () => {
+      it("should throw error with default function name when used outside Form context", () => {
+        expect(() => {
+          renderHook(() => Form.useFieldValue("count"));
+        }).toThrow("useContext must be used within a Form context value");
+      });
+    });
+
+    describe("other form hooks error messages", () => {
+      it("should throw error for useContext in Form.useFieldList", () => {
+        expect(() => {
+          renderHook(() => Form.useFieldList("items"));
+        }).toThrow("useContext must be used within a Form context value");
+      });
+
+      it("should throw error for useContext in Form.useFieldListUtils", () => {
+        expect(() => {
+          renderHook(() => Form.useFieldListUtils("tags"));
+        }).toThrow("useContext must be used within a Form context value");
+      });
+    });
+  });
+});

--- a/pluto/src/form/Context.spec.tsx
+++ b/pluto/src/form/Context.spec.tsx
@@ -266,7 +266,7 @@ describe("useContext", () => {
       it("should throw error with default function name when used outside Form context", () => {
         expect(() => {
           renderHook(() => Form.useFieldState("status"));
-        }).toThrow("useContext must be used within a Form context value");
+        }).toThrow("Form.useContext must be used within a Form context value");
       });
     });
 
@@ -274,7 +274,7 @@ describe("useContext", () => {
       it("should throw error with default function name when used outside Form context", () => {
         expect(() => {
           renderHook(() => Form.useFieldValue("count"));
-        }).toThrow("useContext must be used within a Form context value");
+        }).toThrow("Form.useContext must be used within a Form context value");
       });
     });
 
@@ -282,13 +282,13 @@ describe("useContext", () => {
       it("should throw error for useContext in Form.useFieldList", () => {
         expect(() => {
           renderHook(() => Form.useFieldList("items"));
-        }).toThrow("useContext must be used within a Form context value");
+        }).toThrow("Form.useContext must be used within a Form context value");
       });
 
       it("should throw error for useContext in Form.useFieldListUtils", () => {
         expect(() => {
           renderHook(() => Form.useFieldListUtils("tags"));
-        }).toThrow("useContext must be used within a Form context value");
+        }).toThrow("Form.useContext must be used within a Form context value");
       });
     });
   });

--- a/pluto/src/form/Context.ts
+++ b/pluto/src/form/Context.ts
@@ -11,7 +11,7 @@ import { type Destructor, type status } from "@synnaxlabs/x";
 import { createContext, use } from "react";
 import { type z } from "zod";
 
-import { type FieldState, type State } from "@/form/state";
+import { type State } from "@/form/state";
 
 export interface RemoveFunc {
   (path: string): void;
@@ -52,31 +52,14 @@ export interface ContextValue<Z extends z.ZodType = z.ZodType> {
   getStatuses: () => status.Crude[];
 }
 
-export const Context = createContext<ContextValue>({
-  mode: "normal",
-  bind: () => () => {},
-  set: () => {},
-  reset: () => {},
-  remove: () => {},
-  get: <V = unknown>(): FieldState<V> => ({
-    value: undefined as V,
-    status: { key: "", variant: "success", message: "" },
-    touched: false,
-    required: false,
-  }),
-  validate: () => false,
-  validateAsync: () => Promise.resolve(false),
-  value: () => ({}),
-  has: () => false,
-  setStatus: () => {},
-  clearStatuses: () => {},
-  setCurrentStateAsInitialValues: () => {},
-  getStatuses: () => [],
-});
+export const Context = createContext<ContextValue | null>(null);
 
 export const useContext = <Z extends z.ZodType = z.ZodType>(
   override?: ContextValue<Z>,
+  funcName: string = "useContext",
 ): ContextValue<Z> => {
   const internal = use(Context);
+  if (internal == null)
+    throw new Error(`${funcName} must be used within a Form context value`);
   return override ?? (internal as unknown as ContextValue<Z>);
 };

--- a/pluto/src/form/Context.ts
+++ b/pluto/src/form/Context.ts
@@ -56,7 +56,7 @@ export const Context = createContext<ContextValue | null>(null);
 
 export const useContext = <Z extends z.ZodType = z.ZodType>(
   override?: ContextValue<Z>,
-  funcName: string = "useContext",
+  funcName: string = "Form.useContext",
 ): ContextValue<Z> => {
   const internal = use(Context);
   if (internal == null)

--- a/pluto/src/form/Field.tsx
+++ b/pluto/src/form/Field.tsx
@@ -54,7 +54,7 @@ export const Field = <I = string | number, O = I>({
     onChange,
     defaultValue,
   });
-  const ctx = useContext();
+  const ctx = useContext(undefined, `Field(${path})`);
   if (field == null) return null;
   if (path == null) throw new Error("No path provided to Form Field");
   label ??= caseconv.capitalize(deep.element(path, -1));

--- a/pluto/src/form/useField.ts
+++ b/pluto/src/form/useField.ts
@@ -78,8 +78,8 @@ export const useField = (<I, O = I>(
   opts: UseFieldOptions<I, O> & GetOptions<I> = {},
 ): UseFieldReturn<I, O> | null => {
   const { optional = false, onChange, defaultValue } = opts;
-  const ctx = useContext(opts?.ctx);
-  const { get: getState, bind, set, setStatus } = ctx;
+  const ctx = useContext(opts?.ctx, `useField(${path})`);
+  const { get, bind, set, setStatus } = ctx;
 
   const handleChange = useCallback(
     (value: O) => {
@@ -96,8 +96,8 @@ export const useField = (<I, O = I>(
   const state = useSyncExternalStore(
     bind,
     useCallback(
-      () => getState<I>(path, { optional, defaultValue }),
-      [path, getState, optional, defaultValue],
+      () => get<I>(path, { optional, defaultValue }),
+      [path, get, optional, defaultValue],
     ),
   );
   if (state == null) {

--- a/pluto/src/hooks/useRequiredContext.spec.tsx
+++ b/pluto/src/hooks/useRequiredContext.spec.tsx
@@ -1,0 +1,255 @@
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { NotFoundError } from "@synnaxlabs/client";
+import { renderHook } from "@testing-library/react";
+import { createContext } from "react";
+import { describe, expect, it } from "vitest";
+
+import { useRequiredContext } from "@/hooks/useRequiredContext";
+
+interface TestContextValue {
+  value: string;
+  count: number;
+}
+
+describe("useRequiredContext", () => {
+  it("should return the context value when it is not null", () => {
+    const TestContext = createContext<TestContextValue | null>({
+      value: "test",
+      count: 42,
+    });
+    TestContext.displayName = "TestContext";
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <TestContext.Provider value={{ value: "test", count: 42 }}>
+        {children}
+      </TestContext.Provider>
+    );
+
+    const { result } = renderHook(() => useRequiredContext(TestContext), {
+      wrapper,
+    });
+
+    expect(result.current).toEqual({ value: "test", count: 42 });
+    expect(result.current.value).toBe("test");
+    expect(result.current.count).toBe(42);
+  });
+
+  it("should throw NotFoundError when context value is null", () => {
+    const TestContext = createContext<TestContextValue | null>(null);
+    TestContext.displayName = "TestContext";
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <TestContext.Provider value={null}>{children}</TestContext.Provider>
+    );
+
+    expect(() =>
+      renderHook(() => useRequiredContext(TestContext), { wrapper }),
+    ).toThrow(NotFoundError);
+
+    expect(() =>
+      renderHook(() => useRequiredContext(TestContext), { wrapper }),
+    ).toThrow("useRequiredContext: context value is null for TestContext");
+  });
+
+  it("should throw NotFoundError when context value is undefined", () => {
+    const TestContext = createContext<TestContextValue | null>(null);
+    TestContext.displayName = "UndefinedTestContext";
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <TestContext.Provider value={undefined as any}>{children}</TestContext.Provider>
+    );
+
+    expect(() =>
+      renderHook(() => useRequiredContext(TestContext), { wrapper }),
+    ).toThrow(NotFoundError);
+
+    expect(() =>
+      renderHook(() => useRequiredContext(TestContext), { wrapper }),
+    ).toThrow("useRequiredContext: context value is null for UndefinedTestContext");
+  });
+
+  it("should throw when used outside of a provider", () => {
+    const TestContext = createContext<TestContextValue | null>(null);
+    TestContext.displayName = "NoProviderContext";
+
+    expect(() => renderHook(() => useRequiredContext(TestContext))).toThrow(
+      NotFoundError,
+    );
+
+    expect(() => renderHook(() => useRequiredContext(TestContext))).toThrow(
+      "useRequiredContext: context value is null for NoProviderContext",
+    );
+  });
+
+  it("should work with primitive context values", () => {
+    const StringContext = createContext<string | null>("default");
+    StringContext.displayName = "StringContext";
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <StringContext.Provider value="test string">{children}</StringContext.Provider>
+    );
+
+    const { result } = renderHook(() => useRequiredContext(StringContext), {
+      wrapper,
+    });
+
+    expect(result.current).toBe("test string");
+  });
+
+  it("should work with number context values including zero", () => {
+    const NumberContext = createContext<number | null>(null);
+    NumberContext.displayName = "NumberContext";
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <NumberContext.Provider value={0}>{children}</NumberContext.Provider>
+    );
+
+    const { result } = renderHook(() => useRequiredContext(NumberContext), {
+      wrapper,
+    });
+
+    expect(result.current).toBe(0);
+  });
+
+  it("should work with boolean false values", () => {
+    const BooleanContext = createContext<boolean | null>(null);
+    BooleanContext.displayName = "BooleanContext";
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <BooleanContext.Provider value={false}>{children}</BooleanContext.Provider>
+    );
+
+    const { result } = renderHook(() => useRequiredContext(BooleanContext), {
+      wrapper,
+    });
+
+    expect(result.current).toBe(false);
+  });
+
+  it("should work with empty string values", () => {
+    const EmptyStringContext = createContext<string | null>(null);
+    EmptyStringContext.displayName = "EmptyStringContext";
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <EmptyStringContext.Provider value="">{children}</EmptyStringContext.Provider>
+    );
+
+    const { result } = renderHook(() => useRequiredContext(EmptyStringContext), {
+      wrapper,
+    });
+
+    expect(result.current).toBe("");
+  });
+
+  it("should work with array context values", () => {
+    const ArrayContext = createContext<number[] | null>(null);
+    ArrayContext.displayName = "ArrayContext";
+
+    const testArray = [1, 2, 3];
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <ArrayContext.Provider value={testArray}>{children}</ArrayContext.Provider>
+    );
+
+    const { result } = renderHook(() => useRequiredContext(ArrayContext), {
+      wrapper,
+    });
+
+    expect(result.current).toEqual([1, 2, 3]);
+    expect(result.current).toBe(testArray);
+  });
+
+  it("should work with empty array values", () => {
+    const EmptyArrayContext = createContext<any[] | null>(null);
+    EmptyArrayContext.displayName = "EmptyArrayContext";
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <EmptyArrayContext.Provider value={[]}>{children}</EmptyArrayContext.Provider>
+    );
+
+    const { result } = renderHook(() => useRequiredContext(EmptyArrayContext), {
+      wrapper,
+    });
+
+    expect(result.current).toEqual([]);
+  });
+
+  it("should handle context without displayName", () => {
+    const NoNameContext = createContext<string | null>(null);
+
+    expect(() => renderHook(() => useRequiredContext(NoNameContext))).toThrow(
+      "useRequiredContext: context value is null for undefined",
+    );
+  });
+
+  it("should update when context value changes", () => {
+    const DynamicContext = createContext<number | null>(null);
+    DynamicContext.displayName = "DynamicContext";
+
+    let value = 1;
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <DynamicContext.Provider value={value}>{children}</DynamicContext.Provider>
+    );
+
+    const { result, rerender } = renderHook(() => useRequiredContext(DynamicContext), {
+      wrapper,
+    });
+
+    expect(result.current).toBe(1);
+
+    value = 2;
+    rerender();
+
+    expect(result.current).toBe(2);
+  });
+
+  it("should work with nested context providers", () => {
+    const OuterContext = createContext<string | null>(null);
+    const InnerContext = createContext<number | null>(null);
+    OuterContext.displayName = "OuterContext";
+    InnerContext.displayName = "InnerContext";
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <OuterContext.Provider value="outer">
+        <InnerContext.Provider value={42}>{children}</InnerContext.Provider>
+      </OuterContext.Provider>
+    );
+
+    const { result } = renderHook(
+      () => ({
+        outer: useRequiredContext(OuterContext),
+        inner: useRequiredContext(InnerContext),
+      }),
+      { wrapper },
+    );
+
+    expect(result.current.outer).toBe("outer");
+    expect(result.current.inner).toBe(42);
+  });
+
+  it("should properly type the return value as NonNullable", () => {
+    const TypedContext = createContext<{ optional?: string } | null>(null);
+    TypedContext.displayName = "TypedContext";
+
+    const wrapper = ({ children }: { children: React.ReactNode }) => (
+      <TypedContext.Provider value={{ optional: "value" }}>
+        {children}
+      </TypedContext.Provider>
+    );
+
+    const { result } = renderHook(() => useRequiredContext(TypedContext), {
+      wrapper,
+    });
+
+    type ResultType = typeof result.current;
+    const _typeCheck: ResultType = { optional: "test" };
+    expect(result.current.optional).toBe("value");
+  });
+});

--- a/pluto/src/hooks/useRequiredContext.ts
+++ b/pluto/src/hooks/useRequiredContext.ts
@@ -15,6 +15,8 @@ export const useRequiredContext = <T>(
 ): NonNullable<T> => {
   const value = use(context);
   if (value == null)
-    throw new NotFoundError(`useRequiredContext: context value is null`);
+    throw new NotFoundError(
+      `useRequiredContext: context value is null for ${context.displayName}`,
+    );
   return value;
 };


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2936](https://linear.app/synnax/issue/SY-2936/fix-form-context)

## Description

Makes it so that calls to `Form.useContext()` no longer return a zero value and instead now throw an error. Also added tests that error messages are actually good.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.
