### PR TITLE
SY-Schematic: Square Control Chip if Claimed

### DIFF
--- a/pluto/src/icon/registry.tsx
+++ b/pluto/src/icon/registry.tsx
@@ -153,6 +153,7 @@ import {
   MdSaveAlt,
   MdSensors,
   MdShield,
+  MdSquare,
   MdSquareFoot,
   MdTextFields,
   MdTypeSpecimen,
@@ -238,6 +239,7 @@ import { Valve } from "@/icon/Valve";
 export const Pause = wrapSVGIcon(MdPause, "pause");
 export const Play = wrapSVGIcon(MdPlayArrow, "play");
 export const Circle = wrapSVGIcon(MdFiberManualRecord, "circle");
+export const Square = wrapSVGIcon(MdSquare, "square");
 export const Edit = wrapSVGIcon(MdEdit, "edit");
 export const EditOff = wrapSVGIcon(MdEditOff, "edit-off");
 export const Add = wrapSVGIcon(HiOutlinePlus, "add");

--- a/pluto/src/telem/control/Chip.spec.ts
+++ b/pluto/src/telem/control/Chip.spec.ts
@@ -1,0 +1,91 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { control } from "@synnaxlabs/client";
+import { type status, TimeStamp } from "@synnaxlabs/x";
+import { describe, expect, it } from "vitest";
+import { type z } from "zod";
+
+import { Icon } from "@/icon";
+import { type control as controlAether } from "@/telem/control/aether";
+import { tooltipMessage } from "@/telem/control/Chip";
+
+const makeStatus = (
+  variant: status.Variant,
+  details: Partial<z.infer<typeof controlAether.chipStatusDetailsZ>> = {},
+): status.Status<typeof controlAether.chipStatusDetailsZ> => ({
+  key: "test",
+  name: "test",
+  variant,
+  message: "",
+  time: TimeStamp.now(),
+  details: { authority: undefined, valid: false, ...details },
+});
+
+describe("tooltipMessage", () => {
+  describe("icon", () => {
+    it("should return a circle icon when the user has control", () => {
+      const { chipIcon } = tooltipMessage(makeStatus("success"));
+      expect(chipIcon).toBe(Icon.Circle);
+    });
+
+    it("should return a circle icon when the user has absolute control", () => {
+      const { chipIcon } = tooltipMessage(
+        makeStatus("success", { authority: control.ABSOLUTE_AUTHORITY }),
+      );
+      expect(chipIcon).toBe(Icon.Circle);
+    });
+
+    it("should return a square icon when someone else has control", () => {
+      const { chipIcon } = tooltipMessage(makeStatus("error"));
+      expect(chipIcon).toBe(Icon.Square);
+    });
+
+    it("should return a circle icon when the channel is uncontrolled", () => {
+      const { chipIcon } = tooltipMessage(makeStatus("disabled", { valid: true }));
+      expect(chipIcon).toBe(Icon.Circle);
+    });
+
+    it("should return a circle icon when no channel is connected", () => {
+      const { chipIcon } = tooltipMessage(makeStatus("disabled", { valid: false }));
+      expect(chipIcon).toBe(Icon.Circle);
+    });
+  });
+
+  describe("color", () => {
+    it("should return the error color when someone else has control", () => {
+      const { chipColor } = tooltipMessage(makeStatus("error"));
+      expect(chipColor).toBe("var(--pluto-error-z)");
+    });
+
+    it("should return the primary color when the user has control", () => {
+      const { chipColor } = tooltipMessage(makeStatus("success"));
+      expect(chipColor).toBe("var(--pluto-primary-z)");
+    });
+
+    it("should return the secondary color for absolute control", () => {
+      const { chipColor } = tooltipMessage(
+        makeStatus("success", { authority: control.ABSOLUTE_AUTHORITY }),
+      );
+      expect(chipColor).toBe("var(--pluto-secondary-z)");
+    });
+  });
+
+  describe("disabled", () => {
+    it("should be disabled when no channel is connected", () => {
+      const { disabled } = tooltipMessage(makeStatus("disabled", { valid: false }));
+      expect(disabled).toBe(true);
+    });
+
+    it("should not be disabled when the channel is uncontrolled", () => {
+      const { disabled } = tooltipMessage(makeStatus("disabled", { valid: true }));
+      expect(disabled).toBeUndefined();
+    });
+  });
+});

--- a/pluto/src/telem/control/Chip.spec.ts
+++ b/pluto/src/telem/control/Chip.spec.ts
@@ -29,63 +29,61 @@ const makeStatus = (
 });
 
 describe("tooltipMessage", () => {
-  describe("icon", () => {
-    it("should return a circle icon when the user has control", () => {
-      const { chipIcon } = tooltipMessage(makeStatus("success"));
-      expect(chipIcon).toBe(Icon.Circle);
-    });
-
-    it("should return a circle icon when the user has absolute control", () => {
-      const { chipIcon } = tooltipMessage(
-        makeStatus("success", { authority: control.ABSOLUTE_AUTHORITY }),
-      );
-      expect(chipIcon).toBe(Icon.Circle);
-    });
-
-    it("should return a square icon when someone else has control", () => {
-      const { chipIcon } = tooltipMessage(makeStatus("error"));
-      expect(chipIcon).toBe(Icon.Square);
-    });
-
-    it("should return a circle icon when the channel is uncontrolled", () => {
-      const { chipIcon } = tooltipMessage(makeStatus("disabled", { valid: true }));
-      expect(chipIcon).toBe(Icon.Circle);
-    });
-
-    it("should return a circle icon when no channel is connected", () => {
-      const { chipIcon } = tooltipMessage(makeStatus("disabled", { valid: false }));
-      expect(chipIcon).toBe(Icon.Circle);
+  it("should return controlled style when the user has control", () => {
+    const result = tooltipMessage(makeStatus("success"));
+    expect(result).toEqual({
+      message: "You're in control. Release schematic to release control.",
+      chipColor: "var(--pluto-primary-z)",
+      chipIcon: Icon.Circle,
     });
   });
 
-  describe("color", () => {
-    it("should return the error color when someone else has control", () => {
-      const { chipColor } = tooltipMessage(makeStatus("error"));
-      expect(chipColor).toBe("var(--pluto-error-z)");
-    });
-
-    it("should return the primary color when the user has control", () => {
-      const { chipColor } = tooltipMessage(makeStatus("success"));
-      expect(chipColor).toBe("var(--pluto-primary-z)");
-    });
-
-    it("should return the secondary color for absolute control", () => {
-      const { chipColor } = tooltipMessage(
-        makeStatus("success", { authority: control.ABSOLUTE_AUTHORITY }),
-      );
-      expect(chipColor).toBe("var(--pluto-secondary-z)");
+  it("should return absolute control style with background", () => {
+    const result = tooltipMessage(
+      makeStatus("success", { authority: control.ABSOLUTE_AUTHORITY }),
+    );
+    expect(result).toEqual({
+      message: "You have absolute control. Click to release.",
+      chipColor: "var(--pluto-secondary-z)",
+      chipIcon: Icon.Circle,
+      buttonStyle: { background: "var(--pluto-secondary-z-30)" },
     });
   });
 
-  describe("disabled", () => {
-    it("should be disabled when no channel is connected", () => {
-      const { disabled } = tooltipMessage(makeStatus("disabled", { valid: false }));
-      expect(disabled).toBe(true);
+  it("should return error style with square icon when someone else has control", () => {
+    const result = tooltipMessage(makeStatus("error"));
+    expect(result).toEqual({
+      message: "Not controlled by you. Click to take absolute control.",
+      chipColor: "var(--pluto-error-z)",
+      chipIcon: Icon.Square,
     });
+  });
 
-    it("should not be disabled when the channel is uncontrolled", () => {
-      const { disabled } = tooltipMessage(makeStatus("disabled", { valid: true }));
-      expect(disabled).toBeUndefined();
+  it("should return uncontrolled style when the channel is uncontrolled", () => {
+    const result = tooltipMessage(makeStatus("disabled", { valid: true }));
+    expect(result).toEqual({
+      message: "Uncontrolled. Click to take control.",
+      chipColor: "var(--pluto-gray-l12)",
+      chipIcon: Icon.Circle,
+    });
+  });
+
+  it("should return disabled style when no channel is connected", () => {
+    const result = tooltipMessage(makeStatus("disabled", { valid: false }));
+    expect(result).toEqual({
+      message: "No channel connected. This element cannot be controlled.",
+      chipColor: "var(--pluto-gray-l7)",
+      chipIcon: Icon.Circle,
+      disabled: true,
+    });
+  });
+
+  it("should return error style for an unexpected variant", () => {
+    const result = tooltipMessage(makeStatus("info" as status.Variant));
+    expect(result).toEqual({
+      message: "Unexpected status.",
+      chipColor: "var(--pluto-error-z)",
+      chipIcon: Icon.Square,
     });
   });
 });

--- a/pluto/src/telem/control/Chip.tsx
+++ b/pluto/src/telem/control/Chip.tsx
@@ -28,11 +28,12 @@ export interface ChipProps
 interface ChipStyle {
   message: string;
   chipColor: string;
+  chipIcon: Icon.FC;
   buttonStyle?: CSSProperties;
   disabled?: boolean;
 }
 
-const tooltipMessage = (
+export const tooltipMessage = (
   status: status.Status<typeof control.chipStatusDetailsZ>,
 ): ChipStyle => {
   switch (status.variant) {
@@ -41,10 +42,12 @@ const tooltipMessage = (
         return {
           message: "Uncontrolled. Click to take control.",
           chipColor: "var(--pluto-gray-l12)",
+          chipIcon: Icon.Circle,
         };
       return {
         message: "No channel connected. This element cannot be controlled.",
         chipColor: "var(--pluto-gray-l7)",
+        chipIcon: Icon.Circle,
         disabled: true,
       };
 
@@ -52,12 +55,14 @@ const tooltipMessage = (
       return {
         message: "Not controlled by you. Click to take absolute control.",
         chipColor: "var(--pluto-error-z)",
+        chipIcon: Icon.Square,
       };
     case "success":
       if (status.details?.authority === clientControl.ABSOLUTE_AUTHORITY)
         return {
           message: "You have absolute control. Click to release.",
           chipColor: "var(--pluto-secondary-z)",
+          chipIcon: Icon.Circle,
           buttonStyle: {
             background: "var(--pluto-secondary-z-30)",
           },
@@ -65,11 +70,13 @@ const tooltipMessage = (
       return {
         message: "You're in control. Release schematic to release control.",
         chipColor: "var(--pluto-primary-z)",
+        chipIcon: Icon.Circle,
       };
     default:
       return {
         message: "Unexpected status.",
         chipColor: "var(--pluto-error-z)",
+        chipIcon: Icon.Square,
       };
   }
 };
@@ -101,7 +108,13 @@ export const Chip = ({ source, sink, className, ...rest }: ChipProps): ReactElem
     [setState],
   );
 
-  const { message, chipColor, buttonStyle, disabled } = tooltipMessage(status);
+  const {
+    message,
+    chipColor,
+    chipIcon: ChipIcon,
+    buttonStyle,
+    disabled,
+  } = tooltipMessage(status);
 
   return (
     <Button.Button
@@ -113,7 +126,7 @@ export const Chip = ({ source, sink, className, ...rest }: ChipProps): ReactElem
       style={buttonStyle}
       {...rest}
     >
-      <Icon.Circle color={chipColor} />
+      <ChipIcon color={chipColor} />
     </Button.Button>
   );
 };


### PR DESCRIPTION
# Issue Pull Request

## Description

Red/Green cannot be distinguished for a large portion on the population. Displaying a square when the color is `--pluto-error-z` to improve accessibility.

<img width="353" height="138" alt="image" src="https://github.com/user-attachments/assets/e14f9c9f-b521-4045-80d9-f1948b828647" />

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves accessibility for the control chip component by rendering a square icon when another controller has claimed the channel (the `error` status), instead of relying solely on the `--pluto-error-z` red color that's indistinguishable for red/green colorblind users. A new `Square` icon is registered from `MdSquare`, `tooltipMessage` is exported to enable unit testing, and a `chipIcon` field is added to `ChipStyle` so each status branch picks its own icon. A new spec file covers icon, color, and disabled cases for all status variants.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all remaining findings are P2 style suggestions with no correctness impact.

The implementation is correct: the Square icon is returned for the right states, the Circle icon is preserved everywhere else, and the component renders the dynamic icon cleanly. Tests cover all production-relevant branches. The only gap is missing coverage for the unreachable-in-practice default case, which is a P2 suggestion.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pluto/src/icon/registry.tsx | Adds MdSquare import and exports it as Icon.Square via wrapSVGIcon — clean, minimal change with no issues. |
| pluto/src/telem/control/Chip.tsx | Adds chipIcon to ChipStyle, exports tooltipMessage, uses Square icon for error/default states — logic is correct and well-structured. |
| pluto/src/telem/control/Chip.spec.ts | New spec file covering icon, color, and disabled behavior; missing coverage for the default (unexpected status) branch. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[tooltipMessage called] --> B{status.variant}
    B -->|disabled| C{details.valid === true?}
    C -->|yes| D[Circle icon\ngray-l12\nUncontrolled]
    C -->|no| E[Circle icon\ngray-l7\nNo channel, disabled]
    B -->|error| F[Square icon\nerror-z\nNot your control]
    B -->|success| G{authority === ABSOLUTE?}
    G -->|yes| H[Circle icon\nsecondary-z\nAbsolute control]
    G -->|no| I[Circle icon\nprimary-z\nYou have control]
    B -->|default| J[Square icon\nerror-z\nUnexpected status]
```

<sub>Reviews (1): Last reviewed commit: ["Square control chip error or already cla..."](https://github.com/synnaxlabs/synnax/commit/18234a7931c50b164878a2a098d74cca7aebedf9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28556633)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->