### PR TITLE
SY-4044: Add Nodes to  Schematic `Text Box` Symbol

### DIFF
--- a/pluto/src/schematic/symbol/Primitives.tsx
+++ b/pluto/src/schematic/symbol/Primitives.tsx
@@ -2112,6 +2112,18 @@ export const TextBox = ({
       className={CSS(CSS.B("text-box"), CSS.loc(orientation), className)}
       {...rest}
     >
+      <HandleBoundary orientation={orientation}>
+        <Handle location="left" orientation={orientation} left={0} top={50} id="1" />
+        <Handle location="right" orientation={orientation} left={100} top={50} id="2" />
+        <Handle location="top" orientation={orientation} left={50} top={0} id="3" />
+        <Handle
+          location="bottom"
+          orientation={orientation}
+          left={50}
+          top={100}
+          id="4"
+        />
+      </HandleBoundary>
       <Text.MaybeEditable
         className={CSS.BE("symbol", "label")}
         color={color.cssString(colorVal)}

--- a/pluto/src/schematic/symbol/Symbols.tsx
+++ b/pluto/src/schematic/symbol/Symbols.tsx
@@ -1194,6 +1194,7 @@ export const TextBox = ({
   autoFit,
   level,
   value,
+  orientation,
 }: SymbolProps<Omit<TextBoxProps, "onChange">>): ReactElement => (
   <Primitives.TextBox
     className={DRAG_HANDLE_CLASS}
@@ -1205,6 +1206,7 @@ export const TextBox = ({
     width={width}
     align={align}
     autoFit={autoFit}
+    orientation={orientation}
   />
 );
 


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4044](https://linear.app/synnax/issue/SY-4044/add-nodes-to-text-box-schematic-element)

## Description

* Add Nodes to  Schematic `Text Box` Symbol
* Correct/enable orientation control
## Basic Readiness

- [x] I have performed a self-review of my code.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds four connection handles (left, right, top, bottom) to the `TextBox` schematic primitive and fixes a silent prop-drop bug where `orientation` was accepted in `Symbols.TextBox`'s type but never destructured or forwarded to the underlying `Primitives.TextBox`, leaving orientation control non-functional.

<h3>Confidence Score: 5/5</h3>

Safe to merge — changes are minimal, follow established patterns, and fix a real bug where orientation was silently dropped.

Both changes are straightforward: handle nodes follow identical patterns used by every other symbol in the file, and the orientation prop-forwarding fix is a one-liner that corrects clearly broken behavior with no side effects.

No files require special attention.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pluto/src/schematic/symbol/Primitives.tsx | Adds a HandleBoundary with four Handle nodes (left, right, top, bottom) to the TextBox primitive; follows the existing handle pattern used by all other symbols in the file. |
| pluto/src/schematic/symbol/Symbols.tsx | Destructures and forwards the previously-dropped orientation prop in the TextBox symbol wrapper, enabling orientation control to work correctly. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Symbols.TextBox\n(SymbolProps wrapper)"] -->|"orientation (newly forwarded)"| B["Primitives.TextBox"]
    B --> C{"In React Flow\ncontext?"}
    C -->|Yes| D["HandleBoundary\n(orientation)"]
    C -->|No - throws| E["returns null\n(no handles rendered)"]
    D --> F["Handle left id=1\nleft=0 top=50"]
    D --> G["Handle right id=2\nleft=100 top=50"]
    D --> H["Handle top id=3\nleft=50 top=0"]
    D --> I["Handle bottom id=4\nleft=50 top=100"]
    B --> J["Text.MaybeEditable\n(label content)"]
```

<sub>Reviews (1): Last reviewed commit: ["SY-4044: Enable/fix orientation control ..."](https://github.com/synnaxlabs/synnax/commit/d667cc6dece4ec09c70207394a77989d6e7efab8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27790800)</sub>

<!-- /greptile_comment -->