### PR TITLE
SY-3903: Include Version in `synnax service status` Output

### DIFF
--- a/core/cmd/service/cmd_windows.go
+++ b/core/cmd/service/cmd_windows.go
@@ -23,6 +23,7 @@ import (
 	"github.com/synnaxlabs/synnax/cmd/cert"
 	"github.com/synnaxlabs/synnax/cmd/instrumentation"
 	cmdstart "github.com/synnaxlabs/synnax/cmd/start"
+	"github.com/synnaxlabs/synnax/pkg/version"
 	"github.com/synnaxlabs/x/errors"
 )
 
@@ -159,8 +160,13 @@ func runStatus(c *cobra.Command, _ []string) error {
 	if err != nil {
 		return err
 	}
+	FormatStatus(c, info)
+	return nil
+}
 
+func FormatStatus(c *cobra.Command, info StatusInfo) {
 	c.Printf("Service: %s\n", name)
+	c.Printf("Version: %s\n", version.Get())
 	if !info.Installed {
 		c.Println("Status:  Not installed")
 	} else if info.ProcessID > 0 {
@@ -211,8 +217,6 @@ func runStatus(c *cobra.Command, _ []string) error {
 			}
 		}
 	}
-
-	return nil
 }
 
 // logEntry represents a parsed JSON log entry from zap.

--- a/core/cmd/service/service_windows_test.go
+++ b/core/cmd/service/service_windows_test.go
@@ -12,16 +12,66 @@
 package service_test
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 
 	"github.com/synnaxlabs/synnax/cmd/service"
+	"github.com/synnaxlabs/synnax/pkg/version"
 	"github.com/synnaxlabs/x/testutil"
 )
+
+var _ = Describe("FormatStatus", func() {
+	It("Should include the version in the output", func() {
+		cmd := &cobra.Command{}
+		buf := new(bytes.Buffer)
+		cmd.SetOut(buf)
+
+		info := service.StatusInfo{
+			Installed:  true,
+			State:      "Running",
+			ProcessID:  12345,
+			ConfigPath: `C:\ProgramData\Synnax\config.yaml`,
+			DataDir:    `C:\ProgramData\Synnax\data`,
+			Listen:     "localhost:9090",
+			Insecure:   true,
+		}
+		service.FormatStatus(cmd, info)
+		output := buf.String()
+		Expect(output).To(ContainSubstring("Version: "))
+		Expect(output).To(ContainSubstring(version.Get()))
+	})
+
+	It("Should show Not installed when service is not installed", func() {
+		cmd := &cobra.Command{}
+		buf := new(bytes.Buffer)
+		cmd.SetOut(buf)
+
+		info := service.StatusInfo{ConfigPath: `C:\ProgramData\Synnax\config.yaml`}
+		service.FormatStatus(cmd, info)
+		Expect(buf.String()).To(ContainSubstring("Status:  Not installed"))
+	})
+
+	It("Should show PID when service is running", func() {
+		cmd := &cobra.Command{}
+		buf := new(bytes.Buffer)
+		cmd.SetOut(buf)
+
+		info := service.StatusInfo{
+			Installed:  true,
+			State:      "Running",
+			ProcessID:  42,
+			ConfigPath: `C:\ProgramData\Synnax\config.yaml`,
+		}
+		service.FormatStatus(cmd, info)
+		Expect(buf.String()).To(ContainSubstring("Status:  Running (PID: 42)"))
+	})
+})
 
 var _ = Describe("WriteConfig", func() {
 	var (


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-3903](https://linear.app/synnax/issue/SY-3903/include-version-in-synnax-service-status-output)

## Description
Add version to `synnax service status` output on Windows

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds the Synnax version to the `synnax service status` output on Windows by calling `version.Get()` in the new exported `FormatStatus` function. The `runStatus` handler is refactored to delegate formatting to `FormatStatus`, and three new Ginkgo tests are added covering the version line, "Not installed" state, and running-with-PID state.

<h3>Confidence Score: 5/5</h3>

Safe to merge — change is minimal, well-tested, and introduces no regressions.

The refactoring is clean: error handling is preserved in runStatus, FormatStatus has no new failure modes, and the three new Ginkgo tests cover the primary branches. The only improvement opportunity is cosmetic (Full() vs Get()).

No files require special attention.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| core/cmd/service/cmd_windows.go | Refactors runStatus to call new exported FormatStatus; adds version.Get() line to status output. Logic is correct and error handling preserved. |
| core/cmd/service/service_windows_test.go | Adds three Ginkgo tests for FormatStatus covering version output, not-installed state, and running-with-PID state. Tests are well-structured and correct. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[synnax service status] --> B[runStatus]
    B --> C{status error?}
    C -- yes --> D[return error]
    C -- no --> E[FormatStatus]
    E --> F[Print Service name]
    F --> G[Print Version via version.Get]
    G --> H{Installed?}
    H -- no --> I[Print Not installed]
    H -- yes PID gt 0 --> J[Print State and PID]
    H -- yes PID eq 0 --> K[Print State only]
    K --> L{Stopped with exit code?}
    L -- yes --> M[Print exit code details]
    L -- no --> N[Print Configuration block]
    I --> N
    J --> N
    M --> N
    N --> O{Installed and Stopped with LogFile?}
    O -- yes --> P[Print recent warnings and errors]
    O -- no --> Q[Done]
    P --> Q
```

<sub>Reviews (1): Last reviewed commit: ["SY-3903: add version to \`synnax service ..."](https://github.com/synnaxlabs/synnax/commit/0e087d7f5048d56c361c35854f23547c11893b78) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27763094)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->