### PR TITLE
SY-2967: Fix Task Key Generation Race

### DIFF
--- a/core/pkg/service/hardware/rack/rack_test.go
+++ b/core/pkg/service/hardware/rack/rack_test.go
@@ -125,7 +125,7 @@ var _ = Describe("Rack", Ordered, func() {
 			Expect(w.Create(ctx, r)).To(Succeed())
 			t1 := MustSucceed(svc.NewWriter(nil).NewTaskKey(ctx, r.Key))
 			t2 := MustSucceed(svc.NewWriter(nil).NewTaskKey(ctx, r.Key))
-			Expect(t2 - t1).To(Equal(uint32(1)))
+			Expect(t2 - t1).To(BeEquivalentTo(1))
 		})
 
 		It("Should return sequential keys even when racing", func() {
@@ -150,7 +150,7 @@ var _ = Describe("Rack", Ordered, func() {
 				if i == 0 {
 					continue
 				}
-				Expect(keys[i] - keys[i-1]).To(Equal(uint32(1)))
+				Expect(keys[i] - keys[i-1]).To(BeEquivalentTo(1))
 			}
 
 		})

--- a/core/pkg/service/hardware/rack/rack_test.go
+++ b/core/pkg/service/hardware/rack/rack_test.go
@@ -10,6 +10,9 @@
 package rack_test
 
 import (
+	"slices"
+	"sync"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/synnaxlabs/synnax/pkg/distribution/cluster"
@@ -112,6 +115,44 @@ var _ = Describe("Rack", Ordered, func() {
 			var embeddedRack rack.Rack
 			Expect(svc.NewRetrieve().WhereKeys(svc.EmbeddedKey).Entry(&embeddedRack).Exec(ctx, tx)).To(Succeed())
 			Expect(embeddedRack.Embedded).To(BeTrue())
+		})
+	})
+
+	Describe("NewTaskKey", func() {
+		It("Should correctly return sequential keys", func() {
+			r := &rack.Rack{Name: "niceRack"}
+			w := svc.NewWriter(nil)
+			Expect(w.Create(ctx, r)).To(Succeed())
+			t1 := MustSucceed(svc.NewWriter(nil).NewTaskKey(ctx, r.Key))
+			t2 := MustSucceed(svc.NewWriter(nil).NewTaskKey(ctx, r.Key))
+			Expect(t2 - t1).To(Equal(uint32(1)))
+		})
+
+		It("Should return sequential keys even when racing", func() {
+			var (
+				r     = &rack.Rack{Name: "niceRack"}
+				w     = svc.NewWriter(nil)
+				count = 100
+				keys  = make([]uint32, count)
+				wg    sync.WaitGroup
+			)
+			Expect(w.Create(ctx, r)).To(Succeed())
+
+			for i := range count {
+				wg.Go(func() {
+					keys[i] = MustSucceed(svc.NewWriter(nil).NewTaskKey(ctx, r.Key))
+				})
+			}
+			wg.Wait()
+
+			slices.Sort(keys)
+			for i := range keys {
+				if i == 0 {
+					continue
+				}
+				Expect(keys[i] - keys[i-1]).To(Equal(uint32(1)))
+			}
+
 		})
 	})
 })

--- a/core/pkg/service/hardware/task/task_test.go
+++ b/core/pkg/service/hardware/task/task_test.go
@@ -85,14 +85,14 @@ var _ = Describe("Task", Ordered, func() {
 				Name: "Test Task",
 			}
 			Expect(w.Create(ctx, m)).To(Succeed())
-			Expect(m.Key).To(Equal(task.NewKey(rack_.Key, 1)))
+			Expect(m.Key).To(Equal(task.NewKey(rack_.Key, 2)))
 			Expect(m.Name).To(Equal("Test Task"))
 			m = &task.Task{
 				Key:  task.NewKey(rack_.Key, 0),
 				Name: "Test Task",
 			}
 			Expect(w.Create(ctx, m)).To(Succeed())
-			Expect(m.Key).To(Equal(task.NewKey(rack_.Key, 2)))
+			Expect(m.Key).To(Equal(task.NewKey(rack_.Key, 3)))
 			Expect(m.Name).To(Equal("Test Task"))
 		})
 	})
@@ -105,11 +105,11 @@ var _ = Describe("Task", Ordered, func() {
 				Name: "Test Task",
 			}
 			Expect(w.Create(ctx, m)).To(Succeed())
-			Expect(m.Key).To(Equal(task.NewKey(rack_.Key, 1)))
+			Expect(m.Key).To(Equal(task.NewKey(rack_.Key, 4)))
 			Expect(m.Name).To(Equal("Test Task"))
 			t, err := w.Copy(ctx, m.Key, "Copied Task", false)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(t.Key).To(Equal(task.NewKey(rack_.Key, 2)))
+			Expect(t.Key).To(Equal(task.NewKey(rack_.Key, 5)))
 		})
 
 		It("Should create a snapshot of an existing task", func() {
@@ -118,11 +118,11 @@ var _ = Describe("Task", Ordered, func() {
 				Name: "Test Task",
 			}
 			Expect(w.Create(ctx, m)).To(Succeed())
-			Expect(m.Key).To(Equal(task.NewKey(rack_.Key, 1)))
+			Expect(m.Key).To(Equal(task.NewKey(rack_.Key, 6)))
 			Expect(m.Name).To(Equal("Test Task"))
 			t, err := w.Copy(ctx, m.Key, "Snapshotted Task", true)
 			Expect(err).ToNot(HaveOccurred())
-			Expect(t.Key).To(Equal(task.NewKey(rack_.Key, 2)))
+			Expect(t.Key).To(Equal(task.NewKey(rack_.Key, 7)))
 			Expect(t.Snapshot).To(BeTrue())
 		})
 
@@ -135,7 +135,7 @@ var _ = Describe("Task", Ordered, func() {
 				Name: "Test Task",
 			}
 			Expect(w.Create(ctx, m)).To(Succeed())
-			Expect(m.Key).To(Equal(task.NewKey(rack_.Key, 1)))
+			Expect(m.Key).To(Equal(task.NewKey(rack_.Key, 8)))
 			Expect(m.Name).To(Equal("Test Task"))
 			var res task.Task
 			Expect(svc.NewRetrieve().WhereKeys(m.Key).Entry(&res).Exec(ctx, tx)).To(Succeed())
@@ -150,7 +150,7 @@ var _ = Describe("Task", Ordered, func() {
 				Name: "Test Task",
 			}
 			Expect(w.Create(ctx, m)).To(Succeed())
-			Expect(m.Key).To(Equal(task.NewKey(rack_.Key, 1)))
+			Expect(m.Key).To(Equal(task.NewKey(rack_.Key, 9)))
 			Expect(m.Name).To(Equal("Test Task"))
 			Expect(w.Delete(ctx, m.Key, false)).To(Succeed())
 			Expect(svc.NewRetrieve().WhereKeys(m.Key).Exec(ctx, tx)).To(MatchError(query.NotFound))

--- a/core/pkg/service/hardware/task/writer.go
+++ b/core/pkg/service/hardware/task/writer.go
@@ -11,6 +11,7 @@ package task
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/synnaxlabs/synnax/pkg/distribution/group"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
@@ -27,7 +28,7 @@ type Writer struct {
 
 func (w Writer) Create(ctx context.Context, t *Task) (err error) {
 	if !t.Key.IsValid() {
-		localKey, err := w.rack.NextTaskKey(ctx, t.Rack())
+		localKey, err := w.rack.NewTaskKey(ctx, t.Rack())
 		if err != nil {
 			return err
 		}
@@ -72,7 +73,7 @@ func (w Writer) Copy(
 	name string,
 	snapshot bool,
 ) (Task, error) {
-	localKey, err := w.rack.NextTaskKey(ctx, key.Rack())
+	localKey, err := w.rack.NewTaskKey(ctx, key.Rack())
 	if err != nil {
 		return Task{}, err
 	}
@@ -80,6 +81,7 @@ func (w Writer) Copy(
 	var res Task
 	err = gorp.NewUpdate[Key, Task]().WhereKeys(key).Change(func(t Task) Task {
 		t.Key = newKey
+		fmt.Println(t.Name, newKey)
 		t.Name = name
 		t.Snapshot = snapshot
 		res = t

--- a/core/pkg/service/hardware/task/writer.go
+++ b/core/pkg/service/hardware/task/writer.go
@@ -11,7 +11,6 @@ package task
 
 import (
 	"context"
-	"fmt"
 
 	"github.com/synnaxlabs/synnax/pkg/distribution/group"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
@@ -79,14 +78,15 @@ func (w Writer) Copy(
 	}
 	newKey := NewKey(key.Rack(), localKey)
 	var res Task
-	err = gorp.NewUpdate[Key, Task]().WhereKeys(key).Change(func(t Task) Task {
+	if err = gorp.NewUpdate[Key, Task]().WhereKeys(key).Change(func(t Task) Task {
 		t.Key = newKey
-		fmt.Println(t.Name, newKey)
 		t.Name = name
 		t.Snapshot = snapshot
 		res = t
 		return t
-	}).Exec(ctx, w.tx)
+	}).Exec(ctx, w.tx); err != nil {
+		return res, err
+	}
 	if err := w.otg.DefineResource(ctx, OntologyID(newKey)); err != nil {
 		return Task{}, err
 	}


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2967](https://linear.app/synnax/issue/SY-2967/fix-task-key-assignment-race)

## Description

Fixes an issue where task keys generated concurrently wouldn't actually be in succession because they were using open transactions instead of writing directly to the underlying key-value database. 

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.
