### PR TITLE
Update read_latest() doc strings

### DIFF
--- a/client/py/synnax/framer/client.py
+++ b/client/py/synnax/framer/client.py
@@ -266,14 +266,18 @@ class Client:
         channels: channel.Params,
         n: int = 1,
     ) -> Frame | MultiSeries:
-        """
-        Reads the latest n samples from time_channel and data_channel.
+        """Reads the latest n samples from the given channel(s).
+
+        If fewer than n samples are available, returns only the samples that
+        exist.
 
         Args:
-            n: The number of samples to read.
+            channels: A single channel key/name or a list of channel keys/names.
+            n: The maximum number of samples to read. Defaults to 1.
 
         Returns:
-            A frame containing the latest n samples from time_channel and data_channel
+            A MultiSeries when a single channel is provided, or a Frame when
+            multiple channels are provided.
         """
         normal = channel.normalize_params(channels)
         aggregate = Frame()

--- a/client/ts/src/framer/client.ts
+++ b/client/ts/src/framer/client.ts
@@ -180,6 +180,18 @@ export class Client {
 
   async readLatest(channels: channel.Params, n: number): Promise<Frame>;
 
+  /**
+   * Reads the latest n samples from the given channel(s).
+   *
+   * If fewer than n samples are available, returns only the samples that
+   * exist.
+   *
+   * @param channels - A single channel key/name or an array of channel
+   * keys/names.
+   * @param n - The maximum number of samples to read. Defaults to 1.
+   * @returns A MultiSeries when a single channel is provided, or a Frame when
+   * multiple channels are provided.
+   */
   async readLatest(
     channels: channel.Params,
     n: number = 1,

--- a/docs/site/src/pages/reference/client/read-data.mdx
+++ b/docs/site/src/pages/reference/client/read-data.mdx
@@ -514,6 +514,6 @@ const frame = await client.readLatest(["my_tc", "my_sg", "my_pt"], 5);
 
 </Client.Tabs>
 
-The returned data follows the same conventions as regular reads - a `Series` for single
-channels or a `Frame` for multiple channels. If fewer than `n` samples are available,
-the method returns only the samples that exist.
+The returned data follows the same conventions as regular reads - a `MultiSeries` for
+single channels or a `Frame` for multiple channels. If fewer than `n` samples are
+available, the method returns only the samples that exist.

--- a/docs/site/src/pages/reference/client/read-data.mdx
+++ b/docs/site/src/pages/reference/client/read-data.mdx
@@ -515,4 +515,5 @@ const frame = await client.readLatest(["my_tc", "my_sg", "my_pt"], 5);
 </Client.Tabs>
 
 The returned data follows the same conventions as regular reads - a `Series` for single
-channels or a `Frame` for multiple channels.
+channels or a `Frame` for multiple channels. If fewer than `n` samples are available,
+the method returns only the samples that exist.


### PR DESCRIPTION
## Description
 
Update `read_latest()` doc string.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the `readLatest` / `read_latest` docstrings in the Python client, TypeScript client, and the MDX documentation page to document the `channels` parameter, the default value of `n`, partial-result behaviour, and return types. No logic is changed.

The inline docstrings now correctly say `MultiSeries` for single-channel results, but the MDX page still says `Series` in the existing sentence that was not updated.

<h3>Confidence Score: 5/5</h3>

Safe to merge — documentation-only changes with one minor wording inconsistency.

All changes are documentation/docstring updates with no logic modifications. The single finding is a P2 style inconsistency (`Series` vs `MultiSeries` in the MDX page) that does not block merge.

docs/site/src/pages/reference/client/read-data.mdx — `Series` should be updated to `MultiSeries` for consistency with the new docstrings.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| client/py/synnax/framer/client.py | Docstring improved with clearer `channels` arg description, explicit default for `n`, and accurate return type (`MultiSeries` vs `Frame`). |
| client/ts/src/framer/client.ts | JSDoc comment added to the implementation overload, consistent with the Python docstring; no logic changes. |
| docs/site/src/pages/reference/client/read-data.mdx | Added clarification about partial results, but the existing `Series` wording is now inconsistent with the new inline docstrings that say `MultiSeries`. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["readLatest(channels, n)"] --> B{n > 0?}
    B -- No --> C["Return empty Frame / MultiSeries"]
    B -- Yes --> D["Open iterator over TimeRange.MAX"]
    D --> E["seekLast → prev(AUTO_SPAN)"]
    E --> F["Collect frame"]
    F --> G{Single channel?}
    G -- Yes --> H["Return MultiSeries"]
    G -- No --> I["Return Frame"]
```

<sub>Reviews (1): Last reviewed commit: ["Update read\_latest() doc strings"](https://github.com/synnaxlabs/synnax/commit/693bccdf2ae5e29e218486ba068ee7d8a4223d18) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28240048)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->