### PR TITLE
SY-4043: Oracle Fixes for Arc Refactor

### DIFF
--- a/oracle/analyzer/analyzer.go
+++ b/oracle/analyzer/analyzer.go
@@ -804,19 +804,7 @@ func isRecursive(typ *resolution.Type, table *resolution.Table) bool {
 		return false
 	}
 	for _, field := range form.Fields {
-		if typeRefersTo(field.Type, typ, table) {
-			return true
-		}
-	}
-	return false
-}
-
-func typeRefersTo(ref resolution.TypeRef, target *resolution.Type, table *resolution.Table) bool {
-	if ref.Name == target.QualifiedName {
-		return true
-	}
-	for _, arg := range ref.TypeArgs {
-		if typeRefersTo(arg, target, table) {
+		if resolution.RefersTo(field.Type, typ.QualifiedName, table) {
 			return true
 		}
 	}

--- a/oracle/analyzer/analyzer_test.go
+++ b/oracle/analyzer/analyzer_test.go
@@ -1368,5 +1368,80 @@ var _ = Describe("Analyzer", func() {
 			form := simpleType.Form.(resolution.StructForm)
 			Expect(form.IsRecursive).To(BeFalse())
 		})
+
+		It("Should detect mutual recursion through struct fields", func(ctx SpecContext) {
+			source := `
+				A struct {
+					b B?
+				}
+				B struct {
+					a A?
+				}
+			`
+			table, diag := analyzer.AnalyzeSource(ctx, source, "test", loader)
+			Expect(diag.Ok()).To(BeTrue())
+
+			aForm := table.MustGet("test.A").Form.(resolution.StructForm)
+			bForm := table.MustGet("test.B").Form.(resolution.StructForm)
+			Expect(aForm.IsRecursive).To(BeTrue())
+			Expect(bForm.IsRecursive).To(BeTrue())
+		})
+
+		It("Should detect mutual recursion through a distinct array wrapper", func(ctx SpecContext) {
+			source := `
+				A struct {
+					bs Bs
+				}
+				B struct {
+					a A?
+				}
+				Bs B[]
+			`
+			table, diag := analyzer.AnalyzeSource(ctx, source, "test", loader)
+			Expect(diag.Ok()).To(BeTrue())
+
+			aForm := table.MustGet("test.A").Form.(resolution.StructForm)
+			bForm := table.MustGet("test.B").Form.(resolution.StructForm)
+			Expect(aForm.IsRecursive).To(BeTrue())
+			Expect(bForm.IsRecursive).To(BeTrue())
+		})
+
+		It("Should detect mutual recursion through an alias wrapper", func(ctx SpecContext) {
+			source := `
+				A struct {
+					bs Bs
+				}
+				B struct {
+					a A?
+				}
+				Bs = B[]
+			`
+			table, diag := analyzer.AnalyzeSource(ctx, source, "test", loader)
+			Expect(diag.Ok()).To(BeTrue())
+
+			aForm := table.MustGet("test.A").Form.(resolution.StructForm)
+			bForm := table.MustGet("test.B").Form.(resolution.StructForm)
+			Expect(aForm.IsRecursive).To(BeTrue())
+			Expect(bForm.IsRecursive).To(BeTrue())
+		})
+
+		It("Should detect mutual recursion through a distinct struct wrapper", func(ctx SpecContext) {
+			source := `
+				A struct {
+					b BWrap?
+				}
+				B struct {
+					a A?
+				}
+				BWrap B
+			`
+			table, diag := analyzer.AnalyzeSource(ctx, source, "test", loader)
+			Expect(diag.Ok()).To(BeTrue())
+
+			aForm := table.MustGet("test.A").Form.(resolution.StructForm)
+			bForm := table.MustGet("test.B").Form.(resolution.StructForm)
+			Expect(aForm.IsRecursive).To(BeTrue())
+			Expect(bForm.IsRecursive).To(BeTrue())
+		})
 	})
 })

--- a/oracle/paths/paths.go
+++ b/oracle/paths/paths.go
@@ -41,20 +41,21 @@ func RepoRoot() (string, error) {
 	return findGitRoot(cwd)
 }
 
-// findGitRoot walks up the directory tree looking for a .git directory.
+// findGitRoot walks up the directory tree looking for a .git entry. Accepts
+// both a directory (main checkout) and a file (linked worktree, where .git
+// is a file containing a gitdir: pointer).
 func findGitRoot(startPath string) (string, error) {
 	current := startPath
 
 	for {
 		gitPath := filepath.Join(current, ".git")
-		if info, err := os.Stat(gitPath); err == nil && info.IsDir() {
+		if _, err := os.Stat(gitPath); err == nil {
 			return current, nil
 		}
 
 		parent := filepath.Dir(current)
 		if parent == current {
-			// Reached filesystem root
-			return "", errors.Newf("oracle must be run within a git repository: no .git directory found in %s or any parent", startPath)
+			return "", errors.Newf("oracle must be run within a git repository: no .git entry found in %s or any parent", startPath)
 		}
 		current = parent
 	}

--- a/oracle/paths/paths_test.go
+++ b/oracle/paths/paths_test.go
@@ -29,8 +29,8 @@ var _ = Describe("Paths", func() {
 	Describe("RepoRoot", func() {
 		It("Should find repo root from current directory", func() {
 			root := MustSucceed(paths.RepoRoot())
-			Expect(root).To(HaveSuffix("synnax"))
-			Expect(filepath.Join(root, ".git")).To(BeADirectory())
+			Expect(filepath.Join(root, "pnpm-workspace.yaml")).To(BeAnExistingFile())
+			Expect(filepath.Join(root, "MODULE.bazel")).To(BeAnExistingFile())
 		})
 
 		It("Should find repo root from a subdirectory", func() {

--- a/oracle/plugin/cpp/json/json.go
+++ b/oracle/plugin/cpp/json/json.go
@@ -285,16 +285,11 @@ func (p *Plugin) processStruct(
 	return serializer, nil
 }
 
-func isSelfReference(t resolution.TypeRef, parent resolution.Type) bool {
-	if t.Name == parent.QualifiedName {
-		return true
-	}
-	for _, arg := range t.TypeArgs {
-		if isSelfReference(arg, parent) {
-			return true
-		}
-	}
-	return false
+// isSelfReference reports whether t directly or transitively references parent.
+// Stays consistent with the cpp types plugin's decision on hard-optional
+// fields by sharing resolution.RefersTo.
+func isSelfReference(t resolution.TypeRef, parent resolution.Type, table *resolution.Table) bool {
+	return resolution.RefersTo(t, parent.QualifiedName, table)
 }
 
 func (p *Plugin) resolveToArrayElement(typeRef resolution.TypeRef, data *templateData) (resolution.TypeRef, bool) {
@@ -338,7 +333,7 @@ func (p *Plugin) processField(field resolution.Field, parent resolution.Type, da
 		typeParamName = field.Type.TypeParam.Name
 	}
 
-	isSelfRef := field.IsHardOptional && isSelfReference(field.Type, parent)
+	isSelfRef := field.IsHardOptional && isSelfReference(field.Type, parent, data.table)
 
 	parseExpr := p.parseExprForField(field, parent, cppType, data, isSelfRef)
 	toJSONExpr := p.toJSONExprForField(field, parent, data, isSelfRef)
@@ -648,6 +643,16 @@ func (p *Plugin) toJSONExprForField(field resolution.Field, parent resolution.Ty
         j["%s"] = this->%s.to_json();`, typeName, jsonName, fieldName, typeName, jsonName, jsonName, fieldName)
 	}
 
+	// Self-referential hard-optional fields are wrapped as x::mem::indirect<T>
+	// by the types plugin. indirect<T> has the same has_value() + -> interface
+	// as std::optional<T>, and the underlying T (struct, or a distinct/alias
+	// resolving to one) always has to_json(). Emit the unwrap pattern here so
+	// the cycle-through-distinct case doesn't fall through to the default
+	// assignment below, which would be ill-typed against indirect<T>.
+	if isSelfRef {
+		return fmt.Sprintf(`if (this->%s.has_value()) j["%s"] = this->%s->to_json();`, fieldName, jsonName, fieldName)
+	}
+
 	if resolved, ok := typeRef.Resolve(data.table); ok {
 		if distinctForm, isDistinct := resolved.Form.(resolution.DistinctForm); isDistinct {
 			if distinctForm.Base.Name == "Array" && len(distinctForm.Base.TypeArgs) > 0 {
@@ -675,6 +680,22 @@ func (p *Plugin) toJSONExprForField(field resolution.Field, parent resolution.Ty
 		if elemResolved, ok := elemType.Resolve(data.table); ok {
 			if _, isStruct := elemResolved.Form.(resolution.StructForm); isStruct {
 				return fmt.Sprintf(`j["%s"] = x::json::to_array(this->%s);`, jsonName, fieldName)
+			}
+			// Nested-array-of-struct case: outer element resolves to another
+			// array (e.g., Members = []Member) whose inner element is a
+			// struct. nlohmann_json can't serialize vector<vector<Struct>>
+			// directly — serialize each inner array via to_array and bundle
+			// them in a JSON array.
+			if innerElem, ok := p.resolveToArrayElement(elemType, data); ok {
+				if innerResolved, ok := innerElem.Resolve(data.table); ok {
+					if _, isStruct := innerResolved.Form.(resolution.StructForm); isStruct {
+						return fmt.Sprintf(`{
+        auto arr = x::json::json::array();
+        for (const auto& inner : this->%s) arr.push_back(x::json::to_array(inner));
+        j["%s"] = arr;
+    }`, fieldName, jsonName)
+					}
+				}
 			}
 		}
 

--- a/oracle/plugin/cpp/json/json_test.go
+++ b/oracle/plugin/cpp/json/json_test.go
@@ -488,5 +488,177 @@ var _ = Describe("C++ JSON Plugin", func() {
 					ToNotContain(`Details<`)
 			})
 		})
+
+		Context("soft-optional primitive defaults", func() {
+			It("Should call parser.field with a default value for each numeric/bool/string primitive", func(ctx SpecContext) {
+				source := `
+					@cpp output "client/cpp/types"
+
+					Settings struct {
+						count    uint32?
+						ratio    float64?
+						enabled  bool?
+						label    string?
+					}
+				`
+				resp := MustGenerate(ctx, source, "types", loader, jsonPlugin)
+
+				ExpectContent(resp, "json.gen.h").
+					ToContain(
+						// defaultValueForPrimitive: numeric → 0, float → 0.0,
+						// bool → false, string → "".
+						`parser.field<std::uint32_t>("count", 0)`,
+						`parser.field<double>("ratio", 0.0)`,
+						`parser.field<bool>("enabled", false)`,
+						`parser.field<std::string>("label", "")`,
+					)
+			})
+
+			It("Should default soft-optional uuid fields to x::uuid::UUID{}", func(ctx SpecContext) {
+				source := `
+					@cpp output "client/cpp/types"
+
+					Record struct {
+						owner uuid?
+					}
+				`
+				resp := MustGenerate(ctx, source, "types", loader, jsonPlugin)
+
+				ExpectContent(resp, "json.gen.h").
+					ToContain(`parser.field<x::uuid::UUID>("owner", x::uuid::UUID{})`)
+			})
+
+			It("Should default soft-optional signed integer fields", func(ctx SpecContext) {
+				source := `
+					@cpp output "client/cpp/types"
+
+					Reading struct {
+						delta_small int8?
+						delta_med   int16?
+						delta_big   int64?
+					}
+				`
+				resp := MustGenerate(ctx, source, "types", loader, jsonPlugin)
+
+				ExpectContent(resp, "json.gen.h").
+					ToContain(
+						`parser.field<std::int8_t>("delta_small", 0)`,
+						`parser.field<std::int16_t>("delta_med", 0)`,
+						`parser.field<std::int64_t>("delta_big", 0)`,
+					)
+			})
+		})
+
+		Context("uuid detection through distinct and alias chains", func() {
+			It("Should detect a distinct type wrapping uuid and call to_json()", func(ctx SpecContext) {
+				source := `
+					@cpp output "client/cpp/types"
+
+					Key uuid
+
+					Entity struct {
+						id Key
+					}
+				`
+				resp := MustGenerate(ctx, source, "types", loader, jsonPlugin)
+
+				ExpectContent(resp, "json.gen.h").
+					ToContain(`j["id"] = this->id.to_json();`)
+			})
+
+			It("Should detect a uuid via an alias chain and call to_json()", func(ctx SpecContext) {
+				source := `
+					@cpp output "client/cpp/types"
+
+					Primary = uuid
+					KeyRef  = Primary
+
+					Entity struct {
+						id KeyRef
+					}
+				`
+				resp := MustGenerate(ctx, source, "types", loader, jsonPlugin)
+
+				ExpectContent(resp, "json.gen.h").
+					ToContain(`j["id"] = this->id.to_json();`)
+			})
+		})
+
+		Context("fixed-size uint8 array from another namespace", func() {
+			It("Should include the distinct-type-specific header, not json.gen.h, for a cross-namespace reference", func(ctx SpecContext) {
+				loader.Add("schemas/crypto", `
+					@cpp output "x/cpp/crypto"
+
+					Hash uint8[32]
+				`)
+
+				source := `
+					import "schemas/crypto"
+
+					@cpp output "client/cpp/types"
+
+					Digest struct {
+						hash crypto.Hash
+					}
+				`
+				resp := MustGenerate(ctx, source, "types", loader, jsonPlugin)
+
+				ExpectContent(resp, "json.gen.h").
+					ToContain(
+						// isFixedSizeUint8ArrayType drives typeRefToCpp to include
+						// <output>/<snake_case name>.h rather than json.gen.h.
+						`#include "x/cpp/crypto/hash.h"`,
+						// Qualified type reference uses the derived namespace.
+						`::x::crypto::Hash`,
+					).
+					ToNotContain(
+						`#include "x/cpp/crypto/json.gen.h"`,
+					)
+			})
+		})
+
+		Context("cross-namespace struct extension", func() {
+			It("Should qualify the base type by namespace and include the base's json header", func(ctx SpecContext) {
+				loader.Add("schemas/base", `
+					@cpp output "x/cpp/base"
+
+					BaseEntity struct {
+						key string
+					}
+				`)
+
+				source := `
+					import "schemas/base"
+
+					@cpp output "client/cpp/derived"
+
+					Derived struct extends base.BaseEntity {
+						name string
+					}
+				`
+				resp := MustGenerate(ctx, source, "derived", loader, jsonPlugin)
+
+				ExpectContent(resp, "json.gen.h").
+					ToContain(
+						// resolveExtendsType emits the cross-namespace qualified
+						// name and registers the base's json.gen.h include.
+						`#include "x/cpp/base/json.gen.h"`,
+						`::x::base::BaseEntity`,
+					)
+			})
+		})
+
+		Context("plugin interface", func() {
+			It("Should return default options with json.gen.h filename", func() {
+				opts := json.DefaultOptions()
+				Expect(opts.FileNamePattern).To(Equal("json.gen.h"))
+			})
+
+			It("Should report nil for Check and PostWrite when formatter is disabled", func() {
+				Expect(jsonPlugin.Check(nil)).To(Succeed())
+				Expect(jsonPlugin.PostWrite(nil)).To(Succeed())
+				Expect(jsonPlugin.PostWrite([]string{})).To(Succeed())
+			})
+		})
 	})
 })

--- a/oracle/plugin/cpp/json/json_test.go
+++ b/oracle/plugin/cpp/json/json_test.go
@@ -175,6 +175,51 @@ var _ = Describe("C++ JSON Plugin", func() {
 					)
 			})
 
+			It("Should handle mutually recursive types", func(ctx SpecContext) {
+				source := `
+					@cpp output "client/cpp/types"
+
+					A struct {
+						b B??
+					}
+					B struct {
+						a A??
+					}
+				`
+				resp := MustGenerate(ctx, source, "types", loader, jsonPlugin)
+
+				ExpectContent(resp, "json.gen.h").
+					ToContain(
+						`parser.field<x::mem::indirect<B>>("b")`,
+						`parser.field<x::mem::indirect<A>>("a")`,
+						`if (this->b.has_value()) j["b"] = this->b->to_json()`,
+						`if (this->a.has_value()) j["a"] = this->a->to_json()`,
+					)
+			})
+
+			It("Should handle cycles through a distinct struct wrapper", func(ctx SpecContext) {
+				source := `
+					@cpp output "client/cpp/types"
+
+					A struct {
+						b BWrap??
+					}
+					B struct {
+						a A??
+					}
+					BWrap B
+				`
+				resp := MustGenerate(ctx, source, "types", loader, jsonPlugin)
+
+				ExpectContent(resp, "json.gen.h").
+					ToContain(
+						`parser.field<x::mem::indirect<BWrap>>("b")`,
+						`parser.field<x::mem::indirect<A>>("a")`,
+						`if (this->b.has_value()) j["b"] = this->b->to_json()`,
+						`if (this->a.has_value()) j["a"] = this->a->to_json()`,
+					)
+			})
+
 			It("Should handle nested self-references via type arguments", func(ctx SpecContext) {
 				source := `
 					@cpp output "arc/cpp/types"

--- a/oracle/plugin/cpp/pb/pb.go
+++ b/oracle/plugin/cpp/pb/pb.go
@@ -1099,6 +1099,41 @@ func (p *Plugin) generateNestedArrayConversion(
 	typeRef resolution.TypeRef,
 	data *templateData,
 ) (forward, backward string) {
+	// Inner element type (e.g., Member for []Members where Members = []Member).
+	// When it's a struct, delegate to its to_proto/from_proto helpers so the
+	// nested conversion type-checks and propagates errors correctly. The
+	// primitive-inner path preserves the original `add_values(v)` form.
+	if elemType, ok := p.getArrayElementType(typeRef, data.table); ok {
+		if innerElem, ok := p.getArrayElementType(elemType, data.table); ok {
+			if innerResolved, ok := innerElem.Resolve(data.table); ok {
+				if _, isStruct := innerResolved.Form.(resolution.StructForm); isStruct {
+					if innerResolved.Namespace != data.rawNs {
+						targetOutputPath := output.GetPath(innerResolved, "cpp")
+						if targetOutputPath != "" {
+							data.includes.addInternal(fmt.Sprintf("%s/proto.gen.h", targetOutputPath))
+							data.includes.addInternal(fmt.Sprintf("%s/json.gen.h", targetOutputPath))
+						}
+					}
+					innerCppType := p.typeRefToCppForTranslator(innerElem, data)
+					forward = fmt.Sprintf(`for (const auto& item : this->%s) {
+        auto* wrapper = pb.add_%s();
+        for (const auto& v : item) {
+            auto [v_pb, err] = v.to_proto();
+            if (err) return {{}, err};
+            *wrapper->add_values() = v_pb;
+        }
+    }`, cppFieldName, pbAccessorName)
+					backward = fmt.Sprintf(`for (const auto& wrapper : pb.%s()) {
+        std::vector<%s> inner;
+        if (auto err = x::pb::from_proto_repeated<%s>(inner, wrapper.values())) return {{}, err};
+        cpp.%s.push_back(std::move(inner));
+    }`, pbAccessorName, innerCppType, innerCppType, cppFieldName)
+					return forward, backward
+				}
+			}
+		}
+	}
+
 	forward = fmt.Sprintf(`for (const auto& item : this->%s) {
         auto* wrapper = pb.add_%s();
         for (const auto& v : item) wrapper->add_values(v);

--- a/oracle/plugin/cpp/pb/pb_test.go
+++ b/oracle/plugin/cpp/pb/pb_test.go
@@ -652,6 +652,45 @@ var _ = Describe("C++ PB Plugin", func() {
 						"wrapper->add_values(v)",
 					)
 			})
+
+			It("Should delegate to to_proto/from_proto when inner element is a struct", func(ctx SpecContext) {
+				source := `
+					@cpp output "arc/cpp/ir"
+					@pb output "arc/go/ir/pb"
+
+					Cell struct {
+						key string
+						value int32
+					}
+
+					Row = Cell[]
+					Grid Row[]
+
+					Matrix struct {
+						cells Grid
+					}
+				`
+				resp := MustGenerate(ctx, source, "ir", loader, pbPlugin)
+
+				ExpectContent(resp, "proto.gen.h").
+					ToContain(
+						// Forward: delegate per-cell via to_proto with error propagation
+						"for (const auto& item : this->cells)",
+						"auto* wrapper = pb.add_cells()",
+						"auto [v_pb, err] = v.to_proto()",
+						"if (err) return {{}, err}",
+						"*wrapper->add_values() = v_pb",
+						// Backward: delegate per-cell via from_proto_repeated
+						"for (const auto& wrapper : pb.cells())",
+						"std::vector<Cell> inner",
+						"x::pb::from_proto_repeated<Cell>(inner, wrapper.values())",
+						"cpp.cells.push_back(std::move(inner))",
+					).
+					ToNotContain(
+						// Must not fall through to the primitive add_values(v) form
+						"for (const auto& v : item) wrapper->add_values(v);",
+					)
+			})
 		})
 
 		Describe("Array Wrapper Proto Generation", func() {
@@ -955,6 +994,167 @@ var _ = Describe("C++ PB Plugin", func() {
 
 				ExpectContent(resp, "proto.gen.h").
 					ToContain("id")
+			})
+
+			It("Should cast through a true distinct (non-alias) primitive wrapper", func(ctx SpecContext) {
+				source := `
+					@cpp output "client/cpp/types"
+					@pb output "core/pkg/service/types/pb"
+
+					Priority uint16
+
+					Task struct {
+						priority Priority
+					}
+				`
+				resp := MustGenerate(ctx, source, "types", loader, pbPlugin)
+
+				ExpectContent(resp, "proto.gen.h").
+					ToContain(
+						// generateDistinctConversion primitive branch routes through
+						// primitiveToProtoType — uint16 maps to uint32_t on the wire.
+						"pb.set_priority(static_cast<uint32_t>(this->priority))",
+						"cpp.priority = Priority(pb.priority())",
+					)
+			})
+		})
+
+		Context("fixed-size uint8 array", func() {
+			It("Should use set_<field>(data(), size()) forward and std::copy backward", func(ctx SpecContext) {
+				source := `
+					@cpp output "client/cpp/types"
+					@pb output "core/pkg/service/types/pb"
+
+					Hash uint8[32]
+
+					Digest struct {
+						hash Hash
+					}
+				`
+				resp := MustGenerate(ctx, source, "types", loader, pbPlugin)
+
+				ExpectContent(resp, "proto.gen.h").
+					ToContain(
+						"#include <algorithm>",
+						"pb.set_hash(this->hash.data(), this->hash.size())",
+						"std::copy(pb.hash().begin(), pb.hash().end(), cpp.hash.begin());",
+					)
+			})
+		})
+
+		Context("proto include resolution", func() {
+			It("Should add the proto header from the @go output path (+ /pb + namespace.pb.h)", func(ctx SpecContext) {
+				source := `
+					@cpp output "client/cpp/status"
+					@go output "core/status"
+					@pb
+
+					Status struct {
+						key string
+					}
+				`
+				resp := MustGenerate(ctx, source, "status", loader, pbPlugin)
+
+				ExpectContent(resp, "proto.gen.h").
+					ToContain(
+						// deriveProtoInclude builds "<pbPath>/<namespace>.pb.h".
+						`#include "core/status/pb/status.pb.h"`,
+					)
+			})
+		})
+
+		Context("array wrapper with explicit @pb name", func() {
+			It("Should emit a proto-wrapped array translator for primitive elements", func(ctx SpecContext) {
+				source := `
+					@cpp output "client/cpp/types"
+					@go output "core/types"
+					@pb
+
+					Channels uint32[] {
+						@pb name "Channels"
+					}
+				`
+				resp := MustGenerate(ctx, source, "types", loader, pbPlugin)
+
+				ExpectContent(resp, "proto.gen.h").
+					ToContain(
+						// Primitive-element wrappers add each item directly to the
+						// wrapper's "values" repeated field.
+						"pb.add_values(item)",
+						"cpp.push_back(item)",
+					)
+			})
+
+			It("Should emit a proto-wrapped array translator for struct elements with error handling", func(ctx SpecContext) {
+				source := `
+					@cpp output "client/cpp/types"
+					@go output "core/types"
+					@pb
+
+					Item struct {
+						key string
+					}
+
+					Items Item[] {
+						@pb name "Items"
+					}
+				`
+				resp := MustGenerate(ctx, source, "types", loader, pbPlugin)
+
+				ExpectContent(resp, "proto.gen.h").
+					ToContain(
+						// Struct-element wrapper delegates to to_proto/from_proto
+						// per-element, propagating errors out of the wrapper.
+						"auto [v, err] = item.to_proto()",
+						"x::pb::from_proto_repeated<Item>",
+					)
+			})
+		})
+
+		Context("generic struct type parameter field", func() {
+			It("Should emit JSON-bridge conversion for unconstrained type-param field", func(ctx SpecContext) {
+				source := `
+					@cpp output "x/cpp/status"
+					@pb output "x/go/status/pb"
+
+					Status struct<Details> {
+						key     string
+						details Details
+					}
+				`
+				resp := MustGenerate(ctx, source, "status", loader, pbPlugin)
+
+				ExpectContent(resp, "proto.gen.h").
+					ToContain(
+						// Forward: compile-time branch on Details via if constexpr,
+						// ultimately calling x::json::to_any.
+						"if constexpr (std::is_same_v<Details, std::monostate>)",
+						"*pb.mutable_details() = x::json::to_any",
+						// Backward: x::json::from_any with Parser::parse fallback.
+						"auto [val, err] = x::json::from_any(pb.details())",
+						"Details::parse(x::json::Parser(val))",
+					)
+			})
+
+			It("Should emit optional-guarded JSON-bridge conversion for hard-optional type-param field", func(ctx SpecContext) {
+				source := `
+					@cpp output "x/cpp/status"
+					@pb output "x/go/status/pb"
+
+					Status struct<Details> {
+						key     string
+						details Details??
+					}
+				`
+				resp := MustGenerate(ctx, source, "status", loader, pbPlugin)
+
+				ExpectContent(resp, "proto.gen.h").
+					ToContain(
+						"if (this->details.has_value())",
+						"*pb.mutable_details() = x::json::to_any",
+						"if (pb.has_details())",
+						"auto [val, err] = x::json::from_any(pb.details())",
+					)
 			})
 		})
 	})

--- a/oracle/plugin/cpp/types/types.go
+++ b/oracle/plugin/cpp/types/types.go
@@ -773,7 +773,7 @@ func getUnderlyingPrimitive(typeRef resolution.TypeRef, table *resolution.Table)
 
 func (p *Plugin) processField(field resolution.Field, entry resolution.Type, data *templateData) fieldData {
 	cppType := p.typeRefToCpp(field.Type, data)
-	isSelfRef := isSelfReference(field.Type, entry)
+	isSelfRef := resolution.RefersTo(field.Type, entry.QualifiedName, data.table)
 	underlyingPrimitive := getUnderlyingPrimitive(field.Type, data.table)
 
 	if field.IsHardOptional {
@@ -819,18 +819,6 @@ func (p *Plugin) processField(field resolution.Field, entry resolution.Type, dat
 		IsSelfRef:    isSelfRef,
 		DefaultValue: defaultValue,
 	}
-}
-
-func isSelfReference(t resolution.TypeRef, parent resolution.Type) bool {
-	if t.Name == parent.QualifiedName {
-		return true
-	}
-	for _, arg := range t.TypeArgs {
-		if isSelfReference(arg, parent) {
-			return true
-		}
-	}
-	return false
 }
 
 func (p *Plugin) typeRefToCpp(typeRef resolution.TypeRef, data *templateData) string {

--- a/oracle/plugin/cpp/types/types_test.go
+++ b/oracle/plugin/cpp/types/types_test.go
@@ -992,6 +992,71 @@ var _ = Describe("C++ Types Plugin", func() {
 			Expect(content).NotTo(ContainSubstring(`std::optional<Node>`))
 		})
 
+		It("Should use indirect for mutually recursive optional fields", func(ctx SpecContext) {
+			source := `
+				@cpp output "client/cpp/types"
+
+				A struct {
+					b B??
+				}
+				B struct {
+					a A??
+				}
+			`
+			resp := MustGenerate(ctx, source, "types", loader, cppPlugin)
+			ExpectContent(resp, "types.gen.h").
+				ToContain(
+					`x::mem::indirect<B> b;`,
+					`x::mem::indirect<A> a;`,
+				).
+				ToNotContain(
+					`std::optional<A>`,
+					`std::optional<B>`,
+				)
+		})
+
+		It("Should use indirect for cycles through array wrappers", func(ctx SpecContext) {
+			source := `
+				@cpp output "client/cpp/types"
+
+				Node struct {
+					children Node[]
+					parent Parent??
+				}
+				Parent struct {
+					nodes Node[]
+				}
+			`
+			resp := MustGenerate(ctx, source, "types", loader, cppPlugin)
+			ExpectContent(resp, "types.gen.h").
+				ToContain(`x::mem::indirect<Parent> parent;`).
+				ToNotContain(`std::optional<Parent>`)
+		})
+
+		It("Should use indirect for cycles through a distinct struct wrapper", func(ctx SpecContext) {
+			source := `
+				@cpp output "client/cpp/types"
+
+				A struct {
+					b BWrap??
+				}
+				B struct {
+					a A??
+				}
+				BWrap B
+			`
+			resp := MustGenerate(ctx, source, "types", loader, cppPlugin)
+			ExpectContent(resp, "types.gen.h").
+				ToContain(
+					`x::mem::indirect<BWrap> b;`,
+					`x::mem::indirect<A> a;`,
+				).
+				ToNotContain(
+					`std::optional<BWrap>`,
+					`std::optional<A>`,
+				)
+		})
+
 		It("Should use optional for non-self-referential optional fields", func(ctx SpecContext) {
 			source := `
 				@cpp output "client/cpp/types"

--- a/oracle/plugin/go/pb/pb.go
+++ b/oracle/plugin/go/pb/pb.go
@@ -1325,12 +1325,100 @@ func (p *Plugin) generateNestedArrayConversion(
 ) (forward, backward string, hasError bool) {
 	wrapperName := p.getNestedArrayWrapperName(typeRef, data.table)
 
-	data.imports.AddExternal("github.com/samber/lo")
+	// Delegate per-element conversion to the inner slice's existing
+	// XYZToPB / XYZFromPB helpers. This preserves type safety and error
+	// propagation for nested named-slice fields (e.g., Strata []Members).
+	// Falls back to the earlier broken lo.Map form only for [][]primitive,
+	// which has no struct helper to call — that path was not used by any
+	// schema at the time this fix landed.
+	if f, b, ok := p.generateStructNestedArrayConversion(typeRef, data, goField, pbField, wrapperName); ok {
+		return f, b, true
+	}
 
+	data.imports.AddExternal("github.com/samber/lo")
 	forward = fmt.Sprintf("lo.Map(%s, func(inner []string, _ int) *%s { return &%s{Values: inner} })", goField, wrapperName, wrapperName)
 	backward = fmt.Sprintf("lo.Map(%s, func(w *%s, _ int) []string { return w.Values })", pbField, wrapperName)
-
 	return forward, backward, false
+}
+
+// generateStructNestedArrayConversion emits the nested-array translation for
+// the common case of a slice-of-named-slice-of-struct (e.g., field type
+// []Members where Members = []Member). Returns ok=false if the schema does
+// not match this shape (e.g., [][]primitive), in which case the caller
+// should fall back to a simpler emission.
+//
+// The emitted forward expression has signature `([]*<Wrapper>, error)` and
+// the backward expression has signature `(<outer-go-type>, error)`. Both
+// delegate to the pre-existing XYZToPB / XYZFromPB helpers that the
+// generator emits for every named array type, so per-element error handling
+// and type conversions stay in one place.
+func (p *Plugin) generateStructNestedArrayConversion(
+	typeRef resolution.TypeRef,
+	data *templateData,
+	goField, pbField, wrapperName string,
+) (forward, backward string, ok bool) {
+	elemType, ok := p.getArrayElementType(typeRef, data.table)
+	if !ok {
+		return "", "", false
+	}
+	elemResolved, ok := elemType.Resolve(data.table)
+	if !ok {
+		return "", "", false
+	}
+	innerElem, ok := p.getArrayElementType(elemType, data.table)
+	if !ok {
+		return "", "", false
+	}
+	innerElemResolved, ok := innerElem.Resolve(data.table)
+	if !ok {
+		return "", "", false
+	}
+	if _, isStruct := innerElemResolved.Form.(resolution.StructForm); !isStruct {
+		return "", "", false
+	}
+
+	translatorPrefix, translatorStructName := p.resolvePBTranslatorInfo(innerElemResolved, data)
+	pluralName := pluralizeDistinct(translatorStructName)
+
+	// If the outer typeRef resolves to a distinct named type (e.g., Strata),
+	// use its qualified Go name so the IIFE's make() and return types match
+	// the field exactly. Otherwise, use []<elem-go-type>, which is assignable
+	// to an unnamed outer slice field.
+	outerGoType := ""
+	if outerResolved, ok := typeRef.Resolve(data.table); ok {
+		if _, isDistinct := outerResolved.Form.(resolution.DistinctForm); isDistinct {
+			outerGoType = data.parentAlias + "." + outerResolved.Name
+		}
+	}
+	if outerGoType == "" {
+		outerGoType = "[]" + data.parentAlias + "." + elemResolved.Name
+	}
+
+	forward = fmt.Sprintf(`func() ([]*%s, error) {
+		result := make([]*%s, len(%s))
+		for i, inner := range %s {
+			vals, err := %s%sToPB(inner)
+			if err != nil {
+				return nil, err
+			}
+			result[i] = &%s{Values: vals}
+		}
+		return result, nil
+	}()`, wrapperName, wrapperName, goField, goField, translatorPrefix, pluralName, wrapperName)
+
+	backward = fmt.Sprintf(`func() (%s, error) {
+		result := make(%s, len(%s))
+		for i, w := range %s {
+			vals, err := %s%sFromPB(w.Values)
+			if err != nil {
+				return nil, err
+			}
+			result[i] = vals
+		}
+		return result, nil
+	}()`, outerGoType, outerGoType, pbField, pbField, translatorPrefix, pluralName)
+
+	return forward, backward, true
 }
 
 func (p *Plugin) generateEnumTranslator(

--- a/oracle/plugin/go/pb/pb_test.go
+++ b/oracle/plugin/go/pb/pb_test.go
@@ -449,6 +449,51 @@ var _ = Describe("Go PB Plugin", func() {
 			})
 		})
 
+		Context("nested array of struct", func() {
+			It("Should delegate to generated helpers via IIFE when inner element is a struct", func(ctx SpecContext) {
+				source := `
+					@go output "arc/go/ir"
+					@pb
+
+					Member struct {
+						key string
+						value int32
+					}
+
+					Members = Member[]
+
+					Strata Members[]
+
+					Stage struct {
+						key string
+						strata Strata
+					}
+				`
+				resp := MustGenerate(ctx, source, "ir", loader, pbPlugin)
+
+				ExpectContent(resp, "translator.gen.go").
+					ToContain(
+						// Outer type matches the distinct named wrapper
+						"func() (ir.Strata, error) {",
+						"result := make(ir.Strata, len(pb.Strata))",
+						// Forward IIFE delegates to MembersToPB per inner slice
+						"func() ([]*MembersWrapper, error) {",
+						"result := make([]*MembersWrapper, len(r.Strata))",
+						"for i, inner := range r.Strata {",
+						"vals, err := MembersToPB(inner)",
+						"result[i] = &MembersWrapper{Values: vals}",
+						// Backward IIFE delegates to MembersFromPB
+						"for i, w := range pb.Strata {",
+						"vals, err := MembersFromPB(w.Values)",
+					).
+					ToNotContain(
+						// Must not fall back to the broken primitive lo.Map form
+						"lo.Map(r.Strata, func(inner []string",
+						"lo.Map(pb.Strata, func(w *MembersWrapper",
+					)
+			})
+		})
+
 		Context("generic struct translation", func() {
 			It("Should generate generic translator functions", func(ctx SpecContext) {
 				source := `
@@ -1288,6 +1333,200 @@ var _ = Describe("Go PB Plugin", func() {
 
 				ExpectContent(resp, "translator.gen.go").
 					ToContain("StatusToPB(r.Status)")
+			})
+		})
+
+		Context("distinct type wrapping a primitive", func() {
+			It("Should cast in and out of the distinct Go type via protoType", func(ctx SpecContext) {
+				source := `
+					@go output "core/task"
+					@pb
+
+					Priority uint16
+
+					Task struct {
+						key uuid
+						priority Priority
+					}
+				`
+				resp := MustGenerate(ctx, source, "task", loader, pbPlugin)
+
+				ExpectContent(resp, "translator.gen.go").
+					ToContain(
+						// uint16 → uint32 on the wire, same-package alias prefix.
+						"uint32(r.Priority)",
+						"task.Priority(pb.Priority)",
+					)
+			})
+
+			It("Should use uuid.Parse when distinct wraps a uuid", func(ctx SpecContext) {
+				source := `
+					@go output "core/task"
+					@pb
+
+					TaskID uuid
+
+					Task struct {
+						id TaskID
+						name string
+					}
+				`
+				resp := MustGenerate(ctx, source, "task", loader, pbPlugin)
+
+				ExpectContent(resp, "translator.gen.go").
+					ToContain(
+						// Forward calls .String(); backward parses and casts to the
+						// distinct wrapper.
+						"r.ID.String()",
+						"uuid.Parse(pb.Id)",
+						"task.TaskID",
+					)
+			})
+		})
+
+		Context("fixed-size uint8 array", func() {
+			It("Should delegate to the distinct type's Bytes/FromBytes helpers", func(ctx SpecContext) {
+				source := `
+					@go output "core/crypto"
+					@pb
+
+					Hash uint8[32]
+
+					Digest struct {
+						hash Hash
+					}
+				`
+				resp := MustGenerate(ctx, source, "crypto", loader, pbPlugin)
+
+				ExpectContent(resp, "translator.gen.go").
+					ToContain(
+						"r.Hash.Bytes()",
+						".FromBytes(pb.Hash)",
+					)
+			})
+		})
+
+		Context("delegation translator (distinct wrapping a struct)", func() {
+			It("Should generate a delegating translator that calls the base type's ToPB/FromPB", func(ctx SpecContext) {
+				loader.Add("schemas/ranger", `
+					@go output "core/ranger"
+					@pb output "core/ranger/pb"
+
+					Range struct {
+						key  uuid
+						name string
+					}
+				`)
+
+				source := `
+					import "schemas/ranger"
+
+					@go output "core/ranger/ts"
+					@pb output "core/ranger/ts/pb"
+
+					TSRange ranger.Range
+				`
+				resp := MustGenerate(ctx, source, "tsranger", loader, pbPlugin)
+
+				// Delegation translator lives in the TSRange output path and
+				// calls through to the base ranger.Range translator.
+				ExpectContent(resp, "core/ranger/ts/pb/translator.gen.go").
+					ToContain(
+						"ranger_pb.RangeToPB(ranger.Range(r))",
+						"ranger_pb.RangeFromPB",
+						"ts.TsRange(result)",
+					)
+			})
+		})
+
+		Context("struct with @key numeric field", func() {
+			It("Should cast through the Key type via protoType and namespace alias", func(ctx SpecContext) {
+				loader.Add("schemas/ids", `
+					@go output "core/ids"
+					@pb
+
+					Key uint32 {
+						@doc value "is an identifier"
+					}
+				`)
+
+				source := `
+					import "schemas/ids"
+
+					@go output "core/node"
+					@pb
+
+					Node struct {
+						id ids.Key {
+							@key
+						}
+						name string
+					}
+				`
+				resp := MustGenerate(ctx, source, "node", loader, pbPlugin)
+
+				ExpectContent(resp, "translator.gen.go").
+					ToContain(
+						"uint32(r.ID)",
+						"ids.Key(pb.Id)",
+					)
+			})
+
+			It("Should cast a bare numeric primitive @key field through the parent package alias", func(ctx SpecContext) {
+				source := `
+					@go output "core/node"
+					@pb
+
+					Node struct {
+						id uint32 {
+							@key
+						}
+						name string
+					}
+				`
+				resp := MustGenerate(ctx, source, "node", loader, pbPlugin)
+
+				ExpectContent(resp, "translator.gen.go").
+					ToContain(
+						// isNumericPrimitive branch: forward is protoType(goField),
+						// backward casts the pb value through <pkg>.Key(...).
+						"uint32(r.ID)",
+						"node.Key(pb.Id)",
+					)
+			})
+		})
+
+		Context("generic struct instantiated with a struct type arg", func() {
+			It("Should emit ToPBAny/FromPBAny helpers for the struct-typed instantiation", func(ctx SpecContext) {
+				source := `
+					@go output "core/control"
+					@pb
+
+					Details struct {
+						label string
+					}
+
+					Status struct<D> {
+						key     string
+						details D
+					}
+
+					Channel struct {
+						status Status<Details>
+					}
+				`
+				resp := MustGenerate(ctx, source, "control", loader, pbPlugin)
+
+				ExpectContent(resp, "translator.gen.go").
+					ToContain(
+						// ensureAnyHelper appends a ToPBAny/FromPBAny helper pair
+						// for each struct-typed generic instantiation.
+						"DetailsToPBAny",
+						"DetailsFromPBAny",
+						// Generic struct conversion forwards the typed converters.
+						"StatusToPB[control.Details]",
+						"StatusFromPB[control.Details]",
+					)
 			})
 		})
 	})

--- a/oracle/plugin/gomod/parser.go
+++ b/oracle/plugin/gomod/parser.go
@@ -84,11 +84,13 @@ func ResolveImportPath(outputPath, repoRoot, fallbackPrefix string) string {
 }
 
 // FindRepoRoot walks up from the given path to find the git repository root.
+// Accepts both a .git directory (main checkout) and a .git file (linked
+// worktree, where .git contains a gitdir: pointer).
 func FindRepoRoot(path string) string {
 	dir := filepath.Dir(path)
 	for {
 		gitPath := filepath.Join(dir, ".git")
-		if info, err := os.Stat(gitPath); err == nil && info.IsDir() {
+		if _, err := os.Stat(gitPath); err == nil {
 			return dir
 		}
 		parent := filepath.Dir(dir)

--- a/oracle/plugin/ts/types/types.go
+++ b/oracle/plugin/ts/types/types.go
@@ -2322,6 +2322,27 @@ export interface {{ .TSName }} extends z.{{ if .UseInput }}input{{ else }}infer{
 
 {{ formatDoc .TSName .Doc }}
 {{- end }}
+{{- if and .IsRecursive $.GenerateTypes }}
+export interface {{ .TSName }} {
+{{- range .Fields }}
+  {{ .TSName }}{{ if or .IsOptional .IsHardOptional }}?{{ end }}: {{ .TSType }}{{ if .IsArray }}[]{{ end }};
+{{- end }}
+}
+export const {{ camelCase .TSName }}Z: z.ZodType<{{ .TSName }}> = z.object({
+{{- range .Fields }}
+{{- if .Doc }}
+  {{ formatDoc .TSName .Doc }}
+{{- end }}
+{{- if .IsSelfRef }}
+  get {{ .TSName }}() {
+    return {{ .ZodType }};
+  },
+{{- else }}
+  {{ .TSName }}: {{ .ZodType }},
+{{- end }}
+{{- end }}
+});
+{{- else }}
 export const {{ camelCase .TSName }}Z = z.object({
 {{- range .Fields }}
 {{- if .Doc }}
@@ -2338,6 +2359,7 @@ export const {{ camelCase .TSName }}Z = z.object({
 });
 {{- if $.GenerateTypes }}
 export interface {{ .TSName }} extends z.{{ if .UseInput }}input{{ else }}infer{{ end }}<typeof {{ camelCase .TSName }}Z> {}
+{{- end }}
 {{- end }}
 {{- end }}
 {{- end }}

--- a/oracle/plugin/ts/types/types_test.go
+++ b/oracle/plugin/ts/types/types_test.go
@@ -792,11 +792,11 @@ var _ = Describe("TS Types Plugin", func() {
 			Expect(err).To(BeNil())
 
 			content := string(resp.Files[0].Content)
-			Expect(content).To(ContainSubstring(`export const typeZ = z.object({`))
+			Expect(content).To(ContainSubstring(`export interface Type {`))
+			Expect(content).To(ContainSubstring(`export const typeZ: z.ZodType<Type> = z.object({`))
 			Expect(content).To(ContainSubstring(`kind: kindZ`))
-			Expect(content).To(ContainSubstring(`get elem():`))
+			Expect(content).To(ContainSubstring(`get elem() {`))
 			Expect(content).To(ContainSubstring(`return typeZ.optional()`))
-			Expect(content).To(ContainSubstring(`export interface Type extends z.infer<typeof typeZ> {}`))
 		})
 
 		It("Should generate getter for array self-referencing struct", func(ctx SpecContext) {
@@ -819,10 +819,64 @@ var _ = Describe("TS Types Plugin", func() {
 			Expect(err).To(BeNil())
 
 			content := string(resp.Files[0].Content)
-			Expect(content).To(ContainSubstring(`export const nodeZ = z.object({`))
-			Expect(content).To(ContainSubstring(`get children():`))
-			// Optional arrays use zod.nullToUndefined with array schema
+			Expect(content).To(ContainSubstring(`export interface Node {`))
+			Expect(content).To(ContainSubstring(`export const nodeZ: z.ZodType<Node> = z.object({`))
+			Expect(content).To(ContainSubstring(`get children() {`))
 			Expect(content).To(ContainSubstring(`return zod.nullToUndefined(nodeZ.array())`))
+		})
+
+		It("Should emit Zod v4 recursive pattern for mutually recursive structs", func(ctx SpecContext) {
+			source := `
+				@ts output "out"
+
+				A struct {
+					b B?
+				}
+
+				B struct {
+					a A?
+				}
+			`
+			resp := MustGenerate(ctx, source, "cycle", loader, typesPlugin)
+			ExpectContent(resp, "types.gen.ts").
+				ToContain(
+					`export interface A {`,
+					`export interface B {`,
+					`export const aZ: z.ZodType<A> = z.object({`,
+					`export const bZ: z.ZodType<B> = z.object({`,
+				).
+				ToNotContain(
+					`extends z.infer<typeof aZ>`,
+					`extends z.infer<typeof bZ>`,
+				)
+		})
+
+		It("Should emit Zod v4 recursive pattern for cycles through a distinct wrapper", func(ctx SpecContext) {
+			source := `
+				@ts output "out"
+
+				A struct {
+					b BWrap?
+				}
+
+				B struct {
+					a A?
+				}
+
+				BWrap B
+			`
+			resp := MustGenerate(ctx, source, "cycle", loader, typesPlugin)
+			ExpectContent(resp, "types.gen.ts").
+				ToContain(
+					`export interface A {`,
+					`export interface B {`,
+					`export const aZ: z.ZodType<A> = z.object({`,
+					`export const bZ: z.ZodType<B> = z.object({`,
+				).
+				ToNotContain(
+					`extends z.infer<typeof aZ>`,
+					`extends z.infer<typeof bZ>`,
+				)
 		})
 
 		It("Should generate getter for struct with multiple recursive fields", func(ctx SpecContext) {
@@ -846,10 +900,11 @@ var _ = Describe("TS Types Plugin", func() {
 			Expect(err).To(BeNil())
 
 			content := string(resp.Files[0].Content)
-			Expect(content).To(ContainSubstring(`export const mosaicNodeZ = z.object({`))
-			Expect(content).To(ContainSubstring(`get first():`))
+			Expect(content).To(ContainSubstring(`export interface MosaicNode {`))
+			Expect(content).To(ContainSubstring(`export const mosaicNodeZ: z.ZodType<MosaicNode> = z.object({`))
+			Expect(content).To(ContainSubstring(`get first() {`))
 			Expect(content).To(ContainSubstring(`return mosaicNodeZ.optional()`))
-			Expect(content).To(ContainSubstring(`get last():`))
+			Expect(content).To(ContainSubstring(`get last() {`))
 		})
 
 		It("Should generate getter for generic recursive struct with single param", func(ctx SpecContext) {

--- a/oracle/resolution/resolution_test.go
+++ b/oracle/resolution/resolution_test.go
@@ -885,3 +885,135 @@ var _ = Describe("SubstituteTypeRef", func() {
 		Expect(result.TypeArgs[1].TypeArgs[0].Name).To(Equal("uuid"))
 	})
 })
+
+var _ = Describe("RefersTo", func() {
+	const target = "ns.Target"
+
+	var table *resolution.Table
+
+	BeforeEach(func() {
+		table = resolution.NewTable()
+		Expect(table.Add(resolution.Type{
+			Name:          "Target",
+			QualifiedName: target,
+			Namespace:     "ns",
+			Form:          resolution.StructForm{},
+		})).To(Succeed())
+	})
+
+	It("returns true on a direct name match", func() {
+		ref := resolution.TypeRef{Name: target}
+		Expect(resolution.RefersTo(ref, target, table)).To(BeTrue())
+	})
+
+	It("returns true when the match is nested in a type argument", func() {
+		ref := resolution.TypeRef{
+			Name:     "Array",
+			TypeArgs: []resolution.TypeRef{{Name: target}},
+		}
+		Expect(resolution.RefersTo(ref, target, table)).To(BeTrue())
+	})
+
+	It("returns true when the match is deep in nested type arguments", func() {
+		ref := resolution.TypeRef{
+			Name: "Map",
+			TypeArgs: []resolution.TypeRef{
+				{Name: "string"},
+				{Name: "Array", TypeArgs: []resolution.TypeRef{{Name: target}}},
+			},
+		}
+		Expect(resolution.RefersTo(ref, target, table)).To(BeTrue())
+	})
+
+	It("returns true when the match is reachable through a struct field", func() {
+		Expect(table.Add(resolution.Type{
+			Name: "HasTarget", QualifiedName: "ns.HasTarget", Namespace: "ns",
+			Form: resolution.StructForm{
+				Fields: []resolution.Field{
+					{Name: "t", Type: resolution.TypeRef{Name: target}},
+				},
+			},
+		})).To(Succeed())
+		ref := resolution.TypeRef{Name: "ns.HasTarget"}
+		Expect(resolution.RefersTo(ref, target, table)).To(BeTrue())
+	})
+
+	It("returns true when the match is reachable through an alias target", func() {
+		Expect(table.Add(resolution.Type{
+			Name: "AliasToTarget", QualifiedName: "ns.AliasToTarget", Namespace: "ns",
+			Form: resolution.AliasForm{Target: resolution.TypeRef{Name: target}},
+		})).To(Succeed())
+		ref := resolution.TypeRef{Name: "ns.AliasToTarget"}
+		Expect(resolution.RefersTo(ref, target, table)).To(BeTrue())
+	})
+
+	It("returns true when the match is reachable through a distinct base", func() {
+		Expect(table.Add(resolution.Type{
+			Name: "DistinctFromTarget", QualifiedName: "ns.DistinctFromTarget", Namespace: "ns",
+			Form: resolution.DistinctForm{Base: resolution.TypeRef{Name: target}},
+		})).To(Succeed())
+		ref := resolution.TypeRef{Name: "ns.DistinctFromTarget"}
+		Expect(resolution.RefersTo(ref, target, table)).To(BeTrue())
+	})
+
+	It("returns false when the ref name is absent from the table", func() {
+		ref := resolution.TypeRef{Name: "ns.Ghost"}
+		Expect(resolution.RefersTo(ref, target, table)).To(BeFalse())
+	})
+
+	It("returns false when the struct references only unrelated types", func() {
+		Expect(table.Add(resolution.Type{
+			Name: "Unrelated", QualifiedName: "ns.Unrelated", Namespace: "ns",
+			Form: resolution.StructForm{
+				Fields: []resolution.Field{
+					{Name: "x", Type: resolution.TypeRef{Name: "int32"}},
+				},
+			},
+		})).To(Succeed())
+		ref := resolution.TypeRef{Name: "ns.Unrelated"}
+		Expect(resolution.RefersTo(ref, target, table)).To(BeFalse())
+	})
+
+	It("terminates on a cycle that does not involve the target", func() {
+		Expect(table.Add(resolution.Type{
+			Name: "CycleA", QualifiedName: "ns.CycleA", Namespace: "ns",
+			Form: resolution.StructForm{
+				Fields: []resolution.Field{
+					{Name: "b", Type: resolution.TypeRef{Name: "ns.CycleB"}},
+				},
+			},
+		})).To(Succeed())
+		Expect(table.Add(resolution.Type{
+			Name: "CycleB", QualifiedName: "ns.CycleB", Namespace: "ns",
+			Form: resolution.StructForm{
+				Fields: []resolution.Field{
+					{Name: "a", Type: resolution.TypeRef{Name: "ns.CycleA"}},
+				},
+			},
+		})).To(Succeed())
+		ref := resolution.TypeRef{Name: "ns.CycleA"}
+		Expect(resolution.RefersTo(ref, target, table)).To(BeFalse())
+	})
+
+	It("detects the target even when reached via a cycle", func() {
+		Expect(table.Add(resolution.Type{
+			Name: "A", QualifiedName: "ns.A", Namespace: "ns",
+			Form: resolution.StructForm{
+				Fields: []resolution.Field{
+					{Name: "b", Type: resolution.TypeRef{Name: "ns.B"}},
+					{Name: "t", Type: resolution.TypeRef{Name: target}},
+				},
+			},
+		})).To(Succeed())
+		Expect(table.Add(resolution.Type{
+			Name: "B", QualifiedName: "ns.B", Namespace: "ns",
+			Form: resolution.StructForm{
+				Fields: []resolution.Field{
+					{Name: "a", Type: resolution.TypeRef{Name: "ns.A"}},
+				},
+			},
+		})).To(Succeed())
+		ref := resolution.TypeRef{Name: "ns.B"}
+		Expect(resolution.RefersTo(ref, target, table)).To(BeTrue())
+	})
+})

--- a/oracle/resolution/type.go
+++ b/oracle/resolution/type.go
@@ -142,6 +142,51 @@ func (r TypeRef) MustResolve(table *Table) Type {
 	return table.MustGet(r.Name)
 }
 
+// RefersTo reports whether ref directly or transitively references a type
+// identified by targetQualifiedName. The search follows type arguments, struct
+// field types, alias targets, and distinct bases, so mutual-recursion cycles
+// (A → B → A) are detected, not just direct self-reference (A → A). A visited
+// set prevents infinite loops on non-target cycles.
+//
+// This is the shared primitive behind the analyzer's IsRecursive detection
+// and the C++ plugin's decision between std::optional<T> and
+// x::mem::indirect<T> for hard-optional fields.
+func RefersTo(ref TypeRef, targetQualifiedName string, table *Table) bool {
+	return refersTo(ref, targetQualifiedName, table, set.New[string]())
+}
+
+func refersTo(ref TypeRef, targetQN string, table *Table, visited set.Set[string]) bool {
+	if ref.Name == targetQN {
+		return true
+	}
+	for _, arg := range ref.TypeArgs {
+		if refersTo(arg, targetQN, table, visited) {
+			return true
+		}
+	}
+	if visited.Contains(ref.Name) {
+		return false
+	}
+	visited.Add(ref.Name)
+	resolved, ok := table.Get(ref.Name)
+	if !ok {
+		return false
+	}
+	switch form := resolved.Form.(type) {
+	case StructForm:
+		for _, f := range form.Fields {
+			if refersTo(f.Type, targetQN, table, visited) {
+				return true
+			}
+		}
+	case AliasForm:
+		return refersTo(form.Target, targetQN, table, visited)
+	case DistinctForm:
+		return refersTo(form.Base, targetQN, table, visited)
+	}
+	return false
+}
+
 type TypeParam struct {
 	Constraint *TypeRef
 	Default    *TypeRef


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4043](https://linear.app/synnax/issue/SY-4043)

## Description

Preparation PR extracted from #2222 to keep the oracle-related generator changes reviewable in isolation. The new arc IR shape (nested slice types like `Strata []Members` where `Members = []Member`, plus recursive `Stage` structs) surfaced latent bugs across every target language's oracle generator. Once this lands, #2222 rebases onto the new `rc`.

### Generator fixes

- `resolution.RefersTo`: shared transitive type-reference primitive with a cycle-safe visited set. Follows type args, struct fields, alias targets, and distinct bases. Consolidates three divergent copies across `analyzer`, `cpp/json`, and `cpp/types`, and fixes the cycle-through-distinct case (A → distinct(B) → A) that the previous direct-only checks missed.
- `cpp/json`: symmetric `isSelfRef` early return in `toJSONExprForField` so `x::mem::indirect<T>` fields emit `has_value()/->to_json()` instead of falling through to a default assignment that was ill-typed. Adds a nested-array-of-struct branch using `x::json::to_array`.
- `cpp/pb`: nested-array-of-struct conversion delegates to per-element `to_proto`/`from_proto` with error propagation, replacing the primitive-only `add_values(v)` emission.
- `go/pb`: replaces the broken `lo.Map` emission for `[]Named` slices with an IIFE that calls the generated `XYZToPB`/`XYZFromPB` helpers. Outer return type picks up the distinct Go name when applicable so the IIFE is assignable to the field.
- `ts/types`: recursive struct generation via explicit interface plus `z.ZodType<T>` with getter accessors on self-referential fields.
- Coverage: new `RefersTo` branches (direct, type-arg, struct-field, alias-target, distinct-base, cycle) and end-to-end generator tests for cycle-through-distinct across `cpp/json`, `cpp/types`, and `ts/types`.

### Worktree robustness

`paths.findGitRoot` and `gomod.FindRepoRoot` both required `.git` to be a directory, so both returned no root inside a linked git worktree (where `.git` is a file containing a `gitdir:` pointer). Dropping the `IsDir()` check accepts both shapes. Also replaces `paths_test.go`'s hardcoded `HaveSuffix("synnax")` with checks for two Synnax-specific committed root files (`pnpm-workspace.yaml` and `MODULE.bazel`), so the test identifies the repo root by contents rather than the worktree directory name.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes latent bugs in the Oracle code generator exposed by the new Arc IR shape (nested slice types and recursive `Stage` structs). It consolidates three divergent `isSelfReference` implementations into a single `resolution.RefersTo` primitive with proper cycle detection via a visited set, fixes nested-array-of-struct emission in the C++, Go, and TypeScript generators, and patches git worktree root-walk failures where `.git` is a file rather than a directory.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2 style; no correctness or data-integrity issues found

The cycle detection algorithm is correct, test coverage for RefersTo is thorough (direct, type-arg, struct-field, alias, distinct, and cycle cases), and the generator fixes are well-targeted. The only finding is dead code at json.go line 708 that cannot affect runtime behavior.

oracle/plugin/cpp/json/json.go — dead isSelfRef branch at line 708

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| oracle/resolution/type.go | Adds RefersTo/refersTo with cycle-safe visited set; correctly shares the set across recursive calls to avoid infinite loops on non-target cycles |
| oracle/analyzer/analyzer.go | Replaces local typeRefersTo (type-args only) with resolution.RefersTo; now correctly marks mutually recursive types as IsRecursive via struct fields, alias targets, and distinct bases |
| oracle/plugin/cpp/json/json.go | Adds symmetric isSelfRef early return and nested-array-of-struct branch; however the early return at line 652 makes the isSelfRef check at line 708 unreachable dead code |
| oracle/plugin/cpp/pb/pb.go | Adds struct-aware nested-array conversion that delegates to per-element to_proto/from_proto helpers with error propagation; falls back to existing primitive path |
| oracle/plugin/cpp/types/types.go | Replaces local isSelfReference with resolution.RefersTo; removes the now-redundant helper function |
| oracle/plugin/go/pb/pb.go | Adds generateStructNestedArrayConversion IIFE path for slice-of-named-slice-of-struct, correctly handles distinct outer Go type naming; fallback primitive path is acknowledged as broken but unused |
| oracle/plugin/ts/types/types.go | Adds new template branch for IsRecursive structs (Zod v4 z.ZodType<T> with explicit interface + getter accessors for forward references); non-recursive path unchanged |
| oracle/paths/paths.go | Drops IsDir() check in findGitRoot so linked worktrees (.git as file) are accepted alongside normal checkouts |
| oracle/plugin/gomod/parser.go | Drops IsDir() check in FindRepoRoot for the same worktree reason; comment updated to document both accepted shapes |
| oracle/paths/paths_test.go | Replaces brittle HaveSuffix("synnax") assertion with content-based checks (pnpm-workspace.yaml, MODULE.bazel); more robust across worktree directory names |
| oracle/resolution/resolution_test.go | Adds thorough RefersTo test suite covering direct match, type-arg nesting, struct fields, alias targets, distinct bases, cycle termination, and cycle-with-target detection |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["resolution.RefersTo(ref, target, table)"] --> B{"ref.Name == target?"}
    B -- yes --> RET_TRUE["return true"]
    B -- no --> C["check type args recursively"]
    C --> D{"any arg refers to target?"}
    D -- yes --> RET_TRUE
    D -- no --> E{"ref.Name in visited?"}
    E -- yes --> RET_FALSE["return false"]
    E -- no --> F["visited.Add(ref.Name)"]
    F --> G{"resolve ref in table"}
    G -- not found --> RET_FALSE
    G -- StructForm --> H["check each field type recursively"]
    G -- AliasForm --> I["follow alias target"]
    G -- DistinctForm --> J["follow distinct base"]
    H --> K{"any field refers to target?"}
    K -- yes --> RET_TRUE
    K -- no --> RET_FALSE
    I --> A
    J --> A
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `oracle/plugin/cpp/json/json.go`, line 708-710 ([link](https://github.com/synnaxlabs/synnax/blob/3851e6b06990e0649150c644813379602aa0de7e/oracle/plugin/cpp/json/json.go#L708-L710)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Unreachable `isSelfRef` branch**

   The early return added at line 652 (`if isSelfRef { return ... }`) guarantees `isSelfRef` is `false` by the time execution reaches this point, so this branch can never fire. The `if field.IsHardOptional` check on line 711 already handles the remaining hard-optional struct case identically, so no behavior is lost — but the dead branch adds noise.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["oracle: accept .git as file or directory..."](https://github.com/synnaxlabs/synnax/commit/3851e6b06990e0649150c644813379602aa0de7e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28673804)</sub>

<!-- /greptile_comment -->