### PR TITLE
SY-4085: Add data validation before writing series

### DIFF
--- a/cesium/gc_test.go
+++ b/cesium/gc_test.go
@@ -96,9 +96,10 @@ var _ = Describe("Garbage collection", Ordered, func() {
 
 					By("Checking the resulting file size")
 					Eventually(func(g Gomega) uint32 {
-						i := MustSucceed(fs.Stat(path.Join(channelKeyToPath(basic) + "/1.domain")))
+						i, err := fs.Stat(path.Join(channelKeyToPath(basic) + "/1.domain"))
+						g.Expect(err).ToNot(HaveOccurred())
 						return uint32(i.Size())
-					}).Should(Equal(uint32(42 * telem.Int64T.Density())))
+					}).Should(Equal(42 * uint32(telem.Int64T.Density())))
 				})
 			})
 
@@ -149,18 +150,20 @@ var _ = Describe("Garbage collection", Ordered, func() {
 					Expect(db.DeleteTimeRange(ctx, []cesium.ChannelKey{basic}, (20 * telem.SecondTS).Range(50*telem.SecondTS))).To(Succeed())
 
 					Consistently(func(g Gomega) uint32 {
-						i := MustSucceed(fs.Stat(path.Join(channelKeyToPath(basic) + "/1.domain")))
+						i, err := fs.Stat(path.Join(channelKeyToPath(basic) + "/1.domain"))
+						g.Expect(err).ToNot(HaveOccurred())
 						return uint32(i.Size())
-					}).Should(Equal(uint32(90 * telem.Int64T.Density())))
+					}).Should(Equal(90 * uint32(telem.Int64T.Density())))
 
 					By("Deleting more data, which should trigger GC")
 					Expect(db.DeleteTimeRange(ctx, []cesium.ChannelKey{basic}, (60 * telem.SecondTS).Range(66*telem.SecondTS))).To(Succeed())
 
 					By("Checking the resulting file size")
 					Eventually(func(g Gomega) uint32 {
-						i := MustSucceed(fs.Stat(path.Join(channelKeyToPath(basic) + "/1.domain")))
+						i, err := fs.Stat(path.Join(channelKeyToPath(basic) + "/1.domain"))
+						g.Expect(err).ToNot(HaveOccurred())
 						return uint32(i.Size())
-					}).Should(Equal(uint32(54 * telem.Int64T.Density())))
+					}).Should(Equal(54 * uint32(telem.Int64T.Density())))
 
 					By("Asserting that the data is still correct", func() {
 						f := MustSucceed(db.Read(ctx, telem.TimeRangeMax, basic))
@@ -227,14 +230,21 @@ var _ = Describe("Garbage collection", Ordered, func() {
 					// File 5 should be garbage collected (5 * 8 > 39).
 
 					Consistently(func(g Gomega) uint32 {
-						i := MustSucceed(fs.Stat(path.Join(channelKeyToPath(basic) + "/2.domain")))
+						i, err := fs.Stat(path.Join(channelKeyToPath(basic) + "/2.domain"))
+						g.Expect(err).ToNot(HaveOccurred())
 						return uint32(i.Size())
-					}).Should(Equal(uint32(10 * telem.Int64T.Density())))
+					}).Should(Equal(10 * uint32(telem.Int64T.Density())))
 
 					Eventually(func(g Gomega) {
-						g.Expect(MustSucceed(fs.Stat(path.Join(channelKeyToPath(basic) + "/3.domain"))).Size()).To(Equal(int64(0)))
-						g.Expect(MustSucceed(fs.Stat(path.Join(channelKeyToPath(basic) + "/4.domain"))).Size()).To(Equal(int64(0)))
-						g.Expect(MustSucceed(fs.Stat(path.Join(channelKeyToPath(basic) + "/5.domain"))).Size()).To(Equal(int64(40)))
+						i, err := fs.Stat(path.Join(channelKeyToPath(basic) + "/3.domain"))
+						g.Expect(err).ToNot(HaveOccurred())
+						g.Expect(i.Size()).To(Equal(int64(0)))
+						i, err = fs.Stat(path.Join(channelKeyToPath(basic) + "/4.domain"))
+						g.Expect(err).ToNot(HaveOccurred())
+						g.Expect(i.Size()).To(Equal(int64(0)))
+						i, err = fs.Stat(path.Join(channelKeyToPath(basic) + "/5.domain"))
+						g.Expect(err).ToNot(HaveOccurred())
+						g.Expect(i.Size()).To(Equal(int64(40)))
 					}).Should(Succeed())
 
 					By("Writing more data – they should go to the newly freed files, i.e. file 3 or file 4")

--- a/core/pkg/distribution/framer/writer/service.go
+++ b/core/pkg/distribution/framer/writer/service.go
@@ -27,7 +27,6 @@ import (
 	"github.com/synnaxlabs/alamos"
 	"github.com/synnaxlabs/synnax/pkg/distribution/channel"
 	"github.com/synnaxlabs/synnax/pkg/distribution/cluster"
-
 	"github.com/synnaxlabs/synnax/pkg/distribution/framer/relay"
 	"github.com/synnaxlabs/synnax/pkg/distribution/proxy"
 	"github.com/synnaxlabs/synnax/pkg/storage/ts"
@@ -338,7 +337,11 @@ func (s *Service) NewStream(ctx context.Context, cfgs ...Config) (StreamWriter, 
 		routeValidatorTo  address.Address
 	)
 
-	v := &validator{keys: cfg.Keys}
+	channelMap := make(map[channel.Key]channel.Channel, len(channels))
+	for _, ch := range channels {
+		channelMap[ch.Key()] = ch
+	}
+	v := &validator{keys: cfg.Keys, channels: channelMap}
 	plumber.SetSegment(pipe, validatorAddr, v)
 	plumber.SetSource(pipe, validatorResponsesAddr, &v.responses)
 	plumber.SetSegment(

--- a/core/pkg/distribution/framer/writer/validator.go
+++ b/core/pkg/distribution/framer/writer/validator.go
@@ -17,6 +17,7 @@ import (
 	"github.com/synnaxlabs/x/confluence"
 	"github.com/synnaxlabs/x/errors"
 	"github.com/synnaxlabs/x/signal"
+	"github.com/synnaxlabs/x/telem"
 	"github.com/synnaxlabs/x/validate"
 )
 
@@ -26,8 +27,9 @@ type validator struct {
 		confluence.NopFlow
 		confluence.AbstractUnarySource[Response]
 	}
-	keys   channel.Keys
-	seqNum int
+	keys     channel.Keys
+	channels map[channel.Key]channel.Channel
+	seqNum   int
 }
 
 // Flow implements the confluence.Flow interface.
@@ -70,7 +72,31 @@ func (v *validator) validate(req Request) error {
 			if !lo.Contains(v.keys, k) {
 				return errors.Wrapf(validate.ErrValidation, "invalid key: %s", k)
 			}
+			s := req.Frame.RawSeriesAt(rawI)
+			if ch, ok := v.channels[k]; ok {
+				if err := s.Validate(); err != nil {
+					return errors.Wrapf(err, "channel %s", ch)
+				}
+				if err := validateSeriesDataType(ch, s); err != nil {
+					return err
+				}
+			}
 		}
+	}
+	return nil
+}
+
+func validateSeriesDataType(ch channel.Channel, s telem.Series) error {
+	sDt := s.DataType
+	cDt := ch.DataType
+	isEquivalent := (sDt == telem.Int64T || sDt == telem.TimeStampT) &&
+		(cDt == telem.Int64T || cDt == telem.TimeStampT)
+	if cDt != sDt && !isEquivalent {
+		return errors.Wrapf(
+			validate.ErrValidation,
+			"channel %s: expected data type %s, got %s",
+			ch, cDt, sDt,
+		)
 	}
 	return nil
 }

--- a/core/pkg/distribution/framer/writer/writer_test.go
+++ b/core/pkg/distribution/framer/writer/writer_test.go
@@ -209,6 +209,177 @@ var _ = Describe("Writer", func() {
 		})
 	})
 
+	Describe("Series Validation", func() {
+		Describe("Misaligned Fixed Density", func() {
+			It("Should return an error when series data is not aligned to density", func(ctx SpecContext) {
+				s := gatewayOnlyScenario(ctx)
+				defer func() { Expect(s.closer.Close()).To(Succeed()) }()
+				w := MustSucceed(s.dist.Framer.OpenWriter(ctx, writer.Config{
+					Keys:  s.keys,
+					Start: 10 * telem.SecondTS,
+					Sync:  new(true),
+				}))
+				Expect(w.Write(frame.NewMulti(
+					s.keys,
+					[]telem.Series{
+						{DataType: telem.Int64T, Data: make([]byte, 7)},
+						telem.NewSeriesV[int64](1),
+						telem.NewSeriesV[int64](1),
+					},
+				))).Error().To(MatchError(validate.ErrValidation))
+				Expect(w.Close()).To(MatchError(validate.ErrValidation))
+			})
+		})
+
+		Describe("Wrong Data Type", func() {
+			It("Should return an error when series data type does not match channel", func(ctx SpecContext) {
+				s := gatewayOnlyScenario(ctx)
+				defer func() { Expect(s.closer.Close()).To(Succeed()) }()
+				w := MustSucceed(s.dist.Framer.OpenWriter(ctx, writer.Config{
+					Keys:  s.keys,
+					Start: 10 * telem.SecondTS,
+					Sync:  new(true),
+				}))
+				Expect(w.Write(frame.NewMulti(
+					s.keys,
+					[]telem.Series{
+						telem.NewSeriesV(1.0),
+						telem.NewSeriesV[int64](1),
+						telem.NewSeriesV[int64](1),
+					},
+				))).Error().To(MatchError(validate.ErrValidation))
+				Expect(w.Close()).To(MatchError(validate.ErrValidation))
+			})
+		})
+
+		Describe("Invalid JSON", Ordered, func() {
+			var s scenario
+			BeforeAll(func(ctx SpecContext) {
+				builder := mock.ProvisionCluster(ctx, 1)
+				dist := builder.Nodes[1]
+				idxCh := channel.Channel{
+					Name:     channel.NewRandomName(),
+					IsIndex:  true,
+					DataType: telem.TimeStampT,
+				}
+				Expect(dist.Channel.Create(ctx, &idxCh)).To(Succeed())
+				jsonCh := channel.Channel{
+					Name:       channel.NewRandomName(),
+					DataType:   telem.JSONT,
+					LocalIndex: idxCh.LocalKey,
+				}
+				Expect(dist.Channel.Create(ctx, &jsonCh)).To(Succeed())
+				s = scenario{
+					dist:   dist,
+					closer: builder,
+					keys:   []channel.Key{idxCh.Key(), jsonCh.Key()},
+				}
+			})
+			AfterAll(func() { Expect(s.closer.Close()).To(Succeed()) })
+			It("Should return an error when JSON series contains invalid JSON", func(ctx SpecContext) {
+				w := MustSucceed(s.dist.Framer.OpenWriter(ctx, writer.Config{
+					Keys:  s.keys,
+					Start: 10 * telem.SecondTS,
+					Sync:  new(true),
+				}))
+				invalidJSON := telem.MarshalVariableSample([]byte(`{not json}`))
+				Expect(w.Write(frame.NewMulti(
+					s.keys,
+					[]telem.Series{
+						telem.NewSeriesSecondsTSV(10),
+						{DataType: telem.JSONT, Data: invalidJSON},
+					},
+				))).Error().To(MatchError(validate.ErrValidation))
+				Expect(w.Close()).To(MatchError(validate.ErrValidation))
+			})
+		})
+
+		Describe("Invalid UTF-8", Ordered, func() {
+			var s scenario
+			BeforeAll(func(ctx SpecContext) {
+				builder := mock.ProvisionCluster(ctx, 1)
+				dist := builder.Nodes[1]
+				idxCh := channel.Channel{
+					Name:     channel.NewRandomName(),
+					IsIndex:  true,
+					DataType: telem.TimeStampT,
+				}
+				Expect(dist.Channel.Create(ctx, &idxCh)).To(Succeed())
+				strCh := channel.Channel{
+					Name:       channel.NewRandomName(),
+					DataType:   telem.StringT,
+					LocalIndex: idxCh.LocalKey,
+				}
+				Expect(dist.Channel.Create(ctx, &strCh)).To(Succeed())
+				s = scenario{
+					dist:   dist,
+					closer: builder,
+					keys:   []channel.Key{idxCh.Key(), strCh.Key()},
+				}
+			})
+			AfterAll(func() { Expect(s.closer.Close()).To(Succeed()) })
+			It("Should return an error when string series contains invalid UTF-8", func(ctx SpecContext) {
+				w := MustSucceed(s.dist.Framer.OpenWriter(ctx, writer.Config{
+					Keys:  s.keys,
+					Start: 10 * telem.SecondTS,
+					Sync:  new(true),
+				}))
+				invalidUTF8 := telem.MarshalVariableSample([]byte{0xFF, 0xFE})
+				Expect(w.Write(frame.NewMulti(
+					s.keys,
+					[]telem.Series{
+						telem.NewSeriesSecondsTSV(10),
+						{DataType: telem.StringT, Data: invalidUTF8},
+					},
+				))).Error().To(MatchError(validate.ErrValidation))
+				Expect(w.Close()).To(MatchError(validate.ErrValidation))
+			})
+		})
+
+		Describe("Malformed Variable Prefix", Ordered, func() {
+			var s scenario
+			BeforeAll(func(ctx SpecContext) {
+				builder := mock.ProvisionCluster(ctx, 1)
+				dist := builder.Nodes[1]
+				idxCh := channel.Channel{
+					Name:     channel.NewRandomName(),
+					IsIndex:  true,
+					DataType: telem.TimeStampT,
+				}
+				Expect(dist.Channel.Create(ctx, &idxCh)).To(Succeed())
+				strCh := channel.Channel{
+					Name:       channel.NewRandomName(),
+					DataType:   telem.StringT,
+					LocalIndex: idxCh.LocalKey,
+				}
+				Expect(dist.Channel.Create(ctx, &strCh)).To(Succeed())
+				s = scenario{
+					dist:   dist,
+					closer: builder,
+					keys:   []channel.Key{idxCh.Key(), strCh.Key()},
+				}
+			})
+			AfterAll(func() { Expect(s.closer.Close()).To(Succeed()) })
+			It("Should return an error when variable-density prefix is malformed", func(ctx SpecContext) {
+				w := MustSucceed(s.dist.Framer.OpenWriter(ctx, writer.Config{
+					Keys:  s.keys,
+					Start: 10 * telem.SecondTS,
+					Sync:  new(true),
+				}))
+				valid := telem.NewSeriesV("ok")
+				valid.Data = append(valid.Data, 0xFF, 0xFF)
+				Expect(w.Write(frame.NewMulti(
+					s.keys,
+					[]telem.Series{
+						telem.NewSeriesSecondsTSV(10),
+						valid,
+					},
+				))).Error().To(MatchError(validate.ErrValidation))
+				Expect(w.Close()).To(MatchError(validate.ErrValidation))
+			})
+		})
+	})
+
 	Describe("Free Write Group Propagation", func() {
 		It("Should propagate the writer's group to the streamer response", func(ctx SpecContext) {
 			s := freeWriterScenario(ctx)
@@ -365,7 +536,7 @@ var _ = Describe("Writer", func() {
 				Start: 10 * telem.SecondTS,
 				Sync:  new(true),
 			}))
-			data := telem.NewSeriesV[int64](1, 2)
+			data := telem.NewSeriesV[float32](1, 2)
 			idx := telem.NewSeriesSecondsTSV(10*telem.SecondTS, 11*telem.SecondTS)
 			MustSucceed(writer.Write(frame.NewMulti(
 				keys,
@@ -381,7 +552,7 @@ var _ = Describe("Writer", func() {
 			Expect(writtenData.Alignment.SampleIndex()).To(BeEquivalentTo(0))
 			Expect(writtenIdx.Alignment.DomainIndex()).To(BeEquivalentTo(cesium.ZeroLeadingAlignment + 1))
 			Expect(writtenIdx.Alignment.SampleIndex()).To(BeEquivalentTo(0))
-			data = telem.NewSeriesV[int64](3, 4)
+			data = telem.NewSeriesV[float32](3, 4)
 			idx = telem.NewSeriesSecondsTSV(12*telem.SecondTS, 13*telem.SecondTS)
 			MustSucceed(writer.Write(frame.NewMulti(
 				keys,

--- a/x/go/telem/density.go
+++ b/x/go/telem/density.go
@@ -10,11 +10,10 @@
 package telem
 
 // Density represents a density in bytes per value.
-type Density uint32
+type Density uint8
 
 // SampleCount returns the number of samples within the number of bytes provided in
-// Size.
-// For example,
+// Size. For example,
 //
 //	Bit64.SampleCount(16) == 2
 func (d Density) SampleCount(size Size) int64 {
@@ -24,9 +23,8 @@ func (d Density) SampleCount(size Size) int64 {
 	return int64(size) / int64(d)
 }
 
-// Size returns the number of bytes occupied by the number of samples provided
-// in sampleCount.
-// For example,
+// Size returns the number of bytes occupied by the number of samples provided in
+// sampleCount. For example,
 //
 //	Bit64.Size(2) == 16
 func (d Density) Size(sampleCount int64) Size {

--- a/x/go/telem/series.go
+++ b/x/go/telem/series.go
@@ -57,7 +57,7 @@ func (s Series) Len() int64 {
 // length-prefix chain exactly consumes the buffer. For JSONT, it additionally verifies
 // that each sample is valid JSON. For StringT, it verifies that each sample is valid
 // UTF-8.
-func (s Series) Validate() error {
+func (s *Series) Validate() error {
 	if len(s.Data) == 0 {
 		return nil
 	}
@@ -78,7 +78,7 @@ func (s Series) Validate() error {
 	return nil
 }
 
-func (s Series) validateVariable() error {
+func (s *Series) validateVariable() error {
 	var (
 		offset int
 		count  int64

--- a/x/go/telem/series.go
+++ b/x/go/telem/series.go
@@ -11,16 +11,20 @@ package telem
 
 import (
 	"encoding/binary"
+	"encoding/json"
 	"fmt"
 	"iter"
 	"slices"
 	"strings"
+	"unicode/utf8"
 
 	"github.com/samber/lo"
 	"github.com/synnaxlabs/x/bounds"
+	"github.com/synnaxlabs/x/errors"
 	xslices "github.com/synnaxlabs/x/slices"
 	"github.com/synnaxlabs/x/stringer"
 	xunsafe "github.com/synnaxlabs/x/unsafe"
+	"github.com/synnaxlabs/x/validate"
 )
 
 // Len returns the number of samples currently in the Series.
@@ -45,6 +49,77 @@ func (s Series) Len() int64 {
 		return *s.cachedLength
 	}
 	return s.DataType.Density().SampleCount(s.Size())
+}
+
+// Validate checks that the series data buffer is structurally valid for its declared
+// DataType. For fixed-density types, it verifies that the buffer length is an exact
+// multiple of the sample size. For variable-density types, it verifies that the
+// length-prefix chain exactly consumes the buffer. For JSONT, it additionally verifies
+// that each sample is valid JSON. For StringT, it verifies that each sample is valid
+// UTF-8.
+func (s Series) Validate() error {
+	if len(s.Data) == 0 {
+		return nil
+	}
+	if s.DataType.IsVariable() {
+		return s.validateVariable()
+	}
+	d := s.DataType.Density()
+	if d == UnknownDensity {
+		return nil
+	}
+	if len(s.Data)%int(d) != 0 {
+		return errors.Wrapf(
+			validate.ErrValidation,
+			"expected data length to be a multiple of %d for data type %s, but got %d",
+			d, s.DataType, len(s.Data),
+		)
+	}
+	return nil
+}
+
+func (s Series) validateVariable() error {
+	var (
+		offset int
+		count  int64
+	)
+	for offset+variableLengthPrefixSize <= len(s.Data) {
+		length := int(binary.LittleEndian.Uint32(s.Data[offset:]))
+		offset += variableLengthPrefixSize
+		if offset+length > len(s.Data) {
+			return errors.Wrapf(
+				validate.ErrValidation,
+				"variable-density length prefix at byte %d claims %d bytes, but only %d remain",
+				offset-variableLengthPrefixSize, length, len(s.Data)-offset,
+			)
+		}
+		sample := s.Data[offset : offset+length]
+		if s.DataType == JSONT && !json.Valid(sample) {
+			return errors.Wrapf(
+				validate.ErrValidation,
+				"sample at byte offset %d is not valid JSON",
+				offset,
+			)
+		}
+		if s.DataType == StringT && !utf8.Valid(sample) {
+			return errors.Wrapf(
+				validate.ErrValidation,
+				"sample at byte offset %d is not valid UTF-8",
+				offset,
+			)
+		}
+		offset += length
+		count++
+	}
+	if offset != len(s.Data) {
+		return errors.Wrapf(
+			validate.ErrValidation,
+			"variable-density buffer has %d trailing bytes after last complete sample",
+			len(s.Data)-offset,
+		)
+	}
+	s.cachedLength = &count
+	return nil
 }
 
 // Size returns the number of bytes in the Series.

--- a/x/go/telem/series.go
+++ b/x/go/telem/series.go
@@ -97,15 +97,15 @@ func (s Series) validateVariable() error {
 		if s.DataType == JSONT && !json.Valid(sample) {
 			return errors.Wrapf(
 				validate.ErrValidation,
-				"sample at byte offset %d is not valid JSON",
-				offset,
+				"sample %q is not valid JSON",
+				sample,
 			)
 		}
 		if s.DataType == StringT && !utf8.Valid(sample) {
 			return errors.Wrapf(
 				validate.ErrValidation,
-				"sample at byte offset %d is not valid UTF-8",
-				offset,
+				"sample %q is not valid UTF-8",
+				sample,
 			)
 		}
 		offset += length

--- a/x/go/telem/series_bench_test.go
+++ b/x/go/telem/series_bench_test.go
@@ -10,6 +10,8 @@
 package telem_test
 
 import (
+	"encoding/json"
+	"fmt"
 	"testing"
 
 	"github.com/synnaxlabs/x/telem"
@@ -53,4 +55,61 @@ func BenchmarkSetValueAtLargeSlice(b *testing.B) {
 	for i := 0; b.Loop(); i++ {
 		telem.SetValueAt(series, i%10000, float64(i))
 	}
+}
+
+func BenchmarkValidate(b *testing.B) {
+	b.Run("FixedDensity", func(b *testing.B) {
+		for _, size := range []int{10, 100, 1000, 10000} {
+			b.Run(fmt.Sprintf("Float64/%d", size), func(b *testing.B) {
+				data := make([]float64, size)
+				for i := range data {
+					data[i] = float64(i)
+				}
+				s := telem.NewSeriesV(data...)
+				for b.Loop() {
+					if err := s.Validate(); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	})
+
+	b.Run("String", func(b *testing.B) {
+		for _, size := range []int{10, 100, 1000} {
+			b.Run(fmt.Sprintf("%d", size), func(b *testing.B) {
+				data := make([]string, size)
+				for i := range data {
+					data[i] = fmt.Sprintf("sample-%d", i)
+				}
+				s := telem.NewSeriesV(data...)
+				for b.Loop() {
+					if err := s.Validate(); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	})
+
+	b.Run("JSON", func(b *testing.B) {
+		for _, size := range []int{10, 100, 1000} {
+			b.Run(fmt.Sprintf("%d", size), func(b *testing.B) {
+				data := make([][]byte, size)
+				for i := range data {
+					data[i], _ = json.Marshal(map[string]any{
+						"key": fmt.Sprintf("value-%d", i),
+						"num": i,
+					})
+				}
+				s := telem.NewSeriesV(data...)
+				s.DataType = telem.JSONT
+				for b.Loop() {
+					if err := s.Validate(); err != nil {
+						b.Fatal(err)
+					}
+				}
+			})
+		}
+	})
 }

--- a/x/go/telem/series_test.go
+++ b/x/go/telem/series_test.go
@@ -10,12 +10,15 @@
 package telem_test
 
 import (
+	"encoding/binary"
+
 	"github.com/google/uuid"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/synnaxlabs/x/telem"
 	. "github.com/synnaxlabs/x/testutil"
 	xunsafe "github.com/synnaxlabs/x/unsafe"
+	"github.com/synnaxlabs/x/validate"
 )
 
 func valueAtTest[T telem.FixedSample](value T, dt telem.DataType) func() {
@@ -27,6 +30,130 @@ func valueAtTest[T telem.FixedSample](value T, dt telem.DataType) func() {
 }
 
 var _ = Describe("Series", func() {
+	Describe("Validate", func() {
+		Context("Fixed Density", func() {
+			DescribeTable("valid data",
+				func(s telem.Series) {
+					Expect(s.Validate()).To(Succeed())
+				},
+				Entry("int64", telem.NewSeriesV[int64](1, 2, 3)),
+				Entry("int32", telem.NewSeriesV[int32](1, 2, 3)),
+				Entry("int16", telem.NewSeriesV[int16](1, 2, 3)),
+				Entry("int8", telem.NewSeriesV[int8](1, 2, 3)),
+				Entry("uint64", telem.NewSeriesV[uint64](1, 2, 3)),
+				Entry("uint32", telem.NewSeriesV[uint32](1, 2, 3)),
+				Entry("uint16", telem.NewSeriesV[uint16](1, 2, 3)),
+				Entry("uint8", telem.NewSeriesV[uint8](1, 2, 3)),
+				Entry("float64", telem.NewSeriesV(1.0, 2.0, 3.0)),
+				Entry("float32", telem.NewSeriesV[float32](1.0, 2.0)),
+				Entry("timestamp", telem.NewSeriesSecondsTSV(1, 2, 3)),
+				Entry("uuid", telem.NewSeriesV(uuid.New())),
+				Entry("empty", telem.Series{DataType: telem.Int64T}),
+			)
+
+			DescribeTable("misaligned data",
+				func(dt telem.DataType, dataLen int) {
+					s := telem.Series{DataType: dt, Data: make([]byte, dataLen)}
+					Expect(s.Validate()).Error().To(MatchError(validate.ErrValidation))
+				},
+				Entry("uint32 with 7 bytes", telem.Uint32T, 7),
+				Entry("uint32 with 1 byte", telem.Uint32T, 1),
+				Entry("float64 with 13 bytes", telem.Float64T, 13),
+				Entry("int64 with 5 bytes", telem.Int64T, 5),
+				Entry("int16 with 3 bytes", telem.Int16T, 3),
+				Entry("uuid with 17 bytes", telem.UUIDT, 17),
+				Entry("timestamp with 9 bytes", telem.TimeStampT, 9),
+			)
+		})
+
+		Context("Variable Density", func() {
+			It("Should accept valid string series", func() {
+				s := telem.NewSeriesV("hello", "world")
+				Expect(s.Validate()).To(Succeed())
+			})
+
+			It("Should accept valid bytes series", func() {
+				s := telem.NewSeriesV([]byte{1, 2, 3}, []byte{4, 5})
+				Expect(s.Validate()).To(Succeed())
+			})
+
+			It("Should accept valid JSON series", func() {
+				s := MustSucceed(telem.NewJSONSeriesV(
+					map[string]any{"key": "value"},
+					map[string]any{"arr": []int{1, 2, 3}},
+				))
+				Expect(s.Validate()).To(Succeed())
+			})
+
+			It("Should accept an empty variable series", func() {
+				s := telem.Series{DataType: telem.StringT}
+				Expect(s.Validate()).To(Succeed())
+			})
+
+			It("Should reject a prefix pointing past the buffer end", func() {
+				data := make([]byte, 8)
+				binary.LittleEndian.PutUint32(data[0:], 100)
+				s := telem.Series{DataType: telem.StringT, Data: data}
+				Expect(s.Validate()).Error().To(MatchError(validate.ErrValidation))
+			})
+
+			It("Should reject trailing bytes after valid samples", func() {
+				valid := telem.NewSeriesV("ok")
+				valid.Data = append(valid.Data, 0xFF, 0xFF)
+				Expect(valid.Validate()).Error().To(MatchError(validate.ErrValidation))
+			})
+
+			It("Should reject trailing bytes that are less than a prefix", func() {
+				valid := telem.NewSeriesV("ok")
+				valid.Data = append(valid.Data, 0xFF)
+				Expect(valid.Validate()).Error().To(MatchError(validate.ErrValidation))
+			})
+		})
+
+		Context("JSON Validity", func() {
+			It("Should reject invalid JSON", func() {
+				data := telem.MarshalVariableSample([]byte(`{not json}`))
+				s := telem.Series{DataType: telem.JSONT, Data: data}
+				Expect(s.Validate()).Error().To(MatchError(validate.ErrValidation))
+			})
+
+			It("Should accept valid JSON primitives", func() {
+				data := telem.MarshalVariableSample([]byte(`42`))
+				data = append(data, telem.MarshalVariableSample([]byte(`"hello"`))...)
+				data = append(data, telem.MarshalVariableSample([]byte(`true`))...)
+				data = append(data, telem.MarshalVariableSample([]byte(`null`))...)
+				s := telem.Series{DataType: telem.JSONT, Data: data}
+				Expect(s.Validate()).To(Succeed())
+			})
+		})
+
+		Context("UTF-8 Validity", func() {
+			It("Should reject invalid UTF-8 in string series", func() {
+				invalidUTF8 := []byte{0xFF, 0xFE}
+				data := telem.MarshalVariableSample(invalidUTF8)
+				s := telem.Series{DataType: telem.StringT, Data: data}
+				Expect(s.Validate()).Error().To(MatchError(validate.ErrValidation))
+			})
+
+			It("Should accept valid UTF-8 including multi-byte characters", func() {
+				s := telem.NewSeriesV("hello", "日本語", "émoji 🎉")
+				Expect(s.Validate()).To(Succeed())
+			})
+
+			It("Should not check UTF-8 for bytes series", func() {
+				s := telem.NewSeriesV([]byte{0xFF, 0xFE})
+				Expect(s.Validate()).To(Succeed())
+			})
+		})
+
+		Context("Unknown DataType", func() {
+			It("Should skip validation for unknown data types", func() {
+				s := telem.Series{DataType: telem.UnknownT, Data: []byte{1, 2, 3}}
+				Expect(s.Validate()).To(Succeed())
+			})
+		})
+	})
+
 	Describe("Len", func() {
 		It("Should correctly return the number of samples in a series with a fixed length data type", func() {
 			s := telem.NewSeriesV[int64](1, 2, 3)


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue number and link -->

[SY-4085](https://linear.app/synnax/issue/SY-4085/add-data-validation-before-writing)

## Description

<!-- Write a description describing the changes. -->

Add data validation before writing series. This ensures that series have the following properties before they are written to Cesium / propagated to streamers:

- Fixed-density series are of the right length (e.g., the length of a `uint32` series needs to be a multiple of 4)
- Variable-density series do not have issues due to either missing bytes or extra bytes
- All string samples are valid UTF-8
- All JSON samples are valid JSON

Benchmarks are below, allocations are from setting the cached length:

goos: darwin
goarch: arm64
pkg: github.com/synnaxlabs/x/telem
cpu: Apple M3 Max
| Benchmark | Samples | ns/op | B/op | allocs/op |                                                                   
  |-----------|---------|-------|------|-----------|                                                                   
  | FixedDensity/Float64 | 10 | 4.496 | 0 | 0 |                                                                        
  | FixedDensity/Float64 | 100 | 4.344 | 0 | 0 |                                                                       
  | FixedDensity/Float64 | 1,000 | 4.032 | 0 | 0 |                                                                     
  | FixedDensity/Float64 | 10,000 | 4.646 | 0 | 0 |                                                                    
  | String | 10 | 118.2 | 8 | 1 |                                                                                      
  | String | 100 | 1,003 | 8 | 1 |                                                                                     
  | String | 1,000 | 6,740 | 8 | 1 |                                                                                   
  | JSON | 10 | 1,119 | 8 | 1 |
  | JSON | 100 | 11,078 | 8 | 1 |                                                                                      
  | JSON | 1,000 | 97,052 | 8 | 1 |                        

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds pre-write data validation to the distribution writer pipeline, guarding against malformed series before they reach Cesium or streamers. The validation covers fixed-density alignment, variable-density length-prefix chain integrity, UTF-8 correctness for `StringT`, and JSON validity for `JSONT`, with good unit and integration test coverage.

The previously flagged `cachedLength` pointer-receiver issue has been resolved — `validateVariable` now correctly uses a `*Series` receiver so the cached sample count persists on the caller's struct and benefits subsequent `Len()` calls.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no blocking issues found; all prior concerns addressed.

All remaining findings are informational. The pointer-receiver caching fix is correct, validation logic correctly handles all edge cases (oversized length prefixes, sub-prefix trailing bytes, empty samples), and error propagation follows the established pipeline pattern. Test coverage at both unit and integration levels is thorough.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| x/go/telem/series.go | Adds Validate() (pointer receiver) and validateVariable() (pointer receiver) to Series; correctly handles fixed-density alignment, variable-density prefix-chain integrity, JSON validity, and UTF-8 validity; pointer receiver ensures cachedLength caching actually persists. |
| core/pkg/distribution/framer/writer/validator.go | Integrates series-level Validate() and validateSeriesDataType checks into the write pipeline; validation failure terminates the writer goroutine consistently with existing command-validation behavior. |
| x/go/telem/series_test.go | Good coverage: fixed-density misalignment, variable-density prefix errors, trailing bytes (both sub-prefix and larger), invalid JSON, invalid UTF-8, and unknown data type bypass. |
| x/go/telem/series_bench_test.go | Adds BenchmarkValidate covering fixed-density, string, and JSON paths; uses modern b.Loop() API; 1 alloc/op for variable types is expected due to heap-escaping count variable. |
| core/pkg/distribution/framer/writer/writer_test.go | New integration tests cover misaligned fixed-density, wrong data type, and invalid JSON end-to-end through the full writer pipeline. |
| core/pkg/distribution/framer/writer/service.go | Unchanged logic; channels map passed to validator is guaranteed to contain all configured keys via validateChannelKeys, so the if ch, ok := v.channels[k] guard in validator is always true for valid keys. |
| x/go/telem/density.go | No functional changes; UnknownDensity constant used correctly in Validate() to skip validation for unknown types. |
| cesium/gc_test.go | Test fix only; no logic changes to reviewed validation code. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Validator
    participant Switch as PeerGatewaySwitch
    participant Writer as GatewayWriter/Peer/Free
    participant Sync as Synchronizer

    Client->>Validator: Request (Frame)
    Validator->>Validator: validateCommand(req.Command)
    Validator->>Validator: for each series: s.Validate() [fixed/variable/UTF-8/JSON]
    Validator->>Validator: validateSeriesDataType(ch, s)
    alt Validation fails
        Validator-->>Client: goroutine terminates with ErrValidation
    else Validation passes
        Validator->>Switch: Forward Request
        Switch->>Writer: Route by channel leaseholder
        Writer->>Sync: Response
        Sync-->>Client: Acknowledge
    end
```

<sub>Reviews (2): Last reviewed commit: ["Fix Cesium tests"](https://github.com/synnaxlabs/synnax/commit/243c177d1021d689dfb8bb5ca0f6644362be7a63) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28921746)</sub>

<!-- /greptile_comment -->