### PR TITLE
SY-4145: Fix Schematic Keyboard Triggering

### DIFF
--- a/pluto/src/triggers/Triggers.spec.tsx
+++ b/pluto/src/triggers/Triggers.spec.tsx
@@ -439,6 +439,53 @@ describe("Triggers", () => {
       fireEvent.keyUp(document.body, { code: "KeyA" });
     });
 
+    it("should not trigger when target is in a sibling subtree of the region", async () => {
+      Element.prototype.getBoundingClientRect = mockBoundingClientRect(0, 0, 100, 100);
+      const callback = vi.fn();
+      const regionRef = { current: document.createElement("div") };
+      const C = () => {
+        Triggers.use({
+          callback,
+          triggers: [["Control", "V"]],
+          region: regionRef,
+          loose: true,
+        });
+        return <div ref={regionRef}>Target Region</div>;
+      };
+      const { container } = render(
+        <Triggers.Provider>
+          <C />
+          <input data-testid="modal-input" />
+        </Triggers.Provider>,
+      );
+      const modalInput = container.querySelector("input")!;
+
+      // Move cursor into region
+      fireEvent.mouseMove(regionRef.current, { clientX: 10, clientY: 10 });
+
+      // Keyboard event targeting the sibling input should NOT fire "start"
+      fireEvent.keyDown(modalInput, { code: "ControlLeft" });
+      fireEvent.keyDown(modalInput, { code: "KeyV", ctrlKey: true });
+      const startCalls = callback.mock.calls.filter(
+        (args) => (args[0] as Triggers.UseEvent).stage === "start",
+      );
+      expect(startCalls).toHaveLength(0);
+
+      fireEvent.keyUp(modalInput, { code: "KeyV" });
+      fireEvent.keyUp(modalInput, { code: "ControlLeft" });
+
+      // Same shortcut targeting body (normal case) SHOULD fire "start"
+      fireEvent.keyDown(document.body, { code: "ControlLeft" });
+      fireEvent.keyDown(document.body, { code: "KeyV", ctrlKey: true });
+      const startCalls2 = callback.mock.calls.filter(
+        (args) => (args[0] as Triggers.UseEvent).stage === "start",
+      );
+      expect(startCalls2).toHaveLength(1);
+
+      fireEvent.keyUp(document.body, { code: "KeyV" });
+      fireEvent.keyUp(document.body, { code: "ControlLeft" });
+    });
+
     it("should handle regionMustBeElement correctly", async () => {
       vi.useFakeTimers();
       const callback = vi.fn();

--- a/pluto/src/triggers/Triggers.spec.tsx
+++ b/pluto/src/triggers/Triggers.spec.tsx
@@ -506,18 +506,19 @@ describe("Triggers", () => {
         </Triggers.Provider>,
       );
 
-      // // Move cursor into region but trigger on body
+      // Move cursor into region but trigger on body — both start and end
+      // should be suppressed since body !== regionRef.current
       fireEvent.mouseMove(regionRef.current, { clientX: 10, clientY: 10 });
       fireEvent.keyDown(document.body, { code: "KeyA" });
       fireEvent.keyUp(document.body, { code: "KeyA" });
-      expect(callback).toHaveBeenCalledTimes(1);
+      expect(callback).not.toHaveBeenCalled();
       fireEvent.mouseMove(regionRef.current, { clientX: 10, clientY: 10 });
 
       vi.advanceTimersByTime(500);
 
       // Trigger directly on region element
       fireEvent.keyDown(regionRef.current, { code: "KeyA" });
-      expect(callback).toHaveBeenCalledTimes(2);
+      expect(callback).toHaveBeenCalledOnce();
       expect(callback).toHaveBeenLastCalledWith({
         target: regionRef.current,
         triggers: [["A"]],
@@ -548,11 +549,11 @@ describe("Triggers", () => {
         </Triggers.Provider>,
       );
 
-      // // Mouse click outside region
+      // Mouse click outside region — both start and end should be suppressed
       fireEvent.mouseMove(document.body, { clientX: -10, clientY: -10 });
       fireEvent.mouseDown(document.body, { button: 0 });
       fireEvent.mouseUp(document.body, { button: 0 });
-      expect(callback).toHaveBeenCalledOnce();
+      expect(callback).not.toHaveBeenCalled();
 
       vi.advanceTimersByTime(500);
 

--- a/pluto/src/triggers/hooks.ts
+++ b/pluto/src/triggers/hooks.ts
@@ -92,7 +92,10 @@ const filterInRegion = (
   return added.filter((t) => {
     const rg = regionMustBeElement ?? t.some((v) => v.includes("Mouse"));
     if (rg) return box.contains(b, cursor) && target === region.current;
-    return box.contains(b, cursor);
+    return (
+      box.contains(b, cursor) &&
+      (region.current!.contains(target) || target.contains(region.current))
+    );
   });
 };
 

--- a/pluto/src/triggers/hooks.ts
+++ b/pluto/src/triggers/hooks.ts
@@ -70,11 +70,18 @@ export const use = ({
       const removed = res[1];
       if (added.length === 0 && removed.length === 0) return;
       added = filterInRegion(e.target, e.cursor, added, region, regionMustBeElement);
+      const filteredRemoved = filterInRegion(
+        e.target,
+        e.cursor,
+        removed,
+        region,
+        regionMustBeElement,
+      );
       const base = { target: e.target, cursor: e.cursor };
       if (added.length > 0)
         f?.({ ...base, stage: "start", triggers: added, prevTriggers: e.prev });
-      if (removed.length > 0)
-        f?.({ ...base, stage: "end", triggers: removed, prevTriggers: e.prev });
+      if (filteredRemoved.length > 0)
+        f?.({ ...base, stage: "end", triggers: filteredRemoved, prevTriggers: e.prev });
     });
   }, [f, memoTriggers, listen, loose, region, double, regionMustBeElement]);
 };


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4145](https://linear.app/synnax/issue/SY-4145/fix-schematic-keyboard-triggering)

## Description

Suppress keyboard triggers when target is outside the trigger region.
Fixed at the trigger level rather than checking modal state, so it applies universally to any overlay (modals, dialogs, command palette, etc.).


## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes keyboard shortcut triggers firing inside schematic when a modal/dialog/overlay is open, by suppressing triggers whose `target` is in a sibling DOM subtree (not an ancestor or descendant of the region). It also closes the previously noted gap where `"end"` events were emitted even when the matching `"start"` had been blocked, by routing `removed` triggers through the same `filterInRegion` guard.

<h3>Confidence Score: 5/5</h3>

Safe to merge — logic is correct, tests are updated, and the only findings are P2 style suggestions.

No P0 or P1 issues found. The ancestor-or-descendant containment check correctly blocks sibling-subtree events while preserving the existing document.body-targeted keyboard shortcut path. Both start and end filtering are now symmetric.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| pluto/src/triggers/hooks.ts | Applies `filterInRegion` to `removed` triggers (fixing spurious `"end"` events) and extends the non-mouseEvent branch to require `target` and `region.current` share an ancestor-descendant relationship, blocking sibling-subtree events. Logic is correct; minor style nit with `region.current!` inside the filter. |
| pluto/src/triggers/Triggers.spec.tsx | New test covers sibling-subtree suppression; two existing tests updated to reflect that `filteredRemoved` now also gates `"end"` events. Missing explicit `"end"`-count assertion in the new test. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Trigger event fires] --> B{added or removed?}
    B --> C[filterInRegion for added]
    B --> D[filterInRegion for removed]
    C --> E{region provided?}
    D --> E
    E -- no --> F[pass through]
    E -- yes --> G{region.current null?}
    G -- yes --> H[block all]
    G -- no --> I{regionMustBeElement or Mouse trigger?}
    I -- yes --> J{cursor in box AND target === region.current?}
    I -- no --> K{cursor in box AND region contains target OR target contains region?}
    J -- yes --> L[allow trigger]
    J -- no --> M[block trigger]
    K -- yes --> L
    K -- no --> M
    L --> N{added.length > 0?}
    L --> O{filteredRemoved.length > 0?}
    N -- yes --> P[fire stage: start]
    O -- yes --> Q[fire stage: end]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `pluto/src/triggers/hooks.ts`, line 69-77 ([link](https://github.com/synnaxlabs/synnax/blob/456423a088fce21a2af60c7edaa585951fd25400/pluto/src/triggers/hooks.ts#L69-L77)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Spurious `"end"` events without a preceding `"start"`**

   With this change, a keyboard trigger's `"start"` is now suppressed when the event target is in a sibling subtree (correct), but the `removed` diff is **never** passed through `filterInRegion`. That means when the keys are released after a blocked start, the callback is still called with `stage: "end"` even though `stage: "start"` was never fired.

   For callers like `useHeldRef`, a spurious `"end"` is benign (`purge` on an empty list is a no-op). But any caller that treats `"start"` and `"end"` as a matched pair (e.g. setting a loading state to true on start and false on end) could enter an inconsistent state here.

   Consider applying the same target-containment guard to `removed`:
   ```typescript
   const filteredRemoved = filterInRegion(e.target, e.cursor, removed, region, regionMustBeElement);
   if (added.length > 0)
     f?.({ ...base, stage: "start", triggers: added, prevTriggers: e.prev });
   if (filteredRemoved.length > 0)
     f?.({ ...base, stage: "end", triggers: filteredRemoved, prevTriggers: e.prev });
   ```
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["SY-4145: Filter removed triggers through..."](https://github.com/synnaxlabs/synnax/commit/0aa793136a9df611a65a9bf6d67e9da316637e94) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30484715)</sub>

<!-- /greptile_comment -->