### PR TITLE
SY-4042: Fix CI port 9090 flakiness by replacing Docker services with…

### DIFF
--- a/.github/workflows/test.arc.yaml
+++ b/.github/workflows/test.arc.yaml
@@ -69,6 +69,10 @@ jobs:
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor
           }} --password-stdin
 
+      - name: Ensure Port 9090 is Free
+        run: |
+          docker ps -q --filter "publish=9090" | xargs -r docker rm -f || true
+
       - name: Start Synnax
         run: |
           docker run -d --name synnax-test-arc \
@@ -88,6 +92,11 @@ jobs:
             echo "Waiting for port 9090... (attempt $i/30)"
             sleep 1
           done
+          if ! nc -z localhost 9090 2>/dev/null; then
+            echo "Synnax failed to start within 30 seconds"
+            docker logs synnax-test-arc
+            exit 1
+          fi
 
       - name: Install Rust
         run: rustup update

--- a/.github/workflows/test.arc.yaml
+++ b/.github/workflows/test.arc.yaml
@@ -71,6 +71,7 @@ jobs:
 
       - name: Ensure Port 9090 is Free
         run: |
+          docker rm -f synnax-test-arc || true
           docker ps -q --filter "publish=9090" | xargs -r docker rm -f || true
 
       - name: Start Synnax

--- a/.github/workflows/test.arc.yaml
+++ b/.github/workflows/test.arc.yaml
@@ -56,23 +56,38 @@ jobs:
     name: Test C++ (ubuntu-build-bot)
     runs-on: ubuntu-build-bot
     needs: [server]
-    services:
-      synnax:
-        image: ghcr.io/synnaxlabs/synnax:${{ github.sha }}
-        env:
-          SYNNAX_LISTEN: localhost:9090
-          SYNNAX_VERBOSE: true
-          SYNNAX_INSECURE: true
-          SYNNAX_MEM: true
-          SYNNAX_LICENSE_KEY: ${{ secrets.SYNNAX_LICENSE_KEY }}
-        credentials:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-        ports:
-          - 9090:9090
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
+
+      - name: Force Quit Existing Synnax Processes
+        continue-on-error: true
+        run: integration/scripts/kill_synnax_processes_unix.sh
+
+      - name: Login to GitHub Container Registry
+        run:
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor
+          }} --password-stdin
+
+      - name: Start Synnax
+        run: |
+          docker run -d --name synnax-test-arc \
+            -p 9090:9090 \
+            -e SYNNAX_LISTEN=localhost:9090 \
+            -e SYNNAX_VERBOSE=true \
+            -e SYNNAX_INSECURE=true \
+            -e SYNNAX_MEM=true \
+            -e SYNNAX_LICENSE_KEY=${{ secrets.SYNNAX_LICENSE_KEY }} \
+            ghcr.io/synnaxlabs/synnax:${{ github.sha }}
+          echo "Waiting for Synnax to be ready..."
+          for i in $(seq 1 30); do
+            if nc -z localhost 9090 2>/dev/null; then
+              echo "Synnax is ready"
+              break
+            fi
+            echo "Waiting for port 9090... (attempt $i/30)"
+            sleep 1
+          done
 
       - name: Install Rust
         run: rustup update
@@ -104,6 +119,10 @@ jobs:
             --test_env=LSAN_OPTIONS="suppressions=${{ github.workspace }}/scripts/sanitizers/lsan_suppressions.txt" \
             --spawn_strategy=local \
             --jobs=1
+
+      - name: Stop Synnax
+        if: always()
+        run: docker rm -f synnax-test-arc || true
 
   test-cpp:
     name: Test C++ (${{ matrix.os }})

--- a/.github/workflows/test.driver.yaml
+++ b/.github/workflows/test.driver.yaml
@@ -81,6 +81,10 @@ jobs:
           echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor
           }} --password-stdin
 
+      - name: Ensure Port 9090 is Free
+        run: |
+          docker ps -q --filter "publish=9090" | xargs -r docker rm -f || true
+
       - name: Start Synnax
         run: |
           docker run -d --name synnax-test-driver \
@@ -100,6 +104,11 @@ jobs:
             echo "Waiting for port 9090... (attempt $i/30)"
             sleep 1
           done
+          if ! nc -z localhost 9090 2>/dev/null; then
+            echo "Synnax failed to start within 30 seconds"
+            docker logs synnax-test-driver
+            exit 1
+          fi
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/test.driver.yaml
+++ b/.github/workflows/test.driver.yaml
@@ -83,6 +83,7 @@ jobs:
 
       - name: Ensure Port 9090 is Free
         run: |
+          docker rm -f synnax-test-driver || true
           docker ps -q --filter "publish=9090" | xargs -r docker rm -f || true
 
       - name: Start Synnax

--- a/.github/workflows/test.driver.yaml
+++ b/.github/workflows/test.driver.yaml
@@ -68,23 +68,38 @@ jobs:
     name: Test
     runs-on: ubuntu-build-bot
     needs: server
-    services:
-      synnax:
-        image: ghcr.io/synnaxlabs/synnax:${{ github.sha }}-test-driver
-        env:
-          SYNNAX_LISTEN: localhost:9090
-          SYNNAX_VERBOSE: true
-          SYNNAX_INSECURE: true
-          SYNNAX_MEM: true
-          SYNNAX_LICENSE_KEY: ${{ secrets.SYNNAX_LICENSE_KEY }}
-        credentials:
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-        ports:
-          - 9090:9090
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v6
+
+      - name: Force Quit Existing Synnax Processes
+        continue-on-error: true
+        run: integration/scripts/kill_synnax_processes_unix.sh
+
+      - name: Login to GitHub Container Registry
+        run:
+          echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor
+          }} --password-stdin
+
+      - name: Start Synnax
+        run: |
+          docker run -d --name synnax-test-driver \
+            -p 9090:9090 \
+            -e SYNNAX_LISTEN=localhost:9090 \
+            -e SYNNAX_VERBOSE=true \
+            -e SYNNAX_INSECURE=true \
+            -e SYNNAX_MEM=true \
+            -e SYNNAX_LICENSE_KEY=${{ secrets.SYNNAX_LICENSE_KEY }} \
+            ghcr.io/synnaxlabs/synnax:${{ github.sha }}-test-driver
+          echo "Waiting for Synnax to be ready..."
+          for i in $(seq 1 30); do
+            if nc -z localhost 9090 2>/dev/null; then
+              echo "Synnax is ready"
+              break
+            fi
+            echo "Waiting for port 9090... (attempt $i/30)"
+            sleep 1
+          done
 
       - name: Install Dependencies
         run: |
@@ -121,3 +136,7 @@ jobs:
             --test_env=LSAN_OPTIONS="suppressions=${{ github.workspace }}/scripts/sanitizers/lsan_suppressions.txt" \
             --spawn_strategy=local \
             --jobs=1 --test_tag_filters=-hardware
+
+      - name: Stop Synnax
+        if: always()
+        run: docker rm -f synnax-test-driver || true

--- a/integration/scripts/kill_synnax_processes_unix.sh
+++ b/integration/scripts/kill_synnax_processes_unix.sh
@@ -40,6 +40,18 @@ if [ "$KILLED_PROCESSES" = true ]; then
     sleep 10
 fi
 
+echo "Checking for Docker containers using port 9090..."
+DOCKER_CONTAINERS=$(docker ps -q --filter "publish=9090" 2> /dev/null || true)
+if [ -n "$DOCKER_CONTAINERS" ]; then
+    echo "Found Docker containers using port 9090, killing them..."
+    echo "$DOCKER_CONTAINERS" | xargs -r docker kill 2> /dev/null || true
+    echo "$DOCKER_CONTAINERS" | xargs -r docker rm -f 2> /dev/null || true
+    echo "Docker containers killed"
+    KILLED_PROCESSES=true
+else
+    echo "No Docker containers found using port 9090"
+fi
+
 echo "Cleaning up synnax directories..."
 [ -d "$HOME/synnax-binaries" ] && rm -rf "$HOME/synnax-binaries" && echo "Removed synnax-binaries directory from $HOME" || echo "No synnax-binaries directory found in $HOME"
 [ -d "$HOME/synnax-data" ] && rm -rf "$HOME/synnax-data" && echo "Removed synnax-data directory from $HOME" || echo "No synnax-data directory found in $HOME"


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4042](https://linear.app/synnax/issue/SY-4042/prevent-docker-port-9090-conflicts-on-self-hosted-ci-runners)

## Description

Fix CI port 9090 flakiness by replacing Docker services with manual container management and pre-cleanup

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes CI port-9090 flakiness on self-hosted runners by replacing GitHub Actions `services:` blocks (which can leave stale containers across runs) with explicit Docker lifecycle steps: pre-cleanup via `kill_synnax_processes_unix.sh`, a port-free check, a readiness loop with failure detection and log dump, and a guaranteed teardown step. The shell script is also extended to kill any Docker container publishing port 9090 during the pre-cleanup phase.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the previous P1 concern (silent readiness-loop success) is fully addressed; only P2 style findings remain.

All three files contain straightforward CI infrastructure changes. The readiness loop now includes a proper failure check with log dump. The only remaining findings are P2 (unquoted secret value in docker run, benign in practice for alphanumeric license keys). No logic or correctness issues were found.

No files require special attention.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. The `GITHUB_TOKEN` is piped via stdin (not passed as a CLI argument), and no new secrets are introduced. The unquoted secret value noted inline is a robustness issue, not a secret-exposure risk.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/test.arc.yaml | Replaces declarative `services:` block with manual Docker container management; adds pre-cleanup, explicit Docker login, port-free verification, a 30-second readiness loop with failure check and log dump, and a guaranteed cleanup step. |
| .github/workflows/test.driver.yaml | Mirrors the arc workflow changes — same manual Docker lifecycle pattern applied to the driver test job with a different container name (`synnax-test-driver`) and image tag. |
| integration/scripts/kill_synnax_processes_unix.sh | Extends the pre-cleanup script to also kill and remove any Docker containers publishing port 9090, complementing the existing process-level cleanup. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions
    participant Script as kill_synnax_processes_unix.sh
    participant Docker as Docker Engine
    participant Synnax as Synnax Container

    GHA->>Script: Force Quit Existing Synnax Processes
    Script->>Docker: docker ps --filter publish=9090
    Docker-->>Script: container IDs
    Script->>Docker: docker kill + docker rm -f
    Script->>Script: Kill native synnax PIDs

    GHA->>Docker: docker login ghcr.io

    GHA->>Docker: Ensure Port 9090 is Free
    Docker-->>GHA: Port cleared

    GHA->>Docker: docker run -d --name synnax-test-*
    Docker->>Synnax: Start container

    loop Up to 30s
        GHA->>GHA: nc -z localhost 9090
        alt Port open
            GHA->>GHA: break (ready)
        else Not open
            GHA->>GHA: sleep 1
        end
    end

    alt Synnax never bound port
        GHA->>Docker: docker logs synnax-test-*
        GHA->>GHA: exit 1
    end

    GHA->>GHA: Run Bazel tests

    GHA->>Docker: docker rm -f synnax-test-* (always)
```

<sub>Reviews (3): Last reviewed commit: ["SY-4042: Remove stopped containers by na..."](https://github.com/synnaxlabs/synnax/commit/c0efd6410066f12b96b33b4431772fa8bd9e72b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27761207)</sub>

<!-- /greptile_comment -->