### PR TITLE
SY-4127: Divide F64 Typecast - Trade and RFC

### DIFF
--- a/docs/tech/rfc/0038-260425-divide-typecast-f64-trade-study.md
+++ b/docs/tech/rfc/0038-260425-divide-typecast-f64-trade-study.md
@@ -41,11 +41,18 @@ outputs must match inputs.**
 
 ### Type System Consistency
 
+**What "consistency" means here.** Option A's consistency is that each operator returns
+a type matching **what the operation actually represents**, not that every operator
+returns its input type. `+`, `-`, `*`, `%` stay in the integer domain because they
+produce exact integer results from integer inputs. `/` and `**` do not, so they return
+`f64`. The rule is in the math (like derivative), not in matching the input datatype,
+which ignores what the operators actually do.
+
 **"Divide and pow behave differently from add/subtract/multiply."**
 
 LabVIEW, numpy, and scipy all have separate divide (float) and quotient (integer)
 operations. This is standard. Both `divide` and `pow` can produce non-integer results
-from integer inputs (`1/2 = 0.5`, `2^-1 = 0.5`), unlike add, subtract, and multiply,
+from integer inputs (`1/2 = 0.5`, `2**-1 = 0.5`), unlike add, subtract, and multiply,
 which always produce exact integers from integer inputs.
 
 Arc already has precedent: `math.derivative` returns `f64` regardless of input type
@@ -53,6 +60,10 @@ because rate of change is inherently continuous. Division and power have the sam
 property.
 
 **"A user might expect `i32 / i32 → i32`."**
+
+Arc's users come from Python, LabVIEW, and MATLAB. In all of these environments, `/`
+produces a result in the continuous domain. Customer research confirms this expectation.
+A C-style integer truncation would surprise the majority of Arc's actual users.
 
 Two integer division variants can be added later if requested: `math.floor_division()`
 (round toward negative infinity, Python `//` semantics: `-7 // 2 = -4`) and
@@ -67,13 +78,32 @@ In Python, `int(1) / int(3)` returns `float(0.333...)`. In numpy,
 returns `float64(inf)`. The Synnax Python client's `Series.to_numpy()` returns
 `numpy.ndarray`, so when a user queries two integer series from Synnax and divides them,
 numpy casts to `float64` and produces `+/-Inf`/`NaN` on zero denominators. Option A
-makes Arc consistent with behavior that already exists in our own client library.
+makes Arc consistent with behavior that already exists in our own client library. The
+Python client can already write `+Inf`, `-Inf`, and `NaN` directly to `f64` channels:
+
+```python
+import synnax as sy
+import numpy as np
+
+client = sy.Synnax()
+
+idx = client.channels.retrieve("inf_nan_time")
+ch = client.channels.retrieve("inf_nan_f64")
+
+VALUES = [np.inf, -np.inf, np.nan]
+
+now = sy.TimeStamp.now()
+timestamps = [int(now + i * sy.TimeSpan.SECOND) for i in range(len(VALUES))]
+
+with client.open_writer(start=now, channels=[idx.key, ch.key]) as w:
+    w.write({idx.key: timestamps, ch.key: VALUES})
+```
 
 For power, numpy's `np.power(int, negative_int)` raises `ValueError` entirely rather
 than produce a wrong integer answer. `np.float_power` always returns `float64`. Option A
 uses `float_power` semantics for both `divide` and `pow`.
 
-### Precision
+### Precision Errors
 
 | Scenario       | Option A (`f64` output)  | Option B (integer output)   |
 | -------------- | ------------------------ | --------------------------- |
@@ -81,8 +111,9 @@ uses `float_power` semantics for both `divide` and `pow`.
 | `7 / 3`        | `2.333...`, correct      | `2`, 14% error (truncation) |
 | `(2^53+1) / 1` | loses 1 bit of precision | exact                       |
 
-Option B loses precision on every non-exact division. Option A only loses precision for
-integers exceeding 2^53 (~9 quadrillion), which is outside the range of any real sensor.
+Option B has increased error due to not having the ability to represent precision for a
+solution in the continuous domain. Option A only loses precision for integers exceeding
+2^53 (~9 quadrillion), which is outside the range of any real sensor.
 
 For `f32` inputs, promoting to `f64` is a free precision gain: `f32` has ~7 decimal
 digits of precision, while `f64` has ~15. `f32(1.0) / f32(3.0)` computed in `f64`
@@ -130,17 +161,21 @@ Every mainstream language treats these differently. Python 3: `int / int = float
 `int * int = int`. Rust, Go, C: multiplication wraps, division truncates. Nobody
 auto-promotes multiplication.
 
+Arc integer arithmetic wraps on overflow (two's complement, WASM semantics), the same as
+C and Go.
+
 **Overflow is a width problem. Division is a domain problem. Different problems,
-different solutions.**
+different solutions.** Overflow behavior is out of scope for this RFC and is an
+independent design decision that does not affect the case for Option A.
 
 ### Divide by Zero
 
-| Scenario             | Option A (`f64`)                                                     | Option B (integer)                               |
-| -------------------- | -------------------------------------------------------------------- | ------------------------------------------------ |
-| `n/0`, `-n/0`, `0/0` | `+Inf`, `-Inf`, `NaN`. Deterministic per IEEE 754.                   | Panic (current), or requires new error handling. |
-| Downstream impact    | `+Inf`, `-Inf`, and `NaN` are all non-truthy. Won't trigger control. | No output, possible cascade failure.             |
-| Debugging            | `+Inf`, `-Inf`, `NaN` visible in the Log view, traceable.            | Depends on resolution.                           |
-| Recovery             | System keeps running.                                                | Depends on resolution.                           |
+| Scenario             | Option A (`f64`)                                                                           | Option B (integer)                               |
+| -------------------- | ------------------------------------------------------------------------------------------ | ------------------------------------------------ |
+| `n/0`, `-n/0`, `0/0` | `+Inf`, `-Inf`, `NaN`. Deterministic per IEEE 754.                                         | Panic (current), or requires new error handling. |
+| Downstream impact    | `NaN` is non-truthy (won't trigger control). `+Inf`/`-Inf` are truthy, matching Python/JS. | No output, possible cascade failure.             |
+| Debugging            | `+Inf`, `-Inf`, `NaN` visible in the Log view, traceable.                                  | Depends on resolution.                           |
+| Recovery             | System keeps running.                                                                      | Depends on resolution.                           |
 
 #### What Option B actually requires
 
@@ -192,7 +227,7 @@ What does "reliable" mean for a telemetry language?
 
 The operations that preserve input type (add, subtract, multiply, min, max) do so
 because integer inputs always produce exact integer results. Division and power do not
-have that property: `1 / 2` is `0.5`, `2^-1` is `0.5`. Returning `f64` is the
+have that property: `1 / 2` is `0.5`, `2**-1` is `0.5`. Returning `f64` is the
 mathematically correct choice, consistent with how `math.derivative` already works.
 
 The counterargument is that low-level hardware engineers expect C-style integer
@@ -203,8 +238,10 @@ MATLAB, where division returns floats.
 
 `+Inf`, `-Inf`, and `NaN` are safe in Arc's control model:
 
-- **Non-truthy**: `isSeriesTruthy` treats `+Inf`, `-Inf`, and `NaN` as non-truthy. They
-  will not trigger control logic.
+- **Predictable truthiness**: `isSeriesTruthy` treats `NaN` as non-truthy (it is
+  genuinely undefined, since `0/0` has no magnitude). `+Inf` and `-Inf` are truthy,
+  consistent with Python and JavaScript. Programs that need to guard against
+  divide-by-zero triggering control should check the denominator explicitly.
 - **Visible**: `∞`/`Infinity`, `-∞`/`-Infinity`, and `NaN` already render in the UI.
   They are not silent.
 - **Consistent**: Both flow nodes and WASM functions produce the same values.
@@ -212,29 +249,28 @@ MATLAB, where division returns floats.
 Under Option B, either the system outputs incorrect data (sentinel value of 0), silently
 drops the output (no signal to the user), or behaves differently depending on whether
 the division is in a flow node or a `func` block. All three are worse for safety than a
-visible, non-truthy IEEE 754 value.
+visible IEEE 754 value with well-defined truthiness semantics.
 
 ---
 
 ## Trade Summary
 
-| Criterion            | Option A | Option B                        |
-| -------------------- | -------- | ------------------------------- |
-| Type strictness      | Wins     |                                 |
-| Type consistency     | Wins     |                                 |
-| Precision            | Wins     |                                 |
-| Timestamp precision  |          | Wins (not practically relevant) |
-| Overflow consistency | Wins     |                                 |
-| Divide by zero       | Wins     |                                 |
-| Language identity    | Wins     |                                 |
-| Reliability          | Wins     |                                 |
-| Safety               | Wins     |                                 |
+| Criterion            | Option A | Option B |
+| -------------------- | -------- | -------- |
+| Type strictness      | ✓        | ✓        |
+| Type consistency     | ✓        |          |
+| Precision            | ✓        |          |
+| Overflow consistency | ✓        |          |
+| Divide by zero       | ✓        |          |
+| Language identity    | ✓        |          |
+| Reliability          | ✓        |          |
+| Safety               | ✓        |          |
 
 ## Recommendation
 
 Option A is the recommended option. It wins on every criterion evaluated in this study
-except timestamp precision, where Option B preserves exact nanosecond values. Under
-Option A, the precision loss is ~2-4 nanoseconds on year-long time deltas.
+except the timestamp precision sub-topic, where Option B preserves exact nanosecond
+values. Under Option A, the precision loss is ~2-4 nanoseconds on year-long time deltas.
 
 The intuition behind Option B is reasonable. "The output type should match the input
 type" is a clean mental model, and integer division is familiar to anyone who has

--- a/docs/tech/rfc/0038-260425-divide-typecast-f64-trade-study.md
+++ b/docs/tech/rfc/0038-260425-divide-typecast-f64-trade-study.md
@@ -1,0 +1,252 @@
+# Division and Power Output Type: Trade Study
+
+## Overview
+
+This trade study evaluates two options for the output type of `divide` and `pow`
+operations in Arc, and the behavior of division by zero.
+
+## Options
+
+- **Option A**: `divide` and `pow` always return `f64`. Division by zero produces IEEE
+  754 values (`+Inf`, `-Inf`, `NaN`). This is what LabVIEW, numpy, and scipy do.
+- **Option B**: `divide` and `pow` return the input type (no typecast to `f64`).
+  Division by zero must be handled separately, either by erroring, trapping, or
+  producing a sentinel value. This is what C does.
+
+---
+
+## Trade Criteria
+
+### Type Strictness and Strong Typing
+
+These terms overlap in casual use but mean different things:
+
+- **Strictly typed**: Every value has a definite type known at compile time, and the
+  compiler enforces type rules at every boundary.
+- **Strongly typed**: No implicit coercion between unrelated types. The programmer must
+  explicitly convert (e.g., JavaScript's `"5" + 3 = "53"` is weak typing).
+
+Option A satisfies both. The `/` operator has a **concrete, compile-time return type:
+`f64`**. Always. There is no ambiguity, no runtime coercion, no type that depends on
+context. If you try to assign the result to an `i32` channel, the compiler rejects it
+with a clear error. That is the opposite of "fuzzy."
+
+The concern behind Option B is often: "the output type doesn't match the input type, and
+that feels surprising." That is a fair UX reaction, but it is a preference, not a
+type-system property. LabVIEW is considered strongly typed: every wire has an explicit
+type, and the divide node explicitly returns `DBL` (double).
+
+**"Type-strict" means the compiler enforces types at every boundary. It does not mean
+outputs must match inputs.**
+
+### Type System Consistency
+
+**"Divide and pow behave differently from add/subtract/multiply."**
+
+LabVIEW, numpy, and scipy all have separate divide (float) and quotient (integer)
+operations. This is standard. Both `divide` and `pow` can produce non-integer results
+from integer inputs (`1/2 = 0.5`, `2^-1 = 0.5`), unlike add, subtract, and multiply,
+which always produce exact integers from integer inputs.
+
+Arc already has precedent: `math.derivative` returns `f64` regardless of input type
+because rate of change is inherently continuous. Division and power have the same
+property.
+
+**"A user might expect `i32 / i32 → i32`."**
+
+Two integer division variants can be added later if requested: `math.floor_division()`
+(round toward negative infinity, Python `//` semantics: `-7 // 2 = -4`) and
+`math.quotient()` (truncate toward zero, C semantics: `-7 / 2 = -3`). These differ only
+on negative inputs. YAGNI applies to both. For now, `i32(math.divide(a, b))` works for
+anyone who needs integer output.
+
+**Existing behavior in the Synnax ecosystem:**
+
+In Python, `int(1) / int(3)` returns `float(0.333...)`. In numpy,
+`np.int64(1) / np.int64(3)` returns `float64(0.333...)` and `np.int64(1) / np.int64(0)`
+returns `float64(inf)`. The Synnax Python client's `Series.to_numpy()` returns
+`numpy.ndarray`, so when a user queries two integer series from Synnax and divides them,
+numpy casts to `float64` and produces `+/-Inf`/`NaN` on zero denominators. Option A
+makes Arc consistent with behavior that already exists in our own client library.
+
+For power, numpy's `np.power(int, negative_int)` raises `ValueError` entirely rather
+than produce a wrong integer answer. `np.float_power` always returns `float64`. Option A
+uses `float_power` semantics for both `divide` and `pow`.
+
+### Precision
+
+| Scenario       | Option A (`f64` output)  | Option B (integer output)   |
+| -------------- | ------------------------ | --------------------------- |
+| `1 / 2`        | `0.5`, correct           | `0`, 100% error             |
+| `7 / 3`        | `2.333...`, correct      | `2`, 14% error (truncation) |
+| `(2^53+1) / 1` | loses 1 bit of precision | exact                       |
+
+Option B loses precision on every non-exact division. Option A only loses precision for
+integers exceeding 2^53 (~9 quadrillion), which is outside the range of any real sensor.
+
+For `f32` inputs, promoting to `f64` is a free precision gain: `f32` has ~7 decimal
+digits of precision, while `f64` has ~15. `f32(1.0) / f32(3.0)` computed in `f64`
+produces a more accurate result than computing in `f32`. Option B would return the less
+precise `f32` answer.
+
+#### Timestamps
+
+Synnax timestamps are int64 nanoseconds since epoch (~1.7 x 10^18), which exceeds f64's
+2^53 exact integer range. So `timestamp / n` would lose nanoseconds.
+
+However, dividing a raw timestamp (`now / 3`) is not a meaningful operation. What is
+meaningful is dividing time _deltas_ (`(now - yesterday) / 3`). A one-day delta is ~8.6
+x 10^13 nanoseconds (well within 2^53). Even a one-year delta (~3.15 x 10^16) only loses
+~2-4 nanoseconds of precision in the f64 representation, which is negligible for any
+real sensor application.
+
+More importantly, under integer division, `timedelta / n` where `timedelta < n` returns
+**zero**. That is not a precision loss; that is a total loss. The f64 path gives a
+meaningful sub-nanosecond answer; the integer path gives nothing.
+
+### Overflow and Consistency with Other Operations
+
+**"If division auto-promotes to f64, shouldn't multiplication also auto-promote to
+prevent overflow? Otherwise the type system is inconsistent."**
+
+No. Division and overflow are fundamentally different problems:
+
+- Division and power produce results that **leave the integers entirely**. `1 / 2 = 0.5`
+  is not representable as any integer type. The correct result lives in a different
+  numeric domain.
+- Overflow produces a result that **is still an integer**, just one that doesn't fit in
+  the container. `u8(255) * u8(255) = 65025` is a perfectly valid integer; the problem
+  is the container width, not the numeric domain.
+- For division, there is a single well-defined promotion target: `f64`. For overflow,
+  there is no single right answer: promote to `u16`? `u32`? `u64`? It depends on the
+  values at runtime, which would require arbitrary-precision integers or
+  runtime-dependent types, both of which actually _would_ make the type system fuzzy.
+
+If multiplication promotes to prevent overflow, so must addition and subtraction (they
+also overflow). Then every arithmetic operation returns a wider type, and having
+different integer widths becomes pointless.
+
+Every mainstream language treats these differently. Python 3: `int / int = float`, but
+`int * int = int`. Rust, Go, C: multiplication wraps, division truncates. Nobody
+auto-promotes multiplication.
+
+**Overflow is a width problem. Division is a domain problem. Different problems,
+different solutions.**
+
+### Divide by Zero
+
+| Scenario             | Option A (`f64`)                                                     | Option B (integer)                               |
+| -------------------- | -------------------------------------------------------------------- | ------------------------------------------------ |
+| `n/0`, `-n/0`, `0/0` | `+Inf`, `-Inf`, `NaN`. Deterministic per IEEE 754.                   | Panic (current), or requires new error handling. |
+| Downstream impact    | `+Inf`, `-Inf`, and `NaN` are all non-truthy. Won't trigger control. | No output, possible cascade failure.             |
+| Debugging            | `+Inf`, `-Inf`, `NaN` visible in the Log view, traceable.            | Depends on resolution.                           |
+| Recovery             | System keeps running.                                                | Depends on resolution.                           |
+
+#### What Option B actually requires
+
+The current behavior before this change is a panic that crashes the flow scheduler. That
+is a bug, not a design choice. If we pursued Option B properly, we would need to resolve
+it. The options are different depending on context:
+
+**Flow nodes** (e.g. `divide{}` in flow statements):
+
+1. **Don't output** (skip the tick). Downstream nodes never fire. The user gets no
+   signal that something went wrong. Silent failure.
+2. **Report an error**. `node.Context` has a `report_error` callback, but it is for
+   logging, not stopping execution. We would need to define what "error" means: stop the
+   whole program? Just this node? Just this tick?
+3. **Output a sentinel value** (e.g. 0). This is lying about the result, which is the
+   original problem.
+
+**WASM functions** (division inside `func` blocks):
+
+WASM already traps on integer divide-by-zero (controlled termination). But division
+backed by host functions returns values, not errors. We would need an error ABI (return
+a tuple, or set a global error flag) to surface the failure.
+
+**The inconsistency problem**: under Option B, a `divide{}` flow node behaves
+differently from division in a `func` block. The user writes the same operation in two
+contexts and gets two different failure modes.
+
+Option A avoids all of this. Both paths produce the same IEEE 754 result. No error
+handling infrastructure needed. No inconsistency between flow and WASM.
+
+### Language Identity
+
+Arc's actual users convert Python scripts and LabVIEW diagrams. The C user is
+hypothetical.
+
+| Context                            | Option A                                               | Option B  |
+| ---------------------------------- | ------------------------------------------------------ | --------- |
+| Arc users converting Python        | Matches Python `/` behavior                            |           |
+| LabVIEW precedent (decades, FPGAs) | Exact same behavior (divide returns DBL)               |           |
+| C behavior expectation             | Addressed by future `//` operator if needed            | Matches C |
+| FPGA deployment concern            | LabVIEW proves float divide works predictably on FPGAs |           |
+
+Designing for a hypothetical C user at the expense of current Python and LabVIEW users
+violates YAGNI.
+
+### Reliability
+
+What does "reliable" mean for a telemetry language?
+
+The operations that preserve input type (add, subtract, multiply, min, max) do so
+because integer inputs always produce exact integer results. Division and power do not
+have that property: `1 / 2` is `0.5`, `2^-1` is `0.5`. Returning `f64` is the
+mathematically correct choice, consistent with how `math.derivative` already works.
+
+The counterargument is that low-level hardware engineers expect C-style integer
+division. Every customer we have spoken to disagrees. They come from Python, LabVIEW, or
+MATLAB, where division returns floats.
+
+### Safety
+
+`+Inf`, `-Inf`, and `NaN` are safe in Arc's control model:
+
+- **Non-truthy**: `isSeriesTruthy` treats `+Inf`, `-Inf`, and `NaN` as non-truthy. They
+  will not trigger control logic.
+- **Visible**: `∞`/`Infinity`, `-∞`/`-Infinity`, and `NaN` already render in the UI.
+  They are not silent.
+- **Consistent**: Both flow nodes and WASM functions produce the same values.
+
+Under Option B, either the system outputs incorrect data (sentinel value of 0), silently
+drops the output (no signal to the user), or behaves differently depending on whether
+the division is in a flow node or a `func` block. All three are worse for safety than a
+visible, non-truthy IEEE 754 value.
+
+---
+
+## Trade Summary
+
+| Criterion            | Option A | Option B                        |
+| -------------------- | -------- | ------------------------------- |
+| Type strictness      | Wins     |                                 |
+| Type consistency     | Wins     |                                 |
+| Precision            | Wins     |                                 |
+| Timestamp precision  |          | Wins (not practically relevant) |
+| Overflow consistency | Wins     |                                 |
+| Divide by zero       | Wins     |                                 |
+| Language identity    | Wins     |                                 |
+| Reliability          | Wins     |                                 |
+| Safety               | Wins     |                                 |
+
+## Recommendation
+
+Option A is the recommended option. It wins on every criterion evaluated in this study
+except timestamp precision, where Option B preserves exact nanosecond values. Under
+Option A, the precision loss is ~2-4 nanoseconds on year-long time deltas.
+
+The intuition behind Option B is reasonable. "The output type should match the input
+type" is a clean mental model, and integer division is familiar to anyone who has
+written C. But that intuition breaks down when applied to operations that are
+mathematically continuous: `1 / 2` is `0.5`, not `0`. Every language that our users
+actually come from (Python, LabVIEW, MATLAB, numpy) resolved this the same way. Option B
+is not more type-safe or strict than Option A. The `/` operator under Option A has a
+single, concrete, compile-time return type (`f64`). That is the definition of
+type-strict. The argument that matching input types is "stricter" confuses a UX
+preference with a type-system property. Option B also introduces more uncertainty,
+unreliability, and therefore, increased risk.
+
+If integer division is needed in the future, `math.floor_division()` (toward negative
+infinity) and `math.quotient()` (truncation toward zero) can be added without changing
+existing behavior.

--- a/docs/tech/rfc/0038-260425-divide-typecast-f64-trade-study.md
+++ b/docs/tech/rfc/0038-260425-divide-typecast-f64-trade-study.md
@@ -17,53 +17,111 @@ operations in Arc, and the behavior of division by zero.
 
 ## Trade Criteria
 
-### Type Strictness and Strong Typing
+### Static and Strong Typing
 
-These terms overlap in casual use but mean different things:
+A common framing of the Option B preference is that Option A "feels less type-safe"
+because the output type differs from the input. That conflates a UX preference with the
+two canonical type-system properties the trade actually turns on:
 
-- **Strictly typed**: Every value has a definite type known at compile time, and the
-  compiler enforces type rules at every boundary.
-- **Strongly typed**: No implicit coercion between unrelated types. The programmer must
-  explicitly convert (e.g., JavaScript's `"5" + 3 = "53"` is weak typing).
+- **Static typing**: every value has a type known at compile time, and the compiler
+  enforces type rules before the program runs.
+- **Strong typing**: the language does not silently coerce values between unrelated
+  types at user-visible boundaries. The programmer must explicitly convert (JavaScript's
+  `"5" + 3 = "53"` is weak typing).
 
-Option A satisfies both. The `/` operator has a **concrete, compile-time return type:
-`f64`**. Always. There is no ambiguity, no runtime coercion, no type that depends on
-context. If you try to assign the result to an `i32` channel, the compiler rejects it
-with a clear error. That is the opposite of "fuzzy."
+These are the standard programming-language type axes: see Pierce, _Types and
+Programming Languages_ (MIT Press, 2002), §1.1, and Cardelli & Wegner, "On Understanding
+Types, Data Abstraction, and Polymorphism" (ACM Computing Surveys, 17(4), 1985). The
+strong/weak distinction converges on "no implicit coercion between unrelated types"
+across [Wikipedia](https://en.wikipedia.org/wiki/Strong_and_weak_typing), Python's
+[language reference](https://docs.python.org/3/reference/datamodel.html), and the
+[Haskell wiki](https://wiki.haskell.org/Type), all of which describe their respective
+languages as strongly typed.
 
-The concern behind Option B is often: "the output type doesn't match the input type, and
-that feels surprising." That is a fair UX reaction, but it is a preference, not a
-type-system property. LabVIEW is considered strongly typed: every wire has an explicit
-type, and the divide node explicitly returns `DBL` (double).
+Option A satisfies both.
 
-**"Type-strict" means the compiler enforces types at every boundary. It does not mean
-outputs must match inputs.**
+**Static.** The `/` operator has a single, concrete, compile-time return type: `f64`.
+The return type does not depend on runtime values, on the inferred type of either
+operand, or on context. The analyzer fixes it during type inference.
+
+**Strong.** Assigning the result of `/` to a non-`f64` destination is a compile error:
+
+```arc
+some_int_channel = sensor_a / sensor_b
+// type mismatch: cannot write f64 to channel 'some_int_channel' (type i32)
+```
+
+The user must explicitly cast (`i32(sensor_a / sensor_b)`) or change the destination.
+There is no silent bridging between unrelated types.
+
+The internal promotion of integer operands to `f64` inside the divide operation is part
+of the operator's defined signature `(T, T) -> f64`, not implicit coercion across the
+type system. Every strongly typed language with numeric operators does this: Python
+(`int / int -> float`), Haskell (typeclass-driven numerics), and LabVIEW (divide node
+returns `DBL` from integer inputs) are all considered strongly typed.
+
+The intuition that "outputs should match inputs" is a reasonable UX preference, but it
+is not what static or strong typing means. LabVIEW is the closest precedent in the
+safety-critical engineering domain Arc targets, and its divide node explicitly returns
+`DBL`.
 
 ### Type System Consistency
 
-**What "consistency" means here.** Option A's consistency is that each operator returns
-a type matching **what the operation actually represents**, not that every operator
-returns its input type. `+`, `-`, `*`, `%` stay in the integer domain because they
-produce exact integer results from integer inputs. `/` and `**` do not, so they return
-`f64`. The rule is in the math (like derivative), not in matching the input datatype,
-which ignores what the operators actually do.
+Two type-consistency criteria are in tension, and the Trade Summary scores them
+separately:
 
-**"Divide and pow behave differently from add/subtract/multiply."**
+- **Type consistency** (this section's primary focus): does each operator's return type
+  match what the operation semantically produces? Closed operators (`+`, `-`, `*`, `%`)
+  stay in the integer domain because their result is exact. Non-closed operators (`/`,
+  `**`) promote to `f64` because their result is continuous. Option A satisfies this;
+  Option B does not.
+- **Same-type rule uniformity**: does one surface rule (operands must match, output type
+  matches input type) apply across all operators? Option B satisfies this; Option A does
+  not, because `/` and `**` are deliberate exceptions.
 
-LabVIEW, numpy, and scipy all have separate divide (float) and quotient (integer)
-operations. This is standard. Both `divide` and `pow` can produce non-integer results
-from integer inputs (`1/2 = 0.5`, `2**-1 = 0.5`), unlike add, subtract, and multiply,
-which always produce exact integers from integer inputs.
+The rest of this section explains why the trade-off resolves toward Option A.
 
-Arc already has precedent: `math.derivative` returns `f64` regardless of input type
-because rate of change is inherently continuous. Division and power have the same
-property.
+**Principle: minimize coercion.** Coercion is the source of the most-cited class of
+silent numeric bugs in industrial control languages. Arc's rule is to require coercion
+to be explicit everywhere it can be, and to apply a single uniform rule where the math
+forces it. Concretely, `+`, `-`, `*`, `%` are closed over the integer domain (integer
+inputs produce exact integer results), so they require same-type operands and offer no
+implicit conversion. `/` and `**` are not closed (`1 / 2 = 0.5`, `2**-1 = 0.5`); they
+are the only binary arithmetic operators whose mathematical answer falls outside the
+input domain for non-trivial inputs. Arc already has this pattern: `math.derivative`
+returns `f64` regardless of input type because rate of change is inherently continuous.
+`/` and `**` share that property.
 
-**"A user might expect `i32 / i32 → i32`."**
+**Cautionary evidence: LabVIEW.** NI's own LabVIEW documentation is the canonical
+reference for what pervasive auto-coercion does in practice. The
+[coercion-dots page](https://www.ni.com/docs/en-US/bundle/labview/page/coercion-dots.html)
+documents `i16(-10) + u16(5)` silently producing `u16(65531)`: LabVIEW promotes the
+signed value to the unsigned type and the answer is wrong by 65,536. NI's recommended
+remediation is to match data types at the wire. Arc adopts the same conclusion
+structurally: do not coerce on `+`, `-`, `*`, `%`. Make the user write the cast.
 
-Arc's users come from Python, LabVIEW, and MATLAB. In all of these environments, `/`
-produces a result in the continuous domain. Customer research confirms this expectation.
-A C-style integer truncation would surprise the majority of Arc's actual users.
+**Precedent for the split: Python 3 and NumPy.** Both already make exactly the split Arc
+proposes:
+
+- **Python 3**: `int(1) + int(2)` returns `int(3)`, but `int(1) / int(2)` returns
+  `float(0.5)`. Same-type rule preserved for closed operators, broken deliberately for
+  `/`.
+- **NumPy**: `np.int32(1) + np.int32(2)` returns `np.int32(3)`, but
+  `np.int32(1) / np.int32(2)` returns `np.float64(0.5)`. Same split. NumPy preserves
+  `f32` when both inputs are `f32`; Arc's choice to promote `f32 / f32` to `f64` extends
+  one step further as part of the single-target-type rule below.
+
+**Single target type, owning the exception.** `/` and `**` always return `f64`,
+regardless of input type. The alternative (return `f32` for `f32` inputs, `f64` for
+everything else) is exactly the input-dependent output-type rule that LabVIEW's docs
+warn about. One rule, uniformly applied, is easier to teach and harder to misuse. This
+is the deliberate exception to the same-type rule that `+`, `-`, `*`, `%` enforce. A
+user can write `i32(1) / f32(2)` but not `i32(1) + f32(2)`, and that is a real
+source-level inconsistency. The exception is justified because the math is different and
+the alternative (`/` and `**` also requiring explicit casts) creates more, not fewer,
+opportunities for the user to silently get the wrong answer (`1 / 2` returns `0`,
+`2**-1` returns `0`). The exception is communicated to the user in the editor via
+operator tooltips (see [§Operator Tooltips](#operator-tooltips)).
 
 Two integer division variants can be added later if requested: `math.floor_division()`
 (round toward negative infinity, Python `//` semantics: `-7 // 2 = -4`) and
@@ -71,39 +129,13 @@ Two integer division variants can be added later if requested: `math.floor_divis
 on negative inputs. YAGNI applies to both. For now, `i32(math.divide(a, b))` works for
 anyone who needs integer output.
 
-**Existing behavior in the Synnax ecosystem:**
-
-In Python, `int(1) / int(3)` returns `float(0.333...)`. In numpy,
-`np.int64(1) / np.int64(3)` returns `float64(0.333...)` and `np.int64(1) / np.int64(0)`
-returns `float64(inf)`. The Synnax Python client's `Series.to_numpy()` returns
-`numpy.ndarray`, so when a user queries two integer series from Synnax and divides them,
-numpy casts to `float64` and produces `+/-Inf`/`NaN` on zero denominators. Option A
-makes Arc consistent with behavior that already exists in our own client library. The
-Python client can already write `+Inf`, `-Inf`, and `NaN` directly to `f64` channels:
-
-```python
-import synnax as sy
-import numpy as np
-
-client = sy.Synnax()
-
-idx = client.channels.retrieve("inf_nan_time")
-ch = client.channels.retrieve("inf_nan_f64")
-
-VALUES = [np.inf, -np.inf, np.nan]
-
-now = sy.TimeStamp.now()
-timestamps = [int(now + i * sy.TimeSpan.SECOND) for i in range(len(VALUES))]
-
-with client.open_writer(start=now, channels=[idx.key, ch.key]) as w:
-    w.write({idx.key: timestamps, ch.key: VALUES})
-```
-
-For power, numpy's `np.power(int, negative_int)` raises `ValueError` entirely rather
-than produce a wrong integer answer. `np.float_power` always returns `float64`. Option A
-uses `float_power` semantics for both `divide` and `pow`.
-
 ### Precision Errors
+
+"Precision" here is proximity to the mathematical answer in the continuous domain, not
+"does the operator return its own defined output." That alternative framing is
+meaningless because every operator passes it by construction: an integer-division `/` is
+trivially "precise" since returning `2` for `7/3` is exactly what it is defined to do.
+The meaningful question is which result lands closer to the mathematical answer.
 
 | Scenario       | Option A (`f64` output)  | Option B (integer output)   |
 | -------------- | ------------------------ | --------------------------- |
@@ -199,12 +231,43 @@ WASM already traps on integer divide-by-zero (controlled termination). But divis
 backed by host functions returns values, not errors. We would need an error ABI (return
 a tuple, or set a global error flag) to surface the failure.
 
-**The inconsistency problem**: under Option B, a `divide{}` flow node behaves
-differently from division in a `func` block. The user writes the same operation in two
-contexts and gets two different failure modes.
-
 Option A avoids all of this. Both paths produce the same IEEE 754 result. No error
-handling infrastructure needed. No inconsistency between flow and WASM.
+handling infrastructure needed.
+
+The implementation cost enumerated here is scored separately in
+[§Error Handling](#error-handling).
+
+### Error Handling
+
+A trade-study criterion separate from §Divide by Zero. §Divide by Zero asks what happens
+for a specific input; this section asks what infrastructure each option requires to
+surface runtime conditions through the type and ABI surface. The conditions in scope are
+divide-by-zero, undefined results (`0/0`), and operations whose result cannot be
+represented in the nominal output type.
+
+**Option A: errors are values.** `+Inf`, `-Inf`, and `NaN` are valid `f64` values that
+propagate through subsequent operations per IEEE 754. The expression `a / b` is
+well-defined for any `a`, `b`: when `b == 0`, the result is `+Inf`, `-Inf`, or `NaN`,
+all fully specified. The user does not write error-handling code at the operator
+boundary; they check for non-finite values where it actually matters (typically before
+writing to a control channel). No new calling-convention surface is required.
+
+**Option B: errors must be plumbed.** Integer divide-by-zero is not a value, so it has
+to be signaled out-of-band. Arc's two execution contexts (flow nodes, `func` blocks)
+need a shared error-ABI surface so the same expression fails the same way in both. The
+plumbing required in each context is enumerated above in
+[§What Option B actually requires](#what-option-b-actually-requires): for flow nodes, a
+definition of what "error" means and how it propagates; for `func` blocks, an
+error-return convention for host functions to match the WASM trap behavior on native
+integer divide. The cross-context divergence under the current implementation is covered
+in [§Reliability and User Expectations](#reliability-and-user-expectations) under
+"Cross-context consistency."
+
+**The trade.** Option A does not require an error-handling system for these operators.
+Option B does, and the cost is a calling-convention extension that touches host-function
+ABIs, the WASM runtime, the flow scheduler, and every consumer of these operators in
+user code. That is a substantial implementation cost the trade summary scores as a
+separate criterion.
 
 ### Language Identity
 
@@ -221,18 +284,72 @@ hypothetical.
 Designing for a hypothetical C user at the expense of current Python and LabVIEW users
 violates YAGNI.
 
-### Reliability
+### Reliability and User Expectations
 
-What does "reliable" mean for a telemetry language?
+Reliability for a telemetry language means three things: the program does what users
+mean, fails visibly when something goes wrong, and behaves the same way across every
+context it can run in. Option A delivers all three; Option B fails on each. The Trade
+Summary scores "Cross-context consistency" as a separate row because it also depends on
+runtime ABI choices, not solely on user-facing behavior; the other two properties are
+scored under "Reliability."
 
-The operations that preserve input type (add, subtract, multiply, min, max) do so
-because integer inputs always produce exact integer results. Division and power do not
-have that property: `1 / 2` is `0.5`, `2**-1` is `0.5`. Returning `f64` is the
-mathematically correct choice, consistent with how `math.derivative` already works.
+**Results match user expectations.** Arc's users come from Python, LabVIEW, MATLAB, and
+numpy, where `/` produces a result in the continuous domain. Customer research confirms
+this expectation. Under Option B, a user writing `1 / 2` and expecting `0.5` gets `0`
+instead, a silent wrong answer fed straight into a control loop. That is the worst kind
+of reliability failure: the program runs, produces a plausible-looking number, and there
+is no signal to the operator until something downstream breaks.
 
-The counterargument is that low-level hardware engineers expect C-style integer
-division. Every customer we have spoken to disagrees. They come from Python, LabVIEW, or
-MATLAB, where division returns floats.
+This expectation already lives in the Synnax ecosystem. In Python, `int(1) / int(3)`
+returns `float(0.333...)`. In numpy, `np.int64(1) / np.int64(3)` returns
+`float64(0.333...)` and `np.int64(1) / np.int64(0)` returns `float64(inf)`. The Synnax
+Python client's `Series.to_numpy()` returns `numpy.ndarray`, so when a user queries two
+integer series from Synnax and divides them, numpy casts to `float64` and produces
+`+/-Inf`/`NaN` on zero denominators. Option A makes Arc consistent with behavior that
+already exists in our own client library. The Python client can already write `+Inf`,
+`-Inf`, and `NaN` directly to `f64` channels:
+
+```python
+import synnax as sy
+import numpy as np
+
+client = sy.Synnax()
+
+idx = client.channels.retrieve("inf_nan_time")
+ch = client.channels.retrieve("inf_nan_f64")
+
+VALUES = [np.inf, -np.inf, np.nan]
+
+now = sy.TimeStamp.now()
+timestamps = [int(now + i * sy.TimeSpan.SECOND) for i in range(len(VALUES))]
+
+with client.open_writer(start=now, channels=[idx.key, ch.key]) as w:
+    w.write({idx.key: timestamps, ch.key: VALUES})
+```
+
+For power, numpy's `np.power(int, negative_int)` raises `ValueError` rather than produce
+a wrong integer answer. `np.float_power` always returns `float64`. Option A uses
+`float_power` semantics for both `divide` and `pow`.
+
+**Cross-context consistency.** The same `/` expression in a `divide{}` flow node and
+inside a WASM `func` block must fail the same way. Under Option A, both produce IEEE 754
+values, identical behavior. Under Option B, a flow node panics and a `func` block traps:
+identical source code with two different failure modes depending on where it runs.
+Closing that gap requires building error-ABI plumbing (return tuples or global error
+flags from host functions) that Option A does not need. The infrastructure cost of
+closing that gap is treated in [§Error Handling](#error-handling).
+
+**Failure visibility.** Under Option A, problems surface as `NaN`/`Inf` in the UI and
+logs. They are loud, traceable, and easy to point at when debugging a misbehaving
+control loop. Under Option B, problems are either silent (integer truncation gives a
+number that looks fine until it doesn't) or catastrophic (a scheduler panic crashes the
+program with no specific signal about which expression caused it). Neither serves an
+operator trying to understand what their program did.
+
+**Output across input range.** Option A produces a meaningful, deterministic result for
+every input combination, including `/0`. Option B has discontinuities: works fine for
+non-zero denominators, panics on zero, and silently truncates for integer division. A
+reliable operator has no cliffs.
 
 ### Safety
 
@@ -244,44 +361,87 @@ MATLAB, where division returns floats.
   divide-by-zero triggering control should check the denominator explicitly.
 - **Visible**: `∞`/`Infinity`, `-∞`/`-Infinity`, and `NaN` already render in the UI.
   They are not silent.
-- **Consistent**: Both flow nodes and WASM functions produce the same values.
 
 Under Option B, either the system outputs incorrect data (sentinel value of 0), silently
 drops the output (no signal to the user), or behaves differently depending on whether
 the division is in a flow node or a `func` block. All three are worse for safety than a
 visible IEEE 754 value with well-defined truthiness semantics.
 
+### Operator Tooltips
+
+Regardless of which option is chosen, `/` and `**` need a tooltip in the editor: their
+behavior is not self-evident from the operator glyph. The question is what mental model
+the tooltip has to teach.
+
+**Option A tooltip** (one sentence):
+
+> `/` and `**` always operate in the continuous domain. Inputs are cast to `f64`; the
+> result is `f64`. Divide-by-zero produces `+Inf`, `-Inf`, or `NaN` per IEEE 754.
+
+**Option B tooltip** (multi-clause):
+
+> `/` truncates toward zero when both inputs are integers. For continuous division, cast
+> inputs explicitly: `f64(a) / f64(b)`. Divide-by-zero behavior differs between flow
+> nodes (panic) and `func` blocks (trap on integer divide, IEEE 754 on float). The same
+> caveats apply to `**` for negative integer exponents (see
+> [§What Option B actually requires](#what-option-b-actually-requires)).
+
+Option A's tooltip is one sentence because the rule is uniform. Option B's tooltip has
+to teach truncation, the explicit-cast workaround, and a cross-context divergence on
+`/0`. Easier-to-teach is the better default. This is also a clean rebuttal to "Option B
+is simpler": its surface model is simpler; its teaching surface is not.
+
+The tooltip is also the mitigation for the same-type rule break. Option A makes `/` and
+`**` exceptions to the rule that `+`, `-`, `*`, `%` enforce, and the tooltip is what
+closes the gap. LabVIEW's defense for its own coercion is that it is graphically
+visible: a red dot appears on the wire where coercion happens. In practice the dot
+reports _that_ coercion happened, not _what the resolved type is_; recovering the actual
+type requires the Probe Tool on a specific wire. Arc already surfaces resolved variable
+types in editor tooltips. An operator tooltip on `/` and `**` describing the `f64`
+promotion combines with that existing surface to give the user full operator-level type
+information at hover, with strictly less friction than a red dot plus a probe action.
+The same-type rule break is real; it is also cheap to mitigate.
+
 ---
 
 ## Trade Summary
 
-| Criterion            | Option A | Option B |
-| -------------------- | -------- | -------- |
-| Type strictness      | ✓        | ✓        |
-| Type consistency     | ✓        |          |
-| Precision            | ✓        |          |
-| Overflow consistency | ✓        |          |
-| Divide by zero       | ✓        |          |
-| Language identity    | ✓        |          |
-| Reliability          | ✓        |          |
-| Safety               | ✓        |          |
+| Criterion                 | Option A | Option B |
+| ------------------------- | -------- | -------- |
+| Static + strong typing    | ✓        | ✓        |
+| Type consistency          | ✓        |          |
+| Same-type rule uniformity |          | ✓        |
+| Precision                 | ✓        |          |
+| Overflow consistency      | ✓        |          |
+| Divide by zero            | ✓        |          |
+| Error handling            | ✓        |          |
+| Language identity         | ✓        |          |
+| Reliability               | ✓        |          |
+| Cross-context consistency | ✓        |          |
+| Safety                    | ✓        |          |
+| Tooltip                   | ✓        |          |
 
 ## Recommendation
 
-Option A is the recommended option. It wins on every criterion evaluated in this study
-except the timestamp precision sub-topic, where Option B preserves exact nanosecond
-values. Under Option A, the precision loss is ~2-4 nanoseconds on year-long time deltas.
+Option A is the recommended option. It wins on every criterion in this study except two.
+On timestamp precision, Option B preserves exact nanosecond values; under Option A, the
+loss is ~2-4 nanoseconds on year-long time deltas. On same-type rule uniformity, Option
+B keeps `/` and `**` under the same surface rule as `+`, `-`, `*`, `%`; under Option A,
+the cost is one operator tooltip teaching a single uniform rule. Both losses are
+bounded. Option B's losses (silent wrong answers from `1 / 2 = 0`, multi-clause tooltip,
+cross-context divergence on `/0`) are not.
 
 The intuition behind Option B is reasonable. "The output type should match the input
 type" is a clean mental model, and integer division is familiar to anyone who has
 written C. But that intuition breaks down when applied to operations that are
 mathematically continuous: `1 / 2` is `0.5`, not `0`. Every language that our users
 actually come from (Python, LabVIEW, MATLAB, numpy) resolved this the same way. Option B
-is not more type-safe or strict than Option A. The `/` operator under Option A has a
-single, concrete, compile-time return type (`f64`). That is the definition of
-type-strict. The argument that matching input types is "stricter" confuses a UX
-preference with a type-system property. Option B also introduces more uncertainty,
-unreliability, and therefore, increased risk.
+is not more type-safe than Option A. The `/` operator under Option A is both statically
+typed (single, concrete, compile-time return type of `f64`) and strongly typed (the
+compiler rejects assignments to non-`f64` destinations without an explicit cast). The
+argument that matching input types is "stricter" confuses a UX preference with a
+type-system property. Option B also introduces more uncertainty, unreliability, and
+therefore, increased risk.
 
 If integer division is needed in the future, `math.floor_division()` (toward negative
 infinity) and `math.quotient()` (truncation toward zero) can be added without changing

--- a/docs/tech/rfc/0038-260425-division-power-f64-typecast.md
+++ b/docs/tech/rfc/0038-260425-division-power-f64-typecast.md
@@ -7,7 +7,7 @@
 
 # 0 - Summary
 
-All `/` and `^` operations in Arc will return `f64` regardless of input type. Division
+All `/` and `**` operations in Arc will return `f64` regardless of input type. Division
 by zero will produce IEEE 754 values (`+Inf`, `-Inf`, `NaN`) instead of panicking and
 crashing the flow scheduler. The
 [trade study](0038-260425-divide-typecast-f64-trade-study.md) evaluates and justifies
@@ -26,9 +26,10 @@ Division and power should produce mathematically correct results by default, not
 silently truncate or panic. The `/` operator should behave the way it does in every
 language Arc's users already know.
 
-**Control safety.** Divide-by-zero must not crash the scheduler or silently activate
-control logic. IEEE 754 special values (`+Inf`, `-Inf`, `NaN`) are deterministic,
-visible in the UI, and non-truthy in Arc's control model.
+**Control safety.** Divide-by-zero must not crash the scheduler. IEEE 754 special values
+(`+Inf`, `-Inf`, `NaN`) are deterministic and visible in the UI. `NaN` (`0/0`) is
+non-truthy and will not trigger control logic. `+Inf` and `-Inf` are truthy, consistent
+with Python and JavaScript semantics.
 
 **Consistency.** Both execution contexts (flow nodes and WASM `func` blocks) should
 produce identical results for the same operation. Under the current behavior, a
@@ -38,12 +39,16 @@ divide-by-zero.
 # 2 - Non-Goals
 
 - **Integer division operators.** `//`, `math.quotient()`, and `math.floor_division()`
-  are future work if requested. This RFC only changes `/` and `^`.
+  are future work if requested. This RFC only changes `/` and `**`.
 - **Modulo type promotion.** `%` will not promote to `f64`. It returns the input type
   (int in, int out; float in, float out). It will be expanded to accept float inputs,
   matching numpy and LabVIEW.
 - **Overflow behavior.** Add, subtract, and multiply continue to return the input type.
   Overflow is a container-width problem, not a numeric-domain problem (see trade study).
+- **Sized integer types.** Whether Arc should keep sized integer types (`i8`, `u32`,
+  etc.) or collapse them into a single `int`/`number` is a separate language design
+  question. Sized types exist because Arc targets hardware telemetry, where channel
+  widths are fixed by the sensor/protocol. This RFC does not change that.
 - **New error handling infrastructure.** IEEE 754 handles divide-by-zero natively. No
   new error ABI, sentinel values, or skip-tick logic is needed.
 
@@ -55,7 +60,7 @@ divide-by-zero.
 | --------------------- | ------------------------- | --------------------------------------------- |
 | `1 / 2`               | `i64(0)`                  | `f64(0.5)`                                    |
 | `7 / 3`               | `i64(2)`                  | `f64(2.333...)`                               |
-| `2 ^ -1`              | `i64(0)`                  | `f64(0.5)`                                    |
+| `2 ** -1`             | `i64(0)`                  | `f64(0.5)`                                    |
 | `n / 0` (integer)     | panic (crashes scheduler) | `f64(+Inf)`                                   |
 | `0 / 0`               | panic (crashes scheduler) | `f64(NaN)`                                    |
 | `a / b * c` (all i64) | `i64` throughout          | `a / b` produces `f64`, `c` promoted to `f64` |
@@ -70,21 +75,38 @@ from integer inputs.
 
 ## 3.2 - Control Safety: `isSeriesTruthy`
 
-`+Inf`, `-Inf`, and `NaN` will all be treated as **non-truthy** values. This will
-prevent divide-by-zero results from triggering downstream control logic:
+`NaN` will be treated as **non-truthy**. `+Inf` and `-Inf` will be treated as
+**truthy**, consistent with Python and JavaScript semantics.
+
+`NaN` arises only from `0/0`, which is genuinely undefined. It has no meaningful
+magnitude, so non-truthy is the correct interpretation. `+Inf` and `-Inf` arise from
+`n/0` where `n ≠ 0`. They represent a real, if extreme, result and behave as truthy:
 
 ```arc
-// sensor_b is 0, so sensor_a / sensor_b = +Inf
-// +Inf is non-truthy, so the valve does NOT open
+// sensor_b is 0 and sensor_a is non-zero, so sensor_a / sensor_b = +Inf
+// +Inf is truthy, so the valve WILL open
+if sensor_a / sensor_b {
+    open_valve()
+}
+
+// sensor_a and sensor_b are both 0, so sensor_a / sensor_b = NaN
+// NaN is non-truthy, so the valve does NOT open
 if sensor_a / sensor_b {
     open_valve()
 }
 ```
 
-All three IEEE 754 special values (`+Inf`, `-Inf`, `NaN`) will follow this rule. A
-divide-by-zero will never silently activate a control path.
+Programs that divide by a potentially-zero denominator should guard explicitly if
+`+Inf`/`-Inf` triggering control is undesirable.
 
-## 3.3 - Future: Integer Division
+## 3.3 - Power Operator Syntax: `^` to `**`
+
+The power operator will change from `^` to `**`, matching Python. `^` is the
+conventional symbol for bitwise XOR in C-family languages, and reserving it for that
+future use avoids a breaking change later. `math.pow` has not been released publicly
+yet, so this is the opportune time to make the swap.
+
+## 3.4 - Future: Integer Division
 
 If integer division (truncating) is needed in the future, it can be added as a `//`
 operator or `math.quotient()` function without changing existing `/` behavior. This
@@ -109,7 +131,7 @@ mirrors the Python 3 distinction between `/` (float) and `//` (integer).
 
 Instead of emitting native WASM division opcodes (e.g. `i64.div_s`), the compiler will
 emit a call to the `math.divide` host function, which will accept operands in their
-native type and return `f64`. This is consistent with how `^` already uses a host
+native type and return `f64`. This is consistent with how `**` already uses a host
 function call.
 
 ## 4.2 - Scalar Power: Compiler
@@ -173,9 +195,15 @@ type. No-op for `f64`.
 
 **Files:** `arc/go/lsp/hover.go`
 
+- The `/` and `**` operators will have LSP hover documentation explicitly stating their
+  `f64` return type and IEEE 754 divide-by-zero behavior. This addresses the
+  discoverability gap between built-in operators and explicit function calls like
+  `math.derivative`, which can be hovered to inspect their return type.
 - `math.divide` hover doc will be updated to note f64 output and IEEE 754 divide-by-zero
   behavior.
 - `math.pow` hover doc will be updated to note f64 output.
+- Variable type inference is visible on hover: `x := 1 / 2` infers `x` as `f64`,
+  surfacing the return type at the assignment site.
 
 # 5 - Migration
 
@@ -240,12 +268,14 @@ New test scenarios required by this change:
 
 - **Division by zero**: `n/0` produces `+Inf`, `-n/0` produces `-Inf`, `0/0` produces
   `NaN` (instead of panicking)
-- **`isSeriesTruthy` on special values**: `+Inf`, `-Inf`, and `NaN` all return
-  non-truthy
+- **`isSeriesTruthy` on special values**: `NaN` returns non-truthy; `+Inf` and `-Inf`
+  return truthy
 - **Integer division output type**: `i32 / i32` returns `f64`, `i64 / i64` returns `f64`
 - **Series integer division output type**: `series<i64> / scalar` returns `series<f64>`
 - **Chained expressions**: `a / b * c` produces `f64` throughout when inputs are integer
-- **f32 precision gain**: `f32 / f32` computed in `f64` produces a more precise result
-- **Negative exponents**: `2 ^ -1` returns `f64(0.5)`, not `i64(0)`
+- **Reduced rounding error for non-64bit inputs**: `f32 / f32` computed in `f64` reduces
+  rounding error in the operation itself, producing a result closer to the true
+  mathematical value
+- **Negative exponents**: `2 ** -1` returns `f64(0.5)`, not `i64(0)`
 - **Type mismatch error**: Assigning `f64` division result to an `i32` channel produces
   a compile-time error

--- a/docs/tech/rfc/0038-260425-division-power-f64-typecast.md
+++ b/docs/tech/rfc/0038-260425-division-power-f64-typecast.md
@@ -1,0 +1,251 @@
+# 38 - Division and Power f64 Typecast
+
+**Feature Name**: Division and Power f64 Typecast <br /> **Start Date**: 2026-04-25
+<br /> **Authors**: Nico Alba <br />
+
+**Related:** [Trade Study](0038-260425-divide-typecast-f64-trade-study.md)
+
+# 0 - Summary
+
+All `/` and `^` operations in Arc will return `f64` regardless of input type. Division
+by zero will produce IEEE 754 values (`+Inf`, `-Inf`, `NaN`) instead of panicking and
+crashing the flow scheduler. The
+[trade study](0038-260425-divide-typecast-f64-trade-study.md) evaluates and justifies
+this decision against the alternative of preserving the input type.
+
+The changes span the analyzer, compiler, WASM host functions, flow node runtime, and
+series operations across Go and C++. `math.divide` will become a private
+(non-user-accessible) implementation detail; users will interact with it through the `/`
+operator and flow node only.
+
+# 1 - Goals
+
+**Reliability and ease of use.** Arc is a high-level telemetry language for operators,
+engineers, and IT professionals. Its users come from Python, LabVIEW, and MATLAB.
+Division and power should produce mathematically correct results by default, not
+silently truncate or panic. The `/` operator should behave the way it does in every
+language Arc's users already know.
+
+**Control safety.** Divide-by-zero must not crash the scheduler or silently activate
+control logic. IEEE 754 special values (`+Inf`, `-Inf`, `NaN`) are deterministic,
+visible in the UI, and non-truthy in Arc's control model.
+
+**Consistency.** Both execution contexts (flow nodes and WASM `func` blocks) should
+produce identical results for the same operation. Under the current behavior, a
+`divide{}` flow node and division inside a `func` block have different failure modes on
+divide-by-zero.
+
+# 2 - Non-Goals
+
+- **Integer division operators.** `//`, `math.quotient()`, and `math.floor_division()`
+  are future work if requested. This RFC only changes `/` and `^`.
+- **Modulo type promotion.** `%` will not promote to `f64`. It returns the input type
+  (int in, int out; float in, float out). It will be expanded to accept float inputs,
+  matching numpy and LabVIEW.
+- **Overflow behavior.** Add, subtract, and multiply continue to return the input type.
+  Overflow is a container-width problem, not a numeric-domain problem (see trade study).
+- **New error handling infrastructure.** IEEE 754 handles divide-by-zero natively. No
+  new error ABI, sentinel values, or skip-tick logic is needed.
+
+# 3 - Behavior Changes
+
+## 3.0 - Before and After
+
+| Expression            | Before (current)          | After (proposed)                              |
+| --------------------- | ------------------------- | --------------------------------------------- |
+| `1 / 2`               | `i64(0)`                  | `f64(0.5)`                                    |
+| `7 / 3`               | `i64(2)`                  | `f64(2.333...)`                               |
+| `2 ^ -1`              | `i64(0)`                  | `f64(0.5)`                                    |
+| `n / 0` (integer)     | panic (crashes scheduler) | `f64(+Inf)`                                   |
+| `0 / 0`               | panic (crashes scheduler) | `f64(NaN)`                                    |
+| `a / b * c` (all i64) | `i64` throughout          | `a / b` produces `f64`, `c` promoted to `f64` |
+
+## 3.1 - What Does NOT Change
+
+Add, subtract, multiply, modulo, bitwise operations, comparisons, and unary negation
+will still return the input type. These operations always produce exact integer results
+from integer inputs, so no typecast is needed. Only division and power are affected,
+because they are the only arithmetic operations that can produce non-integer results
+from integer inputs.
+
+## 3.2 - Control Safety: `isSeriesTruthy`
+
+`+Inf`, `-Inf`, and `NaN` will all be treated as **non-truthy** values. This will
+prevent divide-by-zero results from triggering downstream control logic:
+
+```arc
+// sensor_b is 0, so sensor_a / sensor_b = +Inf
+// +Inf is non-truthy, so the valve does NOT open
+if sensor_a / sensor_b {
+    open_valve()
+}
+```
+
+All three IEEE 754 special values (`+Inf`, `-Inf`, `NaN`) will follow this rule. A
+divide-by-zero will never silently activate a control path.
+
+## 3.3 - Future: Integer Division
+
+If integer division (truncating) is needed in the future, it can be added as a `//`
+operator or `math.quotient()` function without changing existing `/` behavior. This
+mirrors the Python 3 distinction between `/` (float) and `//` (integer).
+
+# 4 - Changes by Layer
+
+## 4.0 - Type Inference: Analyzer
+
+**Files:** `arc/go/analyzer/types/infer_expression.go`
+
+- **`InferMultiplicative`**: When any operator in the expression is `/`, the result type
+  will be forced to `f64` (or `series<f64>` for series operands). Currently, only series
+  division is promoted to f64.
+- **`InferPower`**: Will always return `f64`. Currently it returns the base operand's
+  type.
+
+## 4.1 - Scalar Division: Compiler
+
+**Files:** `arc/go/compiler/expression/binary.go`,
+`arc/go/compiler/expression/compiler.go`
+
+Instead of emitting native WASM division opcodes (e.g. `i64.div_s`), the compiler will
+emit a call to the `math.divide` host function, which will accept operands in their
+native type and return `f64`. This is consistent with how `^` already uses a host
+function call.
+
+## 4.2 - Scalar Power: Compiler
+
+**Files:** `arc/go/compiler/expression/binary.go`
+
+Both operands will be converted to `f64` before calling `math.pow(f64, f64) -> f64`.
+Currently, `math.pow` accepts and returns the input type.
+
+## 4.3 - Hint Stripping and Chained Expressions: Compiler
+
+**Files:** `arc/go/compiler/expression/binary.go`, `arc/go/compiler/resolve/emit.go`
+
+- **Hint stripping**: When the first operator in a multiplicative expression is `/`, the
+  compiler will strip the caller's type hint so operands compile in their natural type.
+  The f64 conversion will be handled by the host function, not by hint propagation.
+- **Chained expressions**: After a division, subsequent operations in the same
+  expression (e.g. `a / b * c`) will convert the right-hand operand to `f64` to match
+  the intermediate result.
+
+## 4.4 - f64 Conversion Helper: WASM Writer
+
+**Files:** `arc/go/compiler/wasm/writer.go`
+
+`WriteConvertToF64(fromType)` will be added to the WASM writer to emit the appropriate
+conversion opcode (`f64.convert_i32_s`, `f64.promote_f32`, etc.) based on the source
+type. No-op for `f64`.
+
+## 4.5 - Host Functions: WASM Runtime
+
+**Files:** `arc/go/stl/math/math.go`, `arc/cpp/stl/math/math.h`
+
+- **`math.divide`** host functions (`divide_i32`, `divide_i64`, `divide_f32`,
+  `divide_f64`, etc.): Will change from `(T, T) -> T` to `(T, T) -> f64`. Integer
+  operands will be cast to `float64` before division, producing IEEE 754 results
+  (`+Inf`, `-Inf`, `NaN`) on division by zero instead of panicking.
+- **`math.pow`** host functions: Will change from `(T, T) -> T` to `(T, T) -> f64`.
+  Integer power will use `math.Pow(float64(base), float64(exp))` instead of the custom
+  `IntPow` utility.
+- **`math.divide` will be private**: The `math.divide` symbol will not be
+  user-accessible. It will serve as an internal implementation backing the `/` operator
+  and the `divide{}` flow node.
+
+## 4.6 - Flow Node Runtime
+
+**Files:** `arc/go/stl/math/math.go`, `arc/go/runtime/node/state.go`
+
+- **`divide{}` flow node**: Will get a dedicated code path (separate from add/subtract/
+  multiply) that outputs `f64` series regardless of input type.
+- **`isSeriesTruthy`**: See [3.2 - Control Safety](#32---control-safety-isseriestruthy).
+
+## 4.7 - Series Operations
+
+**Files:** `x/go/telem/op/gen.go`, `x/go/telem/op/op_generated.go`
+
+- **`DivideXxx` operations** (e.g. `DivideI64`, `DivideU32`): Will change to always
+  output a `Float64T` series. Operands will be cast to `float64` before division.
+- Integer divide-by-zero guard will be removed: `float64` division handles it natively.
+
+## 4.8 - LSP Hover Documentation
+
+**Files:** `arc/go/lsp/hover.go`
+
+- `math.divide` hover doc will be updated to note f64 output and IEEE 754 divide-by-zero
+  behavior.
+- `math.pow` hover doc will be updated to note f64 output.
+
+# 5 - Migration
+
+Existing automation that writes the output of a division or power operation to a
+non-`f64` channel will fail to compile after this change. The compiler will report a
+clear type mismatch error:
+
+```
+type mismatch: cannot write f64 to channel 'some_int_channel' (type i32)
+```
+
+The fix is straightforward: cast the result before writing:
+
+```arc
+// Before (will fail to compile):
+some_int_channel = sensor_a / sensor_b
+
+// After (option 1: cast to match existing channel):
+some_int_channel = i32(sensor_a / sensor_b)
+
+// After (option 2: use an f64 channel instead):
+some_float_channel = sensor_a / sensor_b
+```
+
+The same applies to compound assignment (`/=`) on integer channels, which would need to
+be rewritten as an explicit assignment with a cast.
+
+In practice, integer-to-integer division that silently truncates to `0` (e.g. `1 / 2`)
+is rarely the intended behavior, so most affected programs are likely already producing
+incorrect results.
+
+# 6 - Change Footprint
+
+~30 files, ~1400 insertions, ~1100 deletions.
+
+| Area             | Files | Insertions | Deletions |
+| ---------------- | ----- | ---------- | --------- |
+| Go (production)  | ~10   | ~1000      | ~800      |
+| Go (tests)       | ~15   | ~350       | ~260      |
+| C++ (production) | ~2    | ~35        | ~20       |
+| C++ (tests)      | ~2    | ~25        | ~10       |
+| Python (tests)   | ~1    | ~40        | ~1        |
+
+The Go production numbers are inflated by `op_generated.go` (~700 lines), which is
+auto-generated from `gen.go`. The actual hand-written production changes are ~300 lines
+across ~9 files. The bulk of the test changes are updating expected return types and
+opcodes, not new test logic.
+
+# 7 - Test Coverage
+
+All existing test suites will need to be updated to expect `f64` output from division
+and power:
+
+- **Compiler unit tests**: ~60 entries across expression, statement, and literal tests
+- **Analyzer type inference tests**: Division and power return type expectations
+- **WASM integration tests**: End-to-end execution through wazero
+- **Series operation tests**: `telem/op` generated operation tests
+- **C++ runtime tests**: `math.h` host function tests
+- **Integration tests**: `stl_math.py` end-to-end arc program tests
+
+New test scenarios required by this change:
+
+- **Division by zero**: `n/0` produces `+Inf`, `-n/0` produces `-Inf`, `0/0` produces
+  `NaN` (instead of panicking)
+- **`isSeriesTruthy` on special values**: `+Inf`, `-Inf`, and `NaN` all return
+  non-truthy
+- **Integer division output type**: `i32 / i32` returns `f64`, `i64 / i64` returns `f64`
+- **Series integer division output type**: `series<i64> / scalar` returns `series<f64>`
+- **Chained expressions**: `a / b * c` produces `f64` throughout when inputs are integer
+- **f32 precision gain**: `f32 / f32` computed in `f64` produces a more precise result
+- **Negative exponents**: `2 ^ -1` returns `f64(0.5)`, not `i64(0)`
+- **Type mismatch error**: Assigning `f64` division result to an `i32` channel produces
+  a compile-time error


### PR DESCRIPTION
# Pull Request

[SY-4127](https://linear.app/synnax/issue/SY-4127/refactor-arc-divide-by-0-to-not-panic-on-a-crash)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces two new RFC documents for SY-4127: a trade study and a formal RFC specifying that `/` and `**` in Arc will always return `f64` (with IEEE 754 divide-by-zero semantics), replacing the current behavior of returning the input type and panicking on integer divide-by-zero. The trade study thoroughly covers type theory, precision, reliability, safety, and language identity; the RFC details the implementation plan across the analyzer, compiler, WASM runtime, flow nodes, and series operations.

<h3>Confidence Score: 5/5</h3>

Safe to merge — documentation-only PR with no production code changes.

Both files are new RFC/trade-study markdown documents with no code changes. The two findings are P2 documentation clarity issues that do not affect correctness of the spec's conclusions.

docs/tech/rfc/0038-260425-division-power-f64-typecast.md — minor wording clarifications in §3.2 and §4.3.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/tech/rfc/0038-260425-division-power-f64-typecast.md | New RFC specifying that `/` and `**` always return `f64` with IEEE 754 divide-by-zero behavior; two minor documentation clarity issues found: identical code examples in §3.2 and ambiguous "first operator" wording in §4.3. |
| docs/tech/rfc/0038-260425-divide-typecast-f64-trade-study.md | New trade study evaluating Option A (always f64) vs Option B (preserve input type); comprehensive analysis across type theory, precision, safety, and reliability criteria; no new issues beyond those already addressed in prior review threads. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Arc Expression: a / b or a ** b"] --> B{Analyzer: InferMultiplicative / InferPower}
    B --> C["Force result type to f64"]
    C --> D{Compiler: binary.go}
    D --> E["Strip caller type hint (§4.3)"]
    E --> F["Emit host function call\nmath.divide(T,T) → f64 / math.pow(f64,f64) → f64"]
    F --> G{WASM Runtime}
    G --> H["Cast operands to float64"]
    H --> I{Division by zero?}
    I -- "n/0 (n≠0)" --> J["f64(+Inf) or f64(-Inf)"]
    I -- "0/0" --> K["f64(NaN)"]
    I -- "normal" --> L["f64 result"]
    J --> M{isSeriesTruthy}
    K --> M
    L --> M
    M -- "+Inf / -Inf" --> N["truthy → control fires"]
    M -- "NaN" --> O["non-truthy → control blocked"]
    M -- "normal f64" --> P["truthy if non-zero"]
```

<sub>Reviews (4): Last reviewed commit: ["SY-4127: Reviewer feedback and RFC updat..."](https://github.com/synnaxlabs/synnax/commit/99368dddcb784f8182ee519fbd84777e1caed1e3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=29959343)</sub>

<!-- /greptile_comment -->