### PR TITLE
SY-2952: Log Warning instead of returning error

### DIFF
--- a/driver/labjack/factory.cpp
+++ b/driver/labjack/factory.cpp
@@ -35,7 +35,13 @@ common::ConfigureResult configure_read(
     }
     auto [dev, d_err] = devs->acquire(cfg.device_key);
     if (d_err) {
-        result.error = d_err;
+        LOG(WARNING) << "[labjack] failed to acquire device " << cfg.device_key
+                     << " for read task " << task.name << ": " << d_err.message();
+        ctx->set_status({
+            .variant = status::variant::WARNING,
+            .message = "Device disconnected: " + d_err.message(),
+            .details = synnax::TaskStatusDetails{.task = task.key}
+        });
         return result;
     }
     std::unique_ptr<common::Source> source;
@@ -66,7 +72,13 @@ common::ConfigureResult configure_write(
     }
     auto [dev, d_err] = devs->acquire(cfg.device_key);
     if (d_err) {
-        result.error = d_err;
+        LOG(WARNING) << "[labjack] failed to acquire device " << cfg.device_key
+                     << " for write task " << task.name << ": " << d_err.message();
+        ctx->set_status({
+            .variant = status::variant::WARNING,
+            .message = "Device disconnected: " + d_err.message(),
+            .details = synnax::TaskStatusDetails{.task = task.key}
+        });
         return result;
     }
     result.auto_start = cfg.auto_start;


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue
[SY-2952](https://linear.app/synnax/issue/SY-2952/labjack-device-search-bug)

## Description
Log warning for Labjack Factory when a task exists, but the device acquisition for that task fails. Do not return error.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [ ] ~I have added relevant tests to cover the changes to CI.~
- [ ] ~I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.~
- [x] I have updated in-code documentation to reflect the changes.
- [ ] ~I have updated user-facing documentation to reflect the changes.~
