### PR TITLE
SY-4142: Fix Flaky Deferred-Methods Confluence Test

### DIFF
--- a/x/go/confluence/confluence_test.go
+++ b/x/go/confluence/confluence_test.go
@@ -93,6 +93,7 @@ var _ = Describe("Confluence", func() {
 			i.Inlet() <- 1
 			_, ok := <-o.Outlet()
 			Expect(ok).To(BeFalse())
+			Expect(ctx.Wait()).To(MatchError(ContainSubstring("got 1")))
 			Expect(a.Value()).To(BeEquivalentTo(10))
 		})
 	})


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4142](https://linear.app/synnax/issue/SY-4142)

## Description

The `Confluence > Options > Should still run deferred methods after panic` test
in `x/go/confluence/confluence_test.go` was flaky. It was using the output
stream closing as a proxy for "all deferred functions have run", but
`signal`'s deferrals execute in LIFO order, and `CloseOutputInletsOnExit`
appends its close-inlets deferral last via `AttachClosables` inside `seg.Flow`,
so it runs first. When `<-o.Outlet()` unblocked, the user's
`Defer(func() { a.Add(10) })` had not necessarily run yet, so `a.Value()`
could still observe `0` instead of `10`.

The fix waits on `ctx.Wait()` before asserting on `a.Value()`. `ctx.Wait`
only returns after the routine and all of its deferrals have completed,
making the assertion deterministic regardless of deferral order.

Verified locally: under `--until-it-fails`, the prior test failed within ~800
attempts; with the fix it passes 2,000 sequential `--repeat` runs and the full
36-spec Confluence suite remains green.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a flaky test in `x/go/confluence/confluence_test.go` by adding a `ctx.Wait()` call before asserting on the deferred counter value. The root cause was that `<-o.Outlet()` unblocking was not a reliable proxy for "all deferrals have run" — `CloseOutputInletsOnExit` registers its close deferral last (via `AttachClosables`), so it runs first in LIFO order, and the user-supplied `Defer(func() { a.Add(10) })` could still be pending when the assertion ran.

<h3>Confidence Score: 5/5</h3>

This is a minimal, targeted test fix with no production code changes — safe to merge.

Single-line addition that correctly synchronizes on ctx.Wait() before asserting deferred state. The fix is consistent with the pattern already used on line 63 of the same file. No logic, API surface, or production code is modified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| x/go/confluence/confluence_test.go | Added `ctx.Wait()` assertion before checking deferred counter value, fixing a race condition that caused flaky test results due to LIFO deferral ordering. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test
    participant seg
    participant signal.Context as ctx
    participant Defer as Defer(a.Add(10))
    participant CloseOutputInlets

    Test->>seg: i.Inlet() <- 1
    seg->>ctx: panic("got 1") recovered as error
    Note over ctx: goroutine exits, runs deferrals in LIFO order
    ctx->>CloseOutputInlets: runs first (registered last)
    CloseOutputInlets-->>Test: o.Outlet() closes (unblocks <-o.Outlet())
    Note over Test: Before fix: assert a.Value() here (race!)
    ctx->>Defer: runs second
    Defer-->>ctx: a.Add(10) completes
    ctx-->>Test: ctx.Wait() returns (all deferrals done)
    Note over Test: After fix: assert a.Value() here (deterministic)
```

<sub>Reviews (1): Last reviewed commit: ["SY-4142: Fix flaky deferred-methods Conf..."](https://github.com/synnaxlabs/synnax/commit/42b0c1be48c2324849c37e4be7731cc08655a855) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30353588)</sub>

<!-- /greptile_comment -->