### PR TITLE
SY-4136: Merge channel.Service and leaseProxy

### DIFF
--- a/core/pkg/distribution/channel/lease_proxy.go
+++ b/core/pkg/distribution/channel/lease_proxy.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"fmt"
 	"go/types"
-	"sync"
 
 	"github.com/samber/lo"
 	"github.com/synnaxlabs/synnax/pkg/distribution/group"
@@ -30,108 +29,47 @@ import (
 	"github.com/synnaxlabs/x/validate"
 )
 
-type leaseProxy struct {
-	cfg           ServiceConfig
-	leasedCounter *counter
-	freeCounter   *counter
-	group         group.Group
-	table         *gorp.Table[Key, Channel]
-	mu            struct {
-		externalNonVirtualSet *set.Integer[Key]
-		sync.RWMutex
-	}
-	createRouter proxy.BatchFactory[Channel]
-	renameRouter proxy.BatchFactory[renameBatchEntry]
-	keyRouter    proxy.BatchFactory[Key]
-}
-
 const calculatedIndexNameSuffix = "_time"
 
-func newLeaseProxy(
-	ctx context.Context,
-	cfg ServiceConfig,
-	group group.Group,
-	table *gorp.Table[Key, Channel],
-) (*leaseProxy, error) {
-	leasedCounterKey := []byte(cfg.HostResolver.HostKey().String() + ".distribution.channel.leasedCounter")
-	c, err := openCounter(ctx, cfg.ClusterDB, leasedCounterKey)
-	if err != nil {
-		return nil, err
-	}
-	keyRouter := proxy.BatchFactory[Key]{Host: cfg.HostResolver.HostKey()}
-	var externalNonVirtualChannels []Channel
-	if err := table.NewRetrieve().
-		Where(func(_ gorp.Context, c *Channel) (bool, error) {
-			return !c.Internal && !c.Virtual, nil
-		}).
-		Entries(&externalNonVirtualChannels).
-		Exec(ctx, cfg.ClusterDB); err != nil {
-		return nil, err
-	}
-
-	p := &leaseProxy{
-		cfg:           cfg,
-		createRouter:  proxy.BatchFactory[Channel]{Host: cfg.HostResolver.HostKey()},
-		keyRouter:     keyRouter,
-		renameRouter:  proxy.BatchFactory[renameBatchEntry]{Host: cfg.HostResolver.HostKey()},
-		leasedCounter: c,
-		group:         group,
-		table:         table,
-	}
-	p.mu.externalNonVirtualSet = set.NewInteger(KeysFromChannels(externalNonVirtualChannels))
-	if cfg.HostResolver.HostKey() == node.KeyBootstrapper {
-		freeCounterKey := []byte(cfg.HostResolver.HostKey().String() + ".distribution.channel.counter.free")
-		c, err := openCounter(ctx, cfg.ClusterDB, freeCounterKey)
-		if err != nil {
-			return nil, err
-		}
-		p.freeCounter = c
-	}
-	p.cfg.Transport.CreateServer().BindHandler(p.createHandler)
-	p.cfg.Transport.DeleteServer().BindHandler(p.deleteHandler)
-	p.cfg.Transport.RenameServer().BindHandler(p.renameHandler)
-	return p, nil
-}
-
-func (lp *leaseProxy) createHandler(ctx context.Context, msg CreateMessage) (CreateMessage, error) {
-	txn := lp.cfg.ClusterDB.OpenTx()
-	err := lp.create(ctx, txn, &msg.Channels, msg.Opts)
+func (s *Service) createHandler(ctx context.Context, msg CreateMessage) (CreateMessage, error) {
+	txn := s.cfg.ClusterDB.OpenTx()
+	err := s.create(ctx, txn, &msg.Channels, msg.Opts)
 	if err != nil {
 		return CreateMessage{}, err
 	}
 	return CreateMessage{Channels: msg.Channels}, txn.Commit(ctx)
 }
 
-func (lp *leaseProxy) deleteHandler(ctx context.Context, msg DeleteRequest) (types.Nil, error) {
-	txn := lp.cfg.ClusterDB.OpenTx()
-	err := lp.delete(ctx, txn, msg.Keys, false)
+func (s *Service) deleteHandler(ctx context.Context, msg DeleteRequest) (types.Nil, error) {
+	txn := s.cfg.ClusterDB.OpenTx()
+	err := s.delete(ctx, txn, msg.Keys, false)
 	if err != nil {
 		return types.Nil{}, err
 	}
 	return types.Nil{}, txn.Commit(ctx)
 }
 
-func (lp *leaseProxy) renameHandler(ctx context.Context, msg RenameRequest) (types.Nil, error) {
-	txn := lp.cfg.ClusterDB.OpenTx()
-	err := lp.rename(ctx, txn, msg.Keys, msg.Names, false)
+func (s *Service) renameHandler(ctx context.Context, msg RenameRequest) (types.Nil, error) {
+	txn := s.cfg.ClusterDB.OpenTx()
+	err := s.rename(ctx, txn, msg.Keys, msg.Names, false)
 	if err != nil {
 		return types.Nil{}, err
 	}
 	return types.Nil{}, txn.Commit(ctx)
 }
 
-func (lp *leaseProxy) create(ctx context.Context, tx gorp.Tx, _channels *[]Channel, opts CreateOptions) error {
+func (s *Service) create(ctx context.Context, tx gorp.Tx, _channels *[]Channel, opts CreateOptions) error {
 	channels := *_channels
-	if *lp.cfg.ValidateNames {
+	if *s.cfg.ValidateNames {
 		keys := KeysFromChannels(channels)
 		names := Names(channels)
-		if err := lp.validateChannelNames(ctx, tx, keys, names, opts.RetrieveIfNameExists || opts.OverwriteIfNameExistsAndDifferentProperties); err != nil {
+		if err := s.validateChannelNames(ctx, tx, keys, names, opts.RetrieveIfNameExists || opts.OverwriteIfNameExistsAndDifferentProperties); err != nil {
 			return err
 		}
 	}
 	for i, ch := range channels {
 		if ch.Leaseholder == 0 {
-			channels[i].Leaseholder = lp.cfg.HostResolver.HostKey()
+			channels[i].Leaseholder = s.cfg.HostResolver.HostKey()
 		}
 		if ch.IsCalculated() {
 			// Reject manually-specified indexes on calculated channels
@@ -167,47 +105,47 @@ func (lp *leaseProxy) create(ctx context.Context, tx gorp.Tx, _channels *[]Chann
 	// Append index channels to be created alongside calculated channels
 	channels = append(channels, indexChannels...)
 
-	batch := lp.createRouter.Batch(channels)
+	batch := s.createRouter.Batch(channels)
 	oChannels := make([]Channel, 0, len(channels))
 	for nodeKey, entries := range batch.Peers {
-		remoteChannels, err := lp.createRemote(ctx, nodeKey, entries, opts)
+		remoteChannels, err := s.createRemote(ctx, nodeKey, entries, opts)
 		if err != nil {
 			return err
 		}
 		oChannels = append(oChannels, remoteChannels...)
 	}
 	if len(batch.Free) > 0 {
-		if !lp.cfg.HostResolver.HostKey().IsBootstrapper() {
-			remoteChannels, err := lp.createRemote(ctx, node.KeyBootstrapper, batch.Free, opts)
+		if !s.cfg.HostResolver.HostKey().IsBootstrapper() {
+			remoteChannels, err := s.createRemote(ctx, node.KeyBootstrapper, batch.Free, opts)
 			if err != nil {
 				return err
 			}
 			oChannels = append(oChannels, remoteChannels...)
 		} else {
-			if err := lp.createAndUpdateFreeVirtual(ctx, tx, &batch.Free, opts); err != nil {
+			if err := s.createAndUpdateFreeVirtual(ctx, tx, &batch.Free, opts); err != nil {
 				return err
 			}
 			oChannels = append(oChannels, batch.Free...)
 		}
 	}
-	if err := lp.createGateway(ctx, tx, &batch.Gateway, opts); err != nil {
+	if err := s.createGateway(ctx, tx, &batch.Gateway, opts); err != nil {
 		return err
 	}
 	oChannels = append(oChannels, batch.Gateway...)
 	*_channels = oChannels
-	return lp.maybeSetResources(ctx, tx, oChannels, opts)
+	return s.maybeSetResources(ctx, tx, oChannels, opts)
 }
 
-func (lp *leaseProxy) createAndUpdateFreeVirtual(
+func (s *Service) createAndUpdateFreeVirtual(
 	ctx context.Context,
 	tx gorp.Tx,
 	channels *[]Channel,
 	opts CreateOptions,
 ) error {
-	if lp.freeCounter == nil {
-		panic("[leaseProxy] - tried to assign virtual keys on non-bootstrapper")
+	if s.freeCounter == nil {
+		panic("[channel.Service] - tried to assign virtual keys on non-bootstrapper")
 	}
-	if err := lp.validateFreeVirtual(channels); err != nil {
+	if err := s.validateFreeVirtual(channels); err != nil {
 		return err
 	}
 
@@ -216,7 +154,7 @@ func (lp *leaseProxy) createAndUpdateFreeVirtual(
 	// Filter out zero keys (channels that don't exist yet)
 	existingKeys := lo.Filter(keys, func(k Key, _ int) bool { return k != 0 })
 	if len(existingKeys) > 0 {
-		if err := lp.table.NewUpdate().
+		if err := s.table.NewUpdate().
 			WhereKeys(existingKeys...).
 			ChangeErr(
 				func(_ gorp.Context, c Channel) (Channel, error) {
@@ -245,7 +183,7 @@ func (lp *leaseProxy) createAndUpdateFreeVirtual(
 	}
 
 	if opts.OverwriteIfNameExistsAndDifferentProperties {
-		if err := lp.deleteOverwritten(ctx, tx, channels); err != nil {
+		if err := s.deleteOverwritten(ctx, tx, channels); err != nil {
 			return err
 		}
 	}
@@ -270,11 +208,11 @@ func (lp *leaseProxy) createAndUpdateFreeVirtual(
 	// Add these index channels to the list to be created
 	*channels = append(*channels, indexChannelsForExisting...)
 
-	toCreate, err := lp.retrieveExistingAndAssignKeys(
+	toCreate, err := s.retrieveExistingAndAssignKeys(
 		ctx,
 		tx,
 		channels,
-		lp.freeCounter,
+		s.freeCounter,
 		opts.RetrieveIfNameExists,
 	)
 	if err != nil {
@@ -321,7 +259,7 @@ func (lp *leaseProxy) createAndUpdateFreeVirtual(
 		}
 	}
 
-	if err := lp.table.NewCreate().Entries(&toCreate).Exec(ctx,
+	if err := s.table.NewCreate().Entries(&toCreate).Exec(ctx,
 		tx); err != nil {
 		return err
 	}
@@ -329,7 +267,7 @@ func (lp *leaseProxy) createAndUpdateFreeVirtual(
 	// Update existing calculated channels with their new LocalIndex values
 	if len(existingChannelsToUpdate) > 0 {
 		for _, ch := range existingChannelsToUpdate {
-			if err := lp.table.NewUpdate().
+			if err := s.table.NewUpdate().
 				WhereKeys(ch.Key()).
 				Change(func(_ gorp.Context, c Channel) Channel {
 					c.LocalIndex = ch.LocalIndex
@@ -341,10 +279,10 @@ func (lp *leaseProxy) createAndUpdateFreeVirtual(
 		}
 	}
 
-	return lp.maybeSetResources(ctx, tx, toCreate, opts)
+	return s.maybeSetResources(ctx, tx, toCreate, opts)
 }
 
-func (lp *leaseProxy) validateChannelNames(
+func (s *Service) validateChannelNames(
 	ctx context.Context,
 	tx gorp.Tx,
 	keys Keys,
@@ -370,7 +308,7 @@ func (lp *leaseProxy) validateChannelNames(
 		return nil
 	}
 	var conflictingChannels []Channel
-	if err := lp.table.NewRetrieve().
+	if err := s.table.NewRetrieve().
 		Where(func(_ gorp.Context, c *Channel) (bool, error) {
 			return namesSeen.Contains(c.Name), nil
 		}).
@@ -398,7 +336,7 @@ func (lp *leaseProxy) validateChannelNames(
 	return nil
 }
 
-func (lp *leaseProxy) validateFreeVirtual(channels *[]Channel) error {
+func (s *Service) validateFreeVirtual(channels *[]Channel) error {
 	for _, ch := range *channels {
 		if len(ch.Name) == 0 {
 			return validate.PathedError(validate.ErrRequired, "name")
@@ -407,7 +345,7 @@ func (lp *leaseProxy) validateFreeVirtual(channels *[]Channel) error {
 	return nil
 }
 
-func (lp *leaseProxy) retrieveExistingAndAssignKeys(
+func (s *Service) retrieveExistingAndAssignKeys(
 	ctx context.Context,
 	tx gorp.Tx,
 	channels *[]Channel,
@@ -419,7 +357,7 @@ func (lp *leaseProxy) retrieveExistingAndAssignKeys(
 	incCounterBy := LocalKey(len(*channels))
 	if retrieveIfNameExists {
 		names := Names(*channels)
-		if err = lp.table.NewRetrieve().Where(func(_ gorp.Context, c *Channel) (bool, error) {
+		if err = s.table.NewRetrieve().Where(func(_ gorp.Context, c *Channel) (bool, error) {
 			v := lo.IndexOf(names, c.Name)
 			exists := v != -1
 			if exists {
@@ -457,13 +395,13 @@ func (lp *leaseProxy) retrieveExistingAndAssignKeys(
 	return toCreate, nil
 }
 
-func (lp *leaseProxy) deleteOverwritten(
+func (s *Service) deleteOverwritten(
 	ctx context.Context,
 	tx gorp.Tx,
 	channels *[]Channel,
 ) error {
 	storageToDelete := make([]ts.ChannelKey, 0, len(*channels))
-	if err := lp.table.NewDelete().
+	if err := s.table.NewDelete().
 		Where(func(_ gorp.Context, c *Channel) (bool, error) {
 			ch, i, found := lo.FindIndexOf(*channels, func(ch Channel) bool {
 				return ch.Name == c.Name && ch.Key() != c.Key()
@@ -480,26 +418,26 @@ func (lp *leaseProxy) deleteOverwritten(
 		}).Exec(ctx, tx); err != nil {
 		return err
 	}
-	return lp.cfg.TSChannel.DeleteChannels(storageToDelete)
+	return s.cfg.TSChannel.DeleteChannels(storageToDelete)
 }
 
-func (lp *leaseProxy) createGateway(
+func (s *Service) createGateway(
 	ctx context.Context,
 	tx gorp.Tx,
 	channels *[]Channel,
 	opts CreateOptions,
 ) error {
 	if opts.OverwriteIfNameExistsAndDifferentProperties {
-		if err := lp.deleteOverwritten(ctx, tx, channels); err != nil {
+		if err := s.deleteOverwritten(ctx, tx, channels); err != nil {
 			return err
 		}
 	}
 
-	if err := lp.validateFreeVirtual(channels); err != nil {
+	if err := s.validateFreeVirtual(channels); err != nil {
 		return err
 	}
 
-	toCreate, err := lp.retrieveExistingAndAssignKeys(ctx, tx, channels, lp.leasedCounter, opts.RetrieveIfNameExists)
+	toCreate, err := s.retrieveExistingAndAssignKeys(ctx, tx, channels, s.leasedCounter, opts.RetrieveIfNameExists)
 	if err != nil {
 		return err
 	}
@@ -510,39 +448,39 @@ func (lp *leaseProxy) createGateway(
 			externalCreatedKeys = append(externalCreatedKeys, ch.Key())
 		}
 	}
-	lp.mu.Lock()
-	defer lp.mu.Unlock()
-	count := lp.mu.externalNonVirtualSet.Size()
-	if err = lp.cfg.IntOverflowCheck(xtypes.Uint20(int(count) + len(externalCreatedKeys))); err != nil {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	count := s.mu.externalNonVirtualSet.Size()
+	if err = s.cfg.IntOverflowCheck(xtypes.Uint20(int(count) + len(externalCreatedKeys))); err != nil {
 		return err
 	}
 	storageChannels := toStorage(toCreate)
-	if err = lp.cfg.TSChannel.CreateChannel(ctx, storageChannels...); err != nil {
+	if err = s.cfg.TSChannel.CreateChannel(ctx, storageChannels...); err != nil {
 		return err
 	}
-	if err = lp.table.NewCreate().
+	if err = s.table.NewCreate().
 		Entries(&toCreate).
 		Exec(ctx, tx); err != nil {
 		return err
 	}
-	lp.mu.externalNonVirtualSet.Insert(externalCreatedKeys...)
+	s.mu.externalNonVirtualSet.Insert(externalCreatedKeys...)
 	return nil
 
 }
 
-func (lp *leaseProxy) maybeSetResources(
+func (s *Service) maybeSetResources(
 	ctx context.Context,
 	txn gorp.Tx,
 	channels []Channel,
 	opts CreateOptions,
 ) error {
-	if lp.cfg.Ontology == nil || lp.cfg.Group == nil {
+	if s.cfg.Ontology == nil || s.cfg.Group == nil {
 		return nil
 	}
 	externalIDs := lo.FilterMap(channels, func(ch Channel, _ int) (ontology.ID, bool) {
 		return OntologyID(ch.Key()), !ch.Internal
 	})
-	w := lp.cfg.Ontology.NewWriter(txn)
+	w := s.cfg.Ontology.NewWriter(txn)
 	if err := w.DefineManyResources(ctx, externalIDs); err != nil {
 		return err
 	}
@@ -551,45 +489,45 @@ func (lp *leaseProxy) maybeSetResources(
 	}
 	return w.DefineFromOneToManyRelationships(
 		ctx,
-		group.OntologyID(lp.group.Key),
+		group.OntologyID(s.group.Key),
 		ontology.RelationshipTypeParentOf,
 		externalIDs,
 	)
 }
 
-func (lp *leaseProxy) createRemote(
+func (s *Service) createRemote(
 	ctx context.Context,
 	target node.Key,
 	channels []Channel,
 	opts CreateOptions,
 ) ([]Channel, error) {
-	addr, err := lp.cfg.HostResolver.Resolve(target)
+	addr, err := s.cfg.HostResolver.Resolve(target)
 	if err != nil {
 		return nil, err
 	}
 	cm := CreateMessage{Channels: channels, Opts: opts}
-	res, err := lp.cfg.Transport.CreateClient().Send(ctx, addr, cm)
+	res, err := s.cfg.Transport.CreateClient().Send(ctx, addr, cm)
 	if err != nil {
 		return nil, err
 	}
 	return res.Channels, nil
 }
 
-func (lp *leaseProxy) deleteByName(ctx context.Context, tx gorp.Tx, names []string, allowInternal bool) error {
+func (s *Service) deleteByName(ctx context.Context, tx gorp.Tx, names []string, allowInternal bool) error {
 	var res []Channel
-	if err := lp.table.NewRetrieve().Entries(&res).Where(func(ctx gorp.Context, c *Channel) (bool, error) {
+	if err := s.table.NewRetrieve().Entries(&res).Where(func(ctx gorp.Context, c *Channel) (bool, error) {
 		return lo.Contains(names, c.Name), nil
 	}).Exec(ctx, tx); err != nil {
 		return err
 	}
 	keys := KeysFromChannels(res)
-	return lp.delete(ctx, tx, keys, allowInternal)
+	return s.delete(ctx, tx, keys, allowInternal)
 }
 
-func (lp *leaseProxy) delete(ctx context.Context, tx gorp.Tx, keys Keys, allowInternal bool) error {
+func (s *Service) delete(ctx context.Context, tx gorp.Tx, keys Keys, allowInternal bool) error {
 	if !allowInternal {
 		internalChannels := make([]Channel, 0, len(keys))
-		if err := lp.table.NewRetrieve().
+		if err := s.table.NewRetrieve().
 			WhereKeys(keys...).
 			Where(func(ctx gorp.Context, c *Channel) (bool, error) {
 				return c.Internal, nil
@@ -607,66 +545,66 @@ func (lp *leaseProxy) delete(ctx context.Context, tx gorp.Tx, keys Keys, allowIn
 		}
 	}
 
-	batch := lp.keyRouter.Batch(keys)
+	batch := s.keyRouter.Batch(keys)
 	for nodeKey, entries := range batch.Peers {
-		err := lp.deleteRemote(ctx, nodeKey, entries)
+		err := s.deleteRemote(ctx, nodeKey, entries)
 		if err != nil {
 			return err
 		}
 	}
 	if len(batch.Free) > 0 {
-		err := lp.deleteFreeVirtual(ctx, tx, batch.Free)
+		err := s.deleteFreeVirtual(ctx, tx, batch.Free)
 		if err != nil {
 			return err
 		}
 	}
-	if err := lp.deleteGateway(ctx, tx, batch.Gateway); err != nil {
+	if err := s.deleteGateway(ctx, tx, batch.Gateway); err != nil {
 		return err
 	}
-	return lp.maybeDeleteResources(ctx, tx, keys)
+	return s.maybeDeleteResources(ctx, tx, keys)
 }
 
-func (lp *leaseProxy) deleteFreeVirtual(ctx context.Context, tx gorp.Tx, channels Keys) error {
-	return lp.table.NewDelete().WhereKeys(channels...).Exec(ctx, tx)
+func (s *Service) deleteFreeVirtual(ctx context.Context, tx gorp.Tx, channels Keys) error {
+	return s.table.NewDelete().WhereKeys(channels...).Exec(ctx, tx)
 }
 
-func (lp *leaseProxy) deleteGateway(ctx context.Context, tx gorp.Tx, keys Keys) error {
-	if err := lp.table.NewDelete().WhereKeys(keys...).Exec(ctx, tx); err != nil {
+func (s *Service) deleteGateway(ctx context.Context, tx gorp.Tx, keys Keys) error {
+	if err := s.table.NewDelete().WhereKeys(keys...).Exec(ctx, tx); err != nil {
 		return err
 	}
-	if err := lp.maybeDeleteResources(ctx, tx, keys); err != nil {
+	if err := s.maybeDeleteResources(ctx, tx, keys); err != nil {
 		return err
 	}
 	// It's very important that this goes last, as it's the only operation that can fail
 	// without an atomic guarantee.
-	if err := lp.cfg.TSChannel.DeleteChannels(keys.Storage()); err != nil {
+	if err := s.cfg.TSChannel.DeleteChannels(keys.Storage()); err != nil {
 		return err
 	}
-	lp.mu.Lock()
-	lp.mu.externalNonVirtualSet.Remove(keys...)
-	lp.mu.Unlock()
+	s.mu.Lock()
+	s.mu.externalNonVirtualSet.Remove(keys...)
+	s.mu.Unlock()
 	return nil
 }
 
-func (lp *leaseProxy) maybeDeleteResources(
+func (s *Service) maybeDeleteResources(
 	ctx context.Context,
 	tx gorp.Tx,
 	keys Keys,
 ) error {
-	if lp.cfg.Ontology == nil {
+	if s.cfg.Ontology == nil {
 		return nil
 	}
 	ids := lo.Map(keys, func(k Key, _ int) ontology.ID { return OntologyID(k) })
-	w := lp.cfg.Ontology.NewWriter(tx)
+	w := s.cfg.Ontology.NewWriter(tx)
 	return w.DeleteManyResources(ctx, ids)
 }
 
-func (lp *leaseProxy) deleteRemote(ctx context.Context, target node.Key, keys Keys) error {
-	addr, err := lp.cfg.HostResolver.Resolve(target)
+func (s *Service) deleteRemote(ctx context.Context, target node.Key, keys Keys) error {
+	addr, err := s.cfg.HostResolver.Resolve(target)
 	if err != nil {
 		return err
 	}
-	_, err = lp.cfg.Transport.DeleteClient().Send(ctx, addr, DeleteRequest{Keys: keys})
+	_, err = s.cfg.Transport.DeleteClient().Send(ctx, addr, DeleteRequest{Keys: keys})
 	return err
 }
 
@@ -691,7 +629,7 @@ func newRenameBatch(keys Keys, names []string) []renameBatchEntry {
 	})
 }
 
-func (lp *leaseProxy) rename(
+func (s *Service) rename(
 	ctx context.Context,
 	tx gorp.Tx,
 	keys Keys,
@@ -701,38 +639,38 @@ func (lp *leaseProxy) rename(
 	if len(keys) != len(names) {
 		return errors.Wrap(validate.ErrValidation, "keys and names must be the same length")
 	}
-	if *lp.cfg.ValidateNames {
-		if err := lp.validateChannelNames(ctx, tx, keys, names, false); err != nil {
+	if *s.cfg.ValidateNames {
+		if err := s.validateChannelNames(ctx, tx, keys, names, false); err != nil {
 			return err
 		}
 	}
 
-	batch := lp.renameRouter.Batch(newRenameBatch(keys, names))
+	batch := s.renameRouter.Batch(newRenameBatch(keys, names))
 	for nodeKey, entries := range batch.Peers {
 		keys, names := unzipRenameBatch(entries)
-		if err := lp.renameRemote(ctx, nodeKey, keys, names); err != nil {
+		if err := s.renameRemote(ctx, nodeKey, keys, names); err != nil {
 			return err
 		}
 	}
 	if len(batch.Free) > 0 {
 		keys, names := unzipRenameBatch(batch.Free)
-		if err := lp.renameFreeVirtual(ctx, tx, keys, names, allowInternal); err != nil {
+		if err := s.renameFreeVirtual(ctx, tx, keys, names, allowInternal); err != nil {
 			return err
 		}
 	}
 	if len(batch.Gateway) > 0 {
 		keys, names := unzipRenameBatch(batch.Gateway)
-		return lp.renameGateway(ctx, tx, keys, names, allowInternal)
+		return s.renameGateway(ctx, tx, keys, names, allowInternal)
 	}
 	return nil
 }
 
-func (lp *leaseProxy) renameRemote(ctx context.Context, target node.Key, keys Keys, names []string) error {
-	addr, err := lp.cfg.HostResolver.Resolve(target)
+func (s *Service) renameRemote(ctx context.Context, target node.Key, keys Keys, names []string) error {
+	addr, err := s.cfg.HostResolver.Resolve(target)
 	if err != nil {
 		return err
 	}
-	_, err = lp.cfg.Transport.RenameClient().Send(ctx, addr, RenameRequest{Keys: keys, Names: names})
+	_, err = s.cfg.Transport.RenameClient().Send(ctx, addr, RenameRequest{Keys: keys, Names: names})
 	return err
 }
 
@@ -746,19 +684,19 @@ func channelNameUpdater(allowInternal bool, keys Keys, names []string) gorp.Chan
 	}
 }
 
-func (lp *leaseProxy) renameFreeVirtual(ctx context.Context, tx gorp.Tx, channels Keys, names []string, allowInternal bool) error {
-	return lp.table.NewUpdate().
+func (s *Service) renameFreeVirtual(ctx context.Context, tx gorp.Tx, channels Keys, names []string, allowInternal bool) error {
+	return s.table.NewUpdate().
 		WhereKeys(channels...).
 		ChangeErr(channelNameUpdater(allowInternal, channels, names)).
 		Exec(ctx, tx)
 }
 
-func (lp *leaseProxy) renameGateway(ctx context.Context, tx gorp.Tx, keys Keys, names []string, allowInternal bool) error {
-	if err := lp.table.NewUpdate().
+func (s *Service) renameGateway(ctx context.Context, tx gorp.Tx, keys Keys, names []string, allowInternal bool) error {
+	if err := s.table.NewUpdate().
 		WhereKeys(keys...).
 		ChangeErr(channelNameUpdater(allowInternal, keys, names)).
 		Exec(ctx, tx); err != nil {
 		return err
 	}
-	return lp.cfg.TSChannel.RenameChannels(ctx, keys.Storage(), names)
+	return s.cfg.TSChannel.RenameChannels(ctx, keys.Storage(), names)
 }

--- a/core/pkg/distribution/channel/service.go
+++ b/core/pkg/distribution/channel/service.go
@@ -11,11 +11,13 @@ package channel
 
 import (
 	"context"
+	"sync"
 
 	"github.com/synnaxlabs/alamos"
 	"github.com/synnaxlabs/synnax/pkg/distribution/group"
 	"github.com/synnaxlabs/synnax/pkg/distribution/node"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
+	"github.com/synnaxlabs/synnax/pkg/distribution/proxy"
 	"github.com/synnaxlabs/synnax/pkg/distribution/search"
 	"github.com/synnaxlabs/synnax/pkg/storage/ts"
 	"github.com/synnaxlabs/x/config"
@@ -25,21 +27,37 @@ import (
 	"github.com/synnaxlabs/x/observe"
 	"github.com/synnaxlabs/x/override"
 	"github.com/synnaxlabs/x/service"
+	"github.com/synnaxlabs/x/set"
 	"github.com/synnaxlabs/x/types"
 	"github.com/synnaxlabs/x/validate"
 )
 
 // Service is the central entity for managing channels within Synnax's distribution
-// layer. It provides facilities for creating and retrieving channels.
+// layer. It provides facilities for creating, retrieving, renaming, and deleting
+// channels, and owns the cluster-wide lease routing logic that was previously
+// held by a separate leaseProxy type.
 type Service struct {
 	cfg    ServiceConfig
 	db     *gorp.DB
 	closer io.MultiCloser
 	Writer
-	proxy *leaseProxy
 	otg   *ontology.Ontology
 	group group.Group
 	table *gorp.Table[Key, Channel]
+	// leasedCounter and freeCounter drive local-key assignment for
+	// gateway-leased and free-virtual channels respectively. freeCounter is
+	// only populated on the bootstrapper node.
+	leasedCounter *counter
+	freeCounter   *counter
+	// mu guards externalNonVirtualSet, which tracks the key set used by
+	// validateChannels to enforce the uint20 channel-index overflow limit.
+	mu struct {
+		externalNonVirtualSet *set.Integer[Key]
+		sync.RWMutex
+	}
+	createRouter proxy.BatchFactory[Channel]
+	renameRouter proxy.BatchFactory[renameBatchEntry]
+	keyRouter    proxy.BatchFactory[Key]
 }
 
 type IntOverflowChecker = func(types.Uint20) error
@@ -99,7 +117,14 @@ func OpenService(ctx context.Context, cfgs ...ServiceConfig) (s *Service, err er
 	if err != nil {
 		return nil, err
 	}
-	s = &Service{cfg: cfg, db: cfg.ClusterDB, otg: cfg.Ontology}
+	s = &Service{
+		cfg:          cfg,
+		db:           cfg.ClusterDB,
+		otg:          cfg.Ontology,
+		createRouter: proxy.BatchFactory[Channel]{Host: cfg.HostResolver.HostKey()},
+		keyRouter:    proxy.BatchFactory[Key]{Host: cfg.HostResolver.HostKey()},
+		renameRouter: proxy.BatchFactory[renameBatchEntry]{Host: cfg.HostResolver.HostKey()},
+	}
 	cleanup, ok := service.NewOpener(ctx, &s.closer)
 	defer func() { err = cleanup(err) }()
 	if s.table, err = gorp.OpenTable(ctx, gorp.TableConfig[Channel]{
@@ -114,9 +139,29 @@ func OpenService(ctx context.Context, cfgs ...ServiceConfig) (s *Service, err er
 			return nil, err
 		}
 	}
-	if s.proxy, err = newLeaseProxy(ctx, cfg, s.group, s.table); !ok(err, nil) {
+	leasedCounterKey := []byte(cfg.HostResolver.HostKey().String() + ".distribution.channel.leasedCounter")
+	if s.leasedCounter, err = openCounter(ctx, cfg.ClusterDB, leasedCounterKey); !ok(err, nil) {
 		return nil, err
 	}
+	var externalNonVirtualChannels []Channel
+	if err = s.table.NewRetrieve().
+		Where(func(_ gorp.Context, c *Channel) (bool, error) {
+			return !c.Internal && !c.Virtual, nil
+		}).
+		Entries(&externalNonVirtualChannels).
+		Exec(ctx, cfg.ClusterDB); !ok(err, nil) {
+		return nil, err
+	}
+	s.mu.externalNonVirtualSet = set.NewInteger(KeysFromChannels(externalNonVirtualChannels))
+	if cfg.HostResolver.HostKey() == node.KeyBootstrapper {
+		freeCounterKey := []byte(cfg.HostResolver.HostKey().String() + ".distribution.channel.counter.free")
+		if s.freeCounter, err = openCounter(ctx, cfg.ClusterDB, freeCounterKey); !ok(err, nil) {
+			return nil, err
+		}
+	}
+	cfg.Transport.CreateServer().BindHandler(s.createHandler)
+	cfg.Transport.DeleteServer().BindHandler(s.deleteHandler)
+	cfg.Transport.RenameServer().BindHandler(s.renameHandler)
 	s.Writer = s.NewWriter(nil)
 	if cfg.Ontology != nil {
 		cfg.Ontology.RegisterService(s)
@@ -148,20 +193,20 @@ func (s *Service) NewRetrieve() Retrieve {
 // CountExternalNonVirtual returns the number of external non-virtual channels in the
 // service.
 func (s *Service) CountExternalNonVirtual() uint32 {
-	s.proxy.mu.RLock()
-	defer s.proxy.mu.RUnlock()
-	return uint32(s.proxy.mu.externalNonVirtualSet.Size())
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return uint32(s.mu.externalNonVirtualSet.Size())
 }
 
 func (s *Service) Close() error { return s.closer.Close() }
 
 func (s *Service) validateChannels(channels []Channel) ([]Channel, error) {
 	res := make([]Channel, 0, len(channels))
-	s.proxy.mu.RLock()
-	defer s.proxy.mu.RUnlock()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
 	for i, key := range KeysFromChannels(channels) {
-		if s.proxy.mu.externalNonVirtualSet.Contains(key) {
-			channelNumber := s.proxy.mu.externalNonVirtualSet.NumLessThan(key) + 1
+		if s.mu.externalNonVirtualSet.Contains(key) {
+			channelNumber := s.mu.externalNonVirtualSet.NumLessThan(key) + 1
 			if err := s.cfg.IntOverflowCheck(types.Uint20(channelNumber)); err != nil {
 				return nil, err
 			}

--- a/core/pkg/distribution/channel/writer.go
+++ b/core/pkg/distribution/channel/writer.go
@@ -59,7 +59,7 @@ func (w Writer) CreateMany(ctx context.Context, channels *[]Channel, opts ...Cre
 	for _, opt := range opts {
 		opt(&o)
 	}
-	return w.svc.proxy.create(ctx, w.tx, channels, o)
+	return w.svc.create(ctx, w.tx, channels, o)
 }
 
 func (w Writer) Delete(ctx context.Context, key Key, allowInternal bool) error {
@@ -67,7 +67,7 @@ func (w Writer) Delete(ctx context.Context, key Key, allowInternal bool) error {
 }
 
 func (w Writer) DeleteMany(ctx context.Context, keys []Key, allowInternal bool) error {
-	return w.svc.proxy.delete(ctx, w.tx, keys, allowInternal)
+	return w.svc.delete(ctx, w.tx, keys, allowInternal)
 }
 
 func (w Writer) DeleteByName(ctx context.Context, name string, allowInternal bool) error {
@@ -75,7 +75,7 @@ func (w Writer) DeleteByName(ctx context.Context, name string, allowInternal boo
 }
 
 func (w Writer) DeleteManyByNames(ctx context.Context, names []string, allowInternal bool) error {
-	return w.svc.proxy.deleteByName(ctx, w.tx, names, allowInternal)
+	return w.svc.deleteByName(ctx, w.tx, names, allowInternal)
 }
 
 func (w Writer) MapRename(ctx context.Context, names map[string]string, allowInternal bool) error {
@@ -107,5 +107,5 @@ func (w Writer) RenameMany(
 	newNames []string,
 	allowInternal bool,
 ) error {
-	return w.svc.proxy.rename(ctx, w.tx, keys, newNames, allowInternal)
+	return w.svc.rename(ctx, w.tx, keys, newNames, allowInternal)
 }


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4136](https://linear.app/synnax/issue/SY-4136)

## Description

The `leaseProxy` type in `core/pkg/distribution/channel` was tightly coupled to `Service`: the retrieve validator reached into the proxy's mutex (`s.proxy.mu`) to enforce the channel-index overflow check, and the proxy in turn needed `Service`'s `table` and `group` to do its work. This PR removes the indirection by collapsing `leaseProxy` into `Service`:

- `leaseProxy`'s fields (`leasedCounter`, `freeCounter`, `mu`/`externalNonVirtualSet`, `createRouter` / `keyRouter` / `renameRouter`) move onto `Service`.
- `newLeaseProxy`'s setup (counter open, externalNonVirtualSet seed, free-counter open on the bootstrapper, transport handler binding) is inlined into `OpenService`.
- Every `(lp *leaseProxy)` method becomes a `(s *Service)` method. Bodies are otherwise unchanged — same predicates, same error handling, same `WhereKeys` / `Where(func)` calls.
- `Writer` calls (`w.svc.proxy.create`, etc.) become `w.svc.create`, etc.

Behavior is unchanged. The full distribution test suite (24 suites, including all 135 channel specs) passes locally.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR collapses `leaseProxy` into `Service` in `core/pkg/distribution/channel`. All `(lp *leaseProxy)` methods become `(s *Service)` methods, the proxy's fields move directly onto `Service`, and `newLeaseProxy`'s initialization is inlined into `OpenService`. Call-sites in `Writer` are updated accordingly. The refactoring is purely structural — logic bodies are unchanged, and there are no new behavioral differences.

<h3>Confidence Score: 4/5</h3>

Safe to merge — purely structural refactoring with no logic changes, all test suites pass.

The PR is a clean mechanical merge of leaseProxy into Service. All method bodies are identical to the pre-PR code, imports are correctly redistributed, and the mutex/counter semantics are preserved. No new code paths, no new error handling, no behaviour changes. Score of 4 (not 5) only because the handler transactions (createHandler, deleteHandler, renameHandler) have a pre-existing lack of explicit rollback on error — a minor concern that predates this PR but is now more visible as top-level Service methods.

No files require special attention; all changes are trivially mechanical.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| core/pkg/distribution/channel/service.go | Absorbs all leaseProxy fields (leasedCounter, freeCounter, mu/externalNonVirtualSet, routers) and moves newLeaseProxy's init logic inline into OpenService; CountExternalNonVirtual/validateChannels updated to use s.mu directly. |
| core/pkg/distribution/channel/lease_proxy.go | leaseProxy struct and newLeaseProxy constructor removed; all methods re-bound to *Service; import of "sync" dropped (moved to service.go); logic bodies unchanged. |
| core/pkg/distribution/channel/writer.go | Mechanical call-site update: w.svc.proxy.create/delete/deleteByName/rename → w.svc.create/delete/deleteByName/rename. No logic changes. |

</details>

<h3>Class Diagram</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class Service {
        +cfg ServiceConfig
        +db *gorp.DB
        +closer io.MultiCloser
        +otg *ontology.Ontology
        +group group.Group
        +table *gorp.Table[Key, Channel]
        +leasedCounter *counter
        +freeCounter *counter
        +mu struct~externalNonVirtualSet, sync.RWMutex~
        +createRouter proxy.BatchFactory[Channel]
        +renameRouter proxy.BatchFactory[renameBatchEntry]
        +keyRouter proxy.BatchFactory[Key]
        +create(ctx, tx, channels, opts) error
        +delete(ctx, tx, keys, allowInternal) error
        +rename(ctx, tx, keys, names, allowInternal) error
        +createGateway(ctx, tx, channels, opts) error
        +deleteGateway(ctx, tx, keys) error
        +createHandler(ctx, msg) CreateMessage
        +deleteHandler(ctx, msg) Nil
        +renameHandler(ctx, msg) Nil
        +validateChannels(channels) []Channel
        +CountExternalNonVirtual() uint32
    }

    class Writer {
        +svc *Service
        +tx gorp.Tx
        +CreateMany(ctx, channels, opts) error
        +DeleteMany(ctx, keys, allowInternal) error
        +RenameMany(ctx, keys, names, allowInternal) error
    }

    class leaseProxy {
        <<removed>>
    }

    Writer --> Service : delegates to svc (was svc.proxy)
    Service ..> leaseProxy : merged from (pre-PR)
```

<sub>Reviews (1): Last reviewed commit: ["collapse leaseProxy into channel.Service"](https://github.com/synnaxlabs/synnax/commit/bbdc7296c8fc291c1f01a0c2414b4ec2fd2b3843) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30218482)</sub>

<!-- /greptile_comment -->