### PR TITLE
Maybe fix rust builds

### DIFF
--- a/.github/workflows/build.synnax.yaml
+++ b/.github/workflows/build.synnax.yaml
@@ -242,9 +242,7 @@ jobs:
 
       - name: Install Rust
         if: inputs.driver
-        run: |
-          rustup update
-          rustup default stable
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Build Driver (Windows)
         if: inputs.driver && matrix.os == 'windows-build-bot'
@@ -843,13 +841,10 @@ jobs:
           mv temp.json tauri.conf.json
 
       - name: Install Rust
-        run: rustup update
-
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
+        uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          workspaces: console/src-tauri -> target
-          shared-key: ${{ runner.os }}
+          cache-workspaces: console/src-tauri -> target
+          cache-shared-key: ${{ runner.os }}
 
       - name: Install Dependencies
         run: pnpm install

--- a/.github/workflows/deploy.synnax.yaml
+++ b/.github/workflows/deploy.synnax.yaml
@@ -208,8 +208,8 @@ jobs:
         run: |
           Move-Item -Force scripts/synnax-v${{ needs.setup.outputs.VERSION }}.exe scripts/synnax-server.exe
 
-      - name: Update Rust
-        run: rustup update
+      - name: Install Rust
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Install trusted-signing-cli
         run: cargo install trusted-signing-cli

--- a/.github/workflows/test.arc.yaml
+++ b/.github/workflows/test.arc.yaml
@@ -100,7 +100,7 @@ jobs:
           fi
 
       - name: Install Rust
-        run: rustup update
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Update Submodules
         run: git submodule update --init --recursive

--- a/.github/workflows/test.driver.yaml
+++ b/.github/workflows/test.driver.yaml
@@ -117,7 +117,7 @@ jobs:
           sudo apt-get install -y libsystemd-dev
 
       - name: Install Rust
-        run: rustup update
+        uses: actions-rust-lang/setup-rust-toolchain@v1
 
       - name: Update Submodules
         run: git submodule update --init --recursive


### PR DESCRIPTION
# Pull Request

Go to the `Preview` tab and select the appropriate template for your pull request:

- [Issue](?expand=1&template=issue.md)
- [RC](?expand=1&template=rc.md)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces manual `rustup update` calls across four CI workflow files with the `actions-rust-lang/setup-rust-toolchain@v1` action, which bundles toolchain installation, caching, and problem matchers into a single step. The cache inputs for the Tauri build (`cache-workspaces`, `cache-shared-key`) are correctly remapped from the previous `Swatinem/rust-cache@v2` parameters.

- The action sets `RUSTFLAGS=-D warnings` by default, turning all compiler warnings into hard errors — a silent behaviour change that could immediately break builds if any crate in the workspace has outstanding warnings. Setting `rustflags: \"\"` in each invocation would restore the prior permissive behaviour.

<h3>Confidence Score: 4/5</h3>

Safe to merge only if the Rust codebase is currently warning-free; otherwise the default `RUSTFLAGS=-D warnings` will break all four workflows.

One P1 finding: the implicit `RUSTFLAGS=-D warnings` injected by the new action is a behaviour change that can turn a previously passing build into a hard failure without any code change. Everything else (remapped cache keys, consolidated steps) looks correct.

`build.synnax.yaml` (two call sites), `deploy.synnax.yaml`, `test.arc.yaml`, and `test.driver.yaml` — all need `rustflags: ""` if warning-as-errors should not be enforced.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/build.synnax.yaml | Replaces two separate Rust setup steps with `actions-rust-lang/setup-rust-toolchain@v1`; cache inputs remapped correctly, but default `RUSTFLAGS=-D warnings` could break builds with existing warnings. |
| .github/workflows/deploy.synnax.yaml | Swaps `rustup update` for `actions-rust-lang/setup-rust-toolchain@v1`; same implicit `RUSTFLAGS=-D warnings` risk applies here too. |
| .github/workflows/test.arc.yaml | Swaps `rustup update` for `actions-rust-lang/setup-rust-toolchain@v1`; subject to the same default `RUSTFLAGS` change. |
| .github/workflows/test.driver.yaml | Swaps `rustup update` for `actions-rust-lang/setup-rust-toolchain@v1`; subject to the same default `RUSTFLAGS` change. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Workflow triggered] --> B[setup-rust-toolchain v1]
    B --> C{rustflags input set?}
    C -- not set --> D["RUSTFLAGS=-D warnings\nWarnings become errors"]
    C -- rustflags empty string --> E["RUSTFLAGS unset\nWarnings allowed"]
    D --> F{Rust warnings present?}
    F -- Yes --> G["Build FAILS"]
    F -- No --> H["Build succeeds"]
    E --> H
```

<sub>Reviews (1): Last reviewed commit: ["Maybe fix rust builds"](https://github.com/synnaxlabs/synnax/commit/4300519b7870ad5a862fcd78e01a602ead097851) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29335730)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->