### PR TITLE
SY-2949 - Hotfix Schematic Undo/Redo

### DIFF
--- a/console/package.json
+++ b/console/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@synnaxlabs/console",
   "private": true,
-  "version": "0.45.1",
+  "version": "0.45.2",
   "type": "module",
   "scripts": {
     "check-types": "tsc --noEmit",

--- a/console/src/schematic/slice.ts
+++ b/console/src/schematic/slice.ts
@@ -44,6 +44,7 @@ export const purgeState = (state: State): State => {
   // Reset control states.
   state.control = "released";
   state.controlAcquireTrigger = 0;
+  state.toolbar = { ...state.toolbar, activeTab: "symbols" };
   return state;
 };
 
@@ -264,7 +265,6 @@ export const { actions, reducer } = createSlice({
         clearSelections(schematic);
       }
       state.schematics[layoutKey] = schematic;
-      state.schematics[layoutKey].toolbar.activeTab = "symbols";
     },
     clearSelection: (state, { payload }: PayloadAction<ClearSelectionPayload>) => {
       const { key: layoutKey } = payload;


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2949](https://linear.app/synnax/issue/SY-2949/hotfix-schematic-undoredo)

## Description

Schematic undo and redo were broken due to a readonly assigment. This problem is now fixed.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.
