### PR TITLE
SY-2989: Remove Duplicated status service opening

### DIFF
--- a/core/pkg/service/layer.go
+++ b/core/pkg/service/layer.go
@@ -263,21 +263,6 @@ func Open(ctx context.Context, cfgs ...Config) (*Layer, error) {
 	); !ok(err, l.Status) {
 		return nil, err
 	}
-
-	if l.Status, err = status.OpenService(
-		ctx,
-		status.ServiceConfig{
-			Instrumentation: cfg.Instrumentation.Child("status"),
-			DB:              cfg.Distribution.DB,
-			Signals:         cfg.Distribution.Signals,
-			Ontology:        cfg.Distribution.Ontology,
-			Group:           cfg.Distribution.Group,
-			Label:           l.Label,
-		},
-	); !ok(err, l.Status) {
-		return nil, err
-	}
-
 	if l.Arc, err = arc.OpenService(
 		ctx,
 		arc.ServiceConfig{


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2989](https://linear.app/synnax/issue/SY-2989/remove-second-registration-of-status-service)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

Remove the accidental second call to open the status service.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.
