### PR TITLE
SY-4109: Add partial retries to HTTP Write Task

### DIFF
--- a/driver/http/mock/server.cpp
+++ b/driver/http/mock/server.cpp
@@ -36,6 +36,7 @@ struct Server::Impl {
     mutable std::mutex mu;
     std::vector<ReceivedRequest> requests;
     std::vector<Route> routes;
+    std::vector<std::shared_ptr<std::atomic<int>>> failure_counters;
 
     static Method parse_httplib_method(const std::string &m) {
         if (m == "GET") return Method::GET;
@@ -78,13 +79,22 @@ struct Server::Impl {
         } else {
             this->svr = std::make_unique<httplib::Server>();
         }
+        this->failure_counters.clear();
         for (const auto &route: this->routes)
-            this->register_route(route);
+            this->failure_counters.push_back(
+                std::make_shared<std::atomic<int>>(route.remaining_failures)
+            );
+        for (size_t i = 0; i < this->routes.size(); i++)
+            this->register_route(this->routes[i], this->failure_counters[i]);
     }
 
-    void register_route(const Route &route) {
+    void register_route(
+        const Route &route,
+        const std::shared_ptr<std::atomic<int>> &counter
+    ) {
         auto handler = [this,
-                        route](const httplib::Request &req, httplib::Response &res) {
+                        route,
+                        counter](const httplib::Request &req, httplib::Response &res) {
             log_request(req);
             if (route.delay > x::telem::TimeSpan::ZERO())
                 std::this_thread::sleep_for(route.delay.chrono());
@@ -93,8 +103,16 @@ struct Server::Impl {
                 res.set_redirect(route.redirect_to, route.status_code);
                 return;
             }
-            res.status = route.status_code;
-            res.set_content(route.response_body, route.content_type);
+            if (route.remaining_failures > 0 && counter->fetch_sub(1) > 0) {
+                res.status = route.status_code;
+                res.set_content(route.response_body, route.content_type);
+            } else if (route.remaining_failures > 0) {
+                res.status = 200;
+                res.set_content(R"({"status":"ok"})", route.content_type);
+            } else {
+                res.status = route.status_code;
+                res.set_content(route.response_body, route.content_type);
+            }
         };
 
         switch (route.method) {

--- a/driver/http/mock/server.h
+++ b/driver/http/mock/server.h
@@ -37,6 +37,10 @@ struct Route {
     /// @brief if non-empty, respond with a redirect to this URL instead of the
     /// configured body. status_code should be 301, 302, 307, etc.
     std::string redirect_to;
+    /// @brief when greater than zero, the route returns the configured status_code for
+    /// this many requests, then switches to 200 for subsequent requests. Zero (default)
+    /// means the route always uses status_code.
+    int remaining_failures = 0;
 };
 
 /// @brief a received request logged by the mock server.

--- a/driver/http/mock/server_test.cpp
+++ b/driver/http/mock/server_test.cpp
@@ -573,3 +573,139 @@ TEST(MockServerTest, RedirectRoute) {
 
     server.stop();
 }
+
+/// @brief remaining_failures should return the error status for the configured number
+/// of requests, then switch to 200.
+TEST(MockServerTest, RemainingFailuresCountdown) {
+    mock::ServerConfig cfg;
+    cfg.routes = {{
+        .method = Method::POST,
+        .path = "/flaky",
+        .status_code = 500,
+        .response_body = R"({"error":"internal"})",
+        .remaining_failures = 2,
+    }};
+    mock::Server server(cfg);
+    ASSERT_NIL(server.start());
+
+    httplib::Client cli(server.base_url());
+
+    auto res1 = cli.Post("/flaky", "{}", "application/json");
+    ASSERT_NE(res1, nullptr);
+    EXPECT_EQ(res1->status, 500);
+
+    auto res2 = cli.Post("/flaky", "{}", "application/json");
+    ASSERT_NE(res2, nullptr);
+    EXPECT_EQ(res2->status, 500);
+
+    auto res3 = cli.Post("/flaky", "{}", "application/json");
+    ASSERT_NE(res3, nullptr);
+    EXPECT_EQ(res3->status, 200);
+
+    auto res4 = cli.Post("/flaky", "{}", "application/json");
+    ASSERT_NE(res4, nullptr);
+    EXPECT_EQ(res4->status, 200);
+
+    EXPECT_EQ(server.received_requests().size(), 4);
+
+    server.stop();
+}
+
+/// @brief remaining_failures=0 should always use the configured status_code.
+TEST(MockServerTest, RemainingFailuresZeroUsesConfiguredStatus) {
+    mock::ServerConfig cfg;
+    cfg.routes = {{
+        .method = Method::GET,
+        .path = "/stable",
+        .status_code = 503,
+        .response_body = "unavailable",
+        .content_type = "text/plain",
+        .remaining_failures = 0,
+    }};
+    mock::Server server(cfg);
+    ASSERT_NIL(server.start());
+
+    httplib::Client cli(server.base_url());
+
+    auto res1 = cli.Get("/stable");
+    ASSERT_NE(res1, nullptr);
+    EXPECT_EQ(res1->status, 503);
+    EXPECT_EQ(res1->body, "unavailable");
+
+    auto res2 = cli.Get("/stable");
+    ASSERT_NE(res2, nullptr);
+    EXPECT_EQ(res2->status, 503);
+
+    server.stop();
+}
+
+/// @brief remaining_failures=1 should fail once then succeed on all subsequent
+/// requests.
+TEST(MockServerTest, RemainingFailuresOneFailsThenSucceeds) {
+    mock::ServerConfig cfg;
+    cfg.routes = {{
+        .method = Method::PUT,
+        .path = "/once",
+        .status_code = 429,
+        .response_body = R"({"error":"rate limited"})",
+        .remaining_failures = 1,
+    }};
+    mock::Server server(cfg);
+    ASSERT_NIL(server.start());
+
+    httplib::Client cli(server.base_url());
+
+    auto res1 = cli.Put("/once", "{}", "application/json");
+    ASSERT_NE(res1, nullptr);
+    EXPECT_EQ(res1->status, 429);
+
+    auto res2 = cli.Put("/once", "{}", "application/json");
+    ASSERT_NE(res2, nullptr);
+    EXPECT_EQ(res2->status, 200);
+
+    auto res3 = cli.Put("/once", "{}", "application/json");
+    ASSERT_NE(res3, nullptr);
+    EXPECT_EQ(res3->status, 200);
+
+    server.stop();
+}
+
+/// @brief remaining_failures counters should reset when the server is restarted.
+TEST(MockServerTest, RemainingFailuresResetsOnRestart) {
+    mock::ServerConfig cfg;
+    cfg.routes = {{
+        .method = Method::POST,
+        .path = "/reset",
+        .status_code = 500,
+        .response_body = R"({"error":"internal"})",
+        .remaining_failures = 1,
+    }};
+    mock::Server server(cfg);
+    ASSERT_NIL(server.start());
+
+    httplib::Client cli(server.base_url());
+
+    auto res1 = cli.Post("/reset", "{}", "application/json");
+    ASSERT_NE(res1, nullptr);
+    EXPECT_EQ(res1->status, 500);
+
+    auto res2 = cli.Post("/reset", "{}", "application/json");
+    ASSERT_NE(res2, nullptr);
+    EXPECT_EQ(res2->status, 200);
+
+    server.stop();
+    server.clear_requests();
+    ASSERT_NIL(server.start());
+
+    httplib::Client cli2(server.base_url());
+
+    auto res3 = cli2.Post("/reset", "{}", "application/json");
+    ASSERT_NE(res3, nullptr);
+    EXPECT_EQ(res3->status, 500);
+
+    auto res4 = cli2.Post("/reset", "{}", "application/json");
+    ASSERT_NE(res4, nullptr);
+    EXPECT_EQ(res4->status, 200);
+
+    server.stop();
+}

--- a/driver/http/write_task.cpp
+++ b/driver/http/write_task.cpp
@@ -280,9 +280,14 @@ WriteTaskSink::WriteTaskSink(
 }
 
 x::errors::Error WriteTaskSink::write(x::telem::Frame &frame) {
-    // First pass: build all requests, bailing on conversion errors.
-    std::vector<Request> requests;
-    std::vector<size_t> ep_indices;
+    struct PendingRequest {
+        Request request;
+        size_t ep_idx;
+        synnax::channel::Key ch_key;
+        x::telem::Series series;
+    };
+
+    std::vector<PendingRequest> pending;
     for (const auto &[ch_key, series]: frame) {
         auto it = channel_to_endpoint.find(ch_key);
         if (it == channel_to_endpoint.end()) continue;
@@ -324,41 +329,82 @@ x::errors::Error WriteTaskSink::write(x::telem::Frame &frame) {
 
         auto req = base_requests[ep_idx];
         req.body = build_body(ep, json_val);
-        requests.push_back(std::move(req));
-        ep_indices.push_back(ep_idx);
+        pending.push_back({
+            .request = std::move(req),
+            .ep_idx = ep_idx,
+            .ch_key = ch_key,
+            .series = series.shallow_copy(),
+        });
     }
 
-    if (requests.empty()) return x::errors::NIL;
-
-    auto results = processor->execute(requests);
+    if (pending.empty()) return x::errors::NIL;
 
     std::vector<std::string> error_msgs;
     std::string first_error_type;
-    for (size_t i = 0; i < results.size(); i++) {
-        const auto ep_idx = ep_indices[i];
-        const auto &ep = cfg.endpoints[ep_idx];
-        auto &[resp, req_err] = results[i];
-        if (req_err) {
-            if (first_error_type.empty()) first_error_type = req_err.type;
-            error_msgs.push_back(
-                std::string(to_string(ep.request.method)) + " " +
-                base_requests[ep_idx].url + ": " + req_err.data
-            );
-            continue;
+
+    while (!pending.empty()) {
+        std::vector<Request> batch;
+        batch.reserve(pending.size());
+        for (const auto &p: pending)
+            batch.push_back(p.request);
+        auto results = processor->execute(batch);
+
+        std::vector<PendingRequest> still_pending;
+        bool made_progress = false;
+        x::telem::Frame success_frame;
+
+        for (size_t i = 0; i < results.size(); i++) {
+            const auto &p = pending[i];
+            const auto &ep = cfg.endpoints[p.ep_idx];
+            auto &[resp, req_err] = results[i];
+
+            x::errors::Error err = x::errors::NIL;
+            if (req_err)
+                err = req_err;
+            else if (
+                auto status_err = errors::from_status(resp.status_code); status_err
+            )
+                err = status_err;
+
+            if (!err) {
+                made_progress = true;
+                success_frame.emplace(p.ch_key, p.series.shallow_copy());
+                continue;
+            }
+
+            if (err.matches(errors::TEMPORARY_ERROR)) {
+                still_pending.push_back(std::move(pending[i]));
+            } else {
+                made_progress = true;
+                if (first_error_type.empty()) first_error_type = err.type;
+                auto msg = std::string(to_string(ep.request.method)) + " " +
+                           base_requests[p.ep_idx].url;
+                if (req_err)
+                    msg += ": " + req_err.data;
+                else {
+                    msg += " returned " + std::to_string(resp.status_code);
+                    if (!resp.body.empty()) msg += ": " + resp.body;
+                }
+                error_msgs.push_back(std::move(msg));
+            }
         }
-        if (auto status_err = errors::from_status(resp.status_code); status_err) {
-            if (first_error_type.empty()) first_error_type = status_err.type;
-            auto msg = std::string(to_string(ep.request.method)) + " " +
-                       base_requests[ep_idx].url + " returned " +
-                       std::to_string(resp.status_code);
-            if (!resp.body.empty()) msg += ": " + resp.body;
-            error_msgs.push_back(msg);
-            continue;
-        }
+
+        if (!success_frame.empty()) this->set_state(success_frame);
+        pending = std::move(still_pending);
+        if (!made_progress) break;
     }
-    if (!error_msgs.empty())
-        return {first_error_type, x::strings::join(error_msgs, "; ")};
-    return x::errors::NIL;
+
+    for (const auto &p: pending) {
+        if (first_error_type.empty()) first_error_type = errors::TEMPORARY_ERROR.type;
+        const auto &ep = cfg.endpoints[p.ep_idx];
+        error_msgs.push_back(
+            std::string(to_string(ep.request.method)) + " " +
+            base_requests[p.ep_idx].url + ": timed out"
+        );
+    }
+
+    if (error_msgs.empty()) return x::errors::NIL;
+    return {first_error_type, x::strings::join(error_msgs, "; ")};
 }
 
 std::pair<common::ConfigureResult, x::errors::Error> configure_write(

--- a/driver/http/write_task_test.cpp
+++ b/driver/http/write_task_test.cpp
@@ -59,6 +59,17 @@ make_sink(WriteTaskConfig &cfg, const std::string &base_url) {
         std::move(processor),
     };
 }
+
+/// @brief helper to count requests matching a given path.
+size_t count_requests_for_path(
+    const std::vector<mock::ReceivedRequest> &reqs,
+    const std::string &path
+) {
+    size_t count = 0;
+    for (const auto &r: reqs)
+        if (r.path == path) count++;
+    return count;
+}
 }
 
 /// @brief it should fail to parse config when endpoints array is empty.
@@ -834,9 +845,12 @@ TEST(HTTPWriteTask, ParallelBatchPartialFailure) {
     EXPECT_NE(err.data.find("/api/bad"), std::string::npos)
         << "Expected failing endpoint path in error. Got: " << err.data;
 
-    // Both requests should have been sent (parallel, not short-circuit).
+    // The good endpoint succeeds on round 1 (progress), so the bad endpoint is retried.
+    // Round 2 has only the bad endpoint which fails again (no progress), so the retry
+    // stops. Total: good=1, bad=2.
     auto reqs = server.received_requests();
-    ASSERT_EQ(reqs.size(), 2);
+    EXPECT_EQ(count_requests_for_path(reqs, "/api/good"), 1);
+    EXPECT_EQ(count_requests_for_path(reqs, "/api/bad"), 2);
 }
 
 /// @brief when multiple endpoints in a parallel batch return errors, the combined
@@ -893,17 +907,18 @@ TEST(HTTPWriteTask, ParallelBatchAllFailures) {
     frame.emplace(synnax::channel::Key(2), x::telem::Series(std::vector<double>{20.0}));
 
     auto err = sink->write(frame);
-    // The first error type encountered determines the overall error type.
+    // The critical error (400) is the first error type encountered.
     ASSERT_OCCURRED_AS(err, errors::CRITICAL_ERROR);
     EXPECT_NE(err.data.find("/api/client-err"), std::string::npos)
-        << "Expected first failing endpoint in error. Got: " << err.data;
+        << "Expected critical endpoint in error. Got: " << err.data;
     EXPECT_NE(err.data.find("/api/server-err"), std::string::npos)
-        << "Expected second failing endpoint in error. Got: " << err.data;
-    EXPECT_NE(err.data.find("; "), std::string::npos)
-        << "Expected errors joined by '; '. Got: " << err.data;
+        << "Expected temporary endpoint in error. Got: " << err.data;
 
+    // The critical error on client-err counts as progress, so server-err is retried
+    // once. Round 2: server-err fails again (no progress), retry stops.
     auto reqs = server.received_requests();
-    ASSERT_EQ(reqs.size(), 2);
+    EXPECT_EQ(count_requests_for_path(reqs, "/api/client-err"), 1);
+    EXPECT_EQ(count_requests_for_path(reqs, "/api/server-err"), 2);
 }
 
 /// @brief it should use only the last sample value when a series has multiple
@@ -1668,5 +1683,326 @@ TEST(HTTPWriteTask, EndpointQueryParams) {
     auto verbose_param = reqs[0].query_params.find("verbose");
     ASSERT_NE(verbose_param, reqs[0].query_params.end());
     EXPECT_EQ(verbose_param->second, "true");
+}
+
+/// @brief when one endpoint always succeeds and another fails then succeeds, only the
+/// failing endpoint should be retried.
+TEST(HTTPWriteTask, PartialSuccessRetryOnly) {
+    mock::Server server(
+        mock::ServerConfig{
+            .routes = {
+                {
+                    .method = Method::POST,
+                    .path = "/api/good",
+                    .status_code = 200,
+                    .response_body = R"({"status":"ok"})",
+                },
+                {
+                    .method = Method::POST,
+                    .path = "/api/flaky",
+                    .status_code = 500,
+                    .response_body = R"({"error":"internal"})",
+                    .remaining_failures = 1,
+                },
+            },
+        }
+    );
+    ASSERT_NIL(server.start());
+    x::defer::defer stop_server([&server] { server.stop(); });
+
+    WriteTaskConfig cfg;
+    cfg.device = "test-device";
+    cfg.auto_start = false;
+
+    WriteEndpoint ep1;
+    ep1.request.method = Method::POST;
+    ep1.request.path = "/api/good";
+    ep1.request.request_content_type = "application/json";
+    ep1.channel.pointer = x::json::json::json_pointer("/value");
+    ep1.channel.json_type = x::json::Type::Number;
+    ep1.channel.channel_key = 1;
+
+    WriteEndpoint ep2;
+    ep2.request.method = Method::POST;
+    ep2.request.path = "/api/flaky";
+    ep2.request.request_content_type = "application/json";
+    ep2.channel.pointer = x::json::json::json_pointer("/value");
+    ep2.channel.json_type = x::json::Type::Number;
+    ep2.channel.channel_key = 2;
+
+    cfg.endpoints = {ep1, ep2};
+    cfg.cmd_keys = {1, 2};
+
+    auto [sink, processor] = make_sink(cfg, server.base_url());
+
+    x::telem::Frame frame;
+    frame.emplace(synnax::channel::Key(1), x::telem::Series(std::vector<double>{10.0}));
+    frame.emplace(synnax::channel::Key(2), x::telem::Series(std::vector<double>{20.0}));
+
+    ASSERT_NIL(sink->write(frame));
+
+    auto reqs = server.received_requests();
+    EXPECT_EQ(count_requests_for_path(reqs, "/api/good"), 1);
+    EXPECT_EQ(count_requests_for_path(reqs, "/api/flaky"), 2);
+}
+
+/// @brief when all endpoints fail with temporary errors and no progress is made, retry
+/// should stop after one round.
+TEST(HTTPWriteTask, NoProgressStopsRetry) {
+    mock::Server server(
+        mock::ServerConfig{
+            .routes = {
+                {
+                    .method = Method::POST,
+                    .path = "/api/a",
+                    .status_code = 500,
+                    .response_body = R"({"error":"internal"})",
+                },
+                {
+                    .method = Method::POST,
+                    .path = "/api/b",
+                    .status_code = 500,
+                    .response_body = R"({"error":"internal"})",
+                },
+            },
+        }
+    );
+    ASSERT_NIL(server.start());
+    x::defer::defer stop_server([&server] { server.stop(); });
+
+    WriteTaskConfig cfg;
+    cfg.device = "test-device";
+    cfg.auto_start = false;
+
+    WriteEndpoint ep1;
+    ep1.request.method = Method::POST;
+    ep1.request.path = "/api/a";
+    ep1.request.request_content_type = "application/json";
+    ep1.channel.pointer = x::json::json::json_pointer("/value");
+    ep1.channel.json_type = x::json::Type::Number;
+    ep1.channel.channel_key = 1;
+
+    WriteEndpoint ep2;
+    ep2.request.method = Method::POST;
+    ep2.request.path = "/api/b";
+    ep2.request.request_content_type = "application/json";
+    ep2.channel.pointer = x::json::json::json_pointer("/value");
+    ep2.channel.json_type = x::json::Type::Number;
+    ep2.channel.channel_key = 2;
+
+    cfg.endpoints = {ep1, ep2};
+    cfg.cmd_keys = {1, 2};
+
+    auto [sink, processor] = make_sink(cfg, server.base_url());
+
+    x::telem::Frame frame;
+    frame.emplace(synnax::channel::Key(1), x::telem::Series(std::vector<double>{10.0}));
+    frame.emplace(synnax::channel::Key(2), x::telem::Series(std::vector<double>{20.0}));
+
+    auto err = sink->write(frame);
+    ASSERT_OCCURRED_AS(err, errors::TEMPORARY_ERROR);
+
+    auto reqs = server.received_requests();
+    EXPECT_EQ(reqs.size(), 2);
+}
+
+/// @brief progress-driven retry across multiple rounds: C always succeeds, A fails
+/// once, B fails twice. Each round makes progress until all resolve.
+TEST(HTTPWriteTask, ProgressDrivenMultipleRounds) {
+    mock::Server server(
+        mock::ServerConfig{
+            .routes = {
+                {
+                    .method = Method::POST,
+                    .path = "/api/a",
+                    .status_code = 500,
+                    .response_body = R"({"error":"internal"})",
+                    .remaining_failures = 1,
+                },
+                {
+                    .method = Method::POST,
+                    .path = "/api/b",
+                    .status_code = 500,
+                    .response_body = R"({"error":"internal"})",
+                    .remaining_failures = 2,
+                },
+                {
+                    .method = Method::POST,
+                    .path = "/api/c",
+                    .status_code = 200,
+                    .response_body = R"({"status":"ok"})",
+                },
+            },
+        }
+    );
+    ASSERT_NIL(server.start());
+    x::defer::defer stop_server([&server] { server.stop(); });
+
+    WriteTaskConfig cfg;
+    cfg.device = "test-device";
+    cfg.auto_start = false;
+
+    WriteEndpoint ep_a;
+    ep_a.request.method = Method::POST;
+    ep_a.request.path = "/api/a";
+    ep_a.request.request_content_type = "application/json";
+    ep_a.channel.pointer = x::json::json::json_pointer("/value");
+    ep_a.channel.json_type = x::json::Type::Number;
+    ep_a.channel.channel_key = 1;
+
+    WriteEndpoint ep_b;
+    ep_b.request.method = Method::POST;
+    ep_b.request.path = "/api/b";
+    ep_b.request.request_content_type = "application/json";
+    ep_b.channel.pointer = x::json::json::json_pointer("/value");
+    ep_b.channel.json_type = x::json::Type::Number;
+    ep_b.channel.channel_key = 2;
+
+    WriteEndpoint ep_c;
+    ep_c.request.method = Method::POST;
+    ep_c.request.path = "/api/c";
+    ep_c.request.request_content_type = "application/json";
+    ep_c.channel.pointer = x::json::json::json_pointer("/value");
+    ep_c.channel.json_type = x::json::Type::Number;
+    ep_c.channel.channel_key = 3;
+
+    cfg.endpoints = {ep_a, ep_b, ep_c};
+    cfg.cmd_keys = {1, 2, 3};
+
+    auto [sink, processor] = make_sink(cfg, server.base_url());
+
+    x::telem::Frame frame;
+    frame.emplace(synnax::channel::Key(1), x::telem::Series(std::vector<double>{10.0}));
+    frame.emplace(synnax::channel::Key(2), x::telem::Series(std::vector<double>{20.0}));
+    frame.emplace(synnax::channel::Key(3), x::telem::Series(std::vector<double>{30.0}));
+
+    ASSERT_NIL(sink->write(frame));
+
+    auto reqs = server.received_requests();
+    EXPECT_EQ(count_requests_for_path(reqs, "/api/a"), 2);
+    EXPECT_EQ(count_requests_for_path(reqs, "/api/b"), 3);
+    EXPECT_EQ(count_requests_for_path(reqs, "/api/c"), 1);
+}
+
+/// @brief a critical error (400) on one endpoint should not prevent temporary failures
+/// on other endpoints from being retried.
+TEST(HTTPWriteTask, CriticalErrorDoesNotPreventTemporaryRetry) {
+    mock::Server server(
+        mock::ServerConfig{
+            .routes = {
+                {
+                    .method = Method::POST,
+                    .path = "/api/critical",
+                    .status_code = 400,
+                    .response_body = R"({"error":"bad request"})",
+                },
+                {
+                    .method = Method::POST,
+                    .path = "/api/flaky",
+                    .status_code = 500,
+                    .response_body = R"({"error":"internal"})",
+                    .remaining_failures = 1,
+                },
+            },
+        }
+    );
+    ASSERT_NIL(server.start());
+    x::defer::defer stop_server([&server] { server.stop(); });
+
+    WriteTaskConfig cfg;
+    cfg.device = "test-device";
+    cfg.auto_start = false;
+
+    WriteEndpoint ep1;
+    ep1.request.method = Method::POST;
+    ep1.request.path = "/api/critical";
+    ep1.request.request_content_type = "application/json";
+    ep1.channel.pointer = x::json::json::json_pointer("/value");
+    ep1.channel.json_type = x::json::Type::Number;
+    ep1.channel.channel_key = 1;
+
+    WriteEndpoint ep2;
+    ep2.request.method = Method::POST;
+    ep2.request.path = "/api/flaky";
+    ep2.request.request_content_type = "application/json";
+    ep2.channel.pointer = x::json::json::json_pointer("/value");
+    ep2.channel.json_type = x::json::Type::Number;
+    ep2.channel.channel_key = 2;
+
+    cfg.endpoints = {ep1, ep2};
+    cfg.cmd_keys = {1, 2};
+
+    auto [sink, processor] = make_sink(cfg, server.base_url());
+
+    x::telem::Frame frame;
+    frame.emplace(synnax::channel::Key(1), x::telem::Series(std::vector<double>{10.0}));
+    frame.emplace(synnax::channel::Key(2), x::telem::Series(std::vector<double>{20.0}));
+
+    auto err = sink->write(frame);
+    ASSERT_OCCURRED_AS(err, errors::CRITICAL_ERROR);
+    EXPECT_NE(err.data.find("/api/critical"), std::string::npos);
+
+    auto reqs = server.received_requests();
+    EXPECT_EQ(count_requests_for_path(reqs, "/api/critical"), 1);
+    EXPECT_EQ(count_requests_for_path(reqs, "/api/flaky"), 2);
+}
+
+/// @brief when all endpoints return critical errors, no retry should occur.
+TEST(HTTPWriteTask, AllCriticalNoRetry) {
+    mock::Server server(
+        mock::ServerConfig{
+            .routes = {
+                {
+                    .method = Method::POST,
+                    .path = "/api/a",
+                    .status_code = 400,
+                    .response_body = R"({"error":"bad request"})",
+                },
+                {
+                    .method = Method::POST,
+                    .path = "/api/b",
+                    .status_code = 404,
+                    .response_body = R"({"error":"not found"})",
+                },
+            },
+        }
+    );
+    ASSERT_NIL(server.start());
+    x::defer::defer stop_server([&server] { server.stop(); });
+
+    WriteTaskConfig cfg;
+    cfg.device = "test-device";
+    cfg.auto_start = false;
+
+    WriteEndpoint ep1;
+    ep1.request.method = Method::POST;
+    ep1.request.path = "/api/a";
+    ep1.request.request_content_type = "application/json";
+    ep1.channel.pointer = x::json::json::json_pointer("/value");
+    ep1.channel.json_type = x::json::Type::Number;
+    ep1.channel.channel_key = 1;
+
+    WriteEndpoint ep2;
+    ep2.request.method = Method::POST;
+    ep2.request.path = "/api/b";
+    ep2.request.request_content_type = "application/json";
+    ep2.channel.pointer = x::json::json::json_pointer("/value");
+    ep2.channel.json_type = x::json::Type::Number;
+    ep2.channel.channel_key = 2;
+
+    cfg.endpoints = {ep1, ep2};
+    cfg.cmd_keys = {1, 2};
+
+    auto [sink, processor] = make_sink(cfg, server.base_url());
+
+    x::telem::Frame frame;
+    frame.emplace(synnax::channel::Key(1), x::telem::Series(std::vector<double>{10.0}));
+    frame.emplace(synnax::channel::Key(2), x::telem::Series(std::vector<double>{20.0}));
+
+    auto err = sink->write(frame);
+    ASSERT_OCCURRED_AS(err, errors::CRITICAL_ERROR);
+
+    auto reqs = server.received_requests();
+    EXPECT_EQ(reqs.size(), 2);
 }
 }

--- a/driver/pipeline/base.h
+++ b/driver/pipeline/base.h
@@ -48,7 +48,7 @@ public:
     /// @brief the main run loop for the pipeline.
     virtual void run() = 0;
 
-    /// @brief starts the control pipeline. This method is idempotent.
+    /// @brief starts the pipeline. This method is idempotent.
     /// @returns true if this is the first call to start() ever or the first call to
     /// start() since the pipeline was last stopped.
     /// @returns false otherwise.
@@ -64,11 +64,11 @@ public:
     /// start().
     /// @returns false if this is an N+1 call to stop() since the last call to
     /// start().
-    /// @details this function is safe to call from within the pipeline operation
-    /// thread itself. If done so, the pipeline breaker will be stopped, but the
-    /// thread will not be joined. If calling stop() from within the pipeline
-    /// itself, it's important that stop() be called again before the pipeline is
-    /// destructed to properly join the thread.
+    /// @details this function is safe to call from within the pipeline operation thread
+    /// itself. If done so, the pipeline breaker will be stopped, but the thread will
+    /// not be joined. If calling stop() from within the pipeline itself, it's important
+    /// that stop() be called again before the pipeline is destructed to properly join
+    /// the thread.
     virtual bool stop() {
         const auto stopped = this->breaker.stop();
         if (this->thread.get_id() != std::this_thread::get_id() &&
@@ -77,10 +77,10 @@ public:
         return stopped;
     }
 
-    /// @brief returns true if the pipeline is currently running. This method may
-    /// return true if the pipeline is in a transient state, i.e., start has been
-    /// called, but the pipeline has not started or failed yet or if stop has been
-    /// called, but the pipeline has not stopped yet.
+    /// @brief returns true if the pipeline is currently running. This method may return
+    /// true if the pipeline is in a transient state, i.e., start has been called, but
+    /// the pipeline has not started or failed yet or if stop has been called, but the
+    /// pipeline has not stopped yet.
     bool running() const { return this->breaker.running(); }
 };
 }

--- a/driver/pipeline/control.cpp
+++ b/driver/pipeline/control.cpp
@@ -7,8 +7,6 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-#include <exception>
-#include <stdexcept>
 #include <utility>
 
 #include "driver/errors/errors.h"

--- a/driver/pipeline/control.h
+++ b/driver/pipeline/control.h
@@ -17,21 +17,21 @@
 #include "driver/pipeline/base.h"
 
 namespace driver::pipeline {
-/// @brief an object that writes data to an acquisition computer or other resource.
+/// @brief an object that writes data to a controller or other resource.
 class Sink {
 public:
-    /// @brief writes the given frame to the sink, returning an error if one occurs.
-    /// If the sink returns an error matching driver::TEMPORARY_HARDWARE_ERROR, the
-    /// acquisition pipeline will trigger a breaker (temporary backoff), and then
-    /// retry the read operation. Any other error type will be considered a
-    /// permanent error and the pipeline will exit.
+    /// @brief writes the given frame to the sink, returning an error if one occurs. If
+    /// the sink returns an error matching driver::TEMPORARY_HARDWARE_ERROR, the
+    /// control pipeline will trigger a breaker (temporary backoff), and then retry
+    /// the read operation. Any other error type will be considered a permanent error
+    /// and the pipeline will exit.
     virtual x::errors::Error write(x::telem::Frame &frame) = 0;
 
-    /// @brief communicates an error encountered by the control pipeline that
-    /// occurred during shut down or occurred during a commanded shutdown.
+    /// @brief communicates an error encountered by the control pipeline that occurred
+    /// during shut down or occurred during a commanded shutdown.
     ///
-    /// After this method is called, the pipeline will NOT make nay further calls to
-    /// the source (read, stopped_with_err) until the pipeline is restarted.
+    /// After this method is called, the pipeline will NOT make nay further calls to the
+    /// source (read, stopped_with_err) until the pipeline is restarted.
     ///
     /// This method may be called even if stop() was called on the pipeline.
     virtual void stopped_with_err(const x::errors::Error &_) {}
@@ -39,63 +39,60 @@ public:
     virtual ~Sink() = default;
 };
 
-/// @brief an interface that receives data over the network (from Synnax during
-/// production, and from mock objects during testing).
+/// @brief an interface that receives data the network (from Synnax during production,
+/// and from mock objects during testing).
 class Streamer {
 public:
-    /// @brief blocks until the next frame of telemetry is available. If an error
-    /// is encountered, the streamer should return an error. If the streamer returns
-    /// an error matching driver::TEMPORARY_HARDWARE_ERROR, the control pipeline
-    /// will trigger a breaker (temporary backoff), and then retry the read
-    /// operation. Any other error type will be considered a permanent error and the
-    /// pipeline will exit.
+    /// @brief blocks until the next frame of telemetry is available. If an error is
+    /// encountered, the streamer should return an error. If the streamer returns an
+    /// error matching driver::TEMPORARY_HARDWARE_ERROR, the control pipeline will
+    /// trigger a breaker (temporary backoff), and then retry the read operation. Any
+    /// other error type will be considered a permanent error and the pipeline will
+    /// exit.
     virtual std::pair<x::telem::Frame, x::errors::Error> read() = 0;
 
     /// @brief closes the streamer, returning any error that occurred during normal
-    /// operation. If the returned error is of type freighter::UNREACHABLE, the
-    /// control pipeline will trigger a breaker (temporary backoff), and then retry
-    ///  until the configured number of maximum retries is exceeded. Any other error
-    ///  will
-    /// be considered permanent and the pipeline will exit.
+    /// operation. If the returned error is of type freighter::UNREACHABLE, the control
+    /// pipeline will trigger a breaker (temporary backoff), and then retry until the
+    /// configured number of maximum retries is exceeded. Any other error will be
+    /// considered permanent and the pipeline will exit.
     virtual x::errors::Error close() = 0;
 
-    /// @brief signals the streamer that the caller is done sending requests, and
-    /// that it should being the streamer shutdown process. This mechanism should be
-    /// thread safe when concurrently used with read(). When close_send() is called,
-    /// read() should return as soon as possible.
+    /// @brief signals the streamer that the caller is done sending requests, and that
+    /// it should being the streamer shutdown process. This mechanism should be thread
+    /// safe when concurrently used with read(). When close_send() is called, read()
+    /// should return as soon as possible.
     virtual void close_send() = 0;
 
     virtual ~Streamer() = default;
 };
 
-/// @brief an interface for a factory that can be used to open streamers. In
-/// production, this is typically backed by the Synnax client.
+/// @brief an interface for a factory that can be used to open streamers. In production,
+/// this is typically backed by a Synnax client.
 class StreamerFactory {
 public:
-    /// @brief opens a streamer with the given configuration, returning the streamer
-    /// and an error if one occurs. If the error is of type freighter::UNREACHABLE,
-    /// the control pipeline will trigger a breaker (temporary backoff), and then
-    /// retry until the configured number of maximum retries is exceeded. Any other
-    /// error is considered permanent and the pipeline will exit.
+    /// @brief opens a streamer with the given configuration, returning the streamer and
+    /// an error if one occurs. If the error is of type freighter::UNREACHABLE, the
+    /// control pipeline will trigger a breaker (temporary backoff), and then retry
+    /// until the configured number of maximum retries is exceeded. Any other error is
+    /// considered permanent and the pipeline will exit.
     virtual std::pair<std::unique_ptr<Streamer>, x::errors::Error>
     open_streamer(synnax::framer::StreamerConfig config) = 0;
 
     virtual ~StreamerFactory() = default;
 };
 
-/// @brief an implementation of the pipeline::Streamer interface that is backed
-/// by a Synnax streamer that receives data from a cluster.
+/// @brief an implementation of the pipeline::Streamer interface that is backed by a
+/// Synnax streamer that receives data from a Core.
 class SynnaxStreamer final : public Streamer {
-    /// @brief the wrapped synnax streamer.
+    /// @brief the wrapped Synnax streamer.
     synnax::framer::Streamer internal;
 
 public:
-    /// @brief constructs a new Synnax streamer that wraps the given internal
-    /// streamer.
+    /// @brief constructs a new Synnax streamer that wraps the given internal streamer.
     explicit SynnaxStreamer(synnax::framer::Streamer internal);
 
-    /// @brief implements pipeline::Streamer to read the next frame from the
-    /// streamer.
+    /// @brief implements pipeline::Streamer to read the next frame from the streamer.
     std::pair<x::telem::Frame, x::errors::Error> read() override;
 
     /// @brief implements pipeline::Streamer to close the streamer.
@@ -105,8 +102,8 @@ public:
     void close_send() override;
 };
 
-/// @brief an implementation of the pipeline::StreamerFactory interface that is
-/// backed by an actual synnax client connected to a cluster.
+/// @brief an implementation of the pipeline::StreamerFactory interface that is backed
+/// by an actual Synnax client connected to a Core.
 class SynnaxStreamerFactory final : public StreamerFactory {
     /// @brief the Synnax client to use for opening streamers.
     const std::shared_ptr<synnax::Synnax> client;
@@ -121,11 +118,11 @@ public:
     open_streamer(synnax::framer::StreamerConfig config) override;
 };
 
-/// @brief A pipeline that reads incoming data over the network and writes to a
-/// sink. The pipeline should be used as a utility for implementing a broader
-/// control task. It implements retry handling on connection loss and handles
-/// temporary hardware errors. The pipeline forks a thread to repeatedly read from
-/// the streamer and write to the sink.
+/// @brief A pipeline that reads incoming data over the network and writes to a sink.
+/// The pipeline should be used as a utility for implementing a broader control task. It
+/// implements retry handling on connection loss and handles temporary hardware errors.
+/// The pipeline forks a thread to repeatedly read from the streamer and write to the
+/// sink.
 class Control final : public Base {
     /// @brief a factory used to instantiate Synnax streamers to read commands from.
     /// This is typically backed by a Synnax client, but can be mocked.
@@ -138,8 +135,7 @@ class Control final : public Base {
     std::unique_ptr<Streamer> streamer = nullptr;
 
 public:
-    /// @brief constructs a new control pipeline that opens streamers on a Synnax
-    /// database cluster.
+    /// @brief constructs a new control pipeline that opens streamers on a Synnax Core.
     /// @param client the Synnax client to use for opening streamers.
     /// @param streamer_config the configuration for the Synnax streamer.
     /// @param sink the sink to write data to. See the Sink interface for more
@@ -156,8 +152,7 @@ public:
         std::string thread_name = ""
     );
 
-    //// @brief constructs a new control pipeline that opens streamers using the
-    /// given
+    /// @brief constructs a new control pipeline that opens streamers using the given
     /// streamer factory.
     /// @param streamer_factory the streamer factory to use for opening streamers.
     /// @param streamer_config the configuration for opening the streamer.
@@ -175,9 +170,8 @@ public:
         std::string thread_name = ""
     );
 
-    /// @brief stops the control pipeline, blocking until the control thread has
-    /// exited. If the pipeline has already stopped, this method will return
-    /// immediately.
+    /// @brief stops the control pipeline, blocking until the control thread has exited.
+    /// If the pipeline has already stopped, this method will return immediately.
     bool stop() override;
 
     void run() override;

--- a/driver/pipeline/control.h
+++ b/driver/pipeline/control.h
@@ -39,8 +39,8 @@ public:
     virtual ~Sink() = default;
 };
 
-/// @brief an interface that receives data the network (from Synnax during production,
-/// and from mock objects during testing).
+/// @brief an interface that receives data (from Synnax during production, and from mock
+/// objects during testing).
 class Streamer {
 public:
     /// @brief blocks until the next frame of telemetry is available. If an error is


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue number and link -->

[SY-4109](https://linear.app/synnax/issue/SY-4109/refactor-http-write-task-to-allow-for-partial-retries)

## Description

<!-- Write a description describing the changes. -->

Add partial retry support to HTTP Write Task.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds partial retry support to the HTTP Write Task: instead of treating the entire batch as a unit, the `write()` method now loops — re-sending only the endpoints that returned a `TEMPORARY_ERROR` — and stops when either all endpoints resolve or a round makes no forward progress. The mock server gains a `remaining_failures` counter to simulate transient failures in tests, and six new integration tests cover the key retry scenarios.

<h3>Confidence Score: 5/5</h3>

Safe to merge; the retry loop is provably bounded and all critical paths are covered by tests.

The only finding is a P2 style issue with the "timed out" wording in the no-progress error message. The retry termination logic is sound — each round either shrinks the pending set or breaks immediately — and the six new integration tests validate every documented scenario. Pipeline and control changes are documentation-only.

driver/http/write_task.cpp — minor wording issue on the no-progress error message.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| driver/http/write_task.cpp | Core change: replaces single-pass request execution with a progress-driven retry loop that re-sends only TEMPORARY_ERROR endpoints; logic is sound but the "timed out" message on no-progress exit is misleading. |
| driver/http/mock/server.cpp | Adds per-route atomic failure counters that decrement on each request; logic correctly uses fetch_sub's pre-decrement return value and resets counters on restart. |
| driver/http/mock/server.h | Adds `remaining_failures` field to `Route` struct with clear documentation; default of 0 preserves backward-compatible behavior. |
| driver/http/mock/server_test.cpp | Four new tests cover countdown, zero-failures pass-through, single-failure, and restart-reset behaviors of the new counter; all cases look correct. |
| driver/http/write_task_test.cpp | Six new integration tests cover partial-success retry, no-progress stop, multi-round progress, critical-does-not-block-temporary, all-critical-no-retry, and the helper; comprehensive and match the documented behavior. |
| driver/pipeline/base.h | Documentation-only reformatting; no functional changes. |
| driver/pipeline/control.cpp | Removes two unused #include headers; no functional changes. |
| driver/pipeline/control.h | Documentation reformatting and minor terminology updates (e.g., "cluster" → "Core"); no functional changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Build pending list from frame] --> B{pending empty?}
    B -- yes --> Z[return NIL]
    B -- no --> C[Execute all pending as batch]
    C --> D[Classify each result]
    D --> E{Result type?}
    E -- success --> F[Add to success_frame\nmade_progress = true]
    E -- TEMPORARY_ERROR --> G[Add to still_pending]
    E -- critical error --> H[Add to error_msgs\nmade_progress = true]
    F --> I[Call set_state with success_frame]
    G --> J{made_progress?}
    H --> J
    I --> J
    J -- yes, pending not empty --> C
    J -- no --> K[Remaining pending - no-progress errors]
    J -- yes, pending empty --> L{error_msgs empty?}
    K --> L
    L -- yes --> Z
    L -- no --> M[return joined error]
```

<sub>Reviews (2): Last reviewed commit: ["Merge branch &#39;rc&#39; into sy-4109-refactor-..."](https://github.com/synnaxlabs/synnax/commit/714323e40db0c050879d72621d0df6333cf6a93e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29549379)</sub>

<!-- /greptile_comment -->