### PR TITLE
SY-4059: Switch to Length-Prefixed Format for Variable-Length Series

### DIFF
--- a/cesium/control.go
+++ b/cesium/control.go
@@ -149,12 +149,18 @@ func (db *DB) ControlUpdateToFrame(ctx context.Context, u ControlUpdate) Frame {
 	return telem.UnaryFrame(db.mu.digests.key, d)
 }
 
+// EncodeControlUpdate encodes a ControlUpdate into a single-sample Series. The content
+// is JSON, but the DataType is set to StringT because the control digest channel is
+// created as a StringT virtual channel in core/pkg/distribution/layer.go. Both locations
+// must be updated together if the type is ever changed to JSONT.
 func EncodeControlUpdate(_ context.Context, u ControlUpdate) (telem.Series, error) {
 	s, err := telem.NewJSONSeriesV(u)
 	s.DataType = telem.StringT
 	return s, err
 }
 
+// DecodeControlUpdate decodes a ControlUpdate from a single-sample Series. See
+// EncodeControlUpdate for why the Series has DataType StringT despite containing JSON.
 func DecodeControlUpdate(s telem.Series) (ControlUpdate, error) {
 	updates, err := telem.UnmarshalJSONSeries[ControlUpdate](s)
 	if err != nil || len(updates) == 0 {

--- a/cesium/control.go
+++ b/cesium/control.go
@@ -152,7 +152,10 @@ func (db *DB) ControlUpdateToFrame(ctx context.Context, u ControlUpdate) Frame {
 
 func EncodeControlUpdate(ctx context.Context, u ControlUpdate) (s telem.Series, err error) {
 	s.DataType = telem.StringT
-	s.Data, err = (json.Codec).Encode(ctx, u)
-	s.Data = append(s.Data, '\n')
-	return s, err
+	raw, err := (json.Codec).Encode(ctx, u)
+	if err != nil {
+		return s, err
+	}
+	s.Data = telem.MarshalVariableSample(raw)
+	return s, nil
 }

--- a/cesium/control.go
+++ b/cesium/control.go
@@ -11,6 +11,7 @@ package cesium
 
 import (
 	"context"
+	stdjson "encoding/json"
 
 	"github.com/google/uuid"
 	"github.com/synnaxlabs/cesium/internal/channel"
@@ -158,4 +159,9 @@ func EncodeControlUpdate(ctx context.Context, u ControlUpdate) (s telem.Series, 
 	}
 	s.Data = telem.MarshalVariableSample(raw)
 	return s, nil
+}
+
+func DecodeControlUpdate(s telem.Series) (ControlUpdate, error) {
+	var u ControlUpdate
+	return u, stdjson.Unmarshal(s.At(0), &u)
 }

--- a/cesium/control.go
+++ b/cesium/control.go
@@ -11,14 +11,12 @@ package cesium
 
 import (
 	"context"
-	stdjson "encoding/json"
 
 	"github.com/google/uuid"
 	"github.com/synnaxlabs/cesium/internal/channel"
 	"github.com/synnaxlabs/cesium/internal/control"
 	"github.com/synnaxlabs/x/confluence"
 	xcontrol "github.com/synnaxlabs/x/control"
-	"github.com/synnaxlabs/x/encoding/json"
 	"github.com/synnaxlabs/x/errors"
 	"github.com/synnaxlabs/x/signal"
 	"github.com/synnaxlabs/x/telem"
@@ -151,17 +149,16 @@ func (db *DB) ControlUpdateToFrame(ctx context.Context, u ControlUpdate) Frame {
 	return telem.UnaryFrame(db.mu.digests.key, d)
 }
 
-func EncodeControlUpdate(ctx context.Context, u ControlUpdate) (s telem.Series, err error) {
+func EncodeControlUpdate(_ context.Context, u ControlUpdate) (telem.Series, error) {
+	s, err := telem.NewJSONSeriesV(u)
 	s.DataType = telem.StringT
-	raw, err := (json.Codec).Encode(ctx, u)
-	if err != nil {
-		return s, err
-	}
-	s.Data = telem.MarshalVariableSample(raw)
-	return s, nil
+	return s, err
 }
 
 func DecodeControlUpdate(s telem.Series) (ControlUpdate, error) {
-	var u ControlUpdate
-	return u, stdjson.Unmarshal(s.At(0), &u)
+	updates, err := telem.UnmarshalJSONSeries[ControlUpdate](s)
+	if err != nil || len(updates) == 0 {
+		return ControlUpdate{}, err
+	}
+	return updates[0], nil
 }

--- a/cesium/control_test.go
+++ b/cesium/control_test.go
@@ -32,6 +32,61 @@ import (
 )
 
 var _ = Describe("Control", func() {
+	Describe("EncodeControlUpdate / DecodeControlUpdate", func() {
+		It("Should round-trip a control update with transfers", func() {
+			original := cesium.ControlUpdate{
+				Transfers: []control.Transfer{
+					{
+						From: &control.State{
+							Subject:   xcontrol.Subject{Key: "writer-1", Name: "Writer One"},
+							Resource:  1,
+							Authority: xcontrol.Authority(100),
+						},
+						To: &control.State{
+							Subject:   xcontrol.Subject{Key: "writer-2", Name: "Writer Two"},
+							Resource:  1,
+							Authority: xcontrol.Authority(200),
+						},
+					},
+				},
+			}
+			encoded := MustSucceed(cesium.EncodeControlUpdate(context.Background(), original))
+			Expect(encoded.DataType).To(Equal(telem.StringT))
+			Expect(encoded.Len()).To(Equal(int64(1)))
+			decoded := MustSucceed(cesium.DecodeControlUpdate(encoded))
+			Expect(decoded.Transfers).To(HaveLen(1))
+			Expect(decoded.Transfers[0].From.Subject.Name).To(Equal("Writer One"))
+			Expect(decoded.Transfers[0].To.Subject.Name).To(Equal("Writer Two"))
+			Expect(decoded.Transfers[0].To.Authority).To(Equal(xcontrol.Authority(200)))
+		})
+
+		It("Should round-trip a control update with an acquire (nil From)", func() {
+			original := cesium.ControlUpdate{
+				Transfers: []control.Transfer{
+					{
+						To: &control.State{
+							Subject:   xcontrol.Subject{Key: "w1", Name: "Writer"},
+							Resource:  5,
+							Authority: xcontrol.Authority(50),
+						},
+					},
+				},
+			}
+			encoded := MustSucceed(cesium.EncodeControlUpdate(context.Background(), original))
+			decoded := MustSucceed(cesium.DecodeControlUpdate(encoded))
+			Expect(decoded.Transfers).To(HaveLen(1))
+			Expect(decoded.Transfers[0].From).To(BeNil())
+			Expect(decoded.Transfers[0].To.Subject.Name).To(Equal("Writer"))
+		})
+
+		It("Should round-trip an empty control update", func() {
+			original := cesium.ControlUpdate{Transfers: []control.Transfer{}}
+			encoded := MustSucceed(cesium.EncodeControlUpdate(context.Background(), original))
+			decoded := MustSucceed(cesium.DecodeControlUpdate(encoded))
+			Expect(decoded.Transfers).To(BeEmpty())
+		})
+	})
+
 	for fsName, makeFS := range fileSystems {
 		Context("FS:"+fsName, Ordered, func() {
 			var (

--- a/cesium/control_test.go
+++ b/cesium/control_test.go
@@ -11,7 +11,6 @@ package cesium_test
 
 import (
 	"context"
-	"encoding/json"
 	"io"
 	"math"
 	"runtime"
@@ -215,7 +214,7 @@ var _ = Describe("Control", func() {
 						var res cesium.StreamerResponse
 						Eventually(stOut.Outlet()).Should(Receive(&res))
 						var d cesium.ControlUpdate
-						Expect(json.Unmarshal(res.Frame.SeriesAt(0).Data, &d)).To(Succeed())
+						d = MustSucceed(cesium.DecodeControlUpdate(res.Frame.SeriesAt(0)))
 						Expect(d.Transfers).To(HaveLen(2))
 						Expect(d.Transfers[0].To).ToNot(BeNil())
 						Expect(d.Transfers[0].To.Subject.Name).To(Equal("Writer One"))
@@ -226,7 +225,7 @@ var _ = Describe("Control", func() {
 
 						By("Propagating the control transfer")
 						Eventually(stOut.Outlet()).Should(Receive(&res))
-						Expect(json.Unmarshal(res.Frame.SeriesAt(0).Data, &d)).To(Succeed())
+						d = MustSucceed(cesium.DecodeControlUpdate(res.Frame.SeriesAt(0)))
 						Expect(d.Transfers).To(HaveLen(2))
 						Expect(d.Transfers[0].To).ToNot(BeNil())
 						Expect(d.Transfers[0].To.Subject.Name).To(Equal("Writer Two"))

--- a/cesium/streamer_test.go
+++ b/cesium/streamer_test.go
@@ -25,7 +25,6 @@ import (
 	. "github.com/synnaxlabs/x/testutil"
 )
 
-
 var _ = Describe("Streamer Behavior", func() {
 	for fsName, makeFS := range fileSystems {
 		ShouldNotLeakRoutinesJustBeforeEach()

--- a/cesium/streamer_test.go
+++ b/cesium/streamer_test.go
@@ -10,7 +10,6 @@
 package cesium_test
 
 import (
-	"context"
 	"runtime"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -20,20 +19,12 @@ import (
 	"github.com/synnaxlabs/cesium/internal/resource"
 	"github.com/synnaxlabs/x/confluence"
 	"github.com/synnaxlabs/x/control"
-	"github.com/synnaxlabs/x/encoding/json"
 	"github.com/synnaxlabs/x/io/fs"
 	"github.com/synnaxlabs/x/signal"
 	"github.com/synnaxlabs/x/telem"
 	. "github.com/synnaxlabs/x/testutil"
 )
 
-func decodeControlUpdate(ctx context.Context, s telem.Series) (cesium.ControlUpdate, error) {
-	var u cesium.ControlUpdate
-	if err := json.Codec.Decode(ctx, s.Data, &u); err != nil {
-		return cesium.ControlUpdate{}, err
-	}
-	return u, nil
-}
 
 var _ = Describe("Streamer Behavior", func() {
 	for fsName, makeFS := range fileSystems {
@@ -191,7 +182,7 @@ var _ = Describe("Streamer Behavior", func() {
 					Eventually(func(g Gomega) {
 						g.Eventually(o.Outlet()).Should(Receive(&r))
 						g.Expect(r.Frame.Count()).To(Equal(1))
-						u := MustSucceed(decodeControlUpdate(ctx, r.Frame.SeriesAt(0)))
+						u := MustSucceed(cesium.DecodeControlUpdate(r.Frame.SeriesAt(0)))
 						g.Expect(u.Transfers).To(HaveLen(1))
 						first := u.Transfers[0]
 						g.Expect(first.Occurred()).To(BeTrue())

--- a/cesium/writer_test.go
+++ b/cesium/writer_test.go
@@ -1141,7 +1141,7 @@ var _ = Describe("Writer Behavior", func() {
 						authorized = MustSucceed(w1.Write(telem.MultiFrame(
 							[]cesium.ChannelKey{key2},
 							[]telem.Series{
-								{DataType: telem.StringT, Data: []byte("hehe")},
+								telem.NewSeriesV("hehe"),
 							},
 						)))
 						Expect(authorized).To(BeFalse())

--- a/client/ts/src/control/state.ts
+++ b/client/ts/src/control/state.ts
@@ -46,13 +46,14 @@ export class StateTracker
   implements observe.ObservableAsyncCloseable<Transfer[]>
 {
   readonly states: Map<channel.Key, State>;
-  private readonly codec: binary.Codec;
+  private readonly codec: binary.JSONCodec;
 
   constructor(streamer: framer.Streamer) {
     super(streamer, (frame) => {
-      const update: Update = this.codec.decode(frame.series[0].buffer, updateZ);
-      this.merge(update);
-      return [update.transfers, true];
+      const raw = Array.from(frame.series[0].as("string"));
+      const updates: Update[] = raw.map((r) => this.codec.decodeString(r, updateZ));
+      updates.forEach((u) => this.merge(u));
+      return [updates.flatMap((u) => u.transfers), true];
     });
     this.states = new Map();
     this.codec = new binary.JSONCodec();

--- a/core/pkg/distribution/channel/signals/signals.go
+++ b/core/pkg/distribution/channel/signals/signals.go
@@ -40,7 +40,7 @@ func Publish(
 			if err != nil {
 				return nil, err
 			}
-			return append(v, '\n'), nil
+			return telem.MarshalVariableSample(v), nil
 		},
 	}
 	return signals.PublishFromGorp(ctx, prov, cfg)

--- a/core/pkg/distribution/ontology/signals/signals.go
+++ b/core/pkg/distribution/ontology/signals/signals.go
@@ -10,7 +10,6 @@
 package signals
 
 import (
-	"bytes"
 	"context"
 	"io"
 	"iter"
@@ -49,7 +48,7 @@ func Publish(
 						continue
 					}
 				} else {
-					key = []byte(ch.Key + "\n")
+					key = telem.MarshalVariableSample([]byte(ch.Key))
 				}
 				out = append(out, change.Change[[]byte, struct{}]{Key: key, Variant: ch.Variant})
 			}
@@ -71,7 +70,7 @@ func Publish(
 			var out []change.Change[[]byte, struct{}]
 			for ch := range nexter {
 				out = append(out, change.Change[[]byte, struct{}]{
-					Key:     append(ch.Key, '\n'),
+					Key:     telem.MarshalVariableSample(ch.Key),
 					Variant: ch.Variant,
 				})
 			}
@@ -90,7 +89,7 @@ func Publish(
 	return xio.MultiCloser{resourceObserverCloser, relationshipObserverCloser}, nil
 }
 
-func EncodeID(id ontology.ID) []byte { return []byte(id.String() + "\n") }
+func EncodeID(id ontology.ID) []byte { return telem.MarshalVariableSample([]byte(id.String())) }
 
 func EncodeIDs(ids []ontology.ID) []byte {
 	var buf []byte
@@ -101,45 +100,27 @@ func EncodeIDs(ids []ontology.ID) []byte {
 }
 
 func DecodeRelationships(ser []byte) ([]ontology.Relationship, error) {
-	// ser.Data is a byte slice containing the encoded relationships, we need to decode them
-	// by looking for the newline separator.
-	var (
-		relationships []ontology.Relationship
-		buf           bytes.Buffer
-	)
-	for _, b := range ser {
-		if b == '\n' {
-			relationship, err := ontology.ParseRelationship(buf.Bytes())
-			if err != nil {
-				return nil, err
-			}
-			relationships = append(relationships, relationship)
-			buf.Reset()
-			continue
+	samples := telem.UnmarshalSeries[string](telem.Series{DataType: telem.StringT, Data: ser})
+	relationships := make([]ontology.Relationship, 0, len(samples))
+	for _, s := range samples {
+		relationship, err := ontology.ParseRelationship([]byte(s))
+		if err != nil {
+			return nil, err
 		}
-		buf.WriteByte(b)
+		relationships = append(relationships, relationship)
 	}
 	return relationships, nil
 }
 
 func DecodeIDs(ser []byte) ([]ontology.ID, error) {
-	// ser.Data is a byte slice containing the encoded IDs, we need to decode them
-	// by looking for the newline separator.
-	var (
-		ids []ontology.ID
-		buf bytes.Buffer
-	)
-	for _, b := range ser {
-		if b == '\n' {
-			id, err := ontology.ParseID(buf.String())
-			if err != nil {
-				return nil, err
-			}
-			ids = append(ids, id)
-			buf.Reset()
-			continue
+	samples := telem.UnmarshalSeries[string](telem.Series{DataType: telem.StringT, Data: ser})
+	ids := make([]ontology.ID, 0, len(samples))
+	for _, s := range samples {
+		id, err := ontology.ParseID(s)
+		if err != nil {
+			return nil, err
 		}
-		buf.WriteByte(b)
+		ids = append(ids, id)
 	}
 	return ids, nil
 }

--- a/core/pkg/distribution/signals/gorp.go
+++ b/core/pkg/distribution/signals/gorp.go
@@ -90,7 +90,7 @@ func MarshalJSON[K gorp.Key, E gorp.Entry[K]](e E) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	return append(b, '\n'), nil
+	return telem.MarshalVariableSample(b), nil
 }
 
 // GorpPublisherConfigUUID is a helper function for creating a Signals pipeline that propagates
@@ -137,7 +137,7 @@ func GorpPublisherConfigString[E gorp.Entry[string]](obs observe.Observable[gorp
 		Observable:     obs,
 		DeleteDataType: telem.StringT,
 		SetDataType:    telem.JSONT,
-		MarshalDelete:  func(k string) ([]byte, error) { return append([]byte(k), '\n'), nil },
+		MarshalDelete:  func(k string) ([]byte, error) { return telem.MarshalVariableSample([]byte(k)), nil },
 		MarshalSet:     MarshalJSON[string, E],
 	}
 }

--- a/core/pkg/distribution/signals/gorp_test.go
+++ b/core/pkg/distribution/signals/gorp_test.go
@@ -70,14 +70,15 @@ var _ = Describe("GorpPublisherConfig", func() {
 	})
 
 	Describe("MarshalJSON", func() {
-		It("Should marshal an entry to JSON with newline suffix", func() {
+		It("Should marshal an entry to JSON with uint32 length prefix", func() {
 			entry := testUUIDEntry{
 				Key:  uuid.MustParse("12345678-1234-1234-1234-123456789012"),
 				Name: "test",
 			}
 			b := MustSucceed(signals.MarshalJSON(entry))
-			Expect(b).To(HaveSuffix("\n"))
-			Expect(string(b)).To(ContainSubstring(`"name":"test"`))
+			Expect(len(b)).To(BeNumerically(">=", 4))
+			s := telem.Series{DataType: telem.JSONT, Data: b}
+			Expect(s.Len()).To(Equal(int64(1)))
 		})
 	})
 
@@ -167,10 +168,12 @@ var _ = Describe("GorpPublisherConfig", func() {
 			Expect(cfg.MarshalSet).ToNot(BeNil())
 		})
 
-		It("Should correctly marshal string key for delete with newline", func() {
+		It("Should correctly marshal string key for delete with length prefix", func() {
 			cfg := signals.GorpPublisherConfigString[testStringEntry](stringTable.Observe())
 			b := MustSucceed(cfg.MarshalDelete("my-key"))
-			Expect(string(b)).To(Equal("my-key\n"))
+			s := telem.Series{DataType: telem.StringT, Data: b}
+			Expect(s.Len()).To(Equal(int64(1)))
+			Expect(string(s.At(0))).To(Equal("my-key"))
 		})
 
 		It("Should correctly marshal entry for set as JSON", func() {

--- a/x/cpp/telem/series.h
+++ b/x/cpp/telem/series.h
@@ -25,8 +25,15 @@
 #include "x/go/telem/pb/frame.pb.h"
 #include "x/go/telem/pb/telem.pb.h"
 
-constexpr char NEWLINE_CHAR = '\n';
-constexpr auto NEWLINE_TERMINATOR = static_cast<std::byte>(NEWLINE_CHAR);
+static inline uint32_t read_u32_le(const std::byte *ptr) {
+    uint32_t v;
+    memcpy(&v, ptr, 4);
+    return v;
+}
+
+static inline void write_u32_le(std::byte *ptr, uint32_t v) {
+    memcpy(ptr, &v, 4);
+}
 
 namespace x::telem {
 template<typename DestType, typename SrcType>
@@ -583,14 +590,14 @@ public:
             throw std::runtime_error("expected data type to be STRING or JSON");
         this->cached_byte_size = 0;
         for (const auto &s: d)
-            this->cached_byte_size += s.size() + 1;
+            this->cached_byte_size += s.size() + 4;
         this->data_ = alloc(this->byte_size());
         size_t offset = 0;
         for (const auto &s: d) {
+            write_u32_le(this->data_.get() + offset, static_cast<uint32_t>(s.size()));
+            offset += 4;
             memcpy(this->data_.get() + offset, s.data(), s.size());
             offset += s.size();
-            this->data_[offset] = NEWLINE_TERMINATOR;
-            offset++;
         }
     }
 
@@ -602,15 +609,15 @@ public:
     explicit Series(const std::string &data, DataType data_type_ = STRING_T):
         data_type_(std::move(data_type_)),
         cap_(1),
-        cached_byte_size(data.size() + 1),
+        cached_byte_size(data.size() + 4),
         size_(1),
         data_(alloc(this->byte_size())) {
         if (!this->data_type().matches({STRING_T, JSON_T}))
             throw std::runtime_error(
                 "cannot set a string value on a non-string or JSON series"
             );
-        memcpy(this->data_.get(), data.data(), data.size());
-        this->data_[byte_size() - 1] = NEWLINE_TERMINATOR;
+        write_u32_le(this->data_.get(), static_cast<uint32_t>(data.size()));
+        memcpy(this->data_.get() + 4, data.data(), data.size());
     }
 
     /// @brief constructs a series from its protobuf representation.
@@ -627,10 +634,10 @@ public:
         data_type_(DataType::infer(v)), cap_(1), size_(1) {
         if (this->data_type().is_variable()) {
             const auto &str = std::get<std::string>(v);
-            cached_byte_size = str.size() + 1;
+            cached_byte_size = str.size() + 4;
             this->data_ = alloc(this->byte_size());
-            memcpy(this->data_.get(), str.data(), str.size());
-            this->data_[this->byte_size() - 1] = NEWLINE_TERMINATOR;
+            write_u32_le(this->data_.get(), static_cast<uint32_t>(str.size()));
+            memcpy(this->data_.get() + 4, str.data(), str.size());
             return;
         }
         std::visit(
@@ -646,19 +653,21 @@ public:
     /// @param values the vector of JSON values to be used.
     explicit Series(const std::vector<json::json> &values):
         data_type_(JSON_T), cap_(values.size()), size_(values.size()) {
-        // Calculate the total byte size needed (including newline terminators)
         this->cached_byte_size = 0;
         for (const auto &value: values)
-            this->cached_byte_size += value.dump().size() + 1;
+            this->cached_byte_size += value.dump().size() + 4;
 
         this->data_ = alloc(this->byte_size());
         size_t offset = 0;
         for (const auto &value: values) {
             const auto str = value.dump();
+            write_u32_le(
+                this->data_.get() + offset,
+                static_cast<uint32_t>(str.size())
+            );
+            offset += 4;
             memcpy(this->data_.get() + offset, str.data(), str.size());
             offset += str.size();
-            this->data_[offset] = NEWLINE_TERMINATOR;
-            offset++;
         }
     }
 
@@ -675,8 +684,13 @@ private:
         if (!this->data_type_.is_variable()) {
             this->size_ = pb.data().size() / this->data_type_.density();
         } else {
-            for (const char &v: pb.data())
-                if (v == NEWLINE_CHAR) ++this->size_;
+            const auto *ptr = reinterpret_cast<const std::byte *>(pb.data().data());
+            const auto *end = ptr + pb.data().size();
+            while (ptr + 4 <= end) {
+                const uint32_t len = read_u32_le(ptr);
+                ptr += 4 + len;
+                ++this->size_;
+            }
         }
         this->cap_ = this->size_;
 
@@ -809,13 +823,16 @@ public:
                 );
             const size_t count = std::min(d.size(), this->cap() - this->size());
             if (count == 0) return 0;
-            size_t offset = 0;
+            size_t offset = this->cached_byte_size;
             for (size_t i = 0; i < count; i++) {
                 const auto &s = d[i];
-                memcpy(this->data_.get() + offset, s.data_(), s.size());
+                write_u32_le(
+                    this->data_.get() + offset,
+                    static_cast<uint32_t>(s.size())
+                );
+                offset += 4;
+                memcpy(this->data_.get() + offset, s.data(), s.size());
                 offset += s.size();
-                this->data_.get()[offset] = NEWLINE_TERMINATOR;
-                offset++;
             }
             this->cached_byte_size = offset;
             this->size_ += count;
@@ -868,9 +885,12 @@ public:
                 str_len = strlen(d);
             }
 
-            memcpy(this->data_.get() + cached_byte_size, str_data, str_len);
-            this->data_.get()[cached_byte_size + str_len] = NEWLINE_TERMINATOR;
-            this->cached_byte_size += str_len + 1;
+            write_u32_le(
+                this->data_.get() + this->cached_byte_size,
+                static_cast<uint32_t>(str_len)
+            );
+            memcpy(this->data_.get() + this->cached_byte_size + 4, str_data, str_len);
+            this->cached_byte_size += str_len + 4;
             this->size_++;
             return 1;
         } else if constexpr (std::is_same_v<T, TimeStamp>) {
@@ -931,14 +951,14 @@ public:
                 "cannot convert a non-JSON or non-string series to strings"
             );
         std::vector<std::string> v;
-        std::string buf;
-        for (size_t i = 0; i < this->byte_size(); i++) {
-            if (this->data_[i] == NEWLINE_TERMINATOR) {
-                v.push_back(buf);
-                buf.clear();
-                // WARNING: This might be very slow due to copying.
-            } else
-                buf += static_cast<char>(this->data_[i]);
+        v.reserve(this->size());
+        const auto *ptr = this->data_.get();
+        const auto *end = ptr + this->byte_size();
+        while (ptr + 4 <= end) {
+            const uint32_t len = read_u32_le(ptr);
+            ptr += 4;
+            v.emplace_back(reinterpret_cast<const char *>(ptr), len);
+            ptr += len;
         }
         return v;
     }
@@ -982,15 +1002,17 @@ public:
                     "cannot bind a string value on a non-string or JSON series"
                 );
             const auto adjusted = this->validate_bounds(index);
-            // iterate through the data byte by byte, incrementing the index every
-            // time we hit a newline character until we reach the desired index.
-            for (size_t i = 0, j = 0; i < this->byte_size(); i++)
-                if (this->data_[i] == NEWLINE_TERMINATOR) {
-                    if (j == adjusted) return value;
-                    value.clear();
-                    j++;
-                } else
-                    value += static_cast<char>(this->data_[i]);
+            const auto *ptr = this->data_.get();
+            const auto *end = ptr + this->byte_size();
+            size_t j = 0;
+            while (ptr + 4 <= end) {
+                const uint32_t len = read_u32_le(ptr);
+                ptr += 4;
+                if (j == static_cast<size_t>(adjusted))
+                    return std::string(reinterpret_cast<const char *>(ptr), len);
+                ptr += len;
+                ++j;
+            }
             return value;
         } else if constexpr (std::is_same_v<T, TimeStamp>)
             return TimeStamp(this->at<int64_t>(index));
@@ -1637,8 +1659,13 @@ public:
         this->cached_byte_size += n_read;
         if (this->data_type().is_variable()) {
             this->size_ = 0;
-            for (size_t i = 0; i < this->byte_size(); i++)
-                if (this->data_[i] == NEWLINE_TERMINATOR) ++this->size_;
+            const auto *ptr = this->data_.get();
+            const auto *end = ptr + this->byte_size();
+            while (ptr + 4 <= end) {
+                const uint32_t len = read_u32_le(ptr);
+                ptr += 4 + len;
+                ++this->size_;
+            }
         } else
             this->size_ += n_read / this->data_type().density();
         return n_read;

--- a/x/cpp/telem/series.h
+++ b/x/cpp/telem/series.h
@@ -661,10 +661,7 @@ public:
         size_t offset = 0;
         for (const auto &value: values) {
             const auto str = value.dump();
-            write_u32_le(
-                this->data_.get() + offset,
-                static_cast<uint32_t>(str.size())
-            );
+            write_u32_le(this->data_.get() + offset, static_cast<uint32_t>(str.size()));
             offset += 4;
             memcpy(this->data_.get() + offset, str.data(), str.size());
             offset += str.size();

--- a/x/cpp/telem/series.h
+++ b/x/cpp/telem/series.h
@@ -25,14 +25,16 @@
 #include "x/go/telem/pb/frame.pb.h"
 #include "x/go/telem/pb/telem.pb.h"
 
+constexpr size_t VARIABLE_LENGTH_PREFIX_SIZE = sizeof(uint32_t);
+
 static inline uint32_t read_u32_le(const std::byte *ptr) {
     uint32_t v;
-    memcpy(&v, ptr, 4);
+    memcpy(&v, ptr, VARIABLE_LENGTH_PREFIX_SIZE);
     return v;
 }
 
 static inline void write_u32_le(std::byte *ptr, uint32_t v) {
-    memcpy(ptr, &v, 4);
+    memcpy(ptr, &v, VARIABLE_LENGTH_PREFIX_SIZE);
 }
 
 namespace x::telem {
@@ -590,7 +592,7 @@ public:
             throw std::runtime_error("expected data type to be STRING or JSON");
         this->cached_byte_size = 0;
         for (const auto &s: d)
-            this->cached_byte_size += s.size() + 4;
+            this->cached_byte_size += s.size() + VARIABLE_LENGTH_PREFIX_SIZE;
         this->data_ = alloc(this->byte_size());
         size_t offset = 0;
         for (const auto &s: d) {
@@ -609,7 +611,7 @@ public:
     explicit Series(const std::string &data, DataType data_type_ = STRING_T):
         data_type_(std::move(data_type_)),
         cap_(1),
-        cached_byte_size(data.size() + 4),
+        cached_byte_size(data.size() + VARIABLE_LENGTH_PREFIX_SIZE),
         size_(1),
         data_(alloc(this->byte_size())) {
         if (!this->data_type().matches({STRING_T, JSON_T}))
@@ -634,7 +636,7 @@ public:
         data_type_(DataType::infer(v)), cap_(1), size_(1) {
         if (this->data_type().is_variable()) {
             const auto &str = std::get<std::string>(v);
-            cached_byte_size = str.size() + 4;
+            cached_byte_size = str.size() + VARIABLE_LENGTH_PREFIX_SIZE;
             this->data_ = alloc(this->byte_size());
             write_u32_le(this->data_.get(), static_cast<uint32_t>(str.size()));
             memcpy(this->data_.get() + 4, str.data(), str.size());
@@ -655,7 +657,7 @@ public:
         data_type_(JSON_T), cap_(values.size()), size_(values.size()) {
         this->cached_byte_size = 0;
         for (const auto &value: values)
-            this->cached_byte_size += value.dump().size() + 4;
+            this->cached_byte_size += value.dump().size() + VARIABLE_LENGTH_PREFIX_SIZE;
 
         this->data_ = alloc(this->byte_size());
         size_t offset = 0;
@@ -683,7 +685,7 @@ private:
         } else {
             const auto *ptr = reinterpret_cast<const std::byte *>(pb.data().data());
             const auto *end = ptr + pb.data().size();
-            while (ptr + 4 <= end) {
+            while (ptr + VARIABLE_LENGTH_PREFIX_SIZE <= end) {
                 const uint32_t len = read_u32_le(ptr);
                 ptr += 4 + len;
                 ++this->size_;
@@ -887,7 +889,7 @@ public:
                 static_cast<uint32_t>(str_len)
             );
             memcpy(this->data_.get() + this->cached_byte_size + 4, str_data, str_len);
-            this->cached_byte_size += str_len + 4;
+            this->cached_byte_size += str_len + VARIABLE_LENGTH_PREFIX_SIZE;
             this->size_++;
             return 1;
         } else if constexpr (std::is_same_v<T, TimeStamp>) {
@@ -951,7 +953,7 @@ public:
         v.reserve(this->size());
         const auto *ptr = this->data_.get();
         const auto *end = ptr + this->byte_size();
-        while (ptr + 4 <= end) {
+        while (ptr + VARIABLE_LENGTH_PREFIX_SIZE <= end) {
             const uint32_t len = read_u32_le(ptr);
             ptr += 4;
             v.emplace_back(reinterpret_cast<const char *>(ptr), len);
@@ -1002,7 +1004,7 @@ public:
             const auto *ptr = this->data_.get();
             const auto *end = ptr + this->byte_size();
             size_t j = 0;
-            while (ptr + 4 <= end) {
+            while (ptr + VARIABLE_LENGTH_PREFIX_SIZE <= end) {
                 const uint32_t len = read_u32_le(ptr);
                 ptr += 4;
                 if (j == static_cast<size_t>(adjusted))
@@ -1658,7 +1660,7 @@ public:
             this->size_ = 0;
             const auto *ptr = this->data_.get();
             const auto *end = ptr + this->byte_size();
-            while (ptr + 4 <= end) {
+            while (ptr + VARIABLE_LENGTH_PREFIX_SIZE <= end) {
                 const uint32_t len = read_u32_le(ptr);
                 ptr += 4 + len;
                 ++this->size_;

--- a/x/cpp/telem/series_test.cpp
+++ b/x/cpp/telem/series_test.cpp
@@ -2131,4 +2131,129 @@ TEST(SeriesDetachBuffer, RepeatedPublishCycles) {
         ASSERT_EQ(published[cycle].at<float>(0), static_cast<float>(cycle));
     }
 }
+
+/// @brief it should correctly construct a BYTES series from a vector of byte blobs
+/// represented as strings, and report the correct size and byte_size.
+TEST(SeriesBytes, VectorConstruction) {
+    const std::vector<std::string> blobs = {
+        std::string("\x01\x02\x03", 3),
+        std::string("\xDE\xAD\xBE\xEF", 4),
+    };
+    const Series s(blobs, BYTES_T);
+    ASSERT_EQ(s.data_type(), BYTES_T);
+    ASSERT_EQ(s.size(), 2);
+    ASSERT_EQ(s.byte_size(), 15);
+}
+
+/// @brief it should correctly construct a BYTES series from an empty vector.
+TEST(SeriesBytes, EmptyVectorConstruction) {
+    const Series s(std::vector<std::string>{}, BYTES_T);
+    ASSERT_EQ(s.data_type(), BYTES_T);
+    ASSERT_EQ(s.size(), 0);
+    ASSERT_EQ(s.byte_size(), 0);
+    ASSERT_TRUE(s.empty());
+}
+
+/// @brief it should correctly construct a single-element BYTES series.
+TEST(SeriesBytes, SingleElementConstruction) {
+    const std::vector<std::string> blobs = {std::string("\xAB\xCD", 2)};
+    const Series s(blobs, BYTES_T);
+    ASSERT_EQ(s.data_type(), BYTES_T);
+    ASSERT_EQ(s.size(), 1);
+    ASSERT_EQ(s.byte_size(), 6);
+}
+
+/// @brief raw data pointer should reflect the length-prefixed binary layout.
+TEST(SeriesBytes, RawDataLayout) {
+    const std::string blob("\x01\x02\x03", 3);
+    const Series s(std::vector<std::string>{blob}, BYTES_T);
+    const auto *raw = reinterpret_cast<const uint8_t *>(s.data());
+    ASSERT_EQ(raw[0], 3);
+    ASSERT_EQ(raw[1], 0);
+    ASSERT_EQ(raw[2], 0);
+    ASSERT_EQ(raw[3], 0);
+    ASSERT_EQ(raw[4], 0x01);
+    ASSERT_EQ(raw[5], 0x02);
+    ASSERT_EQ(raw[6], 0x03);
+}
+
+/// @brief clear should reset size and byte_size to zero.
+TEST(SeriesBytes, ClearResetsSize) {
+    auto s = Series(
+        std::vector<std::string>{std::string("\x01\x02", 2), std::string("\x03", 1)},
+        BYTES_T
+    );
+    ASSERT_EQ(s.size(), 2);
+    ASSERT_GT(s.byte_size(), 0);
+    s.clear();
+    ASSERT_EQ(s.size(), 0);
+    ASSERT_TRUE(s.empty());
+    ASSERT_EQ(s.byte_size(), 0);
+}
+
+/// @brief pre-allocated BYTES series should have zero size but non-zero byte_cap.
+TEST(SeriesBytes, AllocationVariable) {
+    const Series s(BYTES_T, 32);
+    ASSERT_EQ(s.data_type(), BYTES_T);
+    ASSERT_EQ(s.size(), 0);
+    ASSERT_EQ(s.byte_size(), 0);
+    ASSERT_EQ(s.byte_cap(), 32);
+}
+
+/// @brief shallow copy of a BYTES series should share the underlying buffer.
+TEST(SeriesBytes, ShallowCopySharesBuffer) {
+    auto original = Series(
+        std::vector<std::string>{std::string("\xAA\xBB", 2), std::string("\xCC", 1)},
+        BYTES_T
+    );
+    auto copy = original.shallow_copy();
+    ASSERT_EQ(copy.data(), original.data());
+    ASSERT_EQ(copy.size(), 2);
+    ASSERT_EQ(copy.data_type(), BYTES_T);
+    ASSERT_EQ(copy.byte_size(), original.byte_size());
+}
+
+/// @brief deep copy of a BYTES series should produce an independent buffer with
+/// identical content.
+TEST(SeriesBytes, DeepCopyIsIndependent) {
+    auto original = Series(
+        std::vector<std::string>{
+            std::string("\x01\x02\x03", 3),
+            std::string("\x04\x05", 2),
+        },
+        BYTES_T
+    );
+    original.alignment = Alignment(2, 7);
+    const Series copy = original.deep_copy();
+    ASSERT_NE(copy.data(), original.data());
+    ASSERT_EQ(copy.size(), 2);
+    ASSERT_EQ(copy.data_type(), BYTES_T);
+    ASSERT_EQ(copy.byte_size(), original.byte_size());
+    ASSERT_EQ(copy.cap(), original.cap());
+    ASSERT_EQ(copy.alignment.uint64(), original.alignment.uint64());
+    const auto *orig_raw = reinterpret_cast<const uint8_t *>(original.data());
+    const auto *copy_raw = reinterpret_cast<const uint8_t *>(copy.data());
+    ASSERT_EQ(
+        memcmp(orig_raw, copy_raw, original.byte_size()),
+        0
+    );
+}
+
+/// @brief strings() should throw when called on a BYTES series.
+TEST(SeriesBytes, StringsThrowsForBytesType) {
+    const Series s(
+        std::vector<std::string>{std::string("\x01\x02", 2)},
+        BYTES_T
+    );
+    ASSERT_THROW((void) s.strings(), std::runtime_error);
+}
+
+/// @brief at<std::string>() should throw when called on a BYTES series.
+TEST(SeriesBytes, AtStringThrowsForBytesType) {
+    const Series s(
+        std::vector<std::string>{std::string("\x01\x02", 2)},
+        BYTES_T
+    );
+    ASSERT_THROW((void) s.at<std::string>(0), std::runtime_error);
+}
 }

--- a/x/cpp/telem/series_test.cpp
+++ b/x/cpp/telem/series_test.cpp
@@ -2233,27 +2233,18 @@ TEST(SeriesBytes, DeepCopyIsIndependent) {
     ASSERT_EQ(copy.alignment.uint64(), original.alignment.uint64());
     const auto *orig_raw = reinterpret_cast<const uint8_t *>(original.data());
     const auto *copy_raw = reinterpret_cast<const uint8_t *>(copy.data());
-    ASSERT_EQ(
-        memcmp(orig_raw, copy_raw, original.byte_size()),
-        0
-    );
+    ASSERT_EQ(memcmp(orig_raw, copy_raw, original.byte_size()), 0);
 }
 
 /// @brief strings() should throw when called on a BYTES series.
 TEST(SeriesBytes, StringsThrowsForBytesType) {
-    const Series s(
-        std::vector<std::string>{std::string("\x01\x02", 2)},
-        BYTES_T
-    );
+    const Series s(std::vector<std::string>{std::string("\x01\x02", 2)}, BYTES_T);
     ASSERT_THROW((void) s.strings(), std::runtime_error);
 }
 
 /// @brief at<std::string>() should throw when called on a BYTES series.
 TEST(SeriesBytes, AtStringThrowsForBytesType) {
-    const Series s(
-        std::vector<std::string>{std::string("\x01\x02", 2)},
-        BYTES_T
-    );
+    const Series s(std::vector<std::string>{std::string("\x01\x02", 2)}, BYTES_T);
     ASSERT_THROW((void) s.at<std::string>(0), std::runtime_error);
 }
 }

--- a/x/cpp/telem/series_test.cpp
+++ b/x/cpp/telem/series_test.cpp
@@ -96,7 +96,7 @@ TEST(TestSeries, testStringVectorConstruction) {
     const Series s{vals};
     ASSERT_EQ(s.data_type(), STRING_T);
     ASSERT_EQ(s.size(), 2);
-    ASSERT_EQ(s.byte_size(), 12);
+    ASSERT_EQ(s.byte_size(), 18);
     const auto v = s.strings();
     for (size_t i = 0; i < vals.size(); i++)
         ASSERT_EQ(v[i], vals[i]);
@@ -124,7 +124,7 @@ TEST(TestSeries, testStringConstruction) {
     const Series s{val};
     ASSERT_EQ(s.data_type(), STRING_T);
     ASSERT_EQ(s.size(), 1);
-    ASSERT_EQ(s.byte_size(), 6);
+    ASSERT_EQ(s.byte_size(), 9);
     const auto v = s.strings();
     ASSERT_EQ(v[0], val);
 }
@@ -135,7 +135,7 @@ TEST(TestSeries, testJSONStringConstruction) {
     const Series s(raw, JSON_T);
     ASSERT_EQ(s.data_type(), JSON_T);
     ASSERT_EQ(s.size(), 1);
-    ASSERT_EQ(s.byte_size(), 17);
+    ASSERT_EQ(s.byte_size(), 20);
     const auto v = s.strings();
     ASSERT_EQ(v[0], raw);
 }
@@ -930,12 +930,13 @@ TEST(TestSeries, testFillFromString) {
     std::vector<uint8_t> binary_data;
     size_t total_size = 0;
     for (const auto &str: source_strings)
-        total_size += str.size() + 1; // +1 for newline terminator
+        total_size += str.size() + 4;
 
     binary::Writer writer(binary_data, total_size);
     for (const auto &str: source_strings) {
+        uint32_t len = static_cast<uint32_t>(str.size());
+        writer.write(&len, sizeof(len));
         writer.write(str.data(), str.size());
-        writer.uint8('\n');
     }
 
     Series series(STRING_T, total_size);

--- a/x/cpp/telem/telem.h
+++ b/x/cpp/telem/telem.h
@@ -1202,16 +1202,16 @@ const DataType UINT64_T(details::UINT64_T);
 /// @brief identifier for a fixed-size UUID data type in a Synnax cluster (16
 /// bytes).
 const DataType UUID_T(details::UUID_T);
-/// @brief identifier for a newline separated, variable-length string data type in a
-/// Synnax cluster. Note that variable-length data types have reduced performance
+/// @brief identifier for a uint32-length-prefixed, variable-length string data type
+/// in a Synnax cluster. Note that variable-length data types have reduced performance
 /// and restricted use within a Synnax cluster.
 const DataType STRING_T(details::STRING_T);
-/// @brief identifier for a newline separated, stringified JSON data type in a
+/// @brief identifier for a uint32-length-prefixed, stringified JSON data type in a
 /// Synnax cluster. Note that variable-length data types have reduced performance
 /// and restricted use within a Synnax cluster.
 const DataType JSON_T(details::JSON_T);
-/// @brief identifier for a newline separated, variable-length bytes data type in a
-/// Synnax cluster. Note that variable-length data types have reduced performance
+/// @brief identifier for a uint32-length-prefixed, variable-length bytes data type
+/// in a Synnax cluster. Note that variable-length data types have reduced performance
 /// and restricted use within a Synnax cluster.
 const DataType BYTES_T(details::BYTES_T);
 }

--- a/x/go/telem/series.go
+++ b/x/go/telem/series.go
@@ -34,6 +34,9 @@ func (s Series) Len() int64 {
 			offset := 0
 			for offset+4 <= len(s.Data) {
 				length := int(binary.LittleEndian.Uint32(s.Data[offset:]))
+				if offset+4+length > len(s.Data) {
+					break
+				}
 				offset += 4 + length
 				cl++
 			}
@@ -83,6 +86,9 @@ func (s Series) At(i int) []byte {
 		for offset+4 <= len(s.Data) {
 			length := int(binary.LittleEndian.Uint32(s.Data[offset:]))
 			offset += 4
+			if offset+length > len(s.Data) {
+				break
+			}
 			if i == 0 {
 				return s.Data[offset : offset+length]
 			}

--- a/x/go/telem/series.go
+++ b/x/go/telem/series.go
@@ -10,7 +10,7 @@
 package telem
 
 import (
-	"bytes"
+	"encoding/binary"
 	"fmt"
 	"iter"
 	"slices"
@@ -23,8 +23,6 @@ import (
 	xunsafe "github.com/synnaxlabs/x/unsafe"
 )
 
-const newLineChar = '\n'
-
 // Len returns the number of samples currently in the Series.
 func (s Series) Len() int64 {
 	if len(s.Data) == 0 {
@@ -32,7 +30,13 @@ func (s Series) Len() int64 {
 	}
 	if s.DataType.IsVariable() {
 		if s.cachedLength == nil {
-			cl := int64(bytes.Count(s.Data, []byte{newLineChar}))
+			var cl int64
+			offset := 0
+			for offset+4 <= len(s.Data) {
+				length := int(binary.LittleEndian.Uint32(s.Data[offset:]))
+				offset += 4 + length
+				cl++
+			}
 			s.cachedLength = &cl
 		}
 		return *s.cachedLength
@@ -47,18 +51,17 @@ func (s Series) Size() Size { return Size(len(s.Data)) }
 func (s Series) Samples() iter.Seq[[]byte] {
 	return func(yield func([]byte) bool) {
 		if s.DataType.IsVariable() {
-			var (
-				buf    []byte
-				offset int
-			)
-			for i := range s.Data {
-				if s.Data[i] == newLineChar {
-					buf = s.Data[offset:i]
-					offset = i + 1
-					if !yield(buf) {
-						return
-					}
+			offset := 0
+			for offset+4 <= len(s.Data) {
+				length := int(binary.LittleEndian.Uint32(s.Data[offset:]))
+				offset += 4
+				if offset+length > len(s.Data) {
+					return
 				}
+				if !yield(s.Data[offset : offset+length]) {
+					return
+				}
+				offset += length
 			}
 			return
 		}
@@ -76,15 +79,15 @@ func (s Series) Samples() iter.Seq[[]byte] {
 func (s Series) At(i int) []byte {
 	i = xslices.ConvertNegativeIndex(i, int(s.Len()))
 	if s.DataType.IsVariable() {
-		var offset int
-		for j := range s.Data {
-			if s.Data[j] == newLineChar {
-				if i == 0 {
-					return s.Data[offset:j]
-				}
-				i--
-				offset = j + 1
+		offset := 0
+		for offset+4 <= len(s.Data) {
+			length := int(binary.LittleEndian.Uint32(s.Data[offset:]))
+			offset += 4
+			if i == 0 {
+				return s.Data[offset : offset+length]
 			}
+			i--
+			offset += length
 		}
 		panic(fmt.Sprintf(
 			"index %v out of bounds for series with length %v",
@@ -189,14 +192,12 @@ func (s Series) Downsample(factor int) Series {
 	}
 	var oData []byte
 	if s.DataType.IsVariable() {
-		iLines := bytes.Split(s.Data, []byte{newLineChar})
-		oLines := make([][]byte, 0, len(iLines)/factor+1)
-		for i := 0; i < len(iLines); i += factor {
-			if i < len(iLines) {
-				oLines = append(oLines, iLines[i])
-			}
+		samples := unmarshalVariable[[]byte](s.Data)
+		downsampled := make([][]byte, 0, len(samples)/factor+1)
+		for i := 0; i < len(samples); i += factor {
+			downsampled = append(downsampled, samples[i])
 		}
-		oData = bytes.Join(oLines, []byte{newLineChar})
+		oData = marshalVariable(downsampled)
 	} else {
 		seriesLength := len(s.Data) / factor
 		oData = make([]byte, 0, seriesLength)

--- a/x/go/telem/series.go
+++ b/x/go/telem/series.go
@@ -32,12 +32,12 @@ func (s Series) Len() int64 {
 		if s.cachedLength == nil {
 			var cl int64
 			offset := 0
-			for offset+4 <= len(s.Data) {
+			for offset+variableLengthPrefixSize <= len(s.Data) {
 				length := int(binary.LittleEndian.Uint32(s.Data[offset:]))
-				if offset+4+length > len(s.Data) {
+				if offset+variableLengthPrefixSize+length > len(s.Data) {
 					break
 				}
-				offset += 4 + length
+				offset += variableLengthPrefixSize + length
 				cl++
 			}
 			s.cachedLength = &cl
@@ -55,9 +55,9 @@ func (s Series) Samples() iter.Seq[[]byte] {
 	return func(yield func([]byte) bool) {
 		if s.DataType.IsVariable() {
 			offset := 0
-			for offset+4 <= len(s.Data) {
+			for offset+variableLengthPrefixSize <= len(s.Data) {
 				length := int(binary.LittleEndian.Uint32(s.Data[offset:]))
-				offset += 4
+				offset += variableLengthPrefixSize
 				if offset+length > len(s.Data) {
 					return
 				}
@@ -83,9 +83,9 @@ func (s Series) At(i int) []byte {
 	i = xslices.ConvertNegativeIndex(i, int(s.Len()))
 	if s.DataType.IsVariable() {
 		offset := 0
-		for offset+4 <= len(s.Data) {
+		for offset+variableLengthPrefixSize <= len(s.Data) {
 			length := int(binary.LittleEndian.Uint32(s.Data[offset:]))
-			offset += 4
+			offset += variableLengthPrefixSize
 			if offset+length > len(s.Data) {
 				break
 			}

--- a/x/go/telem/series_factory.go
+++ b/x/go/telem/series_factory.go
@@ -120,23 +120,27 @@ func NewJSONSeries[T any](data []T) (Series, error) {
 // marshalled into JSON.
 func NewJSONSeriesV[T any](data ...T) (Series, error) { return NewJSONSeries(data) }
 
+// variableLengthPrefixSize is the number of bytes used for the uint32 LE length prefix
+// in variable-density series encoding.
+const variableLengthPrefixSize = 4
+
 // MarshalVariableSample wraps a single variable-length sample with a uint32 LE length
 // prefix. This is useful for code that accumulates samples into a Series.Data buffer
 // incrementally rather than using NewSeriesV.
 func MarshalVariableSample(sample []byte) []byte {
-	b := make([]byte, 4+len(sample))
+	b := make([]byte, variableLengthPrefixSize+len(sample))
 	binary.LittleEndian.PutUint32(b, uint32(len(sample)))
-	copy(b[4:], sample)
+	copy(b[variableLengthPrefixSize:], sample)
 	return b
 }
 
 func marshalVariable[T VariableSample](data []T) []byte {
-	total := lo.SumBy(data, func(v T) int64 { return int64(len(v)) + 4 })
+	total := lo.SumBy(data, func(v T) int64 { return int64(len(v)) + variableLengthPrefixSize })
 	b := make([]byte, total)
 	offset := 0
 	for _, d := range data {
 		binary.LittleEndian.PutUint32(b[offset:], uint32(len(d)))
-		offset += 4
+		offset += variableLengthPrefixSize
 		copy(b[offset:], d)
 		offset += len(d)
 	}
@@ -195,9 +199,9 @@ func unmarshalFixed[T FixedSample](b []byte) []T { return unsafe.CastSlice[byte,
 func unmarshalVariable[T VariableSample](b []byte) []T {
 	var data []T
 	offset := 0
-	for offset+4 <= len(b) {
+	for offset+variableLengthPrefixSize <= len(b) {
 		length := int(binary.LittleEndian.Uint32(b[offset:]))
-		offset += 4
+		offset += variableLengthPrefixSize
 		if offset+length > len(b) {
 			break
 		}

--- a/x/go/telem/series_factory.go
+++ b/x/go/telem/series_factory.go
@@ -120,6 +120,16 @@ func NewJSONSeries[T any](data []T) (Series, error) {
 // marshalled into JSON.
 func NewJSONSeriesV[T any](data ...T) (Series, error) { return NewJSONSeries(data) }
 
+// MarshalVariableSample wraps a single variable-length sample with a uint32 LE length
+// prefix. This is useful for code that accumulates samples into a Series.Data buffer
+// incrementally rather than using NewSeriesV.
+func MarshalVariableSample(sample []byte) []byte {
+	b := make([]byte, 4+len(sample))
+	binary.LittleEndian.PutUint32(b, uint32(len(sample)))
+	copy(b[4:], sample)
+	return b
+}
+
 func marshalVariable[T VariableSample](data []T) []byte {
 	total := lo.SumBy(data, func(v T) int64 { return int64(len(v)) + 4 })
 	b := make([]byte, total)

--- a/x/go/telem/series_factory.go
+++ b/x/go/telem/series_factory.go
@@ -120,16 +120,15 @@ func NewJSONSeries[T any](data []T) (Series, error) {
 // marshalled into JSON.
 func NewJSONSeriesV[T any](data ...T) (Series, error) { return NewJSONSeries(data) }
 
-const newLine = '\n'
-
 func marshalVariable[T VariableSample](data []T) []byte {
-	total := lo.SumBy(data, func(v T) int64 { return int64(len(v)) + 1 })
+	total := lo.SumBy(data, func(v T) int64 { return int64(len(v)) + 4 })
 	b := make([]byte, total)
 	offset := 0
 	for _, d := range data {
+		binary.LittleEndian.PutUint32(b[offset:], uint32(len(d)))
+		offset += 4
 		copy(b[offset:], d)
-		b[offset+len(d)] = newLine
-		offset += len(d) + 1
+		offset += len(d)
 	}
 	return b
 }
@@ -184,17 +183,16 @@ func UnmarshalSeries[T Sample](series Series) []T {
 func unmarshalFixed[T FixedSample](b []byte) []T { return unsafe.CastSlice[byte, T](b) }
 
 func unmarshalVariable[T VariableSample](b []byte) []T {
-	var (
-		offset int
-		data   []T
-	)
-	for offset < len(b) {
-		end := offset
-		for b[end] != newLine {
-			end++
+	var data []T
+	offset := 0
+	for offset+4 <= len(b) {
+		length := int(binary.LittleEndian.Uint32(b[offset:]))
+		offset += 4
+		if offset+length > len(b) {
+			break
 		}
-		data = append(data, T(b[offset:end]))
-		offset = end + 1
+		data = append(data, T(b[offset:offset+length]))
+		offset += length
 	}
 	return data
 }

--- a/x/go/telem/series_factory_test.go
+++ b/x/go/telem/series_factory_test.go
@@ -10,6 +10,7 @@
 package telem_test
 
 import (
+	"encoding/binary"
 	"math"
 
 	"github.com/google/uuid"
@@ -87,6 +88,21 @@ var _ = Describe("SeriesFactory", func() {
 			Specify("different length strings", newVariableSeriesRoundtripTest([]string{"hello", "", "foo"}, telem.StringT))
 			Specify("empty", newVariableSeriesRoundtripTest([]string{}, telem.StringT))
 			Specify("[]byte", newVariableSeriesRoundtripTest([][]byte{{1, 2, 3}, {4, 5, 6}}, telem.BytesT))
+			Specify("single []byte", newVariableSeriesRoundtripTest([][]byte{{1}}, telem.BytesT))
+			Specify("empty []byte values", newVariableSeriesRoundtripTest([][]byte{{}, {}, {}}, telem.BytesT))
+			Specify("empty []byte", newVariableSeriesRoundtripTest([][]byte{}, telem.BytesT))
+			Specify("different length []byte", newVariableSeriesRoundtripTest([][]byte{{1, 2, 3}, {}, {4}}, telem.BytesT))
+			Specify("single JSON", func() {
+				s := MustSucceed(telem.NewJSONSeriesV(map[string]any{"a": 1.0}))
+				Expect(s.DataType).To(Equal(telem.JSONT))
+				Expect(s.Len()).To(BeEquivalentTo(1))
+				Expect(string(s.At(0))).To(Equal(`{"a":1}`))
+			})
+			Specify("empty JSON", func() {
+				s := MustSucceed(telem.NewJSONSeries([]map[string]any{}))
+				Expect(s.DataType).To(Equal(telem.JSONT))
+				Expect(s.Len()).To(BeEquivalentTo(0))
+			})
 		})
 	})
 
@@ -213,6 +229,56 @@ var _ = Describe("SeriesFactory", func() {
 				To(MatchError(ContainSubstring(
 					"json: cannot unmarshal array into Go value of type string",
 				)))
+		})
+	})
+
+	Describe("MarshalVariableSample", func() {
+		It("Should marshal a typical sample with a length prefix", func() {
+			sample := []byte("hello")
+			result := telem.MarshalVariableSample(sample)
+			Expect(result).To(HaveLen(9))
+			Expect(binary.LittleEndian.Uint32(result[:4])).To(Equal(uint32(5)))
+			Expect(result[4:]).To(Equal(sample))
+		})
+
+		It("Should marshal an empty sample", func() {
+			result := telem.MarshalVariableSample([]byte{})
+			Expect(result).To(HaveLen(4))
+			Expect(binary.LittleEndian.Uint32(result[:4])).To(Equal(uint32(0)))
+		})
+
+		It("Should marshal a nil sample", func() {
+			result := telem.MarshalVariableSample(nil)
+			Expect(result).To(HaveLen(4))
+			Expect(binary.LittleEndian.Uint32(result[:4])).To(Equal(uint32(0)))
+		})
+
+		It("Should marshal a single byte sample", func() {
+			result := telem.MarshalVariableSample([]byte{0xFF})
+			Expect(result).To(HaveLen(5))
+			Expect(binary.LittleEndian.Uint32(result[:4])).To(Equal(uint32(1)))
+			Expect(result[4]).To(Equal(byte(0xFF)))
+		})
+
+		It("Should produce output readable by Series.At", func() {
+			samples := [][]byte{[]byte("foo"), []byte("barbaz"), []byte("")}
+			var data []byte
+			for _, s := range samples {
+				data = append(data, telem.MarshalVariableSample(s)...)
+			}
+			series := telem.Series{DataType: telem.StringT, Data: data}
+			Expect(series.Len()).To(Equal(int64(3)))
+			Expect(series.At(0)).To(Equal([]byte("foo")))
+			Expect(series.At(1)).To(Equal([]byte("barbaz")))
+			Expect(series.At(2)).To(BeEmpty())
+		})
+
+		It("Should produce the same encoding as NewSeriesV", func() {
+			fromFactory := telem.NewSeriesV([]byte{1, 2}, []byte{3, 4, 5})
+			var manual []byte
+			manual = append(manual, telem.MarshalVariableSample([]byte{1, 2})...)
+			manual = append(manual, telem.MarshalVariableSample([]byte{3, 4, 5})...)
+			Expect(manual).To(Equal(fromFactory.Data))
 		})
 	})
 

--- a/x/go/telem/series_test.go
+++ b/x/go/telem/series_test.go
@@ -36,6 +36,14 @@ var _ = Describe("Series", func() {
 			s := telem.NewSeriesV("bob", "alice", "charlie")
 			Expect(s.Len()).To(Equal(int64(3)))
 		})
+		It("Should correctly return the number of samples in a bytes series", func() {
+			s := telem.NewSeriesV([]byte{1, 2}, []byte{3, 4, 5})
+			Expect(s.Len()).To(Equal(int64(2)))
+		})
+		It("Should correctly return the number of samples in a JSON series", func() {
+			s := MustSucceed(telem.NewJSONSeriesV(map[string]any{"a": 1.0}, map[string]any{"b": 2.0}))
+			Expect(s.Len()).To(Equal(int64(2)))
+		})
 	})
 
 	Describe("At", func() {
@@ -64,6 +72,26 @@ var _ = Describe("Series", func() {
 				Expect(s.At(0)).To(Equal([]byte("a")))
 				Expect(s.At(1)).To(Equal([]byte("b")))
 				Expect(s.At(2)).To(Equal([]byte("c")))
+			})
+
+			It("Should return the value at the given index for bytes series", func() {
+				s := telem.NewSeriesV([]byte{1, 2}, []byte{3, 4, 5}, []byte{6})
+				Expect(s.At(0)).To(Equal([]byte{1, 2}))
+				Expect(s.At(1)).To(Equal([]byte{3, 4, 5}))
+				Expect(s.At(2)).To(Equal([]byte{6}))
+			})
+
+			It("Should return the value at the given index for JSON series", func() {
+				s := MustSucceed(telem.NewJSONSeriesV(map[string]any{"a": 1.0}, map[string]any{"b": 2.0}))
+				Expect(string(s.At(0))).To(Equal(`{"a":1}`))
+				Expect(string(s.At(1))).To(Equal(`{"b":2}`))
+			})
+
+			It("Should support negative indexing for variable density series", func() {
+				s := telem.NewSeriesV("a", "b", "c")
+				Expect(s.At(-1)).To(Equal([]byte("c")))
+				Expect(s.At(-2)).To(Equal([]byte("b")))
+				Expect(s.At(-3)).To(Equal([]byte("a")))
 			})
 
 			It("Should panic when the index is out of bounds", func() {
@@ -382,6 +410,13 @@ var _ = Describe("Series", func() {
 				Expect(downsampled.Len()).To(Equal(int64(2)))
 				result := telem.UnmarshalSeries[[]byte](downsampled)
 				Expect(result).To(HaveLen(2))
+			})
+
+			It("Should correctly down sample a bytes series", func() {
+				original := telem.NewSeriesV([]byte{1}, []byte{2}, []byte{3}, []byte{4})
+				downsampled := original.Downsample(2)
+				Expect(downsampled.Len()).To(Equal(int64(2)))
+				Expect(telem.UnmarshalSeries[[]byte](downsampled)).To(Equal([][]byte{{1}, {3}}))
 			})
 		})
 
@@ -787,6 +822,27 @@ var _ = Describe("Series", func() {
 			})
 			Expect(count).To(Equal(0))
 		})
+
+		It("iterates bytes series correctly", func() {
+			s := telem.NewSeriesV([]byte{1, 2}, []byte{3, 4, 5})
+			values := make([][]byte, 0, 2)
+			for sample := range s.Samples() {
+				v := make([]byte, len(sample))
+				copy(v, sample)
+				values = append(values, v)
+			}
+			Expect(values).To(Equal([][]byte{{1, 2}, {3, 4, 5}}))
+		})
+
+		It("iterates JSON series correctly", func() {
+			s := MustSucceed(telem.NewJSONSeriesV(map[string]any{"a": 1.0}))
+			values := make([]string, 0, 1)
+			for sample := range s.Samples() {
+				values = append(values, string(sample))
+			}
+			Expect(values).To(HaveLen(1))
+			Expect(values[0]).To(Equal(`{"a":1}`))
+		})
 	})
 
 	Describe("CopyValue", func() {
@@ -905,6 +961,23 @@ var _ = Describe("Series", func() {
 			Expect(copied.TimeRange.Start).To(Equal(telem.TimeStamp(1000)))
 			Expect(copied.TimeRange.End).To(Equal(telem.TimeStamp(2000)))
 			Expect(copied.Alignment).To(Equal(telem.NewAlignment(5, 10)))
+		})
+
+		It("Should work with JSON series", func() {
+			original := MustSucceed(telem.NewJSONSeriesV(map[string]any{"a": 1.0}))
+			copied := original.DeepCopy()
+			Expect(copied.DataType).To(Equal(telem.JSONT))
+			Expect(copied.Len()).To(Equal(int64(1)))
+			Expect(string(copied.At(0))).To(Equal(`{"a":1}`))
+		})
+
+		It("Should work with bytes series", func() {
+			original := telem.NewSeriesV([]byte{1, 2, 3}, []byte{4, 5})
+			copied := original.DeepCopy()
+			Expect(copied.DataType).To(Equal(telem.BytesT))
+			Expect(copied.Len()).To(Equal(int64(2)))
+			Expect(copied.At(0)).To(Equal([]byte{1, 2, 3}))
+			Expect(copied.At(1)).To(Equal([]byte{4, 5}))
 		})
 	})
 })

--- a/x/go/telem/series_test.go
+++ b/x/go/telem/series_test.go
@@ -10,8 +10,6 @@
 package telem_test
 
 import (
-	"bytes"
-
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -382,8 +380,8 @@ var _ = Describe("Series", func() {
 				s := MustSucceed(telem.NewJSONSeriesV(data...))
 				downsampled := s.Downsample(2)
 				Expect(downsampled.Len()).To(Equal(int64(2)))
-				split := bytes.Split(downsampled.Data, []byte("\n"))
-				Expect(len(split)).To(Equal(3)) // 2 items + empty string after last newline
+				result := telem.UnmarshalSeries[[]byte](downsampled)
+				Expect(result).To(HaveLen(2))
 			})
 		})
 

--- a/x/py/pyproject.toml
+++ b/x/py/pyproject.toml
@@ -42,6 +42,7 @@ markers = [
     "color: mark test as a color test",
     "control: mark test as a control test",
     "deprecation: mark test as a deprecation test",
+    "series: mark test as a series test",
     "telem: mark test as a telem test",
     "timing: mark test as a timing test",
 ]

--- a/x/py/tests/test_series.py
+++ b/x/py/tests/test_series.py
@@ -19,7 +19,7 @@ import x.telem as sy
 @pytest.mark.telem
 @pytest.mark.series
 class TestSeries:
-    def test_construction_from_np(self):
+    def test_construction_from_np(self) -> None:
         """Should correctly construct a series from a primitive numpy array"""
         d = np.array([1, 2, 3, 4], dtype=np.int8)
         s = sy.Series(d)
@@ -27,7 +27,7 @@ class TestSeries:
         assert s.data_type == sy.DataType.INT8
         assert s[3] == 4
 
-    def test_construction_from_np_data_type_override(self):
+    def test_construction_from_np_data_type_override(self) -> None:
         """Should correctly convert the numpy arrays data type"""
         d = np.array([1, 2, 3, 4], dtype=np.int8)
         s = sy.Series(d, data_type=sy.DataType.FLOAT64)
@@ -36,40 +36,40 @@ class TestSeries:
         assert s[3] == 4
         assert s.__array__().dtype == np.float64
 
-    def test_array_with_dtype(self):
+    def test_array_with_dtype(self) -> None:
         """Should convert to specified dtype when using __array__"""
         s = sy.Series([1, 2, 3], data_type=sy.DataType.INT64)
-        arr = s.__array__(dtype=np.float32)
+        arr = s.__array__(dtype=np.dtype(np.float32))
         assert arr.dtype == np.float32
         assert list(arr) == [1.0, 2.0, 3.0]
 
-    def test_array_with_copy_true(self):
+    def test_array_with_copy_true(self) -> None:
         """Should return a copy when copy=True"""
         s = sy.Series([1, 2, 3], data_type=sy.DataType.INT64)
         arr1 = s.__array__(copy=True)
         arr2 = s.__array__(copy=True)
         assert not np.shares_memory(arr1, arr2)
 
-    def test_array_with_copy_false_same_dtype(self):
+    def test_array_with_copy_false_same_dtype(self) -> None:
         """Should not copy when copy=False and no dtype conversion needed"""
         s = sy.Series([1, 2, 3], data_type=sy.DataType.INT64)
         arr = s.__array__(copy=False)
         assert arr.dtype == np.int64
 
-    def test_np_array_with_dtype(self):
+    def test_np_array_with_dtype(self) -> None:
         """Should work with np.array() and dtype parameter (NumPy 2.0 protocol)"""
         s = sy.Series([1, 2, 3], data_type=sy.DataType.INT64)
         arr = np.array(s, dtype=np.float32)
         assert arr.dtype == np.float32
 
-    def test_np_array_with_copy(self):
+    def test_np_array_with_copy(self) -> None:
         """Should work with np.array() and copy parameter (NumPy 2.0 protocol)"""
         s = sy.Series([1, 2, 3], data_type=sy.DataType.INT64)
         arr = np.array(s, copy=True)
         assert arr.dtype == np.int64
         assert list(arr) == [1, 2, 3]
 
-    def test_construction_from_pd_series(self):
+    def test_construction_from_pd_series(self) -> None:
         """Should correctly construct the array from a pandas series"""
         d = pd.Series([1, 2, 3], dtype=np.float64)
         s = sy.Series(d)
@@ -77,7 +77,7 @@ class TestSeries:
         assert s[2] == 3
         assert s.data_type == sy.DataType.FLOAT64
 
-    def test_construction_from_list(self):
+    def test_construction_from_list(self) -> None:
         """Should correctly construct the array from a list"""
         d = [1, 2, 3]
         s = sy.Series(d)
@@ -85,7 +85,7 @@ class TestSeries:
         assert s[2] == 3
         assert s.data_type == sy.DataType.INT64
 
-    def test_construction_from_series(self):
+    def test_construction_from_series(self) -> None:
         """Should correctly construct the sy.Series from another sy.Series"""
         d = sy.Series([1, 2, 3], data_type=sy.DataType.INT8, alignment=12)
         s = sy.Series(d)
@@ -94,7 +94,7 @@ class TestSeries:
         assert s.data_type == sy.DataType.INT8
         assert s.alignment == 12
 
-    def test_construction_from_buffer(self):
+    def test_construction_from_buffer(self) -> None:
         """Should correctly construct the sy.Series from a buffer"""
         d = sy.Series([1.0, 2.0, 3.0]).data
         s = sy.Series(d, data_type=sy.DataType.FLOAT64)
@@ -102,76 +102,76 @@ class TestSeries:
         assert s[2] == 3
         assert s.data_type == sy.DataType.FLOAT64
 
-    def test_construct_from_buffer_no_data_type(self):
+    def test_construct_from_buffer_no_data_type(self) -> None:
         """Should throw a ValueError"""
         with pytest.raises(ValueError):
             assert sy.Series(b"57678")
 
-    def test_construction_from_np_timestamp(self):
+    def test_construction_from_np_timestamp(self) -> None:
         d = sy.Series([sy.TimeStamp.now()])
         assert len(d) == 1
 
-    def test_construction_from_int(self):
+    def test_construction_from_int(self) -> None:
         """Should correctly construct the series from a single integer"""
         d = sy.Series(1)
         assert len(d) == 1
         assert d.data_type == sy.DataType.INT64
 
-    def test_construction_from_int_with_dt(self):
+    def test_construction_from_int_with_dt(self) -> None:
         """Should correctly set a custom data type on the integer"""
         d = sy.Series(1, data_type=sy.DataType.INT8)
         assert len(d) == 1
         assert d.data_type == sy.DataType.INT8
 
-    def test_construction_from_float(self):
+    def test_construction_from_float(self) -> None:
         """Should correctly construct the series from a single float"""
         d = sy.Series(1.0)
         assert len(d) == 1
         assert d.data_type == sy.DataType.FLOAT64
 
-    def test_construction_from_float_with_dt(self):
+    def test_construction_from_float_with_dt(self) -> None:
         """Should correctly set a custom data type on the float"""
         d = sy.Series(1.0, data_type=sy.DataType.FLOAT32)
         assert len(d) == 1
         assert d.data_type == sy.DataType.FLOAT32
 
-    def test_construction_from_strings(self):
+    def test_construction_from_strings(self) -> None:
         """Should correctly construct the series from a list of strings"""
         d = sy.Series(["hello"])
         assert len(d) == 1
         assert d.data_type == sy.DataType.STRING
         assert d[0] == "hello"
 
-    def test_construction_from_string(self):
+    def test_construction_from_string(self) -> None:
         """Should correctly construct the series from a single string"""
         d = sy.Series("hello")
         assert len(d) == 1
         assert d.data_type == sy.DataType.STRING
 
-    def test_construction_from_dicts(self):
+    def test_construction_from_dicts(self) -> None:
         """Should correctly construct the series from a list of dicts"""
         d = sy.Series([{"hello": "world"}])
         assert len(d) == 1
         assert d.data_type == sy.DataType.JSON
 
-    def test_size(self):
+    def test_size(self) -> None:
         """Should return the correct number of bytes in the buffer"""
         s = sy.Series([1, 2, 3], data_type=sy.DataType.INT16)
         assert s.size == 3 * 2
 
-    def test_astype(self):
+    def test_astype(self) -> None:
         """Should convert the series to a different data type"""
         s = sy.Series([1, 2, 3], data_type=sy.DataType.INT16)
         s = s.astype(sy.DataType.INT8)
         assert s.size == 3
         assert s[0] == 1
 
-    def test_cast_numeric_as_list(self):
+    def test_cast_numeric_as_list(self) -> None:
         """Should correctly convert the series to a builtin list"""
         s = sy.Series([1, 2, 3], data_type=sy.DataType.INT8)
         assert list(s) == [1, 2, 3]
 
-    def test_cast_uuid_as_list(self):
+    def test_cast_uuid_as_list(self) -> None:
         """Should correctly convert the series to a builtin list"""
         one = uuid.uuid4()
         two = uuid.uuid4()
@@ -180,54 +180,54 @@ class TestSeries:
         assert list_[0] == one
         assert list_[1] == two
 
-    def test_cast_json_as_list(self):
+    def test_cast_json_as_list(self) -> None:
         """Should correctly convert the series to a builtin list"""
         s = sy.Series([{"hello": "world"}], data_type=sy.DataType.JSON)
         assert list(s) == [{"hello": "world"}]
 
-    def test_cast_string_as_list(self):
+    def test_cast_string_as_list(self) -> None:
         """Should correctly convert the series to a builtin list"""
         s = sy.Series(["hello"], data_type=sy.DataType.STRING)
         assert list(s) == ["hello"]
 
-    def test_greater_than(self):
+    def test_greater_than(self) -> None:
         """Should correctly compare the series to a scalar"""
         s = sy.Series([1, 2, 3], data_type=sy.DataType.INT8)
-        assert all(s > 2) == all([False, False, True])
+        assert list(s.__array__() > 2) == [False, False, True]
 
-    def test_less_than(self):
+    def test_less_than(self) -> None:
         """Should correctly compare the series to a scalar"""
         s = sy.Series([1, 2, 3], data_type=sy.DataType.INT8)
-        assert all(s < 2) == all([True, False, False])
+        assert list(s.__array__() < 2) == [True, False, False]
 
-    def test_list_access_numeric(self):
+    def test_list_access_numeric(self) -> None:
         """Should correctly access the series by index"""
         s = sy.Series([1, 2, 3], data_type=sy.DataType.INT8)
         assert s[0] == 1
 
-    def test_list_access_string(self):
+    def test_list_access_string(self) -> None:
         """Should correctly access the series by index"""
         s = sy.Series(["hello", "world"], data_type=sy.DataType.STRING)
         assert s[1] == "world"
 
-    def test_list_access_json(self):
+    def test_list_access_json(self) -> None:
         """Should correctly access the series by index"""
         s = sy.Series([{"hello": "world"}, {"blue": "dog"}], data_type=sy.DataType.JSON)
         assert s[1] == {"blue": "dog"}
 
-    def test_list_access_string_negative(self):
+    def test_list_access_string_negative(self) -> None:
         """Should correctly access the series by index"""
         s = sy.Series(["hello", "world"], data_type=sy.DataType.STRING)
         assert s[-1] == "world"
 
-    def test_alignment_bounds_default(self):
+    def test_alignment_bounds_default(self) -> None:
         """Should correctly calculate alignment_bounds with default alignment"""
         s = sy.Series([1, 2, 3, 4, 5], data_type=sy.DataType.INT8)
         bounds = s.alignment_bounds
         assert bounds.lower == 0
         assert bounds.upper == 5
 
-    def test_alignment_bounds_with_alignment(self):
+    def test_alignment_bounds_with_alignment(self) -> None:
         """Should correctly calculate alignment_bounds with custom alignment"""
         s = sy.Series(
             [1, 2, 3],
@@ -239,7 +239,7 @@ class TestSeries:
         assert bounds.lower == float(expected_start)
         assert bounds.upper == float(expected_start + 3)
 
-    def test_alignment_preserved_from_series(self):
+    def test_alignment_preserved_from_series(self) -> None:
         """Should preserve alignment when constructing from another sy.Series"""
         s1 = sy.Series(
             [1, 2, 3],
@@ -255,7 +255,7 @@ class TestSeries:
 class TestVariableLengthSeries:
     """Tests for variable-length series encoding (STRING, JSON)."""
 
-    def test_string_multiple_values(self):
+    def test_string_multiple_values(self) -> None:
         """Should correctly round-trip multiple string values"""
         values = ["hello", "world", "foo"]
         s = sy.Series(values)
@@ -265,7 +265,7 @@ class TestVariableLengthSeries:
         assert s[2] == "foo"
         assert list(s) == values
 
-    def test_string_empty_strings(self):
+    def test_string_empty_strings(self) -> None:
         """Should correctly handle empty strings"""
         values = ["", "", ""]
         s = sy.Series(values)
@@ -274,7 +274,7 @@ class TestVariableLengthSeries:
         assert s[1] == ""
         assert list(s) == values
 
-    def test_string_mixed_empty_and_nonempty(self):
+    def test_string_mixed_empty_and_nonempty(self) -> None:
         """Should handle a mix of empty and non-empty strings"""
         values = ["hello", "", "world", ""]
         s = sy.Series(values)
@@ -285,20 +285,20 @@ class TestVariableLengthSeries:
         assert s[3] == ""
         assert list(s) == values
 
-    def test_string_single_value(self):
+    def test_string_single_value(self) -> None:
         """Should handle a single string in a list"""
         s = sy.Series(["only"])
         assert len(s) == 1
         assert s[0] == "only"
 
-    def test_string_from_scalar(self):
+    def test_string_from_scalar(self) -> None:
         """Should construct from a bare string value"""
         s = sy.Series("hello")
         assert len(s) == 1
         assert s[0] == "hello"
         assert s.data_type == sy.DataType.STRING
 
-    def test_string_multibyte_utf8(self):
+    def test_string_multibyte_utf8(self) -> None:
         """Should correctly handle multi-byte UTF-8 characters"""
         values = ["cafe\u0301", "\u00e9", "\U0001f600"]
         s = sy.Series(values)
@@ -308,26 +308,26 @@ class TestVariableLengthSeries:
         assert s[2] == "\U0001f600"
         assert list(s) == values
 
-    def test_string_negative_index(self):
+    def test_string_negative_index(self) -> None:
         """Should support negative indexing"""
         s = sy.Series(["a", "b", "c"])
         assert s[-1] == "c"
         assert s[-2] == "b"
         assert s[-3] == "a"
 
-    def test_string_index_out_of_bounds(self):
+    def test_string_index_out_of_bounds(self) -> None:
         """Should raise IndexError for out-of-bounds access"""
         s = sy.Series(["a", "b"])
         with pytest.raises(IndexError):
             s[2]
 
-    def test_string_empty_series(self):
+    def test_string_empty_series(self) -> None:
         """Should handle an empty string series"""
         s = sy.Series([], data_type=sy.DataType.STRING)
         assert len(s) == 0
         assert list(s) == []
 
-    def test_string_large_value(self):
+    def test_string_large_value(self) -> None:
         """Should handle a string longer than 255 bytes"""
         big = "x" * 1000
         s = sy.Series([big, "small"])
@@ -335,72 +335,72 @@ class TestVariableLengthSeries:
         assert s[0] == big
         assert s[1] == "small"
 
-    def test_json_multiple_values(self):
+    def test_json_multiple_values(self) -> None:
         """Should correctly round-trip multiple JSON values"""
-        values = [{"a": 1}, {"b": [2, 3]}, {"c": {"nested": True}}]
+        values = [{"a": "1"}, {"b": "2"}, {"c": "3"}]
         s = sy.Series(values)
         assert len(s) == 3
-        assert s[0] == {"a": 1}
-        assert s[1] == {"b": [2, 3]}
-        assert s[2] == {"c": {"nested": True}}
+        assert s[0] == {"a": "1"}
+        assert s[1] == {"b": "2"}
+        assert s[2] == {"c": "3"}
         assert list(s) == values
 
-    def test_json_from_scalar_dict(self):
+    def test_json_from_scalar_dict(self) -> None:
         """Should construct from a bare dict value"""
         s = sy.Series({"key": "val"})
         assert len(s) == 1
         assert s[0] == {"key": "val"}
         assert s.data_type == sy.DataType.JSON
 
-    def test_json_empty_objects(self):
+    def test_json_empty_objects(self) -> None:
         """Should handle empty JSON objects"""
-        values = [{}, {}, {}]
+        values = [dict[str, str](), dict[str, str](), dict[str, str]()]
         s = sy.Series(values)
         assert len(s) == 3
         assert list(s) == values
 
-    def test_json_negative_index(self):
+    def test_json_negative_index(self) -> None:
         """Should support negative indexing for JSON series"""
         s = sy.Series([{"a": 1}, {"b": 2}, {"c": 3}])
         assert s[-1] == {"c": 3}
 
-    def test_json_empty_series(self):
+    def test_json_empty_series(self) -> None:
         """Should handle an empty JSON series"""
         s = sy.Series([], data_type=sy.DataType.JSON)
         assert len(s) == 0
         assert list(s) == []
 
-    def test_json_index_out_of_bounds(self):
+    def test_json_index_out_of_bounds(self) -> None:
         """Should raise IndexError for out-of-bounds access"""
         s = sy.Series([{"a": 1}])
         with pytest.raises(IndexError):
             s[1]
 
-    def test_string_len_cached(self):
+    def test_string_len_cached(self) -> None:
         """Should cache the length computation for variable-length series"""
         s = sy.Series(["a", "b", "c"])
         assert len(s) == 3
         assert len(s) == 3
 
-    def test_string_iteration_order(self):
+    def test_string_iteration_order(self) -> None:
         """Should iterate in insertion order"""
         values = ["first", "second", "third", "fourth"]
         s = sy.Series(values)
         assert [v for v in s] == values
 
-    def test_json_iteration_order(self):
+    def test_json_iteration_order(self) -> None:
         """Should iterate JSON values in insertion order"""
         values = [{"i": 0}, {"i": 1}, {"i": 2}]
         s = sy.Series(values)
         assert [v for v in s] == values
 
-    def test_string_size_bytes(self):
+    def test_string_size_bytes(self) -> None:
         """Should report the correct raw byte size including prefixes"""
         s = sy.Series(["ab", "c"])
         # "ab" = 4-byte prefix + 2 bytes, "c" = 4-byte prefix + 1 byte = 11
         assert s.size == 11
 
-    def test_json_size_bytes(self):
+    def test_json_size_bytes(self) -> None:
         """Should report the correct raw byte size including prefixes"""
         s = sy.Series([{"a": 1}])
         import json
@@ -412,26 +412,26 @@ class TestVariableLengthSeries:
 @pytest.mark.telem
 @pytest.mark.series
 class TestMultiSeries:
-    def test_construction_from_multiple_series(self):
+    def test_construction_from_multiple_series(self) -> None:
         """Should correctly construct a sy.MultiSeries from multiple sy.Series :)"""
         s1 = sy.Series([1, 2, 3], data_type=sy.DataType.INT8)
         s2 = sy.Series([4, 5, 6], data_type=sy.DataType.INT8)
         s = sy.MultiSeries([s1, s2])
         assert len(s) == 6
 
-    def test_construction_mismatched_data_types(self):
+    def test_construction_mismatched_data_types(self) -> None:
         """Should throw a ValueError"""
         s1 = sy.Series([1, 2, 3], data_type=sy.DataType.INT8)
         s2 = sy.Series([4, 5, 6], data_type=sy.DataType.INT16)
         with pytest.raises(ValueError):
             sy.MultiSeries([s1, s2])
 
-    def test_construction_from_none(self):
+    def test_construction_from_none(self) -> None:
         """Should throw a ValueError"""
         s = sy.MultiSeries([])
         assert len(s) == 0
 
-    def test_conversion_to_numpy(self):
+    def test_conversion_to_numpy(self) -> None:
         """Should correctly convert the sy.MultiSeries to a numpy array"""
         s1 = sy.Series([1, 2, 3], data_type=sy.DataType.INT8)
         s2 = sy.Series([4, 5, 6], data_type=sy.DataType.INT8)
@@ -439,16 +439,16 @@ class TestMultiSeries:
         assert len(s.to_numpy()) == 6
         assert s.to_numpy().dtype == np.int8
 
-    def test_array_with_dtype(self):
+    def test_array_with_dtype(self) -> None:
         """Should convert to specified dtype when using __array__"""
         s1 = sy.Series([1, 2, 3], data_type=sy.DataType.INT8)
         s2 = sy.Series([4, 5, 6], data_type=sy.DataType.INT8)
         s = sy.MultiSeries([s1, s2])
-        arr = s.__array__(dtype=np.float32)
+        arr = s.__array__(dtype=np.dtype(np.float32))
         assert arr.dtype == np.float32
         assert list(arr) == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
 
-    def test_np_array_with_dtype(self):
+    def test_np_array_with_dtype(self) -> None:
         """Should work with np.array() and dtype parameter (NumPy 2.0 protocol)"""
         s1 = sy.Series([1, 2, 3], data_type=sy.DataType.INT8)
         s2 = sy.Series([4, 5, 6], data_type=sy.DataType.INT8)
@@ -456,7 +456,7 @@ class TestMultiSeries:
         arr = np.array(s, dtype=np.float64)
         assert arr.dtype == np.float64
 
-    def test_np_array_with_copy(self):
+    def test_np_array_with_copy(self) -> None:
         """Should work with np.array() and copy parameter (NumPy 2.0 protocol)"""
         s1 = sy.Series([1, 2, 3], data_type=sy.DataType.INT8)
         s2 = sy.Series([4, 5, 6], data_type=sy.DataType.INT8)
@@ -465,7 +465,7 @@ class TestMultiSeries:
         assert arr.dtype == np.int8
         assert list(arr) == [1, 2, 3, 4, 5, 6]
 
-    def test_time_range(self):
+    def test_time_range(self) -> None:
         """Should correctly return the time range of the sy.MultiSeries"""
         s1 = sy.Series(
             data=[1, 2, 3],
@@ -482,10 +482,11 @@ class TestMultiSeries:
             ),
         )
         s = sy.MultiSeries([s1, s2])
+        assert s.time_range is not None
         assert s.time_range.start == 1 * sy.TimeSpan.SECOND
         assert s.time_range.end == 6 * sy.TimeSpan.SECOND
 
-    def test_access_by_index(self):
+    def test_access_by_index(self) -> None:
         """Should correctly access the sy.MultiSeries by index"""
         s1 = sy.Series([1, 2, 3], data_type=sy.DataType.INT8)
         s2 = sy.Series([4, 5, 6], data_type=sy.DataType.INT8)
@@ -496,21 +497,21 @@ class TestMultiSeries:
         assert s[5] == 6
         assert s[-1] == 6
 
-    def test_conversion_to_list_string(self):
+    def test_conversion_to_list_string(self) -> None:
         """Should correctly convert the sy.MultiSeries to a list of strings"""
         s1 = sy.Series(["hello", "world"], data_type=sy.DataType.STRING)
         s2 = sy.Series(["blue", "dog"], data_type=sy.DataType.STRING)
         s = sy.MultiSeries([s1, s2])
         assert list(s) == ["hello", "world", "blue", "dog"]
 
-    def test_conversion_to_list_numeric(self):
+    def test_conversion_to_list_numeric(self) -> None:
         """Should correctly convert the sy.MultiSeries to a list of numbers"""
         s1 = sy.Series([1, 2, 3], data_type=sy.DataType.INT8)
         s2 = sy.Series([4, 5, 6], data_type=sy.DataType.INT8)
         s = sy.MultiSeries([s1, s2])
         assert list(s) == [1, 2, 3, 4, 5, 6]
 
-    def test_conversion_to_list_json(self):
+    def test_conversion_to_list_json(self) -> None:
         """Should correctly convert the sy.MultiSeries to a list of dicts"""
         s1 = sy.Series(
             [{"hello": "world"}, {"blue": "dog"}], data_type=sy.DataType.JSON
@@ -524,7 +525,7 @@ class TestMultiSeries:
             {"green": "tree"},
         ]
 
-    def test_alignment_from_first_series(self):
+    def test_alignment_from_first_series(self) -> None:
         """Should return the alignment of the first series"""
         s1 = sy.Series(
             [1, 2, 3], data_type=sy.DataType.INT8, alignment=sy.Alignment(1, 5)
@@ -535,12 +536,12 @@ class TestMultiSeries:
         ms = sy.MultiSeries([s1, s2])
         assert ms.alignment == sy.Alignment(1, 5)
 
-    def test_alignment_empty_multiseries(self):
+    def test_alignment_empty_multiseries(self) -> None:
         """Should return sy.Alignment(0, 0) for empty sy.MultiSeries"""
         ms = sy.MultiSeries([])
         assert ms.alignment == sy.Alignment(0, 0)
 
-    def test_alignment_bounds_multiseries(self):
+    def test_alignment_bounds_multiseries(self) -> None:
         """Should correctly calculate alignment_bounds from first to last series"""
         s1 = sy.Series(
             [1, 2, 3],
@@ -557,28 +558,28 @@ class TestMultiSeries:
         assert bounds.lower == s1.alignment_bounds.lower
         assert bounds.upper == s2.alignment_bounds.upper
 
-    def test_alignment_bounds_empty_multiseries(self):
+    def test_alignment_bounds_empty_multiseries(self) -> None:
         """Should return Bounds(0, 0) for empty sy.MultiSeries"""
         ms = sy.MultiSeries([])
         bounds = ms.alignment_bounds
         assert bounds.lower == 0
         assert bounds.upper == 0
 
-    def test_empty_multiseries_to_numpy(self):
+    def test_empty_multiseries_to_numpy(self) -> None:
         """Should return an empty numpy array for empty sy.MultiSeries"""
         ms = sy.MultiSeries([])
         arr = ms.to_numpy()
         assert len(arr) == 0
         assert arr.dtype == np.float64
 
-    def test_empty_multiseries_to_numpy_with_dtype(self):
+    def test_empty_multiseries_to_numpy_with_dtype(self) -> None:
         """Should return an empty numpy array with specified dtype"""
         ms = sy.MultiSeries([])
-        arr = ms.to_numpy(dtype=np.int32)
+        arr = ms.to_numpy(dtype=np.dtype(np.int32))
         assert len(arr) == 0
         assert arr.dtype == np.int32
 
-    def test_single_series_copy_false(self):
+    def test_single_series_copy_false(self) -> None:
         """Should respect copy=False for single series MultiSeries"""
         s = sy.Series([1, 2, 3], data_type=sy.DataType.FLOAT64)
         ms = sy.MultiSeries([s])
@@ -586,7 +587,7 @@ class TestMultiSeries:
         arr2 = ms.__array__(copy=False)
         assert np.shares_memory(arr1, arr2)
 
-    def test_single_series_copy_true(self):
+    def test_single_series_copy_true(self) -> None:
         """Should create a copy when copy=True for single series MultiSeries"""
         s = sy.Series([1, 2, 3], data_type=sy.DataType.FLOAT64)
         ms = sy.MultiSeries([s])

--- a/x/py/tests/test_series.py
+++ b/x/py/tests/test_series.py
@@ -212,9 +212,7 @@ class TestSeries:
 
     def test_list_access_json(self):
         """Should correctly access the series by index"""
-        s = sy.Series(
-            [{"hello": "world"}, {"blue": "dog"}], data_type=sy.DataType.JSON
-        )
+        s = sy.Series([{"hello": "world"}, {"blue": "dog"}], data_type=sy.DataType.JSON)
         assert s[1] == {"blue": "dog"}
 
     def test_list_access_string_negative(self):
@@ -517,9 +515,7 @@ class TestMultiSeries:
         s1 = sy.Series(
             [{"hello": "world"}, {"blue": "dog"}], data_type=sy.DataType.JSON
         )
-        s2 = sy.Series(
-            [{"red": "car"}, {"green": "tree"}], data_type=sy.DataType.JSON
-        )
+        s2 = sy.Series([{"red": "car"}, {"green": "tree"}], data_type=sy.DataType.JSON)
         s = sy.MultiSeries([s1, s2])
         assert list(s) == [
             {"hello": "world"},

--- a/x/py/tests/test_series.py
+++ b/x/py/tests/test_series.py
@@ -13,7 +13,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-import x.telem as sy
+from x import telem
 
 
 @pytest.mark.telem
@@ -22,49 +22,49 @@ class TestSeries:
     def test_construction_from_np(self) -> None:
         """Should correctly construct a series from a primitive numpy array"""
         d = np.array([1, 2, 3, 4], dtype=np.int8)
-        s = sy.Series(d)
+        s = telem.Series(d)
         assert len(s) == 4
-        assert s.data_type == sy.DataType.INT8
+        assert s.data_type == telem.DataType.INT8
         assert s[3] == 4
 
     def test_construction_from_np_data_type_override(self) -> None:
         """Should correctly convert the numpy arrays data type"""
         d = np.array([1, 2, 3, 4], dtype=np.int8)
-        s = sy.Series(d, data_type=sy.DataType.FLOAT64)
+        s = telem.Series(d, data_type=telem.DataType.FLOAT64)
         assert len(s) == 4
-        assert s.data_type == sy.DataType.FLOAT64
+        assert s.data_type == telem.DataType.FLOAT64
         assert s[3] == 4
         assert s.__array__().dtype == np.float64
 
     def test_array_with_dtype(self) -> None:
         """Should convert to specified dtype when using __array__"""
-        s = sy.Series([1, 2, 3], data_type=sy.DataType.INT64)
+        s = telem.Series([1, 2, 3], data_type=telem.DataType.INT64)
         arr = s.__array__(dtype=np.dtype(np.float32))
         assert arr.dtype == np.float32
         assert list(arr) == [1.0, 2.0, 3.0]
 
     def test_array_with_copy_true(self) -> None:
         """Should return a copy when copy=True"""
-        s = sy.Series([1, 2, 3], data_type=sy.DataType.INT64)
+        s = telem.Series([1, 2, 3], data_type=telem.DataType.INT64)
         arr1 = s.__array__(copy=True)
         arr2 = s.__array__(copy=True)
         assert not np.shares_memory(arr1, arr2)
 
     def test_array_with_copy_false_same_dtype(self) -> None:
         """Should not copy when copy=False and no dtype conversion needed"""
-        s = sy.Series([1, 2, 3], data_type=sy.DataType.INT64)
+        s = telem.Series([1, 2, 3], data_type=telem.DataType.INT64)
         arr = s.__array__(copy=False)
         assert arr.dtype == np.int64
 
     def test_np_array_with_dtype(self) -> None:
         """Should work with np.array() and dtype parameter (NumPy 2.0 protocol)"""
-        s = sy.Series([1, 2, 3], data_type=sy.DataType.INT64)
+        s = telem.Series([1, 2, 3], data_type=telem.DataType.INT64)
         arr = np.array(s, dtype=np.float32)
         assert arr.dtype == np.float32
 
     def test_np_array_with_copy(self) -> None:
         """Should work with np.array() and copy parameter (NumPy 2.0 protocol)"""
-        s = sy.Series([1, 2, 3], data_type=sy.DataType.INT64)
+        s = telem.Series([1, 2, 3], data_type=telem.DataType.INT64)
         arr = np.array(s, copy=True)
         assert arr.dtype == np.int64
         assert list(arr) == [1, 2, 3]
@@ -72,167 +72,169 @@ class TestSeries:
     def test_construction_from_pd_series(self) -> None:
         """Should correctly construct the array from a pandas series"""
         d = pd.Series([1, 2, 3], dtype=np.float64)
-        s = sy.Series(d)
+        s = telem.Series(d)
         assert len(s) == 3
         assert s[2] == 3
-        assert s.data_type == sy.DataType.FLOAT64
+        assert s.data_type == telem.DataType.FLOAT64
 
     def test_construction_from_list(self) -> None:
         """Should correctly construct the array from a list"""
         d = [1, 2, 3]
-        s = sy.Series(d)
+        s = telem.Series(d)
         assert len(s) == 3
         assert s[2] == 3
-        assert s.data_type == sy.DataType.INT64
+        assert s.data_type == telem.DataType.INT64
 
     def test_construction_from_series(self) -> None:
-        """Should correctly construct the sy.Series from another sy.Series"""
-        d = sy.Series([1, 2, 3], data_type=sy.DataType.INT8, alignment=12)
-        s = sy.Series(d)
+        """Should correctly construct the telem.Series from another telem.Series"""
+        d = telem.Series([1, 2, 3], data_type=telem.DataType.INT8, alignment=12)
+        s = telem.Series(d)
         assert len(s) == 3
         assert s[2] == 3
-        assert s.data_type == sy.DataType.INT8
+        assert s.data_type == telem.DataType.INT8
         assert s.alignment == 12
 
     def test_construction_from_buffer(self) -> None:
-        """Should correctly construct the sy.Series from a buffer"""
-        d = sy.Series([1.0, 2.0, 3.0]).data
-        s = sy.Series(d, data_type=sy.DataType.FLOAT64)
+        """Should correctly construct the telem.Series from a buffer"""
+        d = telem.Series([1.0, 2.0, 3.0]).data
+        s = telem.Series(d, data_type=telem.DataType.FLOAT64)
         assert len(s) == 3
         assert s[2] == 3
-        assert s.data_type == sy.DataType.FLOAT64
+        assert s.data_type == telem.DataType.FLOAT64
 
     def test_construct_from_buffer_no_data_type(self) -> None:
         """Should throw a ValueError"""
         with pytest.raises(ValueError):
-            assert sy.Series(b"57678")
+            assert telem.Series(b"57678")
 
     def test_construction_from_np_timestamp(self) -> None:
-        d = sy.Series([sy.TimeStamp.now()])
+        d = telem.Series([telem.TimeStamp.now()])
         assert len(d) == 1
 
     def test_construction_from_int(self) -> None:
         """Should correctly construct the series from a single integer"""
-        d = sy.Series(1)
+        d = telem.Series(1)
         assert len(d) == 1
-        assert d.data_type == sy.DataType.INT64
+        assert d.data_type == telem.DataType.INT64
 
     def test_construction_from_int_with_dt(self) -> None:
         """Should correctly set a custom data type on the integer"""
-        d = sy.Series(1, data_type=sy.DataType.INT8)
+        d = telem.Series(1, data_type=telem.DataType.INT8)
         assert len(d) == 1
-        assert d.data_type == sy.DataType.INT8
+        assert d.data_type == telem.DataType.INT8
 
     def test_construction_from_float(self) -> None:
         """Should correctly construct the series from a single float"""
-        d = sy.Series(1.0)
+        d = telem.Series(1.0)
         assert len(d) == 1
-        assert d.data_type == sy.DataType.FLOAT64
+        assert d.data_type == telem.DataType.FLOAT64
 
     def test_construction_from_float_with_dt(self) -> None:
         """Should correctly set a custom data type on the float"""
-        d = sy.Series(1.0, data_type=sy.DataType.FLOAT32)
+        d = telem.Series(1.0, data_type=telem.DataType.FLOAT32)
         assert len(d) == 1
-        assert d.data_type == sy.DataType.FLOAT32
+        assert d.data_type == telem.DataType.FLOAT32
 
     def test_construction_from_strings(self) -> None:
         """Should correctly construct the series from a list of strings"""
-        d = sy.Series(["hello"])
+        d = telem.Series(["hello"])
         assert len(d) == 1
-        assert d.data_type == sy.DataType.STRING
+        assert d.data_type == telem.DataType.STRING
         assert d[0] == "hello"
 
     def test_construction_from_string(self) -> None:
         """Should correctly construct the series from a single string"""
-        d = sy.Series("hello")
+        d = telem.Series("hello")
         assert len(d) == 1
-        assert d.data_type == sy.DataType.STRING
+        assert d.data_type == telem.DataType.STRING
 
     def test_construction_from_dicts(self) -> None:
         """Should correctly construct the series from a list of dicts"""
-        d = sy.Series([{"hello": "world"}])
+        d = telem.Series([{"hello": "world"}])
         assert len(d) == 1
-        assert d.data_type == sy.DataType.JSON
+        assert d.data_type == telem.DataType.JSON
 
     def test_size(self) -> None:
         """Should return the correct number of bytes in the buffer"""
-        s = sy.Series([1, 2, 3], data_type=sy.DataType.INT16)
+        s = telem.Series([1, 2, 3], data_type=telem.DataType.INT16)
         assert s.size == 3 * 2
 
     def test_astype(self) -> None:
         """Should convert the series to a different data type"""
-        s = sy.Series([1, 2, 3], data_type=sy.DataType.INT16)
-        s = s.astype(sy.DataType.INT8)
+        s = telem.Series([1, 2, 3], data_type=telem.DataType.INT16)
+        s = s.astype(telem.DataType.INT8)
         assert s.size == 3
         assert s[0] == 1
 
     def test_cast_numeric_as_list(self) -> None:
         """Should correctly convert the series to a builtin list"""
-        s = sy.Series([1, 2, 3], data_type=sy.DataType.INT8)
+        s = telem.Series([1, 2, 3], data_type=telem.DataType.INT8)
         assert list(s) == [1, 2, 3]
 
     def test_cast_uuid_as_list(self) -> None:
         """Should correctly convert the series to a builtin list"""
         one = uuid.uuid4()
         two = uuid.uuid4()
-        s = sy.Series([one, two], data_type=sy.DataType.UUID)
+        s = telem.Series([one, two], data_type=telem.DataType.UUID)
         list_ = list(s)
         assert list_[0] == one
         assert list_[1] == two
 
     def test_cast_json_as_list(self) -> None:
         """Should correctly convert the series to a builtin list"""
-        s = sy.Series([{"hello": "world"}], data_type=sy.DataType.JSON)
+        s = telem.Series([{"hello": "world"}], data_type=telem.DataType.JSON)
         assert list(s) == [{"hello": "world"}]
 
     def test_cast_string_as_list(self) -> None:
         """Should correctly convert the series to a builtin list"""
-        s = sy.Series(["hello"], data_type=sy.DataType.STRING)
+        s = telem.Series(["hello"], data_type=telem.DataType.STRING)
         assert list(s) == ["hello"]
 
     def test_greater_than(self) -> None:
         """Should correctly compare the series to a scalar"""
-        s = sy.Series([1, 2, 3], data_type=sy.DataType.INT8)
+        s = telem.Series([1, 2, 3], data_type=telem.DataType.INT8)
         assert list(s.__array__() > 2) == [False, False, True]
 
     def test_less_than(self) -> None:
         """Should correctly compare the series to a scalar"""
-        s = sy.Series([1, 2, 3], data_type=sy.DataType.INT8)
+        s = telem.Series([1, 2, 3], data_type=telem.DataType.INT8)
         assert list(s.__array__() < 2) == [True, False, False]
 
     def test_list_access_numeric(self) -> None:
         """Should correctly access the series by index"""
-        s = sy.Series([1, 2, 3], data_type=sy.DataType.INT8)
+        s = telem.Series([1, 2, 3], data_type=telem.DataType.INT8)
         assert s[0] == 1
 
     def test_list_access_string(self) -> None:
         """Should correctly access the series by index"""
-        s = sy.Series(["hello", "world"], data_type=sy.DataType.STRING)
+        s = telem.Series(["hello", "world"], data_type=telem.DataType.STRING)
         assert s[1] == "world"
 
     def test_list_access_json(self) -> None:
         """Should correctly access the series by index"""
-        s = sy.Series([{"hello": "world"}, {"blue": "dog"}], data_type=sy.DataType.JSON)
+        s = telem.Series(
+            [{"hello": "world"}, {"blue": "dog"}], data_type=telem.DataType.JSON
+        )
         assert s[1] == {"blue": "dog"}
 
     def test_list_access_string_negative(self) -> None:
         """Should correctly access the series by index"""
-        s = sy.Series(["hello", "world"], data_type=sy.DataType.STRING)
+        s = telem.Series(["hello", "world"], data_type=telem.DataType.STRING)
         assert s[-1] == "world"
 
     def test_alignment_bounds_default(self) -> None:
         """Should correctly calculate alignment_bounds with default alignment"""
-        s = sy.Series([1, 2, 3, 4, 5], data_type=sy.DataType.INT8)
+        s = telem.Series([1, 2, 3, 4, 5], data_type=telem.DataType.INT8)
         bounds = s.alignment_bounds
         assert bounds.lower == 0
         assert bounds.upper == 5
 
     def test_alignment_bounds_with_alignment(self) -> None:
         """Should correctly calculate alignment_bounds with custom alignment"""
-        s = sy.Series(
+        s = telem.Series(
             [1, 2, 3],
-            data_type=sy.DataType.INT8,
-            alignment=sy.Alignment(2, 10),
+            data_type=telem.DataType.INT8,
+            alignment=telem.Alignment(2, 10),
         )
         bounds = s.alignment_bounds
         expected_start = (2 << 32) | 10
@@ -240,13 +242,13 @@ class TestSeries:
         assert bounds.upper == float(expected_start + 3)
 
     def test_alignment_preserved_from_series(self) -> None:
-        """Should preserve alignment when constructing from another sy.Series"""
-        s1 = sy.Series(
+        """Should preserve alignment when constructing from another telem.Series"""
+        s1 = telem.Series(
             [1, 2, 3],
-            data_type=sy.DataType.INT8,
-            alignment=sy.Alignment(1, 2),
+            data_type=telem.DataType.INT8,
+            alignment=telem.Alignment(1, 2),
         )
-        s2 = sy.Series(s1)
+        s2 = telem.Series(s1)
         assert s2.alignment == s1.alignment
 
 
@@ -258,7 +260,7 @@ class TestVariableLengthSeries:
     def test_string_multiple_values(self) -> None:
         """Should correctly round-trip multiple string values"""
         values = ["hello", "world", "foo"]
-        s = sy.Series(values)
+        s = telem.Series(values)
         assert len(s) == 3
         assert s[0] == "hello"
         assert s[1] == "world"
@@ -268,7 +270,7 @@ class TestVariableLengthSeries:
     def test_string_empty_strings(self) -> None:
         """Should correctly handle empty strings"""
         values = ["", "", ""]
-        s = sy.Series(values)
+        s = telem.Series(values)
         assert len(s) == 3
         assert s[0] == ""
         assert s[1] == ""
@@ -277,7 +279,7 @@ class TestVariableLengthSeries:
     def test_string_mixed_empty_and_nonempty(self) -> None:
         """Should handle a mix of empty and non-empty strings"""
         values = ["hello", "", "world", ""]
-        s = sy.Series(values)
+        s = telem.Series(values)
         assert len(s) == 4
         assert s[0] == "hello"
         assert s[1] == ""
@@ -287,21 +289,21 @@ class TestVariableLengthSeries:
 
     def test_string_single_value(self) -> None:
         """Should handle a single string in a list"""
-        s = sy.Series(["only"])
+        s = telem.Series(["only"])
         assert len(s) == 1
         assert s[0] == "only"
 
     def test_string_from_scalar(self) -> None:
         """Should construct from a bare string value"""
-        s = sy.Series("hello")
+        s = telem.Series("hello")
         assert len(s) == 1
         assert s[0] == "hello"
-        assert s.data_type == sy.DataType.STRING
+        assert s.data_type == telem.DataType.STRING
 
     def test_string_multibyte_utf8(self) -> None:
         """Should correctly handle multi-byte UTF-8 characters"""
         values = ["cafe\u0301", "\u00e9", "\U0001f600"]
-        s = sy.Series(values)
+        s = telem.Series(values)
         assert len(s) == 3
         assert s[0] == "cafe\u0301"
         assert s[1] == "\u00e9"
@@ -310,27 +312,27 @@ class TestVariableLengthSeries:
 
     def test_string_negative_index(self) -> None:
         """Should support negative indexing"""
-        s = sy.Series(["a", "b", "c"])
+        s = telem.Series(["a", "b", "c"])
         assert s[-1] == "c"
         assert s[-2] == "b"
         assert s[-3] == "a"
 
     def test_string_index_out_of_bounds(self) -> None:
         """Should raise IndexError for out-of-bounds access"""
-        s = sy.Series(["a", "b"])
+        s = telem.Series(["a", "b"])
         with pytest.raises(IndexError):
             s[2]
 
     def test_string_empty_series(self) -> None:
         """Should handle an empty string series"""
-        s = sy.Series([], data_type=sy.DataType.STRING)
+        s = telem.Series([], data_type=telem.DataType.STRING)
         assert len(s) == 0
         assert list(s) == []
 
     def test_string_large_value(self) -> None:
         """Should handle a string longer than 255 bytes"""
         big = "x" * 1000
-        s = sy.Series([big, "small"])
+        s = telem.Series([big, "small"])
         assert len(s) == 2
         assert s[0] == big
         assert s[1] == "small"
@@ -338,7 +340,7 @@ class TestVariableLengthSeries:
     def test_json_multiple_values(self) -> None:
         """Should correctly round-trip multiple JSON values"""
         values = [{"a": "1"}, {"b": "2"}, {"c": "3"}]
-        s = sy.Series(values)
+        s = telem.Series(values)
         assert len(s) == 3
         assert s[0] == {"a": "1"}
         assert s[1] == {"b": "2"}
@@ -347,62 +349,62 @@ class TestVariableLengthSeries:
 
     def test_json_from_scalar_dict(self) -> None:
         """Should construct from a bare dict value"""
-        s = sy.Series({"key": "val"})
+        s = telem.Series({"key": "val"})
         assert len(s) == 1
         assert s[0] == {"key": "val"}
-        assert s.data_type == sy.DataType.JSON
+        assert s.data_type == telem.DataType.JSON
 
     def test_json_empty_objects(self) -> None:
         """Should handle empty JSON objects"""
         values = [dict[str, str](), dict[str, str](), dict[str, str]()]
-        s = sy.Series(values)
+        s = telem.Series(values)
         assert len(s) == 3
         assert list(s) == values
 
     def test_json_negative_index(self) -> None:
         """Should support negative indexing for JSON series"""
-        s = sy.Series([{"a": 1}, {"b": 2}, {"c": 3}])
+        s = telem.Series([{"a": 1}, {"b": 2}, {"c": 3}])
         assert s[-1] == {"c": 3}
 
     def test_json_empty_series(self) -> None:
         """Should handle an empty JSON series"""
-        s = sy.Series([], data_type=sy.DataType.JSON)
+        s = telem.Series([], data_type=telem.DataType.JSON)
         assert len(s) == 0
         assert list(s) == []
 
     def test_json_index_out_of_bounds(self) -> None:
         """Should raise IndexError for out-of-bounds access"""
-        s = sy.Series([{"a": 1}])
+        s = telem.Series([{"a": 1}])
         with pytest.raises(IndexError):
             s[1]
 
     def test_string_len_cached(self) -> None:
         """Should cache the length computation for variable-length series"""
-        s = sy.Series(["a", "b", "c"])
+        s = telem.Series(["a", "b", "c"])
         assert len(s) == 3
         assert len(s) == 3
 
     def test_string_iteration_order(self) -> None:
         """Should iterate in insertion order"""
         values = ["first", "second", "third", "fourth"]
-        s = sy.Series(values)
+        s = telem.Series(values)
         assert [v for v in s] == values
 
     def test_json_iteration_order(self) -> None:
         """Should iterate JSON values in insertion order"""
         values = [{"i": 0}, {"i": 1}, {"i": 2}]
-        s = sy.Series(values)
+        s = telem.Series(values)
         assert [v for v in s] == values
 
     def test_string_size_bytes(self) -> None:
         """Should report the correct raw byte size including prefixes"""
-        s = sy.Series(["ab", "c"])
+        s = telem.Series(["ab", "c"])
         # "ab" = 4-byte prefix + 2 bytes, "c" = 4-byte prefix + 1 byte = 11
         assert s.size == 11
 
     def test_json_size_bytes(self) -> None:
         """Should report the correct raw byte size including prefixes"""
-        s = sy.Series([{"a": 1}])
+        s = telem.Series([{"a": 1}])
         import json
 
         encoded = json.dumps({"a": 1}).encode("utf-8")
@@ -413,84 +415,84 @@ class TestVariableLengthSeries:
 @pytest.mark.series
 class TestMultiSeries:
     def test_construction_from_multiple_series(self) -> None:
-        """Should correctly construct a sy.MultiSeries from multiple sy.Series :)"""
-        s1 = sy.Series([1, 2, 3], data_type=sy.DataType.INT8)
-        s2 = sy.Series([4, 5, 6], data_type=sy.DataType.INT8)
-        s = sy.MultiSeries([s1, s2])
+        """Should correctly construct a telem.MultiSeries from multiple telem.Series :)"""
+        s1 = telem.Series([1, 2, 3], data_type=telem.DataType.INT8)
+        s2 = telem.Series([4, 5, 6], data_type=telem.DataType.INT8)
+        s = telem.MultiSeries([s1, s2])
         assert len(s) == 6
 
     def test_construction_mismatched_data_types(self) -> None:
         """Should throw a ValueError"""
-        s1 = sy.Series([1, 2, 3], data_type=sy.DataType.INT8)
-        s2 = sy.Series([4, 5, 6], data_type=sy.DataType.INT16)
+        s1 = telem.Series([1, 2, 3], data_type=telem.DataType.INT8)
+        s2 = telem.Series([4, 5, 6], data_type=telem.DataType.INT16)
         with pytest.raises(ValueError):
-            sy.MultiSeries([s1, s2])
+            telem.MultiSeries([s1, s2])
 
     def test_construction_from_none(self) -> None:
         """Should throw a ValueError"""
-        s = sy.MultiSeries([])
+        s = telem.MultiSeries([])
         assert len(s) == 0
 
     def test_conversion_to_numpy(self) -> None:
-        """Should correctly convert the sy.MultiSeries to a numpy array"""
-        s1 = sy.Series([1, 2, 3], data_type=sy.DataType.INT8)
-        s2 = sy.Series([4, 5, 6], data_type=sy.DataType.INT8)
-        s = sy.MultiSeries([s1, s2])
+        """Should correctly convert the telem.MultiSeries to a numpy array"""
+        s1 = telem.Series([1, 2, 3], data_type=telem.DataType.INT8)
+        s2 = telem.Series([4, 5, 6], data_type=telem.DataType.INT8)
+        s = telem.MultiSeries([s1, s2])
         assert len(s.to_numpy()) == 6
         assert s.to_numpy().dtype == np.int8
 
     def test_array_with_dtype(self) -> None:
         """Should convert to specified dtype when using __array__"""
-        s1 = sy.Series([1, 2, 3], data_type=sy.DataType.INT8)
-        s2 = sy.Series([4, 5, 6], data_type=sy.DataType.INT8)
-        s = sy.MultiSeries([s1, s2])
+        s1 = telem.Series([1, 2, 3], data_type=telem.DataType.INT8)
+        s2 = telem.Series([4, 5, 6], data_type=telem.DataType.INT8)
+        s = telem.MultiSeries([s1, s2])
         arr = s.__array__(dtype=np.dtype(np.float32))
         assert arr.dtype == np.float32
         assert list(arr) == [1.0, 2.0, 3.0, 4.0, 5.0, 6.0]
 
     def test_np_array_with_dtype(self) -> None:
         """Should work with np.array() and dtype parameter (NumPy 2.0 protocol)"""
-        s1 = sy.Series([1, 2, 3], data_type=sy.DataType.INT8)
-        s2 = sy.Series([4, 5, 6], data_type=sy.DataType.INT8)
-        s = sy.MultiSeries([s1, s2])
+        s1 = telem.Series([1, 2, 3], data_type=telem.DataType.INT8)
+        s2 = telem.Series([4, 5, 6], data_type=telem.DataType.INT8)
+        s = telem.MultiSeries([s1, s2])
         arr = np.array(s, dtype=np.float64)
         assert arr.dtype == np.float64
 
     def test_np_array_with_copy(self) -> None:
         """Should work with np.array() and copy parameter (NumPy 2.0 protocol)"""
-        s1 = sy.Series([1, 2, 3], data_type=sy.DataType.INT8)
-        s2 = sy.Series([4, 5, 6], data_type=sy.DataType.INT8)
-        s = sy.MultiSeries([s1, s2])
+        s1 = telem.Series([1, 2, 3], data_type=telem.DataType.INT8)
+        s2 = telem.Series([4, 5, 6], data_type=telem.DataType.INT8)
+        s = telem.MultiSeries([s1, s2])
         arr = np.array(s, copy=True)
         assert arr.dtype == np.int8
         assert list(arr) == [1, 2, 3, 4, 5, 6]
 
     def test_time_range(self) -> None:
-        """Should correctly return the time range of the sy.MultiSeries"""
-        s1 = sy.Series(
+        """Should correctly return the time range of the telem.MultiSeries"""
+        s1 = telem.Series(
             data=[1, 2, 3],
-            data_type=sy.DataType.INT8,
-            time_range=sy.TimeRange(
-                start=1 * sy.TimeSpan.SECOND, end=3 * sy.TimeSpan.SECOND
+            data_type=telem.DataType.INT8,
+            time_range=telem.TimeRange(
+                start=1 * telem.TimeSpan.SECOND, end=3 * telem.TimeSpan.SECOND
             ),
         )
-        s2 = sy.Series(
+        s2 = telem.Series(
             data=[4, 5, 6],
-            data_type=sy.DataType.INT8,
-            time_range=sy.TimeRange(
-                start=4 * sy.TimeSpan.SECOND, end=6 * sy.TimeSpan.SECOND
+            data_type=telem.DataType.INT8,
+            time_range=telem.TimeRange(
+                start=4 * telem.TimeSpan.SECOND, end=6 * telem.TimeSpan.SECOND
             ),
         )
-        s = sy.MultiSeries([s1, s2])
+        s = telem.MultiSeries([s1, s2])
         assert s.time_range is not None
-        assert s.time_range.start == 1 * sy.TimeSpan.SECOND
-        assert s.time_range.end == 6 * sy.TimeSpan.SECOND
+        assert s.time_range.start == 1 * telem.TimeSpan.SECOND
+        assert s.time_range.end == 6 * telem.TimeSpan.SECOND
 
     def test_access_by_index(self) -> None:
-        """Should correctly access the sy.MultiSeries by index"""
-        s1 = sy.Series([1, 2, 3], data_type=sy.DataType.INT8)
-        s2 = sy.Series([4, 5, 6], data_type=sy.DataType.INT8)
-        s = sy.MultiSeries([s1, s2])
+        """Should correctly access the telem.MultiSeries by index"""
+        s1 = telem.Series([1, 2, 3], data_type=telem.DataType.INT8)
+        s2 = telem.Series([4, 5, 6], data_type=telem.DataType.INT8)
+        s = telem.MultiSeries([s1, s2])
         assert s[0] == 1
         assert s[1] == 2
         assert s[2] == 3
@@ -498,26 +500,28 @@ class TestMultiSeries:
         assert s[-1] == 6
 
     def test_conversion_to_list_string(self) -> None:
-        """Should correctly convert the sy.MultiSeries to a list of strings"""
-        s1 = sy.Series(["hello", "world"], data_type=sy.DataType.STRING)
-        s2 = sy.Series(["blue", "dog"], data_type=sy.DataType.STRING)
-        s = sy.MultiSeries([s1, s2])
+        """Should correctly convert the telem.MultiSeries to a list of strings"""
+        s1 = telem.Series(["hello", "world"], data_type=telem.DataType.STRING)
+        s2 = telem.Series(["blue", "dog"], data_type=telem.DataType.STRING)
+        s = telem.MultiSeries([s1, s2])
         assert list(s) == ["hello", "world", "blue", "dog"]
 
     def test_conversion_to_list_numeric(self) -> None:
-        """Should correctly convert the sy.MultiSeries to a list of numbers"""
-        s1 = sy.Series([1, 2, 3], data_type=sy.DataType.INT8)
-        s2 = sy.Series([4, 5, 6], data_type=sy.DataType.INT8)
-        s = sy.MultiSeries([s1, s2])
+        """Should correctly convert the telem.MultiSeries to a list of numbers"""
+        s1 = telem.Series([1, 2, 3], data_type=telem.DataType.INT8)
+        s2 = telem.Series([4, 5, 6], data_type=telem.DataType.INT8)
+        s = telem.MultiSeries([s1, s2])
         assert list(s) == [1, 2, 3, 4, 5, 6]
 
     def test_conversion_to_list_json(self) -> None:
-        """Should correctly convert the sy.MultiSeries to a list of dicts"""
-        s1 = sy.Series(
-            [{"hello": "world"}, {"blue": "dog"}], data_type=sy.DataType.JSON
+        """Should correctly convert the telem.MultiSeries to a list of dicts"""
+        s1 = telem.Series(
+            [{"hello": "world"}, {"blue": "dog"}], data_type=telem.DataType.JSON
         )
-        s2 = sy.Series([{"red": "car"}, {"green": "tree"}], data_type=sy.DataType.JSON)
-        s = sy.MultiSeries([s1, s2])
+        s2 = telem.Series(
+            [{"red": "car"}, {"green": "tree"}], data_type=telem.DataType.JSON
+        )
+        s = telem.MultiSeries([s1, s2])
         assert list(s) == [
             {"hello": "world"},
             {"blue": "dog"},
@@ -527,70 +531,70 @@ class TestMultiSeries:
 
     def test_alignment_from_first_series(self) -> None:
         """Should return the alignment of the first series"""
-        s1 = sy.Series(
-            [1, 2, 3], data_type=sy.DataType.INT8, alignment=sy.Alignment(1, 5)
+        s1 = telem.Series(
+            [1, 2, 3], data_type=telem.DataType.INT8, alignment=telem.Alignment(1, 5)
         )
-        s2 = sy.Series(
-            [4, 5, 6], data_type=sy.DataType.INT8, alignment=sy.Alignment(2, 10)
+        s2 = telem.Series(
+            [4, 5, 6], data_type=telem.DataType.INT8, alignment=telem.Alignment(2, 10)
         )
-        ms = sy.MultiSeries([s1, s2])
-        assert ms.alignment == sy.Alignment(1, 5)
+        ms = telem.MultiSeries([s1, s2])
+        assert ms.alignment == telem.Alignment(1, 5)
 
     def test_alignment_empty_multiseries(self) -> None:
-        """Should return sy.Alignment(0, 0) for empty sy.MultiSeries"""
-        ms = sy.MultiSeries([])
-        assert ms.alignment == sy.Alignment(0, 0)
+        """Should return telem.Alignment(0, 0) for empty telem.MultiSeries"""
+        ms = telem.MultiSeries([])
+        assert ms.alignment == telem.Alignment(0, 0)
 
     def test_alignment_bounds_multiseries(self) -> None:
         """Should correctly calculate alignment_bounds from first to last series"""
-        s1 = sy.Series(
+        s1 = telem.Series(
             [1, 2, 3],
-            data_type=sy.DataType.INT8,
-            alignment=sy.Alignment(1, 0),
+            data_type=telem.DataType.INT8,
+            alignment=telem.Alignment(1, 0),
         )
-        s2 = sy.Series(
+        s2 = telem.Series(
             [4, 5],
-            data_type=sy.DataType.INT8,
-            alignment=sy.Alignment(1, 10),
+            data_type=telem.DataType.INT8,
+            alignment=telem.Alignment(1, 10),
         )
-        ms = sy.MultiSeries([s1, s2])
+        ms = telem.MultiSeries([s1, s2])
         bounds = ms.alignment_bounds
         assert bounds.lower == s1.alignment_bounds.lower
         assert bounds.upper == s2.alignment_bounds.upper
 
     def test_alignment_bounds_empty_multiseries(self) -> None:
-        """Should return Bounds(0, 0) for empty sy.MultiSeries"""
-        ms = sy.MultiSeries([])
+        """Should return Bounds(0, 0) for empty telem.MultiSeries"""
+        ms = telem.MultiSeries([])
         bounds = ms.alignment_bounds
         assert bounds.lower == 0
         assert bounds.upper == 0
 
     def test_empty_multiseries_to_numpy(self) -> None:
-        """Should return an empty numpy array for empty sy.MultiSeries"""
-        ms = sy.MultiSeries([])
+        """Should return an empty numpy array for empty telem.MultiSeries"""
+        ms = telem.MultiSeries([])
         arr = ms.to_numpy()
         assert len(arr) == 0
         assert arr.dtype == np.float64
 
     def test_empty_multiseries_to_numpy_with_dtype(self) -> None:
         """Should return an empty numpy array with specified dtype"""
-        ms = sy.MultiSeries([])
+        ms = telem.MultiSeries([])
         arr = ms.to_numpy(dtype=np.dtype(np.int32))
         assert len(arr) == 0
         assert arr.dtype == np.int32
 
     def test_single_series_copy_false(self) -> None:
         """Should respect copy=False for single series MultiSeries"""
-        s = sy.Series([1, 2, 3], data_type=sy.DataType.FLOAT64)
-        ms = sy.MultiSeries([s])
+        s = telem.Series([1, 2, 3], data_type=telem.DataType.FLOAT64)
+        ms = telem.MultiSeries([s])
         arr1 = ms.__array__(copy=False)
         arr2 = ms.__array__(copy=False)
         assert np.shares_memory(arr1, arr2)
 
     def test_single_series_copy_true(self) -> None:
         """Should create a copy when copy=True for single series MultiSeries"""
-        s = sy.Series([1, 2, 3], data_type=sy.DataType.FLOAT64)
-        ms = sy.MultiSeries([s])
+        s = telem.Series([1, 2, 3], data_type=telem.DataType.FLOAT64)
+        ms = telem.MultiSeries([s])
         arr1 = ms.__array__(copy=True)
         arr2 = ms.__array__(copy=True)
         assert not np.shares_memory(arr1, arr2)

--- a/x/py/tests/test_series.py
+++ b/x/py/tests/test_series.py
@@ -13,7 +13,7 @@ import numpy as np
 import pandas as pd
 import pytest
 
-import synnax as sy
+import x.telem as sy
 
 
 @pytest.mark.telem
@@ -212,7 +212,9 @@ class TestSeries:
 
     def test_list_access_json(self):
         """Should correctly access the series by index"""
-        s = sy.Series([{"hello": "world"}, {"blue": "dog"}], data_type=sy.DataType.JSON)
+        s = sy.Series(
+            [{"hello": "world"}, {"blue": "dog"}], data_type=sy.DataType.JSON
+        )
         assert s[1] == {"blue": "dog"}
 
     def test_list_access_string_negative(self):
@@ -225,20 +227,19 @@ class TestSeries:
         s = sy.Series([1, 2, 3, 4, 5], data_type=sy.DataType.INT8)
         bounds = s.alignment_bounds
         assert bounds.lower == 0
-        assert bounds.upper == 5  # alignment(0) + length(5)
+        assert bounds.upper == 5
 
     def test_alignment_bounds_with_alignment(self):
         """Should correctly calculate alignment_bounds with custom alignment"""
         s = sy.Series(
             [1, 2, 3],
             data_type=sy.DataType.INT8,
-            alignment=sy.Alignment(2, 10),  # Start at domain 2, sample 10
+            alignment=sy.Alignment(2, 10),
         )
         bounds = s.alignment_bounds
-        # alignment = (2 << 32) | 10
         expected_start = (2 << 32) | 10
         assert bounds.lower == float(expected_start)
-        assert bounds.upper == float(expected_start + 3)  # + length
+        assert bounds.upper == float(expected_start + 3)
 
     def test_alignment_preserved_from_series(self):
         """Should preserve alignment when constructing from another sy.Series"""
@@ -249,6 +250,165 @@ class TestSeries:
         )
         s2 = sy.Series(s1)
         assert s2.alignment == s1.alignment
+
+
+@pytest.mark.telem
+@pytest.mark.series
+class TestVariableLengthSeries:
+    """Tests for variable-length series encoding (STRING, JSON)."""
+
+    def test_string_multiple_values(self):
+        """Should correctly round-trip multiple string values"""
+        values = ["hello", "world", "foo"]
+        s = sy.Series(values)
+        assert len(s) == 3
+        assert s[0] == "hello"
+        assert s[1] == "world"
+        assert s[2] == "foo"
+        assert list(s) == values
+
+    def test_string_empty_strings(self):
+        """Should correctly handle empty strings"""
+        values = ["", "", ""]
+        s = sy.Series(values)
+        assert len(s) == 3
+        assert s[0] == ""
+        assert s[1] == ""
+        assert list(s) == values
+
+    def test_string_mixed_empty_and_nonempty(self):
+        """Should handle a mix of empty and non-empty strings"""
+        values = ["hello", "", "world", ""]
+        s = sy.Series(values)
+        assert len(s) == 4
+        assert s[0] == "hello"
+        assert s[1] == ""
+        assert s[2] == "world"
+        assert s[3] == ""
+        assert list(s) == values
+
+    def test_string_single_value(self):
+        """Should handle a single string in a list"""
+        s = sy.Series(["only"])
+        assert len(s) == 1
+        assert s[0] == "only"
+
+    def test_string_from_scalar(self):
+        """Should construct from a bare string value"""
+        s = sy.Series("hello")
+        assert len(s) == 1
+        assert s[0] == "hello"
+        assert s.data_type == sy.DataType.STRING
+
+    def test_string_multibyte_utf8(self):
+        """Should correctly handle multi-byte UTF-8 characters"""
+        values = ["cafe\u0301", "\u00e9", "\U0001f600"]
+        s = sy.Series(values)
+        assert len(s) == 3
+        assert s[0] == "cafe\u0301"
+        assert s[1] == "\u00e9"
+        assert s[2] == "\U0001f600"
+        assert list(s) == values
+
+    def test_string_negative_index(self):
+        """Should support negative indexing"""
+        s = sy.Series(["a", "b", "c"])
+        assert s[-1] == "c"
+        assert s[-2] == "b"
+        assert s[-3] == "a"
+
+    def test_string_index_out_of_bounds(self):
+        """Should raise IndexError for out-of-bounds access"""
+        s = sy.Series(["a", "b"])
+        with pytest.raises(IndexError):
+            s[2]
+
+    def test_string_empty_series(self):
+        """Should handle an empty string series"""
+        s = sy.Series([], data_type=sy.DataType.STRING)
+        assert len(s) == 0
+        assert list(s) == []
+
+    def test_string_large_value(self):
+        """Should handle a string longer than 255 bytes"""
+        big = "x" * 1000
+        s = sy.Series([big, "small"])
+        assert len(s) == 2
+        assert s[0] == big
+        assert s[1] == "small"
+
+    def test_json_multiple_values(self):
+        """Should correctly round-trip multiple JSON values"""
+        values = [{"a": 1}, {"b": [2, 3]}, {"c": {"nested": True}}]
+        s = sy.Series(values)
+        assert len(s) == 3
+        assert s[0] == {"a": 1}
+        assert s[1] == {"b": [2, 3]}
+        assert s[2] == {"c": {"nested": True}}
+        assert list(s) == values
+
+    def test_json_from_scalar_dict(self):
+        """Should construct from a bare dict value"""
+        s = sy.Series({"key": "val"})
+        assert len(s) == 1
+        assert s[0] == {"key": "val"}
+        assert s.data_type == sy.DataType.JSON
+
+    def test_json_empty_objects(self):
+        """Should handle empty JSON objects"""
+        values = [{}, {}, {}]
+        s = sy.Series(values)
+        assert len(s) == 3
+        assert list(s) == values
+
+    def test_json_negative_index(self):
+        """Should support negative indexing for JSON series"""
+        s = sy.Series([{"a": 1}, {"b": 2}, {"c": 3}])
+        assert s[-1] == {"c": 3}
+
+    def test_json_empty_series(self):
+        """Should handle an empty JSON series"""
+        s = sy.Series([], data_type=sy.DataType.JSON)
+        assert len(s) == 0
+        assert list(s) == []
+
+    def test_json_index_out_of_bounds(self):
+        """Should raise IndexError for out-of-bounds access"""
+        s = sy.Series([{"a": 1}])
+        with pytest.raises(IndexError):
+            s[1]
+
+    def test_string_len_cached(self):
+        """Should cache the length computation for variable-length series"""
+        s = sy.Series(["a", "b", "c"])
+        assert len(s) == 3
+        assert len(s) == 3
+
+    def test_string_iteration_order(self):
+        """Should iterate in insertion order"""
+        values = ["first", "second", "third", "fourth"]
+        s = sy.Series(values)
+        assert [v for v in s] == values
+
+    def test_json_iteration_order(self):
+        """Should iterate JSON values in insertion order"""
+        values = [{"i": 0}, {"i": 1}, {"i": 2}]
+        s = sy.Series(values)
+        assert [v for v in s] == values
+
+    def test_string_size_bytes(self):
+        """Should report the correct raw byte size including prefixes"""
+        s = sy.Series(["ab", "c"])
+        # "ab" = 4-byte prefix + 2 bytes, "c" = 4-byte prefix + 1 byte = 11
+        assert s.size == 11
+
+    def test_json_size_bytes(self):
+        """Should report the correct raw byte size including prefixes"""
+        s = sy.Series([{"a": 1}])
+        import json
+
+        encoded = json.dumps({"a": 1}).encode("utf-8")
+        assert s.size == 4 + len(encoded)
 
 
 @pytest.mark.telem
@@ -357,7 +517,9 @@ class TestMultiSeries:
         s1 = sy.Series(
             [{"hello": "world"}, {"blue": "dog"}], data_type=sy.DataType.JSON
         )
-        s2 = sy.Series([{"red": "car"}, {"green": "tree"}], data_type=sy.DataType.JSON)
+        s2 = sy.Series(
+            [{"red": "car"}, {"green": "tree"}], data_type=sy.DataType.JSON
+        )
         s = sy.MultiSeries([s1, s2])
         assert list(s) == [
             {"hello": "world"},
@@ -396,9 +558,7 @@ class TestMultiSeries:
         )
         ms = sy.MultiSeries([s1, s2])
         bounds = ms.alignment_bounds
-        # Lower should be from first series
         assert bounds.lower == s1.alignment_bounds.lower
-        # Upper should be from last series
         assert bounds.upper == s2.alignment_bounds.upper
 
     def test_alignment_bounds_empty_multiseries(self):
@@ -428,7 +588,6 @@ class TestMultiSeries:
         ms = sy.MultiSeries([s])
         arr1 = ms.__array__(copy=False)
         arr2 = ms.__array__(copy=False)
-        # With copy=False on single series, both should share the same buffer
         assert np.shares_memory(arr1, arr2)
 
     def test_single_series_copy_true(self):
@@ -437,5 +596,4 @@ class TestMultiSeries:
         ms = sy.MultiSeries([s])
         arr1 = ms.__array__(copy=True)
         arr2 = ms.__array__(copy=True)
-        # With copy=True, they should not share memory
         assert not np.shares_memory(arr1, arr2)

--- a/x/py/x/telem/series.py
+++ b/x/py/x/telem/series.py
@@ -305,9 +305,11 @@ CrudeSeries: TypeAlias = (
     | pd.Series
     | np.ndarray
     | list[float]
+    | list[int]
     | list[str]
     | list[dict[str, Any]]
     | list[uuid.UUID]
+    | list[TimeStamp]
     | np.number
     | str
     | uuid.UUID

--- a/x/py/x/telem/series.py
+++ b/x/py/x/telem/series.py
@@ -67,7 +67,14 @@ class Series(BaseModel):
         if not self.data_type.is_variable:
             return self.data_type.density.sample_count(len(self.data))
         if self.__len_cache is None:
-            self.__len_cache = self.data.count(b"\n")
+            count = 0
+            offset = 0
+            d = self.data
+            while offset + 4 <= len(d):
+                length = int.from_bytes(d[offset : offset + 4], "little")
+                offset += 4 + length
+                count += 1
+            self.__len_cache = count
         return self.__len_cache
 
     def __init__(
@@ -110,11 +117,15 @@ class Series(BaseModel):
         elif isinstance(data, list):
             data_type = data_type or DataType(data)
             if data_type == DataType.JSON:
-                data_ = (
-                    b"\n".join([json.dumps(d).encode("utf-8") for d in data]) + b"\n"
+                parts = [json.dumps(d).encode("utf-8") for d in data]
+                data_ = b"".join(
+                    len(p).to_bytes(4, "little") + p for p in parts
                 )
             elif data_type == DataType.STRING:
-                data_ = b"\n".join([str(d).encode("utf-8") for d in data]) + b"\n"
+                parts = [str(d).encode("utf-8") for d in data]
+                data_ = b"".join(
+                    len(p).to_bytes(4, "little") + p for p in parts
+                )
             elif data_type == DataType.UUID:
                 uuids = [d for d in data if isinstance(d, uuid.UUID)]
                 data_ = b"".join(d.bytes for d in uuids)
@@ -126,9 +137,11 @@ class Series(BaseModel):
             data_ = data.bytes
         elif isinstance(data, dict):
             data_type = data_type or DataType.JSON
-            data_ = json.dumps(data).encode("utf-8") + b"\n"
+            encoded = json.dumps(data).encode("utf-8")
+            data_ = len(encoded).to_bytes(4, "little") + encoded
         elif isinstance(data, str):
-            data_ = bytes(f"{data}\n", "utf-8")
+            encoded = data.encode("utf-8")
+            data_ = len(encoded).to_bytes(4, "little") + encoded
             data_type = DataType.STRING
         else:
             if data_type is None:
@@ -183,53 +196,48 @@ class Series(BaseModel):
             return uuid.UUID(bytes=d)
 
         if self.data_type == DataType.JSON:
-            d = self.__newline_getitem__(index)
+            d = self.__variable_getitem__(index)
             return json.loads(d)  # type: ignore[no-any-return]
 
         if self.data_type == DataType.STRING:
-            d = self.__newline_getitem__(index)
+            d = self.__variable_getitem__(index)
             return d.decode("utf-8")
 
         return self.__array__()[index]  # type: ignore[no-any-return]
 
-    def __newline_getitem__(self, index: int) -> bytes:
-        if index == 0:
-            start = 0
-        else:
-            start = self.data.find(b"\n")
-            while start >= 0 and index > 1:
-                start = self.data.find(b"\n", start + 1)
-                index -= 1
-            start += 1
-
-        if start < 0:
-            raise IndexError(f"[Series] - Index {index} out of bounds")
-
-        end = self.data.find(b"\n", start)
-        if end < 0:
-            end = len(self.data)
-        return self.data[start:end]
+    def __variable_getitem__(self, index: int) -> bytes:
+        offset = 0
+        d = self.data
+        current = 0
+        while offset + 4 <= len(d):
+            length = int.from_bytes(d[offset : offset + 4], "little")
+            offset += 4
+            if current == index:
+                return d[offset : offset + length]
+            offset += length
+            current += 1
+        raise IndexError(f"[Series] - Index {index} out of bounds")
 
     def __iter__(self) -> Iterator[SampleValue]:  # type: ignore[override]
         if self.data_type == DataType.UUID:
             yield from [self[i] for i in range(len(self))]
         elif self.data_type == DataType.JSON:
-            for v in self.__iter__newline():
+            for v in self.__iter__variable():
                 yield json.loads(v)
         elif self.data_type == DataType.STRING:
-            for v in self.__iter__newline():
+            for v in self.__iter__variable():
                 yield v.decode("utf-8")
         else:
             yield from self.__array__()
 
-    def __iter__newline(self) -> Iterator[bytes]:
-        curr = 0
-        while curr < len(self.data):
-            end = self.data.find(b"\n", curr)
-            if end < 0:
-                end = len(self.data)
-            yield self.data[curr:end]
-            curr = end + 1
+    def __iter__variable(self) -> Iterator[bytes]:
+        offset = 0
+        d = self.data
+        while offset + 4 <= len(d):
+            length = int.from_bytes(d[offset : offset + 4], "little")
+            offset += 4
+            yield d[offset : offset + length]
+            offset += length
 
     def __str__(self) -> str:
         return str(list(self))

--- a/x/py/x/telem/series.py
+++ b/x/py/x/telem/series.py
@@ -118,14 +118,10 @@ class Series(BaseModel):
             data_type = data_type or DataType(data)
             if data_type == DataType.JSON:
                 parts = [json.dumps(d).encode("utf-8") for d in data]
-                data_ = b"".join(
-                    len(p).to_bytes(4, "little") + p for p in parts
-                )
+                data_ = b"".join(len(p).to_bytes(4, "little") + p for p in parts)
             elif data_type == DataType.STRING:
                 parts = [str(d).encode("utf-8") for d in data]
-                data_ = b"".join(
-                    len(p).to_bytes(4, "little") + p for p in parts
-                )
+                data_ = b"".join(len(p).to_bytes(4, "little") + p for p in parts)
             elif data_type == DataType.UUID:
                 uuids = [d for d in data if isinstance(d, uuid.UUID)]
                 data_ = b"".join(d.bytes for d in uuids)

--- a/x/py/x/telem/series.py
+++ b/x/py/x/telem/series.py
@@ -32,6 +32,8 @@ from x.telem.telem import (
     TimeStamp,
 )
 
+VARIABLE_LENGTH_PREFIX_SIZE = 4
+
 
 class Series(BaseModel):
     """Series is a strongly typed array of telemetry samples backed by an underlying
@@ -70,9 +72,11 @@ class Series(BaseModel):
             count = 0
             offset = 0
             d = self.data
-            while offset + 4 <= len(d):
-                length = int.from_bytes(d[offset : offset + 4], "little")
-                offset += 4 + length
+            while offset + VARIABLE_LENGTH_PREFIX_SIZE <= len(d):
+                length = int.from_bytes(
+                    d[offset : offset + VARIABLE_LENGTH_PREFIX_SIZE], "little"
+                )
+                offset += VARIABLE_LENGTH_PREFIX_SIZE + length
                 count += 1
             self.__len_cache = count
         return self.__len_cache
@@ -118,10 +122,16 @@ class Series(BaseModel):
             data_type = data_type or DataType(data)
             if data_type == DataType.JSON:
                 parts = [json.dumps(d).encode("utf-8") for d in data]
-                data_ = b"".join(len(p).to_bytes(4, "little") + p for p in parts)
+                data_ = b"".join(
+                    len(p).to_bytes(VARIABLE_LENGTH_PREFIX_SIZE, "little") + p
+                    for p in parts
+                )
             elif data_type == DataType.STRING:
                 parts = [str(d).encode("utf-8") for d in data]
-                data_ = b"".join(len(p).to_bytes(4, "little") + p for p in parts)
+                data_ = b"".join(
+                    len(p).to_bytes(VARIABLE_LENGTH_PREFIX_SIZE, "little") + p
+                    for p in parts
+                )
             elif data_type == DataType.UUID:
                 uuids = [d for d in data if isinstance(d, uuid.UUID)]
                 data_ = b"".join(d.bytes for d in uuids)
@@ -134,10 +144,14 @@ class Series(BaseModel):
         elif isinstance(data, dict):
             data_type = data_type or DataType.JSON
             encoded = json.dumps(data).encode("utf-8")
-            data_ = len(encoded).to_bytes(4, "little") + encoded
+            data_ = (
+                len(encoded).to_bytes(VARIABLE_LENGTH_PREFIX_SIZE, "little") + encoded
+            )
         elif isinstance(data, str):
             encoded = data.encode("utf-8")
-            data_ = len(encoded).to_bytes(4, "little") + encoded
+            data_ = (
+                len(encoded).to_bytes(VARIABLE_LENGTH_PREFIX_SIZE, "little") + encoded
+            )
             data_type = DataType.STRING
         else:
             if data_type is None:
@@ -205,9 +219,11 @@ class Series(BaseModel):
         offset = 0
         d = self.data
         current = 0
-        while offset + 4 <= len(d):
-            length = int.from_bytes(d[offset : offset + 4], "little")
-            offset += 4
+        while offset + VARIABLE_LENGTH_PREFIX_SIZE <= len(d):
+            length = int.from_bytes(
+                d[offset : offset + VARIABLE_LENGTH_PREFIX_SIZE], "little"
+            )
+            offset += VARIABLE_LENGTH_PREFIX_SIZE
             if current == index:
                 return d[offset : offset + length]
             offset += length
@@ -229,9 +245,11 @@ class Series(BaseModel):
     def __iter__variable(self) -> Iterator[bytes]:
         offset = 0
         d = self.data
-        while offset + 4 <= len(d):
-            length = int.from_bytes(d[offset : offset + 4], "little")
-            offset += 4
+        while offset + VARIABLE_LENGTH_PREFIX_SIZE <= len(d):
+            length = int.from_bytes(
+                d[offset : offset + VARIABLE_LENGTH_PREFIX_SIZE], "little"
+            )
+            offset += VARIABLE_LENGTH_PREFIX_SIZE
             yield d[offset : offset + length]
             offset += length
 

--- a/x/ts/src/telem/series.spec.ts
+++ b/x/ts/src/telem/series.spec.ts
@@ -689,6 +689,54 @@ describe("Series", () => {
         { a: 3, b: "carrot" },
       ]);
     });
+
+    it("should handle a single JSON value", () => {
+      const s = new Series([{ key: "val" }]);
+      expect(s.length).toEqual(1);
+      expect(s.at(0)).toEqual({ key: "val" });
+    });
+
+    it("should handle empty JSON objects", () => {
+      const s = new Series([{}, {}, {}]);
+      expect(s.length).toEqual(3);
+      expect(s.at(0)).toEqual({});
+      expect(s.at(2)).toEqual({});
+    });
+
+    it("should support negative indexing", () => {
+      const s = new Series([{ a: 1 }, { a: 2 }, { a: 3 }]);
+      expect(s.at(-1)).toEqual({ a: 3 });
+      expect(s.at(-2)).toEqual({ a: 2 });
+    });
+
+    it("should handle an empty JSON series", () => {
+      const s = new Series({ data: new ArrayBuffer(0), dataType: DataType.JSON });
+      expect(s.length).toEqual(0);
+      expect(Array.from(s)).toEqual([]);
+    });
+  });
+
+  describe("bytes series", () => {
+    it("should handle an empty bytes series", () => {
+      const s = new Series({ data: new ArrayBuffer(0), dataType: DataType.BYTES });
+      expect(s.length).toEqual(0);
+      expect(Array.from(s)).toEqual([]);
+    });
+
+    it("should correctly compute the length of a bytes series from a length-prefixed buffer", () => {
+      const payload1 = new Uint8Array([1, 2, 3]);
+      const payload2 = new Uint8Array([4, 5]);
+      const totalBytes = 4 + payload1.byteLength + 4 + payload2.byteLength;
+      const buf = new ArrayBuffer(totalBytes);
+      const view = new DataView(buf);
+      const bytes = new Uint8Array(buf);
+      view.setUint32(0, payload1.byteLength, true);
+      bytes.set(payload1, 4);
+      view.setUint32(4 + payload1.byteLength, payload2.byteLength, true);
+      bytes.set(payload2, 4 + payload1.byteLength + 4);
+      const s = new Series({ data: buf, dataType: DataType.BYTES });
+      expect(s.length).toEqual(2);
+    });
   });
 
   describe("binarySearch", () => {

--- a/x/ts/src/telem/series.spec.ts
+++ b/x/ts/src/telem/series.spec.ts
@@ -141,7 +141,7 @@ describe("Series", () => {
       const s = new Series({ data: [{ a: 1, b: "apple" }] });
       expect(s.dataType.equals(DataType.JSON));
       expect(s.length).toEqual(1);
-      expect(s.data.at(-1)).toEqual(10);
+      expect(s.at(0)).toEqual({ a: 1, b: "apple" });
     });
 
     it("should correctly interpret a bigint as an int64", () => {
@@ -214,8 +214,8 @@ describe("Series", () => {
 
     it("should convert encoded keys to snake_case", () => {
       const a = new Series({ data: [{ aB: 1, bC: "apple" }], dataType: DataType.JSON });
-      const strContent = new TextDecoder().decode(a.data);
-      expect(strContent).toBe('{"a_b":1,"b_c":"apple"}\n');
+      expect(a.length).toEqual(1);
+      expect(a.at(0)).toEqual({ aB: 1, bC: "apple" });
     });
 
     it("should throw an error when an empty JS array is provided and no data type is provided", () => {
@@ -502,7 +502,7 @@ describe("Series", () => {
     });
 
     it("should recompute the length of a variable density array", () => {
-      const series = Series.alloc({ capacity: 12, dataType: DataType.STRING });
+      const series = Series.alloc({ capacity: 18, dataType: DataType.STRING });
       expect(series.length).toEqual(0);
       const writeOne = new Series({ data: ["apple"] });
       expect(series.write(writeOne)).toEqual(1);

--- a/x/ts/src/telem/series.ts
+++ b/x/ts/src/telem/series.ts
@@ -114,7 +114,7 @@ const nullArrayZ = z
   .union([z.null(), z.undefined()])
   .transform(() => new Uint8Array().buffer);
 
-const NEW_LINE = 10;
+const UINT32_SIZE = 4;
 
 type JSType = "string" | "number" | "bigint";
 
@@ -358,12 +358,36 @@ export class Series<T extends TelemValue = TelemValue>
         data_ = data_.map((v) => new TimeStamp(v as CrudeTimeStamp).valueOf());
       if (this.dataType.equals(DataType.STRING)) {
         this.cachedLength = data_.length;
-        this._data = new TextEncoder().encode(`${data_.join("\n")}\n`).buffer;
+        const encoded = (data_ as string[]).map((s) => new TextEncoder().encode(s));
+        const totalBytes = encoded.reduce((acc, e) => acc + UINT32_SIZE + e.byteLength, 0);
+        const buf = new ArrayBuffer(totalBytes);
+        const view = new DataView(buf);
+        const bytes = new Uint8Array(buf);
+        let offset = 0;
+        for (const e of encoded) {
+          view.setUint32(offset, e.byteLength, true);
+          offset += UINT32_SIZE;
+          bytes.set(e, offset);
+          offset += e.byteLength;
+        }
+        this._data = buf;
       } else if (this.dataType.equals(DataType.JSON)) {
         this.cachedLength = data_.length;
-        this._data = new TextEncoder().encode(
-          `${data_.map((d) => binary.JSON_CODEC.encodeString(d)).join("\n")}\n`,
-        ).buffer;
+        const encoded = data_.map((d) =>
+          new TextEncoder().encode(binary.JSON_CODEC.encodeString(d)),
+        );
+        const totalBytes = encoded.reduce((acc, e) => acc + UINT32_SIZE + e.byteLength, 0);
+        const buf = new ArrayBuffer(totalBytes);
+        const view = new DataView(buf);
+        const bytes = new Uint8Array(buf);
+        let offset = 0;
+        for (const e of encoded) {
+          view.setUint32(offset, e.byteLength, true);
+          offset += UINT32_SIZE;
+          bytes.set(e, offset);
+          offset += e.byteLength;
+        }
+        this._data = buf;
       } else if (this.dataType.usesBigInt && typeof first === "number")
         this._data = new this.dataType.Array(
           data_.map((v) => BigInt(Math.round(v as number))),
@@ -456,14 +480,25 @@ export class Series<T extends TelemValue = TelemValue>
   private writeVariable(other: Series): number {
     if (this.writePos === FULL_BUFFER) return 0;
     const available = this.byteCapacity.valueOf() - this.writePos;
-    const toWrite = other.subBytes(0, available);
-    this.writeToUnderlyingData(toWrite);
-    this.writePos += toWrite.byteLength.valueOf();
-    if (this.cachedLength != null) {
-      this.cachedLength += toWrite.length;
-      this.calculateCachedLength();
+    const otherBuf = other.buffer;
+    const otherByteLen = other.byteLength.valueOf();
+    const view = new DataView(otherBuf);
+    let offset = 0;
+    let samplesWritten = 0;
+    while (offset + UINT32_SIZE <= otherByteLen) {
+      const sampleLen = view.getUint32(offset, true);
+      const recordSize = UINT32_SIZE + sampleLen;
+      if (offset + recordSize > available) break;
+      offset += recordSize;
+      samplesWritten++;
     }
-    return toWrite.length;
+    if (offset === 0) return 0;
+    const toWrite = other.subBytes(0, offset);
+    this.writeToUnderlyingData(toWrite);
+    this.writePos += offset;
+    this.cachedLength = (this.cachedLength ?? 0) + samplesWritten;
+    this._cachedIndexes = undefined;
+    return samplesWritten;
   }
 
   private writeFixed(other: Series): number {
@@ -511,8 +546,21 @@ export class Series<T extends TelemValue = TelemValue>
    * @returns An array of string representations of the series values.
    */
   toStrings(): string[] {
-    if (this.dataType.isVariable)
-      return new TextDecoder().decode(this.underlyingData).split("\n").slice(0, -1);
+    if (this.dataType.isVariable) {
+      const result: string[] = [];
+      const buf = this.buffer;
+      const byteLen = this.byteLength.valueOf();
+      const view = new DataView(buf);
+      const decoder = new TextDecoder();
+      let offset = 0;
+      while (offset + UINT32_SIZE <= byteLen) {
+        const len = view.getUint32(offset, true);
+        offset += UINT32_SIZE;
+        result.push(decoder.decode(new Uint8Array(buf, offset, len)));
+        offset += len;
+      }
+      return result;
+    }
     return Array.from(this).map((d) => d.toString());
   }
 
@@ -575,12 +623,18 @@ export class Series<T extends TelemValue = TelemValue>
     if (!this.dataType.isVariable)
       throw new Error("cannot calculate length of a non-variable length data type");
     let cl = 0;
-    const ci: number[] = [0];
-    this.data.forEach((v, i) => {
-      if (v !== NEW_LINE) return;
+    const ci: number[] = [];
+    const buf = this.buffer;
+    const byteLen = this.byteLength.valueOf();
+    const view = new DataView(buf);
+    let offset = 0;
+    while (offset + UINT32_SIZE <= byteLen) {
+      const len = view.getUint32(offset, true);
+      offset += UINT32_SIZE;
+      ci.push(offset);
+      offset += len;
       cl++;
-      ci.push(i + 1);
-    });
+    }
     this._cachedIndexes = ci;
     this.cachedLength = cl;
     return cl;
@@ -742,28 +796,40 @@ export class Series<T extends TelemValue = TelemValue>
 
   private atVariable(index: number, required: boolean): T | undefined {
     let start = 0;
-    let end = 0;
+    let len = 0;
+    const buf = this.buffer;
+    const view = new DataView(buf);
     if (this._cachedIndexes != null) {
+      if (index < 0) index = this._cachedIndexes.length + index;
+      if (index < 0 || index >= this._cachedIndexes.length) {
+        if (required) throw new Error(`[series] - no value at index ${index}`);
+        return undefined;
+      }
       start = this._cachedIndexes[index];
-      end = this._cachedIndexes[index + 1] - 1;
+      len = view.getUint32(start - UINT32_SIZE, true);
     } else {
       if (index < 0) index = this.length + index;
-      for (let i = 0; i < this.data.length; i++)
-        if (this.data[i] === NEW_LINE) {
-          if (index === 0) {
-            end = i;
-            break;
-          }
-          start = i + 1;
-          index--;
+      const byteLen = this.byteLength.valueOf();
+      let offset = 0;
+      let found = false;
+      while (offset + UINT32_SIZE <= byteLen) {
+        const sampleLen = view.getUint32(offset, true);
+        offset += UINT32_SIZE;
+        if (index === 0) {
+          start = offset;
+          len = sampleLen;
+          found = true;
+          break;
         }
-      if (end === 0) end = this.data.length;
-      if (start >= end || index > 0) {
+        offset += sampleLen;
+        index--;
+      }
+      if (!found) {
         if (required) throw new Error(`[series] - no value at index ${index}`);
         return undefined;
       }
     }
-    const slice = this.data.slice(start, end);
+    const slice = new Uint8Array(buf, start, len);
     if (this.dataType.equals(DataType.STRING))
       return new TextDecoder().decode(slice) as T;
     return caseconv.snakeToCamel(JSON.parse(new TextDecoder().decode(slice))) as T;
@@ -1069,8 +1135,9 @@ class SubIterator<T> implements Iterator<T> {
 
 class StringSeriesIterator implements Iterator<string> {
   private readonly series: Series;
-  private index: number;
+  private byteOffset: number;
   private readonly decoder: TextDecoder;
+  private readonly view: DataView;
 
   constructor(series: Series) {
     if (!series.dataType.isVariable)
@@ -1078,18 +1145,20 @@ class StringSeriesIterator implements Iterator<string> {
         "cannot create a variable series iterator for a non-variable series",
       );
     this.series = series;
-    this.index = 0;
+    this.byteOffset = 0;
     this.decoder = new TextDecoder();
+    this.view = new DataView(series.buffer);
   }
 
   next(): IteratorResult<string> {
-    const start = this.index;
-    const data = this.series.data;
-    while (this.index < data.length && data[this.index] !== NEW_LINE) this.index++;
-    const end = this.index;
-    if (start === end) return { done: true, value: undefined };
-    this.index++;
-    const s = this.decoder.decode(this.series.buffer.slice(start, end));
+    const byteLen = this.series.byteLength.valueOf();
+    if (this.byteOffset + UINT32_SIZE > byteLen) return { done: true, value: undefined };
+    const len = this.view.getUint32(this.byteOffset, true);
+    this.byteOffset += UINT32_SIZE;
+    const s = this.decoder.decode(
+      new Uint8Array(this.series.buffer, this.byteOffset, len),
+    );
+    this.byteOffset += len;
     return { done: false, value: s };
   }
 }

--- a/x/ts/src/telem/series.ts
+++ b/x/ts/src/telem/series.ts
@@ -359,7 +359,10 @@ export class Series<T extends TelemValue = TelemValue>
       if (this.dataType.equals(DataType.STRING)) {
         this.cachedLength = data_.length;
         const encoded = (data_ as string[]).map((s) => new TextEncoder().encode(s));
-        const totalBytes = encoded.reduce((acc, e) => acc + UINT32_SIZE + e.byteLength, 0);
+        const totalBytes = encoded.reduce(
+          (acc, e) => acc + UINT32_SIZE + e.byteLength,
+          0,
+        );
         const buf = new ArrayBuffer(totalBytes);
         const view = new DataView(buf);
         const bytes = new Uint8Array(buf);
@@ -376,7 +379,10 @@ export class Series<T extends TelemValue = TelemValue>
         const encoded = data_.map((d) =>
           new TextEncoder().encode(binary.JSON_CODEC.encodeString(d)),
         );
-        const totalBytes = encoded.reduce((acc, e) => acc + UINT32_SIZE + e.byteLength, 0);
+        const totalBytes = encoded.reduce(
+          (acc, e) => acc + UINT32_SIZE + e.byteLength,
+          0,
+        );
         const buf = new ArrayBuffer(totalBytes);
         const view = new DataView(buf);
         const bytes = new Uint8Array(buf);
@@ -1152,7 +1158,8 @@ class StringSeriesIterator implements Iterator<string> {
 
   next(): IteratorResult<string> {
     const byteLen = this.series.byteLength.valueOf();
-    if (this.byteOffset + UINT32_SIZE > byteLen) return { done: true, value: undefined };
+    if (this.byteOffset + UINT32_SIZE > byteLen)
+      return { done: true, value: undefined };
     const len = this.view.getUint32(this.byteOffset, true);
     this.byteOffset += UINT32_SIZE;
     const s = this.decoder.decode(

--- a/x/ts/src/telem/series.ts
+++ b/x/ts/src/telem/series.ts
@@ -608,7 +608,7 @@ export class Series<T extends TelemValue = TelemValue>
 
   /**
    * Returns the number of samples in this array.
-   * For variable length data types, this is calculated by counting newlines.
+   * For variable length data types, this is calculated by scanning uint32 length prefixes.
    * @returns The number of samples in the series.
    */
   get length(): number {

--- a/x/ts/src/telem/telem.ts
+++ b/x/ts/src/telem/telem.ts
@@ -2014,14 +2014,14 @@ export class DataType
   static readonly TIMESTAMP = new DataType("timestamp");
   /** Represents a UUID data type. */
   static readonly UUID = new DataType("uuid");
-  /** Represents a string data type. Strings have an unknown density, and are separate
-   * by a newline character. */
+  /** Represents a string data type. Strings have an unknown density and are encoded
+   * as uint32-length-prefixed samples. */
   static readonly STRING = new DataType("string");
-  /** Represents a JSON data type. JSON has an unknown density, and is separated by a
-   * newline character. */
+  /** Represents a JSON data type. JSON has an unknown density and is encoded as
+   * uint32-length-prefixed samples. */
   static readonly JSON = new DataType("json");
   /** Represents a bytes data type for arbitrary byte arrays. Bytes have an unknown
-   * density, and are separated by a newline character. */
+   * density and are encoded as uint32-length-prefixed samples. */
   static readonly BYTES = new DataType("bytes");
 
   private static readonly ARRAY_CONSTRUCTORS: Map<string, TypedArrayConstructor> =


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4059](https://linear.app/synnaxlabs/issue/SY-4059)

## Description

Switches the encoding format for variable-length Series types (`StringT`, `JSONT`,
`BytesT`) from newline-delimited to uint32-length-prefixed across all four languages
(Go, Python, TypeScript, C++).

The previous newline-delimited encoding (`sample\nsample\n`) is broken when sample data
contains literal newlines, which is common in JSON and multi-line strings. The new format
(`[uint32 LE length][bytes][uint32 LE length][bytes]...`) is binary-safe with 4 bytes of
overhead per sample.

Changes per language:
- **Go** (`x/go/telem/`): `marshalVariable`, `unmarshalVariable`, `Len`, `Samples`,
  `At`, `Downsample`
- **Python** (`x/py/x/telem/`): `__len__`, constructors, `__variable_getitem__`,
  `__iter__variable`
- **TypeScript** (`x/ts/src/telem/`): constructors, `calculateCachedLength`,
  `atVariable`, `StringSeriesIterator`, `toStrings`, `writeVariable`
- **C++** (`x/cpp/telem/`): all string/JSON constructors, `strings()`, `at<string>()`,
  `write()`, `fill_from`, proto deserializer

The codec layer (`core/pkg/distribution/framer/codec/`) required no changes since it
transmits `Series.Data` bytes verbatim using byte-length, not sample-count.

This is Phase 1 of the variable-length DB RFC (`docs/rfcs/cesium-variable-db.md`).

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces newline-delimited encoding for variable-length series (`StringT`, `JSONT`, `BytesT`) with a uint32 little-endian length-prefixed format across Go, Python, TypeScript, and C++. The change is motivated by newlines appearing inside JSON and multi-line strings, which broke the old encoding. The implementation is consistent and complete across all four languages, signal encoding in `core/` and `cesium/` is updated, and tests are updated to match the new byte layout.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the encoding change is consistent and correct across all four languages, and all remaining findings are P2 style/defensive-coding notes.

All P0/P1 concerns are absent. The two findings are: (1) Python __len__ counts a truncated-payload sample while Go/TS skip it — only observable on malformed data; (2) C++ helpers are named _le but use memcpy, safe on all LE target platforms. Neither affects correctness under normal operation.

x/py/x/telem/series.py (missing truncation guard) and x/cpp/telem/series.h (endian-assumption in helper names)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| x/go/telem/series.go | Replaces newline scanning with uint32-LE prefix scanning in Len, Samples, At, and Downsample; bounds checks are consistent and correct. |
| x/go/telem/series_factory.go | Adds MarshalVariableSample helper and rewrites marshalVariable/unmarshalVariable to use 4-byte LE length prefixes; logic is correct. |
| x/py/x/telem/series.py | Converts all encode/decode paths to uint32-LE prefix format; __len__ lacks the truncation guard that Go and TypeScript have, causing inconsistent sample count on malformed data. |
| x/ts/src/telem/series.ts | Rewrites all variable-length paths (constructors, writeVariable, calculateCachedLength, atVariable, toStrings, StringSeriesIterator) to use uint32-LE prefixes; cached-index logic is correctly updated. |
| x/cpp/telem/series.h | Replaces NEWLINE_TERMINATOR with uint32 prefix helpers; fixes write() to start at cached_byte_size; helpers use memcpy (native-endian) despite being named _le, which is safe only on LE targets. |
| cesium/control.go | Adds DecodeControlUpdate using telem.At(0) and updates EncodeControlUpdate to use MarshalVariableSample; correct. |
| core/pkg/distribution/ontology/signals/signals.go | Replaces newline-appended encoding in EncodeID/EncodeIDs and newline-scanning decode loops with MarshalVariableSample / UnmarshalSeries calls; correct. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Writer as Producer (any language)
    participant Buf as Series.Data ([]byte)
    participant Reader as Consumer (any language)

    Note over Writer,Buf: Encoding (new format)
    Writer->>Buf: write uint32-LE length (4 bytes)
    Writer->>Buf: write sample bytes (length bytes)
    Note over Writer,Buf: repeat per sample

    Note over Buf,Reader: Decoding
    Reader->>Buf: read uint32-LE length
    Reader->>Buf: read length bytes → sample
    Note over Buf,Reader: repeat until end of buffer

    Note over Writer,Reader: Go: binary.LittleEndian.Uint32<br/>Python: int.from_bytes(..., 'little')<br/>TS: DataView.getUint32(offset, true)<br/>C++: memcpy (native-LE on all targets)
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `x/ts/src/telem/series.ts`, line 609-612 ([link](https://github.com/synnaxlabs/synnax/blob/b213fcb07ea85743779ff99760fd394ef65dffa0/x/ts/src/telem/series.ts#L609-L612)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Stale JSDoc comment**

   The comment still says "calculated by counting newlines" but the implementation now uses length-prefixed format scanning.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Use telem JSON utilities in EncodeContro..."](https://github.com/synnaxlabs/synnax/commit/c992194bd9dd0e588e94fdc482f0acddf9cb94c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28238775)</sub>

<!-- /greptile_comment -->