### PR TITLE
SY-3201: Remove outdated `typing` syntax in Python

### DIFF
--- a/alamos/py/alamos/environment.py
+++ b/alamos/py/alamos/environment.py
@@ -7,7 +7,8 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-from typing import Callable, Literal
+from collections.abc import Callable
+from typing import Literal
 
 Environment = Literal["bench", "debug", "prod"]
 

--- a/alamos/py/alamos/instrumentation.py
+++ b/alamos/py/alamos/instrumentation.py
@@ -9,7 +9,8 @@
 
 from __future__ import annotations
 
-from typing import Callable, Concatenate, ParamSpec, Protocol, TypeVar
+from collections.abc import Callable
+from typing import Concatenate, ParamSpec, Protocol, TypeVar
 
 from alamos.environment import Environment
 from alamos.log import NOOP_LOGGER, Logger

--- a/alamos/py/alamos/noop.py
+++ b/alamos/py/alamos/noop.py
@@ -7,7 +7,8 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-from typing import Callable, Concatenate, ParamSpec, Protocol, TypeVar
+from collections.abc import Callable
+from typing import Concatenate, ParamSpec, Protocol, TypeVar
 
 
 class Noop(Protocol):

--- a/alamos/py/alamos/trace.py
+++ b/alamos/py/alamos/trace.py
@@ -7,8 +7,9 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
+from collections.abc import Iterator
 from contextlib import contextmanager
-from typing import Iterator, Protocol
+from typing import Protocol
 
 from opentelemetry.propagators.textmap import Setter, TextMapPropagator
 from opentelemetry.trace import Span as OtelSpan

--- a/client/py/synnax/cli/flow/__init__.py
+++ b/client/py/synnax/cli/flow/__init__.py
@@ -7,7 +7,7 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-from typing import Callable
+from collections.abc import Callable
 
 from synnax.cli.console import Console, SugaredConsole
 

--- a/client/py/synnax/exceptions.py
+++ b/client/py/synnax/exceptions.py
@@ -9,7 +9,7 @@
 
 import json
 from dataclasses import dataclass
-from typing import Any, List, Union
+from typing import Any
 
 import freighter
 
@@ -110,10 +110,10 @@ class PathError(ValidationError):
     """Raised when a validation error occurs on a specific path."""
 
     TYPE = _FREIGHTER_EXCEPTION_PREFIX + "validation.path"
-    path: List[str]
+    path: list[str]
     error: Exception
 
-    def __init__(self, path: Union[str, List[str]], error: Exception):
+    def __init__(self, path: str | list[str], error: Exception):
         if isinstance(path, str):
             path = path.split(".")
         self.path = path

--- a/client/py/synnax/framer/codec.py
+++ b/client/py/synnax/framer/codec.py
@@ -10,7 +10,6 @@
 from __future__ import annotations
 
 import struct
-from typing import Dict, List, Union
 
 from freighter import JSONCodec
 from freighter.codec import Codec as FreighterCodec
@@ -74,10 +73,10 @@ class CodecFlags:
 
 class CodecState:
     keys: ChannelKeys
-    data_types: Dict[ChannelKey, DataType]
+    data_types: dict[ChannelKey, DataType]
     has_variable_data_types: bool
 
-    def __init__(self, keys: ChannelKeys, data_types: List[DataType]) -> None:
+    def __init__(self, keys: ChannelKeys, data_types: list[DataType]) -> None:
         self.keys = sorted(keys)
         self.data_types = {k: dt for k, dt in zip(keys, data_types)}
         self.has_variable_data_types = any(dt.is_variable for dt in data_types)
@@ -90,7 +89,7 @@ class Codec:
     _curr_state: CodecState = None
 
     def __init__(
-        self, keys: ChannelKeys = None, data_types: List[DataType] = None
+        self, keys: ChannelKeys = None, data_types: list[DataType] = None
     ) -> None:
         self._seq_num = 0
         self._states = dict()
@@ -109,7 +108,7 @@ class Codec:
                 f"Please call update() before calling {op_name}()."
             )
 
-    def encode(self, frame: Union[Frame, FramePayload], start_offset: int = 0) -> bytes:
+    def encode(self, frame: Frame | FramePayload, start_offset: int = 0) -> bytes:
         self.throw_if_not_updated("encode")
         pld = frame if isinstance(frame, FramePayload) else frame.to_payload()
         indices = sorted(range(len(pld.keys)), key=lambda i: pld.keys[i])

--- a/client/py/synnax/framer/frame.py
+++ b/client/py/synnax/framer/frame.py
@@ -9,7 +9,8 @@
 
 from __future__ import annotations
 
-from typing import Iterator, overload
+from collections.abc import Iterator
+from typing import overload
 
 from freighter import Payload
 from pandas import DataFrame

--- a/client/py/synnax/hardware/opcua/types.py
+++ b/client/py/synnax/hardware/opcua/types.py
@@ -8,7 +8,7 @@
 #  included in the file licenses/APL.txt.
 
 import json
-from typing import Literal, Union
+from typing import Literal
 from uuid import uuid4
 
 from pydantic import BaseModel, Field
@@ -72,7 +72,7 @@ class ArraySamplingReadTaskConfig(BaseReadTaskConfig):
 
 
 class WrappedReadTaskConfig(BaseModel):
-    config: Union[NonArraySamplingReadTaskConfig, ArraySamplingReadTaskConfig] = Field(
+    config: NonArraySamplingReadTaskConfig | ArraySamplingReadTaskConfig = Field(
         discriminator="array_mode"
     )
 

--- a/client/py/synnax/io/csv.py
+++ b/client/py/synnax/io/csv.py
@@ -8,8 +8,8 @@
 #  included in the file licenses/APL.txt.
 
 import csv
+from collections.abc import Iterator
 from pathlib import Path
-from typing import Iterator
 
 import pandas as pd
 from pandas.io.parsers import TextFileReader

--- a/client/py/synnax/io/protocol.py
+++ b/client/py/synnax/io/protocol.py
@@ -7,9 +7,10 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
+from collections.abc import Iterator
 from enum import Enum
 from pathlib import Path
-from typing import Iterator, Protocol
+from typing import Protocol
 
 from pandas import DataFrame
 
@@ -86,7 +87,7 @@ class BaseReader(File, Protocol):
         ...
 
     def seek_first(self):
-        """Seeks the reader to the first  sampele in the file."""
+        """Seeks the reader to the first sample in the file."""
         ...
 
 

--- a/client/py/synnax/io/tdms.py
+++ b/client/py/synnax/io/tdms.py
@@ -7,21 +7,17 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
+from collections.abc import Iterator
 from math import ceil
 from pathlib import Path
-from typing import Iterator
 
 import pandas as pd
-from nptdms import TdmsChannel, TdmsFile, TdmsGroup
-from pandas.io.parsers import TextFileReader
+from nptdms import TdmsFile
 
-from synnax.exceptions import ValidationError
 from synnax.io.matcher import new_extension_matcher
 from synnax.io.protocol import (
-    BaseReader,
     ChannelMeta,
     ColumnFileReader,
-    File,
     ReaderType,
 )
 

--- a/client/py/synnax/ranger/client.py
+++ b/client/py/synnax/ranger/client.py
@@ -12,7 +12,8 @@ from __future__ import annotations
 
 import functools
 import warnings
-from typing import Callable, overload
+from collections.abc import Callable
+from typing import overload
 from uuid import UUID
 
 import numpy as np

--- a/client/py/synnax/signals/signals.py
+++ b/client/py/synnax/signals/signals.py
@@ -7,9 +7,9 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
+from collections.abc import Callable
 from functools import wraps
 from multiprocessing import Pool
-from typing import Callable
 
 from synnax import framer
 from synnax.channel.payload import ChannelKey, ChannelName, ChannelParams

--- a/client/py/synnax/util/params.py
+++ b/client/py/synnax/util/params.py
@@ -8,7 +8,8 @@
 #  included in the file licenses/APL.txt.
 
 import functools
-from typing import Any, Callable, TypeVar, cast
+from collections.abc import Callable
+from typing import Any, TypeVar, cast
 
 # Define a generic type variable for the function
 F = TypeVar("F", bound=Callable[..., Any])

--- a/client/py/tests/eventually.py
+++ b/client/py/tests/eventually.py
@@ -8,7 +8,7 @@
 #  included in the file licenses/APL.txt.
 
 import time
-from typing import Callable
+from collections.abc import Callable
 
 
 def assert_eventually(

--- a/client/py/tests/test_frame_codec.py
+++ b/client/py/tests/test_frame_codec.py
@@ -7,7 +7,6 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-from typing import List
 
 import numpy as np
 import pytest
@@ -27,7 +26,7 @@ class TestCodec:
             self,
             name: str,
             channels: ChannelKeys,
-            data_types: List[DataType],
+            data_types: list[DataType],
             frame: Frame,
         ):
             self.name = name

--- a/docs/site/src/pages/guides/comparison/performance/one-billion-rows/bench/bench/config.py
+++ b/docs/site/src/pages/guides/comparison/performance/one-billion-rows/bench/bench/config.py
@@ -9,7 +9,7 @@
 
 import numpy as np
 import pandas as pd
-from typing import Iterator
+from collections.abc import Iterator
 import synnax as sy
 
 SAMPLES_PER_CHANNEL = 1_000_000
@@ -19,6 +19,7 @@ CHANNEL_COUNT = 2
 TOTAL_SAMPLES = SAMPLES_PER_CHANNEL * ITERATIONS * CHANNEL_COUNT
 
 START_TIME = sy.TimeStamp.now()
+
 
 class TestConfig:
     _channels: list[sy.Channel]
@@ -31,11 +32,7 @@ class TestConfig:
     def __init__(self):
         c = CHANNEL_COUNT
         c -= 1
-        idx = sy.Channel(
-            name="timestamps",
-            data_type="timestamp",
-            is_index=True
-        )
+        idx = sy.Channel(name="timestamps", data_type="timestamp", is_index=True)
         self._channels = [idx]
         for i in range(c):
             ch = sy.Channel(name=f"channel_{i}", data_type="float32", index=idx.key)
@@ -57,19 +54,23 @@ class TestConfig:
     def frames(self, index: bool = False) -> Iterator[pd.DataFrame]:
         start = self._start_time
         end = start + (SAMPLES_PER_CHANNEL_PER_ITERATION * sy.TimeSpan.MICROSECOND)
-        timestamps = np.linspace(start, end, SAMPLES_PER_CHANNEL_PER_ITERATION, dtype=np.int64)
+        timestamps = np.linspace(
+            start, end, SAMPLES_PER_CHANNEL_PER_ITERATION, dtype=np.int64
+        )
         values = np.linspace(0, 1, SAMPLES_PER_CHANNEL_PER_ITERATION, dtype=np.float32)
         self._cached_data = {
-            'timestamps': np.linspace(start, end, SAMPLES_PER_CHANNEL_PER_ITERATION, dtype=np.int64),
-            **{f'channel_{i}': values for i in range(CHANNEL_COUNT)}
+            "timestamps": np.linspace(
+                start, end, SAMPLES_PER_CHANNEL_PER_ITERATION, dtype=np.int64
+            ),
+            **{f"channel_{i}": values for i in range(CHANNEL_COUNT)},
         }
         for i in range(ITERATIONS):
-            timestamps += (SAMPLES_PER_CHANNEL_PER_ITERATION * sy.TimeSpan.MICROSECOND)
+            timestamps += SAMPLES_PER_CHANNEL_PER_ITERATION * sy.TimeSpan.MICROSECOND
             if index:
                 df = pd.DataFrame(self._cached_data)
-                df.set_index('timestamps', inplace=True)
-                df.index.name = 'time'
+                df.set_index("timestamps", inplace=True)
+                df.index.name = "time"
                 yield df
             else:
-                df['timestamps'] = timestamps
+                df["timestamps"] = timestamps
                 yield pd.DataFrame(self._cached_data)

--- a/freighter/py/freighter/context.py
+++ b/freighter/py/freighter/context.py
@@ -7,8 +7,9 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
+from collections.abc import MutableMapping
 from dataclasses import dataclass
-from typing import Any, Literal, MutableMapping
+from typing import Any, Literal
 
 Role = Literal["client", "server"]
 

--- a/freighter/py/freighter/exceptions.py
+++ b/freighter/py/freighter/exceptions.py
@@ -9,8 +9,8 @@
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from dataclasses import dataclass
-from typing import Callable
 
 from freighter.transport import Payload
 
@@ -36,7 +36,7 @@ def _parse_exception_payload(
 
     1. An ExceptionPayload instance. In this case, a copy of the payload is
     returned.
-    2. A string encoded ExceptionPayload seperated by a '---' separator.
+    2. A string encoded ExceptionPayload separated by a '---' separator.
     3. A payload type and corresponding data.
 
     :returns: the parsed exception payload. If the payload cannot be parsed,

--- a/freighter/py/freighter/transport.py
+++ b/freighter/py/freighter/transport.py
@@ -9,7 +9,8 @@
 
 from __future__ import annotations
 
-from typing import Awaitable, Callable, Protocol, TypeAlias, TypeVar
+from collections.abc import Awaitable, Callable
+from typing import Protocol, TypeAlias, TypeVar
 
 from pydantic import BaseModel
 

--- a/freighter/py/freighter/websocket.py
+++ b/freighter/py/freighter/websocket.py
@@ -8,7 +8,8 @@
 #  included in the file licenses/APL.txt.
 
 import ssl
-from typing import Any, Generic, Literal, MutableMapping, Self
+from collections.abc import MutableMapping
+from typing import Any, Generic, Literal, Self
 
 from pydantic import BaseModel
 from websockets.asyncio.client import ClientConnection as AsyncClientConnection

--- a/integration/console/console.py
+++ b/integration/console/console.py
@@ -10,7 +10,7 @@
 import os
 import random
 import re
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Literal
 
 from playwright.sync_api import Locator, Page
 
@@ -19,7 +19,7 @@ from .log import Log
 from .page import ConsolePage
 from .plot import Plot
 from .schematic import Schematic
-from .task import AnalogRead, AnalogWrite, NITask
+from .task import AnalogRead, AnalogWrite
 
 # Define literal types for page creation
 PageType = Literal[
@@ -91,9 +91,7 @@ class Console:
             > 0
         )
 
-    def select_from_dropdown(
-        self, text: str, placeholder: Optional[str] = None
-    ) -> None:
+    def select_from_dropdown(self, text: str, placeholder: str | None = None) -> None:
         """Select an item from an open dropdown."""
         self.page.wait_for_timeout(300)
         target_item = f".pluto-list__item:not(.pluto-tree__item):has-text('{text}')"
@@ -123,7 +121,7 @@ class Console:
         )
 
     def create_page(
-        self, page_type: PageType, page_name: Optional[str] = None
+        self, page_type: PageType, page_name: str | None = None
     ) -> tuple[Locator, str]:
         """
         Public method for creating a new page in one of two ways:
@@ -143,7 +141,7 @@ class Console:
         return page_tab, page_id
 
     def _create_page_by_new_page_button(
-        self, page_type: PageType, page_name: Optional[str] = None
+        self, page_type: PageType, page_name: str | None = None
     ) -> tuple[Locator, str]:
         """Create a new page via the New Page (+) button."""
 
@@ -154,7 +152,7 @@ class Console:
         return page_tab, page_id
 
     def _create_page_by_command_palette(
-        self, page_type: PageType, page_name: Optional[str] = None
+        self, page_type: PageType, page_name: str | None = None
     ) -> tuple[Locator, str]:
         """Create a new page via command palette"""
 
@@ -174,7 +172,7 @@ class Console:
         return page_tab, page_id
 
     def _handle_new_page(
-        self, page_type: PageType, page_name: Optional[str] = None
+        self, page_type: PageType, page_name: str | None = None
     ) -> tuple[Locator, str]:
         """Handle the new page creation"""
         if self.MODAL_OPEN:
@@ -221,7 +219,7 @@ class Console:
             self.page.get_by_text("Try again").click()
             self.page.wait_for_timeout(200)
 
-    def check_for_notifications(self) -> list[Dict[str, Any]]:
+    def check_for_notifications(self) -> list[dict[str, Any]]:
         """
         Check for notifications in the bottom right corner.
         Returns a list of notification dictionaries with details.
@@ -315,7 +313,7 @@ class Console:
 
         return closed_count
 
-    def screenshot(self, name: Optional[str] = None) -> None:
+    def screenshot(self, name: str | None = None) -> None:
         """Take a screenshot of the entire console page."""
         results_dir = os.path.join(os.path.dirname(__file__), "..", "tests", "results")
         os.makedirs(results_dir, exist_ok=True)
@@ -407,7 +405,7 @@ class Console:
 
         raise RuntimeError(f"No selected button found from options: {button_options}")
 
-    def click(self, selector: str, timeout: Optional[int] = 5000) -> None:
+    def click(self, selector: str, timeout: int | None = 5000) -> None:
         """Wait for and click a selector (by text)"""
         self.page.wait_for_selector(f"text={selector}", timeout=timeout)
         element = self.page.get_by_text(selector, exact=True).first

--- a/integration/console/log.py
+++ b/integration/console/log.py
@@ -7,7 +7,7 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING
 
 from playwright.sync_api import Page
 from synnax.channel.payload import (
@@ -23,14 +23,14 @@ if TYPE_CHECKING:
 class Log(ConsolePage):
     """Log page management interface"""
 
-    channel_name: Optional[ChannelName]
+    channel_name: ChannelName | None
 
     def __init__(self, page: Page, console: "Console") -> None:
         super().__init__(page, console)
         self.page_type = "Log"
         self.pluto_label = ".pluto-log"
 
-    def new(self, channel_name: Optional[ChannelName] = None) -> str:
+    def new(self, channel_name: ChannelName | None = None) -> str:
         page_id = super().new()
         if channel_name is not None:
             self.set_channel(channel_name)

--- a/integration/console/page.py
+++ b/integration/console/page.py
@@ -10,7 +10,7 @@
 import os
 import re
 import time
-from typing import TYPE_CHECKING, Literal, Optional, cast
+from typing import TYPE_CHECKING, Literal, cast
 
 from playwright.sync_api import FloatRect, Locator, Page, ViewportSize
 
@@ -28,9 +28,9 @@ class ConsolePage:
         # Page identification - subclasses should set these
         self.page_type: "PageType" = "Log"  # Default, overridden by subclasses
         self.pluto_label: str = ""
-        self.tab_locator: Optional[Locator] = None
-        self.pane_locator: Optional[Locator] = None
-        self.id: Optional[str] = None
+        self.tab_locator: Locator | None = None
+        self.pane_locator: Locator | None = None
+        self.id: str | None = None
 
     def close(self, page_name: str) -> None:
         """
@@ -65,7 +65,7 @@ class ConsolePage:
         self._dblclick_canvas()
         return self.id or ""
 
-    def screenshot(self, path: Optional[str] = None) -> None:
+    def screenshot(self, path: str | None = None) -> None:
         """Save a screenshot of the pane area with margin."""
         if path is None:
             results_dir = os.path.join(

--- a/integration/console/plot.py
+++ b/integration/console/plot.py
@@ -7,7 +7,7 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-from typing import TYPE_CHECKING, Any, Dict, List, Literal, Union
+from typing import TYPE_CHECKING, Any, Literal
 
 from playwright.sync_api import Page
 
@@ -25,16 +25,14 @@ class Plot(ConsolePage):
         self.page_type = "Line Plot"
         self.pluto_label = ".pluto-line-plot"
 
-        self.data: Dict[str, Any] = {
+        self.data: dict[str, Any] = {
             "Y1": [],
             "Y2": [],
             "Ranges": [],
             "X1": None,
         }
 
-    def add_Y(
-        self, axis: Literal["Y1", "Y2"], channel_ids: Union[str, List[str]]
-    ) -> None:
+    def add_Y(self, axis: Literal["Y1", "Y2"], channel_ids: str | list[str]) -> None:
         channels = [channel_ids] if isinstance(channel_ids, str) else channel_ids
 
         selector = self.page.get_by_text(f"{axis} Select Channels", exact=True)
@@ -49,7 +47,7 @@ class Plot(ConsolePage):
         self.console.ESCAPE
 
     def add_ranges(
-        self, ranges: List[Literal["30s", "1m", "5m", "15m", "30m"]]
+        self, ranges: list[Literal["30s", "1m", "5m", "15m", "30m"]]
     ) -> None:
         """Add time ranges to the plot."""
         self.page.get_by_text("Select Ranges").click()
@@ -61,7 +59,7 @@ class Plot(ConsolePage):
 
         self.console.ESCAPE
 
-    def set_axis(self, axis: Literal["X1", "Y1", "Y2"], config: Dict[str, Any]) -> None:
+    def set_axis(self, axis: Literal["X1", "Y1", "Y2"], config: dict[str, Any]) -> None:
         """Set axis configuration with the given parameters."""
         self.page.get_by_text("Axes").click(timeout=5000)
         self.page.wait_for_selector(".pluto-tabs-selector__btn", timeout=5000)

--- a/integration/console/schematic/button.py
+++ b/integration/console/schematic/button.py
@@ -7,7 +7,7 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-from typing import Any, Dict, Literal, Optional
+from typing import Any, Literal
 
 import synnax as sy
 
@@ -19,18 +19,17 @@ class Button(Symbol):
 
     def edit_properties(
         self,
-        channel_name: Optional[str] = None,
-        activation_delay: Optional[float] = None,
-        show_control_chip: Optional[bool] = None,
-        mode: Optional[
-            Literal["fire", "momentary", "pulse", "Fire", "Momentary", "Pulse"]
-        ] = None,
-        **kwargs: Any,
-    ) -> Dict[str, Any]:
+        channel_name: str | None = None,
+        activation_delay: float | None = None,
+        show_control_chip: bool | None = None,
+        mode: (
+            Literal["fire", "momentary", "pulse", "Fire", "Momentary", "Pulse"] | None
+        ) = None,
+    ) -> dict[str, Any]:
         """Edit Setpoint properties including channel settings."""
         self._click_symbol()
 
-        applied_properties: Dict[str, Any] = {}
+        applied_properties: dict[str, Any] = {}
         if channel_name is not None:
             self.set_label(channel_name)
 
@@ -67,13 +66,13 @@ class Button(Symbol):
 
         return applied_properties
 
-    def get_properties(self) -> Dict[str, Any]:
+    def get_properties(self) -> dict[str, Any]:
         """Get the current properties of the symbol"""
         self._click_symbol()
         self.page.get_by_text("Properties").click()
         self.page.get_by_text("Control").last.click()
 
-        props: Dict[str, Any] = {
+        props: dict[str, Any] = {
             "channel": "",
             "activation_delay": -1.0,
             "show_control_chip": False,

--- a/integration/console/schematic/schematic.py
+++ b/integration/console/schematic/schematic.py
@@ -7,7 +7,7 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-from typing import TYPE_CHECKING, Literal, Optional, Tuple
+from typing import TYPE_CHECKING, Literal
 
 from playwright.sync_api import Page
 
@@ -80,11 +80,11 @@ class Schematic(ConsolePage):
     def create_button(
         self,
         channel_name: str,
-        activation_delay: Optional[float] = None,
-        show_control_chip: Optional[bool] = None,
-        mode: Optional[
-            Literal["fire", "momentary", "pulse", "Fire", "Momentary", "Pulse"]
-        ] = None,
+        activation_delay: float | None = None,
+        show_control_chip: bool | None = None,
+        mode: (
+            Literal["fire", "momentary", "pulse", "Fire", "Momentary", "Pulse"] | None
+        ) = None,
     ) -> Button:
         """Create a button symbol on the schematic."""
         button_id = self._add_symbol("Button")
@@ -100,7 +100,7 @@ class Schematic(ConsolePage):
     def create_valve(
         self,
         channel_name: str,
-        show_control_chip: Optional[bool] = None,
+        show_control_chip: bool | None = None,
         no_state_channel: bool = False,
     ) -> Valve:
         """Create a button symbol on the schematic.
@@ -127,11 +127,11 @@ class Schematic(ConsolePage):
     def create_value(
         self,
         channel_name: str,
-        notation: Optional[str] = None,
-        precision: Optional[int] = None,
-        averaging_window: Optional[int] = None,
-        stale_color: Optional[str] = None,
-        stale_timeout: Optional[int] = None,
+        notation: str | None = None,
+        precision: int | None = None,
+        averaging_window: int | None = None,
+        stale_color: str | None = None,
+        stale_timeout: int | None = None,
     ) -> Value:
         """Create a value symbol on the schematic."""
         value_id = self._add_symbol("Value")
@@ -164,7 +164,7 @@ class Schematic(ConsolePage):
         self.page.mouse.move(target_x, target_y, steps=10)
         self.page.mouse.up()
 
-    def find_symbol_handle(self, symbol: Symbol, handle: str) -> Tuple[float, float]:
+    def find_symbol_handle(self, symbol: Symbol, handle: str) -> tuple[float, float]:
         """Calculate the coordinates of a symbol's connection handle."""
         symbol_box = symbol.symbol.bounding_box()
         if not symbol_box:

--- a/integration/console/schematic/setpoint.py
+++ b/integration/console/schematic/setpoint.py
@@ -7,7 +7,7 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-from typing import Any, Dict, Optional
+from typing import Any
 
 from .symbol import Symbol
 
@@ -17,13 +17,12 @@ class Setpoint(Symbol):
 
     def edit_properties(
         self,
-        channel_name: Optional[str] = None,
-        **kwargs: Any,
-    ) -> Dict[str, Any]:
+        channel_name: str | None = None,
+    ) -> dict[str, Any]:
         """Edit Setpoint properties including channel settings."""
         self._click_symbol()
 
-        applied_properties: Dict[str, Any] = {}
+        applied_properties: dict[str, Any] = {}
         if channel_name is not None:
             self.set_label(channel_name)
 

--- a/integration/console/schematic/symbol.py
+++ b/integration/console/schematic/symbol.py
@@ -7,10 +7,10 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-import time
 from abc import ABC, abstractmethod
+from collections.abc import Generator
 from contextlib import contextmanager
-from typing import TYPE_CHECKING, Any, Dict, Generator, Optional
+from typing import TYPE_CHECKING, Any
 
 from playwright.sync_api import Locator, Page
 
@@ -71,9 +71,9 @@ class Symbol(ABC):
     @abstractmethod
     def edit_properties(
         self,
-        channel_name: Optional[str] = None,
+        channel_name: str | None = None,
         **kwargs: Any,
-    ) -> Dict[str, Any]:
+    ) -> dict[str, Any]:
         """
         Edit symbol properties. Must be implemented by all child classes.
 

--- a/integration/console/schematic/value.py
+++ b/integration/console/schematic/value.py
@@ -8,7 +8,7 @@
 #  included in the file licenses/APL.txt.
 
 import re
-from typing import Any, Dict, Optional
+from typing import Any
 
 from .symbol import Symbol
 
@@ -25,19 +25,18 @@ class Value(Symbol):
 
     def edit_properties(
         self,
-        channel_name: Optional[str] = None,
+        channel_name: str | None = None,
         *,
-        notation: Optional[str] = None,
-        precision: Optional[int] = None,
-        averaging_window: Optional[int] = None,
-        stale_color: Optional[str] = None,
-        stale_timeout: Optional[int] = None,
-        **kwargs: Any,
-    ) -> Dict[str, Any]:
+        notation: str | None = None,
+        precision: int | None = None,
+        averaging_window: int | None = None,
+        stale_color: str | None = None,
+        stale_timeout: int | None = None,
+    ) -> dict[str, Any]:
         """Edit Value symbol properties including channel and telemetry settings."""
         self._click_symbol()
 
-        applied_properties: Dict[str, Any] = {}
+        applied_properties: dict[str, Any] = {}
 
         # Always enforce label = channel_name for easy identification
         if channel_name is not None:
@@ -86,14 +85,14 @@ class Value(Symbol):
 
         return applied_properties
 
-    def get_properties(self) -> Dict[str, Any]:
+    def get_properties(self) -> dict[str, Any]:
         """Get the current properties of the symbol"""
         console = self.console
         self._click_symbol()
         self.page.get_by_text("Properties").click()
         self.page.get_by_text("Telemetry").click()
 
-        props: Dict[str, Any] = {
+        props: dict[str, Any] = {
             "channel": "",
             "notation": "",
             "precision": -1,

--- a/integration/console/schematic/valve.py
+++ b/integration/console/schematic/valve.py
@@ -7,7 +7,7 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-from typing import Any, Dict, Optional
+from typing import Any
 
 import synnax as sy
 
@@ -19,16 +19,14 @@ class Valve(Symbol):
 
     def edit_properties(
         self,
-        channel_name: Optional[str] = None,
-        state_channel: Optional[str] = None,
-        command_channel: Optional[str] = None,
-        show_control_chip: Optional[bool] = None,
-        **kwargs: Any,
-    ) -> Dict[str, Any]:
+        state_channel: str | None = None,
+        command_channel: str | None = None,
+        show_control_chip: bool | None = None,
+    ) -> dict[str, Any]:
         """Edit Setpoint properties including channel settings."""
         self._click_symbol()
 
-        applied_properties: Dict[str, Any] = {}
+        applied_properties: dict[str, Any] = {}
 
         # Navigate to Properties > Control tab
         self.page.get_by_text("Properties").click()
@@ -56,13 +54,13 @@ class Valve(Symbol):
 
         return applied_properties
 
-    def get_properties(self) -> Dict[str, Any]:
+    def get_properties(self) -> dict[str, Any]:
         """Get the current properties of the symbol"""
         self._click_symbol()
         self.page.get_by_text("Properties").click()
         self.page.get_by_text("Control").last.click()
 
-        props: Dict[str, Any] = {
+        props: dict[str, Any] = {
             "channel": "",
             "activation_delay": -1.0,
             "show_control_chip": False,

--- a/integration/console/task/analog_read.py
+++ b/integration/console/task/analog_read.py
@@ -7,7 +7,7 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-from typing import TYPE_CHECKING, Any, Optional, Type
+from typing import TYPE_CHECKING, Any
 
 from playwright.sync_api import Page
 
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
     from console.console import Console
 
 # Valid channel types for NI Analog Read tasks
-ANALOG_READ_CHANNEL_TYPES: dict[str, Type[Analog]] = {
+ANALOG_READ_CHANNEL_TYPES: dict[str, type[Analog]] = {
     "Accelerometer": Accelerometer,
     "Bridge": Bridge,
     "Current": Current,
@@ -81,7 +81,7 @@ class AnalogRead(NITask):
         name: str,
         type: str,
         device: str,
-        dev_name: Optional[str] = None,
+        dev_name: str | None = None,
         **kwargs: Any,
     ) -> Analog:
         """
@@ -117,9 +117,9 @@ class AnalogRead(NITask):
 
     def set_parameters(
         self,
-        task_name: Optional[str] = None,
-        data_saving: Optional[bool] = None,
-        auto_start: Optional[bool] = None,
+        task_name: str | None = None,
+        data_saving: bool | None = None,
+        auto_start: bool | None = None,
         **kwargs: Any,
     ) -> None:
         """

--- a/integration/console/task/analog_write.py
+++ b/integration/console/task/analog_write.py
@@ -7,7 +7,7 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-from typing import TYPE_CHECKING, Any, Optional, Type
+from typing import TYPE_CHECKING, Any
 
 from playwright.sync_api import Page
 
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     from console.console import Console
 
 # Channel type registry for NI Analog Output
-AO_CHANNEL_TYPES: dict[str, Type[Analog]] = {
+AO_CHANNEL_TYPES: dict[str, type[Analog]] = {
     "Voltage": Voltage,
     "Current": Current,
 }
@@ -43,7 +43,7 @@ class AnalogWrite(NITask):
         name: str,
         type: str,
         device: str,
-        dev_name: Optional[str] = None,
+        dev_name: str | None = None,
         **kwargs: Any,
     ) -> Analog:
         """
@@ -85,9 +85,9 @@ class AnalogWrite(NITask):
 
     def set_parameters(
         self,
-        task_name: Optional[str] = None,
-        data_saving: Optional[bool] = None,
-        auto_start: Optional[bool] = None,
+        task_name: str | None = None,
+        data_saving: bool | None = None,
+        auto_start: bool | None = None,
         **kwargs: Any,
     ) -> None:
         """

--- a/integration/console/task/channels/accelerometer.py
+++ b/integration/console/task/channels/accelerometer.py
@@ -7,9 +7,7 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-from typing import TYPE_CHECKING, Any, Literal, Optional
-
-import synnax as sy
+from typing import TYPE_CHECKING, Any, Literal
 
 from console.task.channels.analog import Analog
 
@@ -40,15 +38,10 @@ class Accelerometer(Analog):
         console: "Console",
         name: str,
         device: str,
-        sensitivity: Optional[float] = None,
-        units: Optional[
-            Literal[
-                "mV/g",
-                "V/g",
-            ]
-        ] = None,
-        excitation_source: Optional[Literal["Internal", "External", "None"]] = None,
-        current_excitation_value: Optional[float] = None,
+        sensitivity: float | None = None,
+        units: Literal["mV/g", "V/g"] | None = None,
+        excitation_source: Literal["Internal", "External", "None"] | None = None,
+        current_excitation_value: float | None = None,
         **kwargs: Any,
     ) -> None:
 

--- a/integration/console/task/channels/analog.py
+++ b/integration/console/task/channels/analog.py
@@ -7,9 +7,7 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-from typing import TYPE_CHECKING, Literal, Optional
-
-import synnax as sy
+from typing import TYPE_CHECKING, Literal
 
 if TYPE_CHECKING:
     from console.console import Console
@@ -29,8 +27,8 @@ class Analog:
         name: str,
         device: str,
         type: str,
-        port: Optional[int] = None,
-        terminal_config: Optional[
+        port: int | None = None,
+        terminal_config: (
             Literal[
                 "Default",
                 "Differential",
@@ -38,17 +36,11 @@ class Analog:
                 "Referenced Single Ended",
                 "Non-Referenced Single Ended",
             ]
-        ] = None,
-        min_val: Optional[float] = None,
-        max_val: Optional[float] = None,
-        custom_scale: Optional[
-            Literal[
-                "None",
-                "Linear",
-                "Map",
-                "Table",
-            ]
-        ] = None,
+            | None
+        ) = None,
+        min_val: float | None = None,
+        max_val: float | None = None,
+        custom_scale: Literal["None", "Linear", "Map", "Table"] | None = None,
     ) -> None:
         """
         Initialize analog channel with common configuration.

--- a/integration/console/task/channels/bridge.py
+++ b/integration/console/task/channels/bridge.py
@@ -7,7 +7,7 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal
 
 from console.task.channels.analog import Analog
 
@@ -39,28 +39,13 @@ class Bridge(Analog):
         console: "Console",
         name: str,
         device: str,
-        units: Optional[
-            Literal[
-                "mV/V",
-                "V/V",
-            ]
-        ] = None,
-        configuration: Optional[
-            Literal[
-                "Full Bridge",
-                "Half Bridge",
-                "Quarter Bridge",
-            ]
-        ] = None,
-        resistance: Optional[float] = None,
-        excitation_source: Optional[
-            Literal[
-                "Internal",
-                "External",
-                "None",
-            ]
-        ] = None,
-        excitation_value: Optional[float] = None,
+        units: Literal["mV/V", "V/V"] | None = None,
+        configuration: (
+            Literal["Full Bridge", "Half Bridge", "Quarter Bridge"] | None
+        ) = None,
+        resistance: float | None = None,
+        excitation_source: Literal["Internal", "External", "None"] | None = None,
+        excitation_value: float | None = None,
         **kwargs: Any,
     ) -> None:
 

--- a/integration/console/task/channels/current.py
+++ b/integration/console/task/channels/current.py
@@ -7,9 +7,7 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-from typing import TYPE_CHECKING, Any, Literal, Optional
-
-import synnax as sy
+from typing import TYPE_CHECKING, Any, Literal
 
 from console.task.channels.analog import Analog
 
@@ -38,13 +36,8 @@ class Current(Analog):
         console: "Console",
         name: str,
         device: str,
-        shunt_resistor: Optional[
-            Literal[
-                "Default" "Internal",
-                "External",
-            ]
-        ] = None,
-        resistance: Optional[float] = None,
+        shunt_resistor: Literal["Default" "Internal" "External"] | None = None,
+        resistance: float | None = None,
         **kwargs: Any,
     ) -> None:
 

--- a/integration/console/task/channels/force_bridge_table.py
+++ b/integration/console/task/channels/force_bridge_table.py
@@ -7,7 +7,7 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal
 
 from console.task.channels.analog import Analog
 
@@ -41,42 +41,15 @@ class ForceBridgeTable(Analog):
         console: "Console",
         name: str,
         device: str,
-        force_units: Optional[
-            Literal[
-                "Newtons",
-                "Pounds",
-                "Kilograms",
-            ]
-        ] = None,
-        bridge_configuration: Optional[
-            Literal[
-                "Full Bridge",
-                "Half Bridge",
-                "Quarter Bridge",
-            ]
-        ] = None,
-        resistance: Optional[float] = None,
-        excitation_source: Optional[
-            Literal[
-                "Internal",
-                "External",
-                "None",
-            ]
-        ] = None,
-        excitation_value: Optional[float] = None,
-        physical_units: Optional[
-            Literal[
-                "Newtons",
-                "Pounds",
-                "Kilograms",
-            ]
-        ] = None,
-        electrical_units: Optional[
-            Literal[
-                "mV/V",
-                "V/V",
-            ]
-        ] = None,
+        force_units: Literal["Newtons", "Pounds", "Kilograms"] | None = None,
+        bridge_configuration: (
+            Literal["Full Bridge", "Half Bridge", "Quarter Bridge"] | None
+        ) = None,
+        resistance: float | None = None,
+        excitation_source: Literal["Internal", "External", "None"] | None = None,
+        excitation_value: float | None = None,
+        physical_units: Literal["Newtons", "Pounds", "Kilograms"] | None = None,
+        electrical_units: Literal["mV/V", "V/V"] | None = None,
         **kwargs: Any,
     ) -> None:
 

--- a/integration/console/task/channels/force_bridge_two_point_linear.py
+++ b/integration/console/task/channels/force_bridge_two_point_linear.py
@@ -7,7 +7,7 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal
 
 from console.task.channels.analog import Analog
 
@@ -44,46 +44,19 @@ class ForceBridgeTwoPointLinear(Analog):
         console: "Console",
         name: str,
         device: str,
-        force_units: Optional[
-            Literal[
-                "Newtons",
-                "Pounds",
-                "Kilograms",
-            ]
-        ] = None,
-        bridge_configuration: Optional[
-            Literal[
-                "Full Bridge",
-                "Half Bridge",
-                "Quarter Bridge",
-            ]
-        ] = None,
-        resistance: Optional[float] = None,
-        excitation_source: Optional[
-            Literal[
-                "Internal",
-                "External",
-                "None",
-            ]
-        ] = None,
-        excitation_value: Optional[float] = None,
-        physical_units: Optional[
-            Literal[
-                "Newtons",
-                "Pounds",
-                "Kilograms",
-            ]
-        ] = None,
-        electrical_units: Optional[
-            Literal[
-                "mV/V",
-                "V/V",
-            ]
-        ] = None,
-        physical_value_one: Optional[float] = None,
-        physical_value_two: Optional[float] = None,
-        electrical_value_one: Optional[float] = None,
-        electrical_value_two: Optional[float] = None,
+        force_units: Literal["Newtons", "Pounds", "Kilograms"] | None = None,
+        bridge_configuration: (
+            Literal["Full Bridge", "Half Bridge", "Quarter Bridge"] | None
+        ) = None,
+        resistance: float | None = None,
+        excitation_source: Literal["Internal", "External", "None"] | None = None,
+        excitation_value: float | None = None,
+        physical_units: Literal["Newtons", "Pounds", "Kilograms"] | None = None,
+        electrical_units: Literal["mV/V", "V/V"] | None = None,
+        physical_value_one: float | None = None,
+        physical_value_two: float | None = None,
+        electrical_value_one: float | None = None,
+        electrical_value_two: float | None = None,
         **kwargs: Any,
     ) -> None:
 

--- a/integration/console/task/channels/force_iepe.py
+++ b/integration/console/task/channels/force_iepe.py
@@ -7,7 +7,7 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal
 
 from console.task.channels.analog import Analog
 
@@ -39,27 +39,13 @@ class ForceIEPE(Analog):
         console: "Console",
         name: str,
         device: str,
-        force_units: Optional[
-            Literal[
-                "Newtons",
-                "Pounds",
-            ]
-        ] = None,
-        sensitivity: Optional[float] = None,
-        sensitivity_units: Optional[
-            Literal[
-                "mV/N",
-                "mV/lb",
-            ]
-        ] = None,
-        current_excitation_source: Optional[
-            Literal[
-                "Internal",
-                "External",
-                "None",
-            ]
-        ] = None,
-        current_excitation_value: Optional[float] = None,
+        force_units: Literal["Newtons", "Pounds"] | None = None,
+        sensitivity: float | None = None,
+        sensitivity_units: Literal["mV/N", "mV/lb"] | None = None,
+        current_excitation_source: (
+            Literal["Internal", "External", "None"] | None
+        ) = None,
+        current_excitation_value: float | None = None,
         **kwargs: Any,
     ) -> None:
 

--- a/integration/console/task/channels/microphone.py
+++ b/integration/console/task/channels/microphone.py
@@ -7,7 +7,7 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal
 
 from console.task.channels.analog import Analog
 
@@ -39,17 +39,13 @@ class Microphone(Analog):
         console: "Console",
         name: str,
         device: str,
-        sound_pressure_units: Optional[Literal["Pascals",]] = None,
-        sensitivity: Optional[float] = None,
-        max_sound_pressure_level: Optional[float] = None,
-        current_excitation_source: Optional[
-            Literal[
-                "Internal",
-                "External",
-                "None",
-            ]
-        ] = None,
-        current_excitation_value: Optional[float] = None,
+        sound_pressure_units: Literal["Pascals"] | None = None,
+        sensitivity: float | None = None,
+        max_sound_pressure_level: float | None = None,
+        current_excitation_source: (
+            Literal["Internal", "External", "None"] | None
+        ) = None,
+        current_excitation_value: float | None = None,
         **kwargs: Any,
     ) -> None:
 

--- a/integration/console/task/channels/pressure_bridge_table.py
+++ b/integration/console/task/channels/pressure_bridge_table.py
@@ -7,7 +7,7 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal
 
 from console.task.channels.analog import Analog
 
@@ -41,40 +41,15 @@ class PressureBridgeTable(Analog):
         console: "Console",
         name: str,
         device: str,
-        pressure_units: Optional[
-            Literal[
-                "Pascals",
-                "PSI",
-            ]
-        ] = None,
-        bridge_configuration: Optional[
-            Literal[
-                "Full Bridge",
-                "Half Bridge",
-                "Quarter Bridge",
-            ]
-        ] = None,
-        resistance: Optional[float] = None,
-        excitation_source: Optional[
-            Literal[
-                "Internal",
-                "External",
-                "None",
-            ]
-        ] = None,
-        excitation_value: Optional[float] = None,
-        physical_units: Optional[
-            Literal[
-                "Pascals",
-                "PSI",
-            ]
-        ] = None,
-        electrical_units: Optional[
-            Literal[
-                "mV/V",
-                "V/V",
-            ]
-        ] = None,
+        pressure_units: Literal["Pascals", "PSI"] | None = None,
+        bridge_configuration: (
+            Literal["Full Bridge", "Half Bridge", "Quarter Bridge"] | None
+        ) = None,
+        resistance: float | None = None,
+        excitation_source: Literal["Internal", "External", "None"] | None = None,
+        excitation_value: float | None = None,
+        physical_units: Literal["Pascals", "PSI"] | None = None,
+        electrical_units: Literal["mV/V", "V/V"] | None = None,
         **kwargs: Any,
     ) -> None:
 

--- a/integration/console/task/channels/pressure_bridge_two_point_linear.py
+++ b/integration/console/task/channels/pressure_bridge_two_point_linear.py
@@ -7,7 +7,7 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal
 
 from console.task.channels.analog import Analog
 
@@ -45,44 +45,19 @@ class PressureBridgeTwoPointLinear(Analog):
         console: "Console",
         name: str,
         device: str,
-        pressure_units: Optional[
-            Literal[
-                "Pascals",
-                "PSI",
-            ]
-        ] = None,
-        bridge_configuration: Optional[
-            Literal[
-                "Full Bridge",
-                "Half Bridge",
-                "Quarter Bridge",
-            ]
-        ] = None,
-        resistance: Optional[float] = None,
-        excitation_source: Optional[
-            Literal[
-                "Internal",
-                "External",
-                "None",
-            ]
-        ] = None,
-        excitation_value: Optional[float] = None,
-        physical_units: Optional[
-            Literal[
-                "Pascals",
-                "PSI",
-            ]
-        ] = None,
-        electrical_units: Optional[
-            Literal[
-                "mV/V",
-                "V/V",
-            ]
-        ] = None,
-        physical_value_one: Optional[float] = None,
-        physical_value_two: Optional[float] = None,
-        electrical_value_one: Optional[float] = None,
-        electrical_value_two: Optional[float] = None,
+        pressure_units: Literal["Pascals", "PSI"] | None = None,
+        bridge_configuration: (
+            Literal["Full Bridge", "Half Bridge", "Quarter Bridge"] | None
+        ) = None,
+        resistance: float | None = None,
+        excitation_source: Literal["Internal", "External", "None"] | None = None,
+        excitation_value: float | None = None,
+        physical_units: Literal["Pascals", "PSI"] | None = None,
+        electrical_units: Literal["mV/V", "V/V"] | None = None,
+        physical_value_one: float | None = None,
+        physical_value_two: float | None = None,
+        electrical_value_one: float | None = None,
+        electrical_value_two: float | None = None,
         **kwargs: Any,
     ) -> None:
 

--- a/integration/console/task/channels/resistance.py
+++ b/integration/console/task/channels/resistance.py
@@ -7,7 +7,7 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal
 
 from console.task.channels.analog import Analog
 
@@ -37,21 +37,11 @@ class Resistance(Analog):
         console: "Console",
         name: str,
         device: str,
-        resistance_configuration: Optional[
-            Literal[
-                "2-Wire",
-                "3-Wire",
-                "4-Wire",
-            ]
-        ] = None,
-        current_excitation_source: Optional[
-            Literal[
-                "Internal",
-                "External",
-                "None",
-            ]
-        ] = None,
-        current_excitation_value: Optional[float] = None,
+        resistance_configuration: Literal["2-Wire", "3-Wire", "4-Wire"] | None = None,
+        current_excitation_source: (
+            Literal["Internal", "External", "None"] | None
+        ) = None,
+        current_excitation_value: float | None = None,
         **kwargs: Any,
     ) -> None:
 

--- a/integration/console/task/channels/rtd.py
+++ b/integration/console/task/channels/rtd.py
@@ -7,7 +7,7 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal
 
 from console.task.channels.analog import Analog
 
@@ -40,40 +40,18 @@ class RTD(Analog):
         console: "Console",
         name: str,
         device: str,
-        temperature_units: Optional[
-            Literal[
-                "Celsius",
-                "Fahrenheit",
-                "Kelvin",
-                "Rankine",
-            ]
-        ] = None,
-        rtd_type: Optional[
-            Literal[
-                "Pt3750",
-                "Pt3851",
-                "Pt3911",
-                "Pt3916",
-                "Pt3920",
-                "Pt3928",
-            ]
-        ] = None,
-        resistance_configuration: Optional[
-            Literal[
-                "2-Wire",
-                "3-Wire",
-                "4-Wire",
-            ]
-        ] = None,
-        current_excitation_source: Optional[
-            Literal[
-                "Internal",
-                "External",
-                "None",
-            ]
-        ] = None,
-        current_excitation_value: Optional[float] = None,
-        r0_resistance: Optional[float] = None,
+        temperature_units: (
+            Literal["Celsius", "Fahrenheit", "Kelvin", "Rankine"] | None
+        ) = None,
+        rtd_type: (
+            Literal["Pt3750", "Pt3851", "Pt3911", "Pt3916", "Pt3920", "Pt3928"] | None
+        ) = None,
+        resistance_configuration: Literal["2-Wire", "3-Wire", "4-Wire"] | None = None,
+        current_excitation_source: (
+            Literal["Internal", "External", "None"] | None
+        ) = None,
+        current_excitation_value: float | None = None,
+        r0_resistance: float | None = None,
         **kwargs: Any,
     ) -> None:
 

--- a/integration/console/task/channels/strain_gauge.py
+++ b/integration/console/task/channels/strain_gauge.py
@@ -7,7 +7,7 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal
 
 from console.task.channels.analog import Analog
 
@@ -42,7 +42,7 @@ class StrainGauge(Analog):
         console: "Console",
         name: str,
         device: str,
-        strain_configuration: Optional[
+        strain_configuration: (
             Literal[
                 "Full Bridge I",
                 "Full Bridge II",
@@ -51,20 +51,15 @@ class StrainGauge(Analog):
                 "Half Bridge II",
                 "Quarter Bridge I",
             ]
-        ] = None,
-        excitation_source: Optional[
-            Literal[
-                "Internal",
-                "External",
-                "None",
-            ]
-        ] = None,
-        excitation_value: Optional[float] = None,
-        gage_factor: Optional[float] = None,
-        initial_bridge_voltage: Optional[float] = None,
-        nominal_gage_resistance: Optional[float] = None,
-        poisson_ratio: Optional[float] = None,
-        lead_wire_resistance: Optional[float] = None,
+            | None
+        ) = None,
+        excitation_source: Literal["Internal", "External", "None"] | None = None,
+        excitation_value: float | None = None,
+        gage_factor: float | None = None,
+        initial_bridge_voltage: float | None = None,
+        nominal_gage_resistance: float | None = None,
+        poisson_ratio: float | None = None,
+        lead_wire_resistance: float | None = None,
         **kwargs: Any,
     ) -> None:
 

--- a/integration/console/task/channels/temperature_built_in_sensor.py
+++ b/integration/console/task/channels/temperature_built_in_sensor.py
@@ -7,7 +7,7 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Literal
 
 from console.task.channels.analog import Analog
 
@@ -33,18 +33,11 @@ class TemperatureBuiltInSensor(Analog):
     def __init__(
         self,
         console: "Console",
-        name: str,
         device: str,
-        port: Optional[int] = None,
-        temperature_units: Optional[
-            Literal[
-                "Celsius",
-                "Fahrenheit",
-                "Kelvin",
-                "Rankine",
-            ]
-        ] = None,
-        **kwargs: Any,
+        port: int | None = None,
+        temperature_units: (
+            Literal["Celsius", "Fahrenheit", "Kelvin", "Rankine"] | None
+        ) = None,
     ) -> None:
 
         # Does not call super()

--- a/integration/console/task/channels/thermocouple.py
+++ b/integration/console/task/channels/thermocouple.py
@@ -7,7 +7,7 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Literal
 
 from console.task.channels.analog import Analog
 
@@ -39,37 +39,16 @@ class Thermocouple(Analog):
         console: "Console",
         name: str,
         device: str,
-        port: Optional[int] = None,
-        temperature_units: Optional[
-            Literal[
-                "Celsius",
-                "Fahrenheit",
-                "Kelvin",
-                "Rankine",
-            ]
-        ] = None,
-        thermocouple_type: Optional[
-            Literal[
-                "B",
-                "E",
-                "J",
-                "K",
-                "N",
-                "R",
-                "S",
-                "T",
-            ]
-        ] = None,
-        cjc_source: Optional[
-            Literal[
-                "Built In",
-                "Constant Value",
-                "Channel",
-            ]
-        ] = None,
-        cjc_value: Optional[float] = None,
-        cjc_port: Optional[int] = None,
-        **kwargs: Any,
+        port: int | None = None,
+        temperature_units: (
+            Literal["Celsius", "Fahrenheit", "Kelvin", "Rankine"] | None
+        ) = None,
+        thermocouple_type: (
+            Literal["B", "E", "J", "K", "N", "R", "S", "T"] | None
+        ) = None,
+        cjc_source: Literal["Built In", "Constant Value", "Channel"] | None = None,
+        cjc_value: float | None = None,
+        cjc_port: int | None = None,
     ) -> None:
 
         # Does not call super()

--- a/integration/console/task/channels/torque_bridge_table.py
+++ b/integration/console/task/channels/torque_bridge_table.py
@@ -7,7 +7,7 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal
 
 from console.task.channels.analog import Analog
 
@@ -41,42 +41,21 @@ class TorqueBridgeTable(Analog):
         console: "Console",
         name: str,
         device: str,
-        torque_units: Optional[
-            Literal[
-                "Newton Meters",
-                "Inch Ounces",
-                "Foot Pounds",
-            ]
-        ] = None,
-        bridge_configuration: Optional[
-            Literal[
-                "Full Bridge",
-                "Half Bridge",
-                "Quarter Bridge",
-            ]
-        ] = None,
-        nominal_bridge_resistance: Optional[float] = None,
-        voltage_excitation_source: Optional[
-            Literal[
-                "Internal",
-                "External",
-                "None",
-            ]
-        ] = None,
-        voltage_excitation_value: Optional[float] = None,
-        physical_units: Optional[
-            Literal[
-                "Newton Meters",
-                "Inch Ounces",
-                "Foot Pounds",
-            ]
-        ] = None,
-        electrical_units: Optional[
-            Literal[
-                "mV/V",
-                "V/V",
-            ]
-        ] = None,
+        torque_units: (
+            Literal["Newton Meters", "Inch Ounces", "Foot Pounds"] | None
+        ) = None,
+        bridge_configuration: (
+            Literal["Full Bridge", "Half Bridge", "Quarter Bridge"] | None
+        ) = None,
+        nominal_bridge_resistance: float | None = None,
+        voltage_excitation_source: (
+            Literal["Internal", "External", "None"] | None
+        ) = None,
+        voltage_excitation_value: float | None = None,
+        physical_units: (
+            Literal["Newton Meters", "Inch Ounces", "Foot Pounds"] | None
+        ) = None,
+        electrical_units: Literal["mV/V", "V/V"] | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(

--- a/integration/console/task/channels/torque_bridge_two_point_linear.py
+++ b/integration/console/task/channels/torque_bridge_two_point_linear.py
@@ -7,7 +7,7 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal
 
 from console.task.channels.analog import Analog
 
@@ -45,46 +45,25 @@ class TorqueBridgeTwoPointLinear(Analog):
         console: "Console",
         name: str,
         device: str,
-        torque_units: Optional[
-            Literal[
-                "Newton Meters",
-                "Inch Ounces",
-                "Foot Pounds",
-            ]
-        ] = None,
-        bridge_configuration: Optional[
-            Literal[
-                "Full Bridge",
-                "Half Bridge",
-                "Quarter Bridge",
-            ]
-        ] = None,
-        nominal_bridge_resistance: Optional[float] = None,
-        voltage_excitation_source: Optional[
-            Literal[
-                "Internal",
-                "External",
-                "None",
-            ]
-        ] = None,
-        voltage_excitation_value: Optional[float] = None,
-        physical_units: Optional[
-            Literal[
-                "Newton Meters",
-                "Inch Ounces",
-                "Foot Pounds",
-            ]
-        ] = None,
-        electrical_units: Optional[
-            Literal[
-                "mV/V",
-                "V/V",
-            ]
-        ] = None,
-        physical_value_one: Optional[float] = None,
-        physical_value_two: Optional[float] = None,
-        electrical_value_one: Optional[float] = None,
-        electrical_value_two: Optional[float] = None,
+        torque_units: (
+            Literal["Newton Meters", "Inch Ounces", "Foot Pounds"] | None
+        ) = None,
+        bridge_configuration: (
+            Literal["Full Bridge", "Half Bridge", "Quarter Bridge"] | None
+        ) = None,
+        nominal_bridge_resistance: float | None = None,
+        voltage_excitation_source: (
+            Literal["Internal", "External", "None"] | None
+        ) = None,
+        voltage_excitation_value: float | None = None,
+        physical_units: (
+            Literal["Newton Meters", "Inch Ounces", "Foot Pounds"] | None
+        ) = None,
+        electrical_units: Literal["mV/V", "V/V"] | None = None,
+        physical_value_one: float | None = None,
+        physical_value_two: float | None = None,
+        electrical_value_one: float | None = None,
+        electrical_value_two: float | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(

--- a/integration/console/task/channels/velocity_iepe.py
+++ b/integration/console/task/channels/velocity_iepe.py
@@ -7,7 +7,7 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal
 
 from console.task.channels.analog import Analog
 
@@ -39,27 +39,13 @@ class VelocityIEPE(Analog):
         console: "Console",
         name: str,
         device: str,
-        velocity_units: Optional[
-            Literal[
-                "m/s",
-                "in/s",
-            ]
-        ] = None,
-        sensitivity: Optional[float] = None,
-        sensitivity_units: Optional[
-            Literal[
-                "mV/mm/s",
-                "mV/in/s",
-            ]
-        ] = None,
-        current_excitation_source: Optional[
-            Literal[
-                "Internal",
-                "External",
-                "None",
-            ]
-        ] = None,
-        current_excitation_value: Optional[float] = None,
+        velocity_units: Literal["m/s", "in/s"] | None = None,
+        sensitivity: float | None = None,
+        sensitivity_units: Literal["mV/mm/s", "mV/in/s"] | None = None,
+        current_excitation_source: (
+            Literal["Internal", "External", "None"] | None
+        ) = None,
+        current_excitation_value: float | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(

--- a/integration/console/task/ni.py
+++ b/integration/console/task/ni.py
@@ -8,7 +8,7 @@
 #  included in the file licenses/APL.txt.
 
 from abc import abstractmethod
-from typing import TYPE_CHECKING, Any, Literal, Optional, Type
+from typing import TYPE_CHECKING, Any
 
 import synnax as sy
 from playwright.sync_api import Page
@@ -39,7 +39,7 @@ class NITask(ConsolePage):
         name: str,
         type: str,
         device: str,
-        dev_name: Optional[str] = None,
+        dev_name: str | None = None,
         **kwargs: Any,
     ) -> Analog:
         """
@@ -63,10 +63,9 @@ class NITask(ConsolePage):
     def _add_channel_helper(
         self,
         name: str,
-        type: str,
         device: str,
-        dev_name: Optional[str],
-        channel_class: Type[Analog],
+        dev_name: str | None,
+        channel_class: type[Analog],
         **kwargs: Any,
     ) -> Analog:
         """
@@ -146,10 +145,9 @@ class NITask(ConsolePage):
 
     def set_parameters(
         self,
-        task_name: Optional[str] = None,
-        data_saving: Optional[bool] = None,
-        auto_start: Optional[bool] = None,
-        **kwargs: Any,
+        task_name: str | None = None,
+        data_saving: bool | None = None,
+        auto_start: bool | None = None,
     ) -> None:
         """
         Set the parameters for the task.

--- a/integration/framework/test_case.py
+++ b/integration/framework/test_case.py
@@ -19,9 +19,10 @@ import threading
 import traceback
 from abc import ABC, abstractmethod
 from collections import deque
+from collections.abc import Callable
 from dataclasses import dataclass
 from enum import Enum, auto
-from typing import Any, Callable, Dict, List, Literal, Optional, Set, Union, overload
+from typing import Any, Literal, overload
 
 import synnax as sy
 
@@ -101,7 +102,7 @@ class TestCase(ABC):
     DEFAULT_MANUAL_TIMEOUT: int = -1
 
     logger: logging.Logger
-    frame_in: Optional[sy.Frame]
+    frame_in: sy.Frame | None
 
     def __init__(
         self,
@@ -128,7 +129,7 @@ class TestCase(ABC):
         self.start_time: sy.TimeStamp = sy.TimeStamp.now()
         self._timeout_limit: int = self.DEFAULT_TIMEOUT_LIMIT  # -1 = no timeout
         self._manual_timeout: int = self.DEFAULT_MANUAL_TIMEOUT
-        self.read_frame: Optional[Dict[str, Union[int, float]]] = None
+        self.read_frame: dict[str, int | float] | None = None
         self.read_timeout = self.DEFAULT_READ_TIMEOUT
 
         self.name = validate_and_sanitize_name(name)
@@ -152,7 +153,7 @@ class TestCase(ABC):
         self._should_stop = False
         self.is_running = True
 
-        self.subscribed_channels: Set[str] = set()
+        self.subscribed_channels: set[str] = set()
 
         self.time_index = self.client.channels.create(
             name=f"{self.name}_time",
@@ -367,7 +368,7 @@ class TestCase(ABC):
         if self._status == STATUS.PENDING:
             self.STATUS = STATUS.PASSED
 
-    def _wait_for_client_completion(self, timeout: Optional[float] = None) -> None:
+    def _wait_for_client_completion(self, timeout: float | None = None) -> None:
         """Wait for client threads to complete."""
         # Wait for streamer thread
         if self.streamer_thread.is_alive():
@@ -441,7 +442,7 @@ class TestCase(ABC):
         self.tlm[tlm_name] = initial_value
 
     def subscribe(
-        self, channels: Union[str, List[str]], timeout: Optional[sy.TimeSpan] = 10
+        self, channels: str | list[str], timeout: sy.TimeSpan | None = 10
     ) -> None:
         """
         Subscribe to channels.
@@ -520,14 +521,14 @@ class TestCase(ABC):
     @overload
     def read_tlm(
         self, key: str, default: Literal[None] = None
-    ) -> Optional[Union[int, float]]: ...
+    ) -> int | float | None: ...
 
     @overload
-    def read_tlm(self, key: str, default: Union[int, float]) -> Union[int, float]: ...
+    def read_tlm(self, key: str, default: int | float) -> int | float: ...
 
     def read_tlm(
-        self, key: str, default: Optional[Union[int, float]] = None
-    ) -> Optional[Union[int, float]]:
+        self, key: str, default: int | float | None = None
+    ) -> int | float | None:
         try:
             if self.read_frame is not None:
                 value = self.read_frame.get(key, default)
@@ -563,14 +564,14 @@ class TestCase(ABC):
     @overload
     def get_state(
         self, key: str, default: Literal[None] = None
-    ) -> Optional[Union[int, float]]: ...
+    ) -> int | float | None: ...
 
     @overload
-    def get_state(self, key: str, default: Union[int, float]) -> Union[int, float]: ...
+    def get_state(self, key: str, default: int | float) -> int | float: ...
 
     def get_state(
-        self, key: str, default: Optional[Union[int, float]] = None
-    ) -> Optional[Union[int, float]]:
+        self, key: str, default: int | float | None = None
+    ) -> int | float | None:
         """
         Easily get state of this object.
 
@@ -741,7 +742,7 @@ class TestCase(ABC):
         """Get writer thread status."""
         return "Running" if self.writer_thread.is_alive() else "Stopped"
 
-    def fail(self, message: Optional[str] = None) -> None:
+    def fail(self, message: str | None = None) -> None:
         if message is not None:
             self.log(f"FAILED: {message}")
         self.STATUS = STATUS.FAILED

--- a/integration/scripts/sim_from_task_configs.py
+++ b/integration/scripts/sim_from_task_configs.py
@@ -22,7 +22,7 @@ import random
 import signal
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 import synnax as sy
 
@@ -34,21 +34,21 @@ class SimDAQ:
         self.config_dir = config_dir
 
         # Channel tracking
-        self.sensor_channels: List[Tuple[str, str]] = []  # (name, type)
-        self.valve_pairs: List[Tuple[str, str]] = []  # (cmd_name, state_name)
-        self.ao_pairs: List[Tuple[str, str]] = []  # (cmd_name, state_name)
+        self.sensor_channels: list[tuple[str, str]] = []  # (name, type)
+        self.valve_pairs: list[tuple[str, str]] = []  # (cmd_name, state_name)
+        self.ao_pairs: list[tuple[str, str]] = []  # (cmd_name, state_name)
 
         # Simulation state
-        self.valve_states: Dict[str, float] = {}
-        self.ao_states: Dict[str, float] = {}
+        self.valve_states: dict[str, float] = {}
+        self.ao_states: dict[str, float] = {}
         self.time_offset = sy.TimeStamp.now()
         self.noise = random.Random()
 
         # Index channels
-        self.indices: Dict[str, sy.Channel] = {}
+        self.indices: dict[str, sy.Channel] = {}
 
         # Channel mapping: config_key -> {name, synnax_key}
-        self.channel_mapping: List[Dict[str, Any]] = []
+        self.channel_mapping: list[dict[str, Any]] = []
 
     def get_index(self, name: str) -> sy.Channel:
         """Get or create an index channel."""
@@ -109,7 +109,7 @@ class SimDAQ:
         self._save_channel_mapping()
 
     def _create_digital_outputs(
-        self, channels: list[Dict[str, Any]], filename: str
+        self, channels: list[dict[str, Any]], filename: str
     ) -> None:
         """Create digital output channels (valves)."""
         print(f"[{filename}] Digital outputs")
@@ -168,7 +168,7 @@ class SimDAQ:
             print(f"  ✓ {cmd_name} / {state_name}")
 
     def _create_analog_inputs(
-        self, channels: list[Dict[str, Any]], filename: str
+        self, channels: list[dict[str, Any]], filename: str
     ) -> None:
         """Create analog input channels (sensors)."""
         print(f"[{filename}] Analog inputs")
@@ -207,7 +207,7 @@ class SimDAQ:
             print(f"  ✓ {name}")
 
     def _create_analog_outputs(
-        self, channels: list[Dict[str, Any]], filename: str
+        self, channels: list[dict[str, Any]], filename: str
     ) -> None:
         """Create analog output channels."""
         print(f"[{filename}] Analog outputs")
@@ -266,7 +266,7 @@ class SimDAQ:
             print(f"  ✓ {cmd_name} / {state_name}")
 
     def _generate_sensor_name(
-        self, ch: Dict[str, Any], port: int, ch_type: str, index: int
+        self, ch: dict[str, Any], port: int, ch_type: str, index: int
     ) -> str:
         """Generate a descriptive sensor name."""
         if ch_type == "ai_voltage":

--- a/integration/scripts/transform_schematic.py
+++ b/integration/scripts/transform_schematic.py
@@ -18,10 +18,10 @@ import argparse
 import json
 import sys
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any
 
 
-def load_channel_mapping(mapping_path: Path) -> Dict[int, int]:
+def load_channel_mapping(mapping_path: Path) -> dict[int, int]:
     """Load channel mapping and create config_key -> synnax_key dict."""
     with open(mapping_path) as f:
         mappings = json.load(f)
@@ -37,7 +37,7 @@ def load_channel_mapping(mapping_path: Path) -> Dict[int, int]:
     return key_map
 
 
-def transform_value(value: Any, key_map: Dict[int, int], stats: Dict[str, int]) -> Any:
+def transform_value(value: Any, key_map: dict[int, int], stats: dict[str, int]) -> Any:
     """Recursively transform values, replacing config keys with synnax keys.
 
     Args:


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue and link -->

[SY-3201](https://linear.app/synnax/issue/SY-3201/remove-outdated-typing-syntax-in-python)

## Description

<!-- Write a short (2-3 sentence) description describing the changes. -->

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant tests to cover the changes to CI.
- [x] <!-- prettier-ignore --> I have added needed QA steps to the [release candidate](/synnaxlabs/synnax/blob/main/.github/PULL_REQUEST_TEMPLATE/rc.md) template that cover these changes.
- [x] I have updated in-code documentation to reflect the changes.
- [x] I have updated user-facing documentation to reflect the changes.
