### PR TITLE
SY04119: Fix null HTTP Scan Task config parsing

### DIFF
--- a/console/src/hardware/http/task/types.spec.ts
+++ b/console/src/hardware/http/task/types.spec.ts
@@ -946,7 +946,7 @@ describe("HTTP Task Types", () => {
   });
 });
 
-describe("HTTP Scan Task statusData", () => {
+describe("HTTP Scan Task ", () => {
   describe("config", () => {
     it("should accept null", () => {
       expect(SCAN_SCHEMAS.config.safeParse(null).success).toBe(true);

--- a/console/src/hardware/http/task/types.spec.ts
+++ b/console/src/hardware/http/task/types.spec.ts
@@ -947,10 +947,20 @@ describe("HTTP Task Types", () => {
 });
 
 describe("HTTP Scan Task statusData", () => {
-  it("should accept null", () => {
-    expect(SCAN_SCHEMAS.statusData.safeParse(null).success).toBe(true);
+  describe("config", () => {
+    it("should accept null", () => {
+      expect(SCAN_SCHEMAS.config.safeParse(null).success).toBe(true);
+    });
+    it("should accept undefined", () => {
+      expect(SCAN_SCHEMAS.config.safeParse(undefined).success).toBe(true);
+    });
   });
-  it("should accept undefined", () => {
-    expect(SCAN_SCHEMAS.statusData.safeParse(undefined).success).toBe(true);
+  describe("statusData", () => {
+    it("should accept null", () => {
+      expect(SCAN_SCHEMAS.statusData.safeParse(null).success).toBe(true);
+    });
+    it("should accept undefined", () => {
+      expect(SCAN_SCHEMAS.statusData.safeParse(undefined).success).toBe(true);
+    });
   });
 });

--- a/console/src/hardware/http/task/types.spec.ts
+++ b/console/src/hardware/http/task/types.spec.ts
@@ -946,7 +946,7 @@ describe("HTTP Task Types", () => {
   });
 });
 
-describe("HTTP Scan Task ", () => {
+describe("HTTP Scan Task", () => {
   describe("config", () => {
     it("should accept null", () => {
       expect(SCAN_SCHEMAS.config.safeParse(null).success).toBe(true);

--- a/console/src/hardware/http/task/types.ts
+++ b/console/src/hardware/http/task/types.ts
@@ -284,6 +284,6 @@ export const TEST_CONNECTION_COMMAND_TYPE = "test_connection";
 
 export const SCAN_SCHEMAS = {
   type: z.literal(SCAN_TYPE),
-  config: record.unknownZ(),
+  config: record.nullishToEmpty(),
   statusData: z.null().optional(),
 } as const satisfies task.Schemas;


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue number and link -->

[SY-4110](https://linear.app/synnax/issue/SY-4110/fix-null-task-config-migrations)

## Description

<!-- Write a description describing the changes. -->

Fix null task config for HTTP Scan Task.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes null/undefined `config` parsing for the HTTP Scan Task by replacing `record.unknownZ()` (which does not accept `null` or `undefined`) with `record.nullishToEmpty()` (which coerces both to an empty object `{}`). The test suite is reorganized into nested `describe` blocks and extended to cover the new `config` null/undefined cases alongside the existing `statusData` tests.

<h3>Confidence Score: 5/5</h3>

Safe to merge — targeted one-line fix with appropriate test coverage.

The change is minimal and correct: `nullishToEmpty()` is a well-tested utility that coerces null/undefined to `{}` while passing valid objects through unchanged. No regressions are expected. All findings are P2 or lower.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| console/src/hardware/http/task/types.ts | Single-line fix: `config` schema changed from `record.unknownZ()` to `record.nullishToEmpty()` so null/undefined configs are coerced to `{}` instead of causing parse failures. |
| console/src/hardware/http/task/types.spec.ts | Tests reorganized into nested describes; new `config` null/undefined tests added matching the fix; existing `statusData` tests preserved. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[HTTP Scan Task config received] --> B{Is config null or undefined?}
    B -- Yes --> C["nullishToEmpty: transform to empty object"]
    B -- No --> D["unknownZ: validate object as-is"]
    C --> E["Parsed config: empty object"]
    D --> F["Parsed config: original value"]
    E --> G[Task proceeds normally]
    F --> G
```

<sub>Reviews (2): Last reviewed commit: ["Remove trailing space"](https://github.com/synnaxlabs/synnax/commit/0705b2e4a205a641d7d40c7d6f9aa6fef9b60e64) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29528722)</sub>

<!-- /greptile_comment -->