### PR TITLE
SY-3942: Range Annotation Visibility Toggle

### DIFF
--- a/console/src/components/Controls.css
+++ b/console/src/components/Controls.css
@@ -15,7 +15,11 @@
     right: 2rem;
     z-index: 20;
     opacity: 0;
-    transition: opacity 0.1s ease-in-out;
+}
+
+.console-controls--annotations-visible {
+    top: 0rem;
+    right: 2rem;
 }
 
 .pluto-tabs-content:hover .console-controls {

--- a/console/src/components/Controls.css
+++ b/console/src/components/Controls.css
@@ -15,6 +15,7 @@
     right: 2rem;
     z-index: 20;
     opacity: 0;
+    transition: opacity 0.1s ease-in-out;
 }
 
 .console-controls--annotations-visible {

--- a/console/src/components/Controls.css
+++ b/console/src/components/Controls.css
@@ -19,7 +19,6 @@
 
 .console-controls--annotations-visible {
     top: 0rem;
-    right: 2rem;
 }
 
 .pluto-tabs-content:hover .console-controls {

--- a/console/src/lineplot/Controls.tsx
+++ b/console/src/lineplot/Controls.tsx
@@ -18,6 +18,7 @@ import { Controls as Base } from "@/components";
 import { CSS } from "@/css";
 import { Layout } from "@/layout";
 import {
+  useSelect,
   useSelectControlState,
   useSelectMeasureMode,
   useSelectViewportMode,
@@ -26,16 +27,22 @@ import {
   type ClickMode,
   setControlState,
   setMeasureMode,
+  setRangeAnnotationsVisible,
   setViewport,
   setViewportMode,
 } from "@/lineplot/slice";
 
 export interface ControlsProps {
   layoutKey: string;
+  hasAnnotations: boolean;
 }
 
-export const Controls = ({ layoutKey }: ControlsProps): ReactElement => {
+export const Controls = ({
+  layoutKey,
+  hasAnnotations,
+}: ControlsProps): ReactElement => {
   const control = useSelectControlState(layoutKey);
+  const plot = useSelect(layoutKey);
   const { layoutKey: vis } = Layout.useSelectActiveMosaicTabState();
   const mode = useSelectViewportMode(layoutKey);
   const measureMode = useSelectMeasureMode(layoutKey);
@@ -61,10 +68,18 @@ export const Controls = ({ layoutKey }: ControlsProps): ReactElement => {
     dispatch(setControlState({ key: layoutKey, state: { hold } }));
   };
 
+  const handleAnnotationsVisibilityChange = (visible: boolean): void => {
+    dispatch(setRangeAnnotationsVisible({ key: layoutKey, visible }));
+  };
+
   const triggers = useMemo(() => Viewport.DEFAULT_TRIGGERS[mode], [mode]);
 
   return (
-    <Base>
+    <Base
+      className={CSS(
+        plot.annotations.visible && CSS.BM("controls", "annotations-visible"),
+      )}
+    >
       <Flex.Box x gap="small">
         <Viewport.SelectMode
           value={mode}
@@ -94,6 +109,17 @@ export const Controls = ({ layoutKey }: ControlsProps): ReactElement => {
         >
           <Icon.Tooltip />
         </Button.Toggle>
+        {hasAnnotations && (
+          <Button.Toggle
+            value={plot.annotations.visible}
+            onChange={handleAnnotationsVisibilityChange}
+            size="small"
+            tooltip={`${plot.annotations.visible ? "Hide" : "Show"} range annotations`}
+            tooltipLocation={location.BOTTOM_LEFT}
+          >
+            <Icon.Range />
+          </Button.Toggle>
+        )}
         <Button.Toggle
           value={control.clickMode != null}
           tooltip={`${control.clickMode != null ? "Close" : "Open"} measure tool`}

--- a/console/src/lineplot/Controls.tsx
+++ b/console/src/lineplot/Controls.tsx
@@ -77,7 +77,9 @@ export const Controls = ({
   return (
     <Base
       className={CSS(
-        plot.annotations.visible && CSS.BM("controls", "annotations-visible"),
+        plot.annotations.visible &&
+          hasAnnotations &&
+          CSS.BM("controls", "annotations-visible"),
       )}
     >
       <Flex.Box x gap="small">

--- a/console/src/lineplot/LinePlot.tsx
+++ b/console/src/lineplot/LinePlot.tsx
@@ -444,7 +444,10 @@ const Loaded: Layout.Renderer = ({ layoutKey, focused, visible }) => {
     );
   };
 
+  const [hasAnnotations, setHasAnnotations] = useState(false);
   const rangeProviderProps: Channel.LinePlotProps["rangeProviderProps"] = {
+    visible: vis.annotations.visible,
+    onHasAnnotationsChange: setHasAnnotations,
     menu: (props) => <RangeAnnotationContextMenu lines={propsLines} range={props} />,
   };
 
@@ -495,10 +498,12 @@ const Loaded: Layout.Renderer = ({ layoutKey, focused, visible }) => {
             hasUpdatePermission ? handleMeasureModeChange : undefined
           }
         >
-          {!focused && <Controls layoutKey={layoutKey} />}
+          {!focused && (
+            <Controls layoutKey={layoutKey} hasAnnotations={hasAnnotations} />
+          )}
         </Channel.LinePlot>
       </Menu.ContextMenu>
-      {focused && <Controls layoutKey={layoutKey} />}
+      {focused && <Controls layoutKey={layoutKey} hasAnnotations={hasAnnotations} />}
     </div>
   );
 };

--- a/console/src/lineplot/slice.spec.ts
+++ b/console/src/lineplot/slice.spec.ts
@@ -1,0 +1,62 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { configureStore } from "@reduxjs/toolkit";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  actions,
+  reducer,
+  SLICE_NAME,
+  type StoreState,
+  ZERO_SLICE_STATE,
+  ZERO_STATE,
+} from "@/lineplot/slice";
+
+describe("Lineplot Slice", () => {
+  let store: ReturnType<typeof configureStore<StoreState>>;
+  const plotKey = "plot-1";
+
+  beforeEach(() => {
+    store = configureStore({
+      reducer: { [SLICE_NAME]: reducer },
+      preloadedState: { [SLICE_NAME]: ZERO_SLICE_STATE },
+    });
+    store.dispatch(actions.create({ ...ZERO_STATE, key: plotKey }));
+  });
+
+  describe("setRangeAnnotationsVisible", () => {
+    it("should default to visible on a newly created plot", () => {
+      expect(store.getState()[SLICE_NAME].plots[plotKey].annotations.visible).toBe(
+        true,
+      );
+    });
+
+    it("should hide range annotations", () => {
+      store.dispatch(
+        actions.setRangeAnnotationsVisible({ key: plotKey, visible: false }),
+      );
+      expect(store.getState()[SLICE_NAME].plots[plotKey].annotations.visible).toBe(
+        false,
+      );
+    });
+
+    it("should show range annotations after being hidden", () => {
+      store.dispatch(
+        actions.setRangeAnnotationsVisible({ key: plotKey, visible: false }),
+      );
+      store.dispatch(
+        actions.setRangeAnnotationsVisible({ key: plotKey, visible: true }),
+      );
+      expect(store.getState()[SLICE_NAME].plots[plotKey].annotations.visible).toBe(
+        true,
+      );
+    });
+  });
+});

--- a/console/src/lineplot/slice.ts
+++ b/console/src/lineplot/slice.ts
@@ -40,6 +40,7 @@ export type RuleState = latest.RuleState;
 export type RulesState = latest.RulesState;
 export type ChannelsState = latest.ChannelsState;
 export type RangesState = latest.RangesState;
+export type AnnotationsState = latest.AnnotationsState;
 export type State = latest.State;
 export type ToolbarTab = latest.ToolbarTab;
 export type ToolbarState = latest.ToolbarState;
@@ -170,6 +171,11 @@ export interface SetRemoteCreatedPayload {
 export interface SetMeasureModePayload {
   key: string;
   mode: measure.Mode;
+}
+
+export interface SetRangeAnnotationsVisiblePayload {
+  key: string;
+  visible: boolean;
 }
 
 export const typedLineKeyToString = (key: TypedLineKey): string =>
@@ -369,6 +375,12 @@ export const { actions, reducer } = createSlice({
     setMeasureMode: (state, { payload }: PayloadAction<SetMeasureModePayload>) => {
       state.plots[payload.key].measure.mode = payload.mode;
     },
+    setRangeAnnotationsVisible: (
+      state,
+      { payload }: PayloadAction<SetRangeAnnotationsVisiblePayload>,
+    ) => {
+      state.plots[payload.key].annotations.visible = payload.visible;
+    },
   },
 });
 
@@ -392,6 +404,7 @@ export const {
   setRemoteCreated,
   setSelection,
   setMeasureMode,
+  setRangeAnnotationsVisible,
   create: internalCreate,
 } = actions;
 

--- a/console/src/lineplot/types/index.ts
+++ b/console/src/lineplot/types/index.ts
@@ -62,6 +62,10 @@ export const rangesStateZ = v0.rangesStateZ;
 export type RangesState = v0.RangesState;
 export const ZERO_RANGES_STATE = v0.ZERO_RANGES_STATE;
 
+export const annotationsStateZ = v4.annotationsStateZ;
+export type AnnotationsState = v4.AnnotationsState;
+export const ZERO_ANNOTATIONS_STATE = v4.ZERO_ANNOTATIONS_STATE;
+
 export const stateZ = v4.stateZ;
 export type State = v4.State;
 export const ZERO_STATE = v4.ZERO_STATE;

--- a/console/src/lineplot/types/migrations.spec.ts
+++ b/console/src/lineplot/types/migrations.spec.ts
@@ -10,8 +10,11 @@
 import { describe, expect, it } from "vitest";
 
 import {
+  anyStateZ,
   migrateSlice,
   migrateState,
+  stateZ,
+  ZERO_ANNOTATIONS_STATE,
   ZERO_SLICE_STATE,
   ZERO_STATE,
 } from "@/lineplot/types";
@@ -40,6 +43,16 @@ describe("migrations", () => {
       it(`should migrate slice from ${state.version} to latest`, () => {
         expect(migrateSlice(state)).toEqual(ZERO_SLICE_STATE);
       });
+    });
+  });
+  describe("v4 annotations backward compatibility", () => {
+    it("should fill annotations with default when absent from a persisted v4 state", () => {
+      const { annotations: _omit, ...persisted } = ZERO_STATE;
+      expect(stateZ.parse(persisted).annotations).toEqual(ZERO_ANNOTATIONS_STATE);
+    });
+    it("should load a persisted v4 state without annotations via anyStateZ", () => {
+      const { annotations: _omit, ...persisted } = ZERO_STATE;
+      expect(anyStateZ.parse(persisted)).toEqual(ZERO_STATE);
     });
   });
 });

--- a/console/src/lineplot/types/v4.ts
+++ b/console/src/lineplot/types/v4.ts
@@ -26,15 +26,23 @@ export const ZERO_MEASURE_STATE: MeasureState = {
   mode: "one",
 };
 
+export const annotationsStateZ = z.object({
+  visible: z.boolean().default(true),
+});
+export interface AnnotationsState extends z.infer<typeof annotationsStateZ> {}
+export const ZERO_ANNOTATIONS_STATE: AnnotationsState = { visible: true };
+
 export const stateZ = v3.stateZ.omit({ version: true }).extend({
   version: z.literal(VERSION),
   measure: measureStateZ,
+  annotations: annotationsStateZ.default(ZERO_ANNOTATIONS_STATE),
 });
 export interface State extends z.infer<typeof stateZ> {}
 export const ZERO_STATE: State = {
   ...v3.ZERO_STATE,
   version: VERSION,
   measure: ZERO_MEASURE_STATE,
+  annotations: ZERO_ANNOTATIONS_STATE,
 };
 
 export const sliceStateZ = v3.sliceStateZ
@@ -52,6 +60,7 @@ export const stateMigration = migrate.createMigration<v3.State, State>({
     ...state,
     version: VERSION,
     measure: ZERO_MEASURE_STATE,
+    annotations: ZERO_ANNOTATIONS_STATE,
   }),
 });
 

--- a/integration/console/plot.py
+++ b/integration/console/plot.py
@@ -7,9 +7,10 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
+import re
 from typing import Any, Literal
 
-from playwright.sync_api import Locator
+from playwright.sync_api import Locator, expect
 
 import synnax as sy
 from console.channels import ChannelClient
@@ -377,6 +378,40 @@ class Plot(ConsolePage):
         )
         self.page.get_by_role("textbox", name="Name").fill(range_name)
         self.page.get_by_role("button", name="Save to Synnax").click()
+
+    def get_annotation_toggle(self) -> Locator:
+        """Return the range-annotation visibility toggle button.
+
+        The button only exists in the DOM when at least one range intersects
+        the current plot viewport.
+        """
+        if not self.pane_locator:
+            raise RuntimeError("Plot pane locator not available")
+        return self.pane_locator.locator(
+            ".console-controls button:has(.pluto-icon--range)"
+        )
+
+    def wait_for_annotation_toggle(self, timeout: int = 5000) -> None:
+        """Wait for the annotation visibility toggle to appear."""
+        self.get_annotation_toggle().wait_for(state="visible", timeout=timeout)
+
+    def toggle_annotation_visibility(self) -> None:
+        """Click the annotation visibility toggle."""
+        self.get_annotation_toggle().click(timeout=5000)
+
+    def expect_annotations_visible(
+        self, visible: bool = True, timeout: int = 5000
+    ) -> None:
+        """Assert the annotation visibility toggle reflects the given state.
+
+        Pluto's Button.Toggle renders the "filled" variant when on.
+        """
+        pattern = re.compile(r"pluto-btn--filled")
+        toggle = expect(self.get_annotation_toggle())
+        if visible:
+            toggle.to_have_class(pattern, timeout=timeout)
+        else:
+            toggle.not_to_have_class(pattern, timeout=timeout)
 
     def has_channel(self, axis: Axis, channel_name: str) -> bool:
         """Check if a channel is shown on the specified axis in the toolbar."""

--- a/integration/tests/console/plot/line_plot.py
+++ b/integration/tests/console/plot/line_plot.py
@@ -66,6 +66,7 @@ class LinePlot(ConsoleCase):
         self.test_drag_channel_to_toolbar(plot)
         self.test_download_csv(plot, data_name)
         self.test_create_range_from_selection(plot, suffix)
+        self.test_toggle_range_annotation_visibility(plot)
         self.test_export_json(plot, data_name)
 
         plot_link = self.test_copy_link(plot)
@@ -204,6 +205,21 @@ class LinePlot(ConsoleCase):
         assert created_range.name == range_name, (
             f"Range name mismatch: {created_range.name}"
         )
+
+    def test_toggle_range_annotation_visibility(self, plot: Plot) -> None:
+        """Test toggling range annotation visibility from the plot controls."""
+        self.log("Testing toggle range annotation visibility")
+
+        # test_create_range_from_selection left a range within the plot viewport,
+        # so the annotation toggle should be present and on by default.
+        plot.wait_for_annotation_toggle()
+        plot.expect_annotations_visible(True)
+
+        plot.toggle_annotation_visibility()
+        plot.expect_annotations_visible(False)
+
+        plot.toggle_annotation_visibility()
+        plot.expect_annotations_visible(True)
 
     def test_copy_link(self, plot: Plot) -> str:
         """Test copying a link to the line plot via toolbar button.

--- a/pluto/src/lineplot/range/Provider.tsx
+++ b/pluto/src/lineplot/range/Provider.tsx
@@ -8,7 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { box, xy } from "@synnaxlabs/x";
-import { type ReactElement, useCallback } from "react";
+import { type ReactElement, useCallback, useEffect } from "react";
 
 import { Aether } from "@/aether";
 import { type RenderProp } from "@/component/renderProp";
@@ -20,20 +20,36 @@ import { range } from "@/lineplot/range/aether";
 import { Menu } from "@/menu";
 
 export interface ProviderProps extends Aether.ComponentProps {
+  visible?: boolean;
+  onHasAnnotationsChange?: (hasAnnotations: boolean) => void;
   menu?: RenderProp<range.SelectedState>;
 }
 
-export const Provider = ({ aetherKey, menu, ...rest }: ProviderProps): ReactElement => {
+export const Provider = ({
+  aetherKey,
+  menu,
+  visible = true,
+  onHasAnnotationsChange,
+  ...rest
+}: ProviderProps): ReactElement => {
   const cKey = useUniqueKey(aetherKey);
   const { setViewport, setHold } = useContext("Range.Provider");
   const [, { hovered, count }, setState] = Aether.use({
     aetherKey: cKey,
     type: range.Provider.TYPE,
     schema: range.providerStateZ,
-    initialState: { ...rest, cursor: null, hovered: null, count: 0 },
+    initialState: { ...rest, visible, cursor: null, hovered: null, count: 0 },
+    onAetherChange: useCallback(
+      ({ count }: range.ProviderState) => onHasAnnotationsChange?.(count > 0),
+      [onHasAnnotationsChange],
+    ),
   });
+  useEffect(() => {
+    setState((s) => ({ ...s, visible }));
+  }, [visible, setState]);
+
   const gridStyle = useGridEntry(
-    { key: cKey, loc: "top", size: count > 0 ? 32 : 0, order: 3 },
+    { key: cKey, loc: "top", size: visible && count > 0 ? 32 : 0, order: 3 },
     "Range.Provider",
   );
 

--- a/pluto/src/lineplot/range/aether/provider.ts
+++ b/pluto/src/lineplot/range/aether/provider.ts
@@ -38,9 +38,11 @@ export type SelectedState = z.infer<typeof selectedStateZ>;
 
 export const providerStateZ = z.object({
   cursor: xy.xyZ.or(z.null()),
+  visible: z.boolean().optional().default(true),
   hovered: selectedStateZ.or(z.null()),
   count: z.number(),
 });
+export type ProviderState = z.infer<typeof providerStateZ>;
 
 interface InternalState {
   ranges: Map<string, ranger.Range>;
@@ -85,12 +87,10 @@ export class Provider extends aether.Leaf<typeof providerStateZ, InternalState> 
       if (i.client == null) return;
       if (color.isCrude(changed.color))
         i.ranges.set(changed.key, i.client.ranges.sugarOne(changed));
-      this.setState((s) => ({ ...s, count: i.ranges.size }));
       i.requestRender("tool");
     });
     const removeOnDelete = store.ranges.onDelete(async (changed) => {
       i.ranges.delete(changed);
-      this.setState((s) => ({ ...s, count: i.ranges.size }));
       i.requestRender("tool");
     });
     i.removeListener = () => {
@@ -111,17 +111,19 @@ export class Provider extends aether.Leaf<typeof providerStateZ, InternalState> 
       ranges.forEach((r) => {
         if (color.isCrude(r.color)) i.ranges.set(r.key, r);
       });
-      this.setState((s) => ({ ...s, count: i.ranges.size }));
+      i.requestRender("tool");
     }, "failed to fetch initial ranges");
   }
 
   render(props: ProviderProps): void {
+    if (this.state.visible === false) return;
     const { dataToDecimalScale, region, viewport, timeRange } = props;
     this.fetchInitial(timeRange);
     const { draw, ranges } = this.internal;
     const regionScale = dataToDecimalScale.scale(box.xBounds(region));
     const cursor = this.state.cursor == null ? null : this.state.cursor.x;
     let hoveredState: SelectedState | null = null;
+    let visibleCount = 0;
     const clearScissor = draw.canvas.scissor(
       box.construct(
         { x: box.left(region), y: box.top(region) - 35 },
@@ -135,6 +137,7 @@ export class Provider extends aether.Leaf<typeof providerStateZ, InternalState> 
       let startPos = regionScale.pos(Number(r.timeRange.start.valueOf()));
       const endPos = regionScale.pos(Number(r.timeRange.end.valueOf()));
       if (endPos < box.left(region) || startPos > box.right(region)) return;
+      visibleCount++;
       startPos = clamp(startPos, box.left(region) - 2, box.right(region) - 1);
       let hovered = false;
       if (cursor != null)
@@ -161,7 +164,7 @@ export class Provider extends aether.Leaf<typeof providerStateZ, InternalState> 
           { x: startPos, y: box.top(region) - 1 },
           { x: endPos, y: box.bottom(region) - 1 },
         ),
-        backgroundColor: color.setAlpha(c, 0.2),
+        backgroundColor: color.setAlpha(c, 0.1),
         bordered: false,
       });
       const titleRegion = box.construct(
@@ -191,5 +194,7 @@ export class Provider extends aether.Leaf<typeof providerStateZ, InternalState> 
     clearScissor();
     if (hoveredState != null) this.setState((s) => ({ ...s, hovered: hoveredState }));
     else if (this.state.hovered) this.setState((s) => ({ ...s, hovered: null }));
+    if (this.state.count !== visibleCount)
+      this.setState((s) => ({ ...s, count: visibleCount }));
   }
 }

--- a/pluto/src/lineplot/range/aether/provider.ts
+++ b/pluto/src/lineplot/range/aether/provider.ts
@@ -116,20 +116,22 @@ export class Provider extends aether.Leaf<typeof providerStateZ, InternalState> 
   }
 
   render(props: ProviderProps): void {
-    if (this.state.visible === false) return;
     const { dataToDecimalScale, region, viewport, timeRange } = props;
     this.fetchInitial(timeRange);
     const { draw, ranges } = this.internal;
+    const visible = this.state.visible !== false;
     const regionScale = dataToDecimalScale.scale(box.xBounds(region));
     const cursor = this.state.cursor == null ? null : this.state.cursor.x;
     let hoveredState: SelectedState | null = null;
     let visibleCount = 0;
-    const clearScissor = draw.canvas.scissor(
-      box.construct(
-        { x: box.left(region), y: box.top(region) - 35 },
-        { x: box.right(region), y: box.bottom(region) },
-      ),
-    );
+    const clearScissor = visible
+      ? draw.canvas.scissor(
+          box.construct(
+            { x: box.left(region), y: box.top(region) - 35 },
+            { x: box.right(region), y: box.bottom(region) },
+          ),
+        )
+      : null;
     ranges.forEach((r) => {
       const cRes = color.colorZ.safeParse(r.color);
       if (!cRes.success) return;
@@ -138,6 +140,7 @@ export class Provider extends aether.Leaf<typeof providerStateZ, InternalState> 
       const endPos = regionScale.pos(Number(r.timeRange.end.valueOf()));
       if (endPos < box.left(region) || startPos > box.right(region)) return;
       visibleCount++;
+      if (!visible) return;
       startPos = clamp(startPos, box.left(region) - 2, box.right(region) - 1);
       let hovered = false;
       if (cursor != null)
@@ -191,7 +194,7 @@ export class Provider extends aether.Leaf<typeof providerStateZ, InternalState> 
         maxWidth: endPos - startPos - 16,
       });
     });
-    clearScissor();
+    clearScissor?.();
     if (hoveredState != null) this.setState((s) => ({ ...s, hovered: hoveredState }));
     else if (this.state.hovered) this.setState((s) => ({ ...s, hovered: null }));
     if (this.state.count !== visibleCount)


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-3942](https://linear.app/synnax/issue/SY-3942)

## Description

Adds a toggle in the line plot controls that hides and shows range annotations drawn on the plot. The toggle auto-hides from the control bar when no range annotations overlap the current viewport, so it only appears when there is actually something to hide or show.

On the Pluto side, the range `Provider`'s `count` now reflects the number of ranges drawn in the current viewport (computed per-render from the intersection check) rather than the size of the cached range map. This also collapses the annotation grid row to 0 when nothing is drawn — a latent bug where the row stayed at 32px regardless of what was visible.

The toggle's state is persisted per plot via a new optional \`annotations\` field on the existing v4 line plot state, defaulted via zod so existing persisted states migrate transparently without a new version bump.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a per-plot annotation visibility toggle that auto-hides from the control bar when no ranges intersect the current viewport. The aether `Provider` now computes `count` from actual viewport intersections each render (rather than cache size), resolving the latent 32px grid-row bug and keeping the toggle's visibility signal accurate. State is persisted via a new `annotations` field on the v4 state schema, with a Zod `.default()` enabling transparent migration of existing plots.

The previously-flagged stale-count-while-hidden issue is addressed: `visibleCount` is now computed unconditionally in every `render()` call (drawing is skipped separately), so `count` correctly falls to zero when the user pans away while hidden.

<h3>Confidence Score: 5/5</h3>

Safe to merge — no P0/P1 defects remain; all previously flagged issues have been addressed.

The main correctness concerns raised in prior review threads (stale `count` while hidden, CSS modifier condition not guarding on `hasAnnotations`) are resolved in this version. The one remaining comment (redundant `onHasAnnotationsChange` calls on cursor move) is a P2 performance nit with no user-visible impact, since React's `useState` identity bail-out prevents re-renders.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| pluto/src/lineplot/range/aether/provider.ts | Adds `visible` field to aether state; render now counts viewport-intersecting ranges regardless of visibility and updates `count` accordingly — previously flagged stale-count bug is fixed |
| pluto/src/lineplot/range/Provider.tsx | Adds `visible` prop, `onHasAnnotationsChange` callback wired via `onAetherChange`, and a `useEffect` to sync `visible` into aether state; grid entry size correctly gates on both `visible && count > 0` |
| console/src/lineplot/Controls.tsx | Adds annotation visibility toggle button (gated on `hasAnnotations`) and applies CSS positioning modifier only when both `annotations.visible` and `hasAnnotations` are true |
| console/src/components/Controls.css | Adds `.console-controls--annotations-visible` modifier overriding `top` to `0rem`; base transition and `right` declaration are preserved |
| console/src/lineplot/types/v4.ts | Adds `annotationsStateZ` with Zod `.default()` for transparent migration of persisted v4 states; migration function and ZERO_STATE both include the new field |
| console/src/lineplot/slice.ts | Adds `setRangeAnnotationsVisible` action and exports `AnnotationsState` type; straightforward Redux slice extension |
| console/src/lineplot/LinePlot.tsx | Threads `visible` and `onHasAnnotationsChange` into `rangeProviderProps`; passes `hasAnnotations` state down to both focused and unfocused `Controls` instances |
| console/src/lineplot/types/index.ts | Re-exports `annotationsStateZ`, `AnnotationsState`, and `ZERO_ANNOTATIONS_STATE` from v4 types |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[LinePlot.tsx] -->|rangeProviderProps: visible, onHasAnnotationsChange| B[Channel.LinePlot]
    B --> C[Provider.tsx]
    C -->|initialState + visible effect| D[Aether.use / aether provider.ts]
    D -->|render loop: counts intersecting ranges| E{visibleCount > 0?}
    E -->|Yes| F[setState count = visibleCount]
    E -->|No| G[setState count = 0]
    F --> H[onAetherChange fires]
    G --> H
    H -->|count > 0| I[setHasAnnotations in LinePlot]
    I -->|hasAnnotations prop| J[Controls.tsx]
    J -->|show/hide toggle + CSS modifier| K[UI: annotation toggle button]
    K -->|dispatch setRangeAnnotationsVisible| L[Redux slice]
    L -->|vis.annotations.visible| A
    D -->|visible===false: skip drawing but still count| E
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `console/src/components/Controls.css`, line 12-18 ([link](https://github.com/synnaxlabs/synnax/blob/56dbbfd323aaac78cfad2e17ef81ff386989578e/console/src/components/Controls.css#L12-L18)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Opacity transition accidentally removed**

   The `transition: opacity 0.1s ease-in-out` rule was dropped from `.console-controls` when the closing brace was rearranged to make room for the new modifier class. Without it, the control bar now snaps in/out instantly on hover instead of fading smoothly.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["updated console line plot controls"](https://github.com/synnaxlabs/synnax/commit/fb3a1a062a0e985bc67296da6e24c554dde68579) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29214629)</sub>

<!-- /greptile_comment -->