### PR TITLE
SY-2982: Add`react/jsx-curly-brace-presence` and `react/jsx-boolean-value` ESLint rules

### DIFF
--- a/configs/eslint/index.js
+++ b/configs/eslint/index.js
@@ -87,6 +87,10 @@ export default [
       "simple-import-sort/exports": "error",
       "react/react-in-jsx-scope": "off",
       "react/prop-types": "off",
+      "react/jsx-curly-brace-presence": [
+        "error",
+        { props: "never", children: "never" },
+      ],
       "@typescript-eslint/no-empty-object-type": "off",
       "react/no-unescaped-entities": "off",
       "react/jsx-filename-extension": [

--- a/configs/eslint/index.js
+++ b/configs/eslint/index.js
@@ -97,6 +97,7 @@ export default [
         "error",
         { allow: "as-needed", extensions: [".jsx", ".tsx"] },
       ],
+      "react/jsx-boolean-value": "error",
       "@typescript-eslint/no-deprecated": "error",
       "@typescript-eslint/no-explicit-any": "off",
       "@typescript-eslint/no-floating-promises": "error",

--- a/console/src/label/Edit.tsx
+++ b/console/src/label/Edit.tsx
@@ -96,7 +96,7 @@ const LabelListItem = ({
         <Form.Form<typeof Label.formSchema> {...form}>
           <Form.Field<string>
             hideIfNull
-            path={`color`}
+            path="color"
             padHelpText={false}
             showLabel={false}
           >
@@ -107,7 +107,7 @@ const LabelListItem = ({
           <Form.TextField
             showLabel={false}
             hideIfNull
-            path={`name`}
+            path="name"
             showHelpText={false}
             padHelpText={false}
             inputProps={{

--- a/console/src/range/overview/Details.tsx
+++ b/console/src/range/overview/Details.tsx
@@ -181,7 +181,7 @@ export const Details: FC<DetailsProps> = ({ rangeKey }) => {
             </Button.Button>
             <Button.Button
               tooltip={`Download data for ${name} as a CSV`}
-              tooltipLocation={"bottom"}
+              tooltipLocation="bottom"
               variant="text"
               onClick={() =>
                 handleError(async () => {

--- a/console/src/range/overview/MetaData.tsx
+++ b/console/src/range/overview/MetaData.tsx
@@ -117,7 +117,7 @@ const MetaDataListItem = ({
         {isCreate ? (
           <Form.TextField
             style={{ flexBasis: "30%", width: 250 }}
-            path={"key"}
+            path="key"
             inputProps={{
               ref: inputRef,
               autoFocus: isCreate,
@@ -137,7 +137,7 @@ const MetaDataListItem = ({
           </Text.Text>
         )}
         <Divider.Divider y />
-        <Form.Field<string> path={"value"} showLabel={false} hideIfNull>
+        <Form.Field<string> path="value" showLabel={false} hideIfNull>
           {({ variant: _, ...p }) => <ValueInput onlyChangeOnBlur={!isCreate} {...p} />}
         </Form.Field>
         {isCreate ? (

--- a/console/src/range/overview/MetaData.tsx
+++ b/console/src/range/overview/MetaData.tsx
@@ -40,9 +40,9 @@ const ValueInput = ({ value, ...rest }: ValueInputProps): ReactElement => {
         width: "unset",
         flexGrow: 2,
       }}
-      selectOnFocus={true}
+      selectOnFocus
       variant="shadow"
-      resetOnBlurIfEmpty={true}
+      resetOnBlurIfEmpty
       placeholder="Value"
       textColor={isLink ? "var(--pluto-primary-z)" : "var(--pluto-gray-l10)"}
       {...rest}

--- a/console/src/schematic/symbols/edit/Edit.tsx
+++ b/console/src/schematic/symbols/edit/Edit.tsx
@@ -265,7 +265,7 @@ export const Edit: Layout.Renderer = ({ layoutKey, onClose }): ReactElement => {
                           onChange={(v) => onChange(v / 100)}
                           bounds={SCALE_BOUNDS}
                           dragScale={0.5}
-                          endContent={"%"}
+                          endContent="%"
                         />
                       )}
                     </Form.Field>

--- a/docs/site/src/components/search/Search.tsx
+++ b/docs/site/src/components/search/Search.tsx
@@ -103,7 +103,7 @@ export const SearchListItem = (props: List.ItemRenderProps<string>) => {
       direction="y"
       style={{ padding: "2.5rem 3rem" }}
       gap="medium"
-      aria-selected={true}
+      aria-selected
       href={href}
       {...props}
     >

--- a/pluto/src/button/Button.spec.tsx
+++ b/pluto/src/button/Button.spec.tsx
@@ -258,13 +258,13 @@ describe("Button", () => {
     });
 
     it("should not display the trigger indicator when triggerIndicator is true and no trigger has been set", () => {
-      const c = render(<Button.Button triggerIndicator={true}>Hello</Button.Button>);
+      const c = render(<Button.Button triggerIndicator>Hello</Button.Button>);
       expect(c.queryByLabelText("trigger-indicator")).not.toBeTruthy();
     });
 
     it("should display the trigger indicator when triggerIndicator is true and a trigger has been set", () => {
       const c = render(
-        <Button.Button triggerIndicator={true} trigger={["Enter"]}>
+        <Button.Button triggerIndicator trigger={["Enter"]}>
           Hello
         </Button.Button>,
       );

--- a/pluto/src/input/Input.spec.tsx
+++ b/pluto/src/input/Input.spec.tsx
@@ -427,7 +427,7 @@ describe("Input", () => {
 
     describe("value and onChange", () => {
       it("should render checked when value is true", () => {
-        const c = render(<Input.Checkbox value={true} onChange={vi.fn()} />);
+        const c = render(<Input.Checkbox value onChange={vi.fn()} />);
         const checkbox = c.container.querySelector(
           'input[type="checkbox"]',
         ) as HTMLInputElement;
@@ -446,7 +446,7 @@ describe("Input", () => {
 
       it("should toggle from true to false", () => {
         const onChange = vi.fn();
-        const c = render(<Input.Checkbox value={true} onChange={onChange} />);
+        const c = render(<Input.Checkbox value onChange={onChange} />);
         const checkbox = c.container.querySelector(
           'input[type="checkbox"]',
         ) as HTMLInputElement;
@@ -516,7 +516,7 @@ describe("Input", () => {
 
     describe("value and onChange", () => {
       it("should render on when value is true", () => {
-        const c = render(<Input.Switch value={true} onChange={vi.fn()} />);
+        const c = render(<Input.Switch value onChange={vi.fn()} />);
         const switchInput = c.container.querySelector(
           'input[type="checkbox"]',
         ) as HTMLInputElement;
@@ -535,7 +535,7 @@ describe("Input", () => {
 
       it("should toggle from true to false", () => {
         const onChange = vi.fn();
-        const c = render(<Input.Switch value={true} onChange={onChange} />);
+        const c = render(<Input.Switch value onChange={onChange} />);
         const switchInput = c.container.querySelector(
           'input[type="checkbox"]',
         ) as HTMLInputElement;

--- a/pluto/src/select/Single.spec.tsx
+++ b/pluto/src/select/Single.spec.tsx
@@ -147,7 +147,7 @@ describe("Select.Single", () => {
 
   it("should allow the user to deselect an item when allowNone is true", () => {
     const { SelectSingle, onChange } = createSelectSingle();
-    const c = render(<SelectSingle allowNone={true} />);
+    const c = render(<SelectSingle allowNone />);
     fireEvent.click(c.getByText("Select a Test Item"));
     fireEvent.click(c.getByText("First Item Option"));
 

--- a/pluto/src/showcase/InputShowcase.tsx
+++ b/pluto/src/showcase/InputShowcase.tsx
@@ -142,11 +142,11 @@ export const InputShowcase = () => (
             <Text.Text level="small" weight={500}>
               With End Content
             </Text.Text>
-            <InputShowcaseText endContent={"m/s"} size="huge" />
-            <InputShowcaseText endContent={"m/s"} size="large" />
-            <InputShowcaseText endContent={"m/s"} size="medium" />
-            <InputShowcaseText endContent={"m/s"} size="small" />
-            <InputShowcaseText endContent={"m/s"} size="tiny" />
+            <InputShowcaseText endContent="m/s" size="huge" />
+            <InputShowcaseText endContent="m/s" size="large" />
+            <InputShowcaseText endContent="m/s" size="medium" />
+            <InputShowcaseText endContent="m/s" size="small" />
+            <InputShowcaseText endContent="m/s" size="tiny" />
           </Flex.Box>
         </Flex.Box>
       </SubcategorySection>
@@ -344,8 +344,8 @@ export const InputShowcase = () => (
       description="Inputs with custom colors and different background contrast levels"
     >
       <Flex.Box x gap="large">
-        <InputShowcaseText placeholder="Catalyst" color={"#00FF00"} />
-        <InputShowcaseNumeric placeholder="Catalyst" color={"#00FF00"} />
+        <InputShowcaseText placeholder="Catalyst" color="#00FF00" />
+        <InputShowcaseNumeric placeholder="Catalyst" color="#00FF00" />
       </Flex.Box>
     </SubcategorySection>
 

--- a/pluto/src/showcase/InputShowcase.tsx
+++ b/pluto/src/showcase/InputShowcase.tsx
@@ -208,7 +208,7 @@ export const InputShowcase = () => (
             </Flex.Box>
             <Flex.Box y gap="small" align="center">
               <Text.Text level="small">On</Text.Text>
-              <InputShowcaseSwitch value={true} />
+              <InputShowcaseSwitch value />
             </Flex.Box>
           </Flex.Box>
           <Text.Text level="small" weight={500}>
@@ -221,7 +221,7 @@ export const InputShowcase = () => (
             </Flex.Box>
             <Flex.Box y gap="small" align="center">
               <Text.Text level="small">True</Text.Text>
-              <InputShowcaseSwitch value={true} variant="preview" />
+              <InputShowcaseSwitch value variant="preview" />
             </Flex.Box>
           </Flex.Box>
         </Flex.Box>
@@ -270,7 +270,7 @@ export const InputShowcase = () => (
               </Flex.Box>
               <Flex.Box y gap="small" align="center">
                 <Text.Text level="small">Checked</Text.Text>
-                <InputShowcaseCheckbox value={true} />
+                <InputShowcaseCheckbox value />
               </Flex.Box>
               <Flex.Box y gap="small" align="center">
                 <Text.Text level="small">Disabled</Text.Text>
@@ -289,7 +289,7 @@ export const InputShowcase = () => (
               </Flex.Box>
               <Flex.Box y gap="small" align="center">
                 <Text.Text level="small">True</Text.Text>
-                <InputShowcaseCheckbox value={true} variant="preview" />
+                <InputShowcaseCheckbox value variant="preview" />
               </Flex.Box>
             </Flex.Box>
           </Flex.Box>

--- a/pluto/src/triggers/Triggers.spec.tsx
+++ b/pluto/src/triggers/Triggers.spec.tsx
@@ -604,7 +604,7 @@ describe("Triggers", () => {
           triggers: [["A"], ["Control", "B"]],
         });
         return (
-          <div data-testid="editable" contentEditable={true}>
+          <div data-testid="editable" contentEditable>
             Editable content
           </div>
         );


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2982](https://linear.app/synnax/issue/SY-2982/add-react-eslint-rules-for-string-and-boolean-props-style)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Add two ESLint rules to enforce style consistency in React code.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.
