### PR TITLE
SY-4052: Add msgpack to Decode Fallback

### DIFF
--- a/aspen/internal/cluster/config.go
+++ b/aspen/internal/cluster/config.go
@@ -20,6 +20,7 @@ import (
 	"github.com/synnaxlabs/x/encoding"
 	"github.com/synnaxlabs/x/encoding/gob"
 	"github.com/synnaxlabs/x/encoding/json"
+	"github.com/synnaxlabs/x/encoding/msgpack"
 	"github.com/synnaxlabs/x/kv"
 	"github.com/synnaxlabs/x/override"
 	"github.com/synnaxlabs/x/validate"
@@ -98,9 +99,9 @@ var (
 		StorageKey:           []byte("aspen.cluster"),
 		Gossip:               gossip.DefaultConfig,
 		StorageFlushInterval: 1 * time.Second,
-		// This used to be implemented by a gob codec, but we want to switch to msgpack.
-		// Instead, we will use a fallback codec that tries msgpack to decode first, then gob.
-		Codec: encoding.NewDecodeFallbackCodec(json.Codec, gob.Codec),
+		// Encodes as JSON, decodes with fallback: JSON -> MsgPack -> Gob.
+		// MsgPack was the primary codec from v0.39 to v0.53, Gob before that.
+		Codec: encoding.NewDecodeFallbackCodec(json.Codec, msgpack.Codec, gob.Codec),
 	}
 	FastConfig = DefaultConfig.Override(Config{
 		Pledge: pledge.FastConfig,

--- a/aspen/internal/cluster/join_test.go
+++ b/aspen/internal/cluster/join_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/synnaxlabs/aspen/internal/node"
 	"github.com/synnaxlabs/freighter/mock"
 	"github.com/synnaxlabs/x/address"
+	"github.com/synnaxlabs/x/encoding/gob"
 	"github.com/synnaxlabs/x/encoding/msgpack"
 	"github.com/synnaxlabs/x/kv/memkv"
 	"github.com/synnaxlabs/x/signal"
@@ -143,6 +144,157 @@ var _ = Describe("Open", func() {
 				Expect(clusterTwo.Close()).To(Succeed())
 
 				clusterTwoAgain := MustSucceed(cluster.Open(ctx, clusterTwoConfig))
+				Expect(clusterTwoAgain.Host().Key).To(Equal(node.Key(2)))
+				Expect(clusterTwoAgain.Nodes()).To(HaveLen(2))
+
+				Expect(clusterOne.Close()).To(Succeed())
+				Expect(clusterTwoAgain.Close()).To(Succeed())
+				Expect(kvDB.Close()).To(Succeed())
+			})
+
+			It("Should recover state written by msgpack (v0.39 to v0.53 upgrade)", func(ctx SpecContext) {
+				gossipT1 := gossipNet.UnaryServer("")
+				pledgeT1 := pledgeNet.UnaryServer(gossipT1.Address)
+				clusterOne := MustSucceed(cluster.Open(
+					ctx,
+					cluster.Config{
+						HostAddress: gossipT1.Address,
+						Pledge: pledge.Config{
+							Peers:           []address.Address{},
+							TransportClient: pledgeNet.UnaryClient(),
+							TransportServer: pledgeT1,
+						},
+						Gossip: gossip.Config{
+							TransportClient: gossipNet.UnaryClient(),
+							TransportServer: gossipT1,
+							Interval:        100 * time.Millisecond,
+						},
+					},
+				))
+
+				kvDB := memkv.New()
+				gossipT2 := gossipNet.UnaryServer("")
+				pledgeT2 := pledgeNet.UnaryServer(gossipT2.Address)
+				storageKey := []byte("msgpack-upgrade-test")
+
+				// Simulate a v0.39-v0.53 server that wrote state as msgpack.
+				oldConfig := cluster.Config{
+					HostAddress: gossipT2.Address,
+					Pledge: pledge.Config{
+						Peers:           []address.Address{gossipT1.Address},
+						TransportClient: pledgeNet.UnaryClient(),
+						TransportServer: pledgeT2,
+					},
+					Gossip: gossip.Config{
+						TransportClient: gossipNet.UnaryClient(),
+						TransportServer: gossipT2,
+						Interval:        100 * time.Millisecond,
+					},
+					StorageKey:           storageKey,
+					Storage:              kvDB,
+					StorageFlushInterval: cluster.FlushOnEvery,
+					Codec:                msgpack.Codec,
+				}
+				clusterTwo := MustSucceed(cluster.Open(ctx, oldConfig))
+				Expect(clusterTwo.Host().Key).To(Equal(node.Key(2)))
+				Expect(clusterTwo.Close()).To(Succeed())
+
+				// Reopen with the default codec (JSON primary, msgpack+gob fallback),
+				// simulating an upgrade to v0.54+.
+				gossipT3 := gossipNet.UnaryServer(gossipT2.Address)
+				pledgeT3 := pledgeNet.UnaryServer(gossipT3.Address)
+				upgradedConfig := cluster.Config{
+					HostAddress: gossipT3.Address,
+					Pledge: pledge.Config{
+						Peers:           []address.Address{gossipT1.Address},
+						TransportClient: pledgeNet.UnaryClient(),
+						TransportServer: pledgeT3,
+					},
+					Gossip: gossip.Config{
+						TransportClient: gossipNet.UnaryClient(),
+						TransportServer: gossipT3,
+						Interval:        100 * time.Millisecond,
+					},
+					StorageKey:           storageKey,
+					Storage:              kvDB,
+					StorageFlushInterval: cluster.FlushOnEvery,
+				}
+				clusterTwoAgain := MustSucceed(cluster.Open(ctx, upgradedConfig))
+				Expect(clusterTwoAgain.Host().Key).To(Equal(node.Key(2)))
+				Expect(clusterTwoAgain.Nodes()).To(HaveLen(2))
+
+				Expect(clusterOne.Close()).To(Succeed())
+				Expect(clusterTwoAgain.Close()).To(Succeed())
+				Expect(kvDB.Close()).To(Succeed())
+			})
+
+			It("Should recover state written by gob (pre-v0.39 upgrade)", func(ctx SpecContext) {
+				gossipT1 := gossipNet.UnaryServer("")
+				pledgeT1 := pledgeNet.UnaryServer(gossipT1.Address)
+				clusterOne := MustSucceed(cluster.Open(
+					ctx,
+					cluster.Config{
+						HostAddress: gossipT1.Address,
+						Pledge: pledge.Config{
+							Peers:           []address.Address{},
+							TransportClient: pledgeNet.UnaryClient(),
+							TransportServer: pledgeT1,
+						},
+						Gossip: gossip.Config{
+							TransportClient: gossipNet.UnaryClient(),
+							TransportServer: gossipT1,
+							Interval:        100 * time.Millisecond,
+						},
+					},
+				))
+
+				kvDB := memkv.New()
+				gossipT2 := gossipNet.UnaryServer("")
+				pledgeT2 := pledgeNet.UnaryServer(gossipT2.Address)
+				storageKey := []byte("gob-upgrade-test")
+
+				// Simulate a pre-v0.39 server that wrote state as gob.
+				oldConfig := cluster.Config{
+					HostAddress: gossipT2.Address,
+					Pledge: pledge.Config{
+						Peers:           []address.Address{gossipT1.Address},
+						TransportClient: pledgeNet.UnaryClient(),
+						TransportServer: pledgeT2,
+					},
+					Gossip: gossip.Config{
+						TransportClient: gossipNet.UnaryClient(),
+						TransportServer: gossipT2,
+						Interval:        100 * time.Millisecond,
+					},
+					StorageKey:           storageKey,
+					Storage:              kvDB,
+					StorageFlushInterval: cluster.FlushOnEvery,
+					Codec:                gob.Codec,
+				}
+				clusterTwo := MustSucceed(cluster.Open(ctx, oldConfig))
+				Expect(clusterTwo.Host().Key).To(Equal(node.Key(2)))
+				Expect(clusterTwo.Close()).To(Succeed())
+
+				// Reopen with the default codec, simulating an upgrade to v0.54+.
+				gossipT3 := gossipNet.UnaryServer(gossipT2.Address)
+				pledgeT3 := pledgeNet.UnaryServer(gossipT3.Address)
+				upgradedConfig := cluster.Config{
+					HostAddress: gossipT3.Address,
+					Pledge: pledge.Config{
+						Peers:           []address.Address{gossipT1.Address},
+						TransportClient: pledgeNet.UnaryClient(),
+						TransportServer: pledgeT3,
+					},
+					Gossip: gossip.Config{
+						TransportClient: gossipNet.UnaryClient(),
+						TransportServer: gossipT3,
+						Interval:        100 * time.Millisecond,
+					},
+					StorageKey:           storageKey,
+					Storage:              kvDB,
+					StorageFlushInterval: cluster.FlushOnEvery,
+				}
+				clusterTwoAgain := MustSucceed(cluster.Open(ctx, upgradedConfig))
 				Expect(clusterTwoAgain.Host().Key).To(Equal(node.Key(2)))
 				Expect(clusterTwoAgain.Nodes()).To(HaveLen(2))
 


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4052](https://linear.app/synnax/issue/SY-4052/add-msgpack-fallback-to-cluster-state-codec)

## Description

When upgrading directly from v0.39–v0.53 to v0.54+, the server crashes on startup because it can't decode the persisted cluster state.

v0.39 switched the cluster state codec from Gob to MsgPack. [SY-3293](https://linear.app/synnax/issue/SY-3293/standardize-the-way-we-command-executables-and-handle-their-statuses) later switched the primary encoder to JSON but only kept Gob as a decode fallback. Msgpack was dropped from the chain. Servers that wrote cluster state as MsgPack (any version from v0.39 to v0.53) hit a decode failure on upgrade: JSON fails, Gob fails, no msgpack to try.

In v0.54.0, `DecodeFallbackCodec.Decode` was fixed to properly return an error when all codecs fail (previously it silently returned nil). Upgrading from any version that wrote MsgPack directly to v0.54+ now crashes on startup. Using an intermediary like v0.51.3 appeared to work because the old fallback codec swallowed the decode error. The server would silently bootstrap a new cluster identity and re-write the state as JSON, which v0.54 can then read. This is harmless for single node deployments but would break multi-node membership.

## Fix
Add `msgpack.Codec` to the decode fallback chain in `aspen/internal/cluster/config.go`
```
Codec: encoding.NewDecodeFallbackCodec(json.Codec, msgpack.Codec, gob.Codec),
```

Data auto-migrates to JSON on the first periodic flush (~1s after startup). The codec only affects local persistence gossip/pledge are unaffected, so rolling upgrades are safe.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] Manual testing (In progress: building binaries)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `msgpack.Codec` to the decode fallback chain in `aspen/internal/cluster/config.go`, fixing a crash-on-startup regression when upgrading directly from v0.39–v0.53 to v0.54+. The codec order is now JSON (primary encode) → JSON → MsgPack → Gob (fallback decode), covering all historical encoding formats. Two regression tests are added to verify the msgpack and gob upgrade paths.

<h3>Confidence Score: 5/5</h3>

Safe to merge — minimal, targeted fix with two regression tests covering both historical codec formats.

The change is a one-line insertion into the fallback codec chain with clear rationale; the DecodeFallbackCodec logic already exists and is tested. Two new tests directly exercise the v0.39–v0.53 (msgpack) and pre-v0.39 (gob) upgrade paths. No P0/P1 issues found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| aspen/internal/cluster/config.go | One-line change: inserts `msgpack.Codec` between `json.Codec` and `gob.Codec` in the `DecodeFallbackCodec` chain; comment updated to document codec history clearly. |
| aspen/internal/cluster/join_test.go | Adds two new Ginkgo tests covering the msgpack (v0.39–v0.53) and gob (pre-v0.39) upgrade paths; each test writes state with the legacy codec, then reopens with the default codec and asserts node key and membership are preserved. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Read persisted cluster state bytes] --> B{Try JSON decode}
    B -- success --> G[State restored]
    B -- fail --> C{Try MsgPack decode\nv0.39–v0.53 era}
    C -- success --> G
    C -- fail --> D{Try Gob decode\npre-v0.39 era}
    D -- success --> G
    D -- fail --> E[Return error: all codecs failed]
    G --> F[Auto-migrate: flush as JSON\non next periodic write ~1s]
```

<sub>Reviews (1): Last reviewed commit: ["SY-4052: Add msgpack to decode fallback"](https://github.com/synnaxlabs/synnax/commit/228a19130f79b94264bb24d9dd972cf5a6f633e8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28045230)</sub>

<!-- /greptile_comment -->