### PR TITLE
SY-2985: Tune Pebble Options for Higher Performance

### DIFF
--- a/core/pkg/storage/layer.go
+++ b/core/pkg/storage/layer.go
@@ -313,7 +313,7 @@ func acquireLock(cfg Config, fs vfs.FS) (io.Closer, error) {
 func openPebbleCache(cfg Config) (*pebble.Cache, io.Closer, error) {
 	// Create a shared block cache for Pebble.
 	// For read-heavy workloads, a large cache is critical for performance.
-	// Default is 8 MB, we're using 2 GB for production workloads.
+	// Default is 8 MB, we're using 1 GB for production workloads.
 	// Adjust based on available system memory.
 	cacheSize := 1 * telem.Gigabyte
 	if *cfg.InMemory {


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2985](https://linear.app/synnax/issue/SY-2985/tune-pebble-options-for-higher-performance)

## Description

Turns out the default pebble options are extremely conservative. These changes increase the cache size from 8MB to 1GB, and tune a number of other parameters for read performance.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.
