### PR TITLE
SY-4039: Fix Schematic Custom Symbol Search Bug

### DIFF
--- a/console/src/schematic/toolbar/Symbols.spec.ts
+++ b/console/src/schematic/toolbar/Symbols.spec.ts
@@ -1,0 +1,35 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { Schematic } from "@synnaxlabs/pluto";
+import { describe, expect, it } from "vitest";
+
+import { ALL_STATIC_SYMBOLS, CUSTOM_VARIANTS } from "@/schematic/toolbar/Symbols";
+
+describe("Symbols toolbar", () => {
+  describe("ALL_STATIC_SYMBOLS", () => {
+    it("should not include custom variants", () => {
+      const keys = ALL_STATIC_SYMBOLS.map((s) => s.key);
+      for (const variant of CUSTOM_VARIANTS) expect(keys).not.toContain(variant);
+    });
+
+    it("should include all non-custom registry entries", () => {
+      const allKeys = Object.keys(Schematic.Symbol.REGISTRY);
+      const expectedKeys = allKeys.filter((k) => !CUSTOM_VARIANTS.has(k));
+      const actualKeys = ALL_STATIC_SYMBOLS.map((s) => s.key);
+      expect(actualKeys).toEqual(expect.arrayContaining(expectedKeys));
+      expect(actualKeys).toHaveLength(expectedKeys.length);
+    });
+
+    it("custom variants should exist in the registry", () => {
+      for (const variant of CUSTOM_VARIANTS)
+        expect(Schematic.Symbol.REGISTRY).toHaveProperty(variant);
+    });
+  });
+});

--- a/console/src/schematic/toolbar/Symbols.tsx
+++ b/console/src/schematic/toolbar/Symbols.tsx
@@ -525,7 +525,10 @@ interface SearchSymbolListProps {
   onSelect: (key: string) => void;
 }
 
-const ALL_STATIC_SYMBOLS = Object.values(Schematic.Symbol.REGISTRY);
+export const CUSTOM_VARIANTS = new Set(["customActuator", "customStatic"]);
+export const ALL_STATIC_SYMBOLS = Object.values(Schematic.Symbol.REGISTRY).filter(
+  (s) => !CUSTOM_VARIANTS.has(s.key),
+);
 
 const SearchListItem = (props: List.ItemProps<string>): ReactElement | null => {
   const { itemKey } = props;

--- a/pluto/src/schematic/symbol/Primitives.tsx
+++ b/pluto/src/schematic/symbol/Primitives.tsx
@@ -16,6 +16,7 @@ import {
   direction,
   type location,
   type optional,
+  primitive,
   TimeSpan,
   xy,
 } from "@synnaxlabs/x";
@@ -561,7 +562,10 @@ export const CustomActuator = ({
   stateOverrides,
   ...rest
 }: CustomActuatorProps): ReactElement | null => {
-  const spec = useRetrieve({ key: specKey });
+  const spec = useRetrieve(
+    { key: specKey },
+    { beforeRetrieve: ({ query }) => !primitive.isZero(query.key) },
+  );
   const svgContainerRef = useRef<HTMLButtonElement>(null);
   useCustom({
     container: svgContainerRef.current,
@@ -617,7 +621,10 @@ export const CustomStatic = ({
   stateOverrides,
   ...rest
 }: CustomStaticProps): ReactElement | null => {
-  const spec = useRetrieve({ key: specKey });
+  const spec = useRetrieve(
+    { key: specKey },
+    { beforeRetrieve: ({ query }) => !primitive.isZero(query.key) },
+  );
   const svgContainerRef = useRef<HTMLDivElement>(null);
   useCustom({
     container: svgContainerRef.current,

--- a/pluto/src/schematic/symbol/Primitives.tsx
+++ b/pluto/src/schematic/symbol/Primitives.tsx
@@ -16,7 +16,6 @@ import {
   direction,
   type location,
   type optional,
-  primitive,
   TimeSpan,
   xy,
 } from "@synnaxlabs/x";
@@ -562,10 +561,7 @@ export const CustomActuator = ({
   stateOverrides,
   ...rest
 }: CustomActuatorProps): ReactElement | null => {
-  const spec = useRetrieve(
-    { key: specKey },
-    { beforeRetrieve: ({ query }) => !primitive.isZero(query.key) },
-  );
+  const spec = useRetrieve({ key: specKey });
   const svgContainerRef = useRef<HTMLButtonElement>(null);
   useCustom({
     container: svgContainerRef.current,
@@ -621,10 +617,7 @@ export const CustomStatic = ({
   stateOverrides,
   ...rest
 }: CustomStaticProps): ReactElement | null => {
-  const spec = useRetrieve(
-    { key: specKey },
-    { beforeRetrieve: ({ query }) => !primitive.isZero(query.key) },
-  );
+  const spec = useRetrieve({ key: specKey });
   const svgContainerRef = useRef<HTMLDivElement>(null);
   useCustom({
     container: svgContainerRef.current,


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue
[SY-4039](https://linear.app/synnax/issue/SY-4039/schematic-symbol-search-bug)

## Description
`customActuator` and `customStatic` entries in the REGISTRY have `defaultProps` with `specKey: ""`. When these appear in search results (e.g., "Custom Actuator" matches "a"), their Preview components call `useRetrieve({ key: "" })`, which hits the server with an empty key and fails with `NotFoundError`.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a `NotFoundError` crash in the schematic symbol search by guarding `useRetrieve` calls in `CustomActuator` and `CustomStatic` with a `beforeRetrieve` callback. When the default `specKey` is `""`, the guard returns `false` and skips the server round-trip entirely, preventing the empty-key query.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, targeted fix with no side effects.

The change is small (two identical guard additions) and uses the existing `beforeRetrieve` mechanism exactly as designed. `primitive.isZero` correctly handles empty strings. Components already handle `undefined` spec data gracefully, and the hook re-fetches automatically when `specKey` becomes non-empty. No regressions expected.

No files require special attention.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pluto/src/schematic/symbol/Primitives.tsx | Guards both `useRetrieve` calls in `CustomActuator` and `CustomStatic` with `beforeRetrieve: ({ query }) => !primitive.isZero(query.key)`, correctly skipping the server fetch when `specKey` is empty. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[CustomActuator / CustomStatic renders] --> B{specKey provided?}
    B -- specKey is empty string --> C[beforeRetrieve returns false]
    C --> D[useRetrieve skips server fetch]
    D --> E[Component renders with undefined spec\nhandles=empty, no SVG]
    B -- specKey is non-empty --> F[beforeRetrieve returns true]
    F --> G[useRetrieve fetches from server]
    G --> H{Fetch result}
    H -- success --> I[Component renders with SVG and handles]
    H -- error --> J[errorResult propagated]
```

<sub>Reviews (1): Last reviewed commit: ["SY-4039: skip schematic symbol retrieve ..."](https://github.com/synnaxlabs/synnax/commit/1ff32930e0a0aaec1fbfb8f2b0532fbdce4c9d4c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27757601)</sub>

<!-- /greptile_comment -->