### PR TITLE
SY-4150: Enable writing time.now() to `timestamp` and `int64` - Flow and WASM Pairity

### DIFF
--- a/arc/go/analyzer/flow/flow_test.go
+++ b/arc/go/analyzer/flow/flow_test.go
@@ -328,6 +328,20 @@ producer{} -> consumer{}`))
 				Expect((*ctx.Diagnostics)[0].Message).To(ContainSubstring("is not equal to argument type"))
 			})
 
+			It("Should detect unit mismatch between func output and next func input", func(bCtx SpecContext) {
+				ast := MustSucceed(parser.Parse(`
+func producer() f32 psi {
+    return 5psi
+}
+func consumer(v f32 bar) {}
+producer{} -> consumer{}`))
+				ctx := context.CreateRoot(bCtx, ast, resolver)
+				analyzer.AnalyzeProgram(ctx)
+				Expect(ctx.Diagnostics.Ok()).To(BeFalse())
+				Expect((*ctx.Diagnostics)[0].Message).To(ContainSubstring("return type"))
+				Expect((*ctx.Diagnostics)[0].Message).To(ContainSubstring("is not equal to argument type"))
+			})
+
 			It("Should detect when func with multiple params is used without routing table", func(bCtx SpecContext) {
 				ast := MustSucceed(parser.Parse(`
 func source() u8 {

--- a/arc/go/analyzer/types/check.go
+++ b/arc/go/analyzer/types/check.go
@@ -69,7 +69,7 @@ func Check(
 		return Check(cs, t1.Unwrap(), t2.Unwrap(), source, reason+" (element types)")
 	}
 
-	if !types.Equal(t1, t2) {
+	if !types.Equivalent(t1, t2) {
 		return newTypeMismatchError(t1, t2, reason)
 	}
 	return nil

--- a/arc/go/analyzer/types/check.go
+++ b/arc/go/analyzer/types/check.go
@@ -69,7 +69,7 @@ func Check(
 		return Check(cs, t1.Unwrap(), t2.Unwrap(), source, reason+" (element types)")
 	}
 
-	if !types.Equivalent(t1, t2) {
+	if t1.Kind != t2.Kind || !types.UnitsAssignable(t1.Unit, t2.Unit) {
 		return newTypeMismatchError(t1, t2, reason)
 	}
 	return nil

--- a/arc/go/analyzer/types/check_test.go
+++ b/arc/go/analyzer/types/check_test.go
@@ -132,11 +132,12 @@ var _ = Describe("Check", func() {
 	})
 
 	Describe("Unit Compatibility", func() {
-		It("should succeed for same kind with different units", func() {
+		It("should fail for same kind with different non-nil units", func() {
 			ast := testutil.NewMockAST(1)
 			t1 := types.Type{Kind: types.KindF32, Unit: &types.Unit{Name: "psi"}}
 			t2 := types.Type{Kind: types.KindF32, Unit: &types.Unit{Name: "bar"}}
-			Expect(atypes.Check(cs, t1, t2, ast, "test")).To(Succeed())
+			Expect(atypes.Check(cs, t1, t2, ast, "test")).Error().
+				To(MatchError(ContainSubstring("type mismatch")))
 		})
 
 		It("should succeed for type with unit vs type without unit", func() {

--- a/arc/go/analyzer/types/check_test.go
+++ b/arc/go/analyzer/types/check_test.go
@@ -131,21 +131,19 @@ var _ = Describe("Check", func() {
 		)
 	})
 
-	Describe("Unit Mismatch", func() {
-		It("should fail for same kind with different units", func() {
+	Describe("Unit Compatibility", func() {
+		It("should succeed for same kind with different units", func() {
 			ast := testutil.NewMockAST(1)
 			t1 := types.Type{Kind: types.KindF32, Unit: &types.Unit{Name: "psi"}}
 			t2 := types.Type{Kind: types.KindF32, Unit: &types.Unit{Name: "bar"}}
-			Expect(atypes.Check(cs, t1, t2, ast, "test")).
-				Error().To(MatchError(ContainSubstring("type mismatch in test: expected f32 psi, got f32 bar")))
+			Expect(atypes.Check(cs, t1, t2, ast, "test")).To(Succeed())
 		})
 
-		It("should fail for type with unit vs type without unit", func() {
+		It("should succeed for type with unit vs type without unit", func() {
 			ast := testutil.NewMockAST(1)
 			t1 := types.Type{Kind: types.KindF32, Unit: &types.Unit{Name: "psi"}}
 			t2 := types.F32()
-			Expect(atypes.Check(cs, t1, t2, ast, "test")).
-				Error().To(MatchError(ContainSubstring("type mismatch in test: expected f32 psi, got f32")))
+			Expect(atypes.Check(cs, t1, t2, ast, "test")).To(Succeed())
 		})
 
 		It("should succeed for same kind with same unit", func() {
@@ -153,6 +151,22 @@ var _ = Describe("Check", func() {
 			t1 := types.Type{Kind: types.KindF32, Unit: &types.Unit{Name: "psi", Scale: 1}}
 			t2 := types.Type{Kind: types.KindF32, Unit: &types.Unit{Name: "psi", Scale: 1}}
 			Expect(atypes.Check(cs, t1, t2, ast, "test")).To(Succeed())
+		})
+
+		It("should succeed for i64 ns vs i64 (timestamp <-> int64)", func() {
+			ast := testutil.NewMockAST(1)
+			Expect(atypes.Check(cs, types.TimeStamp(), types.I64(), ast, "test")).To(Succeed())
+			Expect(atypes.Check(cs, types.I64(), types.TimeStamp(), ast, "test")).To(Succeed())
+		})
+
+		It("should succeed for chan i64 ns <-> chan i64", func() {
+			ast := testutil.NewMockAST(1)
+			Expect(atypes.Check(
+				cs,
+				types.Chan(types.TimeStamp()),
+				types.Chan(types.I64()),
+				ast, "test",
+			)).To(Succeed())
 		})
 	})
 

--- a/arc/go/compiler/resolve/derive.go
+++ b/arc/go/compiler/resolve/derive.go
@@ -57,18 +57,27 @@ func DeriveTypeSuffix(originalType, concreteType types.Type) string {
 	for i, inp := range originalType.Inputs {
 		if inp.Type.Kind == types.KindVariable {
 			if i < len(concreteType.Inputs) {
-				return concreteType.Inputs[i].Type.String()
+				return suffixForType(concreteType.Inputs[i].Type)
 			}
 		}
 	}
 	for i, out := range originalType.Outputs {
 		if out.Type.Kind == types.KindVariable {
 			if i < len(concreteType.Outputs) {
-				return concreteType.Outputs[i].Type.String()
+				return suffixForType(concreteType.Outputs[i].Type)
 			}
 		}
 	}
 	return ""
+}
+
+// suffixForType returns the WASM coordinate suffix for a concrete type. Units
+// are stripped because WASM types (i32/i64/f32/f64) are unit-blind, so a
+// timestamp (i64 ns) channel and an int64 channel both bind to the same
+// write_i64 host function.
+func suffixForType(t types.Type) string {
+	t.Unit = nil
+	return t.String()
 }
 
 // DeriveWASMFuncType converts an Arc function type to a WASM FunctionType.

--- a/arc/go/compiler/statement/statement_test.go
+++ b/arc/go/compiler/statement/statement_test.go
@@ -1198,6 +1198,26 @@ var _ = Describe("Statement Compiler", func() {
 					OpCall, uint32(1),
 				))
 			})
+
+			It("Should compile channel write to timestamp channel via write_i64", func(bCtx SpecContext) {
+				resolver := symbol.MapResolver{
+					"ts_ch": {
+						Name: "ts_ch",
+						Kind: symbol.KindChannel,
+						Type: types.Chan(types.TimeStamp()),
+						ID:   800,
+					},
+				}
+				// Value chosen so that any narrowing through float32 would round
+				// to a different integer (float32 ULP at this magnitude is 2^37).
+				bytecode := compileWithChannels(bCtx, "ts_ch = 1778020940471336961", resolver)
+
+				Expect(bytecode).To(MatchOpcodes(
+					OpI32Const, int32(800),
+					OpI64Const, int64(1778020940471336961),
+					OpCall, uint32(0),
+				))
+			})
 		})
 
 		Describe("Channel Reads", func() {

--- a/arc/go/text/text_test.go
+++ b/arc/go/text/text_test.go
@@ -2897,6 +2897,21 @@ var _ = Describe("Text", func() {
 			Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
 		})
 
+		It("Should allow time.now{} to write into a plain i64 channel", func(ctx SpecContext) {
+			resolver := symbol.CompoundResolver{
+				symbol.MapResolver{
+					"int_out": {Name: "int_out", Kind: symbol.KindChannel, Type: types.Chan(types.I64()), ID: 10044},
+				},
+				stl.SymbolResolver,
+			}
+			source := `
+			interval{100ms} -> time.now{} -> int_out
+			`
+			parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
+			_, diagnostics := text.Analyze(ctx, parsedText, resolver)
+			Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
+		})
+
 		It("Should reject a flow-only function called in a func body at analysis time", func(ctx SpecContext) {
 			resolver := symbol.CompoundResolver{
 				symbol.MapResolver{

--- a/arc/go/types/type.go
+++ b/arc/go/types/type.go
@@ -549,6 +549,29 @@ func Equal(t Type, v Type) bool {
 	return t.Unit.Equal(*v.Unit)
 }
 
+// Equivalent compares two types for assignment compatibility. It is identical to
+// Equal except that primitive types with matching kinds are considered compatible
+// regardless of unit metadata. This mirrors the WASM and Cesium layers, which both
+// treat values like i64 ns and i64 as the same underlying representation.
+func Equivalent(t Type, v Type) bool {
+	if t.Kind != v.Kind {
+		return false
+	}
+	if t.Kind == KindChan || t.Kind == KindSeries {
+		if t.Elem == nil && v.Elem == nil {
+			return true
+		}
+		if t.Elem == nil || v.Elem == nil {
+			return false
+		}
+		return Equivalent(*t.Elem, *v.Elem)
+	}
+	if t.Kind == KindVariable || t.Kind == KindFunction {
+		return Equal(t, v)
+	}
+	return true
+}
+
 func paramsEqual(a, b Params) bool {
 	if len(a) != len(b) {
 		return false

--- a/arc/go/types/type.go
+++ b/arc/go/types/type.go
@@ -68,12 +68,13 @@ package types
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/samber/lo"
-	"github.com/synnaxlabs/x/errors"
-	"github.com/synnaxlabs/x/telem"
 	"maps"
 	"math"
 	"slices"
+
+	"github.com/samber/lo"
+	"github.com/synnaxlabs/x/errors"
+	"github.com/synnaxlabs/x/telem"
 )
 
 // IsRead returns true if the direction includes read.
@@ -549,27 +550,16 @@ func Equal(t Type, v Type) bool {
 	return t.Unit.Equal(*v.Unit)
 }
 
-// Equivalent compares two types for assignment compatibility. It is identical to
-// Equal except that primitive types with matching kinds are considered compatible
-// regardless of unit metadata. This mirrors the WASM and Cesium layers, which both
-// treat values like i64 ns and i64 as the same underlying representation.
-func Equivalent(t Type, v Type) bool {
-	if t.Kind != v.Kind {
-		return false
+// UnitsAssignable reports whether a value with unit a may be assigned to a
+// target with unit b. A nil unit on either side is treated as a wildcard,
+// matching the WASM and Cesium representation where i64 and i64 ns share the
+// same wire type (timestamp <-> int64). Two non-nil units must match exactly,
+// so f32 psi vs f32 bar still fails.
+func UnitsAssignable(a, b *Unit) bool {
+	if a == nil || b == nil {
+		return true
 	}
-	if t.Kind == KindChan || t.Kind == KindSeries {
-		if t.Elem == nil && v.Elem == nil {
-			return true
-		}
-		if t.Elem == nil || v.Elem == nil {
-			return false
-		}
-		return Equivalent(*t.Elem, *v.Elem)
-	}
-	if t.Kind == KindVariable || t.Kind == KindFunction {
-		return Equal(t, v)
-	}
-	return true
+	return a.Equal(*b)
 }
 
 func paramsEqual(a, b Params) bool {

--- a/arc/go/types/type_test.go
+++ b/arc/go/types/type_test.go
@@ -636,61 +636,21 @@ var _ = Describe("Types", func() {
 		})
 	})
 
-	Describe("Equivalent", func() {
-		It("Should return true for identical primitive types", func() {
-			Expect(types.Equivalent(types.I32(), types.I32())).To(BeTrue())
-			Expect(types.Equivalent(types.F64(), types.F64())).To(BeTrue())
-		})
+	Describe("UnitsAssignable", func() {
+		ns := &types.Unit{Dimensions: types.DimTime, Scale: 1, Name: "ns"}
+		psi := &types.Unit{Name: "psi", Scale: 1}
+		bar := &types.Unit{Name: "bar", Scale: 1}
 
-		It("Should return false for different primitive kinds", func() {
-			Expect(types.Equivalent(types.I32(), types.I64())).To(BeFalse())
-			Expect(types.Equivalent(types.F32(), types.F64())).To(BeFalse())
-		})
-
-		It("Should ignore unit metadata for matching primitive kinds", func() {
-			Expect(types.Equivalent(types.TimeStamp(), types.I64())).To(BeTrue())
-			Expect(types.Equivalent(types.I64(), types.TimeStamp())).To(BeTrue())
-			Expect(types.Equivalent(types.TimeSpan(), types.I64())).To(BeTrue())
-		})
-
-		It("Should ignore unit metadata recursively for chan and series", func() {
-			Expect(types.Equivalent(
-				types.Chan(types.TimeStamp()),
-				types.Chan(types.I64()),
-			)).To(BeTrue())
-			Expect(types.Equivalent(
-				types.Series(types.I64()),
-				types.Series(types.TimeStamp()),
-			)).To(BeTrue())
-		})
-
-		It("Should still reject chan vs series", func() {
-			Expect(types.Equivalent(
-				types.Chan(types.I64()),
-				types.Series(types.I64()),
-			)).To(BeFalse())
-		})
-
-		It("Should still reject mismatched element kinds in chan/series", func() {
-			Expect(types.Equivalent(
-				types.Chan(types.I64()),
-				types.Chan(types.F64()),
-			)).To(BeFalse())
-		})
-
-		It("Should defer to Equal for type variables and functions", func() {
-			tv1 := types.Variable("T", nil)
-			tv2 := types.Variable("U", nil)
-			Expect(types.Equivalent(tv1, tv2)).To(BeFalse())
-
-			props1 := types.FunctionProperties{
-				Inputs: types.Params{{Name: "x", Type: types.I32()}},
-			}
-			props2 := types.FunctionProperties{
-				Inputs: types.Params{{Name: "x", Type: types.F64()}},
-			}
-			Expect(types.Equivalent(types.Function(props1), types.Function(props2))).To(BeFalse())
-		})
+		DescribeTable("unit compatibility",
+			func(a, b *types.Unit, want bool) {
+				Expect(types.UnitsAssignable(a, b)).To(Equal(want))
+			},
+			Entry("nil + nil", (*types.Unit)(nil), (*types.Unit)(nil), true),
+			Entry("nil + ns (wildcard)", (*types.Unit)(nil), ns, true),
+			Entry("ns + nil (wildcard)", ns, (*types.Unit)(nil), true),
+			Entry("ns + ns (match)", ns, ns, true),
+			Entry("psi + bar (mismatch)", psi, bar, false),
+		)
 	})
 
 	Describe("Function constructor", func() {

--- a/arc/go/types/type_test.go
+++ b/arc/go/types/type_test.go
@@ -636,6 +636,63 @@ var _ = Describe("Types", func() {
 		})
 	})
 
+	Describe("Equivalent", func() {
+		It("Should return true for identical primitive types", func() {
+			Expect(types.Equivalent(types.I32(), types.I32())).To(BeTrue())
+			Expect(types.Equivalent(types.F64(), types.F64())).To(BeTrue())
+		})
+
+		It("Should return false for different primitive kinds", func() {
+			Expect(types.Equivalent(types.I32(), types.I64())).To(BeFalse())
+			Expect(types.Equivalent(types.F32(), types.F64())).To(BeFalse())
+		})
+
+		It("Should ignore unit metadata for matching primitive kinds", func() {
+			Expect(types.Equivalent(types.TimeStamp(), types.I64())).To(BeTrue())
+			Expect(types.Equivalent(types.I64(), types.TimeStamp())).To(BeTrue())
+			Expect(types.Equivalent(types.TimeSpan(), types.I64())).To(BeTrue())
+		})
+
+		It("Should ignore unit metadata recursively for chan and series", func() {
+			Expect(types.Equivalent(
+				types.Chan(types.TimeStamp()),
+				types.Chan(types.I64()),
+			)).To(BeTrue())
+			Expect(types.Equivalent(
+				types.Series(types.I64()),
+				types.Series(types.TimeStamp()),
+			)).To(BeTrue())
+		})
+
+		It("Should still reject chan vs series", func() {
+			Expect(types.Equivalent(
+				types.Chan(types.I64()),
+				types.Series(types.I64()),
+			)).To(BeFalse())
+		})
+
+		It("Should still reject mismatched element kinds in chan/series", func() {
+			Expect(types.Equivalent(
+				types.Chan(types.I64()),
+				types.Chan(types.F64()),
+			)).To(BeFalse())
+		})
+
+		It("Should defer to Equal for type variables and functions", func() {
+			tv1 := types.Variable("T", nil)
+			tv2 := types.Variable("U", nil)
+			Expect(types.Equivalent(tv1, tv2)).To(BeFalse())
+
+			props1 := types.FunctionProperties{
+				Inputs: types.Params{{Name: "x", Type: types.I32()}},
+			}
+			props2 := types.FunctionProperties{
+				Inputs: types.Params{{Name: "x", Type: types.F64()}},
+			}
+			Expect(types.Equivalent(types.Function(props1), types.Function(props2))).To(BeFalse())
+		})
+	})
+
 	Describe("Function constructor", func() {
 		It("Should create function with nil inputs/outputs/config", func() {
 			var props types.FunctionProperties

--- a/client/cpp/framer/codec.cpp
+++ b/client/cpp/framer/codec.cpp
@@ -104,7 +104,11 @@ Codec::encode(const x::telem::Frame &frame, std::vector<uint8_t> &output) {
                 "frame contains extra key " + std::to_string(k) +
                     "not provided when opening the writer"
             );
-        if (dt->second != ser.data_type())
+        const bool is_equivalent = (dt->second == x::telem::INT64_T ||
+                                    dt->second == x::telem::TIMESTAMP_T) &&
+                                   (ser.data_type() == x::telem::INT64_T ||
+                                    ser.data_type() == x::telem::TIMESTAMP_T);
+        if (dt->second != ser.data_type() && !is_equivalent)
             return x::errors::Error(
                 x::errors::VALIDATION,
                 "data type " + dt->second + " for channel + " + std::to_string(k) +

--- a/client/cpp/framer/codec_test.cpp
+++ b/client/cpp/framer/codec_test.cpp
@@ -412,6 +412,44 @@ TEST(CodecTests, EncodeMismatchedDataType) {
     ASSERT_TRUE(err.message().find("data type") != std::string::npos);
 }
 
+/// @brief it should accept an int64 series for a timestamp channel, mirroring the
+/// Int64T <-> TimeStampT equivalence applied by the server-side writer validator
+/// and frame codec.
+TEST(CodecTests, EncodeInt64SeriesForTimestampChannel) {
+    const std::vector data_types = {x::telem::TIMESTAMP_T};
+    const std::vector<channel::Key> channels = {65537};
+    Codec codec(channels, data_types);
+
+    auto frame = x::telem::Frame(1);
+    auto series = x::telem::Series(std::vector<int64_t>{1778020940471336961LL});
+    series.time_range = {x::telem::TimeStamp(1000), x::telem::TimeStamp(2000)};
+    series.alignment = x::telem::Alignment(10);
+    frame.emplace(65537, std::move(series));
+
+    std::vector<uint8_t> encoded;
+    ASSERT_NIL(codec.encode(frame, encoded));
+    ASSERT_FALSE(encoded.empty());
+}
+
+/// @brief it should accept a timestamp series for an int64 channel, mirroring the
+/// Int64T <-> TimeStampT equivalence applied by the server-side writer validator
+/// and frame codec.
+TEST(CodecTests, EncodeTimestampSeriesForInt64Channel) {
+    const std::vector data_types = {x::telem::INT64_T};
+    const std::vector<channel::Key> channels = {65537};
+    Codec codec(channels, data_types);
+
+    auto frame = x::telem::Frame(1);
+    auto series = x::telem::Series(x::telem::TimeStamp(x::telem::SECOND));
+    series.time_range = {x::telem::TimeStamp(1000), x::telem::TimeStamp(2000)};
+    series.alignment = x::telem::Alignment(10);
+    frame.emplace(65537, std::move(series));
+
+    std::vector<uint8_t> encoded;
+    ASSERT_NIL(codec.encode(frame, encoded));
+    ASSERT_FALSE(encoded.empty());
+}
+
 /// @brief it should return a validation erorr when the frame has a key that was not
 /// provided to the codec.
 TEST(CodecTests, EncodeFrameUnknownKey) {

--- a/core/pkg/distribution/framer/codec/codec.go
+++ b/core/pkg/distribution/framer/codec/codec.go
@@ -506,7 +506,9 @@ func (c *Codec) encodeInternal(ctx context.Context, src framer.Frame) error {
 				channel.TryToRetrieveStringer(ctx, c.channels, key),
 			)
 		}
-		if dt != s.DataType {
+		isEquivalent := (dt == telem.Int64T || dt == telem.TimeStampT) &&
+			(s.DataType == telem.Int64T || s.DataType == telem.TimeStampT)
+		if dt != s.DataType && !isEquivalent {
 			return errors.Wrapf(
 				validate.ErrValidation, "data type %s for channel %s does not match series data type %s",
 				dt, channel.TryToRetrieveStringer(ctx, c.channels, key), s.DataType,

--- a/core/pkg/distribution/framer/codec/codec_test.go
+++ b/core/pkg/distribution/framer/codec/codec_test.go
@@ -251,6 +251,28 @@ var _ = Describe("Codec", func() {
 		})
 	})
 
+	Describe("Int64 / TimeStamp Equivalence", func() {
+		It("Should accept an int64 series for a timestamp channel", func(ctx SpecContext) {
+			c := codec.NewStatic(
+				[]channel.Key{1},
+				[]telem.DataType{telem.TimeStampT},
+			)
+			fr := frame.NewUnary(1, telem.NewSeriesV[int64](1778020940471336961))
+			encoded := MustSucceed(c.Encode(ctx, fr))
+			Expect(encoded).ToNot(BeEmpty())
+		})
+
+		It("Should accept a timestamp series for an int64 channel", func(ctx SpecContext) {
+			c := codec.NewStatic(
+				[]channel.Key{1},
+				[]telem.DataType{telem.Int64T},
+			)
+			fr := frame.NewUnary(1, telem.NewSeriesSecondsTSV(1, 2, 3))
+			encoded := MustSucceed(c.Encode(ctx, fr))
+			Expect(encoded).ToNot(BeEmpty())
+		})
+	})
+
 	Describe("Dynamic Codec", Ordered, func() {
 		ShouldNotLeakGoroutinesPerSpec()
 		var (

--- a/integration/tests/arc/edge_cases.py
+++ b/integration/tests/arc/edge_cases.py
@@ -261,6 +261,36 @@ EXEC_CONTEXT_CASES = [
     ),
 ]
 
+# ── Type mismatch sources (invalid, caught at configure time) ──
+
+# f32 psi piped into f32 bar via flow connection between functions.
+# Both units share the pressure dimension but differ by name; the analyzer
+# must reject the assignment so that diagnostics surface unit identity, not
+# just dimensional compatibility.
+ARC_UNIT_MISMATCH_PSI_BAR = """
+func producer() f32 psi {
+    return 5psi
+}
+func consumer(v f32 bar) {}
+producer{} -> consumer{}
+"""
+
+
+@dataclass
+class TypeMismatchCase:
+    label: str
+    source: str
+    wait_substr: str
+
+
+TYPE_MISMATCH_CASES = [
+    TypeMismatchCase(
+        "UnitMismatchPsiBar",
+        ARC_UNIT_MISMATCH_PSI_BAR,
+        "is not equal to argument type",
+    ),
+]
+
 # ── Guarded circular calls (valid, should configure successfully) ──
 # Comprehensive guarded topology coverage is in the Go unit tests.
 
@@ -491,6 +521,24 @@ class EdgeCases(ArcConsoleCase):
                 f"[{case.label}] Expected error notification, got: {notifications}"
             )
 
+    def _verify_type_mismatch_cases(self) -> None:
+        self.log("=== Type mismatch detection ===")
+        for case in TYPE_MISMATCH_CASES:
+            self.log(f"[{case.label}] Testing type mismatch")
+            self.load_arc(
+                case.source, f"TypeMismatch{case.label}", start=False, configure=False
+            )
+
+            self.console.arc.configure_no_wait()
+            status = self.console.arc.wait_for_status(case.wait_substr)
+            self.log(f"[{case.label}] Got expected error: {status}")
+
+            notifications = self.console.notifications.check(timeout=5)
+            error_notifications = [n for n in notifications if n.get("type") == "error"]
+            assert len(error_notifications) > 0, (
+                f"[{case.label}] Expected error notification, got: {notifications}"
+            )
+
     def _verify_read_only_monitor(self) -> None:
         self.log("=== Read-only monitor (no write channels) ===")
         name = self.load_arc(
@@ -515,4 +563,5 @@ class EdgeCases(ArcConsoleCase):
         self._verify_circular_cases()
         self._verify_guarded_cases()
         self._verify_exec_context_cases()
+        self._verify_type_mismatch_cases()
         self._verify_read_only_monitor()

--- a/integration/tests/arc/stl_time.py
+++ b/integration/tests/arc/stl_time.py
@@ -16,6 +16,7 @@ authority 200
 // ──────────────────────────── time.now ───────────────────────────────
 func write_now() {
     time_now_out = time.now()
+    time_now_ts_out = time.now()
 }
 time_trigger -> write_now{}
 
@@ -89,6 +90,7 @@ class StlTime(ArcConsoleCase):
     start_cmd_channel = "start_stl_time_cmd"
     subscribe_channels = [
         "time_now_out",
+        "time_now_ts_out",
         "time_now_flow_out",
         "interval_count",
         "interval_count_mod",
@@ -99,6 +101,7 @@ class StlTime(ArcConsoleCase):
     def setup(self) -> None:
         create_virtual_channel(self.client, "time_trigger", sy.DataType.FLOAT64)
         create_virtual_channel(self.client, "time_now_out", sy.DataType.INT64)
+        create_virtual_channel(self.client, "time_now_ts_out", sy.DataType.TIMESTAMP)
         create_virtual_channel(
             self.client, "time_now_flow_trigger", sy.DataType.FLOAT64
         )
@@ -116,7 +119,10 @@ class StlTime(ArcConsoleCase):
         self.writer.write("time_trigger", 1.0)
         self.log(f"Expecting time_now_out > {JAN_2020_NANOS} (Jan 1, 2020 nanos)")
         self.wait_for_gt("time_now_out", JAN_2020_NANOS, is_virtual=True)
-        self.log("time.now() returned a valid timestamp")
+        self.log("time.now() returned a valid timestamp (int64 channel)")
+        self.log(f"Expecting time_now_ts_out > {JAN_2020_NANOS} (Jan 1, 2020 nanos)")
+        self.wait_for_gt("time_now_ts_out", JAN_2020_NANOS, is_virtual=True)
+        self.log("time.now() wrote successfully to a timestamp channel")
 
     def _test_now_flow(self) -> None:
         self.log("=== time.now{} [Flow] ===")

--- a/integration/tests/arc/stl_time.py
+++ b/integration/tests/arc/stl_time.py
@@ -15,13 +15,14 @@ ARC_STL_TIME_SOURCE = """
 authority 200
 // ──────────────────────────── time.now ───────────────────────────────
 func write_now() {
-    time_now_out = time.now()
+    time_now_int_out = time.now()
     time_now_ts_out = time.now()
 }
 time_trigger -> write_now{}
 
 // time.now{} as a flow node: triggered by any upstream, outputs timestamp.
-time_now_flow_trigger -> time.now{} -> time_now_flow_out
+time_now_flow_ts_trigger -> time.now{} -> time_now_flow_ts_out
+time_now_flow_int_trigger -> time.now{} -> time_now_flow_int_out
 
 // ─────────────────────────── time.interval ──────────────────────────
 // interval is inherently time-triggered (that's the point of the function).
@@ -89,9 +90,10 @@ class StlTime(ArcConsoleCase):
     arc_name_prefix = "ArcStlTime"
     start_cmd_channel = "start_stl_time_cmd"
     subscribe_channels = [
-        "time_now_out",
+        "time_now_int_out",
         "time_now_ts_out",
-        "time_now_flow_out",
+        "time_now_flow_ts_out",
+        "time_now_flow_int_out",
         "interval_count",
         "interval_count_mod",
         "toggle_cmd",
@@ -100,12 +102,18 @@ class StlTime(ArcConsoleCase):
 
     def setup(self) -> None:
         create_virtual_channel(self.client, "time_trigger", sy.DataType.FLOAT64)
-        create_virtual_channel(self.client, "time_now_out", sy.DataType.INT64)
+        create_virtual_channel(self.client, "time_now_int_out", sy.DataType.INT64)
         create_virtual_channel(self.client, "time_now_ts_out", sy.DataType.TIMESTAMP)
         create_virtual_channel(
-            self.client, "time_now_flow_trigger", sy.DataType.FLOAT64
+            self.client, "time_now_flow_ts_trigger", sy.DataType.FLOAT64
         )
-        create_virtual_channel(self.client, "time_now_flow_out", sy.DataType.TIMESTAMP)
+        create_virtual_channel(
+            self.client, "time_now_flow_ts_out", sy.DataType.TIMESTAMP
+        )
+        create_virtual_channel(
+            self.client, "time_now_flow_int_trigger", sy.DataType.FLOAT64
+        )
+        create_virtual_channel(self.client, "time_now_flow_int_out", sy.DataType.INT64)
         create_virtual_channel(self.client, "interval_count", sy.DataType.INT64)
         create_virtual_channel(self.client, "interval_count_mod", sy.DataType.INT64)
         create_virtual_channel(self.client, "start_wait_cmd", sy.DataType.UINT8)
@@ -117,8 +125,8 @@ class StlTime(ArcConsoleCase):
     def _test_now(self) -> None:
         self.log("=== time.now() [WASM] ===")
         self.writer.write("time_trigger", 1.0)
-        self.log(f"Expecting time_now_out > {JAN_2020_NANOS} (Jan 1, 2020 nanos)")
-        self.wait_for_gt("time_now_out", JAN_2020_NANOS, is_virtual=True)
+        self.log(f"Expecting time_now_int_out > {JAN_2020_NANOS} (Jan 1, 2020 nanos)")
+        self.wait_for_gt("time_now_int_out", JAN_2020_NANOS, is_virtual=True)
         self.log("time.now() returned a valid timestamp (int64 channel)")
         self.log(f"Expecting time_now_ts_out > {JAN_2020_NANOS} (Jan 1, 2020 nanos)")
         self.wait_for_gt("time_now_ts_out", JAN_2020_NANOS, is_virtual=True)
@@ -126,9 +134,9 @@ class StlTime(ArcConsoleCase):
 
     def _test_now_flow(self) -> None:
         self.log("=== time.now{} [Flow] ===")
-        self.writer.write("time_now_flow_trigger", 1.0)
-        self.wait_for_gt("time_now_flow_out", 0, is_virtual=True)
-        ts = self.read_tlm("time_now_flow_out", 0)
+        self.writer.write("time_now_flow_ts_trigger", 1.0)
+        self.wait_for_gt("time_now_flow_ts_out", 0, is_virtual=True)
+        ts = self.read_tlm("time_now_flow_ts_out", 0)
         now = int(sy.TimeStamp.now())
         drift = abs(ts - now)
         max_drift = 500 * int(sy.TimeSpan.MILLISECOND)
@@ -138,6 +146,11 @@ class StlTime(ArcConsoleCase):
         )
         if drift > max_drift:
             self.fail(f"time.now{{}} drift {drift / 1e6:.1f}ms exceeds 500ms tolerance")
+        self.log(
+            f"Expecting time_now_flow_int_out > {JAN_2020_NANOS} (Jan 1, 2020 nanos)"
+        )
+        self.writer.write("time_now_flow_int_trigger", 1.0)
+        self.wait_for_gt("time_now_flow_int_out", JAN_2020_NANOS, is_virtual=True)
 
     def _check_interval_rate(self, channel: str, label: str) -> None:
         baseline = self.read_tlm(channel, 0)


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4150](https://linear.app/synnax/issue/SY-4150/enable-writing-i64-ns-to-timestamp-channels)

## Description

`time.now()` and `time.now{}` now write into either an `i64` or `timestamp` channel in any combination. Previously only the unit-matching pair worked.

Two layers were rejecting the cross-unit case:

- **WASM**: `DeriveTypeSuffix` produced `channel.write_i64 ns` for timestamp channels; host bindings only register `write_i64`. Strip the unit before suffix derivation, and add the `Int64T` <-> `TimeStampT` equivalence fix to the Go core codec and C++ client codec so the resulting `i64` series encodes for a `timestamp` channel.
- **Analyzer**: The IR-edge type check rejected `i64 ns -> i64` because `types.Equal` is unit-strict. Add `types.UnitsAssignable(a, b *Unit)`, a small predicate that treats a missing unit as a wildcard but still rejects two non-nil mismatched units (e.g. `f32 psi` vs `f32 bar`), and call it  from the one `Check` site that validates flow-edge compatibility, alongside an inline `Kind` equality guard. Constraint-solver callsites stay strict.

All three layers (analyzer, codec, writer validator) now agree that `i64` and `timestamp` are wire-compatible, while genuine unit mismatches still surface a `type mismatch` diagnostic.

<img width="1009" height="471" alt="image" src="https://github.com/user-attachments/assets/d757ad3b-f253-44c0-8546-5f9c64b86bf7" />

<img width="1012" height="479" alt="image" src="https://github.com/user-attachments/assets/79df3648-3efd-425b-9fee-4d01d8615fc3" />


## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes `time.now()` and `time.now{}` writable to both `timestamp` and `int64` channels interchangeably, fixing a mismatch between how the Arc analyzer, WASM codegen, and the frame codecs each validated the `i64 ns ↔ i64` type pair.

- **Analyzer (`check.go`)**: Flow-edge type check relaxed from `types.Equal` to a Kind + `UnitsAssignable` guard, where a nil unit on either side acts as a wildcard — preserving `f32 psi → f32 bar` rejection while allowing `timestamp (i64 ns) ↔ i64`.
- **WASM codegen (`derive.go`)**: `suffixForType` strips units before producing the binding name, so a timestamp-typed channel correctly resolves to `write_i64` rather than the non-existent `write_i64_ns`.
- **Server Go codec + C++ client codec**: An `isEquivalent` guard treats `Int64T` and `TimeStampT` as wire-compatible, keeping the encoder from rejecting cross-type series.

<h3>Confidence Score: 5/5</h3>

All three enforcement layers (analyzer, WASM codegen, frame codec) are updated symmetrically, genuine unit mismatches (e.g., `f32 psi → f32 bar`) still surface errors, and the change is guarded by unit, integration, and end-to-end tests.

The three code paths that previously disagreed on `i64 ns ↔ i64` compatibility are now aligned. The nil-unit wildcard semantics introduced by `UnitsAssignable` are intentional and documented, non-nil unit mismatches are still rejected, and the regression suite explicitly covers the boundary cases. No unguarded data-loss or silent encoding path was found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| arc/go/analyzer/types/check.go | Flow-edge compatibility check replaced from strict `types.Equal` to `t1.Kind != t2.Kind || !types.UnitsAssignable(...)`, relaxing nil-unit handling; constraint-solver callsites are left strict. |
| arc/go/types/type.go | Adds `UnitsAssignable(a, b *Unit) bool` — nil on either side acts as a wildcard (matching WASM/Cesium wire-type parity), while two non-nil mismatched units still return false. |
| arc/go/compiler/resolve/derive.go | Introduces `suffixForType` which strips the unit before calling `String()`, ensuring `timestamp` (i64 ns) resolves to the `write_i64` WASM host binding rather than a non-existent `write_i64_ns`. |
| core/pkg/distribution/framer/codec/codec.go | Adds `isEquivalent` guard so that `Int64T` and `TimeStampT` are treated as wire-compatible in the server-side frame encoder, mirroring the same change in the C++ client. |
| client/cpp/framer/codec.cpp | Symmetric `is_equivalent` check for `INT64_T` / `TIMESTAMP_T` interop added to the C++ client encoder; correct and consistent with the Go-side change. |
| integration/tests/arc/stl_time.py | Expands the `time.now` integration test to cover both WASM and flow modes writing to both `TIMESTAMP` and `INT64` channels; drift validation retained for the timestamp case. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Arc source\ntime.now() → int_out / ts_out"] --> B["Analyzer\narc/go/analyzer/types/check.go"]
    B -- "KindI64 match\nUnitsAssignable(ns, nil) = true" --> C["Analysis passes ✓"]
    A --> D["Compiler\narc/go/compiler/resolve/derive.go"]
    D -- "suffixForType strips unit\ntimestamp → i64 suffix" --> E["write_i64 WASM binding ✓"]
    C --> F["Runtime write"]
    E --> F
    F --> G["Go codec\ncore/.../framer/codec/codec.go"]
    G -- "isEquivalent:\nInt64T ↔ TimeStampT" --> H["Encode succeeds ✓"]
    F --> I["C++ codec\nclient/cpp/framer/codec.cpp"]
    I -- "is_equivalent:\nINT64_T ↔ TIMESTAMP_T" --> J["Encode succeeds ✓"]
    H --> K[("Channel store\nINT64 or TIMESTAMP")]
    J --> K
```

<sub>Reviews (3): Last reviewed commit: ["SY-4150: add unit mismach tests"](https://github.com/synnaxlabs/synnax/commit/c4307631cb9f5ba818e037a3233270ad64837325) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30942967)</sub>

<!-- /greptile_comment -->