### PR TITLE
SY-4137: Refactor Telemetry Control Legend to Use Proper Colors

### DIFF
--- a/console/src/schematic/Schematic.tsx
+++ b/console/src/schematic/Schematic.tsx
@@ -29,7 +29,7 @@ import {
   useSyncedRef,
   Viewport,
 } from "@synnaxlabs/pluto";
-import { box, deep, location, type sticky, uuid, xy } from "@synnaxlabs/x";
+import { box, type color, deep, location, type sticky, uuid, xy } from "@synnaxlabs/x";
 import {
   type ReactElement,
   useCallback,
@@ -403,7 +403,7 @@ export const Loaded: Layout.Renderer = ({ layoutKey, visible }) => {
   );
 
   const handleLegendColorsChange = useCallback(
-    (colors: Record<string, string>) =>
+    (colors: Record<string, color.Color>) =>
       syncDispatch(setLegend({ key: layoutKey, legend: { colors } })),
     [layoutKey, syncDispatch],
   );

--- a/console/src/schematic/types/index.ts
+++ b/console/src/schematic/types/index.ts
@@ -16,26 +16,35 @@ import * as v2 from "@/schematic/types/v2";
 import * as v3 from "@/schematic/types/v3";
 import * as v4 from "@/schematic/types/v4";
 import * as v5 from "@/schematic/types/v5";
+import * as v6 from "@/schematic/types/v6";
 
 export type NodeProps = v0.NodeProps;
 export type EdgeProps = v0.EdgeProps;
-export type State = v5.State;
-export type SliceState = v5.SliceState;
+export type State = v6.State;
+export type SliceState = v6.SliceState;
 export type ToolbarTab = v0.ToolbarTab;
 export type ToolbarState = v0.ToolbarState;
-export type LegendState = v1.LegendState;
+export type LegendState = v6.LegendState;
 export type CopyBuffer = v0.CopyBuffer;
-export type AnyState = v0.State | v1.State | v2.State | v3.State | v4.State | v5.State;
+export type AnyState =
+  | v0.State
+  | v1.State
+  | v2.State
+  | v3.State
+  | v4.State
+  | v5.State
+  | v6.State;
 export type AnySliceState =
   | v0.SliceState
   | v1.SliceState
   | v2.SliceState
   | v3.SliceState
   | v4.SliceState
-  | v5.SliceState;
+  | v5.SliceState
+  | v6.SliceState;
 
-export const ZERO_STATE = v5.ZERO_STATE;
-export const ZERO_SLICE_STATE = v5.ZERO_SLICE_STATE;
+export const ZERO_STATE = v6.ZERO_STATE;
+export const ZERO_SLICE_STATE = v6.ZERO_SLICE_STATE;
 
 const STATE_MIGRATIONS: migrate.Migrations = {
   [v0.VERSION]: v1.stateMigration,
@@ -43,6 +52,7 @@ const STATE_MIGRATIONS: migrate.Migrations = {
   [v2.VERSION]: v3.stateMigration,
   [v3.VERSION]: v4.stateMigration,
   [v4.VERSION]: v5.stateMigration,
+  [v5.VERSION]: v6.stateMigration,
 };
 
 const SLICE_MIGRATIONS: migrate.Migrations = {
@@ -51,6 +61,7 @@ const SLICE_MIGRATIONS: migrate.Migrations = {
   [v2.VERSION]: v3.sliceMigration,
   [v3.VERSION]: v4.sliceMigration,
   [v4.VERSION]: v5.sliceMigration,
+  [v5.VERSION]: v6.sliceMigration,
 };
 
 export const migrateState = migrate.migrator<AnyState, State>({
@@ -66,5 +77,5 @@ export const migrateSlice = migrate.migrator<AnySliceState, SliceState>({
 });
 
 export const anyStateZ = z
-  .union([v5.stateZ, v4.stateZ, v3.stateZ, v2.stateZ, v1.stateZ, v0.stateZ])
+  .union([v6.stateZ, v5.stateZ, v4.stateZ, v3.stateZ, v2.stateZ, v1.stateZ, v0.stateZ])
   .transform((state) => migrateState(state));

--- a/console/src/schematic/types/migrations.spec.ts
+++ b/console/src/schematic/types/migrations.spec.ts
@@ -21,6 +21,7 @@ import * as v2 from "@/schematic/types/v2";
 import * as v3 from "@/schematic/types/v3";
 import * as v4 from "@/schematic/types/v4";
 import * as v5 from "@/schematic/types/v5";
+import * as v6 from "@/schematic/types/v6";
 
 describe("migrations", () => {
   describe("state", () => {
@@ -31,6 +32,7 @@ describe("migrations", () => {
       v3.ZERO_STATE,
       v4.ZERO_STATE,
       v5.ZERO_STATE,
+      v6.ZERO_STATE,
     ];
     STATES.forEach((state) => {
       it(`should migrate state from ${state.version} to latest`, () => {
@@ -47,6 +49,7 @@ describe("migrations", () => {
       v3.ZERO_SLICE_STATE,
       v4.ZERO_SLICE_STATE,
       v5.ZERO_SLICE_STATE,
+      v6.ZERO_SLICE_STATE,
     ];
     STATES.forEach((state) => {
       it(`should migrate slice from ${state.version} to latest`, () => {

--- a/console/src/schematic/types/migrations.spec.ts
+++ b/console/src/schematic/types/migrations.spec.ts
@@ -40,6 +40,23 @@ describe("migrations", () => {
         expect({ ...migrated, key: expect.anything() }).toEqual(ZERO_STATE);
       });
     });
+    it("should migrate a v5 state whose legend has no colors", () => {
+      const { colors: _colors, ...legendWithoutColors } = v5.ZERO_STATE.legend;
+      const state = {
+        ...v5.ZERO_STATE,
+        legend: {
+          ...legendWithoutColors,
+          position: { x: 123, y: 456, units: { x: "px", y: "px" } },
+        },
+      } as unknown as v5.State;
+      const migrated = migrateState(state);
+      expect(migrated.legend.colors).toEqual({});
+      expect(migrated.legend.position).toEqual({
+        x: 123,
+        y: 456,
+        units: { x: "px", y: "px" },
+      });
+    });
   });
   describe("slice", () => {
     const STATES = [

--- a/console/src/schematic/types/v6.ts
+++ b/console/src/schematic/types/v6.ts
@@ -55,7 +55,7 @@ export const stateMigration = migrate.createMigration<v5.State, State>({
   migrate: (state) => ({
     ...state,
     version: VERSION,
-    legend: { ...state.legend, colors: migrateColors(state.legend.colors) },
+    legend: { ...state.legend, colors: migrateColors(state.legend.colors ?? {}) },
   }),
 });
 

--- a/console/src/schematic/types/v6.ts
+++ b/console/src/schematic/types/v6.ts
@@ -1,0 +1,76 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { color, migrate } from "@synnaxlabs/x";
+import { z } from "zod";
+
+import * as v1 from "@/schematic/types/v1";
+import * as v5 from "@/schematic/types/v5";
+
+export const VERSION = "6.0.0";
+
+export const legendStateZ = v1.legendStateZ
+  .omit({ colors: true })
+  .extend({ colors: z.record(z.string(), color.colorZ).default({}) });
+export interface LegendState extends z.infer<typeof legendStateZ> {}
+const ZERO_LEGEND_STATE: LegendState = {
+  visible: true,
+  position: { x: 50, y: 50, units: { x: "px", y: "px" } },
+  colors: {},
+};
+
+export const stateZ = v5.stateZ
+  .omit({ version: true, legend: true })
+  .extend({ version: z.literal(VERSION), legend: legendStateZ });
+export interface State extends z.infer<typeof stateZ> {}
+export const ZERO_STATE: State = {
+  ...v5.ZERO_STATE,
+  version: VERSION,
+  legend: ZERO_LEGEND_STATE,
+};
+
+export const sliceStateZ = v5.sliceStateZ
+  .omit({ version: true, schematics: true })
+  .extend({ version: z.literal(VERSION), schematics: z.record(z.string(), stateZ) });
+export interface SliceState extends z.infer<typeof sliceStateZ> {}
+export const ZERO_SLICE_STATE: SliceState = {
+  ...v5.ZERO_SLICE_STATE,
+  version: VERSION,
+  schematics: {},
+};
+
+const migrateColors = (
+  colors: Record<string, string>,
+): Record<string, color.Color> =>
+  Object.fromEntries(
+    Object.entries(colors).map(([key, value]) => [key, color.construct(value)]),
+  );
+
+export const stateMigration = migrate.createMigration<v5.State, State>({
+  name: v1.STATE_MIGRATION_NAME,
+  migrate: (state) => ({
+    ...state,
+    version: VERSION,
+    legend: { ...state.legend, colors: migrateColors(state.legend.colors) },
+  }),
+});
+
+export const sliceMigration = migrate.createMigration<v5.SliceState, SliceState>({
+  name: v1.SLICE_MIGRATION_NAME,
+  migrate: ({ schematics, ...rest }) => ({
+    ...rest,
+    schematics: Object.fromEntries(
+      Object.entries(schematics).map(([key, schematic]) => [
+        key,
+        stateMigration(schematic),
+      ]),
+    ),
+    version: VERSION,
+  }),
+});

--- a/console/src/schematic/types/v6.ts
+++ b/console/src/schematic/types/v6.ts
@@ -45,9 +45,7 @@ export const ZERO_SLICE_STATE: SliceState = {
   schematics: {},
 };
 
-const migrateColors = (
-  colors: Record<string, string>,
-): Record<string, color.Color> =>
+const migrateColors = (colors: Record<string, string>): Record<string, color.Color> =>
   Object.fromEntries(
     Object.entries(colors).map(([key, value]) => [key, color.construct(value)]),
   );

--- a/integration/console/schematic/schematic.py
+++ b/integration/console/schematic/schematic.py
@@ -33,7 +33,7 @@ class SchematicProperties(TypedDict):
     show_control_legend: bool
 
 
-SCHEMATIC_VERSION = "5.0.0"
+SCHEMATIC_VERSION = "6.0.0"
 
 AlignmentType = Literal[
     "vertical",

--- a/pluto/src/telem/control/Legend.tsx
+++ b/pluto/src/telem/control/Legend.tsx
@@ -115,7 +115,7 @@ export const Legend = (props: LegendProps): ReactElement | null => {
 interface LegendEntryProps {
   entryKey: string;
   name: string;
-  color: color.Crude;
+  color: color.Color;
   isSelf: boolean;
   onColorChange: (key: string, color: color.Color) => void;
   onColorPickerVisibleChange: state.Setter<boolean>;

--- a/pluto/src/telem/control/Legend.tsx
+++ b/pluto/src/telem/control/Legend.tsx
@@ -8,7 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { UnexpectedError } from "@synnaxlabs/client";
-import { color, unique } from "@synnaxlabs/x";
+import { type color, unique } from "@synnaxlabs/x";
 import { type ReactElement, useCallback, useEffect, useState } from "react";
 
 import { Aether } from "@/aether";
@@ -36,8 +36,8 @@ const parseSubjectName = (name: string): ParsedName => {
 };
 
 export interface LegendProps extends Omit<Base.SimpleProps, "data" | "onEntryChange"> {
-  colors?: Record<string, string>;
-  onColorsChange?: (colors: Record<string, string>) => void;
+  colors?: Record<string, color.Color>;
+  onColorsChange?: (colors: Record<string, color.Color>) => void;
 }
 
 export const Legend = (props: LegendProps): ReactElement | null => {
@@ -63,8 +63,7 @@ export const Legend = (props: LegendProps): ReactElement | null => {
   } = restProps;
 
   const handleColorChange = useCallback(
-    (key: string, c: color.Crude) =>
-      onColorsChange?.({ ...colors, [key]: color.hex(c) }),
+    (key: string, c: color.Color) => onColorsChange?.({ ...colors, [key]: c }),
     [colors, onColorsChange],
   );
 
@@ -118,7 +117,7 @@ interface LegendEntryProps {
   name: string;
   color: color.Crude;
   isSelf: boolean;
-  onColorChange: (key: string, color: color.Crude) => void;
+  onColorChange: (key: string, color: color.Color) => void;
   onColorPickerVisibleChange: state.Setter<boolean>;
 }
 
@@ -132,7 +131,7 @@ const LegendEntry = ({
 }: LegendEntryProps): ReactElement => {
   const parsed = parseSubjectName(name);
   const handleColorChange = useCallback(
-    (c: color.Crude) => onColorChange(entryKey, c),
+    (c: color.Color) => onColorChange(entryKey, c),
     [entryKey, onColorChange],
   );
   return (

--- a/pluto/src/telem/control/aether/legend.ts
+++ b/pluto/src/telem/control/aether/legend.ts
@@ -8,7 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { channel } from "@synnaxlabs/client";
-import { control, type destructor } from "@synnaxlabs/x";
+import { color, control, type destructor } from "@synnaxlabs/x";
 import { z } from "zod";
 
 import { aether } from "@/aether/aether";
@@ -17,7 +17,7 @@ import { StateProvider, sugaredStateZ } from "@/telem/control/aether/state";
 export const legendStateZ = z.object({
   needsControlOf: channel.keyZ.array(),
   states: sugaredStateZ.array(),
-  colors: z.record(z.string(), z.string()).default({}),
+  colors: z.record(z.string(), color.colorZ).default({}),
 });
 
 interface InternalState {

--- a/pluto/src/telem/control/aether/state.ts
+++ b/pluto/src/telem/control/aether/state.ts
@@ -122,7 +122,7 @@ export class StateProvider extends aether.Composite<
     return this.obs.onChange(cb);
   }
 
-  setColorOverrides(overrides: Record<string, string>): void {
+  setColorOverrides(overrides: Record<string, color.Color>): void {
     const entries = Object.entries(overrides);
     if (
       entries.length === this.colorOverrides.size &&


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4137](https://linear.app/synnax/issue/SY-4137)

## Description

Switches the telemetry control `Legend` from passing colors around as raw hex strings to the typed `color.Color` representation from `@synnaxlabs/x`. The `LegendProps.colors` map, the `onColorsChange` / `onColorChange` callbacks, the aether `legendStateZ` schema, and `StateProvider.setColorOverrides` are all updated to accept and emit `color.Color` values directly, removing the ad hoc `color.hex(...)` conversion at the entry callback site and validating overrides against `color.colorZ` instead of an opaque `z.string()`.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the telemetry control Legend to replace raw `string` hex values with typed `color.Color` values from `@synnaxlabs/x` throughout the stack — `LegendProps.colors`, `onColorsChange`/`onColorChange` callbacks, the aether `legendStateZ` schema, and `StateProvider.setColorOverrides`. A new schematic v6 migration converts persisted hex strings to `color.Color` on load, and tests cover the v5→v6 path including absent `colors` fields.

<h3>Confidence Score: 5/5</h3>

This PR is safe to merge — it is a consistent type-level refactor with a correct migration and no logic regressions.

All changes are a straight substitution of `string` with `color.Color` across a well-defined boundary; the v5→v6 migration correctly handles absent `colors` fields; the aether schema validation is tightened; no runtime behaviour changes beyond type enforcement. The only pre-existing minor redundancy (`color.construct` on an already-typed value) was flagged in a prior review.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| pluto/src/telem/control/aether/state.ts | Updated `setColorOverrides` parameter from `Record<string, string>` to `Record<string, color.Color>`; `color.construct` call on already-typed value is a minor leftover (noted in prior review). |
| pluto/src/telem/control/aether/legend.ts | Replaced `z.string()` with `color.colorZ` in `legendStateZ.colors`; clean and consistent with the rest of the refactor. |
| pluto/src/telem/control/Legend.tsx | Updated `LegendProps`, `LegendEntryProps`, and callbacks to `color.Color`; removed the ad-hoc `color.hex()` conversion; `color` import narrowed to type-only since no runtime usage remains. |
| console/src/schematic/types/v6.ts | New v6 schema and migrations converting `Record<string, string>` legend colors to `color.Color`; handles absent `colors` field via `?? {}` guard. |
| console/src/schematic/types/index.ts | Re-exports updated to point to v6; v5→v6 migration steps added to both STATE_MIGRATIONS and SLICE_MIGRATIONS; `anyStateZ` union updated correctly. |
| console/src/schematic/types/migrations.spec.ts | Tests updated with v6 ZERO states; new dedicated test covers v5 state missing the `colors` field, confirming robust migration. |
| console/src/schematic/Schematic.tsx | `handleLegendColorsChange` callback type updated from `Record<string, string>` to `Record<string, color.Color>`; `color` type imported from `@synnaxlabs/x`. |
| integration/console/schematic/schematic.py | Version string bumped from `5.0.0` to `6.0.0` to match the new schema version. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["LegendProps.colors\nRecord<string, color.Color>"] --> B["Legend component\n(Legend.tsx)"]
    B --> C["handleColorChange\n(key, c: color.Color)"]
    C --> D["onColorsChange callback\nRecord<string, color.Color>"]
    D --> E["Schematic.handleLegendColorsChange\n(Schematic.tsx)"]
    E --> F["Redux: setLegend\n{ colors: Record<string, color.Color> }"]
    B --> G["Aether.use / setState\nlegendStateZ (colors: color.colorZ)"]
    G --> H["StateProvider.setColorOverrides\nRecord<string, color.Color>"]
    I["Persisted v5 State\ncolors: Record<string, string>"] -->|"v6 migration\nmigrateColors()"| J["v6 State\ncolors: Record<string, color.Color>"]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `pluto/src/telem/control/aether/state.ts`, line 137 ([link](https://github.com/synnaxlabs/synnax/blob/0869e0c648a36923a2b073227c757b701482b3dd/pluto/src/telem/control/aether/state.ts#L137)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Redundant `color.construct` on already-typed `color.Color`**

   `overrides` is now `Record<string, color.Color>`, so each `value` is already a fully-constructed `color.Color`. Wrapping it in `color.construct(value)` is likely a no-op, but it's leftover from when the parameter was `Record<string, string>`. Consider removing it for clarity, unless you intentionally want a defensive normalization step.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (6): Last reviewed commit: ["bump integration test SCHEMATIC\_VERSION ..."](https://github.com/synnaxlabs/synnax/commit/21b757635ef80e9e2006ebd1274db55e5fe1925e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30221409)</sub>

<!-- /greptile_comment -->