### PR TITLE
SY-4083: Version 55 Release Notes

### DIFF
--- a/arc/ts/src/grammar/arc.tmLanguage.json
+++ b/arc/ts/src/grammar/arc.tmLanguage.json
@@ -6,6 +6,9 @@
       "include": "#comments"
     },
     {
+      "include": "#for-statement"
+    },
+    {
       "include": "#keywords"
     },
     {
@@ -47,6 +50,49 @@
           "name": "comment.block.arc",
           "begin": "/\\*",
           "end": "\\*/"
+        }
+      ]
+    },
+    "for-statement": {
+      "patterns": [
+        {
+          "name": "meta.for-statement.arc",
+          "begin": "\\bfor\\b",
+          "beginCaptures": {
+            "0": {
+              "name": "keyword.control.arc"
+            }
+          },
+          "end": "(?=\\{)",
+          "patterns": [
+            {
+              "include": "#comments"
+            },
+            {
+              "include": "#numbers"
+            },
+            {
+              "include": "#strings"
+            },
+            {
+              "include": "#operators"
+            },
+            {
+              "include": "#flow-operators"
+            },
+            {
+              "include": "#types"
+            },
+            {
+              "include": "#functions"
+            },
+            {
+              "include": "#channels"
+            },
+            {
+              "include": "#identifiers"
+            }
+          ]
         }
       ]
     },
@@ -206,7 +252,7 @@
         },
         {
           "name": "support.function.builtin.arc",
-          "match": "\\b(len|now|pow|panic|interval|wait|concat|equal)\\b(?=\\s*[({])"
+          "match": "\\b(len|now|pow|panic|interval|wait|concat|equal|range)\\b(?=\\s*[({])"
         },
         {
           "name": "entity.name.function.arc",

--- a/docs/site/src/middleware.ts
+++ b/docs/site/src/middleware.ts
@@ -11,6 +11,7 @@ import type { MiddlewareHandler } from "astro";
 
 export const onRequest: MiddlewareHandler = async (_, next) => {
   const response = await next();
+  if (import.meta.env.DEV) return response;
 
   response.headers.set(
     "Content-Security-Policy",

--- a/docs/site/src/pages/reference/core/installation.mdx
+++ b/docs/site/src/pages/reference/core/installation.mdx
@@ -23,7 +23,7 @@ export const components = mdxOverrides;
 This page will walk you through how to install the Synnax binary on Windows, macOS, and
 Linux. To get started, select your operating system below:
 
-<Platform.Tabs client:only="react">
+<Platform.Tabs client:load>
 
 <Fragment slot="Docker">
 

--- a/docs/site/src/pages/reference/core/quick-start.mdx
+++ b/docs/site/src/pages/reference/core/quick-start.mdx
@@ -21,7 +21,7 @@ export const components = mdxOverrides;
 This page will walk you through starting a Synnax Core. To get started, select your
 operating system below:
 
-<Platform.Tabs client:only="react">
+<Platform.Tabs client:load>
 <Fragment slot="Docker">
 
 ## Using Docker

--- a/docs/site/src/pages/reference/installation.mdx
+++ b/docs/site/src/pages/reference/installation.mdx
@@ -28,7 +28,7 @@ to get started.
 The Core is the heart of every Synnax deployment. It stores all sensor and actuator data
 and serves as a central hub where devices, Consoles, and control sequences communicate.
 
-<Platform.Tabs client:only="react">
+<Platform.Tabs client:load>
 
 <Fragment slot="Docker">
 
@@ -155,7 +155,7 @@ You should see:
 
 ## <Step step={2} level="h2">Start the Core</Step>
 
-<Platform.Tabs client:only="react">
+<Platform.Tabs client:load>
 
 <Fragment slot="Docker">
 

--- a/docs/site/src/pages/releases/0-31-0.mdx
+++ b/docs/site/src/pages/releases/0-31-0.mdx
@@ -5,6 +5,7 @@ title: "Version 0.31 Release Notes"
 import { Image } from "@/components/media/Media";
 import Release from "@/components/releases/Release.astro";
 import Diagram from "@/components/diagram/Diagram.astro";
+import { Divider } from "@synnaxlabs/pluto";
 import { mdxOverrides } from "@/components/mdxOverrides";
 export const components = mdxOverrides;
 
@@ -17,6 +18,8 @@ export const components = mdxOverrides;
 <Diagram preview>
   <Image client:only="react" id="releases/0-31-0/thumbnail" />
 </Diagram>
+
+<Divider.Divider x />
 
 ### Summary
 
@@ -40,6 +43,8 @@ This release also introduces six new schematic symbols.
 <Image client:only="react" id="releases/0-31-0/new-symbols" />
 
 The label positions and wrap widths of all symbols can now be customized.
+
+<Divider.Divider x />
 
 ### Breaking Changes
 

--- a/docs/site/src/pages/releases/0-32-0.mdx
+++ b/docs/site/src/pages/releases/0-32-0.mdx
@@ -5,6 +5,7 @@ title: "Version 0.32 Release Notes"
 import { Image } from "@/components/media/Media";
 import Diagram from "@/components/diagram/Diagram.astro";
 import Release from "@/components/releases/Release.astro";
+import { Divider } from "@synnaxlabs/pluto";
 import { mdxOverrides } from "@/components/mdxOverrides";
 export const components = mdxOverrides;
 
@@ -15,6 +16,8 @@ title="Multi-Device NI Analog Read Tasks"
 >
 
 <Image client:only="react" id="releases/0-32-0/thumbnail" />
+
+<Divider.Divider x />
 
 ### Summary
 
@@ -30,6 +33,8 @@ scenarios:
 
 Instead of choosing the device at the top level of the task, you can now specify the
 device for each channel.
+
+<Divider.Divider x />
 
 ### Breaking Changes
 

--- a/docs/site/src/pages/releases/0-33-0.mdx
+++ b/docs/site/src/pages/releases/0-33-0.mdx
@@ -6,6 +6,7 @@ import { Image } from "@/components/media/Media";
 import Release from "@/components/releases/Release.astro";
 import Diagram from "@/components/diagram/Diagram.astro";
 import LabJack from "@/pages/releases/LabJack.astro";
+import { Divider } from "@synnaxlabs/pluto";
 import { mdxOverrides } from "@/components/mdxOverrides";
 export const components = mdxOverrides;
 
@@ -36,6 +37,8 @@ We've added a new [log component](/reference/console/logs) to the Synnax
 format. This component can be connected to any channel, and is particularly useful for
 tracking the progress of [control sequences](/reference/control/get-started) and other
 automated hardware control processes.
+
+<Divider.Divider x />
 
 ### Breaking Changes
 

--- a/docs/site/src/pages/releases/0-34-0.mdx
+++ b/docs/site/src/pages/releases/0-34-0.mdx
@@ -6,6 +6,7 @@ import { Image } from "@/components/media/Media";
 import Diagram from "@/components/diagram/Diagram.astro";
 import Release from "@/components/releases/Release.astro";
 import LabJack from "@/pages/releases/LabJack.astro";
+import { Divider } from "@synnaxlabs/pluto";
 import { mdxOverrides } from "@/components/mdxOverrides";
 export const components = mdxOverrides;
 
@@ -27,11 +28,15 @@ acquire data from inputs.
 Synnax currently only supports LabJack devices on Windows, although we plan to add
 support for other operating systems soon.
 
+<Divider.Divider x />
+
 ### Taring Functionality
 
 Both [National Instruments](/reference/driver/ni) and
 [LabJack](/reference/driver/labjack) read tasks now support taring functionality. This
 feature allows you to zero out the current value of a read task.
+
+<Divider.Divider x />
 
 ### Other Minor Improvements and Bug Fixes
 
@@ -41,6 +46,8 @@ feature allows you to zero out the current value of a read task.
 - Font sizes on a [schematic](/reference/console/schematics) value are now configurable.
 - [Schematic](/reference/console/schematics) values can now be displayed in scientific
   notation.
+
+<Divider.Divider x />
 
 ### Breaking Changes
 

--- a/docs/site/src/pages/releases/0-35-0.mdx
+++ b/docs/site/src/pages/releases/0-35-0.mdx
@@ -6,6 +6,7 @@ import { Image, Video } from "@/components/media/Media";
 import Release from "@/components/releases/Release.astro";
 import Diagram from "@/components/diagram/Diagram.astro";
 import LabJack from "@/pages/releases/LabJack.astro";
+import { Divider } from "@synnaxlabs/pluto";
 import { mdxOverrides } from "@/components/mdxOverrides";
 export const components = mdxOverrides;
 
@@ -36,11 +37,15 @@ Synnax version 0.35.0 introduces a new table component, fixes a few issues with 
 recently released LabJack driver, makes several improvements to schematic editing, and
 fixes a number of performance related bugs.
 
+<Divider.Divider x />
+
 ### Table Component
 
 The new table component is a powerful tool for displaying and interacting with tabular
 data. Tables are particularly useful for displaying data from many different channels,
 and for displaying data that should be flagged for exceeding certain thresholds.
+
+<Divider.Divider x />
 
 ### Schematic Improvements
 
@@ -108,6 +113,8 @@ your schematic.
   }}
 />
 
+<Divider.Divider x />
+
 ### Other Minor Improvements and Bug Fixes
 
 - Reduced response times for configuring [LabJack](/reference/driver/labjack) tasks.
@@ -116,6 +123,8 @@ your schematic.
 - Improved shutdown procedure for the Synnax Core and embedded Driver.
 - The light schematic symbol can now accept telemetry types beyond just boolean sources,
   and includes a threshold setting to trigger state changes
+
+<Divider.Divider x />
 
 ### Breaking Changes
 

--- a/docs/site/src/pages/releases/0-36-0.mdx
+++ b/docs/site/src/pages/releases/0-36-0.mdx
@@ -6,6 +6,7 @@ import { Image, Video } from "@/components/media/Media";
 import Diagram from "@/components/diagram/Diagram.astro";
 import Release from "@/components/releases/Release.astro";
 import LabJack from "@/pages/releases/LabJack.astro";
+import { Divider } from "@synnaxlabs/pluto";
 import { mdxOverrides } from "@/components/mdxOverrides";
 export const components = mdxOverrides;
 
@@ -19,6 +20,8 @@ export const components = mdxOverrides;
 Synnax v0.36.0 introduces several new quality of life improvements and bug fixes,
 including a new line plot annotation tool, schematic undo/redo, a new way to select the
 time of the range, and a refactored LabJack write task.
+
+<Divider.Divider x />
 
 ### Line Plot Annotation Tool
 
@@ -35,6 +38,8 @@ can be accessed by clicking the 'Annotations' tab in the Visualization Toolbar.
   }}
 />
 
+<Divider.Divider x />
+
 ### Schematic Undo/Redo
 
 You can now undo and redo changes to a schematic. This feature is possible by using the
@@ -42,6 +47,8 @@ You can now undo and redo changes to a schematic. This feature is possible by us
 editing.
 
 <Video client:only="react" id="releases/0-36-0/schematic-undo" themed={false} />
+
+<Divider.Divider x />
 
 ### New Range DateTime Selector
 
@@ -52,12 +59,16 @@ the appropriate date and time.
 
 <Image client:only="react" id="releases/0-36-0/range" themed={false} />
 
+<Divider.Divider x />
+
 ### Breaking Changes
 
 This release introduces a breaking change in the communication protocol that the Core
 and Console use to communicate. This change means that **Console versions 0.36.0 and
 newer** will not work with **Core versions of 0.35.0 and older**. To avoid issues,
 please ensure that your Core and Console are updated to the same version.
+
+<Divider.Divider x />
 
 ### Other Improvements and Bug Fixes
 

--- a/docs/site/src/pages/releases/0-37-0.mdx
+++ b/docs/site/src/pages/releases/0-37-0.mdx
@@ -4,6 +4,7 @@ title: "Version 0.37 Release Notes"
 
 import { Image, Video } from "@/components/media/Media";
 import Release from "@/components/releases/Release.astro";
+import { Divider } from "@synnaxlabs/pluto";
 import { mdxOverrides } from "@/components/mdxOverrides";
 import Thumbnail from "@/pages/releases/Thumbnail0370.astro";
 export const components = mdxOverrides;
@@ -18,6 +19,8 @@ export const components = mdxOverrides;
 
 Synnax v0.37.0 is our final release for 2024, and is focused on touching up many of the
 features our team has built over the past year.
+
+<Divider.Divider x />
 
 ### More Schematic Symbols
 
@@ -35,6 +38,8 @@ meters, flame arresters, new valves, pumps, heat exchangers, strainers, and a th
   }}
 />
 
+<Divider.Divider x />
+
 ### Minor Improvements
 
 - Cleaned up the look of the schematic set point component, and prevented `NaN` from
@@ -43,6 +48,8 @@ meters, flame arresters, new valves, pumps, heat exchangers, strainers, and a th
   it easier to navigate the tree.
 - Upgraded a number of dependencies to make the Synnax Python client compatible with
   Python 3.13.
+
+<Divider.Divider x />
 
 ### Bug Fixes
 

--- a/docs/site/src/pages/releases/0-38-0.mdx
+++ b/docs/site/src/pages/releases/0-38-0.mdx
@@ -3,6 +3,7 @@ title: "Version 0.38 Release Notes"
 ---
 
 import { Image } from "@/components/media/Media";
+import { Divider } from "@synnaxlabs/pluto";
 import { mdxOverrides } from "@/components/mdxOverrides";
 import Release from "@/components/releases/Release.astro";
 import Diagram from "@/components/diagram/Diagram.astro";
@@ -26,6 +27,8 @@ export const components = mdxOverrides;
 Synnax v0.38.0 is our first release of 2025, and contains a large number of new features
 including beta calculated channels, workspace importing, and more.
 
+<Divider.Divider x />
+
 ### Calculated Channels
 
 [Calculated channels](/reference/console/calculated-channels) are a new feature that
@@ -37,6 +40,8 @@ Calculated channels are currently in beta, and you may run into stability issues
 unexpected behavior while using them. If you run into any issues, please report it to
 the Synnax team.
 
+<Divider.Divider x />
+
 ### Workspace Importing and Exporting
 
 The Synnax Console now supports sharing workspaces via a directory configuration.
@@ -44,11 +49,15 @@ Workspaces can be shared by
 [importing and exporting](/reference/console/workspaces#sharing-via-file) workspaces
 into directories to be stored on your desktop.
 
+<Divider.Divider x />
+
 ### Windows Core Installer
 
 The Windows version of the Core can now be installed by an installer. This means you
 only need to download a single installer file, and then run it to install the Core. More
 information can be found on our [Core installation page](/reference/core/installation).
+
+<Divider.Divider x />
 
 ### Python CLI Command Deprecation
 
@@ -59,6 +68,8 @@ access the Python client, you should now use the `sy` command:
 ```bash
 sy login
 ```
+
+<Divider.Divider x />
 
 ### Improvements
 
@@ -71,6 +82,8 @@ sy login
 - Groups are now positioned above all other items within the Resources Toolbar.
 - Line plots render `uint8` data faster.
 - `Cmd + A` can now be used to group all schematic elements.
+
+<Divider.Divider x />
 
 ### Bug Fixes
 

--- a/docs/site/src/pages/releases/0-39-0.mdx
+++ b/docs/site/src/pages/releases/0-39-0.mdx
@@ -7,7 +7,7 @@ import Release from "@/components/releases/Release.astro";
 import Diagram from "@/components/diagram/Diagram.astro";
 import LabJack from "@/pages/releases/LabJack.astro";
 import { mdxOverrides } from "@/components/mdxOverrides";
-import { Note } from "@synnaxlabs/pluto";
+import { Note, Divider } from "@synnaxlabs/pluto";
 export const components = mdxOverrides;
 
 <Release
@@ -28,6 +28,8 @@ Synnax v0.39.0 introduces embedded control sequences. Write and deploy tightly t
 control loops directly within the Synnax Console. We've done major refactoring work on
 the Synnax Driver to make it more reliable and user-friendly.
 
+<Divider.Divider x />
+
 ### Embedded Control Sequences
 
 <Note.Note variant="warning">
@@ -41,17 +43,23 @@ and operate control sequences on devices. While this new system does not replace
 existing [Python-based control sequences](/reference/control/python), it can serve as an
 alternative in many situations.
 
+<Divider.Divider x />
+
 ### NI Linux Real-Time Driver
 
 We've released the [Synnax Driver](/reference/driver/installation) as a separate binary
 for deployment on NI controllers running NI Linux Real-Time. This allows you to acquire
 data, control hardware, and even run embedded sequences directly on a cRIO controller.
 
+<Divider.Divider x />
+
 ### NI Analog Write Task
 
 We've added a new [NI Analog Write Task](/reference/driver/ni/analog-write-task) that
 allows you to write analog data to NI devices. This task is useful for a wide variety of
 applications, such as generating test signals or controlling hardware.
+
+<Divider.Divider x />
 
 ### Driver Performance & Experience Improvements
 
@@ -60,12 +68,16 @@ stability. We've improved our device discovery mechanisms, made tasks more resil
 device disconnects, and made a number of changes to the Console task configuration UI's
 to make them easier to use.
 
+<Divider.Divider x />
+
 ### Removal of Deprecated `synnax` Python Client Command
 
 <Note.Note variant="warning">
   The `synnax` command for the Python client was deprecated in v0.38.0 and is now
   removed. Please use `sy` instead.
 </Note.Note>
+
+<Divider.Divider x />
 
 ### Other Improvements
 
@@ -76,6 +88,8 @@ to make them easier to use.
   communicating with a Core have a significant time difference.
 - Added warnings when you attempt to configure a task on a Driver that is not alive.
 - Improved error messages in the Python client when methods require named parameters.
+
+<Divider.Divider x />
 
 ### Bug Fixes
 

--- a/docs/site/src/pages/releases/0-40-0.mdx
+++ b/docs/site/src/pages/releases/0-40-0.mdx
@@ -7,7 +7,7 @@ import Diagram from "@/components/diagram/Diagram.astro";
 import Release from "@/components/releases/Release.astro";
 import LabJack from "@/pages/releases/LabJack.astro";
 import { mdxOverrides } from "@/components/mdxOverrides";
-import { Note } from "@synnaxlabs/pluto";
+import { Note, Divider } from "@synnaxlabs/pluto";
 export const components = mdxOverrides;
 
 <Release
@@ -20,6 +20,8 @@ Synnax v0.40.0 is a maintenance release that introduces no breaking changes, imp
 performance of the Synnax Driver, and fixes a few bugs related to the embedded control
 sequences.
 
+<Divider.Divider x />
+
 ### Driver Clock Skew Improvements
 
 Our refactor of the Driver in Synnax v0.39 made several major improvements, and,
@@ -28,6 +30,8 @@ release, we've introduced a new
 [clock skew detection algorithm](/reference/driver/timing) that automatically corrects
 for timing offsets in hardware timed tasks.
 
+<Divider.Divider x />
+
 ### Warnings on Slow Data Acquisition Tasks
 
 In previous versions of Synnax, tasks that were set at too high of a stream rate would
@@ -35,10 +39,14 @@ silently fall behind drop data samples. This release introduces a new warning me
 that updates the Console task configuration dialog and logs a warning to the Driver logs
 when Synnax cannot keep up with the requested stream rate.
 
+<Divider.Divider x />
+
 ### Improved Device Disconnection Retry
 
 We've improved the device disconnection retry mechanisms for NI, LabJack, and OPC UA to
 better handle unexpected cable disconnections and loss of power.
+
+<Divider.Divider x />
 
 ### Cleaner Transfer of Devices Across Drivers
 
@@ -46,10 +54,14 @@ We've implemented a smoother mechanisms for moving data acquisition modules acro
 Drivers, ensuring that existing tasks on a device are correctly transferred and started
 on new Drivers.
 
+<Divider.Divider x />
+
 ### Other Improvements
 
 - It's now possible to change the identifier of a device after configuring it.
 - Added the location of a device to the device drop-down list selectors.
+
+<Divider.Divider x />
 
 ### Bug Fixes
 

--- a/docs/site/src/pages/releases/0-41-0.mdx
+++ b/docs/site/src/pages/releases/0-41-0.mdx
@@ -95,6 +95,8 @@ Previously, the only way to rename a channel bound to a task was within the Reso
 Toolbar. We've added a new context menu item within all task configuration dialogs that
 allows you to rename a particular channel from within the dialog itself.
 
+<Divider.Divider x />
+
 ### Schematic Symbols
 
 An additional set of schematic symbols were added, including general polygon shapes, a

--- a/docs/site/src/pages/releases/0-47-0.mdx
+++ b/docs/site/src/pages/releases/0-47-0.mdx
@@ -33,6 +33,8 @@ We've also added three statistical aggregation functions: `avg`, `min`, and `max
 functions can be used to calculate the average, minimum, and maximum values of a
 calculation over a time- or trigger-based window.
 
+<Divider.Divider x />
+
 ### Deprecation of Lua-Based Calculations
 
 With the introduction of Arc-based calculated channels, Lua-based calculations are

--- a/docs/site/src/pages/releases/0-48-0.mdx
+++ b/docs/site/src/pages/releases/0-48-0.mdx
@@ -18,6 +18,8 @@ export const components = mdxOverrides;
 
 <Image client:only="react" id="releases/0-48-0/thumbnail" themed={false} />
 
+<Divider.Divider x />
+
 ### Login Page
 
 As part of our ongoing effort to improve user access control, we're moving away from the

--- a/docs/site/src/pages/releases/0-49-0.mdx
+++ b/docs/site/src/pages/releases/0-49-0.mdx
@@ -19,6 +19,8 @@ export const components = mdxOverrides;
 
 <Image client:only="react" id="releases/0-49-0/thumbnail" themed={false} />
 
+<Divider.Divider x />
+
 ### Role-Based Access Control
 
 Instead of setting individual permissions for each user, you can now assign users to one

--- a/docs/site/src/pages/releases/0-50-0.mdx
+++ b/docs/site/src/pages/releases/0-50-0.mdx
@@ -21,6 +21,8 @@ language, Arc.
 
 <Image client:only="react" id="releases/0-50-0/thumbnail" themed={false} />
 
+<Divider.Divider x />
+
 ### Arc Sequences
 
 Arc lets you create sequences using a text-based editor in the Synnax Console and deploy

--- a/docs/site/src/pages/releases/0-51-0.mdx
+++ b/docs/site/src/pages/releases/0-51-0.mdx
@@ -28,6 +28,8 @@ Arc is now completely compatible with the Synnax control authority system.
 As always, this release comes with a number of performance, stability, and user
 experience improvements to Synnax.
 
+<Divider.Divider x />
+
 ### EtherCAT Driver
 
 Our new driver supports reading from and writing to slaves on an EtherCAT network. A
@@ -54,6 +56,8 @@ The Synnax Driver also supports EtherCAT on non real-time operating systems, suc
 macOS and Windows. In these environments, Synnax will leverage the tools available on
 the host to achieve maximum performance, but deterministic cycle times are not
 guaranteed.
+
+<Divider.Divider x />
 
 ### Arc Control Authority
 
@@ -98,6 +102,8 @@ to 255 to take precedence over all other writers.
 For the full details on declaring authority, runtime changes, and multi-writer
 coordination, see the
 [control authority documentation](/reference/control/arc/concepts/control-authority).
+
+<Divider.Divider x />
 
 ### Other Minor Improvements and Bug Fixes
 

--- a/docs/site/src/pages/releases/0-52-0.mdx
+++ b/docs/site/src/pages/releases/0-52-0.mdx
@@ -5,6 +5,7 @@ title: "Version 0.52 Release Notes"
 import { Image } from "@/components/media/Media";
 import Release from "@/components/releases/Release.astro";
 import Diagram from "@/components/diagram/Diagram.astro";
+import { Divider } from "@synnaxlabs/pluto";
 import { mdxOverrides } from "@/components/mdxOverrides";
 import HTTP from "@/pages/releases/HTTP.astro";
 
@@ -22,6 +23,8 @@ Synnax v0.52 introduces our new HTTP device driver for integrating with REST API
 web services. We've also added support for extended analog input channels on the LabJack
 T7.
 
+<Divider.Divider x />
+
 ### HTTP Device Driver
 
 Our new HTTP device driver allows you to connect Synnax to any REST API or web service
@@ -37,11 +40,15 @@ availability, with results displayed in the Console's device status indicators.
 Authentication is supported out of the box, including token, API key, and basic
 username/password methods.
 
+<Divider.Divider x />
+
 ### LabJack T7 Extended Analog Inputs
 
 The Console and Driver now support extended analog input channels (AIN 48–127) on the
 LabJack T7 when used with the MUX80 analog multiplexer. Previously, only channels AIN
 0–13 were available.
+
+<Divider.Divider x />
 
 ### Removal of Lua Sequences
 
@@ -49,6 +56,8 @@ Lua-based embedded sequences have been fully removed from Synnax. This includes 
 language server, the sequence driver, and all related Console UI. Users who have not yet
 migrated their Lua sequences to [Arc](/reference/control/arc/get-started) should do so
 before upgrading.
+
+<Divider.Divider x />
 
 ### Minor Improvements and Bug Fixes
 

--- a/docs/site/src/pages/releases/0-53-0.mdx
+++ b/docs/site/src/pages/releases/0-53-0.mdx
@@ -4,6 +4,7 @@ title: "Version 0.53 Release Notes"
 
 import { Image } from "@/components/media/Media";
 import Release from "@/components/releases/Release.astro";
+import { Divider } from "@synnaxlabs/pluto";
 import { mdxOverrides } from "@/components/mdxOverrides";
 export const components = mdxOverrides;
 
@@ -19,6 +20,8 @@ Synnax v0.53 completes the HTTP driver with write task support and adds Python c
 integration for programmatic HTTP task configuration. This release also includes
 stability improvements to the Arc runtime and server.
 
+<Divider.Divider x />
+
 ### HTTP Write Task
 
 The HTTP driver now supports writing data from Synnax channels to REST API endpoints,
@@ -29,12 +32,16 @@ with external web services.
 Combined with the read tasks from v0.52, the HTTP driver provides a full bidirectional
 bridge between Synnax and any REST API.
 
+<Divider.Divider x />
+
 ### Python Client HTTP Support
 
 The Python client can now create and configure HTTP read and write tasks
 programmatically. This provides an alternative to the Console UI for managing HTTP
 integrations, and makes it possible to script and automate HTTP task setup as part of
 larger deployment workflows.
+
+<Divider.Divider x />
 
 ### Minor Improvements and Bug Fixes
 

--- a/docs/site/src/pages/releases/0-54-0.mdx
+++ b/docs/site/src/pages/releases/0-54-0.mdx
@@ -4,7 +4,10 @@ title: "Version 0.54 Release Notes"
 
 import { Image } from "@/components/media/Media";
 import Release from "@/components/releases/Release.astro";
+import { Divider } from "@synnaxlabs/pluto";
 import { mdxOverrides } from "@/components/mdxOverrides";
+import Diagram from "@/components/diagram/Diagram.astro";
+
 export const components = mdxOverrides;
 
 <Release
@@ -13,12 +16,16 @@ export const components = mdxOverrides;
     title="PagerDuty Integration"
 >
 
-<Image client:only="react" id="releases/0-54-0/pagerduty-alert-task" themed={false} />
+<Diagram preview style="padding: 0rem 5rem">
+  <Image client:only="react" id="releases/0-54-0/pagerduty-alert-task" themed={false} />
+</Diagram>
 
 Synnax v0.54 introduces a PagerDuty integration for automated alerting, the ability to
 delete channel data directly from the Console, press-and-hold safety controls for
 schematic valves, and a number of stability and performance improvements across the
 platform.
+
+<Divider.Divider x />
 
 ### PagerDuty Integration
 
@@ -32,6 +39,8 @@ Events are deduplicated by status key, so repeated status changes update existin
 incidents rather than creating duplicates. The integration uses the PagerDuty Events API
 v2 and can be configured from both the Console and the Python client.
 
+<Divider.Divider x />
+
 ### Delete All Channel Data
 
 Users can now permanently delete time-series data from selected channels over a
@@ -40,6 +49,8 @@ first, select channels and a time range, then confirm the irreversible deletion 
 summary screen. Options are provided to delete from the beginning or to the end of time
 for convenience.
 
+<Divider.Divider x />
+
 ### Press and Hold for Schematic Valves
 
 Valve toggle buttons in schematics now support a configurable press-and-hold delay. When
@@ -47,11 +58,15 @@ enabled, users must hold the mouse button for a specified duration before the va
 toggles, preventing accidental activation of critical hardware. Visual feedback
 indicates the hold progress.
 
+<Divider.Divider x />
+
 ### Status Explorer Variant Filtering
 
-The Status Explorer now supports filtering by status variant — error, warning, info, and
-success. Filter chips display active selections and can be removed individually, making
+The Status Explorer now supports filtering by status variant (error, warning, info, and
+success). Filter chips display active selections and can be removed individually, making
 it easier to focus on specific status types across the system.
+
+<Divider.Divider x />
 
 ### Device-Chassis Hierarchy
 
@@ -61,15 +76,19 @@ NISysCfg link properties, and the ontology maintains these parent-child connecti
 across scan cycles. This reflects the physical hardware topology and makes it easier to
 navigate large NI installations.
 
+<Divider.Divider x />
+
 ### Arc Improvements
 
-- The Arc C++ runtime now supports `Select`, `StableFor`, and `SetStatus` node types,
+- The Arc C++ runtime now supports `select`, `stable_for`, and `set_status` node types,
   enabling conditional routing, timed output holds, and status reporting from within Arc
   programs that are executed on a Synnax Driver.
 - A telemetry bypass mode allows high-priority control operations to execute without
   telemetry collection overhead.
 - The "Open Arc" option is now available in the context menu for Arc programs, and the
   Arc Explorer can be launched from the Arc toolbar.
+
+<Divider.Divider x />
 
 ### Minor Improvements and Bug Fixes
 
@@ -99,16 +118,5 @@ navigate large NI installations.
 
 - The calculated channel engine is now more resilient to compilation errors, preventing
   cascading failures when an Arc program contains syntax issues.
-
-#### Infrastructure
-
-- Introduced Oracle, a code generation framework that produces high-performance binary
-  codecs (ORC encoding) for Go structs, with generated clients for Go, Python, and C++.
-- Added a new Gorp migration framework with typed table abstractions and pluggable
-  migration plugins.
-- Upgraded Fiber to v3, Bazel to 9, and updated dependencies across Go, Python,
-  TypeScript, and Rust.
-- Switched Python linting and formatting to Ruff.
-- Consolidated shared Python utilities from `client/py/x` into `x/py`.
 
 </Release>

--- a/docs/site/src/pages/releases/0-55-0.mdx
+++ b/docs/site/src/pages/releases/0-55-0.mdx
@@ -1,0 +1,271 @@
+---
+title: "Version 0.55 Release Notes"
+---
+
+import { Fragment } from "react";
+import { Image } from "@/components/media/Media";
+import Release from "@/components/releases/Release.astro";
+import { Divider } from "@synnaxlabs/pluto";
+import { mdxOverrides } from "@/components/mdxOverrides";
+import { Client } from "@/components/client";
+import Diagram from "@/components/diagram/Diagram.astro";
+import ArcSequence from "@/pages/releases/ArcSequence.astro";
+
+export const components = mdxOverrides;
+
+<Release
+    version="0.55.0"
+    date="Apr 18, 2026"
+    title="Flexible Arc Sequences and Persisted Variable-Length Channels"
+>
+
+<ArcSequence />
+
+Synnax v0.55 ships a redesigned sequence and stage model for Arc, support for persisting
+string, JSON, and binary data channels to disk, for loop support in the Arc language,
+clock skew detection in the Python and TypeScript clients, multi-channel support in the
+Log visualization, and a collection of smaller improvements across the Console and
+drivers.
+
+<Divider.Divider x />
+
+### Flexible Arc Sequences and Stages
+
+Arc's sequencing model has been redesigned around two clearly distinct constructs. A
+**sequence** runs its items in order, with each item completing before the next begins.
+A **stage** is one kind of item, and it runs all of its flow statements concurrently
+until a transition fires and control moves on. Items inside a sequence can be writes
+(`expr -> channel`), `wait{...}` calls, bare condition gates, stages, or nested
+sequences. See the
+[sequences and stages concepts guide](/reference/control/arc/concepts/sequences-and-stages)
+for the full model.
+
+This separation makes common control patterns easier to express. Pressurize, hold, and
+vent routines that previously required manual state tracking can now be written as a
+straight list of phases:
+
+```arc
+sequence main {
+    stage pressurize {
+        1 -> press_vlv_cmd
+        tank_pressure > 700 => abort    // safety
+        tank_pressure > 500 => next     // target reached
+    }
+    0 -> press_vlv_cmd
+    wait{10s}
+    stage vent {
+        1 -> vent_vlv_cmd
+        tank_pressure < 50 => next
+    }
+    0 -> vent_vlv_cmd
+}
+
+sequence abort {
+    stage safed {
+        0 -> press_vlv_cmd
+        1 -> vent_vlv_cmd
+    }
+}
+
+start_btn => main
+```
+
+The `=>` operator is now the single transition operator. It fires while its source
+expression is truthy, and its target may be `next` (advance to the next item in the
+enclosing sequence), a stage name (jump within the current sequence), or a sequence name
+(jump to another sequence or activate it from an entry point). Line order determines
+priority when multiple transitions become truthy in the same cycle, so safety edges go
+first and success edges go last.
+
+Anonymous top-level sequences start automatically when the program loads. Named
+sequences wait for an entry point like `start_btn => main`. Stages are stateless between
+entries, so stateful variables, timers, and inline sub-sequences all reset when a stage
+is re-activated.
+
+Commas are now optional between items in stage and sequence bodies. Newlines are
+sufficient separators, which removes a common source of parse errors when editing
+multi-line programs.
+
+<Divider.Divider x />
+
+### Other Arc Language Improvements
+
+Arc now supports [`for` loops](/reference/control/arc/reference/loops) inside function
+bodies, with range, series, and conditional forms:
+
+```arc
+for x := data { sum = sum + x }
+
+for i, x := data {
+    if x > peak { peak = x; peak_idx = i }
+}
+
+for i := range(5)          { }       // 0..4
+for i := range(5, 10)      { }       // 5..9
+for i := range(0, 10, 2)   { }       // 0, 2, 4, 6, 8
+
+for n > 0 { sum = sum + n; n = n - 1 }
+
+for { if val >= threshold { break } val = val * 2 }
+```
+
+The Arc formatter now collapses short anonymous config blocks onto a single line so
+routine node calls like `wait{duration=2ms}` or `filter{threshold=10}` stay readable.
+
+<Divider.Divider x />
+
+### Persisted Variable-Length Channels
+
+Channels with the `string`, `json`, and `bytes` data types can now be created as indexed
+data channels that persist to disk. Before v0.55, these data types were only available
+as virtual channels, which meant that samples were discarded when the server restarted.
+Event logs, JSON annotations, configuration snapshots, and arbitrary binary payloads can
+now be stored alongside fixed-width telemetry and retrieved by time range.
+
+Variable-length channels behave identically to fixed-width data channels. They require
+an index, accept writes through the standard writer API, and can be read back over any
+time range.
+
+<Client.Tabs client:load exclude={["cpp", "console"]}>
+
+  <Fragment slot="python">
+
+```python
+import synnax as sy
+
+client = sy.Synnax()
+
+idx = client.channels.create(
+    name="event_time",
+    is_index=True,
+    data_type=sy.DataType.TIMESTAMP,
+)
+log = client.channels.create(
+    name="event_log",
+    index=idx.key,
+    data_type=sy.DataType.STRING,
+)
+
+with client.open_writer(
+    start=1 * sy.TimeSpan.SECOND,
+    channels=[idx.key, log.key],
+) as w:
+    w.write({
+        idx.key: [1 * sy.TimeSpan.SECOND, 2 * sy.TimeSpan.SECOND],
+        log.key: ["startup complete", "tank pressurized"],
+    })
+    w.commit()
+
+for sample in client.read(sy.TimeRange.MAX, log.key):
+    print(sample)
+```
+
+  </Fragment>
+
+  <Fragment slot="typescript">
+
+```typescript
+const index = await client.channels.create({
+  name: "event_time",
+  isIndex: true,
+  dataType: DataType.TIMESTAMP,
+});
+const log = await client.channels.create({
+  name: "event_log",
+  index: index.key,
+  dataType: DataType.STRING,
+});
+
+const writer = await client.openWriter({
+  start: TimeStamp.seconds(1),
+  channels: [index, log],
+});
+await writer.write({
+  [index.key]: secondsLinspace(1, 3),
+  [log.key]: new Series({
+    data: ["startup complete", "tank pressurized", "valve opened"],
+    dataType: DataType.STRING,
+  }),
+});
+await writer.commit();
+await writer.close();
+
+const frame = await log.read(TimeRange.MAX);
+console.log(frame.toStrings());
+```
+
+  </Fragment>
+
+</Client.Tabs>
+
+Fixed-width and variable-length channels can share the same writer and the same index,
+so a single call can commit timestamps, numeric samples, and string or JSON annotations
+together. JSON channels accept and return native objects on both the Python and
+TypeScript clients.
+
+As part of this work, the variable-length wire format now uses explicit length prefixes
+instead of newline delimiters. Strings and JSON values containing embedded newlines now
+round-trip through writes and reads correctly.
+
+<Divider.Divider x />
+
+### Multi-Channel Log Visualization
+
+The Console's Log visualization can now stream from multiple channels in the same view.
+Each channel is selectable from the toolbar, and a new Properties panel controls
+per-view configuration. Existing single-channel logs are migrated automatically.
+
+<Divider.Divider x />
+
+### Clock Skew Detection
+
+The Python, TypeScript, and C++ clients now measure the time offset between the client
+machine and the Synnax cluster during the connection check, and surface it alongside the
+rest of the connection diagnostics. This makes it easier to diagnose timestamp drift in
+deployments where machines are not synchronized with the same time source.
+
+<Divider.Divider x />
+
+### Schematic Control Chip
+
+The control chip on schematic elements now changes shape to signal state. It stays a
+circle when the element is uncontrolled, when the current user holds control, or when
+control authority is absolute. It becomes a square when another operator currently holds
+control or when the authority state is unexpected. The shape difference makes it
+immediately obvious when someone else is driving.
+
+<Divider.Divider x />
+
+### Minor Improvements and Bug Fixes
+
+#### Console
+
+- The Log page supports selecting and streaming multiple channels in a single view.
+- Schematic control chips render as squares when another operator holds control, making
+  contested authority visually distinct at a glance.
+
+#### Client
+
+- The Python and TypeScript clients now report the measured clock skew between the local
+  machine and the Synnax cluster during connection checks.
+- Docstrings and reference documentation for `read_latest()` now correctly describe the
+  return type and the behavior when fewer than `n` samples are available.
+
+#### Driver
+
+- EtherCAT PDO discovery, cycle-overrun, SDO-read, and virtual-interface-skip log
+  messages have been moved to more appropriate verbosity levels, significantly reducing
+  noise in standard driver logs during EtherCAT scans and steady-state operation.
+
+#### Core
+
+- Equal-length binary operations on series (arithmetic and comparison) now take a faster
+  branchless path, reducing CPU usage for calculated channels and client-side series
+  math.
+
+#### Docs Site
+
+- The sidebar now preserves its scroll position across page navigations, so clicking a
+  link no longer resets the navigation tree to the top.
+
+</Release>

--- a/docs/site/src/pages/releases/ArcSequence.astro
+++ b/docs/site/src/pages/releases/ArcSequence.astro
@@ -1,0 +1,49 @@
+---
+import Code from "astro/components/Code.astro";
+import { grammar as arcGrammar } from "@synnaxlabs/arc";
+
+const code = `sequence startup {
+    1 -> press_vlv
+    pressure > 500
+    wait{5s}
+    0 -> press_vlv
+    1 -> vent_vlv
+    wait{3s}
+    0 -> vent_vlv
+}`;
+---
+
+<div class="arc-sequence-thumbnail">
+    <Code code={code} lang={arcGrammar} theme="css-variables" />
+</div>
+
+<style is:global>
+    .arc-sequence-thumbnail {
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        margin: 5rem 0;
+        border: var(--pluto-border);
+        border-radius: 2rem;
+        box-shadow: var(--pluto-shadow-v1);
+        border: var(--pluto-border-l5);
+        padding: 10rem 20rem;
+        width: 100%;
+        background-size: cover;
+        background-position: center center;
+        background-repeat: repeat;
+        background-image: url("data:image/svg+xml;utf8,%3Csvg xmlns=%22http:%2F%2Fwww.w3.org%2F2000%2Fsvg%22 width=%222000%22 height=%221400%22%3E%3Cg filter=%22url(%23a)%22%3E%3Cpath fill=%22%231a1f3d%22 d=%22M-1000-700h4000v2800h-4000z%22%2F%3E%3Cpath d=%22m-151-397-250 799 44 637 1486-626%22 fill=%22%232a3560%22%2F%3E%3Cpath d=%22M1465-209 207 768l1332 531 116-156%22 fill=%22%232a3560%22%2F%3E%3Cpath d=%22M2325 298 1001 850l564 745 857-1236%22 fill=%22%232a3560%22%2F%3E%3Cpath d=%22M747 332-503 774 558 1880l536-951%22 fill=%22%231a1f3d%22%2F%3E%3Cpath d=%22M376 1137 265 2354l68 256 1410-82%22 fill=%22%232a3560%22%2F%3E%3Cpath d=%22m1016 1107-72 772 1047 548 356-503%22 fill=%22%232a3560%22%2F%3E%3C%2Fg%3E%3Cpath fill=%22%23fff%22 filter=%22url(%23b)%22 d=%22M0 0h2000v1400H0z%22%2F%3E%3Cdefs%3E%3Cfilter id=%22b%22 x=%22-800%22 y=%22-560%22 width=%222800%22 height=%221960%22 filterUnits=%22userSpaceOnUse%22 primitiveUnits=%22userSpaceOnUse%22 color-interpolation-filters=%22linearRGB%22%3E%3CfeTurbulence type=%22fractalNoise%22 baseFrequency=%22.066%22 numOctaves=%224%22 seed=%2215%22 stitchTiles=%22no-stitch%22 x=%220%22 y=%220%22 width=%222000%22 height=%221400%22 result=%22turbulence%22%2F%3E%3CfeSpecularLighting surfaceScale=%2210%22 specularConstant=%22.202%22 specularExponent=%2220%22 lighting-color=%22%23fff%22 x=%220%22 y=%220%22 width=%222000%22 height=%221400%22 in=%22turbulence%22 result=%22specularLighting%22%3E%3CfeDistantLight azimuth=%223%22 elevation=%22100%22%2F%3E%3C%2FfeSpecularLighting%3E%3C%2Ffilter%3E%3Cfilter id=%22a%22 x=%22-146%22 y=%22-146%22 width=%222292%22 height=%221692%22 filterUnits=%22userSpaceOnUse%22 color-interpolation-filters=%22sRGB%22%3E%3CfeFlood flood-opacity=%220%22 result=%22BackgroundImageFix%22%2F%3E%3CfeBlend in=%22SourceGraphic%22 in2=%22BackgroundImageFix%22 result=%22shape%22%2F%3E%3CfeGaussianBlur stdDeviation=%22146%22 result=%22effect1_foregroundBlur_1_2%22%2F%3E%3C%2Ffilter%3E%3C%2Fdefs%3E%3C%2Fsvg%3E");
+    }
+    .arc-sequence-thumbnail pre.astro-code {
+        padding: 5rem 8rem;
+        border: var(--pluto-border);
+        border-color: var(--pluto-gray-l7);
+        border-radius: 2rem;
+        margin: 0;
+    }
+    .arc-sequence-thumbnail pre.astro-code code {
+        display: block;
+        width: fit-content;
+        margin: 0 auto;
+    }
+</style>

--- a/docs/site/src/pages/releases/ArcSequence.astro
+++ b/docs/site/src/pages/releases/ArcSequence.astro
@@ -23,7 +23,6 @@ const code = `sequence startup {
         justify-content: center;
         align-items: center;
         margin: 5rem 0;
-        border: var(--pluto-border);
         border-radius: 2rem;
         box-shadow: var(--pluto-shadow-v1);
         border: var(--pluto-border-l5);

--- a/docs/site/src/pages/releases/index.mdx
+++ b/docs/site/src/pages/releases/index.mdx
@@ -27,11 +27,16 @@ import Release0510 from "@/pages/releases/0-51-0.mdx";
 import Release0520 from "@/pages/releases/0-52-0.mdx";
 import Release0530 from "@/pages/releases/0-53-0.mdx";
 import Release0540 from "@/pages/releases/0-54-0.mdx";
+import Release0550 from "@/pages/releases/0-55-0.mdx";
 import { mdxOverrides } from "@/components/mdxOverrides";
 export const components = mdxOverrides;
 
 import { Divider } from "@synnaxlabs/pluto";
 
+<div class="release-wrapper">
+  ###### 0.55
+  <Release0550 />
+</div>
 <Divider.Divider x />
 <div class="release-wrapper">
   ###### 0.54


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4083](https://linear.app/synnax/issue/SY-4083)

## Description

Adds release notes for Synnax v0.55, including a new `ArcSequence.astro` component for demonstrating the new sequence and stage mechanics. Also normalizes and backfills small fixes across older release notes (`0-31-0` through `0-54-0`), updates the Arc TextMate grammar for the new syntax, and switches `Platform.Tabs` on the installation and quick-start pages from `client:only` to `client:load` so the tabs SSR with their content.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds release notes for Synnax v0.55, introduces a new `ArcSequence.astro` component for the code thumbnail, normalizes imports and structure across older release notes (v0.31–v0.54), updates the Arc TextMate grammar with a `for-statement` pattern, and switches `Platform.Tabs` on the installation and quick-start pages from `client:only` to `client:load` for SSR compatibility. All remaining findings are P2 style suggestions.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are minor style suggestions with no functional impact.

Only P2 findings remain: a dead CSS `border` declaration in ArcSequence.astro and dividers between h3 sections consistent with the established release-notes pattern. Neither affects correctness or runtime behavior.

docs/site/src/pages/releases/ArcSequence.astro (duplicate border declaration)

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/site/src/pages/releases/0-55-0.mdx | New v0.55 release notes covering Arc sequences/stages, persisted variable-length channels, multi-channel Log, clock skew detection, and schematic control chip; content is clear and consistent with prior release note structure. |
| docs/site/src/pages/releases/ArcSequence.astro | New Astro component rendering a highlighted Arc code snippet for the release thumbnail; has a dead `border` CSS declaration overridden two lines later. |
| docs/site/src/pages/releases/index.mdx | Adds the v0.55 release import and wrapper block at the top of the release index; no issues found. |
| docs/site/src/pages/reference/core/installation.mdx | Switches `Platform.Tabs` from `client:only` to `client:load` so the tabs SSR with content visible before JS hydration. |
| docs/site/src/pages/reference/core/quick-start.mdx | Same `client:only` → `client:load` change as installation.mdx; straightforward and correct. |
| arc/ts/src/grammar/arc.tmLanguage.json | Adds `for-statement` pattern to the TextMate grammar, matching the new `for` loop language feature; grammar pattern looks correct with proper begin/end anchors. |
| docs/site/src/middleware.ts | Copyright year update to 2026; CSP header unchanged. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[PR: v0.55 Release Notes] --> B[New: 0-55-0.mdx\nRelease notes content]
    A --> C[New: ArcSequence.astro\nCode thumbnail component]
    A --> D[Updated: index.mdx\nAdds 0.55 to release index]
    A --> E[Backfill: 0-31-0 to 0-54-0\nNormalize imports & structure]
    A --> F[Updated: arc.tmLanguage.json\nAdd for-statement grammar]
    A --> G[Updated: installation.mdx & quick-start.mdx\nclient:only to client:load]
    C --> H[Imports arcGrammar\nfrom @synnaxlabs/arc]
    C --> I[Renders highlighted\nArc code snippet]
    B --> J[References ArcSequence.astro\nfor hero thumbnail]
```

<sub>Reviews (1): Last reviewed commit: ["version 55 release notes"](https://github.com/synnaxlabs/synnax/commit/326d954aab0e4b3f24e6faf3f13d2a8fab3ff49c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28869169)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule used - In documentation site files (.mdx), dividers shoul... ([source](https://app.greptile.com/review/custom-context?memory=cf4867b6-7b82-416c-9d2d-67f747544eb7))

**Learned From**
[synnaxlabs/synnax#1554](https://github.com/synnaxlabs/synnax/pull/1554)

<!-- /greptile_comment -->