### PR TITLE
SY-3009: Fix FS issues on Windows

### DIFF
--- a/x/go/io/fs/fs_test.go
+++ b/x/go/io/fs/fs_test.go
@@ -11,11 +11,11 @@ package fs_test
 
 import (
 	"os"
-	"syscall"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	xfs "github.com/synnaxlabs/x/io/fs"
+	invariants "github.com/synnaxlabs/x/io/fs/internal/invariants"
 	. "github.com/synnaxlabs/x/testutil"
 )
 
@@ -134,7 +134,7 @@ var _ = Describe("FS", func() {
 
 						file := MustSucceed(fs.Open("test_file.txt", os.O_RDONLY))
 						Expect(file.Write([]byte("tacocat"))).Error().
-							To(MatchError(syscall.EBADF))
+							To(MatchError(invariants.ErrAccessDenied))
 						Expect(file.Close()).To(Succeed())
 
 						file = MustSucceed(fs.Open("test_file.txt", os.O_WRONLY))

--- a/x/go/io/fs/internal/invariants/unix.go
+++ b/x/go/io/fs/internal/invariants/unix.go
@@ -1,0 +1,16 @@
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+//go:build !windows
+
+package invariants
+
+import "golang.org/x/sys/unix"
+
+const ErrAccessDenied = unix.EBADF

--- a/x/go/io/fs/internal/invariants/windows.go
+++ b/x/go/io/fs/internal/invariants/windows.go
@@ -1,0 +1,16 @@
+// Copyright 2025 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+//go:build windows
+
+package invariants
+
+import "golang.org/x/sys/windows"
+
+const ErrAccessDenied = windows.ERROR_ACCESS_DENIED

--- a/x/go/io/fs/mem.go
+++ b/x/go/io/fs/mem.go
@@ -19,7 +19,6 @@ import (
 	"strings"
 	"sync"
 	"sync/atomic"
-	"syscall"
 	"time"
 
 	"github.com/cockroachdb/errors/oserror"
@@ -409,7 +408,7 @@ func (f *memFile) ReadAt(p []byte, off int64) (int, error) {
 
 func (f *memFile) Write(p []byte) (int, error) {
 	if !f.write {
-		return 0, syscall.EBADF
+		return 0, invariants.ErrAccessDenied
 	}
 	if f.n.isDir {
 		return 0, errors.New("memfs: cannot write a directory")

--- a/x/go/io/fs/mem.go
+++ b/x/go/io/fs/mem.go
@@ -36,18 +36,6 @@ func NewMem() *MemFS { return &MemFS{root: newRootMemNode()} }
 type MemFS struct {
 	mu   sync.Mutex
 	root *memNode
-
-	// lockFiles holds a map of open file locks. Presence in this map indicates a file
-	// lock is currently held. Keys are strings holding the path of the locked file. The
-	// stored value is untyped and  unused; only presence of the key within the map is
-	// significant.
-	lockedFiles sync.Map
-	strict      bool
-	ignoreSyncs bool
-	// Windows has peculiar semantics with respect to hard links and deleting open
-	// files. In tests meant to exercise this behavior, this flag can be set to error if
-	// removing an open file.
-	windowsSemantics bool
 }
 
 var _ FS = &MemFS{}
@@ -454,7 +442,7 @@ func (f *memFile) Write(p []byte) (int, error) {
 
 func (f *memFile) WriteAt(p []byte, ofs int64) (int, error) {
 	if !f.write {
-		return 0, syscall.EBADF
+		return 0, invariants.ErrAccessDenied
 	}
 	if f.n.isDir {
 		return 0, errors.New("memfs: cannot write a directory")
@@ -519,9 +507,6 @@ func (f *memFile) Sync() error {
 	}
 	f.fs.mu.Lock()
 	defer f.fs.mu.Unlock()
-	if f.fs.ignoreSyncs {
-		return nil
-	}
 	if f.n.isDir {
 		f.n.syncedChildren = make(map[string]*memNode)
 		maps.Copy(f.n.syncedChildren, f.n.children)


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-3009](https://linear.app/synnax/issue/SY-3009/fix-fs-issues-on-windows)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

1. Fix a failing `x/go` test on Windows due to different error codes being returned for Unix and Windows operating systems.
2. Fix an error that happened in Cesium where updating the metadata file failed because the the temporary file was renamed before the file handle was closed.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.
