### PR TITLE
SY-2881: Fix Renaming Channels in Tasks

### DIFF
--- a/console/src/hardware/common/task/layouts/ChannelList.tsx
+++ b/console/src/hardware/common/task/layouts/ChannelList.tsx
@@ -62,7 +62,7 @@ const EmptyContent = ({ onAdd }: EmptyContentProps) => {
 export interface ChannelListProps<C extends Channel>
   extends Omit<
     CoreProps<C>,
-    "data" | "header" | "emptyContent" | "path" | "remove" | "useListItem" | "value"
+    "data" | "header" | "emptyContent" | "path" | "remove" | "onDuplicate"
   > {
   createChannel: (channels: C[]) => C | null;
   createChannels?: (channels: C[], keys: string[]) => C[];
@@ -72,13 +72,12 @@ export interface ChannelListProps<C extends Channel>
 export const ChannelList = <C extends Channel>({
   createChannel,
   createChannels,
-  onSelect,
   path = "config.channels",
-  listItem,
-  selected,
+  ...rest
 }: ChannelListProps<C>) => {
   const ctx = Form.useContext();
   const { data, push, remove } = Form.useFieldList<C["key"], C>(path);
+  const { onSelect } = rest;
   const handleAdd = useCallback(() => {
     const channels = ctx.get<C[]>(path).value;
     const channel = createChannel(channels);
@@ -97,15 +96,13 @@ export const ChannelList = <C extends Channel>({
   );
   return (
     <Core
+      {...rest}
+      data={data}
       header={<Header onAdd={handleAdd} />}
       emptyContent={<EmptyContent onAdd={handleAdd} />}
       path={path}
-      onSelect={onSelect}
-      onDuplicate={handleDuplicate}
-      data={data}
-      listItem={listItem}
-      selected={selected}
       remove={remove}
+      onDuplicate={handleDuplicate}
     />
   );
 };

--- a/console/src/hardware/ni/task/DigitalChannelList.tsx
+++ b/console/src/hardware/ni/task/DigitalChannelList.tsx
@@ -18,8 +18,12 @@ import { type DigitalChannel } from "@/hardware/ni/task/types";
 
 interface ListItemProps<C extends DigitalChannel>
   extends Omit<Common.Task.ChannelListItemProps, "name"> {
-  name: Component.RenderProp<C>;
+  name: Component.RenderProp<DigitalNameComponentProps<C>>;
 }
+
+export type DigitalNameComponentProps<C extends DigitalChannel> = Omit<C, "key"> & {
+  itemKey: string;
+};
 
 const ListItem = <C extends DigitalChannel>({ name, ...rest }: ListItemProps<C>) => {
   const path = `config.channels.${rest.itemKey}`;
@@ -62,7 +66,7 @@ const ListItem = <C extends DigitalChannel>({ name, ...rest }: ListItemProps<C>)
         </Text.Text>
       </Flex.Box>
       <Flex.Box x align="center" justify="evenly">
-        {name(channel)}
+        {name({ ...channel, itemKey: rest.itemKey })}
         <Common.Task.EnableDisableButton path={`${path}.enabled`} />
       </Flex.Box>
     </Select.ListItem>

--- a/console/src/hardware/ni/task/DigitalRead.tsx
+++ b/console/src/hardware/ni/task/DigitalRead.tsx
@@ -15,7 +15,10 @@ import { type FC } from "react";
 import { Common } from "@/hardware/common";
 import { Device } from "@/hardware/ni/device";
 import { createDIChannel } from "@/hardware/ni/task/createChannel";
-import { DigitalChannelList } from "@/hardware/ni/task/DigitalChannelList";
+import {
+  DigitalChannelList,
+  type DigitalNameComponentProps,
+} from "@/hardware/ni/task/DigitalChannelList";
 import { getDigitalChannelDeviceKey } from "@/hardware/ni/task/getDigitalChannelDeviceKey";
 import {
   type DIChannel,
@@ -54,10 +57,12 @@ const Properties = () => (
   </>
 );
 
-const NameComponent = ({ channel, key }: DIChannel) => (
+interface NameComponentProps extends DigitalNameComponentProps<DIChannel> {}
+
+const NameComponent = ({ channel, itemKey }: NameComponentProps) => (
   <Common.Task.ChannelName
     channel={channel}
-    id={Common.Task.getChannelNameID(key)}
+    id={Common.Task.getChannelNameID(itemKey)}
     level="p"
   />
 );

--- a/console/src/hardware/ni/task/DigitalWrite.tsx
+++ b/console/src/hardware/ni/task/DigitalWrite.tsx
@@ -58,12 +58,8 @@ const Properties = () => (
 
 interface NameComponentProps extends DigitalNameComponentProps<DOChannel> {}
 
-const NameComponent = ({ cmdChannel, itemKey, stateChannel }: NameComponentProps) => (
-  <Common.Task.WriteChannelNames
-    cmdChannel={cmdChannel}
-    stateChannel={stateChannel}
-    itemKey={itemKey}
-  />
+const NameComponent = (props: NameComponentProps) => (
+  <Common.Task.WriteChannelNames {...props} />
 );
 
 const name = Component.renderProp(NameComponent);

--- a/console/src/hardware/ni/task/DigitalWrite.tsx
+++ b/console/src/hardware/ni/task/DigitalWrite.tsx
@@ -15,7 +15,10 @@ import { type FC } from "react";
 import { Common } from "@/hardware/common";
 import { Device } from "@/hardware/ni/device";
 import { createDOChannel } from "@/hardware/ni/task/createChannel";
-import { DigitalChannelList } from "@/hardware/ni/task/DigitalChannelList";
+import {
+  DigitalChannelList,
+  type DigitalNameComponentProps,
+} from "@/hardware/ni/task/DigitalChannelList";
 import { getDigitalChannelDeviceKey } from "@/hardware/ni/task/getDigitalChannelDeviceKey";
 import {
   DIGITAL_WRITE_SCHEMAS,
@@ -53,11 +56,13 @@ const Properties = () => (
   </>
 );
 
-const NameComponent = ({ cmdChannel, key, stateChannel }: DOChannel) => (
+interface NameComponentProps extends DigitalNameComponentProps<DOChannel> {}
+
+const NameComponent = ({ cmdChannel, itemKey, stateChannel }: NameComponentProps) => (
   <Common.Task.WriteChannelNames
     cmdChannel={cmdChannel}
     stateChannel={stateChannel}
-    itemKey={key}
+    itemKey={itemKey}
   />
 );
 

--- a/pluto/src/hardware/rack/Select.tsx
+++ b/pluto/src/hardware/rack/Select.tsx
@@ -22,10 +22,7 @@ import { Select } from "@/select";
 import { Text } from "@/text";
 
 export interface SelectSingleProps
-  extends Omit<
-      Select.SingleFrameProps<rack.Key, rack.Payload | undefined>,
-      "data" | "useListItem"
-    >,
+  extends Omit<Select.SingleFrameProps<rack.Key, rack.Payload | undefined>, "data">,
     Flux.UseListArgs<ListParams, rack.Key, rack.Payload>,
     Omit<Dialog.FrameProps, "onChange">,
     Pick<Select.DialogProps<rack.Key>, "emptyContent"> {}

--- a/pluto/src/label/Select.tsx
+++ b/pluto/src/label/Select.tsx
@@ -110,7 +110,7 @@ export const SelectMultiple = ({
 export interface SelectSingleProps
   extends Omit<
       Select.SingleProps<label.Key, label.Label | undefined>,
-      "data" | "useListItem" | "resourceName" | "subscribe" | "children"
+      "data" | "resourceName" | "subscribe" | "children"
     >,
     Flux.UseListArgs<ListParams, label.Key, label.Label> {}
 

--- a/pluto/src/text/Editable.tsx
+++ b/pluto/src/text/Editable.tsx
@@ -19,7 +19,7 @@ import {
   useState,
 } from "react";
 
-import { CSS } from "@/css";
+import { CSS as PCSS } from "@/css";
 import { useCombinedRefs, useSyncedRef } from "@/hooks";
 import { type Input } from "@/input";
 import { type state } from "@/state";
@@ -35,13 +35,11 @@ export type EditableProps = Omit<TextProps<"p">, "children" | "onChange"> &
   };
 
 const NOMINAL_EXIT_KEYS = ["Escape", "Enter"];
-const BASE_CLASS = CSS.BM("text", "editable");
+const BASE_CLASS = PCSS.BM("text", "editable");
 const MAX_EDIT_RETRIES = 10;
 const RENAMED_EVENT_NAME = "renamed";
 const ESCAPED_EVENT_NAME = "escaped";
 const START_EDITING_EVENT_NAME = "start-editing";
-
-const escapeCharacters = (id: string): string => id.replace(/:/g, "\\:");
 
 export const edit = (
   id: string,
@@ -50,7 +48,7 @@ export const edit = (
   let currRetry = 0;
   const tryEdit = (): void => {
     currRetry++;
-    const el = document.querySelector(`#${escapeCharacters(id)}.${BASE_CLASS}`);
+    const el = document.querySelector(`#${CSS.escape(id)}.${BASE_CLASS}`);
     if (el == null || !el.classList.contains(BASE_CLASS)) {
       if (currRetry < MAX_EDIT_RETRIES) setTimeout(() => tryEdit(), 100);
       else throw new Error(`Could not find element with id ${id}`);
@@ -190,10 +188,10 @@ export const Editable = ({
   return (
     <Text
       ref={combinedRef}
-      className={CSS(
+      className={PCSS(
         className,
-        CSS.BM("text", "editable"),
-        outline && CSS.M("outline"),
+        PCSS.BM("text", "editable"),
+        outline && PCSS.M("outline"),
       )}
       onBlur={() => {
         setEditable(false);


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2881](https://linear.app/synnax/issue/SY-2881/cannot-rename-opc-ua-server-channel)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

1. Fix the `Layouts.ChannelList` component to properly pass props into child components.
2. Use browser-implemented `CSS.escape` instead of custom `escapeCharacters` function in `Text.Editable`.
3. Stop passing key into the name components for NI Digital tasks and instead use itemKey.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.
