### PR TITLE
SY-2026: Fix Issues with Opening Streamers when Channel Key is 0

### DIFF
--- a/client/py/tests/test_channel.py
+++ b/client/py/tests/test_channel.py
@@ -428,6 +428,16 @@ class TestChannel:
             assert channel.key != ""
             assert isinstance(channel.data_type.density, sy.Density)
 
+    def test_retrieve_zero_key_single(self, client: sy.Synnax):
+        """Should retrieve a channel with a key of zero"""
+        with pytest.raises(sy.NotFoundError):
+            client.channels.retrieve(0)
+
+    def test_retrieve_zero_key_multiple(self, client: sy.Synnax):
+        """Should retrieve a list of channels with a key of zero"""
+        with pytest.raises(sy.NotFoundError):
+            client.channels.retrieve([0, 0, 0])
+
 
 class TestChannelRetriever:
     """Tests methods internal to the channel retriever that are not publicly availble

--- a/client/py/tests/test_frame_streamer.py
+++ b/client/py/tests/test_frame_streamer.py
@@ -42,6 +42,13 @@ class TestStreamer:
             with client.open_streamer([123]):
                 pass
 
+    def test_open_streamer_channel_key_zero(self, client: sy.Synnax):
+        """Should throw an exception when a streamer is opened with a channel key of
+        zero"""
+        with pytest.raises(sy.NotFoundError):
+            with client.open_streamer([0, 0, 0]):
+                pass
+
     def test_update_channels(self, virtual_channel: sy.Channel, client: sy.Synnax):
         """Should update the list of channels to stream"""
         with client.open_streamer([]) as s:

--- a/core/pkg/distribution/channel/retrieve.go
+++ b/core/pkg/distribution/channel/retrieve.go
@@ -111,10 +111,6 @@ func (r Retrieve) WhereNames(names ...string) Retrieve {
 // WhereKeys filters for channels with the provided Key. This is an identical interface
 // to gorp.Retrieve.
 func (r Retrieve) WhereKeys(keys ...Key) Retrieve {
-	notFound := lo.IndexOf(keys, 0)
-	if notFound != -1 {
-		keys = lo.Filter(keys, func(k Key, _ int) bool { return k != 0 })
-	}
 	r.keys = append(r.keys, keys...)
 	r.gorp.WhereKeys(keys...)
 	return r

--- a/core/pkg/distribution/channel/retrieve_test.go
+++ b/core/pkg/distribution/channel/retrieve_test.go
@@ -15,7 +15,9 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/synnaxlabs/synnax/pkg/distribution/channel"
 	"github.com/synnaxlabs/synnax/pkg/distribution/mock"
+	"github.com/synnaxlabs/x/query"
 	"github.com/synnaxlabs/x/telem"
+	. "github.com/synnaxlabs/x/testutil"
 )
 
 const internalChannelCount = 1
@@ -179,6 +181,16 @@ var _ = Describe("Retrieve", Ordered, func() {
 				g.Expect(resChannels[0].Name).To(Equal("catalina"))
 			}).Should(Succeed())
 		})
+
+		It("Should return an error when retrieving a channel with a key of 0", func() {
+			var resChannels []channel.Channel
+			Expect(mockCluster.Nodes[1].Channel.
+				NewRetrieve().
+				WhereKeys(0).
+				Entries(&resChannels).
+				Exec(ctx, nil)).To(HaveOccurredAs(query.NotFound))
+		})
+
 	})
 	Describe("Exists", func() {
 		It("Should return true if a channel exists", func() {


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-2026](https://linear.app/synnax/issue/SY-2026/fix-issues-with-opening-streamers-when-channel-key-is-0)

## Description

Trying to retrieve multiple channels with a key of zero will now throw. 

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] <!-- prettier-ignore --> I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

Updated On: 2025-10-11 00:12:01 UTC

### Greptile Summary

This PR addresses SY-2026 by fixing issues with opening streamers when channel key is 0. The changes involve removing filtering logic in the Go channel retrieval system that was silently discarding zero-valued channel keys, and adding comprehensive test coverage to ensure proper error handling.

Previously, the `WhereKeys` method in `core/pkg/distribution/channel/retrieve.go` would filter out channel keys with value 0, which was causing problems when streamers tried to access channels with legitimate zero keys. The fix removes this filtering logic, allowing zero keys to be processed normally. However, the system now properly validates these keys and returns appropriate `NotFoundError` exceptions when attempting to retrieve non-existent channels with key 0.

The PR adds test coverage across both Python client tests (`test_channel.py` and `test_frame_streamer.py`) and Go server tests (`retrieve_test.go`) to ensure consistent error handling behavior. All tests validate that attempting to retrieve channels or open streamers with zero keys results in proper `NotFoundError`/`query.NotFound` exceptions rather than undefined behavior.

### Important Files Changed

<details><summary>Changed Files</summary>

| Filename | Score | Overview |
|----------|-------|----------|
| `client/py/tests/test_channel.py` | 5/5 | Adds test cases validating NotFoundError is raised for zero-key channel retrieval |
| `client/py/tests/test_frame_streamer.py` | 5/5 | Adds test ensuring streamers properly handle zero-key channels with NotFoundError |
| `core/pkg/distribution/channel/retrieve.go` | 4/5 | Removes filtering logic that was discarding zero-valued channel keys |
| `core/pkg/distribution/channel/retrieve_test.go` | 5/5 | Adds test coverage for zero-key retrieval error handling in Go |

</details>

### Confidence score: 4/5

- This PR is safe to merge with minimal risk as it fixes a specific edge case with proper error handling
- Score reflects the removal of existing filtering logic which could potentially change system behavior, though comprehensive test coverage mitigates most concerns  
- Pay close attention to `core/pkg/distribution/channel/retrieve.go` to ensure the removal of zero-key filtering doesn't cause unintended side effects

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Client as "Python Client"
    participant ChannelService as "Channel Service"
    participant Retriever as "Channel Retriever"
    participant Validator as "Channel Validator"

    User->>Client: "channel.retrieve([0, 0, 0])"
    Client->>ChannelService: "retrieve(keys=[0, 0, 0])"
    ChannelService->>Retriever: "NewRetrieve().WhereKeys(0, 0, 0)"
    Retriever->>Validator: "validateRetrievedChannels([])"
    Validator-->>Retriever: "NotFoundError: Channels with keys [0] not found"
    Retriever-->>ChannelService: "NotFoundError"
    ChannelService-->>Client: "NotFoundError"
    Client-->>User: "sy.NotFoundError exception"

    User->>Client: "streamer.open([0, 0, 0])"
    Client->>ChannelService: "retrieve(keys=[0, 0, 0])"
    ChannelService->>Retriever: "NewRetrieve().WhereKeys(0, 0, 0)"
    Retriever->>Validator: "validateRetrievedChannels([])"
    Validator-->>Retriever: "NotFoundError: Channels with keys [0] not found"
    Retriever-->>ChannelService: "NotFoundError"
    ChannelService-->>Client: "NotFoundError"
    Client-->>User: "sy.NotFoundError exception"
```

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=1f93b7ae-395e-4379-bb71-2f5a9a0f0287))

<!-- /greptile_comment -->