### PR TITLE
SY-4047: Fix Task Migration issue

### DIFF
--- a/console/src/hardware/common/device/testutil.ts
+++ b/console/src/hardware/common/device/testutil.ts
@@ -44,6 +44,33 @@ export const testPropertiesSchema = (
         expect(schema.safeParse({}).success).toBe(true);
       });
 
+    if (testEmpty)
+      it("should produce independent objects for successive parses of empty input", () => {
+        const a = schema.parse({});
+        const b = schema.parse({});
+        expect(a).toEqual(b);
+        expect(a).not.toBe(b);
+        // Mutate a nested object/array in `a` and verify `b` is unaffected.
+        const aAny = a as Record<string, unknown>;
+        for (const key of Object.keys(aAny)) {
+          const val = aAny[key];
+          if (val != null && typeof val === "object" && !Array.isArray(val)) {
+            (val as Record<string, unknown>).__test = true;
+            expect((b as Record<string, unknown>)[key]).not.toHaveProperty(
+              "__test",
+            );
+            delete (val as Record<string, unknown>).__test;
+            break;
+          }
+          if (Array.isArray(val)) {
+            val.push("__test");
+            expect((b as Record<string, unknown>)[key]).not.toContain("__test");
+            val.pop();
+            break;
+          }
+        }
+      });
+
     for (const [label, input] of partialCases)
       it(`should parse ${label}`, () => {
         expect(schema.safeParse(input).success).toBe(true);

--- a/console/src/hardware/common/device/testutil.ts
+++ b/console/src/hardware/common/device/testutil.ts
@@ -56,9 +56,7 @@ export const testPropertiesSchema = (
           const val = aAny[key];
           if (val != null && typeof val === "object" && !Array.isArray(val)) {
             (val as Record<string, unknown>).__test = true;
-            expect((b as Record<string, unknown>)[key]).not.toHaveProperty(
-              "__test",
-            );
+            expect((b as Record<string, unknown>)[key]).not.toHaveProperty("__test");
             delete (val as Record<string, unknown>).__test;
             break;
           }

--- a/console/src/hardware/common/device/testutil.ts
+++ b/console/src/hardware/common/device/testutil.ts
@@ -1,0 +1,52 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { describe, expect, it } from "vitest";
+import { type z } from "zod";
+
+/**
+ * Shared test suite that verifies a device propertiesZ schema is tolerant of
+ * missing / incomplete data — the core requirement for backward-compatible
+ * device retrieval.
+ *
+ * @param name - human-readable integration name shown in test output.
+ * @param schema - the Zod schema under test (e.g. `propertiesZ`).
+ * @param zeroProperties - the ZERO_PROPERTIES constant for the integration.
+ * @param partialCases - optional extra cases: each entry is `[label, input]`
+ *   where `input` is a partial properties object that the schema must accept.
+ */
+interface TestPropertiesSchemaOptions {
+  /** Set to false to skip the empty `{}` parse test (e.g., for versioned schemas). */
+  testEmpty?: boolean;
+}
+
+export const testPropertiesSchema = (
+  name: string,
+  schema: z.ZodType,
+  zeroProperties: unknown,
+  partialCases: Array<[string, unknown]> = [],
+  options: TestPropertiesSchemaOptions = {},
+): void => {
+  const { testEmpty = true } = options;
+  describe(`${name} propertiesZ`, () => {
+    it("should parse ZERO_PROPERTIES", () => {
+      expect(schema.safeParse(zeroProperties).success).toBe(true);
+    });
+
+    if (testEmpty)
+      it("should parse completely empty properties", () => {
+        expect(schema.safeParse({}).success).toBe(true);
+      });
+
+    for (const [label, input] of partialCases)
+      it(`should parse ${label}`, () => {
+        expect(schema.safeParse(input).success).toBe(true);
+      });
+  });
+};

--- a/console/src/hardware/ethercat/device/types.spec.ts
+++ b/console/src/hardware/ethercat/device/types.spec.ts
@@ -1,0 +1,34 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { testPropertiesSchema } from "@/hardware/common/device/testutil";
+import {
+  slavePropertiesZ,
+  ZERO_SLAVE_PROPERTIES,
+} from "@/hardware/ethercat/device/types";
+
+testPropertiesSchema("EtherCAT", slavePropertiesZ, ZERO_SLAVE_PROPERTIES, [
+  [
+    "scan-only properties (identifier and position only)",
+    { identifier: "EL3004", position: 1 },
+  ],
+  [
+    "properties missing PDOs",
+    {
+      identifier: "EL3004",
+      serial: 12345,
+      vendorId: 2,
+      productCode: 0x0bbc3052,
+      revision: 0,
+      name: "EL3004",
+      network: "eth0",
+      position: 1,
+    },
+  ],
+]);

--- a/console/src/hardware/ethercat/device/types.ts
+++ b/console/src/hardware/ethercat/device/types.ts
@@ -31,8 +31,8 @@ export interface PDOEntry extends z.infer<typeof pdoEntryZ> {}
 
 /** Schema for PDO collections (inputs and outputs). */
 export const pdosZ = z.object({
-  inputs: z.array(pdoEntryZ).default([]),
-  outputs: z.array(pdoEntryZ).default([]),
+  inputs: z.array(pdoEntryZ).default(() => []),
+  outputs: z.array(pdoEntryZ).default(() => []),
 });
 export interface PDOs extends z.infer<typeof pdosZ> {}
 
@@ -51,15 +51,15 @@ export const slavePropertiesZ = z.object({
   name: z.string().default(""),
   network: z.string().default(""),
   position: z.number().default(0),
-  pdos: pdosZ.default(ZERO_PDOS),
+  pdos: pdosZ.default(() => ({ inputs: [], outputs: [] })),
   readIndex: z.number().default(0),
   writeStateIndex: z.number().default(0),
   read: z
-    .object({ channels: z.record(z.string(), z.number()).default({}) })
-    .default({ channels: {} }),
+    .object({ channels: z.record(z.string(), z.number()).default(() => ({})) })
+    .default(() => ({ channels: {} })),
   write: z
-    .object({ channels: z.record(z.string(), z.number()).default({}) })
-    .default({ channels: {} }),
+    .object({ channels: z.record(z.string(), z.number()).default(() => ({})) })
+    .default(() => ({ channels: {} })),
   enabled: z.boolean().optional().default(true),
 });
 export interface SlaveProperties extends z.infer<typeof slavePropertiesZ> {}

--- a/console/src/hardware/ethercat/device/types.ts
+++ b/console/src/hardware/ethercat/device/types.ts
@@ -31,8 +31,8 @@ export interface PDOEntry extends z.infer<typeof pdoEntryZ> {}
 
 /** Schema for PDO collections (inputs and outputs). */
 export const pdosZ = z.object({
-  inputs: z.array(pdoEntryZ),
-  outputs: z.array(pdoEntryZ),
+  inputs: z.array(pdoEntryZ).default([]),
+  outputs: z.array(pdoEntryZ).default([]),
 });
 export interface PDOs extends z.infer<typeof pdosZ> {}
 
@@ -43,23 +43,23 @@ export const ZERO_PDOS: PDOs = {
 
 /** Slave device properties schema. */
 export const slavePropertiesZ = z.object({
-  identifier: z.string(),
-  serial: z.number(),
-  vendorId: z.number(),
-  productCode: z.number(),
-  revision: z.number(),
-  name: z.string(),
-  network: z.string(),
-  position: z.number(),
-  pdos: pdosZ,
-  readIndex: z.number(),
-  writeStateIndex: z.number(),
-  read: z.object({
-    channels: z.record(z.string(), z.number()),
-  }),
-  write: z.object({
-    channels: z.record(z.string(), z.number()),
-  }),
+  identifier: z.string().default(""),
+  serial: z.number().default(0),
+  vendorId: z.number().default(0),
+  productCode: z.number().default(0),
+  revision: z.number().default(0),
+  name: z.string().default(""),
+  network: z.string().default(""),
+  position: z.number().default(0),
+  pdos: pdosZ.default(ZERO_PDOS),
+  readIndex: z.number().default(0),
+  writeStateIndex: z.number().default(0),
+  read: z
+    .object({ channels: z.record(z.string(), z.number()).default({}) })
+    .default({ channels: {} }),
+  write: z
+    .object({ channels: z.record(z.string(), z.number()).default({}) })
+    .default({ channels: {} }),
   enabled: z.boolean().optional().default(true),
 });
 export interface SlaveProperties extends z.infer<typeof slavePropertiesZ> {}

--- a/console/src/hardware/labjack/device/types.spec.ts
+++ b/console/src/hardware/labjack/device/types.spec.ts
@@ -1,0 +1,26 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { testPropertiesSchema } from "@/hardware/common/device/testutil";
+import { propertiesZ, ZERO_PROPERTIES } from "@/hardware/labjack/device/types";
+
+testPropertiesSchema("LabJack", propertiesZ, ZERO_PROPERTIES, [
+  [
+    "scan-only properties from C++ driver",
+    { serial_number: "470026743", device_type: "T7" },
+  ],
+  [
+    "partially populated (only read channels set)",
+    {
+      identifier: "lj1",
+      readIndex: 123,
+      AI: { channels: { "0": 456 } },
+    },
+  ],
+]);

--- a/console/src/hardware/labjack/device/types.spec.ts
+++ b/console/src/hardware/labjack/device/types.spec.ts
@@ -23,4 +23,21 @@ testPropertiesSchema("LabJack", propertiesZ, ZERO_PROPERTIES, [
       AI: { channels: { "0": 456 } },
     },
   ],
+  [
+    "real v0.51.3 device properties (connection/read/write format, no readIndex/thermocoupleIndex)",
+    {
+      identifier: "mlt",
+      connection: { identifier: "ANY", connection_type: "USB" },
+      read: { index: 0, channels: {} },
+      write: { channels: {} },
+    },
+  ],
+  [
+    "read task configured but no write task (missing writeStateIndex and thermocoupleIndex)",
+    {
+      identifier: "lj1",
+      readIndex: 1048584,
+      AI: { channels: { AIN0: 1048585 } },
+    },
+  ],
 ]);

--- a/console/src/hardware/labjack/device/types.ts
+++ b/console/src/hardware/labjack/device/types.ts
@@ -201,19 +201,29 @@ export const PORTS: Ports = {
   [T8_MODEL]: T8_PORTS,
 };
 
+const ZERO_CHANNELS = { channels: {} };
+
 export const propertiesZ = z.object({
-  identifier: Common.Device.identifierZ,
-  readIndex: channel.keyZ,
-  thermocoupleIndex: channel.keyZ,
-  writeStateIndex: channel.keyZ,
-  [AI_PORT_TYPE]: z.object({ channels: z.record(z.string(), channel.keyZ) }),
-  [AO_PORT_TYPE]: z.object({
-    channels: z.record(z.string(), Common.Device.commandStatePairZ),
-  }),
-  [DI_PORT_TYPE]: z.object({ channels: z.record(z.string(), channel.keyZ) }),
-  [DO_PORT_TYPE]: z.object({
-    channels: z.record(z.string(), Common.Device.commandStatePairZ),
-  }),
+  identifier: Common.Device.identifierZ.catch(""),
+  readIndex: channel.keyZ.catch(0),
+  thermocoupleIndex: channel.keyZ.catch(0),
+  writeStateIndex: channel.keyZ.catch(0),
+  [AI_PORT_TYPE]: z
+    .object({ channels: z.record(z.string(), channel.keyZ).default({}) })
+    .default(ZERO_CHANNELS),
+  [AO_PORT_TYPE]: z
+    .object({
+      channels: z.record(z.string(), Common.Device.commandStatePairZ).default({}),
+    })
+    .default(ZERO_CHANNELS),
+  [DI_PORT_TYPE]: z
+    .object({ channels: z.record(z.string(), channel.keyZ).default({}) })
+    .default(ZERO_CHANNELS),
+  [DO_PORT_TYPE]: z
+    .object({
+      channels: z.record(z.string(), Common.Device.commandStatePairZ).default({}),
+    })
+    .default(ZERO_CHANNELS),
 });
 export type Properties = z.infer<typeof propertiesZ>;
 

--- a/console/src/hardware/labjack/device/types.ts
+++ b/console/src/hardware/labjack/device/types.ts
@@ -201,29 +201,31 @@ export const PORTS: Ports = {
   [T8_MODEL]: T8_PORTS,
 };
 
-const ZERO_CHANNELS = { channels: {} };
-
 export const propertiesZ = z.object({
   identifier: Common.Device.identifierZ.catch(""),
   readIndex: channel.keyZ.catch(0),
   thermocoupleIndex: channel.keyZ.catch(0),
   writeStateIndex: channel.keyZ.catch(0),
   [AI_PORT_TYPE]: z
-    .object({ channels: z.record(z.string(), channel.keyZ).default({}) })
-    .default(ZERO_CHANNELS),
+    .object({ channels: z.record(z.string(), channel.keyZ).default(() => ({})) })
+    .default(() => ({ channels: {} })),
   [AO_PORT_TYPE]: z
     .object({
-      channels: z.record(z.string(), Common.Device.commandStatePairZ).default({}),
+      channels: z
+        .record(z.string(), Common.Device.commandStatePairZ)
+        .default(() => ({})),
     })
-    .default(ZERO_CHANNELS),
+    .default(() => ({ channels: {} })),
   [DI_PORT_TYPE]: z
-    .object({ channels: z.record(z.string(), channel.keyZ).default({}) })
-    .default(ZERO_CHANNELS),
+    .object({ channels: z.record(z.string(), channel.keyZ).default(() => ({})) })
+    .default(() => ({ channels: {} })),
   [DO_PORT_TYPE]: z
     .object({
-      channels: z.record(z.string(), Common.Device.commandStatePairZ).default({}),
+      channels: z
+        .record(z.string(), Common.Device.commandStatePairZ)
+        .default(() => ({})),
     })
-    .default(ZERO_CHANNELS),
+    .default(() => ({ channels: {} })),
 });
 export type Properties = z.infer<typeof propertiesZ>;
 

--- a/console/src/hardware/modbus/device/types.spec.ts
+++ b/console/src/hardware/modbus/device/types.spec.ts
@@ -1,0 +1,18 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { testPropertiesSchema } from "@/hardware/common/device/testutil";
+import { SCHEMAS, ZERO_PROPERTIES } from "@/hardware/modbus/device/types";
+
+testPropertiesSchema("Modbus", SCHEMAS.properties, ZERO_PROPERTIES, [
+  [
+    "properties with only connection config",
+    { connection: { host: "192.168.1.10", port: 502 } },
+  ],
+]);

--- a/console/src/hardware/modbus/device/types.ts
+++ b/console/src/hardware/modbus/device/types.ts
@@ -14,15 +14,26 @@ export const MAKE = "Modbus";
 const makeZ = z.literal(MAKE);
 const modelZ = z.literal("Modbus");
 
+const ZERO_CONNECTION = { host: "", port: 0, swapBytes: false, swapWords: false };
+
 const propertiesZ = z.object({
-  connection: z.object({
-    host: z.string(),
-    port: z.number(),
-    swapBytes: z.boolean(),
-    swapWords: z.boolean(),
-  }),
-  read: z.object({ index: z.number(), channels: z.record(z.string(), z.number()) }),
-  write: z.object({ channels: z.record(z.string(), z.number()) }),
+  connection: z
+    .object({
+      host: z.string().default(""),
+      port: z.number().default(0),
+      swapBytes: z.boolean().default(false),
+      swapWords: z.boolean().default(false),
+    })
+    .default(ZERO_CONNECTION),
+  read: z
+    .object({
+      index: z.number().default(0),
+      channels: z.record(z.string(), z.number()).default({}),
+    })
+    .default({ index: 0, channels: {} }),
+  write: z
+    .object({ channels: z.record(z.string(), z.number()).default({}) })
+    .default({ channels: {} }),
 });
 
 export interface Properties extends z.infer<typeof propertiesZ> {}

--- a/console/src/hardware/modbus/device/types.ts
+++ b/console/src/hardware/modbus/device/types.ts
@@ -14,8 +14,6 @@ export const MAKE = "Modbus";
 const makeZ = z.literal(MAKE);
 const modelZ = z.literal("Modbus");
 
-const ZERO_CONNECTION = { host: "", port: 0, swapBytes: false, swapWords: false };
-
 const propertiesZ = z.object({
   connection: z
     .object({
@@ -24,16 +22,16 @@ const propertiesZ = z.object({
       swapBytes: z.boolean().default(false),
       swapWords: z.boolean().default(false),
     })
-    .default(ZERO_CONNECTION),
+    .default(() => ({ host: "", port: 0, swapBytes: false, swapWords: false })),
   read: z
     .object({
       index: z.number().default(0),
-      channels: z.record(z.string(), z.number()).default({}),
+      channels: z.record(z.string(), z.number()).default(() => ({})),
     })
-    .default({ index: 0, channels: {} }),
+    .default(() => ({ index: 0, channels: {} })),
   write: z
-    .object({ channels: z.record(z.string(), z.number()).default({}) })
-    .default({ channels: {} }),
+    .object({ channels: z.record(z.string(), z.number()).default(() => ({})) })
+    .default(() => ({ channels: {} })),
 });
 
 export interface Properties extends z.infer<typeof propertiesZ> {}

--- a/console/src/hardware/ni/device/enrich.ts
+++ b/console/src/hardware/ni/device/enrich.ts
@@ -26,5 +26,9 @@ export const enrich = (model: string, properties: Properties): Properties => {
   const enriched = (data as record.Unknown)[model] as {
     estimatedPinout: PickedEnrichedProperties;
   };
-  return { ...deep.copy(ZERO_PROPERTIES), ...enriched?.estimatedPinout, ...properties };
+  return deep.override(
+    deep.copy(ZERO_PROPERTIES),
+    enriched?.estimatedPinout ?? {},
+    properties,
+  );
 };

--- a/console/src/hardware/ni/device/types.spec.ts
+++ b/console/src/hardware/ni/device/types.spec.ts
@@ -7,45 +7,40 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { describe, expect, it } from "vitest";
-
+import { testPropertiesSchema } from "@/hardware/common/device/testutil";
 import { propertiesZ, ZERO_PROPERTIES } from "@/hardware/ni/device/types";
 
-describe("NI Device propertiesZ", () => {
-  it("should parse ZERO_PROPERTIES", () => {
-    expect(propertiesZ.safeParse(ZERO_PROPERTIES).success).toBe(true);
-  });
-
-  it("should parse device properties missing counterInput (pre-SY-3060)", () => {
-    const oldProps = {
+testPropertiesSchema("NI", propertiesZ, ZERO_PROPERTIES, [
+  [
+    "properties missing counterInput (pre-SY-3060)",
+    {
       identifier: "Dev1",
       analogInput: { portCount: 4, index: 0, channels: {} },
       analogOutput: { portCount: 2, stateIndex: 0, channels: {} },
-      // counterInput missing — added in SY-3060
       digitalInputOutput: { portCount: 2, lineCounts: [8, 8] },
       digitalInput: { portCount: 2, lineCounts: [8, 8], index: 0, channels: {} },
-      digitalOutput: { portCount: 2, lineCounts: [8, 8], stateIndex: 0, channels: {} },
-    };
-    const result = propertiesZ.safeParse(oldProps);
-    expect(result.success).toBe(true);
-  });
-
-  it("should parse device with partially populated analogOutput", () => {
-    const props = {
+      digitalOutput: {
+        portCount: 2,
+        lineCounts: [8, 8],
+        stateIndex: 0,
+        channels: {},
+      },
+    },
+  ],
+  [
+    "partially populated analogOutput (shallow merge from enriched.json)",
+    {
       identifier: "Dev1",
       analogInput: { portCount: 4, index: 0, channels: {} },
-      analogOutput: { portCount: 2 }, // missing stateIndex, channels
+      analogOutput: { portCount: 2 },
       counterInput: { portCount: 0, index: 0, channels: {} },
       digitalInputOutput: { portCount: 0, lineCounts: [] },
       digitalInput: { portCount: 0, lineCounts: [], index: 0, channels: {} },
       digitalOutput: { portCount: 0, lineCounts: [], stateIndex: 0, channels: {} },
-    };
-    const result = propertiesZ.safeParse(props);
-    expect(result.success).toBe(true);
-  });
-
-  it("should parse completely empty properties", () => {
-    const result = propertiesZ.safeParse({});
-    expect(result.success).toBe(true);
-  });
-});
+    },
+  ],
+  [
+    "scan-only properties from C++ driver",
+    { is_simulated: false, resource_name: "Dev1", is_chassis: false },
+  ],
+]);

--- a/console/src/hardware/ni/device/types.spec.ts
+++ b/console/src/hardware/ni/device/types.spec.ts
@@ -43,4 +43,33 @@ testPropertiesSchema("NI", propertiesZ, ZERO_PROPERTIES, [
     "scan-only properties from C++ driver",
     { is_simulated: false, resource_name: "Dev1", is_chassis: false },
   ],
+  [
+    "real v0.47.1 device properties (snake_case, no counterInput, partial analogOutput)",
+    {
+      identifier: "n9205",
+      analog_input: { port_count: 0, index: 1048585, channels: { "0": 1048586 } },
+      analog_output: { port_count: 0 },
+      digital_input_output: { port_count: 0, line_counts: [] },
+      digital_input: { port_count: 0, line_counts: [], index: 0, channels: {} },
+      digital_output: {
+        port_count: 0,
+        line_counts: [],
+        state_index: 0,
+        channels: {},
+      },
+      is_simulated: true,
+      resource_name: "6C1DE3E6-1E3A-11F1-80FB-9BC4D3F82D6E",
+    },
+  ],
+  [
+    "pre-v0.41.0 analogOutput with only portCount (before SY-1335)",
+    {
+      identifier: "Dev1",
+      analogInput: { portCount: 4, index: 0, channels: {} },
+      analogOutput: { portCount: 0 },
+      digitalInputOutput: { portCount: 0, lineCounts: [] },
+      digitalInput: { portCount: 0, lineCounts: [], index: 0, channels: {} },
+      digitalOutput: { portCount: 0, lineCounts: [], stateIndex: 0, channels: {} },
+    },
+  ],
 ]);

--- a/console/src/hardware/ni/device/types.spec.ts
+++ b/console/src/hardware/ni/device/types.spec.ts
@@ -1,0 +1,51 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { describe, expect, it } from "vitest";
+
+import { propertiesZ, ZERO_PROPERTIES } from "@/hardware/ni/device/types";
+
+describe("NI Device propertiesZ", () => {
+  it("should parse ZERO_PROPERTIES", () => {
+    expect(propertiesZ.safeParse(ZERO_PROPERTIES).success).toBe(true);
+  });
+
+  it("should parse device properties missing counterInput (pre-SY-3060)", () => {
+    const oldProps = {
+      identifier: "Dev1",
+      analogInput: { portCount: 4, index: 0, channels: {} },
+      analogOutput: { portCount: 2, stateIndex: 0, channels: {} },
+      // counterInput missing — added in SY-3060
+      digitalInputOutput: { portCount: 2, lineCounts: [8, 8] },
+      digitalInput: { portCount: 2, lineCounts: [8, 8], index: 0, channels: {} },
+      digitalOutput: { portCount: 2, lineCounts: [8, 8], stateIndex: 0, channels: {} },
+    };
+    const result = propertiesZ.safeParse(oldProps);
+    expect(result.success).toBe(true);
+  });
+
+  it("should parse device with partially populated analogOutput", () => {
+    const props = {
+      identifier: "Dev1",
+      analogInput: { portCount: 4, index: 0, channels: {} },
+      analogOutput: { portCount: 2 }, // missing stateIndex, channels
+      counterInput: { portCount: 0, index: 0, channels: {} },
+      digitalInputOutput: { portCount: 0, lineCounts: [] },
+      digitalInput: { portCount: 0, lineCounts: [], index: 0, channels: {} },
+      digitalOutput: { portCount: 0, lineCounts: [], stateIndex: 0, channels: {} },
+    };
+    const result = propertiesZ.safeParse(props);
+    expect(result.success).toBe(true);
+  });
+
+  it("should parse completely empty properties", () => {
+    const result = propertiesZ.safeParse({});
+    expect(result.success).toBe(true);
+  });
+});

--- a/console/src/hardware/ni/device/types.ts
+++ b/console/src/hardware/ni/device/types.ts
@@ -16,39 +16,58 @@ export const MAKE = "NI";
 export type Make = typeof MAKE;
 export const makeZ = z.literal(MAKE);
 
+const ZERO_AI = { portCount: 0, index: 0, channels: {} };
+const ZERO_AO = { portCount: 0, stateIndex: 0, channels: {} };
+const ZERO_CI = { portCount: 0, index: 0, channels: {} };
+const ZERO_DIO = { portCount: 0, lineCounts: [] as number[] };
+const ZERO_DI = { portCount: 0, lineCounts: [] as number[], index: 0, channels: {} };
+const ZERO_DO = { portCount: 0, lineCounts: [] as number[], stateIndex: 0, channels: {} };
+
 export const propertiesZ = z.object({
-  identifier: Common.Device.identifierZ,
-  analogInput: z.object({
-    portCount: z.number(),
-    index: channel.keyZ,
-    channels: z.record(z.string(), channel.keyZ),
-  }),
-  analogOutput: z.object({
-    portCount: z.number(),
-    stateIndex: channel.keyZ,
-    channels: z.record(z.string(), Common.Device.commandStatePairZ),
-  }),
-  counterInput: z.object({
-    portCount: z.number(),
-    index: channel.keyZ,
-    channels: z.record(z.string(), channel.keyZ),
-  }),
-  digitalInputOutput: z.object({
-    portCount: z.number(),
-    lineCounts: z.array(z.number()),
-  }),
-  digitalInput: z.object({
-    portCount: z.number(),
-    lineCounts: z.array(z.number()),
-    index: channel.keyZ,
-    channels: z.record(z.string(), channel.keyZ),
-  }),
-  digitalOutput: z.object({
-    portCount: z.number(),
-    lineCounts: z.array(z.number()),
-    stateIndex: channel.keyZ,
-    channels: z.record(z.string(), Common.Device.commandStatePairZ),
-  }),
+  identifier: Common.Device.identifierZ.catch(""),
+  analogInput: z
+    .object({
+      portCount: z.number().default(0),
+      index: channel.keyZ.catch(0),
+      channels: z.record(z.string(), channel.keyZ).default({}),
+    })
+    .default(ZERO_AI),
+  analogOutput: z
+    .object({
+      portCount: z.number().default(0),
+      stateIndex: channel.keyZ.catch(0),
+      channels: z.record(z.string(), Common.Device.commandStatePairZ).default({}),
+    })
+    .default(ZERO_AO),
+  counterInput: z
+    .object({
+      portCount: z.number().default(0),
+      index: channel.keyZ.catch(0),
+      channels: z.record(z.string(), channel.keyZ).default({}),
+    })
+    .default(ZERO_CI),
+  digitalInputOutput: z
+    .object({
+      portCount: z.number().default(0),
+      lineCounts: z.array(z.number()).default([]),
+    })
+    .default(ZERO_DIO),
+  digitalInput: z
+    .object({
+      portCount: z.number().default(0),
+      lineCounts: z.array(z.number()).default([]),
+      index: channel.keyZ.catch(0),
+      channels: z.record(z.string(), channel.keyZ).default({}),
+    })
+    .default(ZERO_DI),
+  digitalOutput: z
+    .object({
+      portCount: z.number().default(0),
+      lineCounts: z.array(z.number()).default([]),
+      stateIndex: channel.keyZ.catch(0),
+      channels: z.record(z.string(), Common.Device.commandStatePairZ).default({}),
+    })
+    .default(ZERO_DO),
 });
 export type Properties = z.infer<typeof propertiesZ>;
 

--- a/console/src/hardware/ni/device/types.ts
+++ b/console/src/hardware/ni/device/types.ts
@@ -16,63 +16,55 @@ export const MAKE = "NI";
 export type Make = typeof MAKE;
 export const makeZ = z.literal(MAKE);
 
-const ZERO_AI = { portCount: 0, index: 0, channels: {} };
-const ZERO_AO = { portCount: 0, stateIndex: 0, channels: {} };
-const ZERO_CI = { portCount: 0, index: 0, channels: {} };
-const ZERO_DIO = { portCount: 0, lineCounts: [] as number[] };
-const ZERO_DI = { portCount: 0, lineCounts: [] as number[], index: 0, channels: {} };
-const ZERO_DO = {
-  portCount: 0,
-  lineCounts: [] as number[],
-  stateIndex: 0,
-  channels: {},
-};
-
 export const propertiesZ = z.object({
   identifier: Common.Device.identifierZ.catch(""),
   analogInput: z
     .object({
       portCount: z.number().default(0),
       index: channel.keyZ.catch(0),
-      channels: z.record(z.string(), channel.keyZ).default({}),
+      channels: z.record(z.string(), channel.keyZ).default(() => ({})),
     })
-    .default(ZERO_AI),
+    .default(() => ({ portCount: 0, index: 0, channels: {} })),
   analogOutput: z
     .object({
       portCount: z.number().default(0),
       stateIndex: channel.keyZ.catch(0),
-      channels: z.record(z.string(), Common.Device.commandStatePairZ).default({}),
+      channels: z
+        .record(z.string(), Common.Device.commandStatePairZ)
+        .default(() => ({})),
     })
-    .default(ZERO_AO),
+    .default(() => ({ portCount: 0, stateIndex: 0, channels: {} })),
   counterInput: z
     .object({
       portCount: z.number().default(0),
       index: channel.keyZ.catch(0),
-      channels: z.record(z.string(), channel.keyZ).default({}),
+      channels: z.record(z.string(), channel.keyZ).default(() => ({})),
     })
-    .default(ZERO_CI),
+    .default(() => ({ portCount: 0, index: 0, channels: {} })),
   digitalInputOutput: z
     .object({
       portCount: z.number().default(0),
-      lineCounts: z.array(z.number()).default([]),
+      lineCounts: z.array(z.number()).default(() => []),
     })
-    .default(ZERO_DIO),
+    .default(() => ({ portCount: 0, lineCounts: [] })),
   digitalInput: z
     .object({
       portCount: z.number().default(0),
-      lineCounts: z.array(z.number()).default([]),
+      lineCounts: z.array(z.number()).default(() => []),
       index: channel.keyZ.catch(0),
-      channels: z.record(z.string(), channel.keyZ).default({}),
+      channels: z.record(z.string(), channel.keyZ).default(() => ({})),
     })
-    .default(ZERO_DI),
+    .default(() => ({ portCount: 0, lineCounts: [], index: 0, channels: {} })),
   digitalOutput: z
     .object({
       portCount: z.number().default(0),
-      lineCounts: z.array(z.number()).default([]),
+      lineCounts: z.array(z.number()).default(() => []),
       stateIndex: channel.keyZ.catch(0),
-      channels: z.record(z.string(), Common.Device.commandStatePairZ).default({}),
+      channels: z
+        .record(z.string(), Common.Device.commandStatePairZ)
+        .default(() => ({})),
     })
-    .default(ZERO_DO),
+    .default(() => ({ portCount: 0, lineCounts: [], stateIndex: 0, channels: {} })),
 });
 export type Properties = z.infer<typeof propertiesZ>;
 

--- a/console/src/hardware/ni/device/types.ts
+++ b/console/src/hardware/ni/device/types.ts
@@ -21,7 +21,12 @@ const ZERO_AO = { portCount: 0, stateIndex: 0, channels: {} };
 const ZERO_CI = { portCount: 0, index: 0, channels: {} };
 const ZERO_DIO = { portCount: 0, lineCounts: [] as number[] };
 const ZERO_DI = { portCount: 0, lineCounts: [] as number[], index: 0, channels: {} };
-const ZERO_DO = { portCount: 0, lineCounts: [] as number[], stateIndex: 0, channels: {} };
+const ZERO_DO = {
+  portCount: 0,
+  lineCounts: [] as number[],
+  stateIndex: 0,
+  channels: {},
+};
 
 export const propertiesZ = z.object({
   identifier: Common.Device.identifierZ.catch(""),

--- a/console/src/hardware/opc/device/types/index.ts
+++ b/console/src/hardware/opc/device/types/index.ts
@@ -37,7 +37,9 @@ export const connectionConfigZ = v0.connectionConfigZ;
 export interface ConnectionConfig extends v0.ConnectionConfig {}
 export const ZERO_CONNECTION_CONFIG = v0.ZERO_CONNECTION_CONFIG;
 
-export const propertiesZ = v1.propertiesZ;
+export const propertiesZ: z.ZodType<v1.Properties> = v1.propertiesZ.or(
+  v0.propertiesZ.transform(v1.propertiesMigration),
+);
 export interface Properties extends v1.Properties {}
 export const ZERO_PROPERTIES = v1.ZERO_PROPERTIES;
 

--- a/console/src/hardware/opc/device/types/types.spec.ts
+++ b/console/src/hardware/opc/device/types/types.spec.ts
@@ -1,0 +1,44 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { describe, expect, it } from "vitest";
+
+import { testPropertiesSchema } from "@/hardware/common/device/testutil";
+import { propertiesZ, ZERO_PROPERTIES } from "@/hardware/opc/device/types";
+import * as v0 from "@/hardware/opc/device/types/v0";
+
+// OPC uses versioned schemas — empty `{}` is not valid for either version.
+testPropertiesSchema("OPC UA", propertiesZ, ZERO_PROPERTIES, [], {
+  testEmpty: false,
+});
+
+describe("OPC UA propertiesZ v0 migration", () => {
+  it("should migrate v0 properties through the union", () => {
+    const result = propertiesZ.safeParse(v0.ZERO_PROPERTIES);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.version).toBe("1.0.0");
+      expect(result.data.read.indexes).toEqual([]);
+    }
+  });
+
+  it("should migrate v0 read.index into read.indexes", () => {
+    const v0Props = {
+      ...v0.ZERO_PROPERTIES,
+      read: { index: 42, channels: { "ns=2;s=Tag1": 100 } },
+    };
+    const result = propertiesZ.safeParse(v0Props);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.version).toBe("1.0.0");
+      expect(result.data.read.indexes).toEqual([42]);
+      expect(result.data.read.channels).toEqual({ "ns=2;s=Tag1": 100 });
+    }
+  });
+});

--- a/console/src/hardware/opc/device/types/v1.ts
+++ b/console/src/hardware/opc/device/types/v1.ts
@@ -17,16 +17,16 @@ const VERSION = "1.0.0";
 
 export const propertiesZ = z.object({
   version: z.literal(VERSION),
-  connection: v0.connectionConfigZ.default(v0.ZERO_CONNECTION_CONFIG),
+  connection: v0.connectionConfigZ.default(() => ({ ...v0.ZERO_CONNECTION_CONFIG })),
   read: z
     .object({
-      indexes: z.array(channel.keyZ).default([]),
-      channels: z.record(z.string(), channel.keyZ).default({}),
+      indexes: z.array(channel.keyZ).default(() => []),
+      channels: z.record(z.string(), channel.keyZ).default(() => ({})),
     })
-    .default({ indexes: [], channels: {} }),
+    .default(() => ({ indexes: [], channels: {} })),
   write: z
-    .object({ channels: z.record(z.string(), channel.keyZ).default({}) })
-    .default({ channels: {} }),
+    .object({ channels: z.record(z.string(), channel.keyZ).default(() => ({})) })
+    .default(() => ({ channels: {} })),
 });
 export type Properties = z.infer<typeof propertiesZ>;
 

--- a/console/src/hardware/opc/device/types/v1.ts
+++ b/console/src/hardware/opc/device/types/v1.ts
@@ -17,12 +17,16 @@ const VERSION = "1.0.0";
 
 export const propertiesZ = z.object({
   version: z.literal(VERSION),
-  connection: v0.connectionConfigZ,
-  read: z.object({
-    indexes: z.array(channel.keyZ),
-    channels: z.record(z.string(), channel.keyZ),
-  }),
-  write: z.object({ channels: z.record(z.string(), channel.keyZ) }),
+  connection: v0.connectionConfigZ.default(v0.ZERO_CONNECTION_CONFIG),
+  read: z
+    .object({
+      indexes: z.array(channel.keyZ).default([]),
+      channels: z.record(z.string(), channel.keyZ).default({}),
+    })
+    .default({ indexes: [], channels: {} }),
+  write: z
+    .object({ channels: z.record(z.string(), channel.keyZ).default({}) })
+    .default({ channels: {} }),
 });
 export type Properties = z.infer<typeof propertiesZ>;
 


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4047](https://linear.app/synnax/issue/SY-4047/investigate-firehawk-task-migration-issue)

## Description

Server data is NOT corrupted. This is purely a client-side validation issue.

- Fix `ZodError` when reconfiguring previously created NI tasks (analog read, valve write)
- Add backward-compatible `.default()`/`.catch()` to device `propertiesZ` schemas across **all** hardware integrations (NI, LabJack, Modbus, EtherCAT, OPC UA)
- Fix shallow spread bug in NI `enrich()` that lost nested fields like `stateIndex` and `channels` when merging with `enriched.json` pinout data
- Wire OPC UA v0→v1 property migration into the exported `propertiesZ` schema (matching the existing HTTP pattern)

## Root Cause

In SY-3798 (`db0a17299f`), NI device `Properties` changed from a plain TypeScript type to a strict Zod schema with no defaults. When the Console retrieves a device during `onConfigure`, the Freighter codec validates properties against this schema **before** `enrich()` can fill in missing fields. Devices with incomplete properties (e.g., missing `counterInput` added in SY-3060, or partial `analogOutput` from `enriched.json` shallow merge) fail validation.


## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a client-side `ZodError` that prevented reconfiguring NI tasks by (1) adding `.default()`/`.catch()` to every device `propertiesZ` schema across NI, LabJack, Modbus, EtherCAT, and OPC UA so incomplete persisted data no longer blocks Freighter codec validation, (2) replacing the shallow spread in NI `enrich()` with `deep.override` to preserve nested fields like `stateIndex` and `channels`, and (3) wiring the OPC UA v0→v1 migration into the exported `propertiesZ` union.

The only gap remaining is that the `v0.propertiesZ` branch of the OPC UA union still carries no field defaults, so a partially-populated v0 OPC UA device would still fail to parse — though this is the same state as before the PR (no regression) and is documented via `testEmpty: false`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all remaining findings are P2 style suggestions that do not affect correctness for any currently-known device state.

The fixes are targeted and well-tested. The only open item (v0 OPC UA partial data) is a pre-existing limitation, not a regression introduced here, and is explicitly acknowledged in the new tests with testEmpty:false.

console/src/hardware/opc/device/types/index.ts — the v0 branch of the union still has no field defaults; verify that no partially-populated v0 OPC UA devices exist in production before closing the issue.

<details open><summary><h3>Vulnerabilities</h3></summary>

No security concerns identified. Changes are confined to Zod schema tolerance (adding `.default()`/`.catch()`) and a deep-merge fix; no new data is accepted that wasn't already accepted by the underlying types.
</details>

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| console/src/hardware/ni/device/enrich.ts | Fixes the shallow-spread bug by replacing the previous spread with deep.override(deep.copy(ZERO_PROPERTIES), enriched?.estimatedPinout ?? {}, properties), correctly preserving nested fields like stateIndex and channels. |
| console/src/hardware/ni/device/types.ts | Adds .default() on sub-objects and .catch(0) on channel.keyZ fields throughout propertiesZ, making the schema tolerant of missing counterInput (added post SY-3060) and partially-populated sub-objects from enriched.json. |
| console/src/hardware/opc/device/types/index.ts | Wires v0→v1 migration into propertiesZ via v1.propertiesZ.or(v0.propertiesZ.transform(migration)); v0 schema still has no defaults so partially-populated v0 devices will still fail to parse. |
| console/src/hardware/opc/device/types/v1.ts | Adds .default() to all fields in v1 propertiesZ (connection, read, write sub-objects and their children), making v1 data fully backward-compatible. |
| console/src/hardware/common/device/testutil.ts | New shared test utility that registers Vitest describe/it suites for propertiesZ schemas; correctly imports from vitest and is only consumed by *.spec.ts files. |
| console/src/hardware/ni/device/types.spec.ts | Good coverage of the three known failure modes: missing counterInput, partially-populated analogOutput from enriched.json shallow merge, and scan-only C++ driver properties. |
| console/src/hardware/opc/device/types/types.spec.ts | Tests v0→v1 migration through the union, including index→indexes array conversion; correctly marks testEmpty:false documenting that a bare {} is not valid for either versioned schema. |
| console/src/hardware/labjack/device/types.ts | Adds .default(ZERO_CHANNELS) on port-type sub-objects and .catch(0) on channel key fields; consistent with NI pattern. |
| console/src/hardware/modbus/device/types.ts | Adds .default() to connection, read, and write sub-objects and their scalar children; straightforward backward-compatibility fix. |
| console/src/hardware/ethercat/device/types.ts | Adds .default() to all slavePropertiesZ fields including pdos.inputs/outputs arrays, enabling scan-only partial properties to parse cleanly. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Device retrieved via Freighter] --> B{Codec parses properties\nusing propertiesZ}

    subgraph NI / LabJack / Modbus / EtherCAT
        B --> C[z.object with .default on\nevery sub-object and .catch on\nchannel keys]
        C --> D[Partial / legacy data\nnow fills in zero values]
        D --> E[enrich called\ndeep.override ZERO_PROPERTIES\n+ enriched.json pinout\n+ user properties]
    end

    subgraph OPC UA
        B --> F{v1.propertiesZ\nversion = 1.0.0?}
        F -- yes --> G[Parse with v1 defaults]
        F -- no --> H{v0.propertiesZ\nversion = 0.0.0?}
        H -- yes --> I[Migrate: index to indexes array\nversion bumped to 1.0.0]
        H -- no --> J[ZodError — no version field\nnot handled by union]
    end

    G --> K[onConfigure proceeds]
    I --> K
    E --> K
```

<sub>Reviews (1): Last reviewed commit: ["SY-4047: Extend device property migratio..."](https://github.com/synnaxlabs/synnax/commit/3e63e7a59b25a677aa146d7e939c9bef2cbb0a14) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=27896374)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->