### PR TITLE
SY-3103: Fixed Task Toolbar Retrieval

### DIFF
--- a/client/ts/src/hardware/task/client.ts
+++ b/client/ts/src/hardware/task/client.ts
@@ -179,6 +179,8 @@ const retrieveReqZ = z.object({
   names: z.string().array().optional(),
   types: z.string().array().optional(),
   includeStatus: z.boolean().optional(),
+  internal: z.boolean().optional(),
+  snapshot: z.boolean().optional(),
   searchTerm: z.string().optional(),
   offset: z.number().optional(),
   limit: z.number().optional(),

--- a/client/ts/src/hardware/task/task.spec.ts
+++ b/client/ts/src/hardware/task/task.spec.ts
@@ -264,6 +264,52 @@ describe("Task", async () => {
           })
           .toBe(true);
       });
+
+      it("should filter tasks by snapshot parameter", async () => {
+        const regularTask = await testRack.createTask({
+          name: "regular_test_task",
+          type: "ni",
+          config: { test: true },
+        });
+
+        const snapshotTask = await client.hardware.tasks.copy(
+          regularTask.key,
+          "snapshot_test_task",
+          true,
+        );
+
+        const snapshotOnlyResult = await client.hardware.tasks.retrieve({
+          snapshot: true,
+        });
+        expect(snapshotOnlyResult.some((t) => t.key === snapshotTask.key)).toBe(
+          true,
+        );
+        expect(snapshotOnlyResult.every((t) => t.snapshot === true)).toBe(true);
+
+        const regularOnlyResult = await client.hardware.tasks.retrieve({
+          snapshot: false,
+        });
+        expect(regularOnlyResult.some((t) => t.key === regularTask.key)).toBe(true);
+        expect(regularOnlyResult.every((t) => t.snapshot === false)).toBe(true);
+      });
+
+      it("should combine snapshot filter with other filters", async () => {
+        const task1 = await testRack.createTask({
+          name: "combined_filter_task",
+          type: "ni",
+          config: { test: true },
+        });
+
+        const result = await client.hardware.tasks.retrieve({
+          rack: testRack.key,
+          types: ["ni"],
+          snapshot: false,
+        });
+
+        expect(result.some((t) => t.key === task1.key)).toBe(true);
+        expect(result.every((t) => t.type === "ni")).toBe(true);
+        expect(result.every((t) => t.snapshot === false)).toBe(true);
+      });
     });
   });
 

--- a/client/ts/src/hardware/task/task.spec.ts
+++ b/client/ts/src/hardware/task/task.spec.ts
@@ -281,9 +281,7 @@ describe("Task", async () => {
         const snapshotOnlyResult = await client.hardware.tasks.retrieve({
           snapshot: true,
         });
-        expect(snapshotOnlyResult.some((t) => t.key === snapshotTask.key)).toBe(
-          true,
-        );
+        expect(snapshotOnlyResult.some((t) => t.key === snapshotTask.key)).toBe(true);
         expect(snapshotOnlyResult.every((t) => t.snapshot === true)).toBe(true);
 
         const regularOnlyResult = await client.hardware.tasks.retrieve({

--- a/console/src/hardware/task/Toolbar.tsx
+++ b/console/src/hardware/task/Toolbar.tsx
@@ -54,7 +54,10 @@ const EmptyContent = () => {
   );
 };
 
-const filter = (task: task.Task) => !task.internal && !task.snapshot;
+const INITIAL_QUERY: Task.ListQuery = {
+  internal: false,
+  snapshot: false,
+};
 
 const Content = () => {
   const client = Synnax.use();
@@ -64,8 +67,10 @@ const Content = () => {
   const menuProps = PMenu.useContextMenu();
   const dispatch = useDispatch();
   const placeLayout = Layout.usePlacer();
-  const { data, getItem, subscribe, retrieve } = Task.useList({ filter });
-  const { fetchMore } = List.usePager({ retrieve });
+  const { data, getItem, subscribe, retrieve } = Task.useList({
+    initialQuery: INITIAL_QUERY,
+  });
+  const { fetchMore } = List.usePager({ retrieve, pageSize: 1e3 });
 
   const { update: rename } = Task.useRename({
     beforeUpdate: useCallback(

--- a/console/src/hardware/task/Toolbar.tsx
+++ b/console/src/hardware/task/Toolbar.tsx
@@ -59,6 +59,8 @@ const INITIAL_QUERY: Task.ListQuery = {
   snapshot: false,
 };
 
+const filter = (task: task.Task) => !task.internal && !task.snapshot;
+
 const Content = () => {
   const client = Synnax.use();
   const [selected, setSelected] = useState<task.Key[]>([]);
@@ -69,6 +71,7 @@ const Content = () => {
   const placeLayout = Layout.usePlacer();
   const { data, getItem, subscribe, retrieve } = Task.useList({
     initialQuery: INITIAL_QUERY,
+    filter,
   });
   const { fetchMore } = List.usePager({ retrieve, pageSize: 1e3 });
 

--- a/core/pkg/service/hardware/task/retrieve.go
+++ b/core/pkg/service/hardware/task/retrieve.go
@@ -11,6 +11,7 @@ package task
 
 import (
 	"context"
+
 	"github.com/samber/lo"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology/search"
@@ -74,6 +75,11 @@ func (r Retrieve) Limit(limit int) Retrieve {
 
 func (r Retrieve) WhereInternal(internal bool, opts ...gorp.FilterOption) Retrieve {
 	r.gorp = r.gorp.Where(func(m *Task) bool { return m.Internal == internal }, opts...)
+	return r
+}
+
+func (r Retrieve) WhereSnapshot(snapshot bool, opts ...gorp.FilterOption) Retrieve {
+	r.gorp = r.gorp.Where(func(m *Task) bool { return m.Snapshot == snapshot }, opts...)
 	return r
 }
 

--- a/core/pkg/service/hardware/task/task_test.go
+++ b/core/pkg/service/hardware/task/task_test.go
@@ -143,29 +143,22 @@ var _ = Describe("Task", Ordered, func() {
 		})
 
 		It("Should filter tasks by snapshot status", func() {
-			// Create a regular task
 			regular := &task.Task{
 				Key:  task.NewKey(rack_.Key, 0),
 				Name: "Regular Task",
 			}
 			Expect(w.Create(ctx, regular)).To(Succeed())
-
-			// Create a snapshot task
 			snapshot := &task.Task{
 				Key:      task.NewKey(rack_.Key, 0),
 				Name:     "Snapshot Task",
 				Snapshot: true,
 			}
 			Expect(w.Create(ctx, snapshot)).To(Succeed())
-
-			// Retrieve only snapshot tasks
 			var snapshots []task.Task
 			Expect(svc.NewRetrieve().WhereSnapshot(true).Entries(&snapshots).Exec(ctx, tx)).To(Succeed())
 			Expect(snapshots).To(HaveLen(1))
 			Expect(snapshots[0].Name).To(Equal("Snapshot Task"))
 			Expect(snapshots[0].Snapshot).To(BeTrue())
-
-			// Retrieve only non-snapshot tasks
 			var regulars []task.Task
 			Expect(svc.NewRetrieve().WhereSnapshot(false).Entries(&regulars).Exec(ctx, tx)).To(Succeed())
 			Expect(len(regulars)).To(BeNumerically(">", 0))
@@ -175,23 +168,18 @@ var _ = Describe("Task", Ordered, func() {
 		})
 
 		It("Should combine WhereSnapshot with other filters", func() {
-			// Create a snapshot task
 			snapshot1 := &task.Task{
 				Key:      task.NewKey(rack_.Key, 0),
 				Name:     "Snapshot Task 1",
 				Snapshot: true,
 			}
 			Expect(w.Create(ctx, snapshot1)).To(Succeed())
-
-			// Create another snapshot task
 			snapshot2 := &task.Task{
 				Key:      task.NewKey(rack_.Key, 0),
 				Name:     "Snapshot Task 2",
 				Snapshot: true,
 			}
 			Expect(w.Create(ctx, snapshot2)).To(Succeed())
-
-			// Retrieve specific snapshot by name
 			var res task.Task
 			Expect(svc.NewRetrieve().WhereSnapshot(true).WhereNames("Snapshot Task 1").Entry(&res).Exec(ctx, tx)).To(Succeed())
 			Expect(res.Name).To(Equal("Snapshot Task 1"))
@@ -199,29 +187,22 @@ var _ = Describe("Task", Ordered, func() {
 		})
 
 		It("Should filter tasks by internal status", func() {
-			// Create a regular task
 			regular := &task.Task{
 				Key:  task.NewKey(rack_.Key, 0),
 				Name: "Regular Task 2",
 			}
 			Expect(w.Create(ctx, regular)).To(Succeed())
-
-			// Create an internal task
 			internal := &task.Task{
 				Key:      task.NewKey(rack_.Key, 0),
 				Name:     "Internal Task",
 				Internal: true,
 			}
 			Expect(w.Create(ctx, internal)).To(Succeed())
-
-			// Retrieve only internal tasks
 			var internals []task.Task
 			Expect(svc.NewRetrieve().WhereInternal(true).Entries(&internals).Exec(ctx, tx)).To(Succeed())
 			Expect(internals).To(HaveLen(1))
 			Expect(internals[0].Name).To(Equal("Internal Task"))
 			Expect(internals[0].Internal).To(BeTrue())
-
-			// Retrieve only non-internal tasks
 			var regulars []task.Task
 			Expect(svc.NewRetrieve().WhereInternal(false).Entries(&regulars).Exec(ctx, tx)).To(Succeed())
 			Expect(len(regulars)).To(BeNumerically(">", 0))
@@ -231,23 +212,18 @@ var _ = Describe("Task", Ordered, func() {
 		})
 
 		It("Should combine WhereInternal with other filters", func() {
-			// Create an internal task
 			internal1 := &task.Task{
 				Key:      task.NewKey(rack_.Key, 0),
 				Name:     "Internal Task 1",
 				Internal: true,
 			}
 			Expect(w.Create(ctx, internal1)).To(Succeed())
-
-			// Create another internal task
 			internal2 := &task.Task{
 				Key:      task.NewKey(rack_.Key, 0),
 				Name:     "Internal Task 2",
 				Internal: true,
 			}
 			Expect(w.Create(ctx, internal2)).To(Succeed())
-
-			// Retrieve specific internal by name
 			var res task.Task
 			Expect(svc.NewRetrieve().WhereInternal(true).WhereNames("Internal Task 1").Entry(&res).Exec(ctx, tx)).To(Succeed())
 			Expect(res.Name).To(Equal("Internal Task 1"))

--- a/pluto/src/hardware/task/queries.ts
+++ b/pluto/src/hardware/task/queries.ts
@@ -175,7 +175,11 @@ export const useList = Flux.createList<ListQuery, task.Key, task.Task, FluxSubSt
   name: PLURAL_RESOURCE_NAME,
   retrieveCached: ({ store }) => store.tasks.list(),
   retrieve: async ({ client, query, store }) => {
-    const tasks = await client.hardware.tasks.retrieve({ ...BASE_QUERY, ...query });
+    const tasks = await client.hardware.tasks.retrieve({
+      ...BASE_QUERY,
+      internal: false,
+      ...query,
+    });
     store.tasks.set(tasks, "payload");
     return tasks;
   },


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-3100](https://linear.app/synnax/issue/SY-3100/fix-task-channel-name-loading-issues)

## Description

Hotfixes the number of list items displayed in the task toolbar, and properly remote filters internal and snapshot tasks. One of the notable things is the `1000` list item limit in the task toolbar. This is a temp fix and will eventually need to be addressed.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] <!-- prettier-ignore --> I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.
