### PR TITLE
SY-2947: Add Primitive Zero Handling Check to Flux List Get Item

### DIFF
--- a/pluto/src/flux/list.ts
+++ b/pluto/src/flux/list.ts
@@ -556,9 +556,15 @@ export const createList =
 
     const getItem = useCallback(
       ((key?: K | K[]) => {
-        if (key == null) return undefined;
         if (Array.isArray(key))
           return key.map((k) => getItem(k)).filter((v) => v != null);
+        // Zero-value keys that are not null or undefined are common as
+        // initialized fields in various data structures ("", 0, etc.).
+        // A 'zero-value' is never valid as a key in Synnax, and a simple
+        // null check would result in excessive server refetches for
+        // keys we already know are invalid, so we do a full check
+        // for a zero-value instead.
+        if (primitive.isZero(key)) return undefined;
         const res = dataRef.current.get(key);
         if (res === undefined) retrieveSingle(key);
         return res;

--- a/pluto/src/form/Context.spec.tsx
+++ b/pluto/src/form/Context.spec.tsx
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { type status, TimeStamp } from "@synnaxlabs/x";
+import { TimeStamp } from "@synnaxlabs/x";
 import { render, renderHook } from "@testing-library/react";
 import { type PropsWithChildren, type ReactElement } from "react";
 import { describe, expect, it } from "vitest";
@@ -154,13 +154,6 @@ describe("useContext", () => {
     });
 
     it("should return override context when provided", () => {
-      const status: status.Status = {
-        key: "test",
-        variant: "success",
-        message: "",
-        description: undefined,
-        time: TimeStamp.now(),
-      };
       const { result } = renderHook(() => useContext(mockOverride, "TestFunction"), {
         wrapper: FormWrapper,
       });


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2947](https://linear.app/synnax/issue/SY-2947/flux-make-it-so-that-key-based-retrieves-do-not-retrieve-on-zero)

## Description

See comment on non-test diff for explanation of this change.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.
