### PR TITLE
SY-4050: Fix Task Status Data Migration Bug

### DIFF
--- a/console/src/hardware/ethercat/task/types.ts
+++ b/console/src/hardware/ethercat/task/types.ts
@@ -150,7 +150,7 @@ const readStatusDataZ = z
     message: z.string(),
     errors: z.array(z.object({ message: z.string(), path: z.string() })).optional(),
   })
-  .or(z.null());
+  .nullish();
 
 export const READ_SCHEMAS = {
   type: z.literal(READ_TYPE),
@@ -192,7 +192,7 @@ const writeStatusDataZ = z
     message: z.string(),
     errors: z.array(z.object({ message: z.string(), path: z.string() })).optional(),
   })
-  .or(z.null());
+  .nullish();
 
 export const WRITE_SCHEMAS = {
   type: z.literal(WRITE_TYPE),

--- a/console/src/hardware/http/task/types.ts
+++ b/console/src/hardware/http/task/types.ts
@@ -103,7 +103,7 @@ const ZERO_READ_CONFIG = {
 
 const readStatusDataZ = z
   .object({ running: z.boolean(), message: z.string() })
-  .or(z.null());
+  .nullish();
 
 export const READ_SCHEMAS = {
   type: z.literal(READ_TYPE),
@@ -285,5 +285,5 @@ export const TEST_CONNECTION_COMMAND_TYPE = "test_connection";
 export const SCAN_SCHEMAS = {
   type: z.literal(SCAN_TYPE),
   config: record.unknownZ(),
-  statusData: z.null(),
+  statusData: z.null().optional(),
 } as const satisfies task.Schemas;

--- a/console/src/hardware/labjack/task/types.ts
+++ b/console/src/hardware/labjack/task/types.ts
@@ -257,7 +257,7 @@ const ZERO_READ_CONFIG = {
 
 const readStatusDataZ = z
   .object({ errors: z.array(z.object({ message: z.string(), path: z.string() })) })
-  .or(z.null());
+  .nullish();
 
 export const READ_SCHEMAS = {
   type: z.literal(READ_TYPE),

--- a/console/src/hardware/modbus/task/types.ts
+++ b/console/src/hardware/modbus/task/types.ts
@@ -242,7 +242,7 @@ export const SCAN_TYPE = `${PREFIX}_scan`;
 export const SCAN_SCHEMAS = {
   type: z.literal(SCAN_TYPE),
   config: record.nullishToEmpty(),
-  statusData: z.object({}).or(z.null()),
+  statusData: z.object({}).nullish(),
 } as const satisfies task.Schemas;
 
 export const TEST_CONNECTION_COMMAND_TYPE = "test_connection";

--- a/console/src/hardware/opc/task/types.ts
+++ b/console/src/hardware/opc/task/types.ts
@@ -195,7 +195,7 @@ export interface ScannedNode extends z.infer<typeof scannedNodeZ> {}
 
 const scanCommandResponseZ = z
   .object({ channels: z.array(scannedNodeZ), connection: connectionConfigZ })
-  .or(z.null());
+  .nullish();
 
 export const TEST_CONNECTION_COMMAND_TYPE = "test_connection";
 


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue number and link -->

[SY-####]()

## Description

<!-- Write a description describing the changes. -->

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a task status data migration bug across five hardware integration types (EtherCAT, HTTP, LabJack, Modbus, OPC UA) by changing Zod `statusData` schemas from `.or(z.null())` to `.nullish()`. The old schemas rejected `undefined`, causing failures when loading persisted tasks whose `statusData` field was absent; the new schemas accept `null | undefined`, allowing migration to succeed.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, targeted schema changes that correctly fix a migration regression with no side effects.

All five changed schemas are straightforward one-line Zod changes. `.nullish()` is the idiomatic Zod fix for schemas that previously rejected `undefined`, and the http scan outlier (`z.null().optional()`) is semantically equivalent. No logic, rendering, or API surface is altered. No P0 or P1 findings remain.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| console/src/hardware/ethercat/task/types.ts | readStatusDataZ and writeStatusDataZ changed from .or(z.null()) to .nullish() — correct fix, accepts undefined in addition to null |
| console/src/hardware/http/task/types.ts | readStatusDataZ changed to .nullish(); SCAN_SCHEMAS.statusData changed from z.null() to z.null().optional() — both semantically accept null|undefined, consistent with the fix intent |
| console/src/hardware/labjack/task/types.ts | readStatusDataZ changed from .or(z.null()) to .nullish() — straightforward, correct fix |
| console/src/hardware/modbus/task/types.ts | SCAN_SCHEMAS.statusData changed from z.object({}).or(z.null()) to z.object({}).nullish() — correct fix |
| console/src/hardware/opc/task/types.ts | scanCommandResponseZ changed from .or(z.null()) to .nullish() — correct fix |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Task loaded from storage] --> B{statusData field present?}
    B -- "undefined (missing field)" --> C_old["❌ OLD: .or(z.null()) rejects undefined\nMigration fails"]
    B -- "undefined (missing field)" --> C_new["✅ NEW: .nullish() accepts undefined\nMigration succeeds"]
    B -- "null" --> D["Both old & new accept null\nNo change in behavior"]
    B -- "object" --> E["Both old & new accept object\nNo change in behavior"]

    style C_old fill:#ffcccc,stroke:#cc0000
    style C_new fill:#ccffcc,stroke:#009900
```

<sub>Reviews (1): Last reviewed commit: ["fixed task status data migration bug"](https://github.com/synnaxlabs/synnax/commit/a99cb1e3c383a8a6044a2c807f761fff3db96331) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28016993)</sub>

<!-- /greptile_comment -->