### PR TITLE
SY-4097: Inject Synnax Version Into C++ Client Compatibility Checker

### DIFF
--- a/client/cpp/BUILD.bazel
+++ b/client/cpp/BUILD.bazel
@@ -4,6 +4,7 @@ cc_library(
     name = "synnax",
     srcs = [
         "transport.cpp",
+        "//core/pkg/version",
     ],
     hdrs = [
         "synnax.h",

--- a/client/cpp/synnax.h
+++ b/client/cpp/synnax.h
@@ -23,6 +23,7 @@
 #include "client/cpp/status/status.h"
 #include "client/cpp/transport.h"
 #include "client/cpp/view/view.h"
+#include "core/pkg/version/version.h"
 #include "x/cpp/json/json.h"
 #include "x/cpp/log/log.h"
 #include "x/cpp/path/path.h"
@@ -179,7 +180,7 @@ public:
             std::make_shared<connection::Checker>(
                 std::move(this->t.connectivity_check),
                 30 * x::telem::SECOND,
-                "",
+                SYNNAX_VERSION,
                 cfg.host,
                 cfg.clock_skew_threshold
             )

--- a/client/cpp/synnax.h
+++ b/client/cpp/synnax.h
@@ -23,10 +23,11 @@
 #include "client/cpp/status/status.h"
 #include "client/cpp/transport.h"
 #include "client/cpp/view/view.h"
-#include "core/pkg/version/version.h"
 #include "x/cpp/json/json.h"
 #include "x/cpp/log/log.h"
 #include "x/cpp/path/path.h"
+
+#include "core/pkg/version/version.h"
 
 namespace synnax {
 ///// @brief Internal namespace. Do not use.

--- a/core/pkg/version/BUILD.bazel
+++ b/core/pkg/version/BUILD.bazel
@@ -5,7 +5,8 @@ genrule(
     srcs = ["VERSION"],
     outs = ["version.h"],
     cmd = """
-        echo '#define SYNNAX_DRIVER_VERSION \"'$$(cat $(location VERSION))'\"' > $@ &&
+        echo '#define SYNNAX_VERSION \"'$$(cat $(location VERSION))'\"' > $@ &&
+        echo '#define SYNNAX_DRIVER_VERSION SYNNAX_VERSION' >> $@ &&
         echo '#define SYNNAX_BUILD_TIMESTAMP \"'$$(date "+%Y-%m-%d %H:%M:%S")'\"' >> $@
     """,
     stamp = 1,

--- a/core/pkg/version/BUILD.bazel
+++ b/core/pkg/version/BUILD.bazel
@@ -5,7 +5,8 @@ genrule(
     srcs = ["VERSION"],
     outs = ["version.h"],
     cmd = """
-        echo '#define SYNNAX_VERSION \"'$$(cat $(location VERSION))'\"' > $@ &&
+        echo '#pragma once' > $@ &&
+        echo '#define SYNNAX_VERSION \"'$$(cat $(location VERSION))'\"' >> $@ &&
         echo '#define SYNNAX_DRIVER_VERSION SYNNAX_VERSION' >> $@ &&
         echo '#define SYNNAX_BUILD_TIMESTAMP \"'$$(date "+%Y-%m-%d %H:%M:%S")'\"' >> $@
     """,


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4097](https://linear.app/synnax/issue/SY-4097)

## Description

The C++ client's `connection::Checker` was being constructed with an empty
`client_version`, so the version compatibility check against the Core silently
compared `""` to the node version and always reported a mismatch.

This PR extends the existing `//core/pkg/version` genrule to emit a
`SYNNAX_VERSION` macro in `version.h` (with `SYNNAX_DRIVER_VERSION` kept as an
alias so the driver build is unaffected), pulls the generated header into the
`//client/cpp:synnax` target, and passes `SYNNAX_VERSION` to the `Checker`
constructor in place of the empty string.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a latent bug where `connection::Checker` was receiving an empty `client_version`, causing every version-compatibility check to silently report a mismatch. The fix extends the `//core/pkg/version` genrule to emit a `SYNNAX_VERSION` macro (keeping `SYNNAX_DRIVER_VERSION` as an alias), wires that header into `client/cpp:synnax`, and passes the macro to the `Checker` constructor.

- The generated `version.h` has no `#pragma once` or `#ifndef` guard. After this PR, `driver/cmd/cmd.h` will include it twice in every driver compilation unit — once transitively through `synnax.h` (line 27) and once directly (line 31) — potentially triggering `-Wmacro-redefined` warnings or a build error under `-Werror`.

<h3>Confidence Score: 4/5</h3>

Safe once the include-guard issue in the genrule is resolved; the core fix is correct.

One P1 finding: the missing `#pragma once` in the generated `version.h` causes double macro definition in driver translation units now that `synnax.h` also includes it, which risks build failures under `-Werror`. The rest of the change is straightforward and correct.

`core/pkg/version/BUILD.bazel` — the genrule `cmd` needs a `#pragma once` prepended to the generated output.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| core/pkg/version/BUILD.bazel | Adds `SYNNAX_VERSION` as the primary macro and demotes `SYNNAX_DRIVER_VERSION` to an alias; the generated header lacks include guards, causing double-definition in driver compilation units now that `synnax.h` also includes it. |
| client/cpp/BUILD.bazel | Adds `//core/pkg/version` to `srcs`, following the same pattern already used by `driver/cmd/BUILD.bazel`; no issues. |
| client/cpp/synnax.h | Includes `version.h` and passes `SYNNAX_VERSION` to the `Checker` constructor, correctly fixing the silent empty-string version mismatch. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    VF["VERSION file\n(0.55.0)"] --> GR["genrule :version\ncore/pkg/version/BUILD.bazel"]
    GR --> VH["version.h\n#define SYNNAX_VERSION ...\n#define SYNNAX_DRIVER_VERSION SYNNAX_VERSION\n#define SYNNAX_BUILD_TIMESTAMP ..."]
    VH -->|"#include (new)"| SH["client/cpp/synnax.h"]
    VH -->|"#include (existing)"| CMD["driver/cmd/cmd.h"]
    SH -->|"#include (existing)"| CMD
    SH --> SC["Synnax::Synnax()\nChecker(... SYNNAX_VERSION ...)"]
    CMD --> DV["driver/cmd/version.cpp\nSYNNAX_DRIVER_VERSION"]
    SC --> CHK["connection::Checker\nclient_version = '0.55.0'"]
    style VH fill:#ffd,stroke:#aa0
    style CMD fill:#fdd,stroke:#a00
```

<sub>Reviews (1): Last reviewed commit: ["Wire Synnax version into C++ client comp..."](https://github.com/synnaxlabs/synnax/commit/4b1afe9ed94037f902b5fe5a0efc3970e9537cd4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29020066)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->