### PR TITLE
SY-3880: Arc String Conversion Support

### DIFF
--- a/arc/cpp/runtime/wasm/module.h
+++ b/arc/cpp/runtime/wasm/module.h
@@ -112,6 +112,8 @@ sample_from_wasm(const wasmtime::Val &val, const types::Type &type) {
             return x::telem::SampleValue(val.f32());
         case types::Kind::F64:
             return x::telem::SampleValue(val.f64());
+        case types::Kind::String:
+            return x::telem::SampleValue(val.i32());
         default:
             return x::telem::SampleValue(0);
     }

--- a/arc/cpp/runtime/wasm/node.h
+++ b/arc/cpp/runtime/wasm/node.h
@@ -31,6 +31,7 @@ class Node : public node::Node {
     std::vector<Module::Function::Result> results;
     std::vector<int> offsets;
     std::vector<bool> string_inputs;
+    std::vector<bool> string_outputs;
     std::shared_ptr<stl::str::State> str_state;
     bool initialized = false;
     bool is_entry_node = false;
@@ -58,6 +59,9 @@ public:
         this->string_inputs.resize(node.inputs.size());
         for (size_t i = 0; i < node.inputs.size(); i++)
             this->string_inputs[i] = node.inputs[i].type.kind == types::Kind::String;
+        this->string_outputs.resize(node.outputs.size());
+        for (size_t i = 0; i < node.outputs.size(); i++)
+            this->string_outputs[i] = node.outputs[i].type.kind == types::Kind::String;
     }
 
     x::errors::Error next(node::Context &ctx) override {
@@ -84,8 +88,19 @@ public:
         for (auto &offset: this->offsets)
             offset = 0;
 
+        // String outputs are variable-density and cannot be resize'd. Their
+        // data buffer is built once at the end of the loop from accumulated
+        // strings. Numeric outputs are pre-sized here so set() can do
+        // fixed-stride writes per sample.
+        std::vector<std::vector<std::string>> string_results;
         for (size_t i = 0; i < this->ir.outputs.size(); i++) {
-            this->state.output(i)->resize(max_length);
+            if (this->string_outputs[i]) {
+                if (string_results.empty())
+                    string_results.resize(this->ir.outputs.size());
+                string_results[i].reserve(max_length);
+            } else {
+                this->state.output(i)->resize(max_length);
+            }
             this->state.output_time(i)->resize(max_length);
         }
 
@@ -131,7 +146,15 @@ public:
             for (size_t j = 0; j < results.size(); j++) {
                 auto [value, changed] = results[j];
                 if (!changed) continue;
-                this->state.output(j)->set(this->offsets[j], value);
+                if (this->string_outputs[j]) {
+                    // WASM returned an i32 string handle; materialize it
+                    // to its actual string value, mirroring the input-side
+                    // conversion above.
+                    const auto handle = static_cast<uint32_t>(std::get<int32_t>(value));
+                    string_results[j].push_back(this->str_state->get(handle));
+                } else {
+                    this->state.output(j)->set(this->offsets[j], value);
+                }
                 this->state.output_time(j)->set(this->offsets[j], ts);
                 this->offsets[j]++;
             }
@@ -139,7 +162,13 @@ public:
 
         for (size_t j = 0; j < this->ir.outputs.size(); j++) {
             const auto off = this->offsets[j];
-            this->state.output(j)->resize(off);
+            if (this->string_outputs[j]) {
+                *this->state.output(
+                    j
+                ) = x::telem::Series(string_results[j], x::telem::STRING_T);
+            } else {
+                this->state.output(j)->resize(off);
+            }
             this->state.output_time(j)->resize(off);
             if (off > 0) ctx.mark_changed(j);
         }

--- a/arc/cpp/runtime/wasm/node.h
+++ b/arc/cpp/runtime/wasm/node.h
@@ -162,13 +162,11 @@ public:
 
         for (size_t j = 0; j < this->ir.outputs.size(); j++) {
             const auto off = this->offsets[j];
-            if (this->string_outputs[j]) {
-                *this->state.output(
-                    j
-                ) = x::telem::Series(string_results[j], x::telem::STRING_T);
-            } else {
-                this->state.output(j)->resize(off);
-            }
+            auto &out = this->state.output(j);
+            if (this->string_outputs[j])
+                *out = x::telem::Series(string_results[j], x::telem::STRING_T);
+            else
+                out->resize(off);
             this->state.output_time(j)->resize(off);
             if (off > 0) ctx.mark_changed(j);
         }

--- a/arc/cpp/runtime/wasm/node_test.cpp
+++ b/arc/cpp/runtime/wasm/node_test.cpp
@@ -1804,6 +1804,143 @@ func qstr_len(s str) i64 {
     EXPECT_EQ(output->at<int64_t>(2), 0); // ""
 }
 
+/// @brief Flow expressions returning a string single default output materialize the
+/// handle returned on the WASM stack (base == 0 path) instead of dropping it.
+TEST(NodeTest, FlowExpressionStringDefaultOutput) {
+    const auto client = new_test_client();
+
+    auto output_name = random_name("str_output");
+    auto output_ch = synnax::channel::Channel{
+        .name = output_name,
+        .data_type = x::telem::STRING_T,
+        .is_virtual = true,
+    };
+    ASSERT_NIL(client.channels.create(output_ch));
+
+    const std::string source = R"(
+func produce_str() str {
+    return str(42)
+}
+produce_str{} -> )" + output_name;
+
+    auto str_st = std::make_shared<stl::str::State>();
+    auto series_st = std::make_shared<stl::series::State>();
+    auto var_st = std::make_shared<stl::stateful::Variables>();
+    auto channel_st = std::make_shared<stl::channel::State>();
+    auto stl_modules = build_stl_modules(channel_st, str_st, series_st, var_st);
+
+    auto mod = compile_arc(client, source);
+    auto wasm_mod = ASSERT_NIL_P(
+        wasm::Module::open({
+            .program = mod,
+            .modules = stl_modules,
+            .strings = str_st,
+        })
+    );
+
+    const auto *func_node = find_node_by_type(mod, "produce_str");
+    ASSERT_NE(func_node, nullptr);
+
+    state::State state(
+        state::Config{
+            .ir = (static_cast<arc::ir::IR>(mod)),
+            .channels = {{output_ch.key, x::telem::STRING_T, 0}}
+        },
+        arc::runtime::errors::noop_handler
+    );
+
+    auto node_state = ASSERT_NIL_P(state.node(func_node->key));
+    auto func = ASSERT_NIL_P(wasm_mod->func("produce_str"));
+
+    arc::ir::Node expr_node = *func_node;
+    expr_node.key = "expression_0";
+
+    wasm::Node node(mod, expr_node, std::move(node_state), func, wasm_mod->strings());
+
+    auto ctx = make_context();
+    std::vector<std::string> changed_outputs;
+    ctx.mark_changed = [&](size_t i) {
+        changed_outputs.push_back(func_node->outputs[i].name);
+    };
+
+    ASSERT_NIL(node.next(ctx));
+    ASSERT_EQ(changed_outputs.size(), 1);
+
+    auto result_state = ASSERT_NIL_P(state.node(func_node->key));
+    const auto &output = result_state.output(0);
+    ASSERT_EQ(output->size(), 1);
+    EXPECT_EQ(output->at<std::string>(0), "42");
+}
+
+/// @brief Flow expressions returning a concatenated string default output preserve the
+/// resulting handle through the WASM stack (base == 0 path), mirroring the integration
+/// test pattern: trigger -> "value=" + str(42) + " items" -> str_chan.
+TEST(NodeTest, FlowExpressionStringConcatDefaultOutput) {
+    const auto client = new_test_client();
+
+    auto output_name = random_name("str_output");
+    auto output_ch = synnax::channel::Channel{
+        .name = output_name,
+        .data_type = x::telem::STRING_T,
+        .is_virtual = true,
+    };
+    ASSERT_NIL(client.channels.create(output_ch));
+
+    const std::string source = R"(
+func produce_str() str {
+    return "value=" + str(42) + " items"
+}
+produce_str{} -> )" + output_name;
+
+    auto str_st = std::make_shared<stl::str::State>();
+    auto series_st = std::make_shared<stl::series::State>();
+    auto var_st = std::make_shared<stl::stateful::Variables>();
+    auto channel_st = std::make_shared<stl::channel::State>();
+    auto stl_modules = build_stl_modules(channel_st, str_st, series_st, var_st);
+
+    auto mod = compile_arc(client, source);
+    auto wasm_mod = ASSERT_NIL_P(
+        wasm::Module::open({
+            .program = mod,
+            .modules = stl_modules,
+            .strings = str_st,
+        })
+    );
+
+    const auto *func_node = find_node_by_type(mod, "produce_str");
+    ASSERT_NE(func_node, nullptr);
+
+    state::State state(
+        state::Config{
+            .ir = (static_cast<arc::ir::IR>(mod)),
+            .channels = {{output_ch.key, x::telem::STRING_T, 0}}
+        },
+        arc::runtime::errors::noop_handler
+    );
+
+    auto node_state = ASSERT_NIL_P(state.node(func_node->key));
+    auto func = ASSERT_NIL_P(wasm_mod->func("produce_str"));
+
+    arc::ir::Node expr_node = *func_node;
+    expr_node.key = "expression_0";
+
+    wasm::Node node(mod, expr_node, std::move(node_state), func, wasm_mod->strings());
+
+    auto ctx = make_context();
+    std::vector<std::string> changed_outputs;
+    ctx.mark_changed = [&](size_t i) {
+        changed_outputs.push_back(func_node->outputs[i].name);
+    };
+
+    ASSERT_NIL(node.next(ctx));
+    ASSERT_EQ(changed_outputs.size(), 1);
+
+    auto result_state = ASSERT_NIL_P(state.node(func_node->key));
+    const auto &output = result_state.output(0);
+    ASSERT_EQ(output->size(), 1);
+    EXPECT_EQ(output->at<std::string>(0), "value=42 items");
+}
+
 /// @brief Node converts string channel inputs to handles for + operator.
 TEST(NodeTest, DISABLED_StringConcatWithChannelData) {
     const auto client = new_test_client();

--- a/arc/cpp/runtime/wasm/node_test.cpp
+++ b/arc/cpp/runtime/wasm/node_test.cpp
@@ -1611,7 +1611,8 @@ func labeler(x i64) (label str, value i64) {
     value = x * 2
 }
 )arc" + input_name +
-        " -> labeler{} -> " + value_out_name;
+        " -> labeler{} -> {label: " + label_out_name + ", value: " + value_out_name +
+        "}";
 
     auto str_st = std::make_shared<stl::str::State>();
     auto series_st = std::make_shared<stl::series::State>();

--- a/arc/cpp/runtime/wasm/node_test.cpp
+++ b/arc/cpp/runtime/wasm/node_test.cpp
@@ -1561,7 +1561,7 @@ func str_len(s str) i64 {
 }
 
 /// @brief Node handles string-typed named outputs without panicking on Density().
-TEST(NodeTest, DISABLED_NamedStringOutputMemoryLayout) {
+TEST(NodeTest, NamedStringOutputMemoryLayout) {
     const auto client = new_test_client();
 
     auto idx_name = random_name("time");

--- a/arc/cpp/stl/str/BUILD.bazel
+++ b/arc/cpp/stl/str/BUILD.bazel
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 cc_library(
     name = "state",
@@ -21,5 +22,24 @@ cc_library(
     deps = [
         ":state",
         "//arc/cpp/stl",
+    ],
+)
+
+cc_test(
+    name = "state_test",
+    srcs = ["state_test.cpp"],
+    deps = [
+        ":state",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "str_test",
+    srcs = ["str_test.cpp"],
+    deps = [
+        ":state",
+        ":str",
+        "@googletest//:gtest_main",
     ],
 )

--- a/arc/cpp/stl/str/str.h
+++ b/arc/cpp/stl/str/str.h
@@ -34,6 +34,7 @@ std::string format_float(T v) {
         v,
         std::chars_format::general
     );
+    if (ec != std::errc{}) return "";
     return {buf, end};
 }
 

--- a/arc/cpp/stl/str/str.h
+++ b/arc/cpp/stl/str/str.h
@@ -9,6 +9,8 @@
 
 #pragma once
 
+#include <charconv>
+#include <cmath>
 #include <cstdio>
 #include <memory>
 #include <string>
@@ -17,6 +19,23 @@
 #include "arc/cpp/stl/str/state.h"
 
 namespace arc::stl::str {
+
+/// Formats v as the shortest round-trippable decimal, matching Go's
+/// strconv.FormatFloat(v, 'g', -1, bitSize). NaN and ±Inf are emitted as
+/// "NaN", "+Inf", "-Inf" to match Go's output exactly.
+template<typename T>
+std::string format_float(T v) {
+    if (std::isnan(v)) return "NaN";
+    if (std::isinf(v)) return v > 0 ? "+Inf" : "-Inf";
+    char buf[32];
+    const auto [end, ec] = std::to_chars(
+        buf,
+        buf + sizeof(buf),
+        v,
+        std::chars_format::general
+    );
+    return {buf, end};
+}
 
 class Module : public stl::Module {
     std::shared_ptr<State> str_state;
@@ -92,6 +111,48 @@ public:
                 [ss](uint32_t handle) -> uint64_t {
                     return static_cast<uint64_t>(ss->get(handle).length());
                 }
+            )
+            .unwrap();
+        linker
+            .func_wrap(
+                "string",
+                "from_i32",
+                [ss](int32_t v) -> uint32_t { return ss->create(std::to_string(v)); }
+            )
+            .unwrap();
+        linker
+            .func_wrap(
+                "string",
+                "from_u32",
+                [ss](uint32_t v) -> uint32_t { return ss->create(std::to_string(v)); }
+            )
+            .unwrap();
+        linker
+            .func_wrap(
+                "string",
+                "from_i64",
+                [ss](int64_t v) -> uint32_t { return ss->create(std::to_string(v)); }
+            )
+            .unwrap();
+        linker
+            .func_wrap(
+                "string",
+                "from_u64",
+                [ss](uint64_t v) -> uint32_t { return ss->create(std::to_string(v)); }
+            )
+            .unwrap();
+        linker
+            .func_wrap(
+                "string",
+                "from_f32",
+                [ss](float v) -> uint32_t { return ss->create(format_float(v)); }
+            )
+            .unwrap();
+        linker
+            .func_wrap(
+                "string",
+                "from_f64",
+                [ss](double v) -> uint32_t { return ss->create(format_float(v)); }
             )
             .unwrap();
     }

--- a/arc/cpp/stl/str/str_test.cpp
+++ b/arc/cpp/stl/str/str_test.cpp
@@ -7,6 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+#include <limits>
 #include <memory>
 #include <string>
 #include <vector>
@@ -24,6 +25,12 @@ const std::string_view STR_WAT = R"wat(
   (import "string" "concat" (func $concat (param i32 i32) (result i32)))
   (import "string" "equal" (func $equal (param i32 i32) (result i32)))
   (import "string" "len" (func $len (param i32) (result i64)))
+  (import "string" "from_i32" (func $from_i32 (param i32) (result i32)))
+  (import "string" "from_u32" (func $from_u32 (param i32) (result i32)))
+  (import "string" "from_i64" (func $from_i64 (param i64) (result i32)))
+  (import "string" "from_u64" (func $from_u64 (param i64) (result i32)))
+  (import "string" "from_f32" (func $from_f32 (param f32) (result i32)))
+  (import "string" "from_f64" (func $from_f64 (param f64) (result i32)))
   (memory (export "memory") 1)
   (data (i32.const 0) "hello")
   (data (i32.const 5) " world")
@@ -39,6 +46,18 @@ const std::string_view STR_WAT = R"wat(
     (call $len (local.get 0)))
   (func (export "from_oob") (result i32)
     (call $from_lit (i32.const 65530) (i32.const 100)))
+  (func (export "call_from_i32") (param i32) (result i32)
+    (call $from_i32 (local.get 0)))
+  (func (export "call_from_u32") (param i32) (result i32)
+    (call $from_u32 (local.get 0)))
+  (func (export "call_from_i64") (param i64) (result i32)
+    (call $from_i64 (local.get 0)))
+  (func (export "call_from_u64") (param i64) (result i32)
+    (call $from_u64 (local.get 0)))
+  (func (export "call_from_f32") (param f32) (result i32)
+    (call $from_f32 (local.get 0)))
+  (func (export "call_from_f64") (param f64) (result i32)
+    (call $from_f64 (local.get 0)))
 )
 )wat";
 
@@ -149,5 +168,128 @@ TEST(StrModule, LenReturnsCorrectLength) {
     auto len_fn = f.get_func("len_handle");
     auto result = len_fn.call(f.store, {wasmtime::Val(h)}).unwrap();
     EXPECT_EQ(result[0].i64(), 5);
+}
+
+template<typename ValT>
+static std::string call_from(StrModuleFixture &f, const std::string &fn_name, ValT v) {
+    auto fn = f.get_func(fn_name);
+    auto result = fn.call(f.store, {wasmtime::Val(v)}).unwrap();
+    return f.state->get(result[0].i32());
+}
+
+TEST(StrModule, FromI32FormatsSignedIntegers) {
+    StrModuleFixture f;
+    EXPECT_EQ(call_from<int32_t>(f, "call_from_i32", 0), "0");
+    EXPECT_EQ(call_from<int32_t>(f, "call_from_i32", 42), "42");
+    EXPECT_EQ(call_from<int32_t>(f, "call_from_i32", -42), "-42");
+    EXPECT_EQ(
+        call_from<int32_t>(f, "call_from_i32", std::numeric_limits<int32_t>::max()),
+        "2147483647"
+    );
+    EXPECT_EQ(
+        call_from<int32_t>(f, "call_from_i32", std::numeric_limits<int32_t>::min()),
+        "-2147483648"
+    );
+}
+
+TEST(StrModule, FromU32FormatsUnsignedIntegers) {
+    StrModuleFixture f;
+    EXPECT_EQ(call_from<int32_t>(f, "call_from_u32", 0), "0");
+    EXPECT_EQ(call_from<int32_t>(f, "call_from_u32", 255), "255");
+    EXPECT_EQ(
+        call_from<int32_t>(
+            f,
+            "call_from_u32",
+            static_cast<int32_t>(static_cast<uint32_t>(4000000000U))
+        ),
+        "4000000000"
+    );
+    EXPECT_EQ(
+        call_from<int32_t>(f, "call_from_u32", static_cast<int32_t>(0xFFFFFFFFU)),
+        "4294967295"
+    );
+}
+
+TEST(StrModule, FromI64FormatsSignedIntegers) {
+    StrModuleFixture f;
+    EXPECT_EQ(call_from<int64_t>(f, "call_from_i64", 0), "0");
+    EXPECT_EQ(call_from<int64_t>(f, "call_from_i64", 42), "42");
+    EXPECT_EQ(call_from<int64_t>(f, "call_from_i64", -42), "-42");
+    EXPECT_EQ(
+        call_from<int64_t>(f, "call_from_i64", std::numeric_limits<int64_t>::max()),
+        "9223372036854775807"
+    );
+    EXPECT_EQ(
+        call_from<int64_t>(f, "call_from_i64", std::numeric_limits<int64_t>::min()),
+        "-9223372036854775808"
+    );
+}
+
+TEST(StrModule, FromU64FormatsUnsignedIntegers) {
+    StrModuleFixture f;
+    EXPECT_EQ(call_from<int64_t>(f, "call_from_u64", 0), "0");
+    EXPECT_EQ(call_from<int64_t>(f, "call_from_u64", 42), "42");
+    EXPECT_EQ(
+        call_from<int64_t>(
+            f,
+            "call_from_u64",
+            static_cast<int64_t>(static_cast<uint64_t>(0xFFFFFFFFFFFFFFFFULL))
+        ),
+        "18446744073709551615"
+    );
+}
+
+TEST(StrModule, FromF32FormatsShortestRoundTrip) {
+    StrModuleFixture f;
+    EXPECT_EQ(call_from<float>(f, "call_from_f32", 3.1f), "3.1");
+    EXPECT_EQ(call_from<float>(f, "call_from_f32", 0.1f), "0.1");
+    EXPECT_EQ(call_from<float>(f, "call_from_f32", 1.0f), "1");
+    EXPECT_EQ(call_from<float>(f, "call_from_f32", 100.0f), "100");
+    EXPECT_EQ(call_from<float>(f, "call_from_f32", -2.5f), "-2.5");
+    EXPECT_EQ(call_from<float>(f, "call_from_f32", 42.5f), "42.5");
+}
+
+TEST(StrModule, FromF64FormatsShortestRoundTrip) {
+    StrModuleFixture f;
+    EXPECT_EQ(call_from<double>(f, "call_from_f64", 3.1), "3.1");
+    EXPECT_EQ(call_from<double>(f, "call_from_f64", 3.14), "3.14");
+    EXPECT_EQ(call_from<double>(f, "call_from_f64", 1.0), "1");
+    EXPECT_EQ(call_from<double>(f, "call_from_f64", -2.5), "-2.5");
+    EXPECT_EQ(
+        call_from<double>(f, "call_from_f64", 0.1234567890123456),
+        "0.1234567890123456"
+    );
+}
+
+TEST(StrModule, FromF64HandlesNaNAndInfinityWithGoCapitalization) {
+    StrModuleFixture f;
+    EXPECT_EQ(
+        call_from<double>(f, "call_from_f64", std::numeric_limits<double>::quiet_NaN()),
+        "NaN"
+    );
+    EXPECT_EQ(
+        call_from<double>(f, "call_from_f64", std::numeric_limits<double>::infinity()),
+        "+Inf"
+    );
+    EXPECT_EQ(
+        call_from<double>(f, "call_from_f64", -std::numeric_limits<double>::infinity()),
+        "-Inf"
+    );
+}
+
+TEST(StrModule, FromF32HandlesNaNAndInfinityWithGoCapitalization) {
+    StrModuleFixture f;
+    EXPECT_EQ(
+        call_from<float>(f, "call_from_f32", std::numeric_limits<float>::quiet_NaN()),
+        "NaN"
+    );
+    EXPECT_EQ(
+        call_from<float>(f, "call_from_f32", std::numeric_limits<float>::infinity()),
+        "+Inf"
+    );
+    EXPECT_EQ(
+        call_from<float>(f, "call_from_f32", -std::numeric_limits<float>::infinity()),
+        "-Inf"
+    );
 }
 }

--- a/arc/go/analyzer/expression/expression.go
+++ b/arc/go/analyzer/expression/expression.go
@@ -652,6 +652,9 @@ func isValidCast(source, target basetypes.Type) bool {
 	if source.Kind == target.Kind {
 		return true
 	}
+	if target.Kind == basetypes.KindString && source.IsNumeric() {
+		return true
+	}
 	if source.Kind == basetypes.KindString || target.Kind == basetypes.KindString {
 		return false
 	}

--- a/arc/go/analyzer/expression/typecast_test.go
+++ b/arc/go/analyzer/expression/typecast_test.go
@@ -231,25 +231,231 @@ var _ = Describe("Type Casts", func() {
 		`),
 	)
 
+	DescribeTable("Numeric to String Casts",
+		func(ctx SpecContext, code string) { expectSuccess(ctx, code, nil) },
+		Entry("i8 to str", `
+			func testFunc() {
+				x i8 := -128
+				y := str(x)
+			}
+		`),
+		Entry("i16 to str", `
+			func testFunc() {
+				x i16 := -32768
+				y := str(x)
+			}
+		`),
+		Entry("i32 to str", `
+			func testFunc() {
+				x i32 := 42
+				y := str(x)
+			}
+		`),
+		Entry("i32 to str (negative)", `
+			func testFunc() {
+				x i32 := -2147483648
+				y := str(x)
+			}
+		`),
+		Entry("i64 to str", `
+			func testFunc() {
+				x i64 := 9223372036854775807
+				y := str(x)
+			}
+		`),
+		Entry("i64 to str (negative)", `
+			func testFunc() {
+				x i64 := -9223372036854775808
+				y := str(x)
+			}
+		`),
+		Entry("u8 to str", `
+			func testFunc() {
+				x u8 := 255
+				y := str(x)
+			}
+		`),
+		Entry("u16 to str", `
+			func testFunc() {
+				x u16 := 65535
+				y := str(x)
+			}
+		`),
+		Entry("u32 to str", `
+			func testFunc() {
+				x u32 := 4000000000
+				y := str(x)
+			}
+		`),
+		Entry("u64 to str", `
+			func testFunc() {
+				x u64 := 18000000000000000000
+				y := str(x)
+			}
+		`),
+		Entry("f32 to str", `
+			func testFunc() {
+				x f32 := 3.14
+				y := str(x)
+			}
+		`),
+		Entry("f32 to str (negative)", `
+			func testFunc() {
+				x f32 := -3.14
+				y := str(x)
+			}
+		`),
+		Entry("f32 to str (integer-valued, trailing zero)", `
+			func testFunc() {
+				x f32 := 1.0
+				y := str(x)
+			}
+		`),
+		Entry("f32 to str (single trailing zero)", `
+			func testFunc() {
+				x f32 := 3.10
+				y := str(x)
+			}
+		`),
+		Entry("f32 to str (multiple trailing zeros)", `
+			func testFunc() {
+				x f32 := 100.000
+				y := str(x)
+			}
+		`),
+		Entry("f64 to str", `
+			func testFunc() {
+				x f64 := 3.14159
+				y := str(x)
+			}
+		`),
+		Entry("f64 to str (negative)", `
+			func testFunc() {
+				x f64 := -3.14159
+				y := str(x)
+			}
+		`),
+		Entry("f64 to str (integer-valued, trailing zero)", `
+			func testFunc() {
+				x f64 := 1.0
+				y := str(x)
+			}
+		`),
+		Entry("f64 to str (single trailing zero)", `
+			func testFunc() {
+				x f64 := 3.10
+				y := str(x)
+			}
+		`),
+		Entry("f64 to str (multiple trailing zeros)", `
+			func testFunc() {
+				x f64 := 100.000
+				y := str(x)
+			}
+		`),
+		Entry("integer literal to str", `
+			func testFunc() {
+				y := str(42)
+			}
+		`),
+		Entry("integer literal to str (negative)", `
+			func testFunc() {
+				y := str(-42)
+			}
+		`),
+		Entry("float literal to str", `
+			func testFunc() {
+				y := str(3.14)
+			}
+		`),
+		Entry("float literal to str (negative)", `
+			func testFunc() {
+				y := str(-3.14)
+			}
+		`),
+		Entry("float literal to str (trailing zero)", `
+			func testFunc() {
+				y := str(1.0)
+			}
+		`),
+		Entry("float literal to str (multiple trailing zeros)", `
+			func testFunc() {
+				y := str(100.000)
+			}
+		`),
+		Entry("str cast in concat expression", `
+			func testFunc() {
+				x i32 := 42
+				y := str(x) + " items"
+			}
+		`),
+	)
+
+	DescribeTable("String to Numeric Casts (rejected)",
+		func(ctx SpecContext, code string) { expectFailure(ctx, code, nil, "cannot cast") },
+		Entry("str to i8", `
+			func testFunc() {
+				x str := "hello"
+				y := i8(x)
+			}
+		`),
+		Entry("str to i16", `
+			func testFunc() {
+				x str := "hello"
+				y := i16(x)
+			}
+		`),
+		Entry("str to i32", `
+			func testFunc() {
+				x str := "hello"
+				y := i32(x)
+			}
+		`),
+		Entry("str to i64", `
+			func testFunc() {
+				x str := "hello"
+				y := i64(x)
+			}
+		`),
+		Entry("str to u8", `
+			func testFunc() {
+				x str := "hello"
+				y := u8(x)
+			}
+		`),
+		Entry("str to u16", `
+			func testFunc() {
+				x str := "hello"
+				y := u16(x)
+			}
+		`),
+		Entry("str to u32", `
+			func testFunc() {
+				x str := "hello"
+				y := u32(x)
+			}
+		`),
+		Entry("str to u64", `
+			func testFunc() {
+				x str := "hello"
+				y := u64(x)
+			}
+		`),
+		Entry("str to f32", `
+			func testFunc() {
+				x str := "hello"
+				y := f32(x)
+			}
+		`),
+		Entry("str to f64", `
+			func testFunc() {
+				x str := "hello"
+				y := f64(x)
+			}
+		`),
+	)
+
 	Describe("Type Cast Failures", func() {
-		It("Should reject casting string to numeric type", func(ctx SpecContext) {
-			expectFailure(ctx, `
-				func testFunc() {
-					x str := "hello"
-					y := i32(x)
-				}
-			`, nil, "cannot cast")
-		})
-
-		It("Should reject casting numeric to string", func(ctx SpecContext) {
-			expectFailure(ctx, `
-				func testFunc() {
-					x i32 := 42
-					y := str(x)
-				}
-			`, nil, "cannot cast")
-		})
-
 		It("Should reject unknown type in cast", func(ctx SpecContext) {
 			expectFailure(ctx, `
 				func testFunc() {

--- a/arc/go/compiler/expression/cast.go
+++ b/arc/go/compiler/expression/cast.go
@@ -26,8 +26,14 @@ func compileTypeCast(
 	if !targetType.IsValid() {
 		return types.Type{}, errors.New("unknown cast target type")
 	}
-	// Pass the target type as a hint so literals can be emitted with the correct type directly
-	sourceType, err := Compile(context.Child(ctx, ctx.AST.Expression()).WithHint(targetType))
+	// Pass the target type as a hint so literals can be emitted with the correct type
+	// directly. For str targets, suppress the hint so a numeric literal gets its natural
+	// type rather than falling through parseIntegerLiteral's default branch.
+	hint := targetType
+	if targetType.Kind == types.KindString {
+		hint = types.Type{}
+	}
+	sourceType, err := Compile(context.Child(ctx, ctx.AST.Expression()).WithHint(hint))
 	if err != nil {
 		return types.Type{}, err
 	}
@@ -39,6 +45,9 @@ func compileTypeCast(
 
 func extractType(typeCtx parser.ITypeContext) types.Type {
 	if prim := typeCtx.PrimitiveType(); prim != nil {
+		if prim.STR() != nil {
+			return types.String()
+		}
 		if num := prim.NumericType(); num != nil {
 			if intType := num.IntegerType(); intType != nil {
 				if intType.I8() != nil {
@@ -74,6 +83,12 @@ func EmitCast[ASTNode antlr.ParserRuleContext](
 	ctx context.Context[ASTNode],
 	from, to types.Type,
 ) error {
+	if to.Kind == types.KindString {
+		if from.Kind == types.KindString {
+			return nil
+		}
+		return ctx.Resolver.EmitNumericToString(ctx.Writer, ctx.WriterID, from)
+	}
 	var (
 		fromWasm = wasm.ConvertType(from)
 		toWasm   = wasm.ConvertType(to)

--- a/arc/go/compiler/expression/cast_test.go
+++ b/arc/go/compiler/expression/cast_test.go
@@ -12,11 +12,14 @@ package expression_test
 import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	acontext "github.com/synnaxlabs/arc/analyzer/context"
+	aexpression "github.com/synnaxlabs/arc/analyzer/expression"
 	ccontext "github.com/synnaxlabs/arc/compiler/context"
 	"github.com/synnaxlabs/arc/compiler/expression"
 	. "github.com/synnaxlabs/arc/compiler/testutil"
 	. "github.com/synnaxlabs/arc/compiler/wasm"
 	"github.com/synnaxlabs/arc/parser"
+	"github.com/synnaxlabs/arc/stl"
 	"github.com/synnaxlabs/arc/types"
 )
 
@@ -111,6 +114,249 @@ var _ = Describe("Type Cast Compilation", func() {
 			int32(42),
 			OpF32ConvertI32U,
 		),
+
+		// Numeric to String — dispatches via Resolver.EmitNumericToString. The Call
+		// index here is uint32(0) because each entry compiles in a fresh context, so
+		// the relevant string.from_* host fn is the first call registered.
+		Entry(
+			"i8 to str",
+			"str(i8(42))",
+			types.String(),
+			OpI32Const, int32(42),
+			OpCall, uint32(0),
+		),
+		Entry(
+			"i8 to str (negative)",
+			"str(i8(-127))",
+			types.String(),
+			OpI32Const, int32(127),
+			OpI32Const, int32(-1),
+			OpI32Mul,
+			OpCall, uint32(0),
+		),
+		Entry(
+			"i16 to str",
+			"str(i16(42))",
+			types.String(),
+			OpI32Const, int32(42),
+			OpCall, uint32(0),
+		),
+		Entry(
+			"i16 to str (negative)",
+			"str(i16(-32767))",
+			types.String(),
+			OpI32Const, int32(32767),
+			OpI32Const, int32(-1),
+			OpI32Mul,
+			OpCall, uint32(0),
+		),
+		Entry(
+			"i32 to str",
+			"str(i32(42))",
+			types.String(),
+			OpI32Const, int32(42),
+			OpCall, uint32(0),
+		),
+		Entry(
+			"i32 to str (negative)",
+			"str(i32(-2147483647))",
+			types.String(),
+			OpI32Const, int32(2147483647),
+			OpI32Const, int32(-1),
+			OpI32Mul,
+			OpCall, uint32(0),
+		),
+		Entry(
+			"i64 to str",
+			"str(i64(42))",
+			types.String(),
+			OpI64Const, int64(42),
+			OpCall, uint32(0),
+		),
+		Entry(
+			"i64 to str (negative)",
+			"str(i64(-9223372036854775807))",
+			types.String(),
+			OpI64Const, int64(9223372036854775807),
+			OpI64Const, int64(-1),
+			OpI64Mul,
+			OpCall, uint32(0),
+		),
+		Entry(
+			"u8 to str",
+			"str(u8(255))",
+			types.String(),
+			OpI32Const, int32(255),
+			OpCall, uint32(0),
+		),
+		Entry(
+			"u16 to str",
+			"str(u16(42))",
+			types.String(),
+			OpI32Const, int32(42),
+			OpCall, uint32(0),
+		),
+		Entry(
+			"u32 to str",
+			"str(u32(42))",
+			types.String(),
+			OpI32Const, int32(42),
+			OpCall, uint32(0),
+		),
+		Entry(
+			"u64 to str",
+			"str(u64(42))",
+			types.String(),
+			OpI64Const, int64(42),
+			OpCall, uint32(0),
+		),
+		Entry(
+			"f32 to str",
+			"str(f32(3.14))",
+			types.String(),
+			OpF32Const, float32(3.14),
+			OpCall, uint32(0),
+		),
+		Entry(
+			"f32 to str (negative)",
+			"str(f32(-3.14))",
+			types.String(),
+			OpF32Const, float32(3.14),
+			OpF32Neg,
+			OpCall, uint32(0),
+		),
+		Entry(
+			"f32 to str (integer-valued, trailing zero)",
+			"str(f32(1.0))",
+			types.String(),
+			OpF32Const, float32(1.0),
+			OpCall, uint32(0),
+		),
+		Entry(
+			"f32 to str (single trailing zero)",
+			"str(f32(3.10))",
+			types.String(),
+			OpF32Const, float32(3.10),
+			OpCall, uint32(0),
+		),
+		Entry(
+			"f32 to str (multiple trailing zeros)",
+			"str(f32(100.000))",
+			types.String(),
+			OpF32Const, float32(100.000),
+			OpCall, uint32(0),
+		),
+		Entry(
+			"f64 to str",
+			"str(f64(3.14))",
+			types.String(),
+			OpF64Const, float64(3.14),
+			OpCall, uint32(0),
+		),
+		Entry(
+			"f64 to str (negative)",
+			"str(f64(-3.14))",
+			types.String(),
+			OpF64Const, float64(3.14),
+			OpF64Neg,
+			OpCall, uint32(0),
+		),
+		Entry(
+			"f64 to str (integer-valued, trailing zero)",
+			"str(f64(1.0))",
+			types.String(),
+			OpF64Const, float64(1.0),
+			OpCall, uint32(0),
+		),
+		Entry(
+			"f64 to str (single trailing zero)",
+			"str(f64(3.10))",
+			types.String(),
+			OpF64Const, float64(3.10),
+			OpCall, uint32(0),
+		),
+		Entry(
+			"f64 to str (multiple trailing zeros)",
+			"str(f64(100.000))",
+			types.String(),
+			OpF64Const, float64(100.000),
+			OpCall, uint32(0),
+		),
+		Entry(
+			"integer literal to str (natural i64)",
+			"str(42)",
+			types.String(),
+			OpI64Const, int64(42),
+			OpCall, uint32(0),
+		),
+		Entry(
+			"integer literal to str (negative)",
+			"str(-42)",
+			types.String(),
+			OpI64Const, int64(42),
+			OpI64Const, int64(-1),
+			OpI64Mul,
+			OpCall, uint32(0),
+		),
+		Entry(
+			"float literal to str (natural f64)",
+			"str(3.14)",
+			types.String(),
+			OpF64Const, float64(3.14),
+			OpCall, uint32(0),
+		),
+		Entry(
+			"float literal to str (negative)",
+			"str(-3.14)",
+			types.String(),
+			OpF64Const, float64(3.14),
+			OpF64Neg,
+			OpCall, uint32(0),
+		),
+		Entry(
+			"float literal to str (trailing zero)",
+			"str(1.0)",
+			types.String(),
+			OpF64Const, float64(1.0),
+			OpCall, uint32(0),
+		),
+		Entry(
+			"float literal to str (multiple trailing zeros)",
+			"str(100.000)",
+			types.String(),
+			OpF64Const, float64(100.000),
+			OpCall, uint32(0),
+		),
+		Entry(
+			"str to str (no-op)",
+			`str("hello")`,
+			types.String(),
+			OpI32Const, int32(0),
+			OpI32Const, int32(5),
+			OpCall, uint32(0),
+		),
+	)
+
+	DescribeTable(
+		"should reject str to numeric casts (analyzer-gated)",
+		func(bCtx SpecContext, source string) {
+			expr, diag := parser.ParseExpression(source)
+			Expect(diag).To(BeNil())
+			analyzerCtx := acontext.CreateRoot(bCtx, expr, stl.SymbolResolver)
+			aexpression.Analyze(analyzerCtx)
+			Expect(analyzerCtx.Diagnostics.Ok()).To(BeFalse())
+			Expect(analyzerCtx.Diagnostics.String()).To(ContainSubstring("cannot cast"))
+		},
+		Entry("str to i8", `i8("hello")`),
+		Entry("str to i16", `i16("hello")`),
+		Entry("str to i32", `i32("hello")`),
+		Entry("str to i64", `i64("hello")`),
+		Entry("str to u8", `u8("hello")`),
+		Entry("str to u16", `u16("hello")`),
+		Entry("str to u32", `u32("hello")`),
+		Entry("str to u64", `u64("hello")`),
+		Entry("str to f32", `f32("hello")`),
+		Entry("str to f64", `f64("hello")`),
 	)
 
 	It("Should propagate literal parsing errors", func(bCtx SpecContext) {

--- a/arc/go/compiler/resolve/emit.go
+++ b/arc/go/compiler/resolve/emit.go
@@ -10,6 +10,8 @@
 package resolve
 
 import (
+	"context"
+
 	"github.com/synnaxlabs/arc/compiler/wasm"
 	"github.com/synnaxlabs/arc/types"
 	"github.com/synnaxlabs/x/errors"
@@ -27,6 +29,25 @@ func (r *Resolver) EmitCall(
 	handle := r.Resolve(name, concreteType)
 	offset := w.WriteCallPlaceholder(handle)
 	r.RecordPlaceholder(writerID, handle, offset)
+}
+
+// EmitFixedCall emits a call to a host function with a fixed signature
+// looked up from the SymbolResolver, so callers do not redeclare it. Use
+// for monomorphic host functions like string.from_i32; for polymorphic
+// ones (channel.read, state.load), use EmitCall with the concrete type.
+func (r *Resolver) EmitFixedCall(w *wasm.Writer, writerID int, name string) error {
+	if r.symbols == nil {
+		return errors.Newf("cannot resolve %s: no symbol resolver", name)
+	}
+	sym, err := r.symbols.Resolve(context.Background(), name)
+	if err != nil {
+		return errors.Wrapf(err, "resolve %s", name)
+	}
+	if sym.Type.Kind != types.KindFunction {
+		return errors.Newf("symbol %s is not a function", name)
+	}
+	r.EmitCall(w, writerID, name, sym.Type)
+	return nil
 }
 
 // emitCallWithSuffix resolves the qualified name with a WASM function type and
@@ -301,81 +322,27 @@ func (r *Resolver) EmitStringLen(w *wasm.Writer, wID int) {
 	r.EmitCall(w, wID, "string.len", ct)
 }
 
-// EmitStringFromI32 emits a call to string.from_i32.
-func (r *Resolver) EmitStringFromI32(w *wasm.Writer, wID int) {
-	ct := types.Function(types.FunctionProperties{
-		Inputs:  types.Params{{Type: types.I32()}},
-		Outputs: types.Params{{Type: types.I32()}},
-	})
-	r.EmitCall(w, wID, "string.from_i32", ct)
-}
-
-// EmitStringFromU32 emits a call to string.from_u32.
-func (r *Resolver) EmitStringFromU32(w *wasm.Writer, wID int) {
-	ct := types.Function(types.FunctionProperties{
-		Inputs:  types.Params{{Type: types.I32()}},
-		Outputs: types.Params{{Type: types.I32()}},
-	})
-	r.EmitCall(w, wID, "string.from_u32", ct)
-}
-
-// EmitStringFromI64 emits a call to string.from_i64.
-func (r *Resolver) EmitStringFromI64(w *wasm.Writer, wID int) {
-	ct := types.Function(types.FunctionProperties{
-		Inputs:  types.Params{{Type: types.I64()}},
-		Outputs: types.Params{{Type: types.I32()}},
-	})
-	r.EmitCall(w, wID, "string.from_i64", ct)
-}
-
-// EmitStringFromU64 emits a call to string.from_u64.
-func (r *Resolver) EmitStringFromU64(w *wasm.Writer, wID int) {
-	ct := types.Function(types.FunctionProperties{
-		Inputs:  types.Params{{Type: types.I64()}},
-		Outputs: types.Params{{Type: types.I32()}},
-	})
-	r.EmitCall(w, wID, "string.from_u64", ct)
-}
-
-// EmitStringFromF32 emits a call to string.from_f32.
-func (r *Resolver) EmitStringFromF32(w *wasm.Writer, wID int) {
-	ct := types.Function(types.FunctionProperties{
-		Inputs:  types.Params{{Type: types.F32()}},
-		Outputs: types.Params{{Type: types.I32()}},
-	})
-	r.EmitCall(w, wID, "string.from_f32", ct)
-}
-
-// EmitStringFromF64 emits a call to string.from_f64.
-func (r *Resolver) EmitStringFromF64(w *wasm.Writer, wID int) {
-	ct := types.Function(types.FunctionProperties{
-		Inputs:  types.Params{{Type: types.F64()}},
-		Outputs: types.Params{{Type: types.I32()}},
-	})
-	r.EmitCall(w, wID, "string.from_f64", ct)
-}
-
-// EmitNumericToString dispatches to the appropriate string.from_* host function
-// based on the source numeric type. Shared by the str() typecast and the future
-// f-string compiler so both produce identical output for the same input.
+// EmitNumericToString emits a call to the string.from_* host fn matching
+// the source numeric type. Shared by the str() typecast and f-strings.
 func (r *Resolver) EmitNumericToString(w *wasm.Writer, wID int, from types.Type) error {
+	var suffix string
 	switch from.Kind {
 	case types.KindI8, types.KindI16, types.KindI32:
-		r.EmitStringFromI32(w, wID)
+		suffix = "i32"
 	case types.KindU8, types.KindU16, types.KindU32:
-		r.EmitStringFromU32(w, wID)
+		suffix = "u32"
 	case types.KindI64:
-		r.EmitStringFromI64(w, wID)
+		suffix = "i64"
 	case types.KindU64:
-		r.EmitStringFromU64(w, wID)
+		suffix = "u64"
 	case types.KindF32:
-		r.EmitStringFromF32(w, wID)
+		suffix = "f32"
 	case types.KindF64:
-		r.EmitStringFromF64(w, wID)
+		suffix = "f64"
 	default:
 		return errors.Newf("cannot convert %s to str", from)
 	}
-	return nil
+	return r.EmitFixedCall(w, wID, "string.from_"+suffix)
 }
 
 // EmitMathPow emits a call to math.pow for the given type.

--- a/arc/go/compiler/resolve/emit.go
+++ b/arc/go/compiler/resolve/emit.go
@@ -301,6 +301,83 @@ func (r *Resolver) EmitStringLen(w *wasm.Writer, wID int) {
 	r.EmitCall(w, wID, "string.len", ct)
 }
 
+// EmitStringFromI32 emits a call to string.from_i32.
+func (r *Resolver) EmitStringFromI32(w *wasm.Writer, wID int) {
+	ct := types.Function(types.FunctionProperties{
+		Inputs:  types.Params{{Type: types.I32()}},
+		Outputs: types.Params{{Type: types.I32()}},
+	})
+	r.EmitCall(w, wID, "string.from_i32", ct)
+}
+
+// EmitStringFromU32 emits a call to string.from_u32.
+func (r *Resolver) EmitStringFromU32(w *wasm.Writer, wID int) {
+	ct := types.Function(types.FunctionProperties{
+		Inputs:  types.Params{{Type: types.I32()}},
+		Outputs: types.Params{{Type: types.I32()}},
+	})
+	r.EmitCall(w, wID, "string.from_u32", ct)
+}
+
+// EmitStringFromI64 emits a call to string.from_i64.
+func (r *Resolver) EmitStringFromI64(w *wasm.Writer, wID int) {
+	ct := types.Function(types.FunctionProperties{
+		Inputs:  types.Params{{Type: types.I64()}},
+		Outputs: types.Params{{Type: types.I32()}},
+	})
+	r.EmitCall(w, wID, "string.from_i64", ct)
+}
+
+// EmitStringFromU64 emits a call to string.from_u64.
+func (r *Resolver) EmitStringFromU64(w *wasm.Writer, wID int) {
+	ct := types.Function(types.FunctionProperties{
+		Inputs:  types.Params{{Type: types.I64()}},
+		Outputs: types.Params{{Type: types.I32()}},
+	})
+	r.EmitCall(w, wID, "string.from_u64", ct)
+}
+
+// EmitStringFromF32 emits a call to string.from_f32.
+func (r *Resolver) EmitStringFromF32(w *wasm.Writer, wID int) {
+	ct := types.Function(types.FunctionProperties{
+		Inputs:  types.Params{{Type: types.F32()}},
+		Outputs: types.Params{{Type: types.I32()}},
+	})
+	r.EmitCall(w, wID, "string.from_f32", ct)
+}
+
+// EmitStringFromF64 emits a call to string.from_f64.
+func (r *Resolver) EmitStringFromF64(w *wasm.Writer, wID int) {
+	ct := types.Function(types.FunctionProperties{
+		Inputs:  types.Params{{Type: types.F64()}},
+		Outputs: types.Params{{Type: types.I32()}},
+	})
+	r.EmitCall(w, wID, "string.from_f64", ct)
+}
+
+// EmitNumericToString dispatches to the appropriate string.from_* host function
+// based on the source numeric type. Shared by the str() typecast and the future
+// f-string compiler so both produce identical output for the same input.
+func (r *Resolver) EmitNumericToString(w *wasm.Writer, wID int, from types.Type) error {
+	switch from.Kind {
+	case types.KindI8, types.KindI16, types.KindI32:
+		r.EmitStringFromI32(w, wID)
+	case types.KindU8, types.KindU16, types.KindU32:
+		r.EmitStringFromU32(w, wID)
+	case types.KindI64:
+		r.EmitStringFromI64(w, wID)
+	case types.KindU64:
+		r.EmitStringFromU64(w, wID)
+	case types.KindF32:
+		r.EmitStringFromF32(w, wID)
+	case types.KindF64:
+		r.EmitStringFromF64(w, wID)
+	default:
+		return errors.Newf("cannot convert %s to str", from)
+	}
+	return nil
+}
+
 // EmitMathPow emits a call to math.pow for the given type.
 func (r *Resolver) EmitMathPow(w *wasm.Writer, wID int, t types.Type) {
 	ct := types.Function(types.FunctionProperties{

--- a/arc/go/compiler/resolve/emit_test.go
+++ b/arc/go/compiler/resolve/emit_test.go
@@ -24,62 +24,6 @@ import (
 // real compiler uses.
 var stringSymbolResolver symbol.Resolver = stlstrings.SymbolResolver
 
-var _ = Describe("EmitStringFrom* helpers", func() {
-	DescribeTable("Should emit a call placeholder and register the matching import",
-		func(
-			emit func(r *resolve.Resolver, w *wasm.Writer, wID int),
-			wantWASMName string,
-		) {
-			r := resolve.NewResolver(stringSymbolResolver)
-			w := wasm.NewWriter()
-			wID := r.TrackWriter(w)
-
-			startLen := w.Len()
-			emit(r, w, wID)
-
-			Expect(w.Len() - startLen).To(Equal(6))
-			Expect(w.Bytes()[startLen]).To(Equal(byte(wasm.OpCall)))
-
-			m := wasm.NewModule()
-			r.Finalize(m)
-			Expect(m.ImportCount()).To(Equal(uint32(1)))
-			Expect(m.ImportNames()).To(ConsistOf(wantWASMName))
-		},
-		Entry("from_i32",
-			func(r *resolve.Resolver, w *wasm.Writer, wID int) { r.EmitStringFromI32(w, wID) },
-			"from_i32"),
-		Entry("from_u32",
-			func(r *resolve.Resolver, w *wasm.Writer, wID int) { r.EmitStringFromU32(w, wID) },
-			"from_u32"),
-		Entry("from_i64",
-			func(r *resolve.Resolver, w *wasm.Writer, wID int) { r.EmitStringFromI64(w, wID) },
-			"from_i64"),
-		Entry("from_u64",
-			func(r *resolve.Resolver, w *wasm.Writer, wID int) { r.EmitStringFromU64(w, wID) },
-			"from_u64"),
-		Entry("from_f32",
-			func(r *resolve.Resolver, w *wasm.Writer, wID int) { r.EmitStringFromF32(w, wID) },
-			"from_f32"),
-		Entry("from_f64",
-			func(r *resolve.Resolver, w *wasm.Writer, wID int) { r.EmitStringFromF64(w, wID) },
-			"from_f64"),
-	)
-
-	It("Should patch the recorded placeholder with the resolved import index", func() {
-		r := resolve.NewResolver(stringSymbolResolver)
-		w := wasm.NewWriter()
-		wID := r.TrackWriter(w)
-		r.EmitStringFromI32(w, wID)
-
-		m := wasm.NewModule()
-		r.FinalizeAndPatch(m)
-
-		bytes := w.Bytes()
-		Expect(bytes[0]).To(Equal(byte(wasm.OpCall)))
-		Expect(bytes[1] & 0x7f).To(Equal(byte(0)))
-	})
-})
-
 var _ = Describe("EmitNumericToString", func() {
 	DescribeTable("Should dispatch to the host fn matching the source type",
 		func(from types.Type, wantWASMName string) {
@@ -112,5 +56,37 @@ var _ = Describe("EmitNumericToString", func() {
 
 		Expect(r.EmitNumericToString(w, wID, types.String())).
 			To(MatchError(ContainSubstring("cannot convert")))
+	})
+})
+
+var _ = Describe("EmitFixedCall", func() {
+	It("Should resolve the signature from the SymbolResolver and emit an import", func() {
+		r := resolve.NewResolver(stringSymbolResolver)
+		w := wasm.NewWriter()
+		wID := r.TrackWriter(w)
+
+		Expect(r.EmitFixedCall(w, wID, "string.from_i32")).To(Succeed())
+
+		m := wasm.NewModule()
+		r.Finalize(m)
+		Expect(m.ImportNames()).To(ConsistOf("from_i32"))
+	})
+
+	It("Should return an error when the symbol does not exist", func() {
+		r := resolve.NewResolver(stringSymbolResolver)
+		w := wasm.NewWriter()
+		wID := r.TrackWriter(w)
+
+		Expect(r.EmitFixedCall(w, wID, "string.does_not_exist")).
+			To(MatchError(ContainSubstring("resolve string.does_not_exist")))
+	})
+
+	It("Should return an error when no SymbolResolver is configured", func() {
+		r := resolve.NewResolver(nil)
+		w := wasm.NewWriter()
+		wID := r.TrackWriter(w)
+
+		Expect(r.EmitFixedCall(w, wID, "string.from_i32")).
+			To(MatchError(ContainSubstring("no symbol resolver")))
 	})
 })

--- a/arc/go/compiler/resolve/emit_test.go
+++ b/arc/go/compiler/resolve/emit_test.go
@@ -1,0 +1,116 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+package resolve_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/synnaxlabs/arc/compiler/resolve"
+	"github.com/synnaxlabs/arc/compiler/wasm"
+	stlstrings "github.com/synnaxlabs/arc/stl/strings"
+	"github.com/synnaxlabs/arc/symbol"
+	"github.com/synnaxlabs/arc/types"
+)
+
+// stringSymbolResolver wraps the strings stdlib's "string" module so that
+// qualified names like "string.from_i32" resolve through the same path the
+// real compiler uses.
+var stringSymbolResolver symbol.Resolver = stlstrings.SymbolResolver
+
+var _ = Describe("EmitStringFrom* helpers", func() {
+	DescribeTable("Should emit a call placeholder and register the matching import",
+		func(
+			emit func(r *resolve.Resolver, w *wasm.Writer, wID int),
+			wantWASMName string,
+		) {
+			r := resolve.NewResolver(stringSymbolResolver)
+			w := wasm.NewWriter()
+			wID := r.TrackWriter(w)
+
+			startLen := w.Len()
+			emit(r, w, wID)
+
+			Expect(w.Len() - startLen).To(Equal(6))
+			Expect(w.Bytes()[startLen]).To(Equal(byte(wasm.OpCall)))
+
+			m := wasm.NewModule()
+			r.Finalize(m)
+			Expect(m.ImportCount()).To(Equal(uint32(1)))
+			Expect(m.ImportNames()).To(ConsistOf(wantWASMName))
+		},
+		Entry("from_i32",
+			func(r *resolve.Resolver, w *wasm.Writer, wID int) { r.EmitStringFromI32(w, wID) },
+			"from_i32"),
+		Entry("from_u32",
+			func(r *resolve.Resolver, w *wasm.Writer, wID int) { r.EmitStringFromU32(w, wID) },
+			"from_u32"),
+		Entry("from_i64",
+			func(r *resolve.Resolver, w *wasm.Writer, wID int) { r.EmitStringFromI64(w, wID) },
+			"from_i64"),
+		Entry("from_u64",
+			func(r *resolve.Resolver, w *wasm.Writer, wID int) { r.EmitStringFromU64(w, wID) },
+			"from_u64"),
+		Entry("from_f32",
+			func(r *resolve.Resolver, w *wasm.Writer, wID int) { r.EmitStringFromF32(w, wID) },
+			"from_f32"),
+		Entry("from_f64",
+			func(r *resolve.Resolver, w *wasm.Writer, wID int) { r.EmitStringFromF64(w, wID) },
+			"from_f64"),
+	)
+
+	It("Should patch the recorded placeholder with the resolved import index", func() {
+		r := resolve.NewResolver(stringSymbolResolver)
+		w := wasm.NewWriter()
+		wID := r.TrackWriter(w)
+		r.EmitStringFromI32(w, wID)
+
+		m := wasm.NewModule()
+		r.FinalizeAndPatch(m)
+
+		bytes := w.Bytes()
+		Expect(bytes[0]).To(Equal(byte(wasm.OpCall)))
+		Expect(bytes[1] & 0x7f).To(Equal(byte(0)))
+	})
+})
+
+var _ = Describe("EmitNumericToString", func() {
+	DescribeTable("Should dispatch to the host fn matching the source type",
+		func(from types.Type, wantWASMName string) {
+			r := resolve.NewResolver(stringSymbolResolver)
+			w := wasm.NewWriter()
+			wID := r.TrackWriter(w)
+
+			Expect(r.EmitNumericToString(w, wID, from)).To(Succeed())
+
+			m := wasm.NewModule()
+			r.Finalize(m)
+			Expect(m.ImportNames()).To(ConsistOf(wantWASMName))
+		},
+		Entry("i8 -> from_i32", types.I8(), "from_i32"),
+		Entry("i16 -> from_i32", types.I16(), "from_i32"),
+		Entry("i32 -> from_i32", types.I32(), "from_i32"),
+		Entry("u8 -> from_u32", types.U8(), "from_u32"),
+		Entry("u16 -> from_u32", types.U16(), "from_u32"),
+		Entry("u32 -> from_u32", types.U32(), "from_u32"),
+		Entry("i64 -> from_i64", types.I64(), "from_i64"),
+		Entry("u64 -> from_u64", types.U64(), "from_u64"),
+		Entry("f32 -> from_f32", types.F32(), "from_f32"),
+		Entry("f64 -> from_f64", types.F64(), "from_f64"),
+	)
+
+	It("Should return an error for non-numeric source types", func() {
+		r := resolve.NewResolver(stringSymbolResolver)
+		w := wasm.NewWriter()
+		wID := r.TrackWriter(w)
+
+		Expect(r.EmitNumericToString(w, wID, types.String())).
+			To(MatchError(ContainSubstring("cannot convert")))
+	})
+})

--- a/arc/go/stl/strings/string.go
+++ b/arc/go/stl/strings/string.go
@@ -11,6 +11,7 @@ package strings
 
 import (
 	"context"
+	"strconv"
 
 	"github.com/synnaxlabs/arc/ir"
 	"github.com/synnaxlabs/arc/symbol"
@@ -60,6 +61,66 @@ var SymbolResolver = &symbol.ModuleResolver{
 			Type: types.Function(types.FunctionProperties{
 				Inputs:  types.Params{{Name: "handle", Type: types.String()}},
 				Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.I64()}},
+			}),
+		},
+		"from_i32": {
+			Name:     "from_i32",
+			Kind:     symbol.KindFunction,
+			Exec:     symbol.ExecWASM,
+			Internal: true,
+			Type: types.Function(types.FunctionProperties{
+				Inputs:  types.Params{{Name: "value", Type: types.I32()}},
+				Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.String()}},
+			}),
+		},
+		"from_u32": {
+			Name:     "from_u32",
+			Kind:     symbol.KindFunction,
+			Exec:     symbol.ExecWASM,
+			Internal: true,
+			Type: types.Function(types.FunctionProperties{
+				Inputs:  types.Params{{Name: "value", Type: types.U32()}},
+				Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.String()}},
+			}),
+		},
+		"from_i64": {
+			Name:     "from_i64",
+			Kind:     symbol.KindFunction,
+			Exec:     symbol.ExecWASM,
+			Internal: true,
+			Type: types.Function(types.FunctionProperties{
+				Inputs:  types.Params{{Name: "value", Type: types.I64()}},
+				Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.String()}},
+			}),
+		},
+		"from_u64": {
+			Name:     "from_u64",
+			Kind:     symbol.KindFunction,
+			Exec:     symbol.ExecWASM,
+			Internal: true,
+			Type: types.Function(types.FunctionProperties{
+				Inputs:  types.Params{{Name: "value", Type: types.U64()}},
+				Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.String()}},
+			}),
+		},
+		"from_f32": {
+			Name:     "from_f32",
+			Kind:     symbol.KindFunction,
+			Exec:     symbol.ExecWASM,
+			Internal: true,
+			Type: types.Function(types.FunctionProperties{
+				Inputs:  types.Params{{Name: "value", Type: types.F32()}},
+				Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.String()}},
+			}),
+		},
+		"from_f64": {
+			Name:     "from_f64",
+			Kind:     symbol.KindFunction,
+			Exec:     symbol.ExecWASM,
+			Internal: true,
+			Type: types.Function(types.FunctionProperties{
+				Inputs:  types.Params{{Name: "value", Type: types.F64()}},
+				Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.String()}},
 			}),
 		},
 	},
@@ -119,6 +180,30 @@ func NewModule(
 			}
 			return 0
 		}).Export("len")
+	builder = builder.NewFunctionBuilder().
+		WithFunc(func(_ context.Context, v int32) uint32 {
+			return s.Create(strconv.FormatInt(int64(v), 10))
+		}).Export("from_i32")
+	builder = builder.NewFunctionBuilder().
+		WithFunc(func(_ context.Context, v uint32) uint32 {
+			return s.Create(strconv.FormatUint(uint64(v), 10))
+		}).Export("from_u32")
+	builder = builder.NewFunctionBuilder().
+		WithFunc(func(_ context.Context, v int64) uint32 {
+			return s.Create(strconv.FormatInt(v, 10))
+		}).Export("from_i64")
+	builder = builder.NewFunctionBuilder().
+		WithFunc(func(_ context.Context, v uint64) uint32 {
+			return s.Create(strconv.FormatUint(v, 10))
+		}).Export("from_u64")
+	builder = builder.NewFunctionBuilder().
+		WithFunc(func(_ context.Context, v float32) uint32 {
+			return s.Create(strconv.FormatFloat(float64(v), 'g', -1, 32))
+		}).Export("from_f32")
+	builder = builder.NewFunctionBuilder().
+		WithFunc(func(_ context.Context, v float64) uint32 {
+			return s.Create(strconv.FormatFloat(v, 'g', -1, 64))
+		}).Export("from_f64")
 	if _, err := builder.Instantiate(ctx); err != nil {
 		return nil, err
 	}

--- a/arc/go/stl/strings/string_test.go
+++ b/arc/go/stl/strings/string_test.go
@@ -10,6 +10,8 @@
 package strings_test
 
 import (
+	"math"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/synnaxlabs/arc/stl/strings"
@@ -118,6 +120,134 @@ var _ = Describe("Strings", func() {
 
 		It("Should return 0 for invalid handle", func(ctx SpecContext) {
 			Expect(callU64(ctx, "len", testutil.U32(9999))).To(Equal(uint64(0)))
+		})
+	})
+
+	Describe("from_i32", func() {
+		DescribeTable("Should format signed 32-bit integers in base-10",
+			func(ctx SpecContext, value int32, expected string) {
+				h := callU32(ctx, "from_i32", testutil.I32(value))
+				Expect(MustBeOk(ss.Get(h))).To(Equal(expected))
+			},
+			Entry("zero", int32(0), "0"),
+			Entry("positive", int32(42), "42"),
+			Entry("negative", int32(-42), "-42"),
+			Entry("i8 min as i32", int32(-128), "-128"),
+			Entry("i8 max as i32", int32(127), "127"),
+			Entry("i16 min as i32", int32(-32768), "-32768"),
+			Entry("i16 max as i32", int32(32767), "32767"),
+			Entry("i32 min", int32(-2147483648), "-2147483648"),
+			Entry("i32 max", int32(2147483647), "2147483647"),
+		)
+	})
+
+	Describe("from_u32", func() {
+		DescribeTable("Should format unsigned 32-bit integers in base-10",
+			func(ctx SpecContext, value uint32, expected string) {
+				h := callU32(ctx, "from_u32", testutil.U32(value))
+				Expect(MustBeOk(ss.Get(h))).To(Equal(expected))
+			},
+			Entry("zero", uint32(0), "0"),
+			Entry("u8 max", uint32(255), "255"),
+			Entry("u16 max", uint32(65535), "65535"),
+			Entry("u32 max", uint32(4294967295), "4294967295"),
+		)
+	})
+
+	Describe("from_i64", func() {
+		DescribeTable("Should format signed 64-bit integers in base-10",
+			func(ctx SpecContext, value int64, expected string) {
+				h := callU32(ctx, "from_i64", testutil.I64(value))
+				Expect(MustBeOk(ss.Get(h))).To(Equal(expected))
+			},
+			Entry("zero", int64(0), "0"),
+			Entry("positive", int64(9223372036854775807), "9223372036854775807"),
+			Entry("negative", int64(-9223372036854775808), "-9223372036854775808"),
+		)
+	})
+
+	Describe("from_u64", func() {
+		DescribeTable("Should format unsigned 64-bit integers in base-10",
+			func(ctx SpecContext, value uint64, expected string) {
+				h := callU32(ctx, "from_u64", testutil.U64(value))
+				Expect(MustBeOk(ss.Get(h))).To(Equal(expected))
+			},
+			Entry("zero", uint64(0), "0"),
+			Entry("max", uint64(18446744073709551615), "18446744073709551615"),
+		)
+	})
+
+	Describe("from_f32", func() {
+		DescribeTable("Should format f32 values with shortest round-trippable representation",
+			func(ctx SpecContext, value float32, expected string) {
+				h := callU32(ctx, "from_f32", testutil.F32(value))
+				Expect(MustBeOk(ss.Get(h))).To(Equal(expected))
+			},
+			Entry("simple decimal", float32(3.14), "3.14"),
+			Entry("zero", float32(0.0), "0"),
+			Entry("negative", float32(-2.5), "-2.5"),
+			Entry("1.0 (integer-valued)", float32(1.0), "1"),
+			Entry("10.0 (integer-valued)", float32(10.0), "10"),
+			Entry("100.00 (multiple trailing zeros)", float32(100.00), "100"),
+			Entry("3.10 (single trailing zero)", float32(3.10), "3.1"),
+			Entry("1.50 (single trailing zero)", float32(1.50), "1.5"),
+			Entry("0.10 (leading + trailing zero)", float32(0.10), "0.1"),
+			Entry("-3.10 (negative trailing zero)", float32(-3.10), "-3.1"),
+			Entry("-1.0 (negative integer-valued)", float32(-1.0), "-1"),
+			Entry("5.000 (three trailing zeros)", float32(5.000), "5"),
+		)
+
+		It("Should format NaN", func(ctx SpecContext) {
+			h := callU32(ctx, "from_f32", testutil.F32(float32(math.NaN())))
+			Expect(MustBeOk(ss.Get(h))).To(Equal("NaN"))
+		})
+
+		It("Should format positive infinity", func(ctx SpecContext) {
+			h := callU32(ctx, "from_f32", testutil.F32(float32(math.Inf(1))))
+			Expect(MustBeOk(ss.Get(h))).To(Equal("+Inf"))
+		})
+
+		It("Should format negative infinity", func(ctx SpecContext) {
+			h := callU32(ctx, "from_f32", testutil.F32(float32(math.Inf(-1))))
+			Expect(MustBeOk(ss.Get(h))).To(Equal("-Inf"))
+		})
+	})
+
+	Describe("from_f64", func() {
+		DescribeTable("Should format f64 values with shortest round-trippable representation",
+			func(ctx SpecContext, value float64, expected string) {
+				h := callU32(ctx, "from_f64", testutil.F64(value))
+				Expect(MustBeOk(ss.Get(h))).To(Equal(expected))
+			},
+			Entry("simple decimal", float64(3.14159), "3.14159"),
+			Entry("zero", float64(0.0), "0"),
+			Entry("negative", float64(-2.5), "-2.5"),
+			Entry("high precision", float64(0.1234567890123456), "0.1234567890123456"),
+			Entry("1.0 (integer-valued)", float64(1.0), "1"),
+			Entry("10.0 (integer-valued)", float64(10.0), "10"),
+			Entry("100.00 (multiple trailing zeros)", float64(100.00), "100"),
+			Entry("3.10 (single trailing zero)", float64(3.10), "3.1"),
+			Entry("1.50 (single trailing zero)", float64(1.50), "1.5"),
+			Entry("0.10 (leading + trailing zero)", float64(0.10), "0.1"),
+			Entry("-3.10 (negative trailing zero)", float64(-3.10), "-3.1"),
+			Entry("-1.0 (negative integer-valued)", float64(-1.0), "-1"),
+			Entry("5.000 (three trailing zeros)", float64(5.000), "5"),
+			Entry("1e10 integer-valued", float64(10000000000.0), "1e+10"),
+		)
+
+		It("Should format NaN", func(ctx SpecContext) {
+			h := callU32(ctx, "from_f64", testutil.F64(math.NaN()))
+			Expect(MustBeOk(ss.Get(h))).To(Equal("NaN"))
+		})
+
+		It("Should format positive infinity", func(ctx SpecContext) {
+			h := callU32(ctx, "from_f64", testutil.F64(math.Inf(1)))
+			Expect(MustBeOk(ss.Get(h))).To(Equal("+Inf"))
+		})
+
+		It("Should format negative infinity", func(ctx SpecContext) {
+			h := callU32(ctx, "from_f64", testutil.F64(math.Inf(-1)))
+			Expect(MustBeOk(ss.Get(h))).To(Equal("-Inf"))
 		})
 	})
 

--- a/arc/go/stl/wasm/node.go
+++ b/arc/go/stl/wasm/node.go
@@ -20,6 +20,7 @@ import (
 	"github.com/synnaxlabs/x/errors"
 	"github.com/synnaxlabs/x/telem"
 	"github.com/tetratelabs/wazero/api"
+	"go.uber.org/zap"
 )
 
 var _ node.Node = (*nodeImpl)(nil)
@@ -123,7 +124,7 @@ func (n *nodeImpl) Next(ctx node.Context) {
 	for j := range n.offsets {
 		n.offsets[j] = 0
 	}
-	// String outputs are variable-density and cannot be Resize'd . Their
+	// String outputs are variable-density and cannot be resized . Their
 	// Data buffer is built once at the end of the loop from accumulated
 	// strings. Numeric outputs are pre-sized here so setValueAt can do
 	// fixed-stride writes per sample.
@@ -205,14 +206,16 @@ func (n *nodeImpl) Next(ctx node.Context) {
 					// conversion above.
 					s, ok := n.strings.Get(uint32(value.Value))
 					if !ok {
-						ctx.ReportError(errors.Newf(
+						// An unregistered handle is an Arc compiler/runtime
+						// bug, not anything a .arc program can provoke.
+						zap.S().DPanicf(
 							"node %s output %d returned unregistered string handle %d at sample %d/%d",
 							n.ir.Key,
 							j,
 							value.Value,
 							i,
 							maxLength,
-						))
+						)
 						continue
 					}
 					stringResults[j] = append(stringResults[j], s)

--- a/arc/go/stl/wasm/node.go
+++ b/arc/go/stl/wasm/node.go
@@ -203,7 +203,18 @@ func (n *nodeImpl) Next(ctx node.Context) {
 					// WASM returned an i32 string handle; materialize it
 					// to its actual string value, mirroring the input-side
 					// conversion above.
-					s, _ := n.strings.Get(uint32(value.Value))
+					s, ok := n.strings.Get(uint32(value.Value))
+					if !ok {
+						ctx.ReportError(errors.Newf(
+							"node %s output %d returned unregistered string handle %d at sample %d/%d",
+							n.ir.Key,
+							j,
+							value.Value,
+							i,
+							maxLength,
+						))
+						continue
+					}
 					stringResults[j] = append(stringResults[j], s)
 				} else {
 					setValueAt(*n.Output(j), n.offsets[j], value.Value)

--- a/arc/go/stl/wasm/node.go
+++ b/arc/go/stl/wasm/node.go
@@ -54,6 +54,7 @@ type nodeImpl struct {
 	clock         telem.MonoClock
 	nodeKeySetter NodeKeySetter
 	stringInputs  []bool
+	stringOutputs []bool
 	strings       *stlstrings.ProgramState
 }
 
@@ -122,8 +123,20 @@ func (n *nodeImpl) Next(ctx node.Context) {
 	for j := range n.offsets {
 		n.offsets[j] = 0
 	}
+	// String outputs are variable-density and cannot be Resize'd . Their
+	// Data buffer is built once at the end of the loop from accumulated
+	// strings. Numeric outputs are pre-sized here so setValueAt can do
+	// fixed-stride writes per sample.
+	var stringResults [][]string
 	for i := range n.ir.Outputs {
-		n.Output(i).Resize(maxLength)
+		if n.stringOutputs[i] {
+			if stringResults == nil {
+				stringResults = make([][]string, len(n.ir.Outputs))
+			}
+			stringResults[i] = make([]string, 0, maxLength)
+		} else {
+			n.Output(i).Resize(maxLength)
+		}
 		n.OutputTime(i).Resize(maxLength)
 	}
 	// Copy alignment and time range from inputs to outputs.
@@ -186,14 +199,27 @@ func (n *nodeImpl) Next(ctx node.Context) {
 		}
 		for j, value := range res {
 			if value.Changed {
-				setValueAt(*n.Output(j), n.offsets[j], value.Value)
+				if n.stringOutputs[j] {
+					// WASM returned an i32 string handle; materialize it
+					// to its actual string value, mirroring the input-side
+					// conversion above.
+					s, _ := n.strings.Get(uint32(value.Value))
+					stringResults[j] = append(stringResults[j], s)
+				} else {
+					setValueAt(*n.Output(j), n.offsets[j], value.Value)
+				}
 				setValueAt(*n.OutputTime(j), n.offsets[j], ts)
 				n.offsets[j]++
 			}
 		}
 	}
 	for j := range n.ir.Outputs {
-		n.Output(j).Resize(int64(n.offsets[j]))
+		if n.stringOutputs[j] {
+			out := n.Output(j)
+			out.Data = telem.NewSeriesV[string](stringResults[j]...).Data
+		} else {
+			n.Output(j).Resize(int64(n.offsets[j]))
+		}
 		n.OutputTime(j).Resize(int64(n.offsets[j]))
 		if n.offsets[j] > 0 {
 			ctx.MarkChanged(j)

--- a/arc/go/stl/wasm/wasm.go
+++ b/arc/go/stl/wasm/wasm.go
@@ -84,6 +84,11 @@ func (w *Module) Create(_ context.Context, cfg node.Config) (node.Node, error) {
 		stringInputs[i] = inp.Type.Kind == types.KindString
 	}
 
+	stringOutputs := make([]bool, len(irFn.Outputs))
+	for i, out := range irFn.Outputs {
+		stringOutputs[i] = out.Type.Kind == types.KindString
+	}
+
 	n := &nodeImpl{
 		State:         cfg.State,
 		ir:            cfg.Node,
@@ -99,6 +104,7 @@ func (w *Module) Create(_ context.Context, cfg node.Config) (node.Node, error) {
 		isEntryNode:   isEntryNode,
 		nodeKeySetter: w.NodeKeySetter,
 		stringInputs:  stringInputs,
+		stringOutputs: stringOutputs,
 		strings:       w.Strings,
 	}
 	return n, nil

--- a/arc/go/stl/wasm/wasm_test.go
+++ b/arc/go/stl/wasm/wasm_test.go
@@ -1416,6 +1416,97 @@ var _ = Describe("WASM", func() {
 
 			Expect(func() { h.Execute(ctx, "tagger") }).ToNot(Panic())
 		})
+
+		It("Should accumulate string output values across multiple input samples", func(ctx SpecContext) {
+			g := arc.Graph{
+				Functions: []ir.Function{
+					{
+						Key:    "stringify",
+						Inputs: types.Params{{Name: "x", Type: types.I64()}},
+						Outputs: types.Params{
+							{Name: ir.DefaultOutputParam, Type: types.String()},
+						},
+						Body: ir.Body{Raw: `{ return str(x) }`},
+					},
+					{
+						Key:     "source",
+						Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.I64()}},
+						Body:    ir.Body{Raw: `{ return 0 }`},
+					},
+				},
+				Nodes: []graph.Node{
+					{Key: "source", Type: "source"},
+					{Key: "stringify", Type: "stringify"},
+				},
+				Edges: []graph.Edge{
+					{
+						Source: ir.Handle{Node: "source", Param: ir.DefaultOutputParam},
+						Target: ir.Handle{Node: "stringify", Param: "x"},
+					},
+				},
+			}
+			h := newHarness(ctx, g, stl.SymbolResolver)
+			defer h.Close(ctx)
+
+			h.SetInput("source", 0,
+				telem.NewSeriesV[int64](1, 22, 333),
+				telem.NewSeriesSecondsTSV(1, 2, 3),
+			)
+
+			changed := h.Execute(ctx, "stringify")
+			Expect(changed.Contains(ir.DefaultOutputParam)).To(BeTrue())
+
+			result := h.Output("stringify", 0)
+			Expect(telem.UnmarshalSeries[string](result)).To(Equal([]string{"1", "22", "333"}))
+		})
+
+		It("Should accumulate string and numeric outputs in lockstep", func(ctx SpecContext) {
+			g := arc.Graph{
+				Functions: []ir.Function{
+					{
+						Key:    "labeler",
+						Inputs: types.Params{{Name: "x", Type: types.I64()}},
+						Outputs: types.Params{
+							{Name: "label", Type: types.String()},
+							{Name: "doubled", Type: types.I64()},
+						},
+						Body: ir.Body{Raw: `{
+							label = str(x)
+							doubled = x * 2
+						}`},
+					},
+					{
+						Key:     "source",
+						Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.I64()}},
+						Body:    ir.Body{Raw: `{ return 0 }`},
+					},
+				},
+				Nodes: []graph.Node{
+					{Key: "source", Type: "source"},
+					{Key: "labeler", Type: "labeler"},
+				},
+				Edges: []graph.Edge{
+					{
+						Source: ir.Handle{Node: "source", Param: ir.DefaultOutputParam},
+						Target: ir.Handle{Node: "labeler", Param: "x"},
+					},
+				},
+			}
+			h := newHarness(ctx, g, stl.SymbolResolver)
+			defer h.Close(ctx)
+
+			h.SetInput("source", 0,
+				telem.NewSeriesV[int64](5, 10, 15),
+				telem.NewSeriesSecondsTSV(1, 2, 3),
+			)
+
+			changed := h.Execute(ctx, "labeler")
+			Expect(changed.Contains("label")).To(BeTrue())
+			Expect(changed.Contains("doubled")).To(BeTrue())
+
+			Expect(telem.UnmarshalSeries[string](h.Output("labeler", 0))).To(Equal([]string{"5", "10", "15"}))
+			Expect(telem.UnmarshalSeries[int64](h.Output("labeler", 1))).To(Equal([]int64{10, 20, 30}))
+		})
 	})
 
 	Describe("No-Input Node Initialization", func() {

--- a/arc/go/str_cast_test.go
+++ b/arc/go/str_cast_test.go
@@ -10,6 +10,8 @@
 package arc_test
 
 import (
+	"math"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/synnaxlabs/arc/stl/channel"
@@ -123,6 +125,12 @@ var _ = Describe("str() typecast end-to-end runtime", func() {
 			func(h *runtimeHarness) { h.Ingest(100, telem.NewSeriesV[float64](3.1)) }, "3.1"),
 		Entry("f64 channel 0.1234567890123456 (high precision)", "f64", types.F64(), telem.Float64T,
 			func(h *runtimeHarness) { h.Ingest(100, telem.NewSeriesV[float64](0.1234567890123456)) }, "0.1234567890123456"),
+		Entry("f64 channel NaN", "f64", types.F64(), telem.Float64T,
+			func(h *runtimeHarness) { h.Ingest(100, telem.NewSeriesV[float64](math.NaN())) }, "NaN"),
+		Entry("f64 channel +Inf", "f64", types.F64(), telem.Float64T,
+			func(h *runtimeHarness) { h.Ingest(100, telem.NewSeriesV[float64](math.Inf(1))) }, "+Inf"),
+		Entry("f64 channel -Inf", "f64", types.F64(), telem.Float64T,
+			func(h *runtimeHarness) { h.Ingest(100, telem.NewSeriesV[float64](math.Inf(-1))) }, "-Inf"),
 		Entry("i32 channel -42 (negative)", "i32", types.I32(), telem.Int32T,
 			func(h *runtimeHarness) { h.Ingest(100, telem.NewSeriesV[int32](-42)) }, "-42"),
 		Entry("u32 channel 4000000000", "u32", types.U32(), telem.Uint32T,

--- a/arc/go/str_cast_test.go
+++ b/arc/go/str_cast_test.go
@@ -214,4 +214,123 @@ var _ = Describe("str() typecast end-to-end runtime", func() {
 			},
 			"3.1 some_words 0.1234567890123456"),
 	)
+
+	DescribeTable("uses str() as an inline typecast stage in a flow chain",
+		func(ctx SpecContext, source string, expected string) {
+			resolver := channelSymbols(map[string]channelDef{
+				"log_mem": {types.String(), 101},
+			})
+			h := newRuntimeHarness(ctx,
+				`time.interval{50ms} -> `+source+` -> log_mem`, resolver,
+				channel.Digest{Key: 101, DataType: telem.StringT},
+			)
+			defer h.Close(ctx)
+
+			h.Tick(ctx, 75*telem.Millisecond)
+			h.channelState.ClearReads()
+			out, _ := h.Flush()
+			Expect(lastString(out, 101)).To(Equal(expected))
+		},
+		Entry("str(1.234) (literal float)", "str(1.234)", "1.234"),
+		Entry("str(3.1) (ghost-precision literal)", "str(3.1)", "3.1"),
+		Entry("str(42) (integer literal)", "str(42)", "42"),
+		Entry("str(f32(3.14)) (explicit f32)", "str(f32(3.14))", "3.14"),
+		Entry("str(f64(0.1234567890123456)) (high-precision f64)", "str(f64(0.1234567890123456))", "0.1234567890123456"),
+		Entry(`str("hello") (string literal no-op)`, `str("hello")`, "hello"),
+	)
+
+	DescribeTable("uses str() as a flow stage to convert a numeric channel to a string channel",
+		func(ctx SpecContext, sensorType types.Type, telemDT telem.DataType, ingestFn func(*runtimeHarness), expected string) {
+			resolver := channelSymbols(map[string]channelDef{
+				"sensor": {sensorType, 100},
+				"log":    {types.String(), 101},
+			})
+			h := newRuntimeHarness(ctx,
+				`sensor -> str(sensor) -> log`, resolver,
+				channel.Digest{Key: 100, DataType: telemDT},
+				channel.Digest{Key: 101, DataType: telem.StringT},
+			)
+			defer h.Close(ctx)
+			ingestFn(h)
+			for i := 0; i < 5; i++ {
+				h.Tick(ctx, telem.Millisecond)
+				h.channelState.ClearReads()
+			}
+			out, _ := h.Flush()
+			Expect(lastString(out, 101)).To(Equal(expected))
+		},
+		Entry("f32 channel 3.1", types.F32(), telem.Float32T,
+			func(h *runtimeHarness) { h.Ingest(100, telem.NewSeriesV[float32](3.1)) }, "3.1"),
+		Entry("f64 channel -2.5", types.F64(), telem.Float64T,
+			func(h *runtimeHarness) { h.Ingest(100, telem.NewSeriesV[float64](-2.5)) }, "-2.5"),
+		Entry("i32 channel -42", types.I32(), telem.Int32T,
+			func(h *runtimeHarness) { h.Ingest(100, telem.NewSeriesV[int32](-42)) }, "-42"),
+		Entry("u8 channel 255", types.U8(), telem.Uint8T,
+			func(h *runtimeHarness) { h.Ingest(100, telem.NewSeriesV[uint8](255)) }, "255"),
+	)
+
+	DescribeTable("concatenates a prefix and suffix around str() of a literal in a flow chain",
+		func(ctx SpecContext, expr string, expected string) {
+			resolver := channelSymbols(map[string]channelDef{
+				"log_mem": {types.String(), 101},
+			})
+			h := newRuntimeHarness(ctx,
+				`time.interval{50ms} -> `+expr+` -> log_mem`, resolver,
+				channel.Digest{Key: 101, DataType: telem.StringT},
+			)
+			defer h.Close(ctx)
+			h.Tick(ctx, 75*telem.Millisecond)
+			h.channelState.ClearReads()
+			out, _ := h.Flush()
+			Expect(lastString(out, 101)).To(Equal(expected))
+		},
+		Entry(`"prefix " + str(1.234) + " suffix"`,
+			`"prefix " + str(1.234) + " suffix"`, "prefix 1.234 suffix"),
+		Entry(`"value=" + str(42)`,
+			`"value=" + str(42)`, "value=42"),
+		Entry(`str(3.14) + " radians"`,
+			`str(3.14) + " radians"`, "3.14 radians"),
+		Entry(`"[" + str(f32(0.1)) + "]" (ghost-precision in middle)`,
+			`"[" + str(f32(0.1)) + "]"`, "[0.1]"),
+	)
+
+	DescribeTable("concatenates a prefix and suffix around str() of a channel value in a flow chain",
+		func(ctx SpecContext, sensorType types.Type, telemDT telem.DataType, ingestFn func(*runtimeHarness), expected string) {
+			resolver := channelSymbols(map[string]channelDef{
+				"sensor": {sensorType, 100},
+				"log":    {types.String(), 101},
+			})
+			h := newRuntimeHarness(ctx,
+				`sensor -> "prefix " + str(sensor) + " suffix" -> log`, resolver,
+				channel.Digest{Key: 100, DataType: telemDT},
+				channel.Digest{Key: 101, DataType: telem.StringT},
+			)
+			defer h.Close(ctx)
+			ingestFn(h)
+			for i := 0; i < 5; i++ {
+				h.Tick(ctx, telem.Millisecond)
+				h.channelState.ClearReads()
+			}
+			out, _ := h.Flush()
+			Expect(lastString(out, 101)).To(Equal(expected))
+		},
+		Entry("f32 channel 3.1", types.F32(), telem.Float32T,
+			func(h *runtimeHarness) { h.Ingest(100, telem.NewSeriesV[float32](3.1)) },
+			"prefix 3.1 suffix"),
+		Entry("f32 channel 100.0 (trailing zeros stripped)", types.F32(), telem.Float32T,
+			func(h *runtimeHarness) { h.Ingest(100, telem.NewSeriesV[float32](100.0)) },
+			"prefix 100 suffix"),
+		Entry("f64 channel 0.1234567890123456 (high precision)", types.F64(), telem.Float64T,
+			func(h *runtimeHarness) { h.Ingest(100, telem.NewSeriesV[float64](0.1234567890123456)) },
+			"prefix 0.1234567890123456 suffix"),
+		Entry("i32 channel -42 (negative)", types.I32(), telem.Int32T,
+			func(h *runtimeHarness) { h.Ingest(100, telem.NewSeriesV[int32](-42)) },
+			"prefix -42 suffix"),
+		Entry("u32 channel 4000000000 (large unsigned)", types.U32(), telem.Uint32T,
+			func(h *runtimeHarness) { h.Ingest(100, telem.NewSeriesV[uint32](4000000000)) },
+			"prefix 4000000000 suffix"),
+		Entry("u8 channel 255 (max byte)", types.U8(), telem.Uint8T,
+			func(h *runtimeHarness) { h.Ingest(100, telem.NewSeriesV[uint8](255)) },
+			"prefix 255 suffix"),
+	)
 })

--- a/arc/go/str_cast_test.go
+++ b/arc/go/str_cast_test.go
@@ -1,0 +1,217 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+package arc_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/synnaxlabs/arc/stl/channel"
+	"github.com/synnaxlabs/arc/types"
+	"github.com/synnaxlabs/x/telem"
+)
+
+var _ = Describe("str() typecast end-to-end runtime", func() {
+	lastString := func(fr telem.Frame[uint32], key uint32) string {
+		ch := fr.Get(key)
+		Expect(ch.Series).ToNot(BeEmpty(), "channel %d not written", key)
+		s := ch.Series[len(ch.Series)-1]
+		vals := telem.UnmarshalSeries[string](s)
+		Expect(vals).ToNot(BeEmpty())
+		return vals[len(vals)-1]
+	}
+
+	DescribeTable("compiles, runs, and writes the expected string to a string channel",
+		func(ctx SpecContext, source string, expected string) {
+			resolver := channelSymbols(map[string]channelDef{
+				"trig": {types.U8(), 100},
+				"log":  {types.String(), 101},
+			})
+			h := newRuntimeHarness(ctx,
+				`func f() {
+				    log = `+source+`
+				}
+				trig -> f{}`, resolver,
+				channel.Digest{Key: 100, DataType: telem.Uint8T},
+				channel.Digest{Key: 101, DataType: telem.StringT},
+			)
+			defer h.Close(ctx)
+
+			h.Ingest(100, telem.NewSeriesV[uint8](1))
+			for i := 0; i < 5; i++ {
+				h.Tick(ctx, telem.Millisecond)
+				h.channelState.ClearReads()
+			}
+			out, _ := h.Flush()
+			Expect(lastString(out, 101)).To(Equal(expected))
+		},
+		Entry("float literal 3.1 (natural f64)", "str(3.1)", "3.1"),
+		Entry("float literal 3.14 (natural f64)", "str(3.14)", "3.14"),
+		Entry("float literal 123.456 (natural f64)", "str(123.456)", "123.456"),
+		Entry("float literal 123.456000 (trailing fractional zeros)", "str(123.456000)", "123.456"),
+		Entry("float literal 123. (whole-valued, no fraction)", "str(123.)", "123"),
+		Entry("float literal 1.0 (integer-valued)", "str(1.0)", "1"),
+		Entry("float literal 100.000 (trailing zeros)", "str(100.000)", "100"),
+		Entry("explicit f32(3.14)", "str(f32(3.14))", "3.14"),
+		Entry("explicit f64(3.14)", "str(f64(3.14))", "3.14"),
+		Entry("integer literal 42", "str(42)", "42"),
+		Entry("explicit i32(42)", "str(i32(42))", "42"),
+		Entry("explicit u32(42)", "str(u32(42))", "42"),
+		Entry("explicit u8(255)", "str(u8(255))", "255"),
+		Entry("string literal", `str("hello")`, "hello"),
+	)
+
+	It("Writes str(3.1) to a string channel via interval trigger (matches Console scenario)", func(ctx SpecContext) {
+		resolver := channelSymbols(map[string]channelDef{
+			"log_mem": {types.String(), 101},
+		})
+		h := newRuntimeHarness(ctx, `
+			func example_func() {
+			    log_mem = str(3.1)
+			}
+			interval{1s} -> example_func{}`, resolver,
+			channel.Digest{Key: 101, DataType: telem.StringT},
+		)
+		defer h.Close(ctx)
+
+		h.Tick(ctx, 2*telem.Second)
+		h.channelState.ClearReads()
+		out, _ := h.Flush()
+		Expect(lastString(out, 101)).To(Equal("3.1"))
+	})
+
+	DescribeTable("reads a numeric channel value, converts via str(), and writes the result to a string channel",
+		func(ctx SpecContext, arcType string, sensorType types.Type, telemDT telem.DataType, ingestFn func(*runtimeHarness), expected string) {
+			resolver := channelSymbols(map[string]channelDef{
+				"sensor": {sensorType, 100},
+				"log":    {types.String(), 101},
+			})
+			h := newRuntimeHarness(ctx,
+				`func emit(val `+arcType+`) {
+				    log = str(val)
+				}
+				sensor -> emit{}`, resolver,
+				channel.Digest{Key: 100, DataType: telemDT},
+				channel.Digest{Key: 101, DataType: telem.StringT},
+			)
+			defer h.Close(ctx)
+			ingestFn(h)
+			for i := 0; i < 5; i++ {
+				h.Tick(ctx, telem.Millisecond)
+				h.channelState.ClearReads()
+			}
+			out, _ := h.Flush()
+			Expect(lastString(out, 101)).To(Equal(expected))
+		},
+		Entry("f32 channel 3.1 (ghost precision case)", "f32", types.F32(), telem.Float32T,
+			func(h *runtimeHarness) { h.Ingest(100, telem.NewSeriesV[float32](3.1)) }, "3.1"),
+		Entry("f32 channel 0.1 (ghost precision case)", "f32", types.F32(), telem.Float32T,
+			func(h *runtimeHarness) { h.Ingest(100, telem.NewSeriesV[float32](0.1)) }, "0.1"),
+		Entry("f32 channel 1.0 (integer-valued)", "f32", types.F32(), telem.Float32T,
+			func(h *runtimeHarness) { h.Ingest(100, telem.NewSeriesV[float32](1.0)) }, "1"),
+		Entry("f32 channel 100.000 (trailing zeros)", "f32", types.F32(), telem.Float32T,
+			func(h *runtimeHarness) { h.Ingest(100, telem.NewSeriesV[float32](100.000)) }, "100"),
+		Entry("f32 channel -2.5 (negative)", "f32", types.F32(), telem.Float32T,
+			func(h *runtimeHarness) { h.Ingest(100, telem.NewSeriesV[float32](-2.5)) }, "-2.5"),
+		Entry("f64 channel 3.1", "f64", types.F64(), telem.Float64T,
+			func(h *runtimeHarness) { h.Ingest(100, telem.NewSeriesV[float64](3.1)) }, "3.1"),
+		Entry("f64 channel 0.1234567890123456 (high precision)", "f64", types.F64(), telem.Float64T,
+			func(h *runtimeHarness) { h.Ingest(100, telem.NewSeriesV[float64](0.1234567890123456)) }, "0.1234567890123456"),
+		Entry("i32 channel -42 (negative)", "i32", types.I32(), telem.Int32T,
+			func(h *runtimeHarness) { h.Ingest(100, telem.NewSeriesV[int32](-42)) }, "-42"),
+		Entry("u32 channel 4000000000", "u32", types.U32(), telem.Uint32T,
+			func(h *runtimeHarness) { h.Ingest(100, telem.NewSeriesV[uint32](4000000000)) }, "4000000000"),
+	)
+
+	DescribeTable("concatenates str() of a numeric channel value with a string suffix",
+		func(ctx SpecContext, arcType string, sensorType types.Type, telemDT telem.DataType, suffix string, ingestFn func(*runtimeHarness), expected string) {
+			resolver := channelSymbols(map[string]channelDef{
+				"sensor": {sensorType, 100},
+				"log":    {types.String(), 101},
+			})
+			h := newRuntimeHarness(ctx,
+				`func emit(val `+arcType+`) {
+				    log = str(val) + "`+suffix+`"
+				}
+				sensor -> emit{}`, resolver,
+				channel.Digest{Key: 100, DataType: telemDT},
+				channel.Digest{Key: 101, DataType: telem.StringT},
+			)
+			defer h.Close(ctx)
+			ingestFn(h)
+			for i := 0; i < 5; i++ {
+				h.Tick(ctx, telem.Millisecond)
+				h.channelState.ClearReads()
+			}
+			out, _ := h.Flush()
+			Expect(lastString(out, 101)).To(Equal(expected))
+		},
+		Entry("f32 channel 42.5 + ' psi'", "f32", types.F32(), telem.Float32T, " psi",
+			func(h *runtimeHarness) { h.Ingest(100, telem.NewSeriesV[float32](42.5)) }, "42.5 psi"),
+		Entry("f32 channel 3.1 + ' psi' (ghost precision case)", "f32", types.F32(), telem.Float32T, " psi",
+			func(h *runtimeHarness) { h.Ingest(100, telem.NewSeriesV[float32](3.1)) }, "3.1 psi"),
+		Entry("f64 channel 3.14 + ' degrees'", "f64", types.F64(), telem.Float64T, " degrees",
+			func(h *runtimeHarness) { h.Ingest(100, telem.NewSeriesV[float64](3.14)) }, "3.14 degrees"),
+		Entry("i32 channel 42 + ' items'", "i32", types.I32(), telem.Int32T, " items",
+			func(h *runtimeHarness) { h.Ingest(100, telem.NewSeriesV[int32](42)) }, "42 items"),
+	)
+
+	DescribeTable("concatenates str() of two float channels with a string literal between them",
+		func(ctx SpecContext, t1, t2 string, dt1, dt2 types.Type, telemDT1, telemDT2 telem.DataType, ingestFn func(*runtimeHarness), expected string) {
+			resolver := channelSymbols(map[string]channelDef{
+				"p1":  {dt1, 100},
+				"p2":  {dt2, 101},
+				"log": {types.String(), 102},
+			})
+			h := newRuntimeHarness(ctx,
+				`func emit() {
+				    log = str(p1) + " some_words " + str(p2)
+				}
+				interval{50ms} -> emit{}`, resolver,
+				channel.Digest{Key: 100, DataType: telemDT1},
+				channel.Digest{Key: 101, DataType: telemDT2},
+				channel.Digest{Key: 102, DataType: telem.StringT},
+			)
+			defer h.Close(ctx)
+			ingestFn(h)
+			h.Tick(ctx, 75*telem.Millisecond)
+			h.channelState.ClearReads()
+			out, _ := h.Flush()
+			Expect(lastString(out, 102)).To(Equal(expected))
+		},
+		Entry("f32 42.5 and f32 3.1",
+			"f32", "f32", types.F32(), types.F32(), telem.Float32T, telem.Float32T,
+			func(h *runtimeHarness) {
+				h.Ingest(100, telem.NewSeriesV[float32](42.5))
+				h.Ingest(101, telem.NewSeriesV[float32](3.1))
+			},
+			"42.5 some_words 3.1"),
+		Entry("f32 0.1 and f32 100.0 (ghost precision + trailing zeros)",
+			"f32", "f32", types.F32(), types.F32(), telem.Float32T, telem.Float32T,
+			func(h *runtimeHarness) {
+				h.Ingest(100, telem.NewSeriesV[float32](0.1))
+				h.Ingest(101, telem.NewSeriesV[float32](100.0))
+			},
+			"0.1 some_words 100"),
+		Entry("f64 3.14 and f64 -2.5",
+			"f64", "f64", types.F64(), types.F64(), telem.Float64T, telem.Float64T,
+			func(h *runtimeHarness) {
+				h.Ingest(100, telem.NewSeriesV[float64](3.14))
+				h.Ingest(101, telem.NewSeriesV[float64](-2.5))
+			},
+			"3.14 some_words -2.5"),
+		Entry("f32 3.1 and f64 0.1234567890123456 (mixed precision)",
+			"f32", "f64", types.F32(), types.F64(), telem.Float32T, telem.Float64T,
+			func(h *runtimeHarness) {
+				h.Ingest(100, telem.NewSeriesV[float32](3.1))
+				h.Ingest(101, telem.NewSeriesV[float64](0.1234567890123456))
+			},
+			"3.1 some_words 0.1234567890123456"),
+	)
+})

--- a/docs/site/src/pages/reference/control/arc/effective-arc.mdx
+++ b/docs/site/src/pages/reference/control/arc/effective-arc.mdx
@@ -239,6 +239,18 @@ x i32 := 42
 y f64 := f64(x) + 1.0
 ```
 
+The same applies when concatenating numbers with strings. Use `str()` to render a
+numeric value as text first:
+
+```arc
+// Wrong
+count i64 := 42
+msg str := "count: " + count // Type error: str + i64
+// Right
+count i64 := 42
+msg str := "count: " + str(count) // "count: 42"
+```
+
 ### Division by Zero in Rates
 
 Rate calculations divide by time. Protect against zero:

--- a/docs/site/src/pages/reference/control/arc/reference/types.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/types.mdx
@@ -189,7 +189,7 @@ further use, but they are not spelled in source code.
 
 ## Type Casting
 
-Explicit casting converts between numeric types:
+Explicit casting converts between numeric types, or from a numeric type to `str`:
 
 ```arc
 x i32 := 42
@@ -197,17 +197,25 @@ y f64 := f64(x) // int to float
 
 a f64 := 3.7
 b i64 := i64(a) // truncates to 3
+
+n i64 := 42
+s str := str(n) // numeric to string: "42"
 ```
 
 ### Casting Rules
 
-| Conversion                      | Behavior                                     |
-| ------------------------------- | -------------------------------------------- |
-| Widening (e.g., `i16` to `i64`) | Safe, sign/zero extend                       |
-| Narrowing (e.g., `i64` to `i8`) | Truncates                                    |
-| Signed to unsigned              | Saturates at bounds                          |
-| Float to integer                | Truncates toward zero, saturates on overflow |
-| Integer overflow                | Two's-complement wrapping                    |
+| Conversion                          | Behavior                                     |
+| ----------------------------------- | -------------------------------------------- |
+| Widening (e.g., `i16` to `i64`)     | Safe, sign/zero extend                       |
+| Narrowing (e.g., `i64` to `i8`)     | Truncates                                    |
+| Signed to unsigned                  | Saturates at bounds                          |
+| Float to integer                    | Truncates toward zero, saturates on overflow |
+| Integer overflow                    | Two's-complement wrapping                    |
+| Numeric to string (e.g., `str(42)`) | Decimal text (e.g., `"42"`, `"3.14"`)        |
+
+Float values render without trailing zeros (`str(1.0)` returns `"1"`), and special
+values render as `"NaN"`, `"+Inf"`, `"-Inf"`. Casting from `str` back to a numeric type
+is not supported.
 
 <Note.Note variant="info">
   Arc requires explicit casts for mixed-type arithmetic. No implicit type promotion.

--- a/integration/tests/arc/conversion.py
+++ b/integration/tests/arc/conversion.py
@@ -114,6 +114,12 @@ flow_trigger -> "v=" + str(in_u64) + "!" -> flow_concat_u64
 flow_trigger -> "v=" + str(in_f32) + "!" -> flow_concat_f32
 flow_trigger -> "v=" + str(in_f64) + "!" -> flow_concat_f64
 
+// Special f64 values: division by zero yields +Inf / -Inf / NaN. Exercises
+// strconv.FormatFloat's non-finite branch via from_f64.
+flow_trigger -> str(f64(1)/f64(0)) -> flow_str_pos_inf
+flow_trigger -> str(f64(-1)/f64(0)) -> flow_str_neg_inf
+flow_trigger -> str(f64(0)/f64(0)) -> flow_str_nan
+
 // Numeric form: one representative cast per opcode family (extend, wrap,
 // convert, trunc, promote/demote) plus one cast composed inside a binary op.
 flow_trigger -> i64(in_i32) -> flow_num_i32_to_i64
@@ -197,6 +203,10 @@ OUTPUT_CHANNELS: list[tuple[str, sy.DataType]] = [
     ("flow_concat_u64", sy.DataType.STRING),
     ("flow_concat_f32", sy.DataType.STRING),
     ("flow_concat_f64", sy.DataType.STRING),
+    # Flow-context str(): special float values
+    ("flow_str_pos_inf", sy.DataType.STRING),
+    ("flow_str_neg_inf", sy.DataType.STRING),
+    ("flow_str_nan", sy.DataType.STRING),
     # Flow-context numeric casts
     ("flow_num_i32_to_i64", sy.DataType.INT64),
     ("flow_num_i64_to_i32", sy.DataType.INT32),
@@ -340,6 +350,12 @@ class Conversion(ArcConsoleCase):
         self.wait_for_eq("flow_concat_u64", "v=42!", is_virtual=True)
         self.wait_for_eq("flow_concat_f32", "v=3.5!", is_virtual=True)
         self.wait_for_eq("flow_concat_f64", "v=3.5!", is_virtual=True)
+
+        # str(): special float values via division by zero. Go's
+        # strconv.FormatFloat emits "+Inf" / "-Inf" / "NaN".
+        self.wait_for_eq("flow_str_pos_inf", "+Inf", is_virtual=True)
+        self.wait_for_eq("flow_str_neg_inf", "-Inf", is_virtual=True)
+        self.wait_for_eq("flow_str_nan", "NaN", is_virtual=True)
 
         # Numeric: one representative per opcode family + one composed in a
         # binary op. i32(in_i64) at 2^31 sign-flips to -2^31.

--- a/integration/tests/arc/conversion.py
+++ b/integration/tests/arc/conversion.py
@@ -1,0 +1,351 @@
+#  Copyright 2026 Synnax Labs, Inc.
+#
+#  Use of this software is governed by the Business Source License included in the file
+#  licenses/BSL.txt.
+#
+#  As of the Change Date specified in that file, in accordance with the Business Source
+#  License, use of this software will be governed by the Apache License, Version 2.0,
+#  included in the file licenses/APL.txt.
+
+import synnax as sy
+from framework.utils import create_virtual_channel
+from tests.arc.arc_case import ArcConsoleCase
+
+# Identity casts (e.g., i32→i32) emit as no-ops in cast.go and are omitted. Among
+# integer sources, i32 / u32 cover the signed-int and unsigned-int extend / convert
+# / wrap opcode families at a nominal value; the i8 / i16 / i64 / u8 / u16 / u64
+# nominal cases would only re-confirm "value 42 stays 42". The i64 source is kept
+# strictly to exercise narrowing wrap at 2^31 (the only behavior that differs from
+# i32). For float sources, {i8, i16, i32} share the same i32.trunc_* opcode and
+# differ only in mask/sign-extend epilogue, so i8 stands in for the group; i64 is
+# kept because it uses the distinct i64.trunc_* opcode. Same shape for unsigned.
+# Negative-value variants are scoped to signed targets to avoid float→unsigned
+# trunc traps.
+ARC_CONVERSION_SOURCE = """
+func cast_i32(x i32) {
+    out_i32_to_i8  = i8(x)
+    out_i32_to_i16 = i16(x)
+    out_i32_to_i64 = i64(x)
+    out_i32_to_u8  = u8(x)
+    out_i32_to_u16 = u16(x)
+    out_i32_to_u32 = u32(x)
+    out_i32_to_u64 = u64(x)
+    out_i32_to_f32 = f32(x)
+    out_i32_to_f64 = f64(x)
+    out_i32_to_str = str(x)
+}
+in_i32 -> cast_i32{}
+
+func cast_u32(x u32) {
+    out_u32_to_i8  = i8(x)
+    out_u32_to_i16 = i16(x)
+    out_u32_to_i32 = i32(x)
+    out_u32_to_i64 = i64(x)
+    out_u32_to_u8  = u8(x)
+    out_u32_to_u16 = u16(x)
+    out_u32_to_u64 = u64(x)
+    out_u32_to_f32 = f32(x)
+    out_u32_to_f64 = f64(x)
+    out_u32_to_str = str(x)
+}
+in_u32 -> cast_u32{}
+
+// i64 source: only narrowing-wrap targets at 2^31 (i32 sign-flip, u32 in-range
+// bitcast, str decimal form).
+func cast_i64(x i64) {
+    out_i64_to_i32 = i32(x)
+    out_i64_to_u32 = u32(x)
+    out_i64_to_str = str(x)
+}
+in_i64 -> cast_i64{}
+
+func cast_f32(x f32) {
+    out_f32_to_i8  = i8(x)
+    out_f32_to_i64 = i64(x)
+    out_f32_to_u8  = u8(x)
+    out_f32_to_u64 = u64(x)
+    out_f32_to_f64 = f64(x)
+    out_f32_to_str = str(x)
+}
+in_f32 -> cast_f32{}
+
+// in_f32_neg avoids float→unsigned trunc traps by skipping unsigned int targets.
+func cast_f32_neg(x f32) {
+    out_f32_neg_to_i8  = i8(x)
+    out_f32_neg_to_i64 = i64(x)
+    out_f32_neg_to_f64 = f64(x)
+    out_f32_neg_to_str = str(x)
+}
+in_f32_neg -> cast_f32_neg{}
+
+func cast_f64(x f64) {
+    out_f64_to_i8  = i8(x)
+    out_f64_to_i64 = i64(x)
+    out_f64_to_u8  = u8(x)
+    out_f64_to_u64 = u64(x)
+    out_f64_to_f32 = f32(x)
+    out_f64_to_str = str(x)
+}
+in_f64 -> cast_f64{}
+
+func cast_f64_neg(x f64) {
+    out_f64_neg_to_i8  = i8(x)
+    out_f64_neg_to_i64 = i64(x)
+    out_f64_neg_to_f32 = f32(x)
+    out_f64_neg_to_str = str(x)
+}
+in_f64_neg -> cast_f64_neg{}
+
+// ───────── Flow-context casts (inline expression in flow) ─────────
+// The cast.go path that compiles in-flow expressions differs from the WASM
+// function-body path above: the value is read straight from channel state at
+// flow-fire time rather than passed via a function parameter on the stack.
+//
+// String form: const cast inside concat exercises str-from-literal; channel
+// cast inside concat exercises one case per from_<type> host function. The
+// concat-wrapped form is a strict superset of the bare str(channel) -> chan
+// form for the cast-emit path, so the bare form is omitted.
+flow_trigger -> "value=" + str(42) + " items" -> flow_concat_const_int
+flow_trigger -> "value=" + str(3.5) + " psi" -> flow_concat_const_float
+flow_trigger -> "v=" + str(in_i32) + "!" -> flow_concat_i32
+flow_trigger -> "v=" + str(in_u32) + "!" -> flow_concat_u32
+flow_trigger -> "v=" + str(in_i64) + "!" -> flow_concat_i64
+flow_trigger -> "v=" + str(in_u64) + "!" -> flow_concat_u64
+flow_trigger -> "v=" + str(in_f32) + "!" -> flow_concat_f32
+flow_trigger -> "v=" + str(in_f64) + "!" -> flow_concat_f64
+
+// Numeric form: one representative cast per opcode family (extend, wrap,
+// convert, trunc, promote/demote) plus one cast composed inside a binary op.
+flow_trigger -> i64(in_i32) -> flow_num_i32_to_i64
+flow_trigger -> i32(in_i64) -> flow_num_i64_to_i32
+flow_trigger -> f64(in_i32) -> flow_num_i32_to_f64
+flow_trigger -> i32(in_f64) -> flow_num_f64_to_i32
+flow_trigger -> f32(in_f64) -> flow_num_f64_to_f32
+flow_trigger -> i32(in_f64) + 100 -> flow_num_arith
+"""
+
+INPUT_CHANNELS: list[tuple[str, sy.DataType]] = [
+    ("in_i32", sy.DataType.INT32),
+    ("in_u32", sy.DataType.UINT32),
+    ("in_i64", sy.DataType.INT64),
+    ("in_u64", sy.DataType.UINT64),
+    ("in_f32", sy.DataType.FLOAT32),
+    ("in_f32_neg", sy.DataType.FLOAT32),
+    ("in_f64", sy.DataType.FLOAT64),
+    ("in_f64_neg", sy.DataType.FLOAT64),
+    ("flow_trigger", sy.DataType.INT64),
+]
+
+OUTPUT_CHANNELS: list[tuple[str, sy.DataType]] = [
+    # i32 source
+    ("out_i32_to_i8", sy.DataType.INT8),
+    ("out_i32_to_i16", sy.DataType.INT16),
+    ("out_i32_to_i64", sy.DataType.INT64),
+    ("out_i32_to_u8", sy.DataType.UINT8),
+    ("out_i32_to_u16", sy.DataType.UINT16),
+    ("out_i32_to_u32", sy.DataType.UINT32),
+    ("out_i32_to_u64", sy.DataType.UINT64),
+    ("out_i32_to_f32", sy.DataType.FLOAT32),
+    ("out_i32_to_f64", sy.DataType.FLOAT64),
+    ("out_i32_to_str", sy.DataType.STRING),
+    # u32 source
+    ("out_u32_to_i8", sy.DataType.INT8),
+    ("out_u32_to_i16", sy.DataType.INT16),
+    ("out_u32_to_i32", sy.DataType.INT32),
+    ("out_u32_to_i64", sy.DataType.INT64),
+    ("out_u32_to_u8", sy.DataType.UINT8),
+    ("out_u32_to_u16", sy.DataType.UINT16),
+    ("out_u32_to_u64", sy.DataType.UINT64),
+    ("out_u32_to_f32", sy.DataType.FLOAT32),
+    ("out_u32_to_f64", sy.DataType.FLOAT64),
+    ("out_u32_to_str", sy.DataType.STRING),
+    # i64 source (overflow only)
+    ("out_i64_to_i32", sy.DataType.INT32),
+    ("out_i64_to_u32", sy.DataType.UINT32),
+    ("out_i64_to_str", sy.DataType.STRING),
+    # f32 source
+    ("out_f32_to_i8", sy.DataType.INT8),
+    ("out_f32_to_i64", sy.DataType.INT64),
+    ("out_f32_to_u8", sy.DataType.UINT8),
+    ("out_f32_to_u64", sy.DataType.UINT64),
+    ("out_f32_to_f64", sy.DataType.FLOAT64),
+    ("out_f32_to_str", sy.DataType.STRING),
+    # f32 neg source
+    ("out_f32_neg_to_i8", sy.DataType.INT8),
+    ("out_f32_neg_to_i64", sy.DataType.INT64),
+    ("out_f32_neg_to_f64", sy.DataType.FLOAT64),
+    ("out_f32_neg_to_str", sy.DataType.STRING),
+    # f64 source
+    ("out_f64_to_i8", sy.DataType.INT8),
+    ("out_f64_to_i64", sy.DataType.INT64),
+    ("out_f64_to_u8", sy.DataType.UINT8),
+    ("out_f64_to_u64", sy.DataType.UINT64),
+    ("out_f64_to_f32", sy.DataType.FLOAT32),
+    ("out_f64_to_str", sy.DataType.STRING),
+    # f64 neg source
+    ("out_f64_neg_to_i8", sy.DataType.INT8),
+    ("out_f64_neg_to_i64", sy.DataType.INT64),
+    ("out_f64_neg_to_f32", sy.DataType.FLOAT32),
+    ("out_f64_neg_to_str", sy.DataType.STRING),
+    # Flow-context str(): const cast inside concat
+    ("flow_concat_const_int", sy.DataType.STRING),
+    ("flow_concat_const_float", sy.DataType.STRING),
+    # Flow-context str(): channel cast inside concat
+    ("flow_concat_i32", sy.DataType.STRING),
+    ("flow_concat_u32", sy.DataType.STRING),
+    ("flow_concat_i64", sy.DataType.STRING),
+    ("flow_concat_u64", sy.DataType.STRING),
+    ("flow_concat_f32", sy.DataType.STRING),
+    ("flow_concat_f64", sy.DataType.STRING),
+    # Flow-context numeric casts
+    ("flow_num_i32_to_i64", sy.DataType.INT64),
+    ("flow_num_i64_to_i32", sy.DataType.INT32),
+    ("flow_num_i32_to_f64", sy.DataType.FLOAT64),
+    ("flow_num_f64_to_i32", sy.DataType.INT32),
+    ("flow_num_f64_to_f32", sy.DataType.FLOAT32),
+    ("flow_num_arith", sy.DataType.INT32),
+]
+
+ALL_CHANNELS = [name for name, _ in INPUT_CHANNELS] + [
+    name for name, _ in OUTPUT_CHANNELS
+]
+
+
+class Conversion(ArcConsoleCase):
+    """End-to-end coverage of numeric typecasts plus numeric→str.
+
+    Two compilation paths are covered.
+
+    - WASM-body casts: each source type runs a
+    single Arc function that casts its input to every target via direct channel
+    writes. Identity casts are omitted (they emit as no-ops). i32 / u32 act as
+    smoke tests for the signed and unsigned int opcode families at a nominal
+    value; i64 covers narrowing wrap at 2^31. For float sources, only one
+    representative target per trunc-opcode group is asserted ({i8, i64} signed;
+    {u8, u64} unsigned), with negative-value variants scoped to signed targets
+    only to avoid float→unsigned trunc traps.
+
+    - Flow-context casts: cast applied as an inline expression in flow position
+    rather than inside a function body. String form covers const cast and
+    channel cast both wrapped in concat (the wrapped form is a strict superset
+    of the bare form's cast-emit path). Numeric form covers one representative
+    pair per opcode family (extend, wrap, convert, trunc, promote/demote) plus
+    one cast composed inside a binary op.
+    """
+
+    arc_source = ARC_CONVERSION_SOURCE
+    arc_name_prefix = "ArcConversion"
+    start_cmd_channel = "start_conversion_cmd"
+    subscribe_channels = ALL_CHANNELS
+
+    def setup(self) -> None:
+        self.set_manual_timeout(300)
+        for name, dtype in INPUT_CHANNELS:
+            create_virtual_channel(self.client, name, dtype)
+        for name, dtype in OUTPUT_CHANNELS:
+            create_virtual_channel(self.client, name, dtype)
+        super().setup()
+
+    def verify_sequence_execution(self) -> None:
+        self._test_32()
+        self._test_i64_overflow()
+        self._test_f32()
+        self._test_f64()
+        self._test_flow_context()
+
+    def _test_32(self) -> None:
+        self.log("=== i32 = 42, u32 = 42 ===")
+        self.writer.write({"in_i32": 42, "in_u32": 42})
+        self.wait_for_eq("out_i32_to_i8", 42, is_virtual=True)
+        self.wait_for_eq("out_i32_to_i16", 42, is_virtual=True)
+        self.wait_for_eq("out_i32_to_i64", 42, is_virtual=True)
+        self.wait_for_eq("out_i32_to_u8", 42, is_virtual=True)
+        self.wait_for_eq("out_i32_to_u16", 42, is_virtual=True)
+        self.wait_for_eq("out_i32_to_u32", 42, is_virtual=True)
+        self.wait_for_eq("out_i32_to_u64", 42, is_virtual=True)
+        self.wait_for_near("out_i32_to_f32", 42.0, tolerance=1e-5, is_virtual=True)
+        self.wait_for_near("out_i32_to_f64", 42.0, tolerance=1e-9, is_virtual=True)
+        self.wait_for_eq("out_i32_to_str", "42", is_virtual=True)
+        self.wait_for_eq("out_u32_to_i8", 42, is_virtual=True)
+        self.wait_for_eq("out_u32_to_i16", 42, is_virtual=True)
+        self.wait_for_eq("out_u32_to_i32", 42, is_virtual=True)
+        self.wait_for_eq("out_u32_to_i64", 42, is_virtual=True)
+        self.wait_for_eq("out_u32_to_u8", 42, is_virtual=True)
+        self.wait_for_eq("out_u32_to_u16", 42, is_virtual=True)
+        self.wait_for_eq("out_u32_to_u64", 42, is_virtual=True)
+        self.wait_for_near("out_u32_to_f32", 42.0, tolerance=1e-5, is_virtual=True)
+        self.wait_for_near("out_u32_to_f64", 42.0, tolerance=1e-9, is_virtual=True)
+        self.wait_for_eq("out_u32_to_str", "42", is_virtual=True)
+
+    def _test_i64_overflow(self) -> None:
+        # i32(2^31) sign-flips to -2^31, u32(2^31) stays in range, str is decimal.
+        self.log("=== i64 = 2^31 (narrowing wrap) ===")
+        self.writer.write("in_i64", 2**31)
+        self.wait_for_eq("out_i64_to_i32", -(2**31), is_virtual=True)
+        self.wait_for_eq("out_i64_to_u32", 2**31, is_virtual=True)
+        self.wait_for_eq("out_i64_to_str", "2147483648", is_virtual=True)
+
+    def _test_f32(self) -> None:
+        self.log("=== f32 = 3.5, f32_neg = -7.0 ===")
+        self.writer.write({"in_f32": 3.5, "in_f32_neg": -7.0})
+        self.wait_for_eq("out_f32_to_i8", 3, is_virtual=True)
+        self.wait_for_eq("out_f32_to_i64", 3, is_virtual=True)
+        self.wait_for_eq("out_f32_to_u8", 3, is_virtual=True)
+        self.wait_for_eq("out_f32_to_u64", 3, is_virtual=True)
+        self.wait_for_near("out_f32_to_f64", 3.5, tolerance=1e-5, is_virtual=True)
+        self.wait_for_eq("out_f32_to_str", "3.5", is_virtual=True)
+        self.wait_for_eq("out_f32_neg_to_i8", -7, is_virtual=True)
+        self.wait_for_eq("out_f32_neg_to_i64", -7, is_virtual=True)
+        self.wait_for_near("out_f32_neg_to_f64", -7.0, tolerance=1e-5, is_virtual=True)
+        self.wait_for_eq("out_f32_neg_to_str", "-7", is_virtual=True)
+
+    def _test_f64(self) -> None:
+        self.log("=== f64 = 3.5, f64_neg = -7.0 ===")
+        self.writer.write({"in_f64": 3.5, "in_f64_neg": -7.0})
+        self.wait_for_eq("out_f64_to_i8", 3, is_virtual=True)
+        self.wait_for_eq("out_f64_to_i64", 3, is_virtual=True)
+        self.wait_for_eq("out_f64_to_u8", 3, is_virtual=True)
+        self.wait_for_eq("out_f64_to_u64", 3, is_virtual=True)
+        self.wait_for_near("out_f64_to_f32", 3.5, tolerance=1e-5, is_virtual=True)
+        self.wait_for_eq("out_f64_to_str", "3.5", is_virtual=True)
+        self.wait_for_eq("out_f64_neg_to_i8", -7, is_virtual=True)
+        self.wait_for_eq("out_f64_neg_to_i64", -7, is_virtual=True)
+        self.wait_for_near("out_f64_neg_to_f32", -7.0, tolerance=1e-5, is_virtual=True)
+        self.wait_for_eq("out_f64_neg_to_str", "-7", is_virtual=True)
+
+    def _test_flow_context(self) -> None:
+        # Pre-write the source channels so they hold values when flow_trigger
+        # fires the inline-expression flows.
+        self.log("=== flow-context casts ===")
+        self.writer.write(
+            {
+                "in_i32": 42,
+                "in_u32": 42,
+                "in_i64": 2**31,
+                "in_u64": 42,
+                "in_f32": 3.5,
+                "in_f64": 3.5,
+                "flow_trigger": 1,
+            }
+        )
+
+        # str(): const cast inside concat
+        self.wait_for_eq("flow_concat_const_int", "value=42 items", is_virtual=True)
+        self.wait_for_eq("flow_concat_const_float", "value=3.5 psi", is_virtual=True)
+
+        # str(): channel cast inside concat
+        self.wait_for_eq("flow_concat_i32", "v=42!", is_virtual=True)
+        self.wait_for_eq("flow_concat_u32", "v=42!", is_virtual=True)
+        self.wait_for_eq("flow_concat_i64", "v=2147483648!", is_virtual=True)
+        self.wait_for_eq("flow_concat_u64", "v=42!", is_virtual=True)
+        self.wait_for_eq("flow_concat_f32", "v=3.5!", is_virtual=True)
+        self.wait_for_eq("flow_concat_f64", "v=3.5!", is_virtual=True)
+
+        # Numeric: one representative per opcode family + one composed in a
+        # binary op. i32(in_i64) at 2^31 sign-flips to -2^31.
+        self.wait_for_eq("flow_num_i32_to_i64", 42, is_virtual=True)
+        self.wait_for_eq("flow_num_i64_to_i32", -(2**31), is_virtual=True)
+        self.wait_for_near("flow_num_i32_to_f64", 42.0, tolerance=1e-9, is_virtual=True)
+        self.wait_for_eq("flow_num_f64_to_i32", 3, is_virtual=True)
+        self.wait_for_near("flow_num_f64_to_f32", 3.5, tolerance=1e-5, is_virtual=True)
+        self.wait_for_eq("flow_num_arith", 103, is_virtual=True)

--- a/integration/tests/arc_tests.json
+++ b/integration/tests/arc_tests.json
@@ -77,6 +77,10 @@
         {
           "case": "arc/backward_jump",
           "parameters": { "rack_key": [65537, 65538] }
+        },
+        {
+          "case": "arc/conversion",
+          "parameters": { "rack_key": [65537, 65538] }
         }
       ]
     },


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-3880](https://linear.app/synnax/issue/SY-3880)

## Description

Adds support for converting numeric primitives (i8-i64, u8-u64, f32, f64) to strings via Arc's existing typecast syntax (e.g., `str(42)`, `str(3.14)`). Floats use shortest round-trippable formatting matching Go's `strconv.FormatFloat(_, 'g', -1, bitSize)`; the reverse direction (str to numeric) remains rejected.

`str()` also works as a flow stage (`channel -> str -> log`). Both Go and C++ WASM runtimes now materialize string-typed outputs into a fresh series at the end of each tick rather than attempting to resize variable-density buffers in place, which previously caused a runtime trap.

Conversion routing lives in a single `Resolver.EmitNumericToString` dispatcher so the planned f-string feature can reuse it without duplicating the source-type to host-fn switch.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `str()` typecast support that converts numeric primitives (i8–i64, u8–u64, f32, f64) to their decimal string representation, and fixes a runtime trap that occurred when attempting to resize variable-density string buffers in place during WASM tick evaluation.

- **Conversion routing** is centralised in `Resolver.EmitNumericToString`, dispatching to one of six new `string.from_*` host functions (backed by `strconv.FormatFloat` with the correct `bitSize` on the Go side and `std::to_chars(…, std::chars_format::general)` on the C++ side). Float formatting matches Go's `strconv.FormatFloat(_, 'g', -1, bitSize)` contract.
- **Both runtimes (Go WASM and C++ WASM)** now accumulate string outputs into a temporary slice per tick and materialise a fresh series at the end, instead of calling `Resize` on a variable-density buffer (which would panic or trap). The `str()` cast also works as an inline flow stage (`channel -> str -> log`).

<h3>Confidence Score: 5/5</h3>

The change is safe to merge. The numeric-to-string conversion path is well-isolated, the variable-density buffer fix correctly avoids the Resize trap in both runtimes, and test coverage spans unit, integration, and end-to-end layers across all numeric source types.

The core logic — accumulating string handles into a temporary slice per tick and materialising a fresh series at the end — is symmetric between Go and C++ runtimes and verified by multi-sample tests. The Go Data-only assignment is correct because telem.Series.Len() for variable-density types always recomputes from Data (Resize panics on variable-density, so cachedLength is never set persistently for string series). Float formatting uses the right bitSize (32 vs 64) to match Go's strconv contract. No logic errors or unsafe paths were found.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| arc/go/compiler/resolve/emit.go | New EmitNumericToString and EmitFixedCall functions; type-switch routing from all 10 numeric kinds to the correct from_* host fn looks correct. |
| arc/go/stl/strings/string.go | Six new host functions added; FormatFloat bitSize is correctly 32 for f32 and 64 for f64. SymbolResolver entries match host function signatures. |
| arc/go/stl/wasm/node.go | String outputs now accumulate into a []string slice; only out.Data is replaced at tick end. Verified safe: telem.Series.Len() for variable-density types recomputes directly from Data (cachedLength is never set persistently via Resize since Resize panics on variable-density). DPanicf on unregistered handle miss is a good defensive addition. |
| arc/cpp/stl/str/str.h | format_float correctly handles NaN/±Inf and now checks the to_chars error code (returning empty string on failure). Six new from_* linker bindings added. |
| arc/cpp/runtime/wasm/node.h | String outputs accumulate into a lazy-allocated vector-of-vectors and are materialised as a full Series assignment at tick end, correctly bypassing the Resize-on-variable-density trap. |
| arc/go/compiler/expression/cast.go | Hint suppression for str() targets prevents numeric literals from inheriting the string type; extractType extended to recognise STR primitive; EmitCast short-circuits to EmitNumericToString for string targets. |
| arc/go/str_cast_test.go | Comprehensive end-to-end tests covering literals, channel reads, flow-stage usage, and concat patterns across all numeric types. Ghost-precision f32 cases included. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["str(x) in Arc source"] --> B{Analyzer isValidCast}
    B -->|"numeric source"| C["Compiler: compileTypeCast\nhint suppressed for str target"]
    B -->|"str source"| D["Rejected: cannot cast"]
    C --> E["EmitCast → EmitNumericToString"]
    E --> F{source kind}
    F -->|"i8/i16/i32"| G["string.from_i32"]
    F -->|"u8/u16/u32"| H["string.from_u32"]
    F -->|"i64"| I["string.from_i64"]
    F -->|"u64"| J["string.from_u64"]
    F -->|"f32"| K["string.from_f32"]
    F -->|"f64"| L["string.from_f64"]
    G & H & I & J --> M["Host fn: FormatInt/Uint → string handle uint32"]
    K & L --> N["Host fn: FormatFloat 'g' -1 bitSize → string handle uint32"]
    M & N --> O["WASM stack: i32 handle"]
    O --> P{Runtime: string output?}
    P -->|yes| Q["Accumulate into stringResults per tick"]
    P -->|no| R["setValueAt numeric output"]
    Q --> S["End of tick: materialise fresh Series from accumulated strings"]
    R --> T["Resize to sample count"]
```

<sub>Reviews (4): Last reviewed commit: ["SY-3380: Implement feedback"](https://github.com/synnaxlabs/synnax/commit/f739706dfbc9ebaddfc2fb38921df7ff0c82f779) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31089983)</sub>

<!-- /greptile_comment -->