### PR TITLE
SY-4143: Dot Module Notation Fixes

### DIFF
--- a/arc/cpp/stl/selector/selector_test.cpp
+++ b/arc/cpp/stl/selector/selector_test.cpp
@@ -416,16 +416,4 @@ TEST(SelectTest, PropagatesAlignmentAndTimeRange) {
     EXPECT_EQ(checker.output_time(1)->time_range, x::telem::TimeRange(1000, 2000));
 }
 
-TEST(SelectorModuleTest, CreatesNodeWithQualifiedTypeViaMultiFactory) {
-    TestSetup setup;
-    auto ir_node = setup.ir.nodes[1];
-    ir_node.type = "selector.select";
-
-    auto module = std::make_shared<Module>();
-    runtime::node::MultiFactory multi({module});
-    auto node = ASSERT_NIL_P(
-        multi.create(runtime::node::Config(setup.ir, ir_node, setup.make_select_node()))
-    );
-    ASSERT_NE(node, nullptr);
-}
 }

--- a/arc/go/analyzer/constraints/unify.go
+++ b/arc/go/analyzer/constraints/unify.go
@@ -140,7 +140,7 @@ func concreteTypeForHint(t types.Type) string {
 		switch t.Constraint.Kind {
 		case types.KindIntegerConstant:
 			return "i64"
-		case types.KindFloatConstant, types.KindNumericConstant, types.KindSignedNumericConstant, types.KindExactIntegerFloatConstant:
+		case types.KindFloatConstant, types.KindNumericConstant, types.KindExactIntegerFloatConstant:
 			return "f64"
 		}
 	}
@@ -206,16 +206,6 @@ func (s *System) unifyTypeVariableWithVisited(
 	visiting set.Set[string],
 ) error {
 	if existing, exists := s.Substitutions[tv.Name]; exists {
-		// If the type variable has a SignedNumericConstraint and the existing
-		// substitution is the signed promotion of the incoming type, the
-		// unification already succeeded on a prior iteration.
-		if tv.Constraint != nil && tv.Constraint.Kind == types.KindSignedNumericConstant &&
-			existing.IsNumeric() && other.IsNumeric() {
-			promoted := types.PromoteUnsignedToSigned(other)
-			if types.Equal(existing, promoted) || types.Equal(existing, other) {
-				return nil
-			}
-		}
 		// Type variable already has a substitution
 		// If we're in a compatible context with numeric types, we may need to promote
 		// BUT: Only promote if both are CONCRETE types. If either is a type variable,
@@ -265,15 +255,6 @@ func (s *System) unifyTypeVariableWithVisited(
 				other,
 			)
 		}
-	} else if tv.Constraint.Kind == types.KindSignedNumericConstant {
-		if !checkType.IsNumeric() {
-			return errors.Wrapf(
-				ErrConstraintViolation,
-				"%v does not satisfy numeric constraint",
-				other,
-			)
-		}
-		other = types.PromoteUnsignedToSigned(other)
 	} else if tv.Constraint.Kind == types.KindIntegerConstant {
 		// Integer constraint: accepts any numeric type (for literal coercion)
 		// Integer literals can be coerced to floats: `x f32 := 42` is valid
@@ -310,7 +291,6 @@ func (s *System) unifyTypeVariableWithVisited(
 	isConstraintKind := tv.Constraint != nil && (tv.Constraint.Kind == types.KindIntegerConstant ||
 		tv.Constraint.Kind == types.KindFloatConstant ||
 		tv.Constraint.Kind == types.KindNumericConstant ||
-		tv.Constraint.Kind == types.KindSignedNumericConstant ||
 		tv.Constraint.Kind == types.KindExactIntegerFloatConstant)
 
 	if !isConstraintKind && tv.Constraint != nil && !types.Equal(*tv.Constraint, other) {
@@ -337,7 +317,7 @@ func defaultTypeForConstraint(constraint types.Type) types.Type {
 	switch constraint.Kind {
 	case types.KindIntegerConstant:
 		return types.I64()
-	case types.KindFloatConstant, types.KindNumericConstant, types.KindSignedNumericConstant, types.KindExactIntegerFloatConstant:
+	case types.KindFloatConstant, types.KindNumericConstant, types.KindExactIntegerFloatConstant:
 		return types.F64()
 	default:
 		return constraint

--- a/arc/go/analyzer/constraints/unify_test.go
+++ b/arc/go/analyzer/constraints/unify_test.go
@@ -295,7 +295,6 @@ var _ = Describe("Type Unification", func() {
 		DescribeTable("should default constraint to expected type",
 			testDefault,
 			Entry("numeric → f64", types.NumericConstraint(), types.F64()),
-			Entry("signed numeric → f64", types.SignedNumericConstraint(), types.F64()),
 			Entry("integer → i64", types.IntegerConstraint(), types.I64()),
 			Entry("float → f64", types.FloatConstraint(), types.F64()),
 			Entry("f32 → f32", types.F32(), types.F32()),
@@ -584,68 +583,6 @@ var _ = Describe("Type Unification", func() {
 			Expect(ok).To(BeTrue())
 			Expect(ue.Hint).To(ContainSubstring("use"))
 			Expect(ue.Hint).To(ContainSubstring("to convert"))
-		})
-	})
-
-	Describe("SignedNumericConstraint", func() {
-		It("should promote u8 to i16", func() {
-			var (
-				system     = constraints.New()
-				constraint = types.SignedNumericConstraint()
-				tv         = types.Variable("T", &constraint)
-			)
-			Expect(system.AddEquality(tv, types.U8(), nil, "T = u8")).To(Succeed())
-			Expect(system.Unify()).To(Succeed())
-			Expect(system.Substitutions["T"]).To(Equal(types.I16()))
-		})
-		It("should promote u16 to i32", func() {
-			var (
-				system     = constraints.New()
-				constraint = types.SignedNumericConstraint()
-				tv         = types.Variable("T", &constraint)
-			)
-			Expect(system.AddEquality(tv, types.U16(), nil, "T = u16")).To(Succeed())
-			Expect(system.Unify()).To(Succeed())
-			Expect(system.Substitutions["T"]).To(Equal(types.I32()))
-		})
-		It("should promote u64 to f64", func() {
-			var (
-				system     = constraints.New()
-				constraint = types.SignedNumericConstraint()
-				tv         = types.Variable("T", &constraint)
-			)
-			Expect(system.AddEquality(tv, types.U64(), nil, "T = u64")).To(Succeed())
-			Expect(system.Unify()).To(Succeed())
-			Expect(system.Substitutions["T"]).To(Equal(types.F64()))
-		})
-		It("should not promote signed types", func() {
-			var (
-				system     = constraints.New()
-				constraint = types.SignedNumericConstraint()
-				tv         = types.Variable("T", &constraint)
-			)
-			Expect(system.AddEquality(tv, types.I32(), nil, "T = i32")).To(Succeed())
-			Expect(system.Unify()).To(Succeed())
-			Expect(system.Substitutions["T"]).To(Equal(types.I32()))
-		})
-		It("should reject non-numeric types", func() {
-			var (
-				system     = constraints.New()
-				constraint = types.SignedNumericConstraint()
-				tv         = types.Variable("T", &constraint)
-			)
-			Expect(system.AddEquality(tv, types.String(), nil, "T = string")).To(MatchError(ContainSubstring("is not compatible with")))
-		})
-		It("should accept re-unification with the original unsigned type", func() {
-			var (
-				system     = constraints.New()
-				constraint = types.SignedNumericConstraint()
-				tv         = types.Variable("T", &constraint)
-			)
-			Expect(system.AddEquality(tv, types.U8(), nil, "T = u8")).To(Succeed())
-			Expect(system.AddEquality(tv, types.U8(), nil, "T = u8 again")).To(Succeed())
-			Expect(system.Unify()).To(Succeed())
-			Expect(system.Substitutions["T"]).To(Equal(types.I16()))
 		})
 	})
 

--- a/arc/go/compiler/expression/compiler.go
+++ b/arc/go/compiler/expression/compiler.go
@@ -219,17 +219,7 @@ func compileFunctionCallExpr(
 		concreteInputs[i].Type = argType
 		if paramType.Kind == types.KindVariable && argType.Kind != types.KindNumericConstant &&
 			argType.Kind != types.KindIntegerConstant && argType.Kind != types.KindFloatConstant {
-			resolvedArg := argType
-			if paramType.Constraint != nil && paramType.Constraint.Kind == types.KindSignedNumericConstant {
-				resolvedArg = types.PromoteUnsignedToSigned(argType)
-				if !types.Equal(resolvedArg, argType) {
-					if err := EmitCast(ctx, argType, resolvedArg); err != nil {
-						return types.Type{}, err
-					}
-					concreteInputs[i].Type = resolvedArg
-				}
-			}
-			varMap[paramType.Name] = resolvedArg
+			varMap[paramType.Name] = argType
 		}
 		if !types.Equal(argType, paramType) && paramType.Kind != types.KindVariable {
 			if err := EmitCast(ctx, argType, paramType); err != nil {

--- a/arc/go/graph/graph_test.go
+++ b/arc/go/graph/graph_test.go
@@ -1131,7 +1131,7 @@ var _ = Describe("Graph", func() {
 	})
 
 	Describe("Qualified Module Names", func() {
-		It("Should analyze selector.select with qualified name", func(ctx SpecContext) {
+		It("Should analyze bare select", func(ctx SpecContext) {
 			g := arc.Graph{
 				Functions: []ir.Function{
 					{
@@ -1152,7 +1152,7 @@ var _ = Describe("Graph", func() {
 					},
 					{
 						Key:  "sel",
-						Type: "selector.select",
+						Type: "select",
 					},
 				},
 				Edges: []ir.Edge{

--- a/arc/go/lsp/hover.go
+++ b/arc/go/lsp/hover.go
@@ -353,7 +353,7 @@ var keywordDocs = map[string]string{
 	"math.min":        runningStatDoc("math.min", "minimum"),
 	"math.max":        runningStatDoc("math.max", "maximum"),
 	"math.derivative": simpleFuncDoc("math.derivative", "Computes the rate of change (derivative) of input values. Output is always f64.", "sensor -> math.derivative{} -> rate_output"),
-	"selector.select": simpleFuncDoc("selector.select", "Routes input values to 'true' or 'false' outputs. Values equal to 1 are routed to the true output; all others to false.", "flag -> selector.select{} -> {\n    true: open_valve,\n    false: shut_valve\n}"),
+	"select":          simpleFuncDoc("select", "Routes input values to 'true' or 'false' outputs. Values equal to 1 are routed to the true output; all others to false.", "flag -> select{} -> {\n    true: open_valve,\n    false: shut_valve\n}"),
 	"stable.for":      simpleFuncDoc("stable.for", "Emits a value only after it has remained stable for a specified duration. Prevents spurious signals from transient fluctuations.", "sensor -> stable.for{duration=5s} -> output"),
 	"stable_for":      deprecatedDoc("stable_for", "stable.for{}", "sensor -> stable.for{duration=5s} -> output"),
 	"len":             simpleFuncDoc("len", "Returns the length of a series or string as i64.", "length := len(data)"),

--- a/arc/go/lsp/hover_test.go
+++ b/arc/go/lsp/hover_test.go
@@ -147,19 +147,19 @@ var _ = Describe("Hover", func() {
 			Expect(hover.Contents.Value).To(ContainSubstring("running average"))
 		})
 
-		It("should provide hover for 'selector.select' function", func(ctx SpecContext) {
-			content := "flag -> selector.select{} -> output"
+		It("should provide hover for 'select' function", func(ctx SpecContext) {
+			content := "flag -> select{} -> output"
 			OpenArcDocument(server, ctx, uri, content)
 
 			hover := MustSucceed(server.Hover(ctx, &protocol.HoverParams{
 				TextDocumentPositionParams: protocol.TextDocumentPositionParams{
 					TextDocument: protocol.TextDocumentIdentifier{URI: uri},
-					Position:     protocol.Position{Line: 0, Character: 16},
+					Position:     protocol.Position{Line: 0, Character: 11},
 				},
 			}))
 
 			Expect(hover).ToNot(BeNil())
-			Expect(hover.Contents.Value).To(ContainSubstring("#### selector.select"))
+			Expect(hover.Contents.Value).To(ContainSubstring("#### select"))
 			Expect(hover.Contents.Value).To(ContainSubstring("Routes input values"))
 		})
 

--- a/arc/go/routing_table_test.go
+++ b/arc/go/routing_table_test.go
@@ -590,15 +590,15 @@ var _ = Describe("Routing Table Runtime", func() {
 		})
 	})
 
-	Describe("Routing with selector.select{}", func() {
-		It("Should use selector.select to route a boolean channel using qualified name", func(ctx SpecContext) {
+	Describe("Routing with select{}", func() {
+		It("Should use select to route a boolean channel", func(ctx SpecContext) {
 			resolver := channelSymbols(map[string]channelDef{
 				"flag":     {types.U8(), 100},
 				"open_cmd": {types.U8(), 200},
 				"shut_cmd": {types.U8(), 300},
 			})
 			h := newRuntimeHarness(ctx, `
-				flag -> selector.select{} -> {
+				flag -> select{} -> {
 					true: open_valve,
 					false: shut_valve
 				}
@@ -625,9 +625,9 @@ var _ = Describe("Routing Table Runtime", func() {
 			h.Tick(ctx, telem.Millisecond)
 			h.channelState.ClearReads()
 
-			selectTrue := h.Output("selector.select_0", 0)
+			selectTrue := h.Output("select_0", 0)
 			Expect(selectTrue.Len()).To(Equal(int64(1)))
-			selectFalse := h.Output("selector.select_0", 1)
+			selectFalse := h.Output("select_0", 1)
 			Expect(selectFalse.Len()).To(Equal(int64(0)))
 
 			out, changed := h.Flush()

--- a/arc/go/stl/selector/selector.go
+++ b/arc/go/stl/selector/selector.go
@@ -54,19 +54,7 @@ var (
 			},
 		}),
 	}
-	deprecatedBare = symbol.Symbol{
-		Name:       symbolName,
-		Kind:       symbol.KindFunction,
-		Exec:       symbol.ExecFlow,
-		Deprecated: "selector.select",
-		Type:       symbolSelect.Type,
-	}
-	bareResolver   = symbol.MapResolver{symbolName: deprecatedBare}
-	moduleMembers  = symbol.MapResolver{symbolName: symbolSelect}
-	SymbolResolver = symbol.CompoundResolver{
-		bareResolver,
-		&symbol.ModuleResolver{Name: "selector", Members: moduleMembers},
-	}
+	SymbolResolver = symbol.MapResolver{symbolName: symbolSelect}
 )
 
 type Module struct{}

--- a/arc/go/stl/selector/selector_test.go
+++ b/arc/go/stl/selector/selector_test.go
@@ -362,14 +362,12 @@ var _ = Describe("Select", func() {
 			Expect(sym.Name).To(Equal("select"))
 			Expect(sym.Kind).To(Equal(symbol.KindFunction))
 		})
-		It("Should resolve qualified selector.select symbol", func(ctx SpecContext) {
-			sym := MustSucceed(selector.SymbolResolver.Resolve(ctx, "selector.select"))
-			Expect(sym.Name).To(Equal("select"))
-			Expect(sym.Kind).To(Equal(symbol.KindFunction))
+		It("Should not resolve qualified selector.select symbol", func(ctx SpecContext) {
+			Expect(selector.SymbolResolver.Resolve(ctx, "selector.select")).Error().To(MatchError(query.ErrNotFound))
 		})
 	})
 	Describe("Factory", func() {
-		It("Should create node for selector.select via CompoundFactory", func(ctx SpecContext) {
+		It("Should create node for bare select via CompoundFactory", func(ctx SpecContext) {
 			g := graph.Graph{
 				Nodes: []graph.Node{
 					{Key: "source", Type: "source"},
@@ -405,7 +403,7 @@ var _ = Describe("Select", func() {
 			s := node.New(analyzed)
 			compound := node.CompoundFactory{selector.NewModule()}
 			cfg := node.Config{
-				Node:  ir.Node{Key: "select", Type: "selector.select"},
+				Node:  ir.Node{Key: "select", Type: "select"},
 				State: s.Node("select"),
 			}
 			n := MustSucceed(compound.Create(ctx, cfg))

--- a/arc/go/text/text_test.go
+++ b/arc/go/text/text_test.go
@@ -606,7 +606,7 @@ var _ = Describe("Text", func() {
 				Expect(diags.Warnings()).To(BeEmpty())
 			})
 
-			It("Should emit deprecation warning for bare select", func(ctx SpecContext) {
+			It("Should not emit deprecation warning for bare select", func(ctx SpecContext) {
 				resolver := symbol.CompoundResolver{
 					stl.SymbolResolver,
 					symbol.MapResolver{
@@ -618,12 +618,10 @@ var _ = Describe("Text", func() {
 				parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
 				_, diags := text.Analyze(ctx, parsedText, resolver)
 				Expect(diags.Ok()).To(BeTrue())
-				Expect(diags.Warnings()).To(HaveLen(1))
-				Expect(diags.Warnings()[0].Message).To(ContainSubstring("deprecated"))
-				Expect(diags.Warnings()[0].Message).To(ContainSubstring("selector.select"))
+				Expect(diags.Warnings()).To(BeEmpty())
 			})
 
-			It("Should not emit deprecation warning for qualified selector.select", func(ctx SpecContext) {
+			It("Should not resolve qualified selector.select", func(ctx SpecContext) {
 				resolver := symbol.CompoundResolver{
 					stl.SymbolResolver,
 					symbol.MapResolver{
@@ -634,8 +632,7 @@ var _ = Describe("Text", func() {
 				source := `flag -> selector.select{} -> output`
 				parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
 				_, diags := text.Analyze(ctx, parsedText, resolver)
-				Expect(diags.Ok()).To(BeTrue())
-				Expect(diags.Warnings()).To(BeEmpty())
+				Expect(diags.Ok()).To(BeFalse())
 			})
 
 			It("Should emit deprecation warning for bare stable_for", func(ctx SpecContext) {

--- a/arc/go/types/kind_string.go
+++ b/arc/go/types/kind_string.go
@@ -39,12 +39,11 @@ func _() {
 	_ = x[KindFunction-19]
 	_ = x[KindSequence-20]
 	_ = x[KindStage-21]
-	_ = x[KindSignedNumericConstant-22]
 }
 
-const _Kind_name = "KindInvalidKindU8KindU16KindU32KindU64KindI8KindI16KindI32KindI64KindF32KindF64KindStringKindChanKindSeriesKindVariableKindNumericConstantKindIntegerConstantKindFloatConstantKindExactIntegerFloatConstantKindFunctionKindSequenceKindStageKindSignedNumericConstant"
+const _Kind_name = "KindInvalidKindU8KindU16KindU32KindU64KindI8KindI16KindI32KindI64KindF32KindF64KindStringKindChanKindSeriesKindVariableKindNumericConstantKindIntegerConstantKindFloatConstantKindExactIntegerFloatConstantKindFunctionKindSequenceKindStage"
 
-var _Kind_index = [...]uint16{0, 11, 17, 24, 31, 38, 44, 51, 58, 65, 72, 79, 89, 97, 107, 119, 138, 157, 174, 203, 215, 227, 236, 260}
+var _Kind_index = [...]uint16{0, 11, 17, 24, 31, 38, 44, 51, 58, 65, 72, 79, 89, 97, 107, 119, 138, 157, 174, 203, 215, 227, 236}
 
 func (i Kind) String() string {
 	idx := int(i) - 0

--- a/arc/go/types/pb/translator.gen.go
+++ b/arc/go/types/pb/translator.gen.go
@@ -508,8 +508,6 @@ func KindToPB(v types.Kind) (Kind, error) {
 		return Kind_KIND_FLOAT_CONSTANT, nil
 	case types.KindExactIntegerFloatConstant:
 		return Kind_KIND_EXACT_INTEGER_FLOAT_CONSTANT, nil
-	case types.KindSignedNumericConstant:
-		return Kind_KIND_SIGNED_NUMERIC_CONSTANT, nil
 	case types.KindFunction:
 		return Kind_KIND_FUNCTION, nil
 	case types.KindSequence:
@@ -562,8 +560,6 @@ func KindFromPB(v Kind) (types.Kind, error) {
 		return types.KindFloatConstant, nil
 	case Kind_KIND_EXACT_INTEGER_FLOAT_CONSTANT:
 		return types.KindExactIntegerFloatConstant, nil
-	case Kind_KIND_SIGNED_NUMERIC_CONSTANT:
-		return types.KindSignedNumericConstant, nil
 	case Kind_KIND_FUNCTION:
 		return types.KindFunction, nil
 	case Kind_KIND_SEQUENCE:

--- a/arc/go/types/pb/types.pb.go
+++ b/arc/go/types/pb/types.pb.go
@@ -18,12 +18,11 @@
 package pb
 
 import (
+	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
+	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 	reflect "reflect"
 	sync "sync"
 	unsafe "unsafe"
-
-	protoreflect "google.golang.org/protobuf/reflect/protoreflect"
-	protoimpl "google.golang.org/protobuf/runtime/protoimpl"
 )
 
 const (
@@ -60,7 +59,6 @@ const (
 	Kind_KIND_FUNCTION                     Kind = 21
 	Kind_KIND_SEQUENCE                     Kind = 22
 	Kind_KIND_STAGE                        Kind = 23
-	Kind_KIND_SIGNED_NUMERIC_CONSTANT      Kind = 24
 )
 
 // Enum value maps for Kind.
@@ -88,7 +86,6 @@ var (
 		21: "KIND_FUNCTION",
 		22: "KIND_SEQUENCE",
 		23: "KIND_STAGE",
-		24: "KIND_SIGNED_NUMERIC_CONSTANT",
 	}
 	Kind_value = map[string]int32{
 		"KIND_INVALID":                      0,
@@ -113,7 +110,6 @@ var (
 		"KIND_FUNCTION":                     21,
 		"KIND_SEQUENCE":                     22,
 		"KIND_STAGE":                        23,
-		"KIND_SIGNED_NUMERIC_CONSTANT":      24,
 	}
 )
 

--- a/arc/go/types/pb/types.proto
+++ b/arc/go/types/pb/types.proto
@@ -31,7 +31,6 @@ enum Kind {
   KIND_FUNCTION = 21;
   KIND_SEQUENCE = 22;
   KIND_STAGE = 23;
-  KIND_SIGNED_NUMERIC_CONSTANT = 24;
 }
 
 // ChanDirection indicates read/write direction for channel-typed config parameters.

--- a/arc/go/types/type.go
+++ b/arc/go/types/type.go
@@ -250,7 +250,7 @@ func (t Type) String() string {
 			return t.Constraint.String()
 		}
 		return "unknown"
-	case KindNumericConstant, KindSignedNumericConstant:
+	case KindNumericConstant:
 		return "numeric"
 	case KindIntegerConstant:
 		return "integer"
@@ -391,33 +391,6 @@ func FloatConstraint() Type { return Type{Kind: KindFloatConstant} }
 // exact integers (like 5.0, 0.0).
 func ExactIntegerFloatConstraint() Type { return Type{Kind: KindExactIntegerFloatConstant} }
 
-// SignedNumericConstraint returns a constraint accepting any numeric type, but
-// unsigned integer types are implicitly promoted to their wider signed equivalents
-// (u8->i16, u16->i32, u32->i64, u64->f64) during type unification.
-func SignedNumericConstraint() Type { return Type{Kind: KindSignedNumericConstant} }
-
-// PromoteUnsignedToSigned returns the signed promotion target for an unsigned
-// integer type. Signed integers and floats are returned unchanged.
-//
-//	u8  -> i16   (i8 can't hold 255)
-//	u16 -> i32
-//	u32 -> i64
-//	u64 -> f64   (no i128 in WASM)
-func PromoteUnsignedToSigned(t Type) Type {
-	switch t.Kind {
-	case KindU8:
-		return I16()
-	case KindU16:
-		return I32()
-	case KindU32:
-		return I64()
-	case KindU64:
-		return F64()
-	default:
-		return t
-	}
-}
-
 // Sequence returns a sequence (state machine) type.
 func Sequence() Type { return Type{Kind: KindSequence} }
 
@@ -437,7 +410,6 @@ func (t Type) IsNumeric() bool {
 			return false
 		}
 		if unwrapped.Constraint.Kind == KindNumericConstant ||
-			unwrapped.Constraint.Kind == KindSignedNumericConstant ||
 			unwrapped.Constraint.Kind == KindIntegerConstant ||
 			unwrapped.Constraint.Kind == KindFloatConstant ||
 			unwrapped.Constraint.Kind == KindExactIntegerFloatConstant {
@@ -449,7 +421,7 @@ func (t Type) IsNumeric() bool {
 	case KindU8, KindU16, KindU32, KindU64,
 		KindI8, KindI16, KindI32, KindI64,
 		KindF32, KindF64,
-		KindNumericConstant, KindSignedNumericConstant, KindIntegerConstant, KindFloatConstant, KindExactIntegerFloatConstant:
+		KindNumericConstant, KindIntegerConstant, KindFloatConstant, KindExactIntegerFloatConstant:
 		return true
 	default:
 		return false

--- a/arc/go/types/types.gen.go
+++ b/arc/go/types/types.gen.go
@@ -44,7 +44,6 @@ const (
 	KindFunction
 	KindSequence
 	KindStage
-	KindSignedNumericConstant
 )
 
 // ChanDirection indicates read/write direction for channel-typed config parameters.

--- a/core/pkg/distribution/channel/codec_gen_test.go
+++ b/core/pkg/distribution/channel/codec_gen_test.go
@@ -17,10 +17,11 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/synnaxlabs/x/encoding/orc"
+
 	"github.com/synnaxlabs/synnax/pkg/distribution/channel"
 	"github.com/synnaxlabs/synnax/pkg/distribution/node"
 	"github.com/synnaxlabs/x/control"
-	"github.com/synnaxlabs/x/encoding/orc"
 	"github.com/synnaxlabs/x/telem"
 )
 

--- a/integration/tests/arc/lifecycle.py
+++ b/integration/tests/arc/lifecycle.py
@@ -31,7 +31,7 @@ func event_log{msg str} () {
     lifecycle_log = msg
 }
 
-press_pt -> check_high_pressure{} -> stable.for{500ms} -> selector.select{} -> {
+press_pt -> check_high_pressure{} -> stable.for{500ms} -> select{} -> {
     true: status.set{
         status_key="lifecycle_press_alarm",
         name="Lifecycle Press Alarm",

--- a/x/ts/src/status/types.gen.ts
+++ b/x/ts/src/status/types.gen.ts
@@ -14,7 +14,7 @@ import { z } from "zod";
 import { id } from "@/id";
 import { label } from "@/label";
 import { type optional } from "@/optional";
-import { telem,TimeStamp } from "@/telem";
+import { telem, TimeStamp } from "@/telem";
 import { zod } from "@/zod";
 
 export const VARIANTS = [

--- a/x/ts/src/status/types.gen.ts
+++ b/x/ts/src/status/types.gen.ts
@@ -14,7 +14,7 @@ import { z } from "zod";
 import { id } from "@/id";
 import { label } from "@/label";
 import { type optional } from "@/optional";
-import { telem, TimeStamp } from "@/telem";
+import { telem,TimeStamp } from "@/telem";
 import { zod } from "@/zod";
 
 export const VARIANTS = [


### PR DESCRIPTION
# Pull Request

[SY-4313](https://linear.app/synnax/issue/SY-4143/dot-module-fixes)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two related removals: it replaces the module-qualified `selector.select` notation with bare `select` as the canonical form (reversing a prior deprecation direction), and it removes `KindSignedNumericConstant` / `SignedNumericConstraint` / `PromoteUnsignedToSigned` from the Arc type system entirely. Both changes are consistently applied across Go types, generated protobuf files, the symbol resolver, constraint unifier, expression compiler, LSP hover docs, and integration tests — with no dangling references remaining in production code.

<h3>Confidence Score: 5/5</h3>

Safe to merge; no production-code bugs found and all removal sites are accounted for.

The cleanup is thorough — grep confirms zero remaining references to KindSignedNumericConstant or selector.select in non-test code. KindSignedNumericConstant was the last iota entry, so no sibling constants were renumbered. The only open concern (proto enum reservation) was already raised in a prior review thread.

arc/go/types/pb/types.proto — enum value 24 removed without a reserved clause (discussed in prior thread).

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| arc/go/stl/selector/selector.go | Simplifies SymbolResolver from a CompoundResolver (bare + module) to a plain MapResolver keyed on "select"; removes the deprecated bare/module split entirely. |
| arc/go/types/type.go | Removes KindSignedNumericConstant from String() and IsNumeric(), and deletes SignedNumericConstraint() and PromoteUnsignedToSigned() helpers entirely. |
| arc/go/types/types.gen.go | Removes KindSignedNumericConstant from the iota — it was the last entry (22), so no other constants are renumbered. |
| arc/go/types/pb/types.proto | Drops KIND_SIGNED_NUMERIC_CONSTANT = 24 without a reserved clause; discussed in an existing thread. |
| arc/go/types/pb/translator.gen.go | Removes KindSignedNumericConstant ↔ Kind_KIND_SIGNED_NUMERIC_CONSTANT mappings from KindToPB and KindFromPB. |
| arc/go/analyzer/constraints/unify.go | Removes all KindSignedNumericConstant branches from unifyTypeVariableWithVisited, concreteTypeForHint, and defaultTypeForConstraint. |
| arc/go/compiler/expression/compiler.go | Removes the KindSignedNumericConstant-triggered unsigned-to-signed promotion and cast emission from compileFunctionCallExpr. |
| arc/go/lsp/hover.go | Renames the keywordDocs entry from "selector.select" to "select"; content and example snippet updated consistently. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Arc source: 'select{}'"] --> B["SymbolResolver.Resolve('select')"]
    B --> C["MapResolver lookup"]
    C --> D["symbolSelect (Name='select')"]
    D --> E["Module.Create: cfg.Node.Type == 'select'"]
    E --> F["selectNode instantiated"]

    A2["Arc source: 'selector.select{}'"] --> B2["SymbolResolver.Resolve('selector.select')"]
    B2 --> C2["MapResolver lookup — key not found"]
    C2 --> G["query.ErrNotFound ❌"]

    style G fill:#f88,stroke:#c00
    style F fill:#8f8,stroke:#080
```

<sub>Reviews (2): Last reviewed commit: ["formatting"](https://github.com/synnaxlabs/synnax/commit/81a472bff683998cf7547af0f0a2d6f63857c6a4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30480557)</sub>

<!-- /greptile_comment -->