### PR TITLE
SY-4106: Update `clang-format` workflows

### DIFF
--- a/.github/workflows/test.arc.yaml
+++ b/.github/workflows/test.arc.yaml
@@ -115,9 +115,9 @@ jobs:
       - name: Install Clang Format
         run: |
           sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
-          sudo apt-get install -y clang-format-20
-          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-20 100
-          sudo update-alternatives --set clang-format /usr/bin/clang-format-20
+          sudo apt-get install -y clang-format-22
+          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-22 100
+          sudo update-alternatives --set clang-format /usr/bin/clang-format-22
 
       - name: Check Formatting
         run: scripts/check_clang_format.sh arc/cpp

--- a/.github/workflows/test.client.yaml
+++ b/.github/workflows/test.client.yaml
@@ -191,9 +191,9 @@ jobs:
       - name: Install Clang Format
         run: |
           sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
-          sudo apt-get install -y clang-format-20
-          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-20 100
-          sudo update-alternatives --set clang-format /usr/bin/clang-format-20
+          sudo apt-get install -y clang-format-22
+          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-22 100
+          sudo update-alternatives --set clang-format /usr/bin/clang-format-22
 
       - name: Check Formatting
         run: scripts/check_clang_format.sh client/cpp

--- a/.github/workflows/test.driver.yaml
+++ b/.github/workflows/test.driver.yaml
@@ -132,9 +132,9 @@ jobs:
       - name: Install Clang Format
         run: |
           sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
-          sudo apt-get install -y clang-format-20
-          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-20 100
-          sudo update-alternatives --set clang-format /usr/bin/clang-format-20
+          sudo apt-get install -y clang-format-22
+          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-22 100
+          sudo update-alternatives --set clang-format /usr/bin/clang-format-22
 
       - name: Check Formatting
         run: scripts/check_clang_format.sh driver

--- a/.github/workflows/test.freighter.cpp.yaml
+++ b/.github/workflows/test.freighter.cpp.yaml
@@ -70,9 +70,9 @@ jobs:
         if: matrix.format
         run: |
           sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
-          sudo apt-get install -y clang-format-20
-          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-20 100
-          sudo update-alternatives --set clang-format /usr/bin/clang-format-20
+          sudo apt-get install -y clang-format-22
+          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-22 100
+          sudo update-alternatives --set clang-format /usr/bin/clang-format-22
 
       - name: Check Formatting
         if: matrix.format

--- a/.github/workflows/test.x.cpp.yaml
+++ b/.github/workflows/test.x.cpp.yaml
@@ -68,9 +68,9 @@ jobs:
         if: matrix.format
         run: |
           sudo bash -c "$(wget -O - https://apt.llvm.org/llvm.sh)"
-          sudo apt-get install -y clang-format-20
-          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-20 100
-          sudo update-alternatives --set clang-format /usr/bin/clang-format-20
+          sudo apt-get install -y clang-format-22
+          sudo update-alternatives --install /usr/bin/clang-format clang-format /usr/bin/clang-format-22 100
+          sudo update-alternatives --set clang-format /usr/bin/clang-format-22
 
       - name: Check Formatting
         if: matrix.format


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue number and link -->

[SY-4106](https://linear.app/synnax/issue/SY-4106/update-clang-format-workflows)

## Description

<!-- Write a description describing the changes. -->

Update `clang-format` workflows to use v22.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates all five C++ `clang-format` CI workflows from version 20 to version 22, consistently across `arc`, `client`, `driver`, `freighter.cpp`, and `x.cpp`. The three-step install pattern (add LLVM APT repo via `llvm.sh`, `apt-get install clang-format-22`, `update-alternatives`) is unchanged from the prior version and applied uniformly.

<h3>Confidence Score: 5/5</h3>

Safe to merge — purely mechanical version bump applied consistently across all workflow files.

All five files receive the same three-line change (20 → 22) with no logic differences or missing updates. No custom rules are violated and no correctness issues were found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/test.arc.yaml | Bumps clang-format installer from version 20 to 22 in the ARC C++ formatting step; change is consistent with the other workflow files. |
| .github/workflows/test.client.yaml | Bumps clang-format installer from version 20 to 22 in the client C++ formatting step; identical pattern to the other files. |
| .github/workflows/test.driver.yaml | Bumps clang-format installer from version 20 to 22 in the driver formatting step. |
| .github/workflows/test.freighter.cpp.yaml | Bumps clang-format installer from version 20 to 22 in the freighter C++ formatting step. |
| .github/workflows/test.x.cpp.yaml | Bumps clang-format installer from version 20 to 22 in the x.cpp formatting step. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[GitHub Actions Workflow Triggered] --> B[Install Clang Format Step]
    B --> C["wget llvm.sh from apt.llvm.org"]
    C --> D["sudo bash llvm.sh\n(adds LLVM APT repo)"]
    D --> E["apt-get install -y clang-format-22"]
    E --> F["update-alternatives --install\n/usr/bin/clang-format → clang-format-22"]
    F --> G["update-alternatives --set\nclang-format → clang-format-22"]
    G --> H[Check Formatting Step]
    H --> I["scripts/check_clang_format.sh <target>"]
    I --> J{Formatting OK?}
    J -- Yes --> K[✅ Pass]
    J -- No --> L[❌ Fail]
```

<sub>Reviews (1): Last reviewed commit: ["Update clang-format workflows"](https://github.com/synnaxlabs/synnax/commit/97de4628e3a1387896b9a10f0110512aacc91780) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29505581)</sub>

<!-- /greptile_comment -->