### PR TITLE
SY-3122: Make Most Boolean API Fields use Pointers

### DIFF
--- a/core/pkg/api/hardware.go
+++ b/core/pkg/api/hardware.go
@@ -87,7 +87,7 @@ type (
 		HostIsNode    *bool      `json:"host_is_node" msgpack:"host_is_node"`
 		Limit         int        `json:"limit" msgpack:"limit"`
 		Offset        int        `json:"offset" msgpack:"offset"`
-		IncludeStatus *bool      `json:"include_status" msgpack:"include_status"`
+		IncludeStatus bool       `json:"include_status" msgpack:"include_status"`
 	}
 	HardwareRetrieveRackResponse struct {
 		Racks []rack.Rack `json:"racks" msgpack:"racks"`
@@ -129,7 +129,7 @@ func (svc *HardwareService) RetrieveRack(ctx context.Context, req HardwareRetrie
 		return res, err
 	}
 
-	if req.IncludeStatus != nil && *req.IncludeStatus {
+	if req.IncludeStatus {
 		for i := range resRacks {
 			if s, ok := svc.internal.State.GetRack(ctx, resRacks[i].Key); ok {
 				resRacks[i].Status = &s.Status
@@ -231,7 +231,7 @@ type (
 		Keys          []task.Key `json:"keys" msgpack:"keys"`
 		Names         []string   `json:"names" msgpack:"names"`
 		Types         []string   `json:"types" msgpack:"types"`
-		IncludeStatus *bool      `json:"include_status" msgpack:"include_status"`
+		IncludeStatus bool       `json:"include_status" msgpack:"include_status"`
 		Internal      *bool      `json:"internal" msgpack:"internal"`
 		Snapshot      *bool      `json:"snapshot" msgpack:"snapshot"`
 		SearchTerm    string     `json:"search_term" msgpack:"search_term"`
@@ -287,7 +287,7 @@ func (svc *HardwareService) RetrieveTask(
 	if err != nil {
 		return res, err
 	}
-	if req.IncludeStatus != nil && *req.IncludeStatus {
+	if req.IncludeStatus {
 		for i := range res.Tasks {
 			s, ok := svc.internal.State.GetTask(ctx, res.Tasks[i].Key)
 			if ok {

--- a/core/pkg/api/label.go
+++ b/core/pkg/api/label.go
@@ -147,7 +147,7 @@ func (s *LabelService) Delete(
 
 type LabelAddRequest struct {
 	Labels  []uuid.UUID `json:"labels" msgpack:"labels" validate:"required"`
-	Replace *bool       `json:"replace" msgpack:"replace"`
+	Replace bool        `json:"replace" msgpack:"replace"`
 	ID      ontology.ID `json:"id" msgpack:"id" validate:"required"`
 }
 
@@ -164,7 +164,7 @@ func (s *LabelService) Add(
 	}
 	return types.Nil{}, s.WithTx(ctx, func(tx gorp.Tx) error {
 		w := s.internal.NewWriter(tx)
-		if req.Replace != nil && *req.Replace {
+		if req.Replace {
 			if err := w.Clear(ctx, req.ID); err != nil {
 				return err
 			}

--- a/core/pkg/api/ontology.go
+++ b/core/pkg/api/ontology.go
@@ -42,7 +42,7 @@ type (
 		IDs              []ontology.ID   `json:"ids" msgpack:"ids" validate:"required"`
 		Children         *bool           `json:"children" msgpack:"children"`
 		Parents          *bool           `json:"parents" msgpack:"parents"`
-		ExcludeFieldData *bool           `json:"exclude_field_data" msgpack:"exclude_field_data"`
+		ExcludeFieldData bool            `json:"exclude_field_data" msgpack:"exclude_field_data"`
 		Types            []ontology.Type `json:"types" msgpack:"types"`
 		SearchTerm       string          `json:"search_term" msgpack:"search_term"`
 		Limit            int             `json:"limit" msgpack:"limit"`
@@ -77,11 +77,7 @@ func (o *OntologyService) Retrieve(
 	if len(req.Types) > 0 {
 		q = q.WhereTypes(req.Types...)
 	}
-	excludeFieldData := false
-	if req.ExcludeFieldData != nil {
-		excludeFieldData = *req.ExcludeFieldData
-	}
-	q.ExcludeFieldData(excludeFieldData)
+	q.ExcludeFieldData(req.ExcludeFieldData)
 	if req.Limit > 0 {
 		q = q.Limit(req.Limit)
 	}

--- a/core/pkg/api/ranger.go
+++ b/core/pkg/api/ranger.go
@@ -121,8 +121,8 @@ type (
 		HasLabels     []uuid.UUID     `json:"has_labels" msgpack:"has_labels"`
 		Limit         int             `json:"limit" msgpack:"limit"`
 		Offset        int             `json:"offset" msgpack:"offset"`
-		IncludeLabels *bool           `json:"include_labels" msgpack:"include_labels"`
-		IncludeParent *bool           `json:"include_parent" msgpack:"include_parent"`
+		IncludeLabels bool            `json:"include_labels" msgpack:"include_labels"`
+		IncludeParent bool            `json:"include_parent" msgpack:"include_parent"`
 	}
 	RangeRetrieveResponse struct {
 		Ranges []Range `json:"ranges" msgpack:"ranges"`
@@ -168,7 +168,7 @@ func (s *RangeService) Retrieve(
 	}
 	apiRanges := translateRangesFromService(svcRanges)
 	var err error
-	if req.IncludeLabels != nil && *req.IncludeLabels {
+	if req.IncludeLabels {
 		for i, rng := range apiRanges {
 			if rng.Labels, err = rng.RetrieveLabels(ctx); err != nil {
 				return RangeRetrieveResponse{}, err
@@ -176,7 +176,7 @@ func (s *RangeService) Retrieve(
 			apiRanges[i] = rng
 		}
 	}
-	if req.IncludeParent != nil && *req.IncludeParent {
+	if req.IncludeParent {
 		for i, rng := range apiRanges {
 			parent, err := rng.RetrieveParent(ctx)
 			if errors.Is(err, query.NotFound) {

--- a/core/pkg/api/status.go
+++ b/core/pkg/api/status.go
@@ -115,9 +115,11 @@ type StatusRetrieveRequest struct {
 	Limit int `json:"limit" msgpack:"limit"`
 	// Offset is the number of statuses to skip.
 	Offset int `json:"offset" msgpack:"offset"`
-	// IncludeLabels
-	IncludeLabels *bool       `json:"include_labels" msgpack:"include_labels"`
-	HasLabels     []uuid.UUID `json:"has_labels" msgpack:"has_labels"`
+	// IncludeLabels sets whether to fetch labels for the retrieved statuses.
+	IncludeLabels bool `json:"include_labels" msgpack:"include_labels"`
+	// HasLabels retrieves statuses that are labeled by one or more labels with the
+	// given keys.
+	HasLabels []uuid.UUID `json:"has_labels" msgpack:"has_labels"`
 }
 
 type StatusRetrieveResponse struct {
@@ -152,7 +154,7 @@ func (s *StatusService) Retrieve(
 	}
 	res.Statuses = translateStatusesFromService(resStatuses)
 	ids := statusAccessOntologyIDs(res.Statuses)
-	if req.IncludeLabels != nil && *req.IncludeLabels {
+	if req.IncludeLabels {
 		for i, stat := range res.Statuses {
 			labels, err := s.label.RetrieveFor(ctx, stat.OntologyID(), nil)
 			if err != nil {


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-3122](https://linear.app/synnax/issue/SY-3122/make-all-boolean-api-fields-use-pointers)

## Description

Our current API implementations use booleans directly for certain parameters (IncludeStatus, Internal, etc.). This is problematic because the default value is false, which means we don't really no if the user specified the value or not. This leads to incorrect query results. This PR refactors the API to use boolean pointers so that optionality is present in these parameters.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] <!-- prettier-ignore --> I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [ ] I have updated in-code documentation to reflect the changes.
- [ ] I have updated user-facing documentation to reflect the changes.
