### PR TITLE
SY-4033: Add Copy Diagnostics to Status Notifications

### DIFF
--- a/console/src-tauri/tauri.conf.json
+++ b/console/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Synnax",
-  "version": "0.54.0",
+  "version": "0.54.1",
   "build": {
     "beforeBuildCommand": "pnpm build-vite",
     "beforeDevCommand": "pnpm dev-vite",

--- a/console/src/hardware/common/task/UtilityButtons.tsx
+++ b/console/src/hardware/common/task/UtilityButtons.tsx
@@ -8,95 +8,106 @@
 // included in the file licenses/APL.txt.
 
 import { task } from "@synnaxlabs/client";
-import { Button, Flex, Form, Icon } from "@synnaxlabs/pluto";
-import { binary } from "@synnaxlabs/x";
+import { Button, Divider, Flex, Form, Icon } from "@synnaxlabs/pluto";
+import { binary, primitive } from "@synnaxlabs/x";
+import { useCallback } from "react";
 
 import { Cluster } from "@/cluster";
 import { useExport } from "@/hardware/common/task/export";
 import { useKey } from "@/hardware/common/task/useKey";
-import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
-
-interface UtilityButtonProps {
-  children: Icon.FC;
-  disabled?: boolean;
-  onClick: () => void;
-  tooltip: string;
-}
-
-const UtilityButton = ({ children: Icon, ...rest }: UtilityButtonProps) => (
-  <Button.Button tooltipLocation="left" variant="text" {...rest}>
-    <Icon style={{ color: "var(--pluto-gray-l9)" }} />
-  </Button.Button>
-);
 
 export const UtilityButtons = () => {
   const ctx = Form.useContext();
   const taskKey = useKey();
   const getName = () => ctx.get<string>("name").value;
-  const copy = useCopyToClipboard();
   const export_ = useExport();
   const handleExport = () => taskKey != null && export_(taskKey);
-  const handleCopyTypeScriptCode = () => {
-    const name = getName();
-    copy(
+  const getTypeScriptCode = useCallback(
+    () =>
       `
-      // Retrieve ${name}
+      // Retrieve ${getName()}
       const task = client.tasks.retrieve("${taskKey}")
       `,
-      `TypeScript code for retrieving ${name}`,
-    );
-  };
-  const handleCopyPythonCode = () => {
-    const name = getName();
-    copy(
+    [ctx, taskKey],
+  );
+  const getPythonCode = useCallback(
+    () =>
       `
-      # Retrieve ${name}
+      # Retrieve ${getName()}
       task = client.tasks.retrieve("${taskKey}")
       `,
-      `Python code for retrieving ${name}`,
-    );
-  };
-  const handleCopyJSONConfig = () => {
-    const name = getName();
+    [ctx, taskKey],
+  );
+  const getJSONConfig = useCallback(() => {
     const config = ctx.get("config").value;
-    copy(binary.JSON_CODEC.encodeString(config), `JSON configuration for ${name}`);
-  };
+    return binary.JSON_CODEC.encodeString(config);
+  }, [ctx]);
   const copyLink = Cluster.useCopyLinkToClipboard();
   const handleCopyLink = () => {
-    const name = getName();
     if (taskKey == null) return;
-    copyLink({ name, ontologyID: task.ontologyID(taskKey) });
+    copyLink({ name: getName(), ontologyID: task.ontologyID(taskKey) });
   };
-  const hasDisabledButtons = taskKey === "";
+  const hasKey = !primitive.isZero(taskKey);
   return (
-    <Flex.Box x empty>
-      <UtilityButton
-        disabled={hasDisabledButtons}
-        onClick={handleCopyTypeScriptCode}
-        tooltip="Copy TypeScript code"
+    <Flex.Box x gap="small">
+      {hasKey && (
+        <>
+          <Button.Copy
+            text={getTypeScriptCode}
+            tooltip="Copy TypeScript code"
+            tooltipLocation="left"
+            variant="text"
+            successMessage="Copied TypeScript code to clipboard"
+            textColor={9}
+          >
+            <Icon.TypeScript />
+          </Button.Copy>
+          <Button.Copy
+            text={getPythonCode}
+            tooltip="Copy Python code"
+            tooltipLocation="left"
+            variant="text"
+            successMessage="Copied Python code to clipboard"
+            textColor={9}
+          >
+            <Icon.Python />
+          </Button.Copy>
+          <Divider.Divider y />
+        </>
+      )}
+      <Button.Copy
+        text={getJSONConfig}
+        tooltip="Copy JSON configuration"
+        tooltipLocation="left"
+        variant="text"
+        successMessage="Copied JSON configuration to clipboard"
+        textColor={9}
       >
-        {Icon.TypeScript}
-      </UtilityButton>
-      <UtilityButton onClick={handleCopyPythonCode} tooltip="Copy Python code">
-        {Icon.Python}
-      </UtilityButton>
-      <UtilityButton onClick={handleCopyJSONConfig} tooltip="Copy JSON configuration">
-        {Icon.JSON}
-      </UtilityButton>
-      <UtilityButton
-        onClick={handleExport}
-        disabled={hasDisabledButtons}
-        tooltip="Export"
-      >
-        {Icon.Export}
-      </UtilityButton>
-      <UtilityButton
-        disabled={hasDisabledButtons}
-        onClick={handleCopyLink}
-        tooltip="Copy link"
-      >
-        {Icon.Link}
-      </UtilityButton>
+        <Icon.JSON />
+      </Button.Copy>
+      {hasKey && (
+        <>
+          <Divider.Divider y />
+          <Button.Button
+            onClick={handleCopyLink}
+            tooltip="Copy link"
+            tooltipLocation="left"
+            variant="text"
+            textColor={9}
+          >
+            <Icon.Link />
+          </Button.Button>
+          <Button.Button
+            onClick={handleExport}
+            tooltip="Export"
+            tooltipLocation="left"
+            variant="text"
+            textColor={9}
+          >
+            <Icon.Export />
+          </Button.Button>
+        </>
+      )}
     </Flex.Box>
   );
 };

--- a/console/src/hardware/common/task/UtilityButtons.tsx
+++ b/console/src/hardware/common/task/UtilityButtons.tsx
@@ -57,7 +57,9 @@ export const UtilityButtons = () => {
             tooltip="Copy TypeScript code"
             tooltipLocation="left"
             variant="text"
-            successMessage="Copied TypeScript code to clipboard"
+            successMessage={() =>
+              `Copied TypeScript code for ${getName()} to clipboard`
+            }
             textColor={9}
           >
             <Icon.TypeScript />
@@ -67,7 +69,7 @@ export const UtilityButtons = () => {
             tooltip="Copy Python code"
             tooltipLocation="left"
             variant="text"
-            successMessage="Copied Python code to clipboard"
+            successMessage={() => `Copied Python code for ${getName()} to clipboard`}
             textColor={9}
           >
             <Icon.Python />
@@ -80,7 +82,7 @@ export const UtilityButtons = () => {
         tooltip="Copy JSON configuration"
         tooltipLocation="left"
         variant="text"
-        successMessage="Copied JSON configuration to clipboard"
+        successMessage={() => `Copied JSON configuration for ${getName()} to clipboard`}
         textColor={9}
       >
         <Icon.JSON />

--- a/console/src/hardware/common/task/layouts/DetailsHeader.tsx
+++ b/console/src/hardware/common/task/layouts/DetailsHeader.tsx
@@ -11,8 +11,6 @@ import { Button, Form, Header, Icon } from "@synnaxlabs/pluto";
 import { binary } from "@synnaxlabs/x";
 import { useCallback } from "react";
 
-import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
-
 export interface DetailsHeaderProps {
   path: string;
   disabled?: boolean;
@@ -20,29 +18,29 @@ export interface DetailsHeaderProps {
 
 export const DetailsHeader = ({ path, disabled = false }: DetailsHeaderProps) => {
   const { get } = Form.useContext();
-  const copy = useCopyToClipboard();
-  const handleCopy = useCallback(() => {
-    copy(binary.JSON_CODEC.encodeString(get(path).value), "details");
-  }, [copy, get, path]);
+  const getText = useCallback(
+    () => binary.JSON_CODEC.encodeString(get(path).value),
+    [get, path],
+  );
   return (
     <Header.Header>
       <Header.Title weight={500} wrap={false} color={10}>
         Details
       </Header.Title>
       <Header.Actions>
-        <Button.Button
+        <Button.Copy
           disabled={disabled}
           tooltip="Copy details as JSON"
           tooltipLocation="left"
           variant="text"
-          onClick={handleCopy}
+          text={getText}
+          successMessage="Copied details to clipboard"
           contrast={2}
+          textColor={9}
         >
-          <Icon.JSON style={ICON_STYLE} />
-        </Button.Button>
+          <Icon.JSON />
+        </Button.Copy>
       </Header.Actions>
     </Header.Header>
   );
 };
-
-const ICON_STYLE = { color: "var(--pluto-gray-l9)" };

--- a/console/src/lineplot/LinePlot.tsx
+++ b/console/src/lineplot/LinePlot.tsx
@@ -367,53 +367,39 @@ const Loaded: Layout.Renderer = ({ layoutKey, focused, visible }) => {
     const placeLayout = Layout.usePlacer();
     const handleError = Status.useErrorHandler();
 
-    const getTimeRange = useCallback(async () => {
+    const getTimeRange = useCallback(async (): Promise<TimeRange> => {
       const bounds = await linePlotRef.current?.getBounds();
-      if (bounds == null) return null;
+      if (bounds == null) throw new Error("No bounds available");
       const s = scale.Scale.scale<number>(1).scale(bounds.x1);
       return new TimeRange(s.pos(box.left(selection)), s.pos(box.right(selection)));
     }, [selection]);
 
     const downloadAsCSV = useDownloadAsCSV();
 
-    const handleCopyISO = () =>
-      handleError(async () => {
-        const tr = await getTimeRange();
-        if (tr == null) return;
-        await navigator.clipboard.writeText(
-          `${tr.start.toString("ISO")} - ${tr.end.toString("ISO")}`,
-        );
-      }, "Failed to copy ISO time range");
+    const getISOText = useCallback(async () => {
+      const tr = await getTimeRange();
+      return `${tr.start.toString("ISO")} - ${tr.end.toString("ISO")}`;
+    }, [getTimeRange]);
 
-    const handleCopyPython = () =>
-      handleError(async () => {
-        const tr = await getTimeRange();
-        if (tr == null) return;
-        await navigator.clipboard.writeText(
-          `sy.TimeRange(${tr.start.valueOf()}, ${tr.end.valueOf()})`,
-        );
-      }, "Failed to copy Python time range");
+    const getPythonText = useCallback(async () => {
+      const tr = await getTimeRange();
+      return `sy.TimeRange(${tr.start.valueOf()}, ${tr.end.valueOf()})`;
+    }, [getTimeRange]);
 
-    const handleCopyTypeScript = () =>
-      handleError(async () => {
-        const tr = await getTimeRange();
-        if (tr == null) return;
-        await navigator.clipboard.writeText(
-          `new TimeRange(${tr.start.valueOf()}, ${tr.end.valueOf()})`,
-        );
-      }, "Failed to copy TypeScript time range");
+    const getTypeScriptText = useCallback(async () => {
+      const tr = await getTimeRange();
+      return `new TimeRange(${tr.start.valueOf()}, ${tr.end.valueOf()})`;
+    }, [getTimeRange]);
 
     const handleCreateRange = () =>
       handleError(async () => {
         const tr = await getTimeRange();
-        if (tr == null) return;
         placeLayout(Range.createCreateLayout({ timeRange: tr.numeric }));
       }, "Failed to create range from selection");
 
     const handleDownloadCSV = () =>
       handleError(async () => {
         const tr = await getTimeRange();
-        if (tr == null) return;
         downloadAsCSV({ timeRanges: [tr], lines, name });
       }, "Failed to download region as CSV");
 
@@ -421,15 +407,27 @@ const Loaded: Layout.Renderer = ({ layoutKey, focused, visible }) => {
       <ContextMenu.Menu>
         {!box.areaIsZero(selection) && (
           <>
-            <Menu.Item itemKey="iso" onClick={handleCopyISO}>
+            <Menu.CopyItem
+              itemKey="iso"
+              text={getISOText}
+              successMessage="Copied ISO time range to clipboard"
+            >
               <Icon.Range /> Copy ISO time range
-            </Menu.Item>
-            <Menu.Item itemKey="python" onClick={handleCopyPython}>
+            </Menu.CopyItem>
+            <Menu.CopyItem
+              itemKey="python"
+              text={getPythonText}
+              successMessage="Copied Python time range to clipboard"
+            >
               <Icon.Python /> Copy Python time range
-            </Menu.Item>
-            <Menu.Item itemKey="typescript" onClick={handleCopyTypeScript}>
+            </Menu.CopyItem>
+            <Menu.CopyItem
+              itemKey="typescript"
+              text={getTypeScriptText}
+              successMessage="Copied TypeScript time range to clipboard"
+            >
               <Icon.TypeScript /> Copy TypeScript time range
-            </Menu.Item>
+            </Menu.CopyItem>
             <Menu.Divider />
             <Menu.Item itemKey="range" onClick={handleCreateRange}>
               <Ranger.CreateIcon /> Create range from selection

--- a/console/src/ontology/CopyPropertiesContextMenuItem.tsx
+++ b/console/src/ontology/CopyPropertiesContextMenuItem.tsx
@@ -7,16 +7,14 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { Icon, Menu } from "@synnaxlabs/pluto";
-import { type ReactElement } from "react";
+import { Menu } from "@synnaxlabs/pluto";
+import { type ReactElement, useCallback } from "react";
 
-import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { type TreeContextMenuProps } from "@/ontology/service";
 
 export const CopyPropertiesContextMenuItem = (
   props: TreeContextMenuProps,
 ): ReactElement | null => {
-  const copy = useCopyToClipboard();
   const {
     selection: { ids },
     state: { getResource },
@@ -24,11 +22,14 @@ export const CopyPropertiesContextMenuItem = (
   if (ids.length !== 1) return null;
   const id = ids[0];
   const { data, name } = getResource(id);
-  const handleClick = () => copy(JSON.stringify(data), `data for ${name}`);
+  const getText = useCallback(() => JSON.stringify(data), [data]);
   return (
-    <Menu.Item itemKey="copyData" onClick={handleClick}>
-      <Icon.Copy />
+    <Menu.CopyItem
+      itemKey="copyData"
+      text={getText}
+      successMessage={`Copied properties for ${name} to clipboard`}
+    >
       Copy properties
-    </Menu.Item>
+    </Menu.CopyItem>
   );
 };

--- a/console/src/range/overview/Details.tsx
+++ b/console/src/range/overview/Details.tsx
@@ -25,7 +25,6 @@ import { type FC, type ReactElement, useCallback } from "react";
 import { Cluster } from "@/cluster";
 import { CSS } from "@/css";
 import { CSV } from "@/csv";
-import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 import { Label } from "@/label";
 import { Layout } from "@/layout";
 import { FavoriteButton } from "@/range/FavoriteButton";
@@ -100,27 +99,21 @@ export const Details: FC<DetailsProps> = ({ rangeKey }) => {
   );
   Layout.useSyncName(rangeKey, name, handleLayoutNameChange);
 
-  const copy = useCopyToClipboard();
-  const handleCopyPythonCode = () => {
-    copy(
+  const getPythonCode = useCallback(
+    () =>
       `
       # Retrieve ${name}
       rng = client.ranges.retrieve(key="${rangeKey}")
     `,
-      `Python code to retrieve ${name}`,
-    );
-  };
-
-  const handleCopyTypeScriptCode = () => {
+    [name, rangeKey],
+  );
+  const getTypeScriptCode = useCallback(() => {
     const name = form.get<string>("name").value;
-    copy(
-      `
+    return `
       // Retrieve ${name}
       const rng = await client.ranges.retrieve("${rangeKey}")
-    `,
-      `TypeScript code to retrieve ${name}`,
-    );
-  };
+    `;
+  }, [form, rangeKey]);
 
   const promptDownloadCSVModal = CSV.useDownloadModal();
 
@@ -153,36 +146,32 @@ export const Details: FC<DetailsProps> = ({ rangeKey }) => {
             <ParentRangeButton rangeKey={rangeKey} />
           </Flex.Box>
           <Flex.Box x style={{ height: "fit-content" }} gap="small">
-            <Button.Button
+            <Button.Copy
+              text={getPythonCode}
               tooltip={`Copy Python code to retrieve ${name}`}
               tooltipLocation="bottom"
               variant="text"
-              onClick={handleCopyPythonCode}
-            >
-              <Icon.Python color={9} />
-            </Button.Button>
-            <Button.Button
-              variant="text"
-              tooltip={`Copy TypeScript code to retrieve ${name}`}
-              tooltipLocation="bottom"
-              onClick={handleCopyTypeScriptCode}
-            >
-              <Icon.TypeScript color={9} />
-            </Button.Button>
-            <Divider.Divider y />
-            <Button.Button
-              variant="text"
-              tooltip={`Copy link to ${name}`}
-              tooltipLocation="bottom"
-              onClick={handleCopyLink}
+              successMessage={`Copied Python code to retrieve ${name} to clipboard`}
               textColor={9}
             >
-              <Icon.Link color={9} />
-            </Button.Button>
+              <Icon.Python />
+            </Button.Copy>
+            <Button.Copy
+              variant="text"
+              text={getTypeScriptCode}
+              tooltip={`Copy TypeScript code to retrieve ${name}`}
+              tooltipLocation="bottom"
+              successMessage={`Copied TypeScript code to retrieve ${name} to clipboard`}
+              textColor={9}
+            >
+              <Icon.TypeScript />
+            </Button.Copy>
+            <Divider.Divider y />
             <Button.Button
               tooltip={`Download data for ${name} as a CSV`}
               tooltipLocation="bottom"
               variant="text"
+              textColor={9}
               onClick={() =>
                 handleError(async () => {
                   await promptDownloadCSVModal(
@@ -196,9 +185,18 @@ export const Details: FC<DetailsProps> = ({ rangeKey }) => {
                 }, "Failed to download CSV")
               }
             >
-              <Icon.CSV color={9} />
+              <Icon.CSV />
             </Button.Button>
             <Divider.Divider y />
+            <Button.Button
+              variant="text"
+              tooltip={`Copy link to ${name}`}
+              tooltipLocation="bottom"
+              onClick={handleCopyLink}
+              textColor={9}
+            >
+              <Icon.Link />
+            </Button.Button>
             {range != null && <FavoriteButton range={range} size="medium" />}
           </Flex.Box>
         </Flex.Box>

--- a/console/src/range/overview/MetaData.tsx
+++ b/console/src/range/overview/MetaData.tsx
@@ -46,7 +46,11 @@ const ValueInput = ({ value, ...rest }: ValueInputProps): ReactElement => {
       propagateClick
       {...rest}
     >
-      <Button.Copy text={value} variant="outlined" successMessage="Copied value to clipboard" />
+      <Button.Copy
+        text={value}
+        variant="outlined"
+        successMessage="Copied value to clipboard"
+      />
       {isLink && (
         <Button.Button
           href={value}

--- a/console/src/range/overview/MetaData.tsx
+++ b/console/src/range/overview/MetaData.tsx
@@ -26,13 +26,11 @@ import { type kv, link } from "@synnaxlabs/x";
 import { type ReactElement, useCallback, useEffect, useRef, useState } from "react";
 
 import { CSS } from "@/css";
-import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
 
 interface ValueInputProps extends Input.TextProps {}
 
 const ValueInput = ({ value, ...rest }: ValueInputProps): ReactElement => {
   const isLink = link.is(value);
-  const copyToClipboard = useCopyToClipboard();
   return (
     <Input.Text
       value={value}
@@ -48,9 +46,7 @@ const ValueInput = ({ value, ...rest }: ValueInputProps): ReactElement => {
       propagateClick
       {...rest}
     >
-      <Button.Button onClick={() => copyToClipboard(value, "value")} variant="outlined">
-        <Icon.Copy />
-      </Button.Button>
+      <Button.Copy text={value} variant="outlined" successMessage="Copied value to clipboard" />
       {isLink && (
         <Button.Button
           href={value}

--- a/console/src/status/list/ContextMenu.tsx
+++ b/console/src/status/list/ContextMenu.tsx
@@ -9,6 +9,7 @@
 
 import { status } from "@synnaxlabs/client";
 import { Access, Component, type Flux, Menu, Status } from "@synnaxlabs/pluto";
+import { status as xstatus } from "@synnaxlabs/x";
 import { useCallback, useMemo } from "react";
 import { useDispatch } from "react-redux";
 
@@ -55,6 +56,11 @@ const ContextMenu = ({ keys }: Menu.ContextMenuMenuProps) => {
     () => keys.some((k) => !favoriteSet.has(k)),
     [favoriteSet, keys],
   );
+  const getCopyText = useCallback(() => {
+    if (q.variant !== "success") return "";
+    return q.data.map((s) => xstatus.toString(s)).join("\n\n");
+  }, [q]);
+
   if (q.variant !== "success") return null;
   const statuses = q.data;
   const isEmpty = statuses.length === 0;
@@ -69,6 +75,18 @@ const ContextMenu = ({ keys }: Menu.ContextMenuMenuProps) => {
         onUnfavorite={() => dispatch(removeFavorites(keys))}
       />
       {(anyFavorited || anyNotFavorited) && <Menu.Divider />}
+      {!isEmpty && (
+        <>
+          <Menu.CopyItem
+            itemKey="copyDiagnostics"
+            text={getCopyText}
+            successMessage="Copied diagnostics to clipboard"
+          >
+            Copy Diagnostics
+          </Menu.CopyItem>
+          <Menu.Divider />
+        </>
+      )}
       {hasDeletePermission && !isEmpty && (
         <CMenu.DeleteItem
           onClick={() => {

--- a/pluto/package.json
+++ b/pluto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synnaxlabs/pluto",
-  "version": "0.54.0",
+  "version": "0.54.1",
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit && vite build",

--- a/pluto/src/button/Copy.spec.tsx
+++ b/pluto/src/button/Copy.spec.tsx
@@ -8,9 +8,23 @@
 // included in the file licenses/APL.txt.
 
 import { act, fireEvent, render } from "@testing-library/react";
+import { type PropsWithChildren } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Button } from "@/button";
+import { Icon } from "@/icon";
+import { Status } from "@/status/base";
+import { type NotificationSpec } from "@/status/base/Aggregator";
+
+const StatusSpy = ({ onStatuses }: { onStatuses: (s: NotificationSpec[]) => void }) => {
+  const { statuses } = Status.useNotifications();
+  onStatuses(statuses);
+  return null;
+};
+
+const wrapper = ({ children }: PropsWithChildren) => (
+  <Status.Aggregator>{children}</Status.Aggregator>
+);
 
 describe("Copy", () => {
   const writeText = vi.fn();
@@ -34,10 +48,20 @@ describe("Copy", () => {
       expect(c.getByLabelText("pluto-icon--copy")).toBeTruthy();
     });
 
-    it("should render children alongside the icon", () => {
+    it("should render text children alongside the copy icon", () => {
       const c = render(<Button.Copy text="hello">Copy me</Button.Copy>);
       expect(c.getByText("Copy me")).toBeTruthy();
       expect(c.getByLabelText("pluto-icon--copy")).toBeTruthy();
+    });
+
+    it("should render a custom icon instead of the copy icon", () => {
+      const c = render(
+        <Button.Copy text="hello">
+          <Icon.Python />
+        </Button.Copy>,
+      );
+      expect(c.getByLabelText("pluto-icon--python")).toBeTruthy();
+      expect(c.queryByLabelText("pluto-icon--copy")).toBeFalsy();
     });
   });
 
@@ -50,7 +74,7 @@ describe("Copy", () => {
       expect(writeText).toHaveBeenCalledWith("hello world");
     });
 
-    it("should copy the result of a function when text is a function", async () => {
+    it("should copy the result of a sync function", async () => {
       const getText = vi.fn(() => "computed text");
       const c = render(<Button.Copy text={getText} />);
       await act(async () => {
@@ -60,6 +84,16 @@ describe("Copy", () => {
       expect(writeText).toHaveBeenCalledWith("computed text");
     });
 
+    it("should copy the result of an async function", async () => {
+      const getText = vi.fn(async () => "async text");
+      const c = render(<Button.Copy text={getText} />);
+      await act(async () => {
+        fireEvent.click(c.getByLabelText("pluto-icon--copy"));
+      });
+      expect(getText).toHaveBeenCalled();
+      expect(writeText).toHaveBeenCalledWith("async text");
+    });
+
     it("should show the check icon after copying", async () => {
       const c = render(<Button.Copy text="hello" />);
       await act(async () => {
@@ -67,6 +101,20 @@ describe("Copy", () => {
       });
       expect(c.getByLabelText("pluto-icon--check")).toBeTruthy();
       expect(c.queryByLabelText("pluto-icon--copy")).toBeFalsy();
+    });
+
+    it("should swap a custom icon for the check icon after copying", async () => {
+      const c = render(
+        <Button.Copy text="hello">
+          <Icon.Python />
+        </Button.Copy>,
+      );
+      expect(c.getByLabelText("pluto-icon--python")).toBeTruthy();
+      await act(async () => {
+        fireEvent.click(c.getByLabelText("pluto-icon--python"));
+      });
+      expect(c.getByLabelText("pluto-icon--check")).toBeTruthy();
+      expect(c.queryByLabelText("pluto-icon--python")).toBeFalsy();
     });
 
     it("should reset to the copy icon after the default duration", async () => {
@@ -80,6 +128,22 @@ describe("Copy", () => {
       });
       expect(c.getByLabelText("pluto-icon--copy")).toBeTruthy();
       expect(c.queryByLabelText("pluto-icon--check")).toBeFalsy();
+    });
+
+    it("should reset a custom icon after the default duration", async () => {
+      const c = render(
+        <Button.Copy text="hello">
+          <Icon.Python />
+        </Button.Copy>,
+      );
+      await act(async () => {
+        fireEvent.click(c.getByLabelText("pluto-icon--python"));
+      });
+      expect(c.getByLabelText("pluto-icon--check")).toBeTruthy();
+      await act(async () => {
+        vi.advanceTimersByTime(2000);
+      });
+      expect(c.getByLabelText("pluto-icon--python")).toBeTruthy();
     });
 
     it("should respect custom copiedDuration", async () => {
@@ -109,25 +173,97 @@ describe("Copy", () => {
       expect(onCopy).toHaveBeenCalledTimes(1);
     });
 
-    it("should call onCopyError when clipboard write fails", async () => {
-      const error = new Error("Clipboard access denied");
-      writeText.mockRejectedValue(error);
-      const onCopyError = vi.fn();
-      const c = render(<Button.Copy text="hello" onCopyError={onCopyError} />);
-      await act(async () => {
-        fireEvent.click(c.getByLabelText("pluto-icon--copy"));
-      });
-      expect(onCopyError).toHaveBeenCalledWith(error);
-    });
-
     it("should not show the check icon when copying fails", async () => {
       writeText.mockRejectedValue(new Error("Failed"));
-      const c = render(<Button.Copy text="hello" />);
+      const c = render(<Button.Copy text="hello" />, { wrapper });
       await act(async () => {
         fireEvent.click(c.getByLabelText("pluto-icon--copy"));
       });
       expect(c.getByLabelText("pluto-icon--copy")).toBeTruthy();
       expect(c.queryByLabelText("pluto-icon--check")).toBeFalsy();
+    });
+  });
+
+  describe("status notification", () => {
+    it("should push a success status when successMessage is provided", async () => {
+      const spy = vi.fn();
+      const c = render(
+        <Status.Aggregator>
+          <StatusSpy onStatuses={spy} />
+          <Button.Copy text="hello" successMessage="Copied!" />
+        </Status.Aggregator>,
+      );
+      await act(async () => {
+        fireEvent.click(c.getByLabelText("pluto-icon--copy"));
+      });
+      const lastCall = spy.mock.lastCall?.[0] as NotificationSpec[];
+      expect(lastCall).toHaveLength(1);
+      expect(lastCall[0].message).toBe("Copied!");
+      expect(lastCall[0].variant).toBe("success");
+    });
+
+    it("should not show the check icon when successMessage is provided", async () => {
+      const c = render(
+        <Status.Aggregator>
+          <Button.Copy text="hello" successMessage="Copied!" />
+        </Status.Aggregator>,
+      );
+      await act(async () => {
+        fireEvent.click(c.getByLabelText("pluto-icon--copy"));
+      });
+      expect(c.getByLabelText("pluto-icon--copy")).toBeTruthy();
+      expect(c.queryByLabelText("pluto-icon--check")).toBeFalsy();
+    });
+
+    it("should not push a status when successMessage is not provided", async () => {
+      const spy = vi.fn();
+      const c = render(
+        <Status.Aggregator>
+          <StatusSpy onStatuses={spy} />
+          <Button.Copy text="hello" />
+        </Status.Aggregator>,
+      );
+      await act(async () => {
+        fireEvent.click(c.getByLabelText("pluto-icon--copy"));
+      });
+      const lastCall = spy.mock.lastCall?.[0] as NotificationSpec[];
+      expect(lastCall).toHaveLength(0);
+    });
+
+    it("should push an error status when clipboard write fails", async () => {
+      writeText.mockRejectedValue(new Error("Clipboard denied"));
+      const spy = vi.fn();
+      const c = render(
+        <Status.Aggregator>
+          <StatusSpy onStatuses={spy} />
+          <Button.Copy text="hello" />
+        </Status.Aggregator>,
+      );
+      await act(async () => {
+        fireEvent.click(c.getByLabelText("pluto-icon--copy"));
+      });
+      const lastCall = spy.mock.lastCall?.[0] as NotificationSpec[];
+      expect(lastCall).toHaveLength(1);
+      expect(lastCall[0].variant).toBe("error");
+      expect(lastCall[0].message).toBe("Clipboard denied");
+    });
+
+    it("should push an error status when an async text function rejects", async () => {
+      const getText = vi.fn(() => Promise.reject(new Error("Failed to compute")));
+      const spy = vi.fn();
+      const c = render(
+        <Status.Aggregator>
+          <StatusSpy onStatuses={spy} />
+          <Button.Copy text={getText} />
+        </Status.Aggregator>,
+      );
+      await act(async () => {
+        fireEvent.click(c.getByLabelText("pluto-icon--copy"));
+      });
+      const lastCall = spy.mock.lastCall?.[0] as NotificationSpec[];
+      expect(lastCall).toHaveLength(1);
+      expect(lastCall[0].variant).toBe("error");
+      expect(lastCall[0].message).toBe("Failed to compute");
     });
   });
 

--- a/pluto/src/button/Copy.spec.tsx
+++ b/pluto/src/button/Copy.spec.tsx
@@ -202,6 +202,24 @@ describe("Copy", () => {
       expect(lastCall[0].variant).toBe("success");
     });
 
+    it("should resolve successMessage from a function at click time", async () => {
+      const spy = vi.fn();
+      let name = "Task A";
+      const c = render(
+        <Status.Aggregator>
+          <StatusSpy onStatuses={spy} />
+          <Button.Copy text="hello" successMessage={() => `Copied ${name}`} />
+        </Status.Aggregator>,
+      );
+      name = "Task B";
+      await act(async () => {
+        fireEvent.click(c.getByLabelText("pluto-icon--copy"));
+      });
+      const lastCall = spy.mock.lastCall?.[0] as NotificationSpec[];
+      expect(lastCall).toHaveLength(1);
+      expect(lastCall[0].message).toBe("Copied Task B");
+    });
+
     it("should not show the check icon when successMessage is provided", async () => {
       const c = render(
         <Status.Aggregator>

--- a/pluto/src/button/Copy.tsx
+++ b/pluto/src/button/Copy.tsx
@@ -29,8 +29,8 @@ export interface CopyProps extends ButtonProps {
   onCopy?: () => void;
   /** Duration in ms to show the checkmark after copying. Defaults to 2000. */
   copiedDuration?: CrudeTimeSpan;
-  /** Status notification message shown on successful copy. */
-  successMessage?: string;
+  /** Status notification message shown on successful copy. Can be a string or a function that returns one. */
+  successMessage?: string | (() => string);
 }
 
 /**
@@ -66,8 +66,11 @@ export const Copy = ({
       handleError(async () => {
         const resolvedText = await (typeof text === "function" ? text() : text);
         await navigator.clipboard.writeText(resolvedText);
-        if (successMessage != null)
-          return addStatus({ variant: "success", message: successMessage });
+        if (successMessage != null) {
+          const message =
+            typeof successMessage === "function" ? successMessage() : successMessage;
+          return addStatus({ variant: "success", message });
+        }
         setCopied(true);
         onCopy?.();
         setTimeout(

--- a/pluto/src/button/Copy.tsx
+++ b/pluto/src/button/Copy.tsx
@@ -66,13 +66,13 @@ export const Copy = ({
       handleError(async () => {
         const resolvedText = await (typeof text === "function" ? text() : text);
         await navigator.clipboard.writeText(resolvedText);
+        onCopy?.();
         if (successMessage != null) {
           const message =
             typeof successMessage === "function" ? successMessage() : successMessage;
           return addStatus({ variant: "success", message });
         }
         setCopied(true);
-        onCopy?.();
         setTimeout(
           () => setCopied(false),
           TimeSpan.fromMilliseconds(copiedDuration).milliseconds,

--- a/pluto/src/button/Copy.tsx
+++ b/pluto/src/button/Copy.tsx
@@ -8,22 +8,29 @@
 // included in the file licenses/APL.txt.
 
 import { type CrudeTimeSpan, TimeSpan } from "@synnaxlabs/x";
-import { type ReactElement, useCallback, useState } from "react";
+import {
+  isValidElement,
+  type MouseEvent,
+  type ReactElement,
+  useCallback,
+  useState,
+} from "react";
 
 import { Button, type ButtonProps } from "@/button/Button";
 import { Icon } from "@/icon";
+import { useAdder, useErrorHandler } from "@/status/base/Aggregator";
 
 const COPIED_DURATION_MS = TimeSpan.seconds(2).milliseconds;
 
-export interface CopyProps extends Omit<ButtonProps, "onClick"> {
-  /** The text to copy to the clipboard, or a function that returns it. */
-  text: string | (() => string);
+export interface CopyProps extends ButtonProps {
+  /** The text to copy to the clipboard, or a function that returns it (sync or async). */
+  text: string | (() => string | Promise<string>);
   /** Optional callback invoked after successfully copying to clipboard. */
   onCopy?: () => void;
-  /** Optional callback invoked if copying fails. */
-  onCopyError?: (error: Error) => void;
   /** Duration in ms to show the checkmark after copying. Defaults to 2000. */
   copiedDuration?: CrudeTimeSpan;
+  /** Status notification message shown on successful copy. */
+  successMessage?: string;
 }
 
 /**
@@ -42,34 +49,42 @@ export interface CopyProps extends Omit<ButtonProps, "onClick"> {
 export const Copy = ({
   text,
   onCopy,
-  onCopyError,
   copiedDuration = COPIED_DURATION_MS,
+  successMessage,
   tooltip = "Copy",
   children,
+  onClick,
   ...rest
 }: CopyProps): ReactElement => {
   const [copied, setCopied] = useState(false);
+  const addStatus = useAdder();
+  const handleError = useErrorHandler();
 
-  const handleClick = useCallback(() => {
-    void (async () => {
-      try {
-        const resolvedText = typeof text === "function" ? text() : text;
+  const handleClick = useCallback(
+    (e: MouseEvent<HTMLButtonElement>) => {
+      onClick?.(e);
+      handleError(async () => {
+        const resolvedText = await (typeof text === "function" ? text() : text);
         await navigator.clipboard.writeText(resolvedText);
+        if (successMessage != null)
+          return addStatus({ variant: "success", message: successMessage });
         setCopied(true);
         onCopy?.();
         setTimeout(
           () => setCopied(false),
           TimeSpan.fromMilliseconds(copiedDuration).milliseconds,
         );
-      } catch (err) {
-        onCopyError?.(err instanceof Error ? err : new Error(String(err)));
-      }
-    })();
-  }, [text, onCopy, onCopyError, copiedDuration]);
+      });
+    },
+    [text, onCopy, copiedDuration, addStatus, successMessage, handleError],
+  );
+
+  const customIcon = isValidElement(children);
+  const icon = copied ? <Icon.Check /> : customIcon ? children : <Icon.Copy />;
 
   return (
     <Button tooltip={copied ? "Copied!" : tooltip} onClick={handleClick} {...rest}>
-      {copied ? <Icon.Check /> : <Icon.Copy />} {children}
+      {icon} {!customIcon && children}
     </Button>
   );
 };

--- a/pluto/src/menu/CopyItem.spec.tsx
+++ b/pluto/src/menu/CopyItem.spec.tsx
@@ -1,0 +1,106 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { act, fireEvent, render } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { Icon } from "@/icon";
+import { Menu } from "@/menu";
+
+describe("CopyItem", () => {
+  const writeText = vi.fn();
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    Object.assign(navigator, {
+      clipboard: { writeText },
+    });
+    writeText.mockResolvedValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    writeText.mockReset();
+  });
+
+  it("should render children as the menu item content", () => {
+    const c = render(
+      <Menu.Menu>
+        <Menu.CopyItem itemKey="copy" text="hello">
+          <Icon.Python /> Copy Python code
+        </Menu.CopyItem>
+      </Menu.Menu>,
+    );
+    expect(c.getByText("Copy Python code")).toBeTruthy();
+  });
+
+  it("should copy text to the clipboard when clicked", async () => {
+    const c = render(
+      <Menu.Menu>
+        <Menu.CopyItem itemKey="copy" text="copied content">Copy</Menu.CopyItem>
+      </Menu.Menu>,
+    );
+    await act(async () => {
+      fireEvent.click(c.getByText("Copy"));
+    });
+    expect(writeText).toHaveBeenCalledWith("copied content");
+  });
+
+  it("should copy the result of a function", async () => {
+    const getText = vi.fn(() => "dynamic content");
+    const c = render(
+      <Menu.Menu>
+        <Menu.CopyItem itemKey="copy" text={getText}>Copy</Menu.CopyItem>
+      </Menu.Menu>,
+    );
+    await act(async () => {
+      fireEvent.click(c.getByText("Copy"));
+    });
+    expect(getText).toHaveBeenCalled();
+    expect(writeText).toHaveBeenCalledWith("dynamic content");
+  });
+
+  it("should copy the result of an async function", async () => {
+    const getText = vi.fn(async () => "async content");
+    const c = render(
+      <Menu.Menu>
+        <Menu.CopyItem itemKey="copy" text={getText}>Copy</Menu.CopyItem>
+      </Menu.Menu>,
+    );
+    await act(async () => {
+      fireEvent.click(c.getByText("Copy"));
+    });
+    expect(getText).toHaveBeenCalled();
+    expect(writeText).toHaveBeenCalledWith("async content");
+  });
+
+  it("should call the menu context onClick with the itemKey", async () => {
+    const onChange = vi.fn();
+    const c = render(
+      <Menu.Menu onChange={onChange}>
+        <Menu.CopyItem itemKey="copyDiag" text="hello">
+          Copy Diagnostics
+        </Menu.CopyItem>
+      </Menu.Menu>,
+    );
+    await act(async () => {
+      fireEvent.click(c.getByText("Copy Diagnostics"));
+    });
+    expect(onChange).toHaveBeenCalledWith("copyDiag");
+  });
+
+  it("should apply the menu-item class", () => {
+    const c = render(
+      <Menu.Menu>
+        <Menu.CopyItem itemKey="copy" text="hello">Copy</Menu.CopyItem>
+      </Menu.Menu>,
+    );
+    expect(c.container.querySelector(".pluto-menu-item")).toBeTruthy();
+  });
+});

--- a/pluto/src/menu/CopyItem.spec.tsx
+++ b/pluto/src/menu/CopyItem.spec.tsx
@@ -43,7 +43,9 @@ describe("CopyItem", () => {
   it("should copy text to the clipboard when clicked", async () => {
     const c = render(
       <Menu.Menu>
-        <Menu.CopyItem itemKey="copy" text="copied content">Copy</Menu.CopyItem>
+        <Menu.CopyItem itemKey="copy" text="copied content">
+          Copy
+        </Menu.CopyItem>
       </Menu.Menu>,
     );
     await act(async () => {
@@ -56,7 +58,9 @@ describe("CopyItem", () => {
     const getText = vi.fn(() => "dynamic content");
     const c = render(
       <Menu.Menu>
-        <Menu.CopyItem itemKey="copy" text={getText}>Copy</Menu.CopyItem>
+        <Menu.CopyItem itemKey="copy" text={getText}>
+          Copy
+        </Menu.CopyItem>
       </Menu.Menu>,
     );
     await act(async () => {
@@ -70,7 +74,9 @@ describe("CopyItem", () => {
     const getText = vi.fn(async () => "async content");
     const c = render(
       <Menu.Menu>
-        <Menu.CopyItem itemKey="copy" text={getText}>Copy</Menu.CopyItem>
+        <Menu.CopyItem itemKey="copy" text={getText}>
+          Copy
+        </Menu.CopyItem>
       </Menu.Menu>,
     );
     await act(async () => {
@@ -98,7 +104,9 @@ describe("CopyItem", () => {
   it("should apply the menu-item class", () => {
     const c = render(
       <Menu.Menu>
-        <Menu.CopyItem itemKey="copy" text="hello">Copy</Menu.CopyItem>
+        <Menu.CopyItem itemKey="copy" text="hello">
+          Copy
+        </Menu.CopyItem>
       </Menu.Menu>,
     );
     expect(c.container.querySelector(".pluto-menu-item")).toBeTruthy();

--- a/pluto/src/menu/CopyItem.tsx
+++ b/pluto/src/menu/CopyItem.tsx
@@ -1,0 +1,41 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { type ReactElement } from "react";
+
+import { Button } from "@/button";
+import { CSS } from "@/css";
+import { useContext } from "@/menu/Menu";
+
+export interface CopyItemProps extends Button.CopyProps {
+  itemKey: string;
+}
+
+export const CopyItem = ({
+  className,
+  itemKey,
+  ...rest
+}: CopyItemProps): ReactElement => {
+  const { onClick: ctxOnClick, level = "p", gap, background } = useContext();
+  const handleClick: Button.ButtonProps["onClick"] = () => ctxOnClick(itemKey);
+  return (
+    <Button.Copy
+      level={level}
+      overflow="nowrap"
+      variant="text"
+      className={CSS(CSS.B("menu-item"), className)}
+      background={background}
+      tooltip={null}
+      gap={gap}
+      onClick={handleClick}
+      propagateClick
+      {...rest}
+    />
+  );
+};

--- a/pluto/src/menu/CopyItem.tsx
+++ b/pluto/src/menu/CopyItem.tsx
@@ -33,9 +33,9 @@ export const CopyItem = ({
       background={background}
       tooltip={null}
       gap={gap}
-      onClick={handleClick}
       propagateClick
       {...rest}
+      onClick={handleClick}
     />
   );
 };

--- a/pluto/src/menu/external.ts
+++ b/pluto/src/menu/external.ts
@@ -8,6 +8,7 @@
 // included in the file licenses/APL.txt.
 
 export * from "@/menu/ContextMenu";
+export * from "@/menu/CopyItem";
 export * from "@/menu/Divider";
 export * from "@/menu/Item";
 export * from "@/menu/Menu";

--- a/pluto/src/status/base/Notification.css
+++ b/pluto/src/status/base/Notification.css
@@ -34,11 +34,11 @@
             max-width: 160px;
         }
     }
-    .pluto-notification__silence {
+    .pluto-notification__header-actions {
         opacity: 0;
     }
     &:hover {
-        .pluto-notification__silence {
+        .pluto-notification__header-actions {
             opacity: 1;
         }
     }

--- a/pluto/src/status/base/Notification.spec.tsx
+++ b/pluto/src/status/base/Notification.spec.tsx
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { TimeStamp } from "@synnaxlabs/x";
+import { status, TimeStamp } from "@synnaxlabs/x";
 import { fireEvent, render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
@@ -55,5 +55,16 @@ describe("Notification Component", () => {
 
     expect(c.getByText("Action 1")).toBeTruthy();
     expect(c.getByText("Action 2")).toBeTruthy();
+  });
+
+  it("should copy diagnostics to clipboard when copy button is clicked", async () => {
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    const c = render(<Notification {...notificationProps} />);
+    const copyButton = c.getByRole("button", { name: /pluto-icon--copy/i });
+    fireEvent.click(copyButton);
+    await vi.waitFor(() => {
+      expect(writeText).toHaveBeenCalledWith(status.toString(notificationProps.status));
+    });
   });
 });

--- a/pluto/src/status/base/Notification.tsx
+++ b/pluto/src/status/base/Notification.tsx
@@ -9,8 +9,8 @@
 
 import "@/status/base/Notification.css";
 
-import { array, primitive } from "@synnaxlabs/x";
-import { isValidElement, type ReactElement, useRef } from "react";
+import { array, primitive, status } from "@synnaxlabs/x";
+import { isValidElement, type ReactElement, useCallback, useRef } from "react";
 
 import { Button } from "@/button";
 import { CSS } from "@/css";
@@ -39,7 +39,7 @@ export interface NotificationProps extends Flex.BoxProps {
 }
 
 export const Notification = ({
-  status: { key, time, count, message, description, variant, name },
+  status: stat,
   silence,
   actions,
   className,
@@ -47,6 +47,8 @@ export const Notification = ({
   ...rest
 }: NotificationProps): ReactElement => {
   const ref = useRef<HTMLDivElement>(null);
+  const { key, time, count, message, description, variant, name } = stat;
+  const getCopyText = useCallback(() => status.toString(stat), [stat]);
 
   return (
     <Flex.Box
@@ -84,14 +86,30 @@ export const Notification = ({
             {time}
           </TelemText.TimeStamp>
         </Flex.Box>
-        <Button.Button
-          className={CSS(CSS.BE("notification", "silence"))}
-          variant="outlined"
-          size="small"
-          onClick={() => silence(key)}
+        <Flex.Box
+          x
+          className={CSS(CSS.BE("notification", "header-actions"))}
+          gap="tiny"
         >
-          <Icon.Close />
-        </Button.Button>
+          <Button.Copy
+            className={CSS(CSS.BE("notification", "copy"))}
+            text={getCopyText}
+            variant="text"
+            size="small"
+            tooltip="Copy diagnostics"
+            square
+            contrast={2}
+            textColor={10}
+          />
+          <Button.Button
+            className={CSS(CSS.BE("notification", "silence"))}
+            variant="outlined"
+            size="small"
+            onClick={() => silence(key)}
+          >
+            <Icon.Close />
+          </Button.Button>
+        </Flex.Box>
       </Flex.Box>
       <Flex.Box
         y

--- a/pluto/src/text/Text.spec.tsx
+++ b/pluto/src/text/Text.spec.tsx
@@ -191,6 +191,17 @@ describe("Text", () => {
       expect(el).toBeTruthy();
       expect(el?.className).toContain("pluto--square");
     });
+
+    it("should treat an icon with a trailing space as square", () => {
+      const c = render(
+        <Text.Text>
+          <Icon.Acquire aria-label="Acquire" /> {false}
+        </Text.Text>,
+      );
+      const el = c.getByLabelText("Acquire").parentElement;
+      expect(el).toBeTruthy();
+      expect(el?.className).toContain("pluto--square");
+    });
   });
 
   describe("status", () => {

--- a/pluto/src/text/Text.tsx
+++ b/pluto/src/text/Text.tsx
@@ -73,7 +73,7 @@ const formatHref = (
 export const isSquare = (children: ReactNode): boolean => {
   if (Children.count(children) !== 1) {
     const parsedChildren = Children.toArray(children).filter(
-      (c) => typeof c !== "boolean",
+      (c) => typeof c !== "boolean" && c != " ",
     );
     if (parsedChildren.length !== 1) return false;
     children = parsedChildren[0];

--- a/x/ts/package.json
+++ b/x/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synnaxlabs/x",
-  "version": "0.54.0",
+  "version": "0.54.1",
   "type": "module",
   "description": "Common Utilities for Synnax Labs",
   "repository": "https://github.com/synnaxlabs/synnax/tree/main/x/ts",

--- a/x/ts/src/status/status.spec.ts
+++ b/x/ts/src/status/status.spec.ts
@@ -296,7 +296,7 @@ describe("status", () => {
       expect(result).not.toContain("Details:");
     });
 
-    it("should not error when the `name` field is accidentally undefindd", () => {
+    it("should not error when the `name` field is accidentally undefined", () => {
       const s = status.create({ message: "cat", variant: "success" });
       const result = status.toString(s);
       expect(result).toContain("cat");

--- a/x/ts/src/status/status.spec.ts
+++ b/x/ts/src/status/status.spec.ts
@@ -295,5 +295,11 @@ describe("status", () => {
       expect(result).toContain("Stack Trace:");
       expect(result).not.toContain("Details:");
     });
+
+    it("should not error when the `name` field is accidentally undefindd", () => {
+      const s = status.create({ message: "cat", variant: "success" });
+      const result = status.toString(s);
+      expect(result).toContain("cat");
+    });
   });
 });

--- a/x/ts/src/status/status.ts
+++ b/x/ts/src/status/status.ts
@@ -12,6 +12,7 @@ import { z } from "zod";
 import { id } from "@/id";
 import { narrow } from "@/narrow";
 import { type optional } from "@/optional";
+import { primitive } from "@/primitive";
 import { type Status, type Variant } from "@/status/types.gen";
 import { TimeStamp } from "@/telem";
 
@@ -103,7 +104,7 @@ export const toString = <Details extends z.ZodType = z.ZodNever>(
   const opts = { ...DEFAULT_TO_STRING_OPTIONS, ...options };
   const parts: string[] = [];
   let header = stat.variant.toUpperCase();
-  if (opts.includeName && stat.name.length > 0) header += ` [${stat.name}]`;
+  if (opts.includeName && primitive.isNonZero(stat.name)) header += ` [${stat.name}]`;
   header += `: ${stat.message}`;
   if (opts.includeTimestamp) header += ` (${stat.time.toString("dateTime", "local")})`;
   parts.push(header);


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4033](https://linear.app/synnaxlabs/issue/SY-4033)

## Description

Adds standardized clipboard copy infrastructure across the console and Pluto:

- **`Button.Copy`** now auto-pushes status notifications on success (via `successMessage` prop) and errors (via `handleError`). Supports async text functions. When a child is a React element (e.g. an icon), it replaces the default copy icon and swaps to a checkmark on success. When `successMessage` is provided, the status notification replaces the checkmark feedback.
- **`Menu.CopyItem`** - new Pluto component wrapping `Button.Copy` styled as a menu item for use in context menus.
- **Status notification toast** - added a copy diagnostics button that appears on hover.
- **Task controls status** - existing copy diagnostics button now uses the shared infrastructure.
- **Console consumers migrated** - task utility buttons, task details header, range overview, line plot context menu, ontology copy properties, and status explorer context menu all now use `Button.Copy` or `Menu.CopyItem` instead of manual `navigator.clipboard` calls.
- **Consistent divider grouping** across task and range pages: copy-as-code | copy-data | share.
- **Task utility buttons** now conditionally render based on whether the task has been saved (no key = only JSON config copy shown).

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces reusable `Button.Copy` and `Menu.CopyItem` components backed by the status aggregator for error handling and success feedback, and systematically migrates manual `navigator.clipboard` calls across the console. The implementation is well-structured and the test coverage is thorough. Three P2 style/improvement issues were found: `onCopy` is silently dropped when `successMessage` is set (an early `return` exits before the callback fires), the `{...rest}` spread in `CopyItem` can silently override the menu context's click handler, and a test description contains a minor typo. None of these block merging.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — all findings are minor style/API consistency improvements.

All three identified issues are P2: one is a subtle callback-omission edge case with no current consumer affected, one is an API footgun with no current exploiter, and one is a test description typo. No data integrity, security, or correctness issues were found.

pluto/src/button/Copy.tsx (onCopy/successMessage interaction), pluto/src/menu/CopyItem.tsx (onClick spread order)

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. Clipboard writes use the standard `navigator.clipboard.writeText` API (browser-sandboxed). Errors are handled by the status aggregator without exposing raw stack traces in the UI. No user-supplied data is executed as code.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pluto/src/button/Copy.tsx | New Button.Copy component with clipboard write, success/error status integration via Aggregator, and checkmark feedback; onCopy/successMessage interaction is a minor inconsistency |
| pluto/src/button/Copy.spec.tsx | Comprehensive tests covering rendering, clipboard copying (sync/async/string), callbacks, status notification push, and button prop passthrough |
| pluto/src/menu/CopyItem.tsx | New Menu.CopyItem wrapping Button.Copy as a styled menu item; onClick spread order creates a minor API footgun with no current impact |
| pluto/src/menu/CopyItem.spec.tsx | Tests for rendering children, clipboard copying, async text functions, menu context onChange, and CSS class application |
| pluto/src/menu/external.ts | Adds CopyItem to menu package exports |
| pluto/src/status/base/Notification.tsx | Adds hover-visible copy diagnostics button (Button.Copy) to status toast header, serializing the notification via status.toString |
| pluto/src/status/base/Notification.css | Hides header-actions by default and reveals them on notification hover for a clean progressive-disclosure UX |
| pluto/src/text/Text.tsx | Minor refactor extracting formatStyle helper for lineClamp CSS application |
| x/ts/src/status/status.ts | Adds toString (with JSON pretty-print, stack trace, and extra details formatting), fromException, keepVariants, and removeVariants utilities |
| x/ts/src/status/status.spec.ts | Thorough tests for all new utilities across all variant types and option combinations; one typo in a test description (undefindd) |
| console/src/hardware/common/task/UtilityButtons.tsx | Migrates manual clipboard calls to Button.Copy with successMessage; code-copy buttons now conditionally render based on whether the task has been saved |
| console/src/hardware/common/task/layouts/DetailsHeader.tsx | Migrates copy details button to Button.Copy with successMessage, removing manual navigator.clipboard call |
| console/src/lineplot/LinePlot.tsx | Migrates context menu copy-range items to Menu.CopyItem with successMessage notifications |
| console/src/ontology/CopyPropertiesContextMenuItem.tsx | Simplified to Menu.CopyItem, removing manual clipboard call and navigator usage |
| console/src/range/overview/Details.tsx | Migrates Python/TypeScript code copy buttons to Button.Copy with per-name success messages |
| console/src/range/overview/MetaData.tsx | Migrates inline copy button in metadata value input to Button.Copy with successMessage |
| console/src/status/list/ContextMenu.tsx | Migrates copy diagnostics context menu item to Menu.CopyItem with successMessage |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant ButtonCopy as Button.Copy
    participant Clipboard as navigator.clipboard
    participant Aggregator as Status.Aggregator
    participant UI as UI State

    User->>ButtonCopy: click
    ButtonCopy->>ButtonCopy: resolve text (sync/async fn or string)
    ButtonCopy->>Clipboard: writeText(resolvedText)
    alt successMessage provided
        Clipboard-->>ButtonCopy: success
        ButtonCopy->>Aggregator: addStatus({ variant: success, message })
        Aggregator-->>UI: toast notification
    else no successMessage
        Clipboard-->>ButtonCopy: success
        ButtonCopy->>UI: setCopied(true) — show checkmark
        ButtonCopy->>ButtonCopy: setTimeout — setCopied(false)
    end
    alt clipboard write fails
        Clipboard-->>ButtonCopy: Error
        ButtonCopy->>Aggregator: addStatus({ variant: error, message: err.message })
        Aggregator-->>UI: error toast notification
    end
```

<sub>Reviews (1): Last reviewed commit: ["checkpoint"](https://github.com/synnaxlabs/synnax/commit/9b1cfa5e068820993a393e63b216d287d8ecc3f2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27657548)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->