### PR TITLE
SY-4125: Fix "Update Core" button not working in Console

### DIFF
--- a/console/src-tauri/tauri.conf.json
+++ b/console/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Synnax",
-  "version": "0.55.0",
+  "version": "0.55.1",
   "build": {
     "beforeBuildCommand": "pnpm build-vite",
     "beforeDevCommand": "pnpm dev-vite",

--- a/console/src/Console.tsx
+++ b/console/src/Console.tsx
@@ -48,6 +48,7 @@ import { Modals } from "@/modals";
 import { Ontology } from "@/ontology";
 import { Palette } from "@/palette";
 import { Range } from "@/range";
+import { Runtime } from "@/runtime";
 import { Schematic } from "@/schematic";
 import { SERVICES } from "@/services";
 import { Status } from "@/status";
@@ -142,6 +143,7 @@ const MainUnderContext = (): ReactElement => {
   const theme = Layout.useThemeProvider();
   const cluster = Cluster.useSelect();
   useBlockDefaultDropBehavior();
+  Runtime.useExternalLinkHandler();
 
   return (
     <Pluto.Provider

--- a/console/src/runtime/external.ts
+++ b/console/src/runtime/external.ts
@@ -8,5 +8,6 @@
 // included in the file licenses/APL.txt.
 
 export * from "@/runtime/download";
+export * from "@/runtime/externalLinks";
 export * from "@/runtime/isMainWindow";
 export * from "@/runtime/runtime";

--- a/console/src/runtime/externalLinks.ts
+++ b/console/src/runtime/externalLinks.ts
@@ -1,0 +1,40 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { open } from "@tauri-apps/plugin-shell";
+import { useEffect } from "react";
+
+import { ENGINE } from "@/runtime/runtime";
+
+const handle = (e: MouseEvent) => {
+  if (!(e.target instanceof Element)) return;
+  const a = e.target.closest("a");
+  if (a == null || a.target !== "_blank" || a.href === "") return;
+  e.preventDefault();
+  e.stopPropagation();
+  open(a.href).catch((err) => console.error(`failed to open ${a.href}`, err));
+};
+
+/**
+ * Routes `<a target="_blank">` clicks to the system browser when running in Tauri.
+ * Tauri's WebView silently drops `target="_blank"` clicks by default; this hook
+ * intercepts those and hands the URL to the shell plugin's `open`. In the browser build
+ * this is a no-op — native `target="_blank"` already opens a new tab.
+ */
+export const useExternalLinkHandler = (): void => {
+  useEffect(() => {
+    if (ENGINE !== "tauri") return;
+    document.addEventListener("click", handle, true);
+    document.addEventListener("auxclick", handle, true);
+    return () => {
+      document.removeEventListener("click", handle, true);
+      document.removeEventListener("auxclick", handle, true);
+    };
+  }, []);
+};


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue number and link -->

[SY-4125](https://linear.app/synnax/issue/SY-3838/add-ci-check-for-buildifier-lint)

## Description

<!-- Write a description describing the changes. -->

Fix the "Update Core" button not working in the Console due to `open` not working in Tauri.
## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the non-functional "Update Core" button in the Tauri console by adding a document-level capture-phase listener that intercepts `<a target="_blank">` clicks and routes them to the system browser via `tauri-plugin-shell`'s `open` function, since Tauri's WebView silently drops such clicks by default. The shell plugin was already initialized in `main.rs` and `shell:allow-open` was already declared in the capabilities file, so no backend changes are needed beyond the patch-version bump.

<h3>Confidence Score: 5/5</h3>

Safe to merge — targeted fix with no behavioral regressions in the web build and proper cleanup in the hook.

All changes are small and well-scoped: the hook is no-op in non-Tauri environments, the required shell plugin was already wired up (Cargo.toml, main.rs, capabilities), and event listener cleanup is correctly implemented. No P0 or P1 issues found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| console/src/runtime/externalLinks.ts | New hook intercepts `<a target="_blank">` clicks in Tauri and routes them to the system browser via `tauri-plugin-shell`; implementation is clean and well-guarded. |
| console/src/Console.tsx | Imports `Runtime` and calls `useExternalLinkHandler` in the top-level component; minimal, correct change. |
| console/src/runtime/external.ts | Re-exports the new `externalLinks` module; no issues. |
| console/src-tauri/tauri.conf.json | Patch version bump from 0.55.0 → 0.55.1 to reflect the bug fix release. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant WebView as Tauri WebView
    participant Hook as useExternalLinkHandler
    participant Shell as tauri-plugin-shell
    participant OS as System Browser

    User->>WebView: Click <a target="_blank" href="...">
    WebView->>Hook: click / auxclick (capture phase)
    Hook->>Hook: closest("a") check, target="_blank" && href != ""
    Hook->>WebView: preventDefault() + stopPropagation()
    Hook->>Shell: open(a.href)
    Shell->>OS: Open URL in default browser
```

<sub>Reviews (1): Last reviewed commit: ["Update Console version"](https://github.com/synnaxlabs/synnax/commit/3e9b0436999c6e400aa6ac5d2dcd35f4e685b212) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29948431)</sub>

<!-- /greptile_comment -->