### PR TITLE
SY-3107: Widen OPC Read Task Display Size

### DIFF
--- a/console/src/hardware/opc/device/Browser.css
+++ b/console/src/hardware/opc/device/Browser.css
@@ -13,6 +13,6 @@
     height: 100%;
     border-right: var(--pluto-border);
     width: 0;
-    flex-basis: 250px;
+    flex-basis: 150px;
     flex-grow: 3;
 }

--- a/console/src/hardware/opc/task/Task.css
+++ b/console/src/hardware/opc/task/Task.css
@@ -13,6 +13,7 @@
 .console-task-configure--opc_write {
     .console-channel-list {
         max-width: 100% !important;
+        flex-grow: 5;
         & .console-channel-name__container {
             max-width: calc(100% - 10rem);
         }


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-3107](https://linear.app/synnax/issue/SY-3107/widen-opc-ua-read-task-display-size)

## Description

Widens OPC UA Read Task display size to make nodes easier to read

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] <!-- prettier-ignore --> I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.
