### PR TITLE
SY-2993: Clean up Search Palette Items

### DIFF
--- a/console/src/channel/services/ontology.tsx
+++ b/console/src/channel/services/ontology.tsx
@@ -35,8 +35,6 @@ import { createUseRename } from "@/ontology/createUseRename";
 import { Range } from "@/range";
 import { Schematic } from "@/schematic";
 
-const canDrop = (): boolean => false;
-
 const handleSelect: Ontology.HandleSelect = ({
   store,
   placeLayout,
@@ -305,7 +303,6 @@ export const ONTOLOGY_SERVICE: Ontology.Service = {
   icon: <Icon.Channel />,
   hasChildren: false,
   onSelect: handleSelect,
-  canDrop,
   haulItems,
   Item,
   TreeContextMenu,

--- a/console/src/hardware/rack/ontology.tsx
+++ b/console/src/hardware/rack/ontology.tsx
@@ -16,7 +16,7 @@ import { Sequence } from "@/hardware/task/sequence";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { Layout } from "@/layout";
 import { Modals } from "@/modals";
-import { type Ontology } from "@/ontology";
+import { Ontology } from "@/ontology";
 import { createUseDelete } from "@/ontology/createUseDelete";
 import { createUseRename } from "@/ontology/createUseRename";
 
@@ -121,12 +121,9 @@ const TreeContextMenu: Ontology.TreeContextMenu = (props) => {
 };
 
 export const ONTOLOGY_SERVICE: Ontology.Service = {
+  ...Ontology.NOOP_SERVICE,
   type: "rack",
   icon: <Icon.Rack />,
-  hasChildren: true,
-  canDrop: () => false,
-  onSelect: () => {},
-  haulItems: () => [],
   TreeContextMenu,
   Item,
 };

--- a/console/src/ontology/service.tsx
+++ b/console/src/ontology/service.tsx
@@ -119,7 +119,6 @@ export interface Service {
 export const NOOP_SERVICE: Omit<Service, "type"> = {
   icon: <></>,
   hasChildren: true,
-  onSelect: () => {},
   canDrop: () => false,
   haulItems: () => [],
 };

--- a/console/src/range/services/external.ts
+++ b/console/src/range/services/external.ts
@@ -8,4 +8,5 @@
 // included in the file licenses/APL.txt.
 
 export * from "@/range/services/link";
+export * from "@/range/services/ontology";
 export * from "@/range/services/palette";

--- a/console/src/range/services/ontology.tsx
+++ b/console/src/range/services/ontology.tsx
@@ -1,0 +1,65 @@
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { type ontology } from "@synnaxlabs/client";
+import { type Haul, Icon, List, Select, Telem, Text } from "@synnaxlabs/pluto";
+import { type CrudeTimeRange, strings } from "@synnaxlabs/x";
+
+import { Ontology } from "@/ontology";
+import { OVERVIEW_LAYOUT } from "@/range/overview/layout";
+import { add } from "@/range/slice";
+import { fromClientRange } from "@/range/translate";
+
+const handleSelect: Ontology.HandleSelect = ({
+  selection,
+  client,
+  store,
+  placeLayout,
+  handleError,
+}) => {
+  const names = strings.naturalLanguageJoin(
+    selection.map(({ name }) => name),
+    "range",
+  );
+  handleError(async () => {
+    const ranges = await client.ranges.retrieve(selection.map((s) => s.id.key));
+    store.dispatch(add({ ranges: fromClientRange(ranges) }));
+    const first = ranges[0];
+    placeLayout({ ...OVERVIEW_LAYOUT, name: first.name, key: first.key });
+  }, `Failed to select ${names}`);
+};
+
+const haulItems = ({ id }: ontology.Resource): Haul.Item[] => [
+  { type: "range", key: id.key },
+];
+
+const PaletteListItem: Ontology.PaletteListItem = (props) => {
+  const resource = List.useItem<string, ontology.Resource>(props.itemKey);
+  return (
+    <Select.ListItem gap="tiny" highlightHovered justify="between" {...props}>
+      <Text.Text weight={450} gap="medium">
+        <Icon.Range />
+        {resource?.name}
+      </Text.Text>
+      <Telem.Text.TimeRange level="small">
+        {resource?.data?.timeRange as CrudeTimeRange}
+      </Telem.Text.TimeRange>
+    </Select.ListItem>
+  );
+};
+
+export const ONTOLOGY_SERVICE: Ontology.Service = {
+  ...Ontology.NOOP_SERVICE,
+  type: "range",
+  icon: <Icon.Range />,
+  onSelect: handleSelect,
+  canDrop: () => true,
+  haulItems,
+  PaletteListItem,
+};

--- a/console/src/services.ts
+++ b/console/src/services.ts
@@ -18,6 +18,7 @@ import { Hardware } from "@/hardware";
 import { LinePlotServices } from "@/lineplot/services";
 import { LogServices } from "@/log/services";
 import { Ontology } from "@/ontology";
+import { RangeServices } from "@/range/services";
 import { SchematicServices } from "@/schematic/services";
 import { TableServices } from "@/table/services";
 import { UserServices } from "@/user/services";
@@ -36,7 +37,7 @@ export const SERVICES: Ontology.Services = {
   builtin: createEmptyService("builtin"),
   node: Node.ONTOLOGY_SERVICE,
   group: GroupServices.ONTOLOGY_SERVICE,
-  range: createEmptyService("range"),
+  range: RangeServices.ONTOLOGY_SERVICE,
   workspace: WorkspaceServices.ONTOLOGY_SERVICE,
   lineplot: LinePlotServices.ONTOLOGY_SERVICE,
   "range-alias": createEmptyService("range-alias"),

--- a/core/pkg/service/layer.go
+++ b/core/pkg/service/layer.go
@@ -263,6 +263,21 @@ func Open(ctx context.Context, cfgs ...Config) (*Layer, error) {
 	); !ok(err, l.Status) {
 		return nil, err
 	}
+
+	if l.Status, err = status.OpenService(
+		ctx,
+		status.ServiceConfig{
+			Instrumentation: cfg.Instrumentation.Child("status"),
+			DB:              cfg.Distribution.DB,
+			Signals:         cfg.Distribution.Signals,
+			Ontology:        cfg.Distribution.Ontology,
+			Group:           cfg.Distribution.Group,
+			Label:           l.Label,
+		},
+	); !ok(err, l.Status) {
+		return nil, err
+	}
+
 	if l.Arc, err = arc.OpenService(
 		ctx,
 		arc.ServiceConfig{

--- a/core/pkg/service/layer.go
+++ b/core/pkg/service/layer.go
@@ -263,21 +263,6 @@ func Open(ctx context.Context, cfgs ...Config) (*Layer, error) {
 	); !ok(err, l.Status) {
 		return nil, err
 	}
-
-	if l.Status, err = status.OpenService(
-		ctx,
-		status.ServiceConfig{
-			Instrumentation: cfg.Instrumentation.Child("status"),
-			DB:              cfg.Distribution.DB,
-			Signals:         cfg.Distribution.Signals,
-			Ontology:        cfg.Distribution.Ontology,
-			Group:           cfg.Distribution.Group,
-			Label:           l.Label,
-		},
-	); !ok(err, l.Status) {
-		return nil, err
-	}
-
 	if l.Arc, err = arc.OpenService(
 		ctx,
 		arc.ServiceConfig{


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2993](https://linear.app/synnax/issue/SY-2993/remove-groups-from-search-palette)

## Description

Remove racks, nodes, and other items that can't be selected from the search palette. Add back in the range item that got deleted in the range PR.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.
