### PR TITLE
SY-4146: Improve Haul Type Safety

### DIFF
--- a/console/src/access/role/ontology.tsx
+++ b/console/src/access/role/ontology.tsx
@@ -8,7 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { access } from "@synnaxlabs/client";
-import { Access, Icon, Menu } from "@synnaxlabs/pluto";
+import { Access, Icon, Menu, User } from "@synnaxlabs/pluto";
 
 import { ContextMenu } from "@/components";
 import { Ontology } from "@/ontology";
@@ -68,10 +68,8 @@ export const ONTOLOGY_SERVICE: Ontology.Service = {
   icon: <Icon.Role />,
   TreeContextMenu,
   hasChildren: true,
-  canDrop: ({ items }) =>
-    items.every(
-      ({ key, type, data }) =>
-        (key.toString().startsWith("user:") || type === "user") &&
-        data?.rootUser !== true,
-    ),
+  canDrop: ({ items }) => {
+    const users = User.filterHaulItems(items);
+    return users.length === items.length && users.every(({ data }) => !data.rootUser);
+  },
 };

--- a/console/src/arc/editor/graph/Editor.spec.ts
+++ b/console/src/arc/editor/graph/Editor.spec.ts
@@ -1,0 +1,63 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { type Haul } from "@synnaxlabs/pluto";
+import { describe, expect, it } from "vitest";
+
+import {
+  canDropHaulItem,
+  createHaulItem,
+  filterHaulItems,
+  HAUL_TYPE,
+  isHaulItem,
+} from "@/arc/editor/graph/Editor";
+
+const KEY = "stage-key";
+const OTHER: Haul.Item = { type: "other_type", key: "other" };
+
+describe("arc element haul utilities", () => {
+  describe("createHaulItem", () => {
+    it("creates an item with the arc element HAUL_TYPE", () => {
+      expect(createHaulItem(KEY).type).toEqual(HAUL_TYPE);
+    });
+
+    it("creates an item with the provided key", () => {
+      expect(createHaulItem(KEY).key).toEqual(KEY);
+    });
+  });
+
+  describe("isHaulItem", () => {
+    it("returns true for an arc element item", () => {
+      expect(isHaulItem(createHaulItem(KEY))).toBe(true);
+    });
+
+    it("returns false for an item of another kind", () => {
+      expect(isHaulItem(OTHER)).toBe(false);
+    });
+  });
+
+  describe("filterHaulItems", () => {
+    it("keeps arc element items and drops items of other kinds", () => {
+      const item = createHaulItem(KEY);
+      expect(filterHaulItems([item, OTHER])).toEqual([item]);
+    });
+  });
+
+  describe("canDropHaulItem", () => {
+    it("returns true when at least one item is an arc element item", () => {
+      expect(
+        canDropHaulItem({ source: OTHER, items: [createHaulItem(KEY), OTHER] }),
+      ).toBe(true);
+    });
+
+    it("returns false when no item is an arc element item", () => {
+      expect(canDropHaulItem({ source: OTHER, items: [OTHER] })).toBe(false);
+    });
+  });
+});

--- a/console/src/arc/editor/graph/Editor.tsx
+++ b/console/src/arc/editor/graph/Editor.tsx
@@ -51,7 +51,19 @@ import { useUndoableDispatch } from "@/hooks/useUndoableDispatch";
 import { Layout } from "@/layout";
 import { type RootState } from "@/store";
 
-export const HAUL_TYPE = "arc-element";
+export const HAUL_TYPE = "arc_element";
+
+export type HaulItem = Haul.Item<typeof HAUL_TYPE, string, undefined>;
+
+export const createHaulItem = (key: string): HaulItem => ({ type: HAUL_TYPE, key });
+
+export const isHaulItem = (item: Haul.Item): item is HaulItem =>
+  item.type === HAUL_TYPE;
+
+export const filterHaulItems = (items: Haul.Item[]): HaulItem[] =>
+  items.filter(isHaulItem);
+
+export const canDropHaulItem = Haul.canDropOfType<HaulItem>(HAUL_TYPE);
 
 interface SymbolRendererProps extends Diagram.SymbolProps {
   layoutKey: string;
@@ -180,9 +192,9 @@ export const Editor: Layout.Renderer = ({ layoutKey, visible }) => {
 
   const handleDrop = useCallback(
     ({ items, event }: Haul.OnDropProps): Haul.Item[] => {
-      const valid = Haul.filterByType(HAUL_TYPE, items);
+      const valid = filterHaulItems(items);
       if (ref.current == null || event == null) return valid;
-      valid.forEach(({ key, data }) => {
+      valid.forEach(({ key }) => {
         const spec = Base.Stage.REGISTRY[key];
         if (spec == null) return;
         const pos = xy.truncate(calculateCursorPosition(event), 0);
@@ -191,7 +203,7 @@ export const Editor: Layout.Renderer = ({ layoutKey, visible }) => {
             key: layoutKey,
             elKey: id.create(),
             node: { position: pos, zIndex: spec.zIndex },
-            props: { key, ...spec.defaultProps(theme), ...(data ?? {}) },
+            props: { key, ...spec.defaultProps(theme) },
           }),
         );
       });
@@ -203,7 +215,7 @@ export const Editor: Layout.Renderer = ({ layoutKey, visible }) => {
   const dropProps = Haul.useDrop({
     type: "arc",
     key: layoutKey,
-    canDrop: Haul.canDropOfType(HAUL_TYPE),
+    canDrop: canDropHaulItem,
     onDrop: handleDrop,
   });
 

--- a/console/src/arc/editor/graph/toolbar/Stages.tsx
+++ b/console/src/arc/editor/graph/toolbar/Stages.tsx
@@ -25,18 +25,19 @@ import {
 import { type ReactElement, useCallback, useMemo, useState } from "react";
 import { useDispatch } from "react-redux";
 
+import { createHaulItem } from "@/arc/editor/graph/Editor";
 import { useAddSymbol } from "@/arc/useAddSymbol";
 import { CSS } from "@/css";
 
 const StaticListItem = (props: List.ItemProps<string>): ReactElement | null => {
   const { itemKey } = props;
   const { startDrag, onDragEnd } = Haul.useDrag({
-    type: "Diagram-Elements",
+    type: "diagram_elements",
     key: "stages",
   });
   const theme = Theming.use();
   const handleDragStart = useCallback(() => {
-    startDrag([{ type: "arc-element", key: itemKey }]);
+    startDrag([createHaulItem(itemKey)]);
   }, [startDrag, itemKey]);
 
   const spec = List.useItem<string, Arc.Stage.Spec>(itemKey);

--- a/console/src/channel/services/ontology.tsx
+++ b/console/src/channel/services/ontology.tsx
@@ -22,7 +22,7 @@ import {
   Tooltip,
   Tree,
 } from "@synnaxlabs/pluto";
-import { primitive, type record, status } from "@synnaxlabs/x";
+import { primitive, status } from "@synnaxlabs/x";
 import { useCallback, useMemo } from "react";
 
 import { Channel } from "@/channel";
@@ -98,20 +98,9 @@ const haulItems = ({ name, id, data }: ontology.Resource): Haul.Item[] => {
     },
     telem: t,
   };
-  const items = [
-    {
-      type: Schematic.HAUL_TYPE,
-      key: "value",
-      data: schematicSymbolProps as record.Unknown,
-    },
-  ];
+  const items = [Schematic.createValueHaulItem(schematicSymbolProps)];
   if (data?.internal === true) return items;
-  return [
-    {
-      type: "channel",
-      key: Number(id.key),
-    },
-  ];
+  return [PChannel.createHaulItem(Number(id.key))];
 };
 
 const allowRename: Ontology.AllowRename = ({ data }) => data?.internal !== true;

--- a/console/src/hardware/opc/device/Browser.spec.ts
+++ b/console/src/hardware/opc/device/Browser.spec.ts
@@ -1,0 +1,76 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { type Haul } from "@synnaxlabs/pluto";
+import { describe, expect, it } from "vitest";
+
+import {
+  canDropHaulItem,
+  createHaulItem,
+  filterHaulItems,
+  HAUL_TYPE,
+  isHaulItem,
+} from "@/hardware/opc/device/Browser";
+import { type ScannedNode } from "@/hardware/opc/task/types";
+
+const NODE: ScannedNode = {
+  key: "ns=2;s=Demo.Static.Scalar.Float",
+  nodeId: "ns=2;s=Demo.Static.Scalar.Float",
+  name: "Demo Float",
+  nodeClass: "Variable",
+  dataType: "float32",
+  isArray: false,
+};
+
+const OTHER: Haul.Item = { type: "other_type", key: "other" };
+
+describe("opc device haul utilities", () => {
+  describe("createHaulItem", () => {
+    it("creates an item with the opc HAUL_TYPE", () => {
+      expect(createHaulItem(NODE).type).toEqual(HAUL_TYPE);
+    });
+
+    it("creates an item with the node nodeId as key", () => {
+      expect(createHaulItem(NODE).key).toEqual(NODE.nodeId);
+    });
+
+    it("creates an item carrying the full scanned node in data", () => {
+      expect(createHaulItem(NODE).data).toEqual(NODE);
+    });
+  });
+
+  describe("isHaulItem", () => {
+    it("returns true for an opc item", () => {
+      expect(isHaulItem(createHaulItem(NODE))).toBe(true);
+    });
+
+    it("returns false for an item of another kind", () => {
+      expect(isHaulItem(OTHER)).toBe(false);
+    });
+  });
+
+  describe("filterHaulItems", () => {
+    it("keeps opc items and drops items of other kinds", () => {
+      const item = createHaulItem(NODE);
+      expect(filterHaulItems([item, OTHER])).toEqual([item]);
+    });
+  });
+
+  describe("canDropHaulItem", () => {
+    it("returns true when at least one item is an opc item", () => {
+      expect(
+        canDropHaulItem({ source: OTHER, items: [createHaulItem(NODE), OTHER] }),
+      ).toBe(true);
+    });
+
+    it("returns false when no item is an opc item", () => {
+      expect(canDropHaulItem({ source: OTHER, items: [OTHER] })).toBe(false);
+    });
+  });
+});

--- a/console/src/hardware/opc/device/Browser.tsx
+++ b/console/src/hardware/opc/device/Browser.tsx
@@ -46,6 +46,22 @@ const parseNodeID = (key: string): string => key.split("---")[0];
 
 export const HAUL_TYPE = "opc";
 
+export type HaulItem = Haul.Item<typeof HAUL_TYPE, string, ScannedNode>;
+
+export const createHaulItem = (node: ScannedNode): HaulItem => ({
+  type: HAUL_TYPE,
+  key: node.nodeId,
+  data: node,
+});
+
+export const isHaulItem = (item: Haul.Item): item is HaulItem =>
+  item.type === HAUL_TYPE;
+
+export const filterHaulItems = (items: Haul.Item[]): HaulItem[] =>
+  items.filter(isHaulItem);
+
+export const canDropHaulItem = Haul.canDropOfType<HaulItem>(HAUL_TYPE);
+
 export interface BrowserProps {
   device: Device;
 }
@@ -61,15 +77,14 @@ const itemRenderProp = Component.renderProp((props: Tree.ItemRenderProps<string>
   const { startDrag } = Haul.useDrag({
     type: HAUL_TYPE,
     key: node?.nodeId,
-    data: node,
   });
   const handleDragStart = useCallback(() => {
     if (node == null) return;
     const selected = array.toArray(getState().value);
     if (getItem != null && selected.includes(props.itemKey)) {
       const nodes = getItem(selected);
-      startDrag(nodes.map((n) => ({ key: n.nodeId, type: HAUL_TYPE, data: n })));
-    } else startDrag([{ key: node.nodeId, type: HAUL_TYPE, data: node }]);
+      startDrag(nodes.map(createHaulItem));
+    } else startDrag([createHaulItem(node)]);
   }, [startDrag, node, getState, getItem, props.itemKey]);
   if (node == null) return null;
   const icon = node.isArray ? <ArrayVariableIcon /> : ICONS[node.nodeClass];

--- a/console/src/hardware/opc/task/Form.tsx
+++ b/console/src/hardware/opc/task/Form.tsx
@@ -115,10 +115,11 @@ const CHANNELS_PATH = "config.channels";
 
 const VARIABLE_NODE_CLASS = "Variable";
 
-const filterHaulItem = (item: Haul.Item): boolean =>
-  item.type === Device.HAUL_TYPE && item.data?.nodeClass === VARIABLE_NODE_CLASS;
+const isVariableHaulItem = (item: Haul.Item): item is Device.HaulItem =>
+  Device.isHaulItem(item) && item.data.nodeClass === VARIABLE_NODE_CLASS;
 
-const canDrop = ({ items }: Haul.DraggingState): boolean => items.some(filterHaulItem);
+const canDrop = ({ items }: Haul.DraggingState): boolean =>
+  items.some(isVariableHaulItem);
 
 interface ChannelListProps<C extends Channel> extends Pick<
   Common.Task.ChannelListProps<C>,
@@ -126,7 +127,7 @@ interface ChannelListProps<C extends Channel> extends Pick<
 > {
   children: Component.RenderProp<ExtraItemProps>;
   device: Device.Device;
-  convertHaulItemToChannel: (item: Haul.Item) => C;
+  convertHaulItemToChannel: (item: Device.HaulItem) => C;
   getChannelKeyAndID: ChannelKeyAndIDGetter<C>;
 }
 
@@ -143,9 +144,9 @@ const ChannelList = <C extends Channel>({
   const handleDrop = useCallback(
     ({ items }: Haul.OnDropProps): Haul.Item[] => {
       const channels = ctx.get<C[]>(CHANNELS_PATH).value;
-      const dropped = items.filter(filterHaulItem);
+      const dropped = items.filter(isVariableHaulItem);
       const toAdd = dropped
-        .filter(({ data }) => !channels.some(({ nodeId }) => nodeId === data?.nodeId))
+        .filter(({ data }) => !channels.some(({ nodeId }) => nodeId === data.nodeId))
         .map(convertHaulItemToChannel);
       push(toAdd);
       return dropped;
@@ -159,7 +160,7 @@ const ChannelList = <C extends Channel>({
     onDrop: handleDrop,
   });
 
-  const isDragging = Haul.canDropOfType(Device.HAUL_TYPE)(Haul.useDraggingState());
+  const isDragging = Device.canDropHaulItem(Haul.useDraggingState());
 
   const [selected, setSelected] = useState(data.length > 0 ? [data[0]] : []);
   const listItem = useCallback(

--- a/console/src/hardware/opc/task/Read.tsx
+++ b/console/src/hardware/opc/task/Read.tsx
@@ -8,7 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { channel, NotFoundError, type Synnax } from "@synnaxlabs/client";
-import { Component, Flex, Form as PForm, type Haul, Icon } from "@synnaxlabs/pluto";
+import { Component, Flex, Form as PForm, Icon } from "@synnaxlabs/pluto";
 import { caseconv, DataType, primitive } from "@synnaxlabs/x";
 import { type FC, type ReactElement } from "react";
 
@@ -100,24 +100,16 @@ const Properties = (): ReactElement => {
   );
 };
 
-const convertHaulItemToChannel = ({ data }: Haul.Item): InputChannel => {
-  if (typeof data?.name !== "string") throw new Error("Invalid name");
-  const nodeName = data?.name;
-  if (typeof data?.nodeId !== "string")
-    throw new Error(`Invalid nodeId for ${nodeName}`);
-  const nodeId = data?.nodeId;
-  const dataType = typeof data?.dataType === "string" ? data.dataType : "float32";
-  return {
-    key: nodeId,
-    nodeName,
-    nodeId,
-    channel: 0,
-    enabled: true,
-    useAsIndex: false,
-    dataType,
-    name: "",
-  };
-};
+const convertHaulItemToChannel = ({ data }: Device.HaulItem): InputChannel => ({
+  key: data.nodeId,
+  nodeName: data.name,
+  nodeId: data.nodeId,
+  channel: 0,
+  enabled: true,
+  useAsIndex: false,
+  dataType: data.dataType,
+  name: "",
+});
 
 const getChannelKeyAndID: ChannelKeyAndIDGetter<InputChannel> = ({ channel, key }) => ({
   key: channel,

--- a/console/src/hardware/opc/task/Write.tsx
+++ b/console/src/hardware/opc/task/Write.tsx
@@ -8,7 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { channel, NotFoundError } from "@synnaxlabs/client";
-import { Component, type Haul, Icon, Menu, Text } from "@synnaxlabs/pluto";
+import { Component, Icon, Menu, Text } from "@synnaxlabs/pluto";
 import { caseconv, primitive } from "@synnaxlabs/x";
 import { type FC } from "react";
 
@@ -45,23 +45,15 @@ const Properties = () => (
   </>
 );
 
-const convertHaulItemToChannel = ({ data }: Haul.Item): OutputChannel => {
-  if (typeof data?.name !== "string") throw new Error("Invalid name");
-  const nodeName = data?.name;
-  if (typeof data?.nodeId !== "string")
-    throw new Error(`Invalid nodeId for ${nodeName}`);
-  const nodeId = data?.nodeId;
-  const dataType = typeof data?.dataType === "string" ? data.dataType : "float32";
-  return {
-    key: nodeId,
-    nodeName,
-    nodeId,
-    name: "",
-    cmdChannel: 0,
-    enabled: true,
-    dataType,
-  };
-};
+const convertHaulItemToChannel = ({ data }: Device.HaulItem): OutputChannel => ({
+  key: data.nodeId,
+  nodeName: data.name,
+  nodeId: data.nodeId,
+  name: "",
+  cmdChannel: 0,
+  enabled: true,
+  dataType: data.dataType,
+});
 
 const getChannelKeyAndID: ChannelKeyAndIDGetter<OutputChannel> = ({
   cmdChannel,

--- a/console/src/hardware/task/ontology.tsx
+++ b/console/src/hardware/task/ontology.tsx
@@ -185,9 +185,7 @@ export const ONTOLOGY_SERVICE: Ontology.Service = {
   icon: <Icon.Task />,
   hasChildren: false,
   onSelect: handleSelect,
-  haulItems: ({ id }) => [
-    { type: Mosaic.HAUL_CREATE_TYPE, key: ontology.idToString(id) },
-  ],
+  haulItems: ({ id }) => [Mosaic.createTabCreateHaulItem(ontology.idToString(id))],
   onMosaicDrop: handleMosaicDrop,
   TreeContextMenu,
 };

--- a/console/src/layout/useDropOutside.ts
+++ b/console/src/layout/useDropOutside.ts
@@ -96,7 +96,7 @@ const useDropOutsideWindows = ({ type, key, ...rest }: UseDropOutsideProps): voi
 };
 
 const canDrop: Haul.CanDrop = ({ items }) =>
-  items.length === 1 && items[0].type === Mosaic.HAUL_DROP_TYPE;
+  items.length === 1 && Mosaic.isTabDropHaulItem(items[0]);
 
 const useBase =
   runtime.getOS() === "macOS" ? useDropOutsideMacOS : useDropOutsideWindows;
@@ -106,7 +106,7 @@ export const useDropOutside = (): void => {
   const dispatch = useDispatch();
   const handleDrop = useCallback(
     ({ items: [item] }: Haul.OnDropProps, cursor?: xy.XY) => {
-      if (item == null) return [];
+      if (item == null || !Mosaic.isTabDropHaulItem(item)) return [];
       const { key } = place(
         createMosaicWindow({
           position: cursor ? xy.translate(cursor, { x: -80, y: -45 }) : undefined,
@@ -116,7 +116,7 @@ export const useDropOutside = (): void => {
         moveMosaicTab({
           windowKey: key,
           key: 1,
-          tabKey: item.key as string,
+          tabKey: item.key,
           loc: "center",
         }),
       );
@@ -125,7 +125,7 @@ export const useDropOutside = (): void => {
     [place],
   );
   const dropProps = {
-    type: "Palette",
+    type: "palette",
     canDrop,
     onDrop: handleDrop,
   };

--- a/console/src/lineplot/services/ontology.tsx
+++ b/console/src/lineplot/services/ontology.tsx
@@ -143,9 +143,7 @@ export const ONTOLOGY_SERVICE: Ontology.Service = {
   icon: <Icon.LinePlot />,
   hasChildren: false,
   onSelect: handleSelect,
-  haulItems: ({ id }) => [
-    { type: Mosaic.HAUL_CREATE_TYPE, key: ontology.idToString(id) },
-  ],
+  haulItems: ({ id }) => [Mosaic.createTabCreateHaulItem(ontology.idToString(id))],
   onMosaicDrop: handleMosaicDrop,
   TreeContextMenu,
 };

--- a/console/src/log/services/ontology.tsx
+++ b/console/src/log/services/ontology.tsx
@@ -141,9 +141,7 @@ export const ONTOLOGY_SERVICE: Ontology.Service = {
   icon: <Icon.Log />,
   hasChildren: false,
   onSelect: handleSelect,
-  haulItems: ({ id }) => [
-    { type: Mosaic.HAUL_CREATE_TYPE, key: ontology.idToString(id) },
-  ],
+  haulItems: ({ id }) => [Mosaic.createTabCreateHaulItem(ontology.idToString(id))],
   onMosaicDrop: handleMosaicDrop,
   TreeContextMenu,
 };

--- a/console/src/ontology/Tree.tsx
+++ b/console/src/ontology/Tree.tsx
@@ -123,12 +123,12 @@ const itemRenderProp = Component.renderProp(
     const [draggingOver, setDraggingOver] = useState(false);
 
     const onDropDrops = Haul.useDrop({
-      type: "Tree.Item",
+      type: Base.HAUL_TYPE,
       key: itemKey,
       canDrop: useCallback(({ items: entities, source }) => {
         const keys = entities.map((item) => item.key);
         setDraggingOver(false);
-        return source.type === "Tree.Item" && !keys.includes(itemKey);
+        return source.type === Base.HAUL_TYPE && !keys.includes(itemKey);
       }, []),
       onDrop: useCallback((props) => onDrop(itemKey, props) ?? [], [onDrop, itemKey]),
       onDragOver: useCallback(() => setDraggingOver(true), []),
@@ -381,23 +381,21 @@ const Internal = ({ root, emptyContent }: InternalProps): ReactElement => {
   const handleDrop = useCallback(
     (key: string, { source, items }: Haul.OnDropProps): Haul.Item[] => {
       const nodesSnapshot = nodesRef.current;
-      const dropped = Haul.filterByType(Base.HAUL_TYPE, items);
-      const isValidDrop = dropped.length > 0 && source.type === "Tree.Item";
+      const dropped = Base.filterHaulItems(items);
+      const isValidDrop = dropped.length > 0 && source.type === Base.HAUL_TYPE;
       if (!isValidDrop) return [];
       const destination = ontology.idZ.parse(key);
       const svc = services[destination.type];
       if (!svc.canDrop({ source, items })) return [];
 
-      const minDepth = Math.min(
-        ...dropped.map(({ data }) => (data?.depth ?? 0) as number),
-      );
-      const firstNodeOfMinDepth = dropped.find(({ data }) => data?.depth === minDepth);
+      const minDepth = Math.min(...dropped.map(({ data }) => data.depth));
+      const firstNodeOfMinDepth = dropped.find(({ data }) => data.depth === minDepth);
       if (firstNodeOfMinDepth == null) return [];
-      const moved = dropped.filter(({ data }) => data?.depth === minDepth);
-      const keys = moved.map(({ key }) => key as string);
+      const moved = dropped.filter(({ data }) => data.depth === minDepth);
+      const keys = moved.map(({ key }) => key);
       const parent = Base.findNodeParent({
         tree: nodesSnapshot,
-        key: firstNodeOfMinDepth.key.toString(),
+        key: firstNodeOfMinDepth.key,
       });
       const sourceID = ontology.idZ.parse(parent?.key ?? ontology.idToString(root));
       contract(...keys);
@@ -408,41 +406,28 @@ const Internal = ({ root, emptyContent }: InternalProps): ReactElement => {
     [client, contract, root],
   );
 
-  const { startDrag, onDragEnd } = Haul.useDrag({ type: "Tree.Item" });
+  const { startDrag, onDragEnd } = Haul.useDrag({ type: Base.HAUL_TYPE });
 
   const handleDragStart = useCallback(
     (itemKey: string) => {
       const selectedResources = getResource(selectedRef.current);
       if (selectedRef.current.includes(itemKey)) {
         const selectedHaulItems = selectedResources.flatMap((res) => {
-          const svcItems = services[res.id.type].haulItems(res);
           const depth = Base.getDepth(itemKey, shapeRef.current);
-          const baseItems: Haul.Item[] = [
-            {
-              type: Base.HAUL_TYPE,
-              key: ontology.idToString(res.id),
-              data: { depth },
-            },
+          const items: Haul.Item[] = [
+            Base.createHaulItem(ontology.idToString(res.id), depth),
           ];
-          if (svcItems != null)
-            baseItems.push(
-              ...svcItems.map((i) => ({
-                ...i,
-                data: { ...i.data, depth },
-              })),
-            );
-          return baseItems;
+          const svcItems = services[res.id.type].haulItems(res);
+          if (svcItems != null) items.push(...svcItems);
+          return items;
         });
         return startDrag(selectedHaulItems);
       }
+      const depth = Base.getDepth(itemKey, shapeRef.current);
       const haulItems = services[ontology.idZ.parse(itemKey).type].haulItems(
         getResource(itemKey),
       );
-      const depth = Base.getDepth(itemKey, shapeRef.current);
-      startDrag([
-        { type: Base.HAUL_TYPE, key: itemKey, data: { depth } },
-        ...haulItems.map((item) => ({ ...item, data: { ...item.data, depth } })),
-      ]);
+      startDrag([Base.createHaulItem(itemKey, depth), ...haulItems]);
     },
     [getResource, selectedRef],
   );

--- a/console/src/range/Toolbar.tsx
+++ b/console/src/range/Toolbar.tsx
@@ -37,7 +37,6 @@ import { CREATE_LAYOUT } from "@/range/Create";
 import { EXPLORER_LAYOUT } from "@/range/Explorer";
 import { select, useSelect, useSelectStaticKeys } from "@/range/selectors";
 import { add, rename, setActive, type StaticRange } from "@/range/slice";
-import { fromClientRange } from "@/range/translate";
 import { type RootState } from "@/store";
 
 const NoRanges = (): ReactElement => {
@@ -66,7 +65,15 @@ const List = (): ReactElement => {
     canDrop: Ranger.canDropHaulItem,
     onDrop: ({ items }) => {
       const dropped = Ranger.filterHaulItems(items);
-      dispatch(add({ ranges: fromClientRange(dropped.map(({ data }) => data)) }));
+      dispatch(
+        add({
+          ranges: dropped.map(({ data }) => ({
+            ...data,
+            persisted: true,
+            variant: "static",
+          })),
+        }),
+      );
       return dropped;
     },
   });

--- a/console/src/range/Toolbar.tsx
+++ b/console/src/range/Toolbar.tsx
@@ -37,6 +37,7 @@ import { CREATE_LAYOUT } from "@/range/Create";
 import { EXPLORER_LAYOUT } from "@/range/Explorer";
 import { select, useSelect, useSelectStaticKeys } from "@/range/selectors";
 import { add, rename, setActive, type StaticRange } from "@/range/slice";
+import { fromClientRange } from "@/range/translate";
 import { type RootState } from "@/store";
 
 const NoRanges = (): ReactElement => {
@@ -61,21 +62,12 @@ const List = (): ReactElement => {
   };
 
   const dropProps = Haul.useDrop({
-    type: "range-toolbar",
-    canDrop: Haul.canDropOfType("range"),
+    type: "range_toolbar",
+    canDrop: Ranger.canDropHaulItem,
     onDrop: ({ items }) => {
-      const ranges = items.map(
-        ({ data, key }) =>
-          ({
-            key,
-            name: data?.name,
-            variant: "static",
-            persisted: true,
-            timeRange: data?.timeRange,
-          }) as StaticRange,
-      );
-      dispatch(add({ ranges }));
-      return items;
+      const dropped = Ranger.filterHaulItems(items);
+      dispatch(add({ ranges: fromClientRange(dropped.map(({ data }) => data)) }));
+      return dropped;
     },
   });
 

--- a/console/src/range/services/ontology.tsx
+++ b/console/src/range/services/ontology.tsx
@@ -7,8 +7,8 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { type ontology } from "@synnaxlabs/client";
-import { type Haul, Icon, List, Select, Telem, Text } from "@synnaxlabs/pluto";
+import { type ontology, type ranger } from "@synnaxlabs/client";
+import { type Haul, Icon, List, Ranger, Select, Telem, Text } from "@synnaxlabs/pluto";
 import { type CrudeTimeRange, strings } from "@synnaxlabs/x";
 
 import { Ontology } from "@/ontology";
@@ -35,9 +35,11 @@ const handleSelect: Ontology.HandleSelect = ({
   }, `Failed to select ${names}`);
 };
 
-const haulItems = ({ id }: ontology.Resource): Haul.Item[] => [
-  { type: "range", key: id.key },
-];
+const haulItems = (resource: ontology.Resource): Haul.Item[] => {
+  const payload = resource.data as ranger.Payload | null | undefined;
+  if (payload == null) return [];
+  return [Ranger.createHaulItem(payload)];
+};
 
 const PaletteListItem: Ontology.PaletteListItem = (props) => {
   const resource = List.useItem<string, ontology.Resource>(props.itemKey);

--- a/console/src/schematic/Schematic.spec.ts
+++ b/console/src/schematic/Schematic.spec.ts
@@ -20,8 +20,8 @@ import {
   isSymbolHaulItem,
   isValueHaulItem,
   SYMBOL_HAUL_TYPE,
-  type ValueHaulData,
   VALUE_HAUL_TYPE,
+  type ValueHaulData,
 } from "@/schematic/Schematic";
 
 const VARIANT = "valve";

--- a/console/src/schematic/Schematic.spec.ts
+++ b/console/src/schematic/Schematic.spec.ts
@@ -1,0 +1,156 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { type Haul } from "@synnaxlabs/pluto";
+import { describe, expect, it } from "vitest";
+
+import {
+  canDropSchematicHaulItem,
+  createSymbolHaulItem,
+  createValueHaulItem,
+  filterSymbolHaulItems,
+  filterValueHaulItems,
+  isSchematicHaulItem,
+  isSymbolHaulItem,
+  isValueHaulItem,
+  SYMBOL_HAUL_TYPE,
+  type ValueHaulData,
+  VALUE_HAUL_TYPE,
+} from "@/schematic/Schematic";
+
+const VARIANT = "valve";
+const SPEC_KEY = "spec-1";
+const VALUE_PROPS = {
+  label: { label: "Pressure", level: "p" },
+  color: "#ff0000",
+} as ValueHaulData;
+
+const OTHER: Haul.Item = { type: "other_type", key: "other" };
+
+describe("schematic symbol haul utilities", () => {
+  describe("createSymbolHaulItem", () => {
+    it("creates an item with the symbol HAUL_TYPE", () => {
+      expect(createSymbolHaulItem(VARIANT).type).toEqual(SYMBOL_HAUL_TYPE);
+    });
+
+    it("creates an item with the variant as the key", () => {
+      expect(createSymbolHaulItem(VARIANT).key).toEqual(VARIANT);
+    });
+
+    it("creates an item with empty data when none is provided", () => {
+      expect(createSymbolHaulItem(VARIANT).data).toEqual({});
+    });
+
+    it("creates an item with the provided specKey in data", () => {
+      expect(createSymbolHaulItem(VARIANT, { specKey: SPEC_KEY }).data).toEqual({
+        specKey: SPEC_KEY,
+      });
+    });
+  });
+
+  describe("isSymbolHaulItem", () => {
+    it("returns true for a symbol item", () => {
+      expect(isSymbolHaulItem(createSymbolHaulItem(VARIANT))).toBe(true);
+    });
+
+    it("returns false for a value item", () => {
+      expect(isSymbolHaulItem(createValueHaulItem(VALUE_PROPS))).toBe(false);
+    });
+
+    it("returns false for an item of another kind", () => {
+      expect(isSymbolHaulItem(OTHER)).toBe(false);
+    });
+  });
+
+  describe("filterSymbolHaulItems", () => {
+    it("keeps only symbol items", () => {
+      const symbol = createSymbolHaulItem(VARIANT);
+      const value = createValueHaulItem(VALUE_PROPS);
+      expect(filterSymbolHaulItems([symbol, value, OTHER])).toEqual([symbol]);
+    });
+  });
+});
+
+describe("schematic value haul utilities", () => {
+  describe("createValueHaulItem", () => {
+    it("creates an item with the value HAUL_TYPE", () => {
+      expect(createValueHaulItem(VALUE_PROPS).type).toEqual(VALUE_HAUL_TYPE);
+    });
+
+    it("creates an item with the literal 'value' as the key", () => {
+      expect(createValueHaulItem(VALUE_PROPS).key).toEqual("value");
+    });
+
+    it("creates an item carrying the full value props in data", () => {
+      expect(createValueHaulItem(VALUE_PROPS).data).toEqual(VALUE_PROPS);
+    });
+  });
+
+  describe("isValueHaulItem", () => {
+    it("returns true for a value item", () => {
+      expect(isValueHaulItem(createValueHaulItem(VALUE_PROPS))).toBe(true);
+    });
+
+    it("returns false for a symbol item", () => {
+      expect(isValueHaulItem(createSymbolHaulItem(VARIANT))).toBe(false);
+    });
+
+    it("returns false for an item of another kind", () => {
+      expect(isValueHaulItem(OTHER)).toBe(false);
+    });
+  });
+
+  describe("filterValueHaulItems", () => {
+    it("keeps only value items", () => {
+      const symbol = createSymbolHaulItem(VARIANT);
+      const value = createValueHaulItem(VALUE_PROPS);
+      expect(filterValueHaulItems([symbol, value, OTHER])).toEqual([value]);
+    });
+  });
+});
+
+describe("schematic combined haul utilities", () => {
+  describe("isSchematicHaulItem", () => {
+    it("returns true for a symbol item", () => {
+      expect(isSchematicHaulItem(createSymbolHaulItem(VARIANT))).toBe(true);
+    });
+
+    it("returns true for a value item", () => {
+      expect(isSchematicHaulItem(createValueHaulItem(VALUE_PROPS))).toBe(true);
+    });
+
+    it("returns false for an item of another kind", () => {
+      expect(isSchematicHaulItem(OTHER)).toBe(false);
+    });
+  });
+
+  describe("canDropSchematicHaulItem", () => {
+    it("returns true when items contain a symbol item", () => {
+      expect(
+        canDropSchematicHaulItem({
+          source: OTHER,
+          items: [createSymbolHaulItem(VARIANT), OTHER],
+        }),
+      ).toBe(true);
+    });
+
+    it("returns true when items contain a value item", () => {
+      expect(
+        canDropSchematicHaulItem({
+          source: OTHER,
+          items: [createValueHaulItem(VALUE_PROPS), OTHER],
+        }),
+      ).toBe(true);
+    });
+
+    it("returns false when items contain neither a symbol nor a value item", () => {
+      expect(canDropSchematicHaulItem({ source: OTHER, items: [OTHER] })).toBe(false);
+    });
+  });
+});

--- a/console/src/schematic/Schematic.tsx
+++ b/console/src/schematic/Schematic.tsx
@@ -78,7 +78,50 @@ import { Selector } from "@/selector";
 import { type RootState } from "@/store";
 import { Workspace } from "@/workspace";
 
-export const HAUL_TYPE = "schematic-element";
+export const SYMBOL_HAUL_TYPE = "schematic_symbol";
+
+export interface SymbolHaulData {
+  specKey?: string;
+}
+
+export type SymbolHaulItem = Haul.Item<typeof SYMBOL_HAUL_TYPE, string, SymbolHaulData>;
+
+export const createSymbolHaulItem = (
+  variant: string,
+  data: SymbolHaulData = {},
+): SymbolHaulItem => ({ type: SYMBOL_HAUL_TYPE, key: variant, data });
+
+export const isSymbolHaulItem = (item: Haul.Item): item is SymbolHaulItem =>
+  item.type === SYMBOL_HAUL_TYPE;
+
+export const filterSymbolHaulItems = (items: Haul.Item[]): SymbolHaulItem[] =>
+  items.filter(isSymbolHaulItem);
+
+export const VALUE_HAUL_TYPE = "schematic_value";
+
+export type ValueHaulData = Base.Symbol.ValueProps;
+
+export type ValueHaulItem = Haul.Item<typeof VALUE_HAUL_TYPE, string, ValueHaulData>;
+
+export const createValueHaulItem = (props: ValueHaulData): ValueHaulItem => ({
+  type: VALUE_HAUL_TYPE,
+  key: "value",
+  data: props,
+});
+
+export const isValueHaulItem = (item: Haul.Item): item is ValueHaulItem =>
+  item.type === VALUE_HAUL_TYPE;
+
+export const filterValueHaulItems = (items: Haul.Item[]): ValueHaulItem[] =>
+  items.filter(isValueHaulItem);
+
+export const isSchematicHaulItem = (
+  item: Haul.Item,
+): item is SymbolHaulItem | ValueHaulItem =>
+  isSymbolHaulItem(item) || isValueHaulItem(item);
+
+export const canDropSchematicHaulItem: Haul.CanDrop = ({ items }) =>
+  items.some(isSchematicHaulItem);
 
 type SchematicRetriever = (key: string) => Promise<schematic.Schematic>;
 
@@ -336,7 +379,7 @@ export const Loaded: Layout.Renderer = ({ layoutKey, visible }) => {
 
   const handleDrop = useCallback(
     ({ items, event }: Haul.OnDropProps): Haul.Item[] => {
-      const valid = Haul.filterByType(HAUL_TYPE, items);
+      const valid = items.filter(isSchematicHaulItem);
       if (event == null) return valid;
       valid.forEach(({ key, data }) => {
         const spec = Base.Symbol.REGISTRY[key as Base.Symbol.Variant];
@@ -350,9 +393,9 @@ export const Loaded: Layout.Renderer = ({ layoutKey, visible }) => {
   );
 
   const dropProps = Haul.useDrop({
-    type: "Schematic",
+    type: "schematic",
     key: layoutKey,
-    canDrop: Haul.canDropOfType(HAUL_TYPE),
+    canDrop: canDropSchematicHaulItem,
     onDrop: handleDrop,
   });
 

--- a/console/src/schematic/services/ontology.tsx
+++ b/console/src/schematic/services/ontology.tsx
@@ -234,9 +234,7 @@ export const ONTOLOGY_SERVICE: Ontology.Service = {
   icon: <Icon.Schematic />,
   hasChildren: false,
   onSelect: handleSelect,
-  haulItems: ({ id }) => [
-    { type: Mosaic.HAUL_CREATE_TYPE, key: ontology.idToString(id) },
-  ],
+  haulItems: ({ id }) => [Mosaic.createTabCreateHaulItem(ontology.idToString(id))],
   onMosaicDrop: handleMosaicDrop,
   TreeContextMenu,
 };

--- a/console/src/schematic/toolbar/Symbols.tsx
+++ b/console/src/schematic/toolbar/Symbols.tsx
@@ -48,6 +48,7 @@ import {
   useImport as useImportSymbol,
   useImportGroup,
 } from "@/schematic/symbols/import";
+import { createSymbolHaulItem } from "@/schematic/Schematic";
 import { useAddSymbol } from "@/schematic/symbols/useAddSymbol";
 import { useDeleteSymbolGroup } from "@/schematic/symbols/useDeleteSymbolGroup";
 
@@ -56,12 +57,12 @@ const StaticListItem = (props: List.ItemProps<string>): ReactElement | null => {
   const theme = Theming.use();
 
   const { startDrag, onDragEnd } = Haul.useDrag({
-    type: "Diagram-Elements",
+    type: "diagram_elements",
     key: "symbols",
   });
 
   const handleDragStart = useCallback(() => {
-    startDrag([{ type: "schematic-element", key: itemKey }]);
+    startDrag([createSymbolHaulItem(itemKey)]);
   }, [startDrag, itemKey]);
   const spec = List.useItem<string, Schematic.Symbol.Spec>(itemKey);
   const defaultProps_ = useMemo(() => spec?.defaultProps(theme), [spec, theme]);
@@ -130,14 +131,12 @@ const RemoteListItem = (props: RemoteListItemProps): ReactElement | null => {
   const Preview = Schematic.Symbol.REGISTRY[variant].Preview;
 
   const { startDrag, onDragEnd } = Haul.useDrag({
-    type: "Diagram-Elements",
+    type: "diagram_elements",
     key: "symbols",
   });
 
   const handleDragStart = useCallback(() => {
-    startDrag([
-      { type: "schematic-element", key: variant, data: { specKey: itemKey } },
-    ]);
+    startDrag([createSymbolHaulItem(variant, { specKey: itemKey })]);
   }, [startDrag, itemKey, variant]);
 
   if (symbol == null) return null;

--- a/console/src/schematic/toolbar/Symbols.tsx
+++ b/console/src/schematic/toolbar/Symbols.tsx
@@ -37,6 +37,7 @@ import { Export } from "@/export";
 import { Layout } from "@/layout";
 import { Modals } from "@/modals";
 import { useConfirmDelete } from "@/ontology/hooks";
+import { createSymbolHaulItem } from "@/schematic/Schematic";
 import { useSelectSelectedSymbolGroup } from "@/schematic/selectors";
 import { setSelectedSymbolGroup } from "@/schematic/slice";
 import { createEditLayout } from "@/schematic/symbols/edit/Edit";
@@ -48,7 +49,6 @@ import {
   useImport as useImportSymbol,
   useImportGroup,
 } from "@/schematic/symbols/import";
-import { createSymbolHaulItem } from "@/schematic/Schematic";
 import { useAddSymbol } from "@/schematic/symbols/useAddSymbol";
 import { useDeleteSymbolGroup } from "@/schematic/symbols/useDeleteSymbolGroup";
 

--- a/console/src/table/services/ontology.tsx
+++ b/console/src/table/services/ontology.tsx
@@ -141,9 +141,7 @@ export const ONTOLOGY_SERVICE: Ontology.Service = {
   icon: <Icon.Table />,
   hasChildren: false,
   onSelect: handleSelect,
-  haulItems: ({ id }) => [
-    { type: Mosaic.HAUL_CREATE_TYPE, key: ontology.idToString(id) },
-  ],
+  haulItems: ({ id }) => [Mosaic.createTabCreateHaulItem(ontology.idToString(id))],
   onMosaicDrop: handleMosaicDrop,
   TreeContextMenu,
 };

--- a/console/src/user/services/ontology.tsx
+++ b/console/src/user/services/ontology.tsx
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { ontology } from "@synnaxlabs/client";
+import { ontology, type user } from "@synnaxlabs/client";
 import { Access, type Flux, Icon, Menu, Text, User } from "@synnaxlabs/pluto";
 import { useCallback } from "react";
 
@@ -118,5 +118,6 @@ export const ONTOLOGY_SERVICE: Ontology.Service = {
   icon: <Icon.User />,
   TreeContextMenu,
   hasChildren: false,
-  haulItems: ({ id, data }) => [{ ...id, data: data ?? undefined }],
+  haulItems: ({ data }) =>
+    data == null ? [] : [User.createHaulItem(data as user.User)],
 };

--- a/pluto/src/access/policy/types.spec.ts
+++ b/pluto/src/access/policy/types.spec.ts
@@ -1,0 +1,63 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  canDropHaulItem,
+  createHaulItem,
+  filterHaulItems,
+  HAUL_TYPE,
+  isHaulItem,
+} from "@/access/policy/types";
+import { type Haul } from "@/haul";
+
+const KEY = "550e8400-e29b-41d4-a716-446655440000";
+const OTHER: Haul.Item = { type: "other_type", key: "other" };
+
+describe("policy haul utilities", () => {
+  describe("createHaulItem", () => {
+    it("creates an item with the policy HAUL_TYPE", () => {
+      expect(createHaulItem(KEY).type).toEqual(HAUL_TYPE);
+    });
+
+    it("creates an item with the provided key", () => {
+      expect(createHaulItem(KEY).key).toEqual(KEY);
+    });
+  });
+
+  describe("isHaulItem", () => {
+    it("returns true for an item of the policy kind", () => {
+      expect(isHaulItem(createHaulItem(KEY))).toBe(true);
+    });
+
+    it("returns false for an item of another kind", () => {
+      expect(isHaulItem(OTHER)).toBe(false);
+    });
+  });
+
+  describe("filterHaulItems", () => {
+    it("keeps policy items and drops items of other kinds", () => {
+      const item = createHaulItem(KEY);
+      expect(filterHaulItems([item, OTHER])).toEqual([item]);
+    });
+  });
+
+  describe("canDropHaulItem", () => {
+    it("returns true when at least one item is a policy item", () => {
+      expect(
+        canDropHaulItem({ source: OTHER, items: [createHaulItem(KEY), OTHER] }),
+      ).toBe(true);
+    });
+
+    it("returns false when no item is a policy item", () => {
+      expect(canDropHaulItem({ source: OTHER, items: [OTHER] })).toBe(false);
+    });
+  });
+});

--- a/pluto/src/access/policy/types.ts
+++ b/pluto/src/access/policy/types.ts
@@ -7,4 +7,23 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+import { type access } from "@synnaxlabs/client";
+
+import { Haul } from "@/haul";
+
 export const HAUL_TYPE = "policy";
+
+export type HaulItem = Haul.Item<typeof HAUL_TYPE, access.policy.Key, undefined>;
+
+export const createHaulItem = (key: access.policy.Key): HaulItem => ({
+  type: HAUL_TYPE,
+  key,
+});
+
+export const isHaulItem = (item: Haul.Item): item is HaulItem =>
+  item.type === HAUL_TYPE;
+
+export const filterHaulItems = (items: Haul.Item[]): HaulItem[] =>
+  items.filter(isHaulItem);
+
+export const canDropHaulItem = Haul.canDropOfType<HaulItem>(HAUL_TYPE);

--- a/pluto/src/channel/LinePlot.tsx
+++ b/pluto/src/channel/LinePlot.tsx
@@ -13,6 +13,7 @@ import { type channel } from "@synnaxlabs/client";
 import {
   box,
   type color,
+  type direction,
   location as loc,
   type TimeRange,
   type TimeSpan,
@@ -27,7 +28,7 @@ import {
   useRef,
 } from "react";
 
-import { HAUL_TYPE } from "@/channel/types";
+import { canDropHaulItem, filterHaulItems } from "@/channel/types";
 import { CSS } from "@/css";
 import { Haul } from "@/haul";
 import { usePrevious } from "@/hooks";
@@ -108,8 +109,6 @@ export interface LinePlotProps extends Omit<Base.LinePlotProps, "ref"> {
   onMeasureModeChange?: (mode: measure.Mode) => void;
   ref?: Ref<Base.LinePlotRef>;
 }
-
-const canDrop = Haul.canDropOfType(HAUL_TYPE);
 
 /**
  * A line plot component that automatically pulls data from specified channels and
@@ -220,6 +219,25 @@ interface XAxisProps extends Pick<
   rangeProviderProps?: Range.ProviderProps;
 }
 
+export const useAxisDrop = (
+  key: string,
+  direction: direction.Direction,
+  onAxisChannelDrop?: (key: string, keys: channel.Key[]) => void,
+): Haul.UseDropReturn =>
+  Haul.useDrop({
+    type: `channel_lineplot_${direction}_axis`,
+    canDrop: canDropHaulItem,
+    onDrop: useCallback(
+      ({ items }) => {
+        const dropped = filterHaulItems(items);
+        const keys = dropped.map(({ key }) => key);
+        onAxisChannelDrop?.(key, keys);
+        return dropped;
+      },
+      [key, onAxisChannelDrop],
+    ),
+  });
+
 const XAxis = ({
   yAxes,
   lines,
@@ -232,24 +250,9 @@ const XAxis = ({
   axis: { location, key, showGrid, ...axis },
   rangeProviderProps,
 }: XAxisProps): ReactElement => {
-  const dropProps = Haul.useDrop({
-    type: "Channel.LinePlot.XAxis",
-    canDrop,
-    onDrop: useCallback(
-      ({ items }) => {
-        const dropped = Haul.filterByType(HAUL_TYPE, items);
-        onAxisChannelDrop?.(
-          key,
-          dropped.map(({ key }) => key as channel.Key),
-        );
-        return dropped;
-      },
-      [key, onAxisChannelDrop],
-    ),
-  });
-
   const xRules = rules?.filter((r) => r.axis === key);
   const dragging = Haul.useDraggingState();
+  const dropProps = useAxisDrop(key, "x", onAxisChannelDrop);
   return (
     <Base.XAxis
       {...axis}
@@ -257,7 +260,7 @@ const XAxis = ({
       location={location as loc.Y}
       axisKey={key}
       showGrid={showGrid ?? index === 0}
-      className={CSS(CSS.dropRegion(Haul.canDropOfType(HAUL_TYPE)(dragging)))}
+      className={CSS(CSS.dropRegion(canDropHaulItem(dragging)))}
       onAutoBoundsChange={(bounds) => onAxisChange?.({ key, bounds })}
       onLabelChange={(value) => onAxisChange?.({ key, label: value })}
     >
@@ -318,31 +321,15 @@ const YAxis = ({
   axis: { key, location: loc, ...props },
   onSelectRule,
 }: YAxisProps): ReactElement => {
-  const dropProps = Haul.useDrop({
-    type: "Channel.LinePlot.YAxis",
-    canDrop,
-    onDrop: useCallback(
-      ({ items }) => {
-        const dropped = Haul.filterByType(HAUL_TYPE, items);
-        onAxisChannelDrop?.(
-          key,
-          dropped.map(({ key }) => key as channel.Key),
-        );
-        return dropped;
-      },
-      [key, onAxisChannelDrop],
-    ),
-  });
-
+  const dropProps = useAxisDrop(key, "y", onAxisChannelDrop);
   const dragging = Haul.useDraggingState();
-
   return (
     <Base.YAxis
       {...props}
       {...dropProps}
       location={loc as loc.X}
       axisKey={key}
-      className={CSS(CSS.dropRegion(Haul.canDropOfType(HAUL_TYPE)(dragging)))}
+      className={CSS(CSS.dropRegion(canDropHaulItem(dragging)))}
       onAutoBoundsChange={(bounds) => onAxisChange?.({ key, bounds })}
       onLabelChange={(value) => onAxisChange?.({ key, label: value })}
     >

--- a/pluto/src/channel/external.ts
+++ b/pluto/src/channel/external.ts
@@ -13,3 +13,4 @@ export * from "@/channel/LinePlot";
 export * from "@/channel/queries";
 export * from "@/channel/resolveIcon";
 export * from "@/channel/Select";
+export * from "@/channel/types";

--- a/pluto/src/channel/types.spec.ts
+++ b/pluto/src/channel/types.spec.ts
@@ -1,0 +1,61 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  canDropHaulItem,
+  createHaulItem,
+  filterHaulItems,
+  HAUL_TYPE,
+  isHaulItem,
+} from "@/channel/types";
+import { type Haul } from "@/haul";
+
+const OTHER: Haul.Item = { type: "other_type", key: "other" };
+
+describe("channel haul utilities", () => {
+  describe("createHaulItem", () => {
+    it("creates an item with the channel HAUL_TYPE", () => {
+      expect(createHaulItem(42).type).toEqual(HAUL_TYPE);
+    });
+
+    it("creates an item with the provided key", () => {
+      expect(createHaulItem(42).key).toEqual(42);
+    });
+  });
+
+  describe("isHaulItem", () => {
+    it("returns true for an item of the channel kind", () => {
+      expect(isHaulItem(createHaulItem(1))).toBe(true);
+    });
+
+    it("returns false for an item of another kind", () => {
+      expect(isHaulItem(OTHER)).toBe(false);
+    });
+  });
+
+  describe("filterHaulItems", () => {
+    it("keeps channel items and drops items of other kinds", () => {
+      const item = createHaulItem(1);
+      expect(filterHaulItems([item, OTHER])).toEqual([item]);
+    });
+  });
+
+  describe("canDropHaulItem", () => {
+    it("returns true when at least one item is a channel item", () => {
+      const item = createHaulItem(1);
+      expect(canDropHaulItem({ source: OTHER, items: [item, OTHER] })).toBe(true);
+    });
+
+    it("returns false when no item is a channel item", () => {
+      expect(canDropHaulItem({ source: OTHER, items: [OTHER] })).toBe(false);
+    });
+  });
+});

--- a/pluto/src/channel/types.ts
+++ b/pluto/src/channel/types.ts
@@ -7,4 +7,23 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+import { type channel } from "@synnaxlabs/client";
+
+import { Haul } from "@/haul";
+
 export const HAUL_TYPE = "channel";
+
+export type HaulItem = Haul.Item<typeof HAUL_TYPE, channel.Key, undefined>;
+
+export const createHaulItem = (key: channel.Key): HaulItem => ({
+  type: HAUL_TYPE,
+  key,
+});
+
+export const isHaulItem = (item: Haul.Item): item is HaulItem =>
+  item.type === HAUL_TYPE;
+
+export const filterHaulItems = (items: Haul.Item[]): HaulItem[] =>
+  items.filter(isHaulItem);
+
+export const canDropHaulItem = Haul.canDropOfType<HaulItem>(HAUL_TYPE);

--- a/pluto/src/color/BaseSwatch.spec.ts
+++ b/pluto/src/color/BaseSwatch.spec.ts
@@ -1,0 +1,63 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { describe, expect, it } from "vitest";
+
+import {
+  canDropHaulItem,
+  createHaulItem,
+  filterHaulItems,
+  HAUL_TYPE,
+  isHaulItem,
+} from "@/color/BaseSwatch";
+import { type Haul } from "@/haul";
+
+const HEX = "#ff0000";
+const OTHER: Haul.Item = { type: "other_type", key: "other" };
+
+describe("color haul utilities", () => {
+  describe("createHaulItem", () => {
+    it("creates an item with the color HAUL_TYPE", () => {
+      expect(createHaulItem(HEX).type).toEqual(HAUL_TYPE);
+    });
+
+    it("creates an item with the provided hex key", () => {
+      expect(createHaulItem(HEX).key).toEqual(HEX);
+    });
+  });
+
+  describe("isHaulItem", () => {
+    it("returns true for an item of the color kind", () => {
+      expect(isHaulItem(createHaulItem(HEX))).toBe(true);
+    });
+
+    it("returns false for an item of another kind", () => {
+      expect(isHaulItem(OTHER)).toBe(false);
+    });
+  });
+
+  describe("filterHaulItems", () => {
+    it("keeps color items and drops items of other kinds", () => {
+      const item = createHaulItem(HEX);
+      expect(filterHaulItems([item, OTHER])).toEqual([item]);
+    });
+  });
+
+  describe("canDropHaulItem", () => {
+    it("returns true when at least one item is a color item", () => {
+      expect(
+        canDropHaulItem({ source: OTHER, items: [createHaulItem(HEX), OTHER] }),
+      ).toBe(true);
+    });
+
+    it("returns false when no item is a color item", () => {
+      expect(canDropHaulItem({ source: OTHER, items: [OTHER] })).toBe(false);
+    });
+  });
+});

--- a/pluto/src/color/BaseSwatch.tsx
+++ b/pluto/src/color/BaseSwatch.tsx
@@ -17,7 +17,22 @@ import { CSS } from "@/css";
 import { Haul } from "@/haul";
 import { Theming } from "@/theming";
 
-const HAUL_TYPE = "color";
+export const HAUL_TYPE = "color";
+
+export type HaulItem = Haul.Item<typeof HAUL_TYPE, color.Hex, undefined>;
+
+export const createHaulItem = (key: color.Hex): HaulItem => ({
+  type: HAUL_TYPE,
+  key,
+});
+
+export const isHaulItem = (item: Haul.Item): item is HaulItem =>
+  item.type === HAUL_TYPE;
+
+export const filterHaulItems = (items: Haul.Item[]): HaulItem[] =>
+  items.filter(isHaulItem);
+
+export const canDropHaulItem = Haul.canDropOfType<HaulItem>(HAUL_TYPE);
 
 export interface BaseSwatchProps extends Omit<
   Button.ButtonProps,
@@ -42,26 +57,26 @@ export const BaseSwatch = ({
   const dragging = Haul.useDraggingState();
   const canDrop: Haul.CanDrop = useCallback(
     ({ items }) => {
-      const [k] = Haul.filterByType(HAUL_TYPE, items);
+      const [k] = filterHaulItems(items);
       return k != null && k.key !== color.hex(clr);
     },
     [clr],
   );
   const handleDrop: Haul.OnDrop = useCallback(
     ({ items }) => {
-      const [k] = Haul.filterByType(HAUL_TYPE, items);
-      if (k != null) onChange?.(color.construct(k.key as string));
+      const [k] = filterHaulItems(items);
+      if (k != null) onChange?.(color.construct(k.key));
       return items;
     },
     [onChange],
   );
   const { startDrag, ...haulProps } = Haul.useDragAndDrop({
-    type: "Color.Swatch",
+    type: "color_swatch",
     onDrop: handleDrop,
     canDrop,
   });
   const handleDragStart = useCallback(() => {
-    startDrag([{ type: HAUL_TYPE, key: color.hex(clr) }]);
+    startDrag([createHaulItem(color.hex(clr))]);
   }, [startDrag, clr]);
   return (
     <Button.Button

--- a/pluto/src/haul/Haul.tsx
+++ b/pluto/src/haul/Haul.tsx
@@ -9,7 +9,7 @@
 
 import "@/haul/Haul.css";
 
-import { type destructor, type optional, record, xy } from "@synnaxlabs/x";
+import { type destructor, type optional, type record, xy } from "@synnaxlabs/x";
 import React, {
   type DragEvent,
   type DragEventHandler,
@@ -31,16 +31,20 @@ export const itemZ = z.object({
   key: z.string().or(z.number()),
   type: z.string(),
   elementID: z.string().optional(),
-  data: record.unknownZ().optional(),
+  data: z.unknown().optional(),
 });
 
-// Item represents a draggable item.
-export interface Item {
-  key: record.Key;
-  type: string;
+// Item represents a draggable item. When `Data` does not include `undefined`,
+// the `data` field is required; otherwise it is optional.
+export type Item<
+  Type extends string = string,
+  Key extends record.Key = record.Key,
+  Data = unknown,
+> = {
+  key: Key;
+  type: Type;
   elementID?: string;
-  data?: record.Unknown;
-}
+} & (undefined extends Data ? { data?: Data } : { data: Data });
 
 export const draggingStateZ = z.object({ source: itemZ, items: z.array(itemZ) });
 
@@ -302,7 +306,7 @@ export const useDragAndDrop = ({
 };
 
 export const canDropOfType =
-  (type: string): CanDrop =>
+  <I extends Item = Item>(type: I["type"]): CanDrop =>
   ({ items }) =>
     items.some((entity) => entity.type === type);
 

--- a/pluto/src/label/types.spec.ts
+++ b/pluto/src/label/types.spec.ts
@@ -1,0 +1,63 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { describe, expect, it } from "vitest";
+
+import { type Haul } from "@/haul";
+import {
+  canDropHaulItem,
+  createHaulItem,
+  filterHaulItems,
+  HAUL_TYPE,
+  isHaulItem,
+} from "@/label/types";
+
+const KEY = "550e8400-e29b-41d4-a716-446655440000";
+const OTHER: Haul.Item = { type: "other_type", key: "other" };
+
+describe("label haul utilities", () => {
+  describe("createHaulItem", () => {
+    it("creates an item with the label HAUL_TYPE", () => {
+      expect(createHaulItem(KEY).type).toEqual(HAUL_TYPE);
+    });
+
+    it("creates an item with the provided key", () => {
+      expect(createHaulItem(KEY).key).toEqual(KEY);
+    });
+  });
+
+  describe("isHaulItem", () => {
+    it("returns true for an item of the label kind", () => {
+      expect(isHaulItem(createHaulItem(KEY))).toBe(true);
+    });
+
+    it("returns false for an item of another kind", () => {
+      expect(isHaulItem(OTHER)).toBe(false);
+    });
+  });
+
+  describe("filterHaulItems", () => {
+    it("keeps label items and drops items of other kinds", () => {
+      const item = createHaulItem(KEY);
+      expect(filterHaulItems([item, OTHER])).toEqual([item]);
+    });
+  });
+
+  describe("canDropHaulItem", () => {
+    it("returns true when at least one item is a label item", () => {
+      expect(
+        canDropHaulItem({ source: OTHER, items: [createHaulItem(KEY), OTHER] }),
+      ).toBe(true);
+    });
+
+    it("returns false when no item is a label item", () => {
+      expect(canDropHaulItem({ source: OTHER, items: [OTHER] })).toBe(false);
+    });
+  });
+});

--- a/pluto/src/mosaic/Mosaic.tsx
+++ b/pluto/src/mosaic/Mosaic.tsx
@@ -175,10 +175,43 @@ interface TabLeafProps extends Omit<
  * This type should be used when the user wants to drop a tab in the mosaic.
  * Dropping an item with this signature will call the {@link Mosaic} onDrop handler.
  */
-export const HAUL_DROP_TYPE = "pluto-mosaic-tab-drop";
+export const HAUL_DROP_TYPE = "pluto_mosaic_tab_drop";
+
+export type TabDropHaulItem = Haul.Item<typeof HAUL_DROP_TYPE, string, undefined>;
+
+export const createTabDropHaulItem = (
+  tabKey: string,
+  elementID?: string,
+): TabDropHaulItem => ({ type: HAUL_DROP_TYPE, key: tabKey, elementID });
+
+export const isTabDropHaulItem = (item: Haul.Item): item is TabDropHaulItem =>
+  item.type === HAUL_DROP_TYPE;
+
+export const filterTabDropHaulItems = (items: Haul.Item[]): TabDropHaulItem[] =>
+  items.filter(isTabDropHaulItem);
+
+export const canDropTabDropHaulItem =
+  Haul.canDropOfType<TabDropHaulItem>(HAUL_DROP_TYPE);
+
 /** This type should be used when the user wants to create a new tab in the mosaic.
 Dropping an item with this signature will call the {@link Mosaic} onCreate handler. */
-export const HAUL_CREATE_TYPE = "pluto-mosaic-tab-create";
+export const HAUL_CREATE_TYPE = "pluto_mosaic_tab_create";
+
+export type TabCreateHaulItem = Haul.Item<typeof HAUL_CREATE_TYPE, string, undefined>;
+
+export const createTabCreateHaulItem = (tabKey: string): TabCreateHaulItem => ({
+  type: HAUL_CREATE_TYPE,
+  key: tabKey,
+});
+
+export const isTabCreateHaulItem = (item: Haul.Item): item is TabCreateHaulItem =>
+  item.type === HAUL_CREATE_TYPE;
+
+export const filterTabCreateHaulItems = (items: Haul.Item[]): TabCreateHaulItem[] =>
+  items.filter(isTabCreateHaulItem);
+
+export const canDropTabCreateHaulItem =
+  Haul.canDropOfType<TabCreateHaulItem>(HAUL_CREATE_TYPE);
 
 /** Checks whether the tab can actually be dropped in this location or not */
 const validDrop = (
@@ -188,9 +221,9 @@ const validDrop = (
 ): boolean => {
   const hasFiles = Haul.filterByType(Haul.FILE_TYPE, dragging).length > 0;
   if (hasFiles && hasFileDrop) return true;
-  const drop = Haul.filterByType(HAUL_DROP_TYPE, dragging).map((t) => t.key);
+  const drop = filterTabDropHaulItems(dragging).map((t) => t.key);
   const willHaveTabRemaining = tabs.filter((t) => !drop.includes(t.tabKey)).length > 0;
-  const create = Haul.filterByType(HAUL_CREATE_TYPE, dragging);
+  const create = filterTabCreateHaulItems(dragging);
   return (
     create.length > 0 ||
     (drop.length > 0 && (willHaveTabRemaining || tabs.length === 0))
@@ -232,15 +265,15 @@ const TabLeaf = memo(
           onFileDrop?.(key, loc, event);
           return items;
         }
-        const dropped = Haul.filterByType(HAUL_DROP_TYPE, items);
+        const dropped = filterTabDropHaulItems(items);
         if (dropped.length > 0) {
           const tabKey = dropped.map(({ key }) => key)[0];
-          onDrop(key, tabKey as string, loc, index);
+          onDrop(key, tabKey, loc, index);
         }
-        const created = Haul.filterByType(HAUL_CREATE_TYPE, items);
+        const created = filterTabCreateHaulItems(items);
         if (created.length > 0) {
           const tabKey = created.map(({ key }) => key);
-          onCreate?.(key, loc, tabKey as string[]);
+          onCreate?.(key, loc, tabKey);
         }
         return dropped;
       },
@@ -272,9 +305,7 @@ const TabLeaf = memo(
 
     const handleDragStart = useCallback(
       (e: DragEvent<HTMLElement>, { tabKey }: Tabs.Tab): void => {
-        startDrag([
-          { key: tabKey, type: HAUL_DROP_TYPE, elementID: e.currentTarget.id },
-        ]);
+        startDrag([createTabDropHaulItem(tabKey, e.currentTarget.id)]);
       },
       [startDrag],
     );

--- a/pluto/src/mosaic/haul.spec.ts
+++ b/pluto/src/mosaic/haul.spec.ts
@@ -1,0 +1,140 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { describe, expect, it } from "vitest";
+
+import { type Haul } from "@/haul";
+import {
+  canDropTabCreateHaulItem,
+  canDropTabDropHaulItem,
+  createTabCreateHaulItem,
+  createTabDropHaulItem,
+  filterTabCreateHaulItems,
+  filterTabDropHaulItems,
+  HAUL_CREATE_TYPE,
+  HAUL_DROP_TYPE,
+  isTabCreateHaulItem,
+  isTabDropHaulItem,
+} from "@/mosaic/Mosaic";
+
+const TAB_KEY = "tab-1";
+const ELEMENT_ID = "element-1";
+const OTHER: Haul.Item = { type: "other_type", key: "other" };
+
+describe("mosaic tab-drop haul utilities", () => {
+  describe("createTabDropHaulItem", () => {
+    it("creates an item with the tab-drop HAUL_TYPE", () => {
+      expect(createTabDropHaulItem(TAB_KEY).type).toEqual(HAUL_DROP_TYPE);
+    });
+
+    it("creates an item with the provided tab key", () => {
+      expect(createTabDropHaulItem(TAB_KEY).key).toEqual(TAB_KEY);
+    });
+
+    it("attaches the optional elementID when provided", () => {
+      expect(createTabDropHaulItem(TAB_KEY, ELEMENT_ID).elementID).toEqual(ELEMENT_ID);
+    });
+  });
+
+  describe("isTabDropHaulItem", () => {
+    it("returns true for a tab-drop item", () => {
+      expect(isTabDropHaulItem(createTabDropHaulItem(TAB_KEY))).toBe(true);
+    });
+
+    it("returns false for a tab-create item", () => {
+      expect(isTabDropHaulItem(createTabCreateHaulItem(TAB_KEY))).toBe(false);
+    });
+
+    it("returns false for an item of another kind", () => {
+      expect(isTabDropHaulItem(OTHER)).toBe(false);
+    });
+  });
+
+  describe("filterTabDropHaulItems", () => {
+    it("keeps only tab-drop items", () => {
+      const drop = createTabDropHaulItem(TAB_KEY);
+      const create = createTabCreateHaulItem(TAB_KEY);
+      expect(filterTabDropHaulItems([drop, create, OTHER])).toEqual([drop]);
+    });
+  });
+
+  describe("canDropTabDropHaulItem", () => {
+    it("returns true when at least one item is a tab-drop item", () => {
+      expect(
+        canDropTabDropHaulItem({
+          source: OTHER,
+          items: [createTabDropHaulItem(TAB_KEY), OTHER],
+        }),
+      ).toBe(true);
+    });
+
+    it("returns false when no item is a tab-drop item", () => {
+      expect(
+        canDropTabDropHaulItem({
+          source: OTHER,
+          items: [createTabCreateHaulItem(TAB_KEY)],
+        }),
+      ).toBe(false);
+    });
+  });
+});
+
+describe("mosaic tab-create haul utilities", () => {
+  describe("createTabCreateHaulItem", () => {
+    it("creates an item with the tab-create HAUL_TYPE", () => {
+      expect(createTabCreateHaulItem(TAB_KEY).type).toEqual(HAUL_CREATE_TYPE);
+    });
+
+    it("creates an item with the provided tab key", () => {
+      expect(createTabCreateHaulItem(TAB_KEY).key).toEqual(TAB_KEY);
+    });
+  });
+
+  describe("isTabCreateHaulItem", () => {
+    it("returns true for a tab-create item", () => {
+      expect(isTabCreateHaulItem(createTabCreateHaulItem(TAB_KEY))).toBe(true);
+    });
+
+    it("returns false for a tab-drop item", () => {
+      expect(isTabCreateHaulItem(createTabDropHaulItem(TAB_KEY))).toBe(false);
+    });
+
+    it("returns false for an item of another kind", () => {
+      expect(isTabCreateHaulItem(OTHER)).toBe(false);
+    });
+  });
+
+  describe("filterTabCreateHaulItems", () => {
+    it("keeps only tab-create items", () => {
+      const drop = createTabDropHaulItem(TAB_KEY);
+      const create = createTabCreateHaulItem(TAB_KEY);
+      expect(filterTabCreateHaulItems([drop, create, OTHER])).toEqual([create]);
+    });
+  });
+
+  describe("canDropTabCreateHaulItem", () => {
+    it("returns true when at least one item is a tab-create item", () => {
+      expect(
+        canDropTabCreateHaulItem({
+          source: OTHER,
+          items: [createTabCreateHaulItem(TAB_KEY), OTHER],
+        }),
+      ).toBe(true);
+    });
+
+    it("returns false when no item is a tab-create item", () => {
+      expect(
+        canDropTabCreateHaulItem({
+          source: OTHER,
+          items: [createTabDropHaulItem(TAB_KEY)],
+        }),
+      ).toBe(false);
+    });
+  });
+});

--- a/pluto/src/ranger/types.spec.ts
+++ b/pluto/src/ranger/types.spec.ts
@@ -39,8 +39,12 @@ describe("range haul utilities", () => {
       expect(createHaulItem(PAYLOAD).key).toEqual(PAYLOAD.key);
     });
 
-    it("creates an item carrying the full payload in data", () => {
-      expect(createHaulItem(PAYLOAD).data).toEqual(PAYLOAD);
+    it("creates an item carrying serializable payload fields in data", () => {
+      expect(createHaulItem(PAYLOAD).data).toEqual({
+        key: PAYLOAD.key,
+        name: PAYLOAD.name,
+        timeRange: PAYLOAD.timeRange.numeric,
+      });
     });
   });
 

--- a/pluto/src/ranger/types.spec.ts
+++ b/pluto/src/ranger/types.spec.ts
@@ -8,7 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { type ranger } from "@synnaxlabs/client";
-import { TimeStamp } from "@synnaxlabs/x";
+import { TimeRange, TimeStamp } from "@synnaxlabs/x";
 import { describe, expect, it } from "vitest";
 
 import { type Haul } from "@/haul";
@@ -23,10 +23,7 @@ import {
 const PAYLOAD: ranger.Payload = {
   key: "550e8400-e29b-41d4-a716-446655440000",
   name: "Test Range",
-  timeRange: {
-    start: TimeStamp.now().valueOf(),
-    end: TimeStamp.now().add(TimeStamp.SECOND).valueOf(),
-  },
+  timeRange: new TimeRange(TimeStamp.now(), TimeStamp.now().add(TimeStamp.SECOND)),
   labels: [],
 };
 

--- a/pluto/src/ranger/types.spec.ts
+++ b/pluto/src/ranger/types.spec.ts
@@ -1,0 +1,78 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { type ranger } from "@synnaxlabs/client";
+import { TimeStamp } from "@synnaxlabs/x";
+import { describe, expect, it } from "vitest";
+
+import { type Haul } from "@/haul";
+import {
+  canDropHaulItem,
+  createHaulItem,
+  filterHaulItems,
+  HAUL_TYPE,
+  isHaulItem,
+} from "@/ranger/types";
+
+const PAYLOAD: ranger.Payload = {
+  key: "550e8400-e29b-41d4-a716-446655440000",
+  name: "Test Range",
+  timeRange: {
+    start: TimeStamp.now().valueOf(),
+    end: TimeStamp.now().add(TimeStamp.SECOND).valueOf(),
+  },
+  labels: [],
+};
+
+const OTHER: Haul.Item = { type: "other_type", key: "other" };
+
+describe("range haul utilities", () => {
+  describe("createHaulItem", () => {
+    it("creates an item with the range HAUL_TYPE", () => {
+      expect(createHaulItem(PAYLOAD).type).toEqual(HAUL_TYPE);
+    });
+
+    it("creates an item with the payload key", () => {
+      expect(createHaulItem(PAYLOAD).key).toEqual(PAYLOAD.key);
+    });
+
+    it("creates an item carrying the full payload in data", () => {
+      expect(createHaulItem(PAYLOAD).data).toEqual(PAYLOAD);
+    });
+  });
+
+  describe("isHaulItem", () => {
+    it("returns true for an item of the range kind", () => {
+      expect(isHaulItem(createHaulItem(PAYLOAD))).toBe(true);
+    });
+
+    it("returns false for an item of another kind", () => {
+      expect(isHaulItem(OTHER)).toBe(false);
+    });
+  });
+
+  describe("filterHaulItems", () => {
+    it("keeps range items and drops items of other kinds", () => {
+      const item = createHaulItem(PAYLOAD);
+      expect(filterHaulItems([item, OTHER])).toEqual([item]);
+    });
+  });
+
+  describe("canDropHaulItem", () => {
+    it("returns true when at least one item is a range item", () => {
+      expect(
+        canDropHaulItem({ source: OTHER, items: [createHaulItem(PAYLOAD), OTHER] }),
+      ).toBe(true);
+    });
+
+    it("returns false when no item is a range item", () => {
+      expect(canDropHaulItem({ source: OTHER, items: [OTHER] })).toBe(false);
+    });
+  });
+});

--- a/pluto/src/ranger/types.ts
+++ b/pluto/src/ranger/types.ts
@@ -7,4 +7,24 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+import { type ranger } from "@synnaxlabs/client";
+
+import { Haul } from "@/haul";
+
 export const HAUL_TYPE = "range";
+
+export type HaulItem = Haul.Item<typeof HAUL_TYPE, ranger.Key, ranger.Payload>;
+
+export const createHaulItem = (payload: ranger.Payload): HaulItem => ({
+  type: HAUL_TYPE,
+  key: payload.key,
+  data: payload,
+});
+
+export const isHaulItem = (item: Haul.Item): item is HaulItem =>
+  item.type === HAUL_TYPE;
+
+export const filterHaulItems = (items: Haul.Item[]): HaulItem[] =>
+  items.filter(isHaulItem);
+
+export const canDropHaulItem = Haul.canDropOfType<HaulItem>(HAUL_TYPE);

--- a/pluto/src/ranger/types.ts
+++ b/pluto/src/ranger/types.ts
@@ -8,17 +8,24 @@
 // included in the file licenses/APL.txt.
 
 import { type ranger } from "@synnaxlabs/client";
+import { type NumericTimeRange } from "@synnaxlabs/x";
 
 import { Haul } from "@/haul";
 
 export const HAUL_TYPE = "range";
 
-export type HaulItem = Haul.Item<typeof HAUL_TYPE, ranger.Key, ranger.Payload>;
+export interface HaulData {
+  key: ranger.Key;
+  name: string;
+  timeRange: NumericTimeRange;
+}
 
-export const createHaulItem = (payload: ranger.Payload): HaulItem => ({
+export type HaulItem = Haul.Item<typeof HAUL_TYPE, ranger.Key, HaulData>;
+
+export const createHaulItem = ({ key, name, timeRange }: ranger.Payload): HaulItem => ({
   type: HAUL_TYPE,
-  key: payload.key,
-  data: payload,
+  key,
+  data: { key, name, timeRange: timeRange.numeric },
 });
 
 export const isHaulItem = (item: Haul.Item): item is HaulItem =>

--- a/pluto/src/schematic/symbol/Grid.tsx
+++ b/pluto/src/schematic/symbol/Grid.tsx
@@ -59,7 +59,7 @@ interface GridElProps {
   onLocationChange: (key: string, loc: location.Location) => void;
 }
 
-const HAUL_TYPE = "Schematic.Grid";
+const HAUL_TYPE = "schematic_grid";
 
 export const DRAG_HANDLE_CLASS = CSS.B("drag-handle");
 
@@ -75,7 +75,7 @@ const createGridEl = (loc: location.Location): FC<GridElProps> => {
     items: fItems,
     onLocationChange,
   }: GridElProps): ReactElement | null => {
-    const haulType = `${symbolKey}.${HAUL_TYPE}`;
+    const haulType = `${symbolKey}_${HAUL_TYPE}`;
     const [draggingOver, setDraggingOver] = useState(false);
     const canDrop: Haul.CanDrop = useMemo(
       () => Haul.canDropOfType(haulType),

--- a/pluto/src/select/Multiple.tsx
+++ b/pluto/src/select/Multiple.tsx
@@ -30,11 +30,14 @@ export interface MultipleProps<
     Omit<MultipleFrameProps<K, E>, "multiple" | "children">,
     Pick<DialogProps<K>, "emptyContent" | "status" | "onSearch" | "actions">,
     Omit<BaseDialog.FrameProps, "onChange" | "children" | "variant">,
-    Pick<MultipleTriggerProps<K>, "disabled" | "icon" | "haulType">,
+    Pick<
+      MultipleTriggerProps<K, E>,
+      "disabled" | "icon" | "haulType" | "createHaulItem"
+    >,
     Pick<List.ItemsProps<K>, "children"> {
   resourceName: string;
-  renderTag?: MultipleTriggerProps<K>["children"];
-  triggerProps?: MultipleTriggerProps<K>;
+  renderTag?: MultipleTriggerProps<K, E>["children"];
+  triggerProps?: MultipleTriggerProps<K, E>;
   dialogProps?: BaseDialog.FrameProps;
   variant?: Variant;
 }
@@ -47,6 +50,7 @@ export const Multiple = <K extends record.Key, E extends record.Keyed<K> | undef
   getItem,
   subscribe,
   haulType,
+  createHaulItem,
   icon,
   disabled,
   onSearch,
@@ -77,8 +81,9 @@ export const Multiple = <K extends record.Key, E extends record.Keyed<K> | undef
       replaceOnSingle={replaceOnSingle}
       virtual={virtual}
     >
-      <MultipleTrigger
+      <MultipleTrigger<K, E>
         haulType={haulType}
+        createHaulItem={createHaulItem}
         icon={icon}
         placeholder={`Select ${plural(resourceName)}`}
         disabled={disabled}

--- a/pluto/src/select/MultipleTrigger.tsx
+++ b/pluto/src/select/MultipleTrigger.tsx
@@ -67,11 +67,12 @@ const MultipleTag = <K extends record.Key, E extends MultipleEntry<K>>({
 
 const multipleTag = renderProp(MultipleTag);
 
-export interface MultipleTriggerProps<K extends record.Key> extends Pick<
-  Button.ButtonProps,
-  "variant" | "disabled"
-> {
+export interface MultipleTriggerProps<
+  K extends record.Key,
+  E extends record.Keyed<K> | undefined = MultipleEntry<K> | undefined,
+> extends Pick<Button.ButtonProps, "variant" | "disabled"> {
   haulType?: string;
+  createHaulItem?: (entry: NonNullable<E>) => Haul.Item;
   placeholder?: ReactNode;
   icon?: Icon.ReactElement;
   hideTags?: boolean;
@@ -90,8 +91,12 @@ export const staticCanDrop = <K extends record.Key>(
   return f.length > 0 && !f.every((h) => value.includes(h.key as K));
 };
 
-export const MultipleTrigger = <K extends record.Key>({
+export const MultipleTrigger = <
+  K extends record.Key,
+  E extends record.Keyed<K> | undefined = MultipleEntry<K> | undefined,
+>({
   haulType = "",
+  createHaulItem,
   disabled,
   placeholder = "Select...",
   variant = "outlined",
@@ -99,10 +104,11 @@ export const MultipleTrigger = <K extends record.Key>({
   hideTags = false,
   children = multipleTag as unknown as RenderProp<MultipleTagProps<K>>,
   renderIcon,
-}: MultipleTriggerProps<K>): ReactElement => {
+}: MultipleTriggerProps<K, E>): ReactElement => {
   const value = useSelection<K>();
   const valueRef = useSyncedRef(value);
   const { setSelected } = useContext<K>();
+  const { getItem } = List.useUtilContext<K, E>();
   const { toggle, visible } = Dialog.useContext();
   const canDrop = useCallback(
     (hauled: Haul.DraggingState) =>
@@ -135,9 +141,15 @@ export const MultipleTrigger = <K extends record.Key>({
 
   const onTagDragStart = useCallback(
     (key: K) => {
+      if (createHaulItem != null && getItem != null) {
+        const entry = getItem(key);
+        if (entry == null) return;
+        startDrag([createHaulItem(entry)], handleSuccessfulDrop);
+        return;
+      }
       startDrag([{ key, type: haulType }], handleSuccessfulDrop);
     },
-    [startDrag, handleSuccessfulDrop, haulType],
+    [startDrag, handleSuccessfulDrop, haulType, createHaulItem, getItem],
   );
   const dragging = Haul.useDraggingState();
   const showAddButton = variant === "text" && value.length !== 0;

--- a/pluto/src/tree/Tree.spec.ts
+++ b/pluto/src/tree/Tree.spec.ts
@@ -1,0 +1,68 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { describe, expect, it } from "vitest";
+
+import { type Haul } from "@/haul";
+import {
+  canDropHaulItem,
+  createHaulItem,
+  filterHaulItems,
+  HAUL_TYPE,
+  isHaulItem,
+} from "@/tree/Tree";
+
+const KEY = "node-1";
+const DEPTH = 3;
+const OTHER: Haul.Item = { type: "other_type", key: "other" };
+
+describe("tree haul utilities", () => {
+  describe("createHaulItem", () => {
+    it("creates an item with the tree HAUL_TYPE", () => {
+      expect(createHaulItem(KEY, DEPTH).type).toEqual(HAUL_TYPE);
+    });
+
+    it("creates an item with the provided key", () => {
+      expect(createHaulItem(KEY, DEPTH).key).toEqual(KEY);
+    });
+
+    it("creates an item carrying the provided depth in data", () => {
+      expect(createHaulItem(KEY, DEPTH).data).toEqual({ depth: DEPTH });
+    });
+  });
+
+  describe("isHaulItem", () => {
+    it("returns true for an item of the tree kind", () => {
+      expect(isHaulItem(createHaulItem(KEY, DEPTH))).toBe(true);
+    });
+
+    it("returns false for an item of another kind", () => {
+      expect(isHaulItem(OTHER)).toBe(false);
+    });
+  });
+
+  describe("filterHaulItems", () => {
+    it("keeps tree items and drops items of other kinds", () => {
+      const item = createHaulItem(KEY, DEPTH);
+      expect(filterHaulItems([item, OTHER])).toEqual([item]);
+    });
+  });
+
+  describe("canDropHaulItem", () => {
+    it("returns true when at least one item is a tree item", () => {
+      expect(
+        canDropHaulItem({ source: OTHER, items: [createHaulItem(KEY, DEPTH), OTHER] }),
+      ).toBe(true);
+    });
+
+    it("returns false when no item is a tree item", () => {
+      expect(canDropHaulItem({ source: OTHER, items: [OTHER] })).toBe(false);
+    });
+  });
+});

--- a/pluto/src/tree/Tree.tsx
+++ b/pluto/src/tree/Tree.tsx
@@ -12,6 +12,7 @@ import { type ReactElement, useCallback, useMemo } from "react";
 
 import { type Component } from "@/component";
 import { CSS } from "@/css";
+import { Haul } from "@/haul";
 import { useCombinedStateAndRef, useSyncedRef } from "@/hooks";
 import { List } from "@/list";
 import { Select } from "@/select";
@@ -20,7 +21,28 @@ import { flatten, getNodeShape, type Node, type Shape } from "@/tree/base";
 import { Context } from "@/tree/Context";
 import { Triggers } from "@/triggers";
 
-export const HAUL_TYPE = "tree-item";
+export const HAUL_TYPE = "tree_item";
+
+export interface HaulData {
+  /** depth is the position of the dragged node in the tree, where 0 is the root. */
+  depth: number;
+}
+
+export type HaulItem = Haul.Item<typeof HAUL_TYPE, string, HaulData>;
+
+export const createHaulItem = (key: string, depth: number): HaulItem => ({
+  type: HAUL_TYPE,
+  key,
+  data: { depth },
+});
+
+export const isHaulItem = (item: Haul.Item): item is HaulItem =>
+  item.type === HAUL_TYPE;
+
+export const filterHaulItems = (items: Haul.Item[]): HaulItem[] =>
+  items.filter(isHaulItem);
+
+export const canDropHaulItem = Haul.canDropOfType<HaulItem>(HAUL_TYPE);
 
 export interface HandleExpandProps<K extends record.Key = string> {
   current: K[];

--- a/pluto/src/user/external.ts
+++ b/pluto/src/user/external.ts
@@ -10,3 +10,4 @@
 export * from "@/user/Avatar";
 export * from "@/user/Icons";
 export * from "@/user/queries";
+export * from "@/user/types";

--- a/pluto/src/user/types.spec.ts
+++ b/pluto/src/user/types.spec.ts
@@ -1,0 +1,75 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { type user } from "@synnaxlabs/client";
+import { describe, expect, it } from "vitest";
+
+import { type Haul } from "@/haul";
+import {
+  canDropHaulItem,
+  createHaulItem,
+  filterHaulItems,
+  HAUL_TYPE,
+  isHaulItem,
+} from "@/user/types";
+
+const USER: user.User = {
+  key: "550e8400-e29b-41d4-a716-446655440000",
+  username: "synnax",
+  firstName: "Test",
+  lastName: "User",
+  rootUser: false,
+};
+
+const OTHER: Haul.Item = { type: "other_type", key: "other" };
+
+describe("user haul utilities", () => {
+  describe("createHaulItem", () => {
+    it("creates an item with the user HAUL_TYPE", () => {
+      expect(createHaulItem(USER).type).toEqual(HAUL_TYPE);
+    });
+
+    it("creates an item with the user payload key", () => {
+      expect(createHaulItem(USER).key).toEqual(USER.key);
+    });
+
+    it("creates an item carrying the full user payload in data", () => {
+      expect(createHaulItem(USER).data).toEqual(USER);
+    });
+  });
+
+  describe("isHaulItem", () => {
+    it("returns true for an item of the user kind", () => {
+      expect(isHaulItem(createHaulItem(USER))).toBe(true);
+    });
+
+    it("returns false for an item of another kind", () => {
+      expect(isHaulItem(OTHER)).toBe(false);
+    });
+  });
+
+  describe("filterHaulItems", () => {
+    it("keeps user items and drops items of other kinds", () => {
+      const item = createHaulItem(USER);
+      expect(filterHaulItems([item, OTHER])).toEqual([item]);
+    });
+  });
+
+  describe("canDropHaulItem", () => {
+    it("returns true when at least one item is a user item", () => {
+      expect(
+        canDropHaulItem({ source: OTHER, items: [createHaulItem(USER), OTHER] }),
+      ).toBe(true);
+    });
+
+    it("returns false when no item is a user item", () => {
+      expect(canDropHaulItem({ source: OTHER, items: [OTHER] })).toBe(false);
+    });
+  });
+});

--- a/pluto/src/user/types.ts
+++ b/pluto/src/user/types.ts
@@ -7,17 +7,18 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { type label } from "@synnaxlabs/client";
+import { type user } from "@synnaxlabs/client";
 
 import { Haul } from "@/haul";
 
-export const HAUL_TYPE = "label";
+export const HAUL_TYPE = "user";
 
-export type HaulItem = Haul.Item<typeof HAUL_TYPE, label.Key, undefined>;
+export type HaulItem = Haul.Item<typeof HAUL_TYPE, user.Key, user.User>;
 
-export const createHaulItem = (key: label.Key): HaulItem => ({
+export const createHaulItem = (payload: user.User): HaulItem => ({
   type: HAUL_TYPE,
-  key,
+  key: payload.key,
+  data: payload,
 });
 
 export const isHaulItem = (item: Haul.Item): item is HaulItem =>


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4146](https://linear.app/synnax/issue/SY-4146)

## Description

Pluto's `Haul` drag-and-drop system carried payloads in an untyped `data: record.Unknown` field, forcing every consumer to write `as` casts (e.g. `key as channel.Key`, `data?.nodeClass as string`) and hoping the producer agreed on the shape. Producers with multiple call sites (notably `schematic-element`) silently emitted different `data` shapes that the drop site couldn't distinguish.

This PR lifts haul typing into per-kind modules and eliminates the casts at every known consumer:

- `Haul.Item<Type, Key, Data>` is now generic, with `data` required when `Data` doesn't include `undefined` and optional otherwise.
- Each haul kind owns a colocated `types.ts` (or section of its primary file) exporting `HAUL_TYPE`, `HaulItem`, `createHaulItem`, `isHaulItem`, `filterHaulItems`, and `canDropHaulItem`. Drop sites now narrow via `Channel.filterHaulItems(items)` etc. with no casts.
- New typed payloads: `Range` carries `ranger.Payload`, `OPC` carries `ScannedNode`, `User` carries `user.User`, `Tree.HaulItem` carries `{ depth: number }` (depth is a tree-drag concept, so it lives in Pluto, not Console).
- The `schematic-element` type is split into `schematic_symbol` (toolbar drag, `{ specKey?: string }`) and `schematic_value` (channel-ontology drag, `Symbol.ValueProps`). The schematic drop accepts both via `canDropSchematicHaulItem`.
- Pluto's `Multiple` Select trigger accepts an optional `createHaulItem` factory so consumers like `Ranger.Select` can populate full payloads at drag-start instead of bare keys, removing the synthetic `as StaticRange` cast in the Range Toolbar.
- All wire-format haul type strings normalized to snake_case (e.g. `arc-element` → `arc_element`, `pluto-mosaic-tab-drop` → `pluto_mosaic_tab_drop`).
- Pluto's `tree-item` and Console's `Tree.Item` zone tags are merged into a single `tree_item` (they were always the same conceptual thing).

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR lifts Pluto's `Haul` drag-and-drop system from an untyped `data: record.Unknown` model to a generic `Item<Type, Key, Data>` type, giving each haul kind its own colocated helpers (`createHaulItem`, `isHaulItem`, `filterHaulItems`, `canDropHaulItem`) and eliminating every `as`-cast at producer and consumer sites. All wire-format type strings are normalised to snake_case, `schematic-element` is cleanly split into `schematic_symbol` / `schematic_value`, and the `Multiple` select trigger gains an optional `createHaulItem` factory for full-payload drags.

<h3>Confidence Score: 5/5</h3>

Safe to merge; all findings are P2 non-blocking suggestions.

No P0 or P1 issues found. The refactor is mechanically consistent across all 46 files, type strings are fully normalised to snake_case, every producer/consumer pair was updated, and the new generic conditional-data type correctly enforces required vs optional data at compile time. The only finding is a P2 UX edge case in MultipleTrigger where a missing list entry silently aborts a drag instead of falling back to a key-only item.

pluto/src/select/MultipleTrigger.tsx — silent drag abort when getItem returns null with a createHaulItem factory present.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| pluto/src/haul/Haul.tsx | Core generic Item<Type, Key, Data> type introduced; conditional data requirement via mapped type; record import changed to type-only; canDropOfType parameterised. |
| pluto/src/mosaic/Mosaic.tsx | HAUL_DROP_TYPE/HAUL_CREATE_TYPE renamed to snake_case; typed helpers for both tab-drop and tab-create haul items added; all cast-based filtering replaced. |
| console/src/schematic/Schematic.tsx | HAUL_TYPE split into SYMBOL_HAUL_TYPE/VALUE_HAUL_TYPE; canDropSchematicHaulItem covers both kinds; handleDrop passes union data to useAddSymbol which uses safeParse — consistent with prior behavior. |
| console/src/ontology/Tree.tsx | Tree drag now uses typed Base.createHaulItem / Base.filterHaulItems; service items no longer have depth merged in (only tree_item items need depth; drop handler already filters to tree_item). |
| pluto/src/select/MultipleTrigger.tsx | Accepts optional createHaulItem factory; uses List.useUtilContext.getItem to resolve full entry at drag-start. Silent abort when entry is null instead of falling back to key-only item. |
| pluto/src/ranger/types.ts | New typed HaulItem carries { key, name, timeRange: NumericTimeRange } payload; createHaulItem converts ranger.Payload to serialisable HaulData. |
| console/src/range/Toolbar.tsx | Drop handler now filters via Ranger.filterHaulItems; constructs StaticRange from typed payload fields eliminating as StaticRange cast; correctly returns only consumed items. |
| console/src/layout/useDropOutside.ts | Type strings normalised to snake_case; isTabDropHaulItem guard added in handleDrop; item.key as string cast removed. |
| pluto/src/tree/Tree.tsx | HAUL_TYPE renamed tree_item; typed HaulItem carrying { depth } added alongside full helper set; Tree.tsx now owns the depth concept. |
| console/src/hardware/opc/device/Browser.tsx | Typed HaulItem carrying ScannedNode as data; drag code replaced with createHaulItem factory; data field removed from useDrag call. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `pluto/src/channel/LinePlot.tsx`, line 1204-1221 ([link](https://github.com/synnaxlabs/synnax/blob/5efdce1c1726b4da705586ca06f9097eb65c376b/pluto/src/channel/LinePlot.tsx#L1204-L1221)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Variable shadowing in `useAxisDrop`**

   Inside the `useCallback`, `dropped.map(({ key }) => key)` introduces a new `key` binding that shadows the outer `key` parameter (the axis key). This works correctly at runtime — the inner `{ key }` is scoped to the map arrow function, so `onAxisChannelDrop?.(key, keys)` still captures the axis key from the closure. However, a reader scanning the callback can mistake which `key` is referenced. Renaming either binding removes the ambiguity.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["SY-4146: Restrict Range Haul Data to Ser..."](https://github.com/synnaxlabs/synnax/commit/4598f2448913f9dc4df5ecaa4d6417f4a4077a60) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30625014)</sub>

<!-- /greptile_comment -->