### PR TITLE
SY-3698: Reduce Excessive EtherCAT Logging

### DIFF
--- a/driver/ethercat/engine/engine.cpp
+++ b/driver/ethercat/engine/engine.cpp
@@ -81,7 +81,7 @@ void Engine::run() {
 
         auto [elapsed, on_time] = timer.wait();
         if (!on_time && this->config.max_overrun.nanoseconds() > 0)
-            VLOG(2) << "[ethercat] cycle overrun: " << elapsed;
+            VLOG(1) << "[ethercat] cycle overrun: " << elapsed;
     }
 
     if (had_receive_error)

--- a/driver/ethercat/igh/master.cpp
+++ b/driver/ethercat/igh/master.cpp
@@ -219,7 +219,7 @@ x::errors::Error Master::receive() {
 
     if (this->output_domain_state.wc_state == EC_WC_INCOMPLETE ||
         this->input_domain_state.wc_state == EC_WC_INCOMPLETE)
-        VLOG(2) << "[ethercat.igh] incomplete WC: output="
+        VLOG(1) << "[ethercat.igh] incomplete WC: output="
                 << this->output_domain_state.working_counter
                 << ", input=" << this->input_domain_state.working_counter;
 
@@ -446,7 +446,7 @@ void Master::configure_slave_pdos(
         LOG(WARNING) << "[ethercat.igh] failed to configure PDOs for slave "
                      << slave.position;
     } else {
-        VLOG(2) << "[ethercat.igh] configured " << output_pdos.size()
+        VLOG(1) << "[ethercat.igh] configured " << output_pdos.size()
                 << " output PDOs and " << input_pdos.size() << " input PDOs for slave "
                 << slave.position;
     }

--- a/driver/ethercat/scan_task.cpp
+++ b/driver/ethercat/scan_task.cpp
@@ -87,7 +87,7 @@ Scanner::scan(const common::ScannerContext &scan_ctx) {
     for (const auto &master_info: masters) {
         auto [slaves, err] = this->pool->discover_slaves(master_info.key);
         if (err) {
-            VLOG(2) << SCAN_LOG_PREFIX << "discovery failed for " << master_info.key
+            VLOG(1) << SCAN_LOG_PREFIX << "discovery failed for " << master_info.key
                     << ": " << err.message();
             continue;
         }

--- a/driver/ethercat/soem/master.cpp
+++ b/driver/ethercat/soem/master.cpp
@@ -344,7 +344,7 @@ void Master::discover_slave_pdos(slave::DiscoveryResult &slave) {
 bool Master::discover_pdos_coe(slave::DiscoveryResult &slave) {
     auto &props = slave.properties;
     auto &status = slave.status;
-    VLOG(2) << "Slave " << props.position << " mbx_proto: 0x" << std::hex
+    VLOG(1) << "Slave " << props.position << " mbx_proto: 0x" << std::hex
             << static_cast<int>(this->api->slave_mbx_proto(props.position)) << std::dec;
     if ((this->api->slave_mbx_proto(props.position) & ECT_MBXPROT_COE) == 0) {
         VLOG(1) << "Slave " << props.position << " (" << props.name
@@ -352,7 +352,7 @@ bool Master::discover_pdos_coe(slave::DiscoveryResult &slave) {
         return false;
     }
 
-    VLOG(2) << "Slave " << props.position << " supports CoE, reading PDO assignments";
+    VLOG(1) << "Slave " << props.position << " supports CoE, reading PDO assignments";
 
     bool tx_success = false;
     bool rx_success = false;
@@ -362,11 +362,11 @@ bool Master::discover_pdos_coe(slave::DiscoveryResult &slave) {
 
     auto err = this->read_pdo_assign(props.position, ECT_SDO_TXPDOASSIGN, true, slave);
     if (err) {
-        VLOG(2) << "Failed to read TxPDO assignment for slave " << props.position
+        VLOG(1) << "Failed to read TxPDO assignment for slave " << props.position
                 << ": " << err.message() << " - trying direct PDO read";
         err = this->read_pdo_mapping(props.position, TXPDO_MAPPING_START, true, slave);
         if (err)
-            VLOG(2) << "Failed to read TxPDO mapping 0x" << std::hex
+            VLOG(1) << "Failed to read TxPDO mapping 0x" << std::hex
                     << TXPDO_MAPPING_START << std::dec << " for slave "
                     << props.position << ": " << err.message();
         else
@@ -378,11 +378,11 @@ bool Master::discover_pdos_coe(slave::DiscoveryResult &slave) {
 
     err = this->read_pdo_assign(props.position, ECT_SDO_RXPDOASSIGN, false, slave);
     if (err) {
-        VLOG(2) << "Failed to read RxPDO assignment for slave " << props.position
+        VLOG(1) << "Failed to read RxPDO assignment for slave " << props.position
                 << ": " << err.message() << " - trying direct PDO read";
         err = this->read_pdo_mapping(props.position, RXPDO_MAPPING_START, false, slave);
         if (err)
-            VLOG(2) << "Failed to read RxPDO mapping 0x" << std::hex
+            VLOG(1) << "Failed to read RxPDO mapping 0x" << std::hex
                     << RXPDO_MAPPING_START << std::dec << " for slave "
                     << props.position << ": " << err.message();
         else
@@ -393,7 +393,7 @@ bool Master::discover_pdos_coe(slave::DiscoveryResult &slave) {
     }
 
     if (!tx_success && !rx_success) {
-        VLOG(2) << "Standard PDO discovery failed for slave " << props.position
+        VLOG(1) << "Standard PDO discovery failed for slave " << props.position
                 << ", scanning object dictionary";
         if (this->scan_object_dictionary_for_pdos(props.position, slave)) {
             tx_success = !props.input_pdos.empty();
@@ -422,7 +422,7 @@ void Master::discover_pdos_sii(slave::DiscoveryResult &slave) {
     for (uint8_t t = 0; t <= 1; ++t) {
         const bool is_input = (t == 0);
         const uint16_t startpos = this->api->siifind(props.position, ECT_SII_PDO + t);
-        VLOG(2) << "Slave " << props.position << " SII category " << (ECT_SII_PDO + t)
+        VLOG(1) << "Slave " << props.position << " SII category " << (ECT_SII_PDO + t)
                 << " (" << (is_input ? "TxPDO" : "RxPDO") << ") startpos: " << startpos;
         if (startpos == 0) continue;
 
@@ -430,7 +430,7 @@ void Master::discover_pdos_sii(slave::DiscoveryResult &slave) {
         uint16_t length = this->api->siigetbyte(props.position, a++);
         length += (this->api->siigetbyte(props.position, a++) << 8);
 
-        VLOG(2) << "Slave " << props.position << " " << (is_input ? "TxPDO" : "RxPDO")
+        VLOG(1) << "Slave " << props.position << " " << (is_input ? "TxPDO" : "RxPDO")
                 << " length: " << length;
 
         uint16_t c = 1;
@@ -507,7 +507,7 @@ void Master::discover_pdos_sii(slave::DiscoveryResult &slave) {
     if (props.input_pdos.empty() && props.output_pdos.empty()) {
         if (this->api->slave_Ibits(props.position) > 0 ||
             this->api->slave_Obits(props.position) > 0) {
-            VLOG(2) << "Slave " << props.position
+            VLOG(1) << "Slave " << props.position
                     << " has Ibits=" << this->api->slave_Ibits(props.position)
                     << " Obits=" << this->api->slave_Obits(props.position)
                     << " but no SII PDO info";
@@ -549,7 +549,7 @@ x::errors::Error Master::read_pdo_assign(
         SDO_TIMEOUT
     );
     if (result <= 0) {
-        VLOG(2) << "Slave " << slave_pos << " SDO read 0x" << std::hex << assign_index
+        VLOG(1) << "Slave " << slave_pos << " SDO read 0x" << std::hex << assign_index
                 << ":0 failed, result=" << std::dec << result
                 << " ecx_err=" << this->api->slave_ALstatuscode(slave_pos);
         return x::errors::Error(
@@ -557,7 +557,7 @@ x::errors::Error Master::read_pdo_assign(
             "failed to read PDO assignment count"
         );
     }
-    VLOG(2) << "Slave " << slave_pos << " PDO assign 0x" << std::hex << assign_index
+    VLOG(1) << "Slave " << slave_pos << " PDO assign 0x" << std::hex << assign_index
             << " has " << std::dec << static_cast<int>(num_pdos) << " PDOs";
 
     int consecutive_failures = 0;
@@ -587,7 +587,7 @@ x::errors::Error Master::read_pdo_assign(
         if (pdo_index == 0) continue;
 
         if (auto err = this->read_pdo_mapping(slave_pos, pdo_index, is_input, slave))
-            VLOG(2) << "Failed to read PDO mapping 0x" << std::hex << pdo_index
+            VLOG(1) << "Failed to read PDO mapping 0x" << std::hex << pdo_index
                     << " for slave " << std::dec << slave_pos << ": " << err.message();
     }
 
@@ -613,14 +613,14 @@ x::errors::Error Master::read_pdo_mapping(
         SDO_TIMEOUT
     );
     if (result <= 0) {
-        VLOG(2) << "Slave " << slave_pos << " SDO read 0x" << std::hex << pdo_index
+        VLOG(1) << "Slave " << slave_pos << " SDO read 0x" << std::hex << pdo_index
                 << ":0 failed, result=" << std::dec << result;
         return x::errors::Error(
             errors::SDO_READ_ERROR,
             "failed to read PDO mapping count"
         );
     }
-    VLOG(2) << "Slave " << slave_pos << " PDO 0x" << std::hex << pdo_index << " has "
+    VLOG(1) << "Slave " << slave_pos << " PDO 0x" << std::hex << pdo_index << " has "
             << std::dec << static_cast<int>(num_entries) << " entries";
 
     int consecutive_failures = 0;
@@ -710,11 +710,11 @@ bool Master::scan_object_dictionary_for_pdos(
     od_list.Slave = slave_pos;
 
     if (this->api->readODlist(slave_pos, &od_list) <= 0) {
-        VLOG(2) << "Slave " << slave_pos << " failed to read object dictionary list";
+        VLOG(1) << "Slave " << slave_pos << " failed to read object dictionary list";
         return false;
     }
 
-    VLOG(2) << "Slave " << slave_pos << " object dictionary has " << od_list.Entries
+    VLOG(1) << "Slave " << slave_pos << " object dictionary has " << od_list.Entries
             << " entries";
 
     std::vector<uint16_t> txpdo_indices;
@@ -724,11 +724,11 @@ bool Master::scan_object_dictionary_for_pdos(
         const uint16_t index = od_list.Index[i];
         if (index >= TXPDO_MAPPING_START && index <= TXPDO_MAPPING_END) {
             txpdo_indices.push_back(index);
-            VLOG(2) << "Slave " << slave_pos << " found TxPDO object 0x" << std::hex
+            VLOG(1) << "Slave " << slave_pos << " found TxPDO object 0x" << std::hex
                     << index << std::dec;
         } else if (index >= RXPDO_MAPPING_START && index <= RXPDO_MAPPING_END) {
             rxpdo_indices.push_back(index);
-            VLOG(2) << "Slave " << slave_pos << " found RxPDO object 0x" << std::hex
+            VLOG(1) << "Slave " << slave_pos << " found RxPDO object 0x" << std::hex
                     << index << std::dec;
         }
     }
@@ -745,7 +745,7 @@ bool Master::scan_object_dictionary_for_pdos(
         if (!err) found_any = true;
     }
 
-    VLOG(2) << "Slave " << slave_pos << " OD scan found " << txpdo_indices.size()
+    VLOG(1) << "Slave " << slave_pos << " OD scan found " << txpdo_indices.size()
             << " TxPDO objects, " << rxpdo_indices.size() << " RxPDO objects";
 
     return found_any;
@@ -801,7 +801,7 @@ std::vector<master::Info> Manager::enumerate() {
             info.description = current->desc;
             masters.push_back(std::move(info));
         } else {
-            VLOG(2) << "[ethercat] skipping virtual interface: " << current->name;
+            VLOG(1) << "[ethercat] skipping virtual interface: " << current->name;
         }
         current = current->next;
     }


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-3698](https://linear.app/synnax/issue/SY-3698)

## Description

Demotes verbose EtherCAT log statements from `VLOG(2)` to `VLOG(1)` across `driver/ethercat/soem/master.cpp`, `driver/ethercat/scan_task.cpp`, `driver/ethercat/igh/master.cpp`, and `driver/ethercat/engine/engine.cpp` to reduce log noise at default verbosity levels.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes all `VLOG(2)` statements across four EtherCAT files to `VLOG(1)`. In glog semantics, `VLOG(1)` fires at `--v >= 1` while `VLOG(2)` requires `--v >= 2`, so this change makes these messages visible at a *lower* verbosity threshold — the opposite direction from "reducing log noise." At the default verbosity (`--v=0`) there is no behavioral difference, but if the system is run at `--v=1`, users will now see all of these verbose per-slave PDO/SDO discovery traces that were previously suppressed at that level.

<h3>Confidence Score: 5/5</h3>

- Safe to merge; only logging verbosity levels are changed with no effect on functional correctness or data integrity.
- All findings are P2. The change has no effect at default verbosity (--v=0) and does not touch any logic, data paths, or error handling. The concern about VLOG level semantics is a diagnostic/observability question, not a production correctness issue.
- driver/ethercat/soem/master.cpp — contains the most verbose per-slave debug traces (~18 changes) that will all become visible at --v=1.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| driver/ethercat/engine/engine.cpp | Single VLOG(2)→VLOG(1) change for cycle overrun logging; now visible at --v=1 instead of --v=2, making it potentially noisy in tight loop if overruns are frequent. |
| driver/ethercat/igh/master.cpp | Two VLOG(2)→VLOG(1) changes: incomplete WC state (operational) and PDO configuration success; both now visible at lower verbosity threshold. |
| driver/ethercat/scan_task.cpp | Single VLOG(2)→VLOG(1) change for discovery failure logging; promoting failure messages to a lower verbosity threshold is reasonable diagnostically. |
| driver/ethercat/soem/master.cpp | ~18 VLOG(2)→VLOG(1) changes across PDO/SDO discovery, object dictionary scanning, and slave enumeration; highly verbose per-slave debug traces now all visible at --v=1. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Runtime verbosity flag<br/>--v=N"] --> B{N >= 2?}
    B -- "Yes (BEFORE this PR)<br/>VLOG(2) fires" --> C["All 4 files log at --v=2:<br/>cycle overrun, incomplete WC,<br/>PDO/SDO traces, OD scan"]
    B -- "No" --> D{N >= 1?}
    D -- "Yes (AFTER this PR)<br/>VLOG(1) fires" --> E["All 4 files log at --v=1:<br/>same verbose output now<br/>visible at lower threshold"]
    D -- "No (default --v=0)" --> F["No VLOG output<br/>(no change at default)"]
    C --> G["--v=2: same output before & after"]
    E --> H["--v=1: MORE output than before<br/>(previously these were silent at --v=1)"]
```

<sub>Reviews (1): Last reviewed commit: ["SY-3698: Reduce Excessive EtherCAT Loggi..."](https://github.com/synnaxlabs/synnax/commit/fd1b00ac020ff02b0538043b55309238eb41ce28) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28367732)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->