### PR TITLE
SY-2954: Api/Freighter - Skip Logging of Certain Websocket Close Errors and context.Canceled Errors

### DIFF
--- a/freighter/go/fhttp/stream.go
+++ b/freighter/go/fhttp/stream.go
@@ -401,7 +401,10 @@ func (s *streamServer[RQ, RS]) handleSocket(
 			return oCtx, s.handler(ctx, stream)
 		}),
 	)
-	if err := stream.close(handlerErr); err != nil {
+	// ErrCloseSent is returned when the client abruptly closes the connection,
+	// which happens when performing tasks like reloading web pages. As such,
+	// we don't consider it anomalous and don't log it.
+	if err := errors.Skip(stream.close(handlerErr), ws.ErrCloseSent); err != nil {
 		s.L.Error("error closing connection", zap.Error(err))
 	}
 }


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2954](https://linear.app/synnax/issue/SY-2954/skip-logging-of-certain-websocket-close-errors)

## Description

Reduces useless API/transport logging that hides actual issues and causes unnecessary concerns with customers.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.
