### PR TITLE
SY-3833-1: Add Pluto Flux Selector Primitive

### DIFF
--- a/pluto/package.json
+++ b/pluto/package.json
@@ -39,6 +39,7 @@
     "react": "catalog:",
     "react-color": "^2.19.3",
     "react-icons": "catalog:",
+    "use-sync-external-store": "^1.6.0",
     "zod": "catalog:"
   },
   "devDependencies": {
@@ -56,6 +57,7 @@
     "@types/react": "catalog:",
     "@types/react-color": "^3.0.13",
     "@types/react-dom": "catalog:",
+    "@types/use-sync-external-store": "^0.0.6",
     "@types/webgl2": "^0.0.12",
     "@vitejs/plugin-react": "catalog:",
     "@vitest/coverage-v8": "catalog:",

--- a/pluto/src/flux/external.ts
+++ b/pluto/src/flux/external.ts
@@ -15,4 +15,5 @@ export * from "@/flux/list";
 export * from "@/flux/Provider";
 export * from "@/flux/result";
 export * from "@/flux/retrieve";
+export * from "@/flux/select";
 export * from "@/flux/update";

--- a/pluto/src/flux/select.spec.tsx
+++ b/pluto/src/flux/select.spec.tsx
@@ -1,0 +1,457 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { type record } from "@synnaxlabs/x";
+import { act, renderHook } from "@testing-library/react";
+import { type PropsWithChildren, type ReactElement } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { aetherTest } from "@/aether/test";
+import { Flux } from "@/flux";
+import { flux } from "@/flux/aether";
+import { type base } from "@/flux/base";
+import { Client } from "@/flux/base/client";
+import { createSelector } from "@/flux/select";
+import { status } from "@/status/aether";
+import { Status } from "@/status/base";
+import { Synnax } from "@/synnax";
+import { synnax } from "@/synnax/aether";
+
+interface Doc extends record.Keyed<string> {
+  key: string;
+  name: string;
+  count: number;
+  nested: { x: number; y: number };
+}
+
+interface TestStore extends base.Store {
+  docs: base.UnaryStore<string, Doc>;
+}
+
+const STORE_CONFIG: base.StoreConfig<TestStore> = {
+  docs: { listeners: [] },
+};
+
+const AetherProvider = aetherTest.createProvider({
+  ...synnax.REGISTRY,
+  ...status.REGISTRY,
+  ...flux.createRegistry({ storeConfig: {} }),
+});
+
+const createTestWrapper = (): {
+  wrapper: React.FC<PropsWithChildren>;
+  fluxClient: Client<TestStore>;
+} => {
+  const handleError = status.createErrorHandler(console.error);
+  const handleAsyncError = status.createAsyncErrorHandler(console.error);
+  const fluxClient = new Client<TestStore>({
+    client: null,
+    storeConfig: STORE_CONFIG,
+    handleError,
+    handleAsyncError,
+  });
+  const Wrapper = ({ children }: PropsWithChildren): ReactElement => (
+    <AetherProvider>
+      <Status.Aggregator>
+        <Synnax.TestProvider client={null}>
+          <Flux.Provider client={fluxClient}>{children}</Flux.Provider>
+        </Synnax.TestProvider>
+      </Status.Aggregator>
+    </AetherProvider>
+  );
+  return { wrapper: Wrapper, fluxClient };
+};
+
+const setDoc = (fluxClient: Client<TestStore>, doc: Doc): void => {
+  const store = fluxClient.scopedStore<TestStore>("test-writer");
+  store.docs.set(doc.key, doc);
+};
+
+describe("createSelector", () => {
+  describe("basic selection", () => {
+    it("should return the selected value from the store", () => {
+      const { wrapper, fluxClient } = createTestWrapper();
+      setDoc(fluxClient, {
+        key: "k1",
+        name: "Alice",
+        count: 1,
+        nested: { x: 0, y: 0 },
+      });
+
+      const useSelectName = createSelector<TestStore, { key: string }, string>({
+        subscribe: (store, { key }, notify) => store.docs.onSet(notify, key),
+        select: (store, { key }) => store.docs.get(key)?.name ?? "",
+      });
+
+      const { result } = renderHook(() => useSelectName({ key: "k1" }), {
+        wrapper,
+      });
+      expect(result.current).toBe("Alice");
+    });
+
+    it("should return a default when document is not in store", () => {
+      const { wrapper } = createTestWrapper();
+
+      const useSelectDoc = createSelector<TestStore, { key: string }, Doc | undefined>({
+        subscribe: (store, { key }, notify) => store.docs.onSet(notify, key),
+        select: (store, { key }) => store.docs.get(key),
+      });
+
+      const { result } = renderHook(() => useSelectDoc({ key: "missing" }), {
+        wrapper,
+      });
+      expect(result.current).toBeUndefined();
+    });
+  });
+
+  describe("reactivity", () => {
+    it("should update when the subscribed key changes in the store", () => {
+      const { wrapper, fluxClient } = createTestWrapper();
+
+      const useSelectName = createSelector<TestStore, { key: string }, string>({
+        subscribe: (store, { key }, notify) => store.docs.onSet(notify, key),
+        select: (store, { key }) => store.docs.get(key)?.name ?? "",
+      });
+
+      const { result } = renderHook(() => useSelectName({ key: "k1" }), {
+        wrapper,
+      });
+      expect(result.current).toBe("");
+
+      act(() =>
+        setDoc(fluxClient, {
+          key: "k1",
+          name: "Alice",
+          count: 1,
+          nested: { x: 0, y: 0 },
+        }),
+      );
+
+      expect(result.current).toBe("Alice");
+    });
+
+    it("should not re-render when a different key changes", () => {
+      const { wrapper, fluxClient } = createTestWrapper();
+      let renderCount = 0;
+
+      const useSelectName = createSelector<TestStore, { key: string }, string>({
+        subscribe: (store, { key }, notify) => store.docs.onSet(notify, key),
+        select: (store, { key }) => {
+          renderCount++;
+          return store.docs.get(key)?.name ?? "";
+        },
+      });
+
+      renderHook(() => useSelectName({ key: "k1" }), { wrapper });
+      const countAfterMount = renderCount;
+
+      act(() =>
+        setDoc(fluxClient, {
+          key: "k2",
+          name: "Bob",
+          count: 2,
+          nested: { x: 0, y: 0 },
+        }),
+      );
+
+      expect(renderCount).toBe(countAfterMount);
+    });
+  });
+
+  describe("equality and caching", () => {
+    it("should use custom equality function to prevent unnecessary updates", () => {
+      const { wrapper, fluxClient } = createTestWrapper();
+      setDoc(fluxClient, {
+        key: "k1",
+        name: "Alice",
+        count: 1,
+        nested: { x: 1, y: 2 },
+      });
+
+      let renderCount = 0;
+      const shallowEqual = (
+        a: { x: number; y: number },
+        b: { x: number; y: number },
+      ): boolean => a.x === b.x && a.y === b.y;
+
+      const useSelectNested = createSelector<
+        TestStore,
+        { key: string },
+        { x: number; y: number }
+      >({
+        subscribe: (store, { key }, notify) => store.docs.onSet(notify, key),
+        select: (store, { key }) => store.docs.get(key)?.nested ?? { x: 0, y: 0 },
+        equal: shallowEqual,
+      });
+
+      const { result } = renderHook(
+        () => {
+          renderCount++;
+          return useSelectNested({ key: "k1" });
+        },
+        { wrapper },
+      );
+
+      const countAfterMount = renderCount;
+      const firstRef = result.current;
+
+      act(() =>
+        setDoc(fluxClient, {
+          key: "k1",
+          name: "Bob",
+          count: 2,
+          nested: { x: 1, y: 2 },
+        }),
+      );
+
+      expect(renderCount).toBe(countAfterMount);
+      expect(result.current).toBe(firstRef);
+    });
+
+    it("should update when selected value actually changes per custom equality", () => {
+      const { wrapper, fluxClient } = createTestWrapper();
+      setDoc(fluxClient, {
+        key: "k1",
+        name: "Alice",
+        count: 1,
+        nested: { x: 1, y: 2 },
+      });
+
+      const shallowEqual = (
+        a: { x: number; y: number },
+        b: { x: number; y: number },
+      ): boolean => a.x === b.x && a.y === b.y;
+
+      const useSelectNested = createSelector<
+        TestStore,
+        { key: string },
+        { x: number; y: number }
+      >({
+        subscribe: (store, { key }, notify) => store.docs.onSet(notify, key),
+        select: (store, { key }) => store.docs.get(key)?.nested ?? { x: 0, y: 0 },
+        equal: shallowEqual,
+      });
+
+      const { result } = renderHook(() => useSelectNested({ key: "k1" }), {
+        wrapper,
+      });
+      expect(result.current).toEqual({ x: 1, y: 2 });
+
+      act(() =>
+        setDoc(fluxClient, {
+          key: "k1",
+          name: "Alice",
+          count: 1,
+          nested: { x: 99, y: 2 },
+        }),
+      );
+
+      expect(result.current).toEqual({ x: 99, y: 2 });
+    });
+
+    it("should skip re-render when primitive selection is unchanged", () => {
+      const { wrapper, fluxClient } = createTestWrapper();
+      setDoc(fluxClient, {
+        key: "k1",
+        name: "Alice",
+        count: 5,
+        nested: { x: 0, y: 0 },
+      });
+
+      let renderCount = 0;
+
+      const useSelectCount = createSelector<TestStore, { key: string }, number>({
+        subscribe: (store, { key }, notify) => store.docs.onSet(notify, key),
+        select: (store, { key }) => store.docs.get(key)?.count ?? 0,
+      });
+
+      const { result } = renderHook(
+        () => {
+          renderCount++;
+          return useSelectCount({ key: "k1" });
+        },
+        { wrapper },
+      );
+
+      expect(result.current).toBe(5);
+      const countAfterMount = renderCount;
+
+      act(() =>
+        setDoc(fluxClient, {
+          key: "k1",
+          name: "Bob",
+          count: 5,
+          nested: { x: 0, y: 0 },
+        }),
+      );
+
+      expect(result.current).toBe(5);
+      expect(renderCount).toBe(countAfterMount);
+
+      act(() =>
+        setDoc(fluxClient, {
+          key: "k1",
+          name: "Bob",
+          count: 10,
+          nested: { x: 0, y: 0 },
+        }),
+      );
+
+      expect(result.current).toBe(10);
+    });
+  });
+
+  describe("derived selection stability", () => {
+    it("should not infinite loop when select returns a new object reference from unchanged data", () => {
+      const { wrapper, fluxClient } = createTestWrapper();
+      setDoc(fluxClient, {
+        key: "k1",
+        name: "Alice",
+        count: 1,
+        nested: { x: 0, y: 0 },
+      });
+
+      let renderCount = 0;
+
+      const useSelectDerived = createSelector<
+        TestStore,
+        { key: string },
+        { name: string; count: number }
+      >({
+        subscribe: (store, { key }, notify) => store.docs.onSet(notify, key),
+        select: (store, { key }) => {
+          const doc = store.docs.get(key);
+          return { name: doc?.name ?? "", count: doc?.count ?? 0 };
+        },
+      });
+
+      const { result } = renderHook(
+        () => {
+          renderCount++;
+          return useSelectDerived({ key: "k1" });
+        },
+        { wrapper },
+      );
+
+      expect(result.current).toEqual({ name: "Alice", count: 1 });
+      expect(renderCount).toBeLessThan(5);
+    });
+
+    it("should still update derived selections when store data changes", () => {
+      const { wrapper, fluxClient } = createTestWrapper();
+      setDoc(fluxClient, {
+        key: "k1",
+        name: "Alice",
+        count: 1,
+        nested: { x: 0, y: 0 },
+      });
+
+      const useSelectDerived = createSelector<
+        TestStore,
+        { key: string },
+        { name: string; count: number }
+      >({
+        subscribe: (store, { key }, notify) => store.docs.onSet(notify, key),
+        select: (store, { key }) => {
+          const doc = store.docs.get(key);
+          return { name: doc?.name ?? "", count: doc?.count ?? 0 };
+        },
+      });
+
+      const { result } = renderHook(() => useSelectDerived({ key: "k1" }), {
+        wrapper,
+      });
+
+      expect(result.current).toEqual({ name: "Alice", count: 1 });
+
+      act(() =>
+        setDoc(fluxClient, {
+          key: "k1",
+          name: "Bob",
+          count: 99,
+          nested: { x: 0, y: 0 },
+        }),
+      );
+
+      expect(result.current).toEqual({ name: "Bob", count: 99 });
+    });
+  });
+
+  describe("args memoization", () => {
+    it("should not re-subscribe when args are deep-equal but referentially different", () => {
+      const { wrapper } = createTestWrapper();
+      const subscribeSpy = vi.fn(
+        (store: TestStore, { key }: { key: string }, notify: () => void) =>
+          store.docs.onSet(notify, key),
+      );
+
+      const useSelectName = createSelector<TestStore, { key: string }, string>({
+        subscribe: subscribeSpy,
+        select: (store, { key }) => store.docs.get(key)?.name ?? "",
+      });
+
+      const { rerender } = renderHook(({ k }) => useSelectName({ key: k }), {
+        wrapper,
+        initialProps: { k: "k1" },
+      });
+
+      const callCountAfterMount = subscribeSpy.mock.calls.length;
+
+      rerender({ k: "k1" });
+
+      expect(subscribeSpy.mock.calls.length).toBe(callCountAfterMount);
+    });
+
+    it("should re-subscribe when args actually change", () => {
+      const { wrapper } = createTestWrapper();
+      const subscribeSpy = vi.fn(
+        (store: TestStore, { key }: { key: string }, notify: () => void) =>
+          store.docs.onSet(notify, key),
+      );
+
+      const useSelectName = createSelector<TestStore, { key: string }, string>({
+        subscribe: subscribeSpy,
+        select: (store, { key }) => store.docs.get(key)?.name ?? "",
+      });
+
+      const { rerender } = renderHook(({ k }) => useSelectName({ key: k }), {
+        wrapper,
+        initialProps: { k: "k1" },
+      });
+
+      const callCountAfterMount = subscribeSpy.mock.calls.length;
+
+      rerender({ k: "k2" });
+
+      expect(subscribeSpy.mock.calls.length).toBeGreaterThan(callCountAfterMount);
+    });
+  });
+
+  describe("cleanup", () => {
+    it("should unsubscribe when the component unmounts", () => {
+      const { wrapper } = createTestWrapper();
+      const unsubscribe = vi.fn();
+
+      const useSelectName = createSelector<TestStore, { key: string }, string>({
+        subscribe: (_store, _args, _notify) => unsubscribe,
+        select: () => "",
+      });
+
+      const { unmount } = renderHook(() => useSelectName({ key: "k1" }), {
+        wrapper,
+      });
+
+      expect(unsubscribe).not.toHaveBeenCalled();
+
+      unmount();
+
+      expect(unsubscribe).toHaveBeenCalled();
+    });
+  });
+});

--- a/pluto/src/flux/select.ts
+++ b/pluto/src/flux/select.ts
@@ -1,0 +1,89 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { type destructor } from "@synnaxlabs/x";
+import { useCallback, useRef, useSyncExternalStore } from "react";
+
+import { type base } from "@/flux/base";
+import { useStore } from "@/flux/Provider";
+import { useMemoDeepEqual } from "@/memo";
+
+export interface CreateSelectorParams<
+  ScopedStore extends base.Store,
+  Args extends {},
+  Selected,
+> {
+  subscribe: (
+    store: ScopedStore,
+    args: Args,
+    notify: () => void,
+  ) => destructor.Destructor;
+  select: (store: ScopedStore, args: Args) => Selected;
+  equal?: (a: Selected, b: Selected) => boolean;
+}
+
+export type UseSelect<Args extends {}, Selected> = (args: Args) => Selected;
+
+export const createSelector = <
+  ScopedStore extends base.Store,
+  Args extends {},
+  Selected,
+>(
+  params: CreateSelectorParams<ScopedStore, Args, Selected>,
+): UseSelect<Args, Selected> => {
+  const equal = params.equal ?? Object.is;
+
+  return (args: Args): Selected => {
+    const store = useStore<ScopedStore>();
+    const memoArgs = useMemoDeepEqual(args);
+
+    // version is bumped by subscribe's notify wrapper. getSnapshot only
+    // re-evaluates select when the version changes, preventing infinite
+    // re-render loops when select returns new object references from
+    // unchanged store data.
+    const cache = useRef<{
+      version: number;
+      args: Args;
+      selected: Selected;
+    } | null>(null);
+    const version = useRef(0);
+
+    const subscribe = useCallback(
+      (onStoreChange: () => void) =>
+        params.subscribe(store, memoArgs, () => {
+          version.current++;
+          onStoreChange();
+        }),
+      [store, memoArgs],
+    );
+
+    const getSnapshot = useCallback((): Selected => {
+      const prev = cache.current;
+      if (prev !== null && prev.version === version.current && prev.args === memoArgs)
+        return prev.selected;
+      const nextSelected = params.select(store, memoArgs);
+      if (prev !== null && equal(nextSelected, prev.selected)) {
+        cache.current = {
+          version: version.current,
+          args: memoArgs,
+          selected: prev.selected,
+        };
+        return prev.selected;
+      }
+      cache.current = {
+        version: version.current,
+        args: memoArgs,
+        selected: nextSelected,
+      };
+      return nextSelected;
+    }, [store, memoArgs]);
+
+    return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+  };
+};

--- a/pluto/src/flux/select.ts
+++ b/pluto/src/flux/select.ts
@@ -8,7 +8,8 @@
 // included in the file licenses/APL.txt.
 
 import { type destructor } from "@synnaxlabs/x";
-import { useCallback, useRef, useSyncExternalStore } from "react";
+import { useCallback, useRef } from "react";
+import { useSyncExternalStoreWithSelector } from "use-sync-external-store/with-selector";
 
 import { type base } from "@/flux/base";
 import { useStore } from "@/flux/Provider";
@@ -30,60 +31,35 @@ export interface CreateSelectorParams<
 
 export type UseSelect<Args extends {}, Selected> = (args: Args) => Selected;
 
-export const createSelector = <
-  ScopedStore extends base.Store,
-  Args extends {},
-  Selected,
->(
-  params: CreateSelectorParams<ScopedStore, Args, Selected>,
-): UseSelect<Args, Selected> => {
-  const equal = params.equal ?? Object.is;
-
-  return (args: Args): Selected => {
+export const createSelector =
+  <ScopedStore extends base.Store, Args extends {}, Selected>(
+    params: CreateSelectorParams<ScopedStore, Args, Selected>,
+  ): UseSelect<Args, Selected> =>
+  (args: Args): Selected => {
     const store = useStore<ScopedStore>();
     const memoArgs = useMemoDeepEqual(args);
-
-    // version is bumped by subscribe's notify wrapper. getSnapshot only
-    // re-evaluates select when the version changes, preventing infinite
-    // re-render loops when select returns new object references from
-    // unchanged store data.
-    const cache = useRef<{
-      version: number;
-      args: Args;
-      selected: Selected;
-    } | null>(null);
-    const version = useRef(0);
+    const versionRef = useRef(0);
 
     const subscribe = useCallback(
       (onStoreChange: () => void) =>
         params.subscribe(store, memoArgs, () => {
-          version.current++;
+          versionRef.current++;
           onStoreChange();
         }),
       [store, memoArgs],
     );
 
-    const getSnapshot = useCallback((): Selected => {
-      const prev = cache.current;
-      if (prev !== null && prev.version === version.current && prev.args === memoArgs)
-        return prev.selected;
-      const nextSelected = params.select(store, memoArgs);
-      if (prev !== null && equal(nextSelected, prev.selected)) {
-        cache.current = {
-          version: version.current,
-          args: memoArgs,
-          selected: prev.selected,
-        };
-        return prev.selected;
-      }
-      cache.current = {
-        version: version.current,
-        args: memoArgs,
-        selected: nextSelected,
-      };
-      return nextSelected;
-    }, [store, memoArgs]);
+    const getSnapshot = useCallback(() => versionRef.current, []);
+    const selector = useCallback(
+      () => params.select(store, memoArgs),
+      [store, memoArgs],
+    );
 
-    return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+    return useSyncExternalStoreWithSelector(
+      subscribe,
+      getSnapshot,
+      undefined,
+      selector,
+      params.equal,
+    );
   };
-};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -775,6 +775,9 @@ importers:
       react-icons:
         specifier: 'catalog:'
         version: 5.6.0(react@19.2.5)
+      use-sync-external-store:
+        specifier: ^1.6.0
+        version: 1.6.0(react@19.2.5)
       zod:
         specifier: 'catalog:'
         version: 4.3.6
@@ -821,6 +824,9 @@ importers:
       '@types/react-dom':
         specifier: 'catalog:'
         version: 19.2.3(@types/react@19.2.14)
+      '@types/use-sync-external-store':
+        specifier: ^0.0.6
+        version: 0.0.6
       '@types/webgl2':
         specifier: ^0.0.12
         version: 0.0.12
@@ -9130,7 +9136,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@29.0.1)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.3))
+      vitest: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(@vitest/coverage-v8@4.1.4)(jsdom@27.4.0)(vite@8.0.8(@types/node@25.6.0)(esbuild@0.27.4)(jiti@2.6.1)(terser@5.44.0)(tsx@4.20.5)(yaml@2.8.3))
 
   '@vitest/expect@4.1.4':
     dependencies:


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-3833](https://linear.app/synnax/issue/SY-3833)

## Description

Adds `Flux.createSelector`, a generic React hook factory for subscribing to scoped flux store state with referential stability. The primitive lives in `pluto/src/flux/select.ts` and is fully decoupled from any specific store schema — it parameterizes over `<ScopedStore extends base.Store, Args, Selected>` and exposes a `subscribe`/`select`/`equal` shape backed by `useSyncExternalStore`.

This is the foundational primitive that the schematic state-ownership migration (subsequent splits in this series) will build on, but it is also reusable by any future visualization that needs reactive selection from a flux store.

Internally:
- `useMemoDeepEqual` deep-compares args so callers can pass freshly constructed objects without re-subscribing.
- A version counter is bumped from inside `subscribe`'s notify wrapper, and `getSnapshot` short-circuits when neither version nor args have changed since the last evaluation. This is what prevents the `useSyncExternalStore` infinite-render trap when `select` returns derived objects.
- An optional `equal` callback compares against the previously selected value to maintain referential stability across rerenders.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds `Flux.createSelector`, a generic React hook factory that wraps `useSyncExternalStoreWithSelector` to provide reactive, referentially-stable selection from any scoped flux store. The version-counter snapshot design correctly prevents the `useSyncExternalStore` infinite-render trap when `select` returns freshly constructed objects, and args stability is handled by `useMemoDeepEqual`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the core implementation is correct and well-tested with no new P0/P1 findings in this review pass.

No P0 or P1 issues were identified in this review. The hook factory pattern, version-based snapshot, selector dependency tracking on [store, memoArgs], and cleanup lifecycle are all implemented correctly. Previously flagged concerns (jsdom downgrade, eslint-disable comment, dead notify expression) remain open but are not new findings here.

pnpm-lock.yaml — the jsdom peer snapshot downgrade from 29.0.1 to 27.4.0 (flagged in a prior review pass) should be resolved before merging.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pluto/src/flux/select.ts | New hook factory using useSyncExternalStoreWithSelector with version-based snapshot tracking and args memoization; implementation is correct and well-structured. |
| pluto/src/flux/select.spec.tsx | Comprehensive test suite covering basic selection, reactivity, equality/caching, derived-object stability, args memoization, and cleanup; good coverage of the intended invariants. |
| pluto/package.json | Adds use-sync-external-store ^1.6.0 as a runtime dep and @types/use-sync-external-store ^0.0.6 as a dev dep; appropriate since useSyncExternalStoreWithSelector is consumed from the shim. |
| pnpm-lock.yaml | Lockfile records the new use-sync-external-store dep; also contains a vitest peer snapshot change from jsdom@29.0.1 to jsdom@27.4.0 (previously flagged). |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Component
    participant Hook as createSelector hook
    participant USEWS as useSyncExternalStoreWithSelector
    participant Store as ScopedStore

    Component->>Hook: useSelectXxx(args)
    Hook->>Hook: useMemoDeepEqual(args) → memoArgs
    Hook->>Hook: useCallback(subscribe, [store, memoArgs])
    Hook->>Hook: useCallback(selector, [store, memoArgs])
    Hook->>USEWS: subscribe, getSnapshot, selector, equal
    USEWS->>Store: params.subscribe(store, memoArgs, wrappedNotify)
    Store-->>USEWS: unsubscribeFn
    USEWS->>Hook: getSnapshot() → versionRef.current (0)
    USEWS->>Hook: selector() → params.select(store, memoArgs)
    USEWS-->>Component: Selected value

    Store->>USEWS: wrappedNotify() [versionRef.current++, onStoreChange()]
    USEWS->>Hook: getSnapshot() → new version
    USEWS->>Hook: selector() → updated Selected value
    alt equal(prev, next) == true
        USEWS-->>Component: prev reference (no re-render)
    else
        USEWS-->>Component: next value (re-render)
    end

    Component->>Hook: unmount
    Hook->>USEWS: cleanup
    USEWS->>Store: unsubscribeFn()
```

<sub>Reviews (6): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/sy-..."](https://github.com/synnaxlabs/synnax/commit/a8e68725a3464c0e3eadae033348265ffb34445d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30539239)</sub>

<!-- /greptile_comment -->