### PR TITLE
SY-2998: Remove extra Divider on Line Plot Selection Context Menu

### DIFF
--- a/console/src/lineplot/LinePlot.tsx
+++ b/console/src/lineplot/LinePlot.tsx
@@ -411,7 +411,6 @@ const Loaded: Layout.Renderer = ({ layoutKey, focused, visible }) => {
             <PMenu.Divider />
           </>
         )}
-        <PMenu.Divider />
         <Menu.HardReloadItem />
       </PMenu.Menu>
     );


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2998](https://linear.app/synnax/issue/SY-2998/fix-dividers-on-line-plot-selection-context-menu)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

remove an extra divider on the line plot selection context menu

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.
