### PR TITLE
[docs] Preserve Sidebar Scroll Position Across Page Navigations

### DIFF
--- a/docs/site/src/components/nav/Page.astro
+++ b/docs/site/src/components/nav/Page.astro
@@ -12,8 +12,13 @@ import { Page as P } from "@/components/nav/Page";
     if (tree != null) {
         const saved = sessionStorage.getItem(SCROLL_KEY);
         if (saved != null) tree.scrollTop = parseFloat(saved);
+        let scrollTimer: ReturnType<typeof setTimeout> | null = null;
         tree.addEventListener("scroll", () => {
-            sessionStorage.setItem(SCROLL_KEY, String(tree.scrollTop));
+            if (scrollTimer != null) clearTimeout(scrollTimer);
+            scrollTimer = setTimeout(
+                () => sessionStorage.setItem(SCROLL_KEY, String(tree.scrollTop)),
+                100,
+            );
         });
     }
 </script>

--- a/docs/site/src/components/nav/Page.astro
+++ b/docs/site/src/components/nav/Page.astro
@@ -5,3 +5,15 @@ import { Page as P } from "@/components/nav/Page";
 <nav class="page-nav" transition:persist>
     <P client:load />
 </nav>
+
+<script>
+    const SCROLL_KEY = "page-nav-scroll";
+    const tree = document.querySelector(".reference-tree");
+    if (tree != null) {
+        const saved = sessionStorage.getItem(SCROLL_KEY);
+        if (saved != null) tree.scrollTop = parseFloat(saved);
+        tree.addEventListener("scroll", () => {
+            sessionStorage.setItem(SCROLL_KEY, String(tree.scrollTop));
+        });
+    }
+</script>


### PR DESCRIPTION
[docs] Preserve Sidebar Scroll Position Across Page Navigations

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a `<script>` block to `Page.astro` that persists the sidebar's scroll position across page navigations using `sessionStorage`. On load it reads any saved position and restores `scrollTop`; on scroll it debounces writes at 100 ms to avoid excessive storage writes. No functional issues found — the implementation is correct and the prior debounce concern is already addressed.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge — it adds a small, well-guarded scroll-persistence script with no logic, security, or correctness concerns.
- Single-file change with a null guard, a 100 ms debounce, and correct sessionStorage usage. Integrates cleanly with the existing transition:persist nav. No P0/P1 findings.
- No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/site/src/components/nav/Page.astro | Adds a debounced scroll-persistence script that reads from and writes to sessionStorage; guarded by a null check and correctly scoped to the persisted nav component. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser
    participant Script as Page.astro Script
    participant DOM as .reference-tree
    participant SS as sessionStorage

    Note over Browser,SS: Initial Page Load
    Browser->>Script: Run (deferred ES module)
    Script->>DOM: querySelector(".reference-tree")
    DOM-->>Script: element or null
    Script->>SS: getItem("page-nav-scroll")
    SS-->>Script: saved position or null
    Script->>DOM: "scrollTop = parseFloat(saved)"
    Script->>DOM: addEventListener("scroll", handler)

    Note over Browser,SS: User Scrolls
    DOM->>Script: scroll event fires
    Script->>Script: clearTimeout(scrollTimer)
    Script->>Script: setTimeout 100ms
    Script->>SS: setItem("page-nav-scroll", scrollTop)

    Note over Browser,SS: View Transition Navigation
    Browser->>DOM: transition:persist keeps nav alive
    Note over DOM: Listener stays attached, scroll maintained by DOM

    Note over Browser,SS: Hard Refresh
    Browser->>Script: Re-run script
    Script->>SS: getItem("page-nav-scroll")
    SS-->>Script: previously saved position
    Script->>DOM: "scrollTop = restored value"
```

<sub>Reviews (2): Last reviewed commit: ["100ms debounce"](https://github.com/synnaxlabs/synnax/commit/8864e1df4cd1641b95d4e5ca451bca24369f9feb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28311326)</sub>

<!-- /greptile_comment -->