### PR TITLE
SY-4119: Update Console to allow creating persisted variable-length channels

### DIFF
--- a/console/src/channel/Create.tsx
+++ b/console/src/channel/Create.tsx
@@ -80,19 +80,14 @@ export const Create: Layout.Renderer = ({ onClose }) => {
               label="Virtual"
               inputProps={{ disabled: isIndex }}
               onChange={(v, ctx) => {
-                if (!v) {
-                  const dataType = ctx.get<string>("dataType").value;
-                  if (new DataType(dataType).isVariable)
-                    ctx.set("dataType", DataType.FLOAT32.toString());
-                  return;
-                }
+                if (!v) return;
                 ctx.set("isIndex", false);
                 ctx.set("index", 0);
               }}
             />
             <Form.SwitchField
               path="isIndex"
-              label="Is Index"
+              label="Is index"
               inputProps={{ disabled: isVirtual }}
               onChange={(v, ctx) => {
                 if (!v) return;
@@ -100,15 +95,9 @@ export const Create: Layout.Renderer = ({ onClose }) => {
                 if (ctx.get("index").value !== 0) ctx.set("index", 0);
               }}
             />
-            <Form.Field<string> path="dataType" label="Data Type" grow>
+            <Form.Field<string> path="dataType" label="Data type" grow>
               {({ variant: _, ...p }) => (
-                <Telem.SelectDataType
-                  {...p}
-                  disabled={isIndex}
-                  zIndex={100}
-                  hideVariableDensity={!isVirtual}
-                  full="x"
-                />
+                <Telem.SelectDataType {...p} disabled={isIndex} zIndex={100} full="x" />
               )}
             </Form.Field>
           </Flex.Box>

--- a/integration/console/channels.py
+++ b/integration/console/channels.py
@@ -106,12 +106,12 @@ class ChannelClient:
         if virtual:
             self.layout.click_checkbox("Virtual")
         if is_index:
-            self.layout.click_checkbox("Is Index")
+            self.layout.click_checkbox("Is index")
         else:
             if index == 0:
                 raise ValueError("Index must be provided if is_index is False")
             data_type_str = str(sy.DataType(data_type))
-            self.layout.click_btn("Data Type")
+            self.layout.click_btn("Data type")
             self.layout.select_from_dropdown(data_type_str, "Search Data Types")
             self.layout.click_btn("Index")
             self.layout.select_from_dropdown(str(index), "Search Channels")
@@ -172,14 +172,14 @@ class ChannelClient:
             if virtual:
                 self.layout.click_checkbox("Virtual")
             if is_index:
-                self.layout.click_checkbox("Is Index")
+                self.layout.click_checkbox("Is index")
             else:
                 if index == 0:
                     raise ValueError(
                         f"Index must be provided for non-index channel: {name}"
                     )
                 data_type_str = str(sy.DataType(data_type))
-                self.layout.click_btn("Data Type")
+                self.layout.click_btn("Data type")
                 self.layout.select_from_dropdown(data_type_str, "Search Data Types")
                 self.layout.click_btn("Index")
                 self.layout.select_from_dropdown(index_str, "Search Channels")

--- a/pluto/src/channel/queries.spec.ts
+++ b/pluto/src/channel/queries.spec.ts
@@ -752,24 +752,6 @@ describe("queries", () => {
       );
     });
 
-    it("should validate that persisted channels have fixed-size data types", async () => {
-      const { result } = renderHook(() => Channel.useForm({ query: {} }), {
-        wrapper,
-      });
-
-      act(() => {
-        result.current.form.set("name", id.create());
-        result.current.form.set("dataType", DataType.STRING.toString());
-        result.current.form.set("virtual", false);
-        result.current.form.set("isIndex", false);
-      });
-
-      expect(result.current.form.validate()).toBe(false);
-      expect(result.current.form.get("dataType").status.message).toContain(
-        "Persisted channels must have a fixed-size data type",
-      );
-    });
-
     it("should validate that name cannot be empty", async () => {
       const { result } = renderHook(() => Channel.useForm({ query: {} }), {
         wrapper,

--- a/pluto/src/channel/queries.ts
+++ b/pluto/src/channel/queries.ts
@@ -82,10 +82,6 @@ export const formSchema = channel.newZ
   .refine((v) => v.isIndex || v.index !== 0 || v.virtual || v.expression !== "", {
     message: "Data channel must have an index",
     path: ["index"],
-  })
-  .refine((v) => v.virtual || !DataType.z.parse(v.dataType).isVariable, {
-    message: "Persisted channels must have a fixed-size data type",
-    path: ["dataType"],
   });
 
 export const calculatedFormSchema = formSchema.safeExtend({


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue number and link -->

[SY-4119](https://linear.app/synnax/issue/SY-4119/update-console-to-allow-creating-persisted-channels)

## Description

<!-- Write a description describing the changes. -->

Update the channel queries and console form to allow for creating persisted variable-length channels.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the client-side restriction that prevented persisted (non-virtual) channels from using variable-length data types. The changes are internally consistent: the UI `SelectDataType` prop `hideVariableDensity` is dropped, the Zod schema `refine` guard is deleted, the corresponding test is removed, and the integration-test helper strings are updated to match the new label casing.

<h3>Confidence Score: 5/5</h3>

Safe to merge; changes are focused and internally consistent with only a minor missing test for the new positive path.

All four touched files are in sync — UI, schema validation, unit tests, and integration helpers all reflect the same intent. The only finding is a P2 missing positive test for the newly-permitted behavior.

pluto/src/channel/queries.spec.ts — no positive test for the new allowed data types on persisted channels.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| console/src/channel/Create.tsx | Removes the dataType reset guard when switching Virtual off, and removes `hideVariableDensity` prop so variable-length types appear in the dropdown for all channels; minor label casing fixes. |
| pluto/src/channel/queries.ts | Removes the `.refine` rule that blocked persisted channels from using variable-length data types, enabling the new feature at the schema level. |
| pluto/src/channel/queries.spec.ts | Removes the test for the deleted validation rule, but no new test was added to positively assert that persisted variable-length channels are now accepted. |
| integration/console/channels.py | Updates integration-test label strings ("Is Index"→"Is index", "Data Type"→"Data type") to match the new UI capitalization. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[User opens Create Channel modal] --> B{Is Index?}
    B -- Yes --> C[Set dataType = TIMESTAMP\nDisable dataType selector]
    B -- No --> D{Is Virtual?}
    D -- Yes --> E[Show all data types\nincl. variable-length\nNo index required]
    D -- No --> F[Show all data types\nincl. variable-length\nPREVIOUSLY: hide variable-length]
    F --> G[Select Index channel]
    E --> H[Submit form]
    G --> H
    C --> H
    H --> I{Schema validation}
    I -- Pass --> J[Create channel via API]
    I -- Fail --> K[Show error]
    style F fill:#d4edda,stroke:#28a745
    style E fill:#d4edda,stroke:#28a745
```

<sub>Reviews (2): Last reviewed commit: ["Update integration test casing"](https://github.com/synnaxlabs/synnax/commit/13a931536e4ef5c16d9573b3eb6bb7b6999e15f5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29770831)</sub>

<!-- /greptile_comment -->