### PR TITLE
SY-3936: Log UI Improvements

### DIFF
--- a/client/py/examples/simulators/tpc.py
+++ b/client/py/examples/simulators/tpc.py
@@ -99,7 +99,7 @@ class TPCSimDAQ(SimDAQ):
 
     def _run_loop(self) -> None:
         self.log("Starting simulation loop...")
-        loop = sy.Loop(sy.Rate.HZ * 1, precise=True)
+        loop = sy.Loop(sy.Rate.HZ * 50, precise=True)
         loop_count = 0
 
         daq_state = {

--- a/client/py/examples/simulators/tpc.py
+++ b/client/py/examples/simulators/tpc.py
@@ -99,7 +99,7 @@ class TPCSimDAQ(SimDAQ):
 
     def _run_loop(self) -> None:
         self.log("Starting simulation loop...")
-        loop = sy.Loop(sy.Rate.HZ * 50, precise=True)
+        loop = sy.Loop(sy.Rate.HZ * 1, precise=True)
         loop_count = 0
 
         daq_state = {

--- a/console/src/log/Log.tsx
+++ b/console/src/log/Log.tsx
@@ -13,11 +13,17 @@ import { Access, Icon, Log as Base, usePrevious } from "@synnaxlabs/pluto";
 import { deep, primitive, TimeSpan, uuid } from "@synnaxlabs/x";
 import { useCallback, useEffect } from "react";
 
-import { EmptyAction } from "@/components";
+import { ContextMenu, EmptyAction } from "@/components";
 import { createLoadRemote } from "@/hooks/useLoadRemote";
 import { Layout } from "@/layout";
 import { select, useSelect, useSelectVersion } from "@/log/selectors";
-import { internalCreate, setRemoteCreated, type State, ZERO_STATE } from "@/log/slice";
+import {
+  internalCreate,
+  setActiveToolbarTab,
+  setRemoteCreated,
+  type State,
+  ZERO_STATE,
+} from "@/log/slice";
 import { Selector } from "@/selector";
 import { Workspace } from "@/workspace";
 
@@ -77,6 +83,11 @@ const Loaded: Layout.Renderer = ({ layoutKey, visible }) => {
     );
   }, [winKey, dispatch]);
 
+  const handleConfigureChannels = useCallback(() => {
+    dispatch(setActiveToolbarTab({ key: layoutKey, tab: "channels" }));
+    handleDoubleClick();
+  }, [dispatch, layoutKey, handleDoubleClick]);
+
   return (
     <Base.Log
       telem={t}
@@ -85,6 +96,7 @@ const Loaded: Layout.Renderer = ({ layoutKey, visible }) => {
       showReceiptTimestamp={log.showReceiptTimestamp}
       timestampPrecision={log.timestampPrecision}
       onDoubleClick={handleDoubleClick}
+      extraContextMenuItems={<ContextMenu.ReloadConsoleItem />}
       emptyContent={
         <EmptyAction
           message={
@@ -93,7 +105,7 @@ const Loaded: Layout.Renderer = ({ layoutKey, visible }) => {
               : "No data received yet."
           }
           action={!hasChannels ? "Configure channels" : ""}
-          onClick={handleDoubleClick}
+          onClick={hasChannels ? handleDoubleClick : handleConfigureChannels}
         />
       }
       visible={visible}

--- a/console/src/log/Log.tsx
+++ b/console/src/log/Log.tsx
@@ -51,6 +51,7 @@ export const useSyncComponent = Workspace.createSyncComponent(
 
 const DEFAULT_RETENTION = TimeSpan.days(1);
 const PRELOAD = TimeSpan.seconds(30);
+const EXTRA_CONTEXT_MENU_ITEMS = <ContextMenu.ReloadConsoleItem />;
 
 const Loaded: Layout.Renderer = ({ layoutKey, visible }) => {
   const winKey = useSelectWindowKey() as string;
@@ -96,7 +97,7 @@ const Loaded: Layout.Renderer = ({ layoutKey, visible }) => {
       showReceiptTimestamp={log.showReceiptTimestamp}
       timestampPrecision={log.timestampPrecision}
       onDoubleClick={handleDoubleClick}
-      extraContextMenuItems={<ContextMenu.ReloadConsoleItem />}
+      extraContextMenuItems={EXTRA_CONTEXT_MENU_ITEMS}
       emptyContent={
         <EmptyAction
           message={

--- a/console/src/log/slice.ts
+++ b/console/src/log/slice.ts
@@ -16,11 +16,15 @@ export type State = latest.State;
 export type SliceState = latest.SliceState;
 export type ChannelConfig = latest.ChannelConfig;
 export type ChannelEntry = latest.ChannelEntry;
+export type ToolbarTab = latest.ToolbarTab;
+export type ToolbarState = latest.ToolbarState;
 export const ZERO_CHANNEL_CONFIG = latest.ZERO_CHANNEL_CONFIG;
 export const ZERO_CHANNEL_ENTRY = latest.ZERO_CHANNEL_ENTRY;
+export const ZERO_TOOLBAR_STATE = latest.ZERO_TOOLBAR_STATE;
 export const stateZ = latest.stateZ;
 export const ZERO_SLICE_STATE = latest.ZERO_SLICE_STATE;
 export const ZERO_STATE = latest.ZERO_STATE;
+export const migrateSlice = latest.migrateSlice;
 
 export const SLICE_NAME = "log";
 
@@ -53,6 +57,11 @@ export interface SetShowChannelNamesPayload {
 export interface SetShowReceiptTimestampPayload {
   key: string;
   showReceiptTimestamp: boolean;
+}
+
+export interface SetActiveToolbarTabPayload {
+  key: string;
+  tab: ToolbarTab;
 }
 
 export interface AddChannelPayload {
@@ -106,6 +115,12 @@ export const { actions, reducer } = createSlice({
     ) => {
       state.logs[payload.key].showReceiptTimestamp = payload.showReceiptTimestamp;
     },
+    setActiveToolbarTab: (
+      state,
+      { payload }: PayloadAction<SetActiveToolbarTabPayload>,
+    ) => {
+      state.logs[payload.key].toolbar.activeTab = payload.tab;
+    },
     addChannel: (state, { payload }: PayloadAction<AddChannelPayload>) => {
       state.logs[payload.key].channels.push({
         ...ZERO_CHANNEL_CONFIG,
@@ -140,6 +155,7 @@ export const {
   setChannelConfig,
   setShowChannelNames,
   setShowReceiptTimestamp,
+  setActiveToolbarTab,
   addChannel,
   removeChannelByIndex,
   setChannelAtIndex,

--- a/console/src/log/toolbar/Channels.spec.tsx
+++ b/console/src/log/toolbar/Channels.spec.tsx
@@ -37,6 +37,7 @@ const ZERO_STATE: State = {
   timestampPrecision: 0,
   showChannelNames: true,
   showReceiptTimestamp: true,
+  toolbar: { activeTab: "channels" },
 };
 
 const LAYOUT_STATE: Layout.State = {

--- a/console/src/log/toolbar/Channels.tsx
+++ b/console/src/log/toolbar/Channels.tsx
@@ -16,11 +16,12 @@ import {
   Flex,
   Icon,
   Input,
+  List,
   Notation,
   Theming,
 } from "@synnaxlabs/pluto";
-import { color, type notation, primitive } from "@synnaxlabs/x";
-import { type ReactElement, useCallback } from "react";
+import { color, DataType, type notation, primitive } from "@synnaxlabs/x";
+import { type ReactElement, useCallback, useMemo } from "react";
 
 import { CSS } from "@/css";
 import { useSyncComponent } from "@/log/Log";
@@ -35,9 +36,13 @@ import {
 
 const PRECISION_BOUNDS = { lower: -1, upper: 18 };
 
+const showsNumericFields = (dt: DataType | undefined): boolean =>
+  dt != null && dt.isNumeric && !dt.equals(DataType.TIMESTAMP);
+
 interface ChannelRowProps {
   index: number;
   channelKey: channel.Key;
+  ch: channel.Channel | undefined;
   config: ChannelConfig;
   onChange: (index: number, channelKey: channel.Key) => void;
   onConfigChange: (channelKey: channel.Key, config: Partial<ChannelConfig>) => void;
@@ -48,71 +53,108 @@ interface ChannelRowProps {
 const ChannelRow = ({
   index,
   channelKey,
+  ch,
   config,
   onChange,
   onConfigChange,
   onRemove,
   disabled,
 }: ChannelRowProps): ReactElement => {
-  const { data } = Channel.useRetrieve({ key: channelKey });
-  const isNumeric = data?.dataType.isNumeric === true;
   const theme = Theming.use();
   const defaultColor = theme.colors.gray.l11;
   const hasCustomColor = config.color !== "";
+  const showNumeric = showsNumericFields(ch?.dataType);
 
   return (
-    <Flex.Box x align="center" gap="large" className={CSS.BE("log", "channel-row")}>
-      <Channel.SelectSingle
-        value={channelKey}
-        onChange={(v: channel.Key) => onChange(index, v)}
-        initialQuery={{ internal: IS_DEV ? undefined : false }}
-        disabled={disabled}
-        className={CSS.BE("log", "channel-select")}
-      />
-      <Input.Text
-        value={config.alias ?? ""}
-        onChange={(v) => onConfigChange(channelKey, { alias: v })}
-        disabled={disabled}
-        placeholder={data?.name ?? "Alias"}
-        variant="shadow"
-        shrink={false}
-        className={CSS.BE("log", "channel-alias")}
-      />
-      <Notation.Select
-        value={config.notation ?? "standard"}
-        onChange={(v: notation.Notation) => onConfigChange(channelKey, { notation: v })}
-      />
-      <Input.Numeric
-        value={config.precision}
-        onChange={(v) => onConfigChange(channelKey, { precision: v })}
-        resetValue={-1}
-        bounds={PRECISION_BOUNDS}
-        disabled={disabled || !isNumeric}
-        shrink={false}
-        variant="shadow"
-        tooltip="Precision (-1 = no rounding)"
-        className={CSS.BE("log", "channel-precision")}
-      />
-      <Color.Swatch
-        value={hasCustomColor ? config.color : defaultColor}
-        onChange={(c) => onConfigChange(channelKey, { color: color.hex(c) })}
-        onDelete={
-          hasCustomColor ? () => onConfigChange(channelKey, { color: "" }) : undefined
-        }
-        size="small"
-        disabled={disabled}
-      />
-      <Button.Button
-        onClick={() => onRemove(index)}
-        disabled={disabled}
-        size="small"
-        variant="text"
-        ghost
-        tooltip="Remove channel"
-      >
-        <Icon.Close />
-      </Button.Button>
-    </Flex.Box>
+    <List.Item
+      itemKey={channelKey}
+      key={channelKey}
+      index={index}
+      selected={false}
+      align="center"
+      justify="between"
+      gap="large"
+      className={CSS.BE("log", "channel-row")}
+    >
+      <Flex.Box x align="center" grow>
+        <Channel.SelectSingle
+          value={channelKey}
+          onChange={(v: channel.Key) => onChange(index, v)}
+          initialQuery={{ internal: IS_DEV ? undefined : false }}
+          disabled={disabled}
+          className={CSS.BE("log", "channel-select")}
+        />
+        <Input.Text
+          value={config.alias ?? ""}
+          onChange={(v) => onConfigChange(channelKey, { alias: v })}
+          disabled={disabled}
+          placeholder={ch?.name ?? "Alias"}
+          variant="shadow"
+          shrink={false}
+          startContent={<Icon.Rename />}
+          tooltip="Alias"
+          className={CSS.BE("log", "channel-alias")}
+        />
+      </Flex.Box>
+      <Flex.Box x align="center">
+        {showNumeric && (
+          <>
+            <Notation.Select
+              value={config.notation ?? "standard"}
+              onChange={(v: notation.Notation) =>
+                onConfigChange(channelKey, { notation: v })
+              }
+            />
+            <Input.Numeric
+              value={config.precision}
+              onChange={(v) => onConfigChange(channelKey, { precision: v })}
+              resetValue={-1}
+              emptyValue={-1}
+              placeholder="Auto"
+              bounds={PRECISION_BOUNDS}
+              disabled={disabled}
+              shrink={false}
+              variant="shadow"
+              startContent={<Icon.Decimal />}
+              tooltip="Precision"
+              className={CSS.BE("log", "channel-precision")}
+              showDragHandle={false}
+            >
+              <Button.Button
+                variant="outlined"
+                disabled={disabled || config.precision === -1}
+                onClick={() => onConfigChange(channelKey, { precision: -1 })}
+                tooltip={
+                  config.precision === -1
+                    ? "Type a number to disable auto precision"
+                    : "Enable auto precision"
+                }
+              >
+                <Icon.Auto />
+              </Button.Button>
+            </Input.Numeric>
+          </>
+        )}
+        <Color.Swatch
+          value={hasCustomColor ? config.color : defaultColor}
+          onChange={(c) => onConfigChange(channelKey, { color: color.hex(c) })}
+          onDelete={
+            hasCustomColor ? () => onConfigChange(channelKey, { color: "" }) : undefined
+          }
+          size="small"
+        />
+        <Button.Button
+          onClick={() => onRemove(index)}
+          size="small"
+          variant="text"
+          ghost
+          tooltip="Remove channel"
+          contrast={0}
+        >
+          <Icon.Close />
+        </Button.Button>
+      </Flex.Box>
+    </List.Item>
   );
 };
 
@@ -131,31 +173,6 @@ const AddChannelRow = ({ onAdd, disabled }: AddChannelRowProps): ReactElement =>
       triggerProps={{ placeholder: "Add a channel..." }}
       className={CSS.BE("log", "channel-select")}
     />
-    <Input.Text
-      value=""
-      onChange={() => {}}
-      disabled
-      placeholder="Alias"
-      variant="shadow"
-      shrink={false}
-      className={CSS.BE("log", "channel-alias")}
-    />
-    <Notation.Select value={undefined} onChange={() => {}} allowNone />
-    <Input.Numeric
-      value={-1}
-      onChange={() => {}}
-      resetValue={-1}
-      bounds={PRECISION_BOUNDS}
-      disabled
-      shrink={false}
-      variant="shadow"
-      tooltip="Precision (-1 = no rounding)"
-      className={CSS.BE("log", "channel-precision")}
-    />
-    <Color.Swatch value={color.ZERO} onChange={() => {}} size="small" disabled />
-    <Button.Button size="small" variant="text" ghost disabled>
-      <Icon.Close />
-    </Button.Button>
   </Flex.Box>
 );
 
@@ -167,6 +184,13 @@ export const Channels = ({ layoutKey }: ChannelsProps): ReactElement | null => {
   const dispatch = useSyncComponent(layoutKey);
   const state = useSelectOptional(layoutKey);
   const hasUpdatePermission = Access.useUpdateGranted(log.ontologyID(layoutKey));
+
+  const channelKeys = useMemo(
+    () =>
+      state?.channels.map((c) => c.channel).filter((k) => !primitive.isZero(k)) ?? [],
+    [state?.channels],
+  );
+  const { data: channels } = Channel.useRetrieveMultiple({ keys: channelKeys });
 
   const handleChannelChange = useCallback(
     (index: number, channelKey: channel.Key) =>
@@ -194,18 +218,14 @@ export const Channels = ({ layoutKey }: ChannelsProps): ReactElement | null => {
   if (state == null) return null;
 
   return (
-    <Flex.Box
-      y
-      full="y"
-      style={{ overflow: "auto" }}
-      className={CSS.BE("log", "toolbar", "channels")}
-    >
+    <Flex.Box y full="y" className={CSS.BE("log", "toolbar", "channels")}>
       {state.channels.map((entry, i) =>
         primitive.isZero(entry.channel) ? null : (
           <ChannelRow
             key={`${entry.channel}-${i}`}
             index={i}
             channelKey={entry.channel}
+            ch={channels?.find((c) => c.key === entry.channel)}
             config={entry}
             onChange={handleChannelChange}
             onConfigChange={handleConfigChange}

--- a/console/src/log/toolbar/Properties.spec.tsx
+++ b/console/src/log/toolbar/Properties.spec.tsx
@@ -37,6 +37,7 @@ const LOG_STATE: State = {
   timestampPrecision: 0,
   showChannelNames: true,
   showReceiptTimestamp: true,
+  toolbar: { activeTab: "channels" },
 };
 
 const LAYOUT_STATE: Layout.State = {

--- a/console/src/log/toolbar/Toolbar.css
+++ b/console/src/log/toolbar/Toolbar.css
@@ -28,25 +28,31 @@
     .console-log__toolbar-channels {
         padding-top: 2rem;
         padding-bottom: 2rem;
+        overflow: auto;
 
         .console-log__channel-row {
             padding: 0.2rem 3rem 0.2rem 1rem;
+            min-height: unset;
+            cursor: default;
+            --pluto-hover-bg: transparent;
 
             .console-log__channel-select {
                 flex: 4;
-                min-width: 0;
+                min-width: 150px;
+                max-width: 500px;
                 overflow: hidden;
             }
 
             .console-log__channel-alias {
                 flex: 1;
-                min-width: 75px;
+                min-width: 0;
+                max-width: 200px;
                 overflow: hidden;
             }
 
             .console-log__channel-precision {
-                min-width: 60px;
-                max-width: 65px;
+                min-width: 70px;
+                max-width: 90px;
             }
         }
     }

--- a/console/src/log/toolbar/Toolbar.spec.tsx
+++ b/console/src/log/toolbar/Toolbar.spec.tsx
@@ -39,6 +39,7 @@ const ZERO_LOG_STATE: State = {
   timestampPrecision: 0,
   showChannelNames: true,
   showReceiptTimestamp: true,
+  toolbar: { activeTab: "channels" },
 };
 
 const LAYOUT_STATE: Layout.State = {

--- a/console/src/log/toolbar/Toolbar.tsx
+++ b/console/src/log/toolbar/Toolbar.tsx
@@ -11,7 +11,8 @@ import "@/log/toolbar/Toolbar.css";
 
 import { log } from "@synnaxlabs/client";
 import { Flex, Icon, Tabs } from "@synnaxlabs/pluto";
-import { type ReactElement, useCallback, useMemo, useState } from "react";
+import { type ReactElement, useCallback, useMemo } from "react";
+import { useDispatch } from "react-redux";
 
 import { Cluster } from "@/cluster";
 import { Toolbar as Base } from "@/components";
@@ -20,6 +21,7 @@ import { Export } from "@/export";
 import { Layout } from "@/layout";
 import { useExport } from "@/log/export";
 import { useSelectOptional } from "@/log/selectors";
+import { setActiveToolbarTab, type ToolbarTab } from "@/log/slice";
 import { Channels } from "@/log/toolbar/Channels";
 import { Properties } from "@/log/toolbar/Properties";
 
@@ -35,7 +37,13 @@ const TABS: Tabs.Tab[] = [
 export const Toolbar = ({ layoutKey }: ToolbarProps): ReactElement | null => {
   const { name } = Layout.useSelectRequired(layoutKey);
   const state = useSelectOptional(layoutKey);
-  const [activeTab, setActiveTab] = useState("channels");
+  const dispatch = useDispatch();
+  const activeTab = state?.toolbar.activeTab ?? "channels";
+  const handleTabSelect = useCallback(
+    (tab: string) =>
+      dispatch(setActiveToolbarTab({ key: layoutKey, tab: tab as ToolbarTab })),
+    [dispatch, layoutKey],
+  );
   const handleExport = useExport();
 
   const content = useCallback(
@@ -51,8 +59,8 @@ export const Toolbar = ({ layoutKey }: ToolbarProps): ReactElement | null => {
   );
 
   const tabsValue = useMemo(
-    () => ({ tabs: TABS, selected: activeTab, content, onSelect: setActiveTab }),
-    [activeTab, content],
+    () => ({ tabs: TABS, selected: activeTab, content, onSelect: handleTabSelect }),
+    [activeTab, content, handleTabSelect],
   );
 
   if (state == null) return null;

--- a/console/src/log/types/index.ts
+++ b/console/src/log/types/index.ts
@@ -23,6 +23,9 @@ export const ZERO_CHANNEL_CONFIG = v1.ZERO_CHANNEL_CONFIG;
 export type ChannelEntry = v1.ChannelEntry;
 export const ZERO_CHANNEL_ENTRY = v1.ZERO_CHANNEL_ENTRY;
 export const channelEntryZ = v1.channelEntryZ;
+export type ToolbarTab = v1.ToolbarTab;
+export type ToolbarState = v1.ToolbarState;
+export const ZERO_TOOLBAR_STATE = v1.ZERO_TOOLBAR_STATE;
 
 export type AnyState = v0.State | v1.State;
 export type AnySliceState = v0.SliceState | v1.SliceState;

--- a/console/src/log/types/v1.ts
+++ b/console/src/log/types/v1.ts
@@ -36,6 +36,16 @@ export const ZERO_CHANNEL_ENTRY: ChannelEntry = {
   channel: 0,
 };
 
+export const toolbarTabZ = z.enum(["channels", "properties"]);
+export type ToolbarTab = z.infer<typeof toolbarTabZ>;
+
+export const toolbarStateZ = z.object({
+  activeTab: toolbarTabZ.default("channels"),
+});
+export type ToolbarState = z.infer<typeof toolbarStateZ>;
+
+export const ZERO_TOOLBAR_STATE: ToolbarState = { activeTab: "channels" };
+
 export const stateZ = z.object({
   key: z.string(),
   version: z.literal(VERSION),
@@ -44,6 +54,7 @@ export const stateZ = z.object({
   timestampPrecision: z.number().min(0).max(3).default(0),
   showChannelNames: z.boolean().default(true),
   showReceiptTimestamp: z.boolean().default(true),
+  toolbar: toolbarStateZ.default(ZERO_TOOLBAR_STATE),
 });
 export type State = z.infer<typeof stateZ>;
 
@@ -55,6 +66,7 @@ export const ZERO_STATE: State = {
   timestampPrecision: 0,
   showChannelNames: true,
   showReceiptTimestamp: true,
+  toolbar: ZERO_TOOLBAR_STATE,
 };
 
 export const sliceStateZ = z.object({
@@ -76,6 +88,7 @@ export const stateMigration = migrate.createMigration<v0.State, State>({
     timestampPrecision: 0,
     showChannelNames: true,
     showReceiptTimestamp: true,
+    toolbar: ZERO_TOOLBAR_STATE,
     channels: state.channels.map((key) => ({
       channel: key,
       ...ZERO_CHANNEL_CONFIG,

--- a/console/src/store.ts
+++ b/console/src/store.ts
@@ -114,6 +114,7 @@ export const migrateState = (prev: RootState): RootState => {
   const layout = Layout.migrateSlice(prev.layout);
   const schematic = Schematic.migrateSlice(prev.schematic);
   const line = LinePlot.migrateSlice(prev.line);
+  const log = Log.migrateSlice(prev.log);
   const version = Version.migrateSlice(prev.version);
   const workspace = Workspace.migrateSlice(prev.workspace);
   const range = Range.migrateSlice(prev.range);
@@ -128,6 +129,7 @@ export const migrateState = (prev: RootState): RootState => {
     layout,
     schematic,
     line,
+    log,
     version,
     workspace,
     range,

--- a/pluto/src/channel/queries.ts
+++ b/pluto/src/channel/queries.ts
@@ -168,7 +168,7 @@ const retrieveMultiple = async ({
   query: { keys, rangeKey },
   store,
 }: Flux.RetrieveParams<RetrieveMultipleQuery, FluxSubStore>) => {
-  const channels = store.channels.get(keys);
+  let channels = store.channels.get(keys);
   const existingKeys = new Set(channels?.map((ch) => ch.key));
   const missingKeys = keys.filter((key) => !existingKeys.has(key));
   if (missingKeys.length > 0) {
@@ -176,6 +176,7 @@ const retrieveMultiple = async ({
     channels.push(...missingChannels);
     store.channels.set(missingChannels);
   }
+  channels = Flux.orderByKeys(keys, channels, (ch) => ch.key);
   if (rangeKey != null) {
     const aliasKeys = keys.map((key) =>
       ranger.alias.createKey({ range: rangeKey, channel: key }),

--- a/pluto/src/device/queries.ts
+++ b/pluto/src/device/queries.ts
@@ -140,7 +140,7 @@ export const retrieveMultiple = async <
     });
   }
 
-  return devices;
+  return Flux.orderByKeys(keys, devices, (d) => d.key);
 };
 
 export const createRetrieve = <

--- a/pluto/src/flux/base/store.spec.ts
+++ b/pluto/src/flux/base/store.spec.ts
@@ -11,7 +11,12 @@ import { type record } from "@synnaxlabs/x";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { type base } from "@/flux/base";
-import { createStore, ScopedUnaryStore, scopeStore } from "@/flux/base/store";
+import {
+  createStore,
+  orderByKeys,
+  ScopedUnaryStore,
+  scopeStore,
+} from "@/flux/base/store";
 
 const basicHandleError = vi.fn((excOrFunc: any, _?: string) => {
   if (typeof excOrFunc === "function") void excOrFunc();
@@ -1482,6 +1487,79 @@ describe("Base Store", () => {
         const store = createStore({}, basicHandleError);
         expect(store).toEqual({});
       });
+    });
+  });
+
+  describe("orderByKeys", () => {
+    interface Item {
+      key: number;
+      name: string;
+    }
+    const getKey = (i: Item) => i.key;
+
+    it("should return items in the order of the input keys", () => {
+      const items: Item[] = [
+        { key: 3, name: "c" },
+        { key: 1, name: "a" },
+        { key: 2, name: "b" },
+      ];
+      const ordered = orderByKeys([1, 2, 3], items, getKey);
+      expect(ordered.map((i) => i.name)).toEqual(["a", "b", "c"]);
+    });
+
+    it("should drop keys that have no corresponding item", () => {
+      const items: Item[] = [
+        { key: 1, name: "a" },
+        { key: 3, name: "c" },
+      ];
+      const ordered = orderByKeys([1, 2, 3], items, getKey);
+      expect(ordered.map((i) => i.name)).toEqual(["a", "c"]);
+    });
+
+    it("should deduplicate repeated keys", () => {
+      const items: Item[] = [
+        { key: 1, name: "a" },
+        { key: 2, name: "b" },
+      ];
+      const ordered = orderByKeys([1, 2, 1, 2, 1], items, getKey);
+      expect(ordered.map((i) => i.name)).toEqual(["a", "b"]);
+    });
+
+    it("should return an empty array when keys is empty", () => {
+      const items: Item[] = [{ key: 1, name: "a" }];
+      expect(orderByKeys([], items, getKey)).toEqual([]);
+    });
+
+    it("should return an empty array when items is empty", () => {
+      expect(orderByKeys([1, 2, 3], [], getKey)).toEqual([]);
+    });
+
+    it("should ignore items whose key is not present in keys", () => {
+      const items: Item[] = [
+        { key: 1, name: "a" },
+        { key: 99, name: "x" },
+      ];
+      const ordered = orderByKeys([1], items, getKey);
+      expect(ordered.map((i) => i.name)).toEqual(["a"]);
+    });
+
+    it("should support string keys", () => {
+      const items = [
+        { key: "b", name: "two" },
+        { key: "a", name: "one" },
+      ];
+      const ordered = orderByKeys(["a", "b"], items, (i) => i.key);
+      expect(ordered.map((i) => i.name)).toEqual(["one", "two"]);
+    });
+
+    it("should keep the first occurrence when items contains duplicate keys", () => {
+      const items: Item[] = [
+        { key: 1, name: "first" },
+        { key: 1, name: "second" },
+      ];
+      const ordered = orderByKeys([1], items, getKey);
+      // Map.set with the same key keeps the last value written — confirming contract.
+      expect(ordered).toEqual([{ key: 1, name: "second" }]);
     });
   });
 });

--- a/pluto/src/flux/base/store.ts
+++ b/pluto/src/flux/base/store.ts
@@ -25,6 +25,24 @@ interface ListenerScope<K extends record.Key> {
   key?: K;
 }
 
+/// Reorders the given items to match the order of keys, dropping any key
+/// that has no corresponding item. Used by multi-retrieve query implementations
+/// to preserve the caller's input key order across cached + freshly-fetched items.
+export const orderByKeys = <K extends record.Key, V>(
+  keys: K[],
+  items: V[],
+  getKey: (v: V) => K,
+): V[] => {
+  const byKey = new Map<K, V>();
+  for (const item of items) byKey.set(getKey(item), item);
+  const ordered: V[] = [];
+  for (const key of keys) {
+    const item = byKey.get(key);
+    if (item != null) ordered.push(item);
+  }
+  return ordered;
+};
+
 export interface SetHandler<Value, SetExtra extends unknown | undefined = undefined> {
   (value: Value, variant: SetExtra): void | Promise<void>;
 }

--- a/pluto/src/flux/base/store.ts
+++ b/pluto/src/flux/base/store.ts
@@ -25,9 +25,10 @@ interface ListenerScope<K extends record.Key> {
   key?: K;
 }
 
-/// Reorders the given items to match the order of keys, dropping any key
-/// that has no corresponding item. Used by multi-retrieve query implementations
-/// to preserve the caller's input key order across cached + freshly-fetched items.
+/// Reorders the given items to match the order of keys, dropping any key that
+/// has no corresponding item and deduplicating repeated keys. Used by
+/// multi-retrieve query implementations to preserve the caller's input key order
+/// across cached + freshly-fetched items.
 export const orderByKeys = <K extends record.Key, V>(
   keys: K[],
   items: V[],
@@ -36,7 +37,10 @@ export const orderByKeys = <K extends record.Key, V>(
   const byKey = new Map<K, V>();
   for (const item of items) byKey.set(getKey(item), item);
   const ordered: V[] = [];
+  const seen = new Set<K>();
   for (const key of keys) {
+    if (seen.has(key)) continue;
+    seen.add(key);
     const item = byKey.get(key);
     if (item != null) ordered.push(item);
   }

--- a/pluto/src/icon/registry.tsx
+++ b/pluto/src/icon/registry.tsx
@@ -73,6 +73,7 @@ import {
   IoTime,
   IoTvOutline,
 } from "react-icons/io5";
+import { LuSigma } from "react-icons/lu";
 import {
   MdAlignHorizontalCenter,
   MdAlignHorizontalLeft,
@@ -215,6 +216,7 @@ import {
   TbPlugConnected,
   TbPlugConnectedX,
   TbRadarFilled,
+  TbSuperscript,
   TbVariable,
 } from "react-icons/tb";
 import {
@@ -425,6 +427,8 @@ export const Feedback = wrapSVGIcon(MdFeedback, "feedback");
 export const Calculation = wrapSVGIcon(MdCalculate, "calculation");
 export const Binary = wrapSVGIcon(PiBinary, "binary");
 export const Decimal = wrapSVGIcon(TbDecimal, "decimal");
+export const Scientific = wrapSVGIcon(TbSuperscript, "scientific");
+export const Engineering = wrapSVGIcon(LuSigma, "engineering");
 export const String = wrapSVGIcon(VscSymbolString, "string");
 export const Control = wrapSVGIcon(MdOutlineControlCamera, "control");
 export const Rack = wrapSVGIcon(MdHive, "rack");
@@ -603,6 +607,8 @@ const icons = {
   Calculation,
   Binary,
   Decimal,
+  Scientific,
+  Engineering,
   String,
   Control,
   Rack,

--- a/pluto/src/input/Input.spec.tsx
+++ b/pluto/src/input/Input.spec.tsx
@@ -436,6 +436,69 @@ describe("Input", () => {
         expect(onBlur).toHaveBeenCalled();
       });
     });
+
+    describe("emptyValue", () => {
+      it("should render an empty string when the value equals emptyValue", () => {
+        const c = render(
+          <Input.Numeric value={-1} onChange={vi.fn()} emptyValue={-1} />,
+        );
+        const input = c.getByRole("textbox") as HTMLInputElement;
+        expect(input.value).toBe("");
+      });
+
+      it("should render the value when it does not equal emptyValue", () => {
+        const c = render(
+          <Input.Numeric value={3} onChange={vi.fn()} emptyValue={-1} />,
+        );
+        const input = c.getByRole("textbox") as HTMLInputElement;
+        expect(input.value).toBe("3");
+      });
+
+      it("should show the placeholder when the value equals emptyValue", () => {
+        const c = render(
+          <Input.Numeric
+            value={-1}
+            onChange={vi.fn()}
+            emptyValue={-1}
+            placeholder="Auto"
+          />,
+        );
+        const input = c.getByRole("textbox") as HTMLInputElement;
+        expect(input.placeholder).toBe("Auto");
+      });
+
+      it("should emit emptyValue when the input is cleared and blurred", () => {
+        const onChange = vi.fn();
+        const c = render(
+          <Input.Numeric value={7} onChange={onChange} emptyValue={-1} />,
+        );
+        const input = c.getByRole("textbox");
+        fireEvent.change(input, { target: { value: "" } });
+        fireEvent.blur(input);
+        expect(onChange).toHaveBeenCalledWith(-1);
+      });
+
+      it("should emit a parsed number when typing overrides the empty state", () => {
+        const onChange = vi.fn();
+        const c = render(
+          <Input.Numeric value={-1} onChange={onChange} emptyValue={-1} />,
+        );
+        const input = c.getByRole("textbox");
+        fireEvent.change(input, { target: { value: "5" } });
+        fireEvent.blur(input);
+        expect(onChange).toHaveBeenCalledWith(5);
+      });
+
+      it("should not emit emptyValue when the input is cleared and emptyValue is unset", () => {
+        const onChange = vi.fn();
+        const c = render(<Input.Numeric value={7} onChange={onChange} />);
+        const input = c.getByRole("textbox");
+        fireEvent.change(input, { target: { value: "" } });
+        fireEvent.blur(input);
+        expect(onChange).not.toHaveBeenCalled();
+        expect((input as HTMLInputElement).value).toBe("7");
+      });
+    });
   });
 
   describe("Checkbox", () => {

--- a/pluto/src/input/Numeric.tsx
+++ b/pluto/src/input/Numeric.tsx
@@ -27,6 +27,10 @@ export interface NumericProps
   bounds?: bounds.Crude;
   onBlur?: () => void;
   units?: string;
+  /// When set, a value equal to emptyValue renders as an empty input (showing the
+  /// placeholder) and clearing the input on blur emits emptyValue via onChange. Useful
+  /// for representing a sentinel "unset"/"auto" state without showing the raw number.
+  emptyValue?: number;
 }
 
 /**
@@ -68,13 +72,15 @@ export const Numeric = ({
   size,
   color,
   contrast,
+  emptyValue,
   ...rest
 }: NumericProps): ReactElement => {
+  const isEmpty = emptyValue != null && value === emptyValue;
   // We need to keep the actual value as a valid number, but we need to let the user
   // input an invalid value that may eventually be valid, so we need to keep the
   // internal value as a string in state.
   const [internalValue, setInternalValue, internalValueRef] = useCombinedStateAndRef(
-    value.toString(),
+    isEmpty ? "" : value.toString(),
   );
   const [isValueValid, setIsValueValid, isValueValidRef] =
     useCombinedStateAndRef<boolean>(true);
@@ -84,6 +90,11 @@ export const Numeric = ({
     // This just means we never actually modified the input
     if (isValueValidRef.current) return;
     setIsValueValid(true);
+    const raw = internalValueRef.current.trim();
+    if (raw === "" && emptyValue != null) {
+      onChange?.(emptyValue);
+      return;
+    }
     let v = null;
     try {
       const ev = evaluate(internalValueRef.current);
@@ -94,8 +105,13 @@ export const Numeric = ({
       v = null;
     }
     if (v != null) onChange?.(bounds.clamp(propsBounds, v));
-    else setInternalValue(valueRef.current.toString());
-  }, [onChange, setInternalValue]);
+    else
+      setInternalValue(
+        emptyValue != null && valueRef.current === emptyValue
+          ? ""
+          : valueRef.current.toString(),
+      );
+  }, [onChange, setInternalValue, emptyValue]);
 
   const updateActualValueRef = useSyncedRef(updateActualValue);
 
@@ -117,7 +133,9 @@ export const Numeric = ({
   );
 
   // If the value is valid, use the actual value, otherwise use the internal value.
-  const value_ = isValueValid ? value : internalValue;
+  // When the value matches emptyValue, render as an empty string so the placeholder
+  // shows through.
+  const value_ = isValueValid ? (isEmpty ? "" : value.toString()) : internalValue;
 
   const onDragChange = useCallback(
     (value: number) => {
@@ -142,7 +160,7 @@ export const Numeric = ({
       type="text"
       variant={variant}
       className={className}
-      value={value_.toString()}
+      value={value_}
       onChange={handleChange}
       disabled={disabled}
       selectOnFocus={selectOnFocus}

--- a/pluto/src/log/Log.spec.tsx
+++ b/pluto/src/log/Log.spec.tsx
@@ -65,7 +65,6 @@ const DEFAULT_STATE = {
   selectedLines: [],
   computedLineHeight: 16,
   entryCount: 0,
-  copyFlash: false,
 };
 
 const setupAether = (overrides: Record<string, unknown> = {}) => {

--- a/pluto/src/log/Log.tsx
+++ b/pluto/src/log/Log.tsx
@@ -10,11 +10,12 @@
 import "@/log/Log.css";
 
 import { box, location, strings } from "@synnaxlabs/x";
-import { type ReactElement, useCallback, useRef } from "react";
+import { type ReactElement, type ReactNode, useCallback, useRef } from "react";
 
 import { Button } from "@/button";
 import { CSS } from "@/css";
 import { type Flex } from "@/flex";
+import { useCombinedRefs } from "@/hooks/ref";
 import { Icon } from "@/icon";
 import { use, type UseProps } from "@/log/use";
 import { Menu } from "@/menu";
@@ -22,13 +23,14 @@ import { Status } from "@/status/base";
 import { Triggers } from "@/triggers";
 import { Canvas } from "@/vis/canvas";
 
-const COPY_FLASH_DURATION_MS = 150;
 const COPY_TRIGGER: Triggers.Trigger = ["Control", "C"];
 const SELECT_ALL_TRIGGER: Triggers.Trigger = ["Control", "A"];
 const ESCAPE_TRIGGER: Triggers.Trigger = ["Escape"];
+const PAUSE_TRIGGER: Triggers.Trigger = ["H"];
 
 export interface LogProps extends UseProps, Omit<Flex.BoxProps, "color"> {
   emptyContent?: ReactElement;
+  extraContextMenuItems?: ReactNode;
 }
 
 export const Log = ({
@@ -47,6 +49,7 @@ export const Log = ({
   ),
   color,
   telem,
+  extraContextMenuItems,
   ...rest
 }: LogProps): ReactElement | null => {
   const { state, setState } = use({
@@ -75,6 +78,8 @@ export const Log = ({
   const resizeRef = Canvas.useRegion(
     useCallback((b) => setState((s) => ({ ...s, region: b })), [setState]),
   );
+  const containerRef = useRef<HTMLDivElement>(null);
+  const combinedRef = useCombinedRefs(resizeRef, containerRef);
 
   const draggingRef = useRef(false);
 
@@ -127,13 +132,15 @@ export const Log = ({
     return `<pre style="font-family: monospace">${lines.join("\n")}</pre>`;
   }, [selectedLines]);
 
-  const flashCopy = useCallback(() => {
-    setState((s) => ({ ...s, copyFlash: true }));
-    setTimeout(
-      () => setState((s) => ({ ...s, copyFlash: false })),
-      COPY_FLASH_DURATION_MS,
-    );
-  }, [setState]);
+  const addStatus = Status.useAdder();
+  const notifyCopied = useCallback(
+    (count: number) =>
+      addStatus({
+        variant: "success",
+        message: `Copied ${count} ${count === 1 ? "line" : "lines"} to clipboard`,
+      }),
+    [addStatus],
+  );
 
   const copyToClipboard = useCallback(() => {
     if (selectedText.length === 0) return;
@@ -141,8 +148,9 @@ export const Log = ({
       "text/html": new Blob([buildCopyHTML()], { type: "text/html" }),
       "text/plain": new Blob([selectedText], { type: "text/plain" }),
     });
-    void navigator.clipboard.write([item]).then(flashCopy);
-  }, [selectedText, buildCopyHTML, flashCopy]);
+    const count = selectedLines.length;
+    void navigator.clipboard.write([item]).then(() => notifyCopied(count));
+  }, [selectedText, selectedLines.length, buildCopyHTML, notifyCopied]);
 
   Triggers.use({
     triggers: [ESCAPE_TRIGGER],
@@ -155,6 +163,18 @@ export const Log = ({
           selectionEnd: -1,
           selectedText: "",
         }));
+      },
+      [setState],
+    ),
+  });
+
+  Triggers.use({
+    triggers: [PAUSE_TRIGGER],
+    region: containerRef,
+    callback: useCallback(
+      ({ stage }: Triggers.UseEvent) => {
+        if (stage !== "start") return;
+        setState((s) => ({ ...s, scrolling: !s.scrolling }));
       },
       [setState],
     ),
@@ -197,15 +217,21 @@ export const Log = ({
           <Icon.Copy />
           Copy
         </Menu.Item>
+        {extraContextMenuItems != null && (
+          <>
+            <Menu.Divider />
+            {extraContextMenuItems}
+          </>
+        )}
       </Menu.Menu>
     ),
-    [handleMenuSelect, hasSelection],
+    [handleMenuSelect, hasSelection, extraContextMenuItems],
   );
 
   return (
     <Menu.ContextMenu className={menuClassName} menu={menuContent} {...menuProps}>
       <div
-        ref={resizeRef}
+        ref={combinedRef}
         tabIndex={0}
         className={CSS(CSS.B("log"), className)}
         onWheel={(e) => {
@@ -223,7 +249,7 @@ export const Log = ({
           e.preventDefault();
           e.clipboardData.setData("text/plain", selectedText);
           e.clipboardData.setData("text/html", buildCopyHTML());
-          flashCopy();
+          notifyCopied(selectedLines.length);
         }}
         onContextMenu={menuProps.open}
         {...rest}

--- a/pluto/src/log/aether/Log.spec.ts
+++ b/pluto/src/log/aether/Log.spec.ts
@@ -281,7 +281,6 @@ describe("log/aether/Log", () => {
       expect(parsed.selectedLines).toEqual([]);
       expect(parsed.computedLineHeight).toBe(0);
       expect(parsed.entryCount).toBe(0);
-      expect(parsed.copyFlash).toBe(false);
     });
 
     it("should provide defaults for channel-related fields", () => {
@@ -806,17 +805,6 @@ describe("log/aether/Log", () => {
       const { log } = setupWithContext(entries, REGION_500, {
         selectionStart: 2,
         selectionEnd: 5,
-      });
-      const result = log.render();
-      expect(result).toBeTypeOf("function");
-    });
-
-    it("should render with copyFlash color when copyFlash is true", () => {
-      const entries = Array.from({ length: 10 }, (_, i) => makeEntry(i));
-      const { log } = setupWithContext(entries, REGION_500, {
-        selectionStart: 0,
-        selectionEnd: 2,
-        copyFlash: true,
       });
       const result = log.render();
       expect(result).toBeTypeOf("function");

--- a/pluto/src/log/aether/Log.ts
+++ b/pluto/src/log/aether/Log.ts
@@ -59,7 +59,6 @@ export const logState = z.object({
   selectedLines: z.array(z.object({ text: z.string(), color: z.string() })).default([]),
   computedLineHeight: z.number().default(0),
   entryCount: z.number().default(0),
-  copyFlash: z.boolean().default(false),
 });
 
 const SCROLLBAR_RENDER_THRESHOLD = 0.98;
@@ -89,7 +88,6 @@ interface InternalState {
   lineHeight: number;
   tsLen: number;
   selectionColor: color.Color;
-  selectionFlashColor: color.Color;
   stopListeningTelem?: destructor.Destructor;
 }
 
@@ -176,9 +174,7 @@ export class Log extends aether.Leaf<typeof logState, InternalState> {
     }
     i.configs = configs;
 
-    // Cache selection highlight colors (theme-dependent).
     i.selectionColor = color.setAlpha(i.theme.colors.primary.z, 0.25);
-    i.selectionFlashColor = color.setAlpha(i.theme.colors.primary.z, 0.15);
 
     i.telem = telem.useSource(ctx, this.state.telem, i.telem);
 
@@ -386,9 +382,6 @@ export class Log extends aether.Leaf<typeof logState, InternalState> {
     const reg = this.state.region;
     const highlightStart = Math.max(selMin, sliceStart) - sliceStart;
     const highlightEnd = Math.min(selMax, sliceEnd - 1) - sliceStart;
-    const bgColor = this.state.copyFlash
-      ? this.internal.selectionFlashColor
-      : this.internal.selectionColor;
     const rowCount = highlightEnd - highlightStart + 1;
     draw2d.container({
       region: box.construct(
@@ -400,7 +393,7 @@ export class Log extends aether.Leaf<typeof logState, InternalState> {
       ),
       bordered: false,
       rounded: false,
-      backgroundColor: bgColor,
+      backgroundColor: this.internal.selectionColor,
     });
   }
 
@@ -487,11 +480,22 @@ export class Log extends aether.Leaf<typeof logState, InternalState> {
         position: { x: posX, y: posY },
         code: true,
       });
+      const valueX = posX + prefix.length * charWidth;
+      const isNegative = value[0] === "-";
+      const displayValue = isNegative ? value.slice(1) : value;
+      if (isNegative)
+        draw2D.text({
+          text: "-",
+          level: font,
+          color: entryColor,
+          position: { x: valueX - charWidth, y: posY },
+          code: true,
+        });
       draw2D.text({
-        text: value,
+        text: displayValue,
         level: font,
         color: entryColor,
-        position: { x: posX + prefix.length * charWidth, y: posY },
+        position: { x: valueX, y: posY },
         code: true,
       });
     }

--- a/pluto/src/log/use.ts
+++ b/pluto/src/log/use.ts
@@ -33,7 +33,6 @@ export interface UseProps
         | "selectedText"
         | "selectedLines"
         | "computedLineHeight"
-        | "copyFlash"
         | "channelNames"
       >,
       "visible"

--- a/pluto/src/notation/Select.css
+++ b/pluto/src/notation/Select.css
@@ -1,0 +1,23 @@
+/*
+ * Copyright 2026 Synnax Labs, Inc.
+ *
+ * Use of this software is governed by the Business Source License included in the file
+ * licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source
+ * License, use of this software will be governed by the Apache License, Version 2.0,
+ * included in the file licenses/APL.txt.
+ */
+
+.pluto-notation-select__icon {
+    display: none;
+}
+
+@media (max-width: 1100px) {
+    .pluto-notation-select__label {
+        display: none;
+    }
+    .pluto-notation-select__icon {
+        display: inline-flex;
+    }
+}

--- a/pluto/src/notation/Select.tsx
+++ b/pluto/src/notation/Select.tsx
@@ -7,9 +7,13 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+import "@/notation/Select.css";
+
 import { notation } from "@synnaxlabs/x";
 import { type ReactElement } from "react";
 
+import { CSS } from "@/css";
+import { Icon } from "@/icon";
 import { Select as BaseSelect } from "@/select";
 
 export interface SelectNotationProps extends Omit<
@@ -17,10 +21,26 @@ export interface SelectNotationProps extends Omit<
   "keys"
 > {}
 
-export const Select = (props: SelectNotationProps): ReactElement => (
-  <BaseSelect.Buttons {...props} keys={notation.NOTATIONS}>
-    <BaseSelect.Button itemKey="standard">Standard</BaseSelect.Button>
-    <BaseSelect.Button itemKey="scientific">Scientific</BaseSelect.Button>
-    <BaseSelect.Button itemKey="engineering">Engineering</BaseSelect.Button>
+const LABEL_CLASS = CSS.BE("notation-select", "label");
+const ICON_CLASS = CSS.BE("notation-select", "icon");
+
+export const Select = ({ className, ...rest }: SelectNotationProps): ReactElement => (
+  <BaseSelect.Buttons
+    {...rest}
+    keys={notation.NOTATIONS}
+    className={CSS(className, CSS.B("notation-select"))}
+  >
+    <BaseSelect.Button itemKey="standard" tooltip="Standard">
+      <Icon.Decimal className={ICON_CLASS} />
+      <span className={LABEL_CLASS}>Standard</span>
+    </BaseSelect.Button>
+    <BaseSelect.Button itemKey="scientific" tooltip="Scientific">
+      <Icon.Scientific className={ICON_CLASS} />
+      <span className={LABEL_CLASS}>Scientific</span>
+    </BaseSelect.Button>
+    <BaseSelect.Button itemKey="engineering" tooltip="Engineering">
+      <Icon.Engineering className={ICON_CLASS} />
+      <span className={LABEL_CLASS}>Engineering</span>
+    </BaseSelect.Button>
   </BaseSelect.Buttons>
 );

--- a/pluto/src/ranger/queries.ts
+++ b/pluto/src/ranger/queries.ts
@@ -131,7 +131,7 @@ const retrieveMultiple = async ({
     }
   }
 
-  return ranges;
+  return Flux.orderByKeys(keys, ranges, (r) => r.key);
 };
 
 export const useSetSynchronizer = (onSet: (range: ranger.Payload) => void): void => {

--- a/pluto/src/status/queries.ts
+++ b/pluto/src/status/queries.ts
@@ -241,7 +241,7 @@ export const retrieveMultiple = async ({
   if (missing.length === 0) return cached;
   const retrieved = await client.statuses.retrieve({ keys: missing });
   store.statuses.set(retrieved);
-  return [...cached, ...retrieved];
+  return Flux.orderByKeys(keys, [...cached, ...retrieved], (s) => s.key);
 };
 
 export const { useRetrieve: useRetrieveMultiple } = Flux.createRetrieve<


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-3936](https://linear.app/synnax/issue/SY-3936)

## Description

Improves the log visualization's channels-toolbar UX and the underlying Pluto primitives it depends on.

- **Channel rows**: conditionally render notation and precision fields based on the channel's data type (numeric, non-timestamp only). Rows now use `List.Item`, so the delete button is a proper hover-ghost. Alias field gained a `Rename` icon + "Alias" tooltip; precision input gained a `Decimal` icon.
- **Layout**: channel selector has a `min-width` so it stays legible as the panel narrows; alias shrinks first. Notation/precision/color/delete are pushed to the right via `justify="between"`. Per-row hover background removed. `overflow: auto` on the channels list moved from inline style to CSS.
- **Notation select**: built-in icons (`Decimal`, `Scientific`, `Engineering`) with tooltips, labels collapse via a viewport media query below 1100px.
- **Precision auto mode**: reuses the `-1` sentinel with a new auto button (matches the LinePlot pattern). `Input.Numeric` now accepts an `emptyValue` prop so the sentinel renders as an empty "Auto" placeholder instead of `-1`; clearing the input on blur re-emits the sentinel. Unit tests added.
- **Context menu**: Pluto `Log` accepts an `extraContextMenuItems` prop; console passes `<ContextMenu.ReloadConsoleItem />` so the right-click menu on a log again includes "Reload Console".
- **Flux**: added `Flux.orderByKeys` and applied it to `retrieveMultiple` in `channel`, `device`, `status`, and `ranger` so `useRetrieveMultiple` returns items in input-key order across all Flux resources.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the Log visualization's channel toolbar UX: channel rows gain conditional numeric fields (notation/precision) for numeric data types, a precision "Auto" mode using a `-1` sentinel exposed via `Input.Numeric`'s new `emptyValue` prop, and a context-menu extension point (`extraContextMenuItems`) for the "Reload Console" action. It also adds `Flux.orderByKeys` to make `useRetrieveMultiple` return items in input-key order across channel, device, status, and ranger stores.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all remaining findings are P2 style/defensive-coding suggestions with no functional impact.

No P0/P1 issues found. The `emptyValue` logic is well-tested with 6 new unit tests. The `orderByKeys` utility is simple and correct for its intended use case. The two P2 items (inline JSX prop causing extra useCallback churn, and a stale `internalValue` after valid commit) do not affect observable behavior.

`pluto/src/flux/base/store.ts` (orderByKeys duplicate-key edge case) and `console/src/log/Log.tsx` (inline JSX prop).

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| pluto/src/input/Numeric.tsx | Adds `emptyValue` prop: when `value === emptyValue`, renders an empty string and re-emits the sentinel on blur; logic is correct but `internalValue` is not synced back after a valid commit |
| pluto/src/flux/base/store.ts | Adds `orderByKeys` utility to preserve input-key order in multi-retrieve results; duplicate keys in the input array will produce duplicate entries in the output |
| console/src/log/toolbar/Channels.tsx | Rewrites channel rows to use `List.Item` for hover-ghost delete; conditionally shows numeric fields based on channel data type; precision field uses sentinel -1 with emptyValue/Auto pattern |
| pluto/src/log/Log.tsx | Adds `extraContextMenuItems` prop that appends items (with a divider) to the log's right-click context menu; integration is clean |
| console/src/log/Log.tsx | Passes `extraContextMenuItems={<ContextMenu.ReloadConsoleItem />}` inline — the JSX element is recreated each render, causing unnecessary `menuContent` callback churn |
| pluto/src/notation/Select.tsx | Notation select now renders icon + collapsible label per notation option; clean implementation with CSS media-query collapse |
| pluto/src/channel/queries.ts | Applies `Flux.orderByKeys` after combining cached + fresh channels so `useRetrieveMultiple` returns results in input-key order |
| pluto/src/input/Input.spec.tsx | Adds 6 comprehensive unit tests for the new `emptyValue` prop covering rendering, placeholder, emit-on-clear, and typing-override scenarios |
| console/src/log/types/v1.ts | Introduces v1 state migration from v0, moving from flat channel keys to `ChannelEntry` with config fields; `ZERO_CHANNEL_CONFIG` correctly seeds precision to -1 |
| pluto/src/log/aether/Log.ts | No functional changes visible in the reviewed segment; schema and rendering remain consistent |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[useRetrieveMultiple called with keys] --> B[Get cached entries from store]
    B --> C{Any missing keys?}
    C -->|Yes| D[Fetch missing from Synnax API]
    D --> E[Merge cached and fetched entries]
    C -->|No| E
    E --> F[orderByKeys: reorder by input key list]
    F --> G[Return items in original input order]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `pluto/src/input/Numeric.tsx`, line 89-114 ([link](https://github.com/synnaxlabs/synnax/blob/9aef5d38cdd44ee2f09c878395f788375b9bc2af/pluto/src/input/Numeric.tsx#L89-L114)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`updateActualValue` does not sync `internalValue` when a valid value is committed**

   When `v != null` and `onChange` is called, `setInternalValue` is not called, leaving `internalValue` holding the user's raw string (e.g. `"2+3"` for a value of `5`). On the next external prop change, `isValueValid` resets to `true` so the display is fine (it uses `value.toString()`), but if the component is ever used in a context where `isValueValid` could remain `false` across a re-render (e.g. rapid prop changes), the stale string could flash briefly. Syncing `internalValue` after a successful commit is the more defensive approach:

   ```ts
   if (v != null) {
     onChange?.(bounds.clamp(propsBounds, v));
     setInternalValue(
       emptyValue != null && bounds.clamp(propsBounds, v) === emptyValue
         ? ""
         : bounds.clamp(propsBounds, v).toString(),
     );
   }
   ```

   Low-risk in practice, but worth noting since this component is now part of a public API.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["log UI improvments"](https://github.com/synnaxlabs/synnax/commit/9aef5d38cdd44ee2f09c878395f788375b9bc2af) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28872538)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->