### PR TITLE
SY-4155: Render Line Breaks in Logs

### DIFF
--- a/pluto/src/log/aether/Log.spec.ts
+++ b/pluto/src/log/aether/Log.spec.ts
@@ -719,6 +719,54 @@ describe("log/aether/Log", () => {
       // Should contain scientific notation (uses unicode ᴇ)
       expect(log.state.selectedText).toMatch(/[eEᴇ]/);
     });
+
+    it("should render continuation entries without name/timestamp but aligned to the value column", () => {
+      const entries: LogEntry[] = [
+        { channelKey: 1, timestamp: TimeStamp.milliseconds(1000), value: "hello" },
+        {
+          channelKey: 1,
+          timestamp: TimeStamp.milliseconds(1000),
+          value: "world",
+          continuation: true,
+        },
+        { channelKey: 1, timestamp: TimeStamp.milliseconds(2000), value: "again" },
+      ];
+      const { log } = setupWithContext(entries, REGION_500, {
+        showChannelNames: true,
+        showReceiptTimestamp: false,
+        channels: [{ channel: 1 }],
+        channelNames: { "1": "log" },
+        selectionStart: 0,
+        selectionEnd: 2,
+      });
+      log.render();
+      const lines = log.state.selectedLines.map((l) => l.text);
+      expect(lines[0]).toContain("[log]");
+      expect(lines[0]).toContain("hello");
+      // Continuation: no [log], but leading whitespace preserves value alignment.
+      expect(lines[1]).not.toContain("[log]");
+      expect(lines[1]).toMatch(/^\s+world$/);
+      expect(lines[1].indexOf("world")).toBe(lines[0].indexOf("hello"));
+      expect(lines[2]).toContain("[log]");
+      expect(lines[2]).toContain("again");
+    });
+
+    it("should render an entry with empty value but no continuation flag with its prefix intact", () => {
+      const entries: LogEntry[] = [
+        { channelKey: 1, timestamp: TimeStamp.milliseconds(1000), value: "" },
+      ];
+      const { log } = setupWithContext(entries, REGION_500, {
+        showChannelNames: true,
+        showReceiptTimestamp: false,
+        channels: [{ channel: 1 }],
+        channelNames: { "1": "log" },
+        selectionStart: 0,
+        selectionEnd: 0,
+      });
+      log.render();
+      const [line] = log.state.selectedLines.map((l) => l.text);
+      expect(line).toContain("[log]");
+    });
   });
 
   describe("selectedText and selectedLines", () => {

--- a/pluto/src/log/aether/Log.spec.ts
+++ b/pluto/src/log/aether/Log.spec.ts
@@ -767,6 +767,128 @@ describe("log/aether/Log", () => {
       const [line] = log.state.selectedLines.map((l) => l.text);
       expect(line).toContain("[log]");
     });
+
+    it("should render a three-line continuation group with consistent alignment", () => {
+      const entries: LogEntry[] = [
+        { channelKey: 1, timestamp: TimeStamp.milliseconds(1000), value: "first" },
+        {
+          channelKey: 1,
+          timestamp: TimeStamp.milliseconds(1000),
+          value: "second",
+          continuation: true,
+        },
+        {
+          channelKey: 1,
+          timestamp: TimeStamp.milliseconds(1000),
+          value: "third",
+          continuation: true,
+        },
+      ];
+      const { log } = setupWithContext(entries, REGION_500, {
+        showChannelNames: true,
+        showReceiptTimestamp: true,
+        channels: [{ channel: 1 }],
+        channelNames: { "1": "sensor" },
+        selectionStart: 0,
+        selectionEnd: 2,
+      });
+      log.render();
+      const lines = log.state.selectedLines.map((l) => l.text);
+      expect(lines[0]).toContain("[sensor]");
+      expect(lines[0]).toContain("first");
+      const valueCol = lines[0].indexOf("first");
+      expect(lines[1]).not.toContain("[sensor]");
+      expect(lines[1].indexOf("second")).toBe(valueCol);
+      expect(lines[2]).not.toContain("[sensor]");
+      expect(lines[2].indexOf("third")).toBe(valueCol);
+    });
+
+    it("should render continuation with both timestamp and channel name hidden", () => {
+      const entries: LogEntry[] = [
+        { channelKey: 1, timestamp: TimeStamp.milliseconds(1000), value: "line1" },
+        {
+          channelKey: 1,
+          timestamp: TimeStamp.milliseconds(1000),
+          value: "line2",
+          continuation: true,
+        },
+      ];
+      const { log } = setupWithContext(entries, REGION_500, {
+        showChannelNames: false,
+        showReceiptTimestamp: false,
+        channels: [{ channel: 1 }],
+        selectionStart: 0,
+        selectionEnd: 1,
+      });
+      log.render();
+      const lines = log.state.selectedLines.map((l) => l.text);
+      expect(lines[0]).toBe("line1");
+      expect(lines[1]).toBe("line2");
+    });
+
+    it("should render continuation entries interleaved between different channels", () => {
+      const entries: LogEntry[] = [
+        { channelKey: 1, timestamp: TimeStamp.milliseconds(1000), value: "a1" },
+        {
+          channelKey: 1,
+          timestamp: TimeStamp.milliseconds(1000),
+          value: "a2",
+          continuation: true,
+        },
+        { channelKey: 2, timestamp: TimeStamp.milliseconds(1000), value: "b1" },
+        {
+          channelKey: 2,
+          timestamp: TimeStamp.milliseconds(1000),
+          value: "b2",
+          continuation: true,
+        },
+      ];
+      const { log } = setupWithContext(entries, REGION_500, {
+        showChannelNames: true,
+        showReceiptTimestamp: false,
+        channels: [{ channel: 1 }, { channel: 2 }],
+        channelNames: { "1": "chA", "2": "chB" },
+        selectionStart: 0,
+        selectionEnd: 3,
+      });
+      log.render();
+      const lines = log.state.selectedLines.map((l) => l.text);
+      expect(lines[0]).toContain("[chA]");
+      expect(lines[0]).toContain("a1");
+      expect(lines[1]).not.toContain("[chA]");
+      expect(lines[1]).toContain("a2");
+      expect(lines[2]).toContain("[chB]");
+      expect(lines[2]).toContain("b1");
+      expect(lines[3]).not.toContain("[chB]");
+      expect(lines[3]).toContain("b2");
+    });
+
+    it("should render a continuation entry with an empty value as a blank aligned line", () => {
+      const entries: LogEntry[] = [
+        { channelKey: 1, timestamp: TimeStamp.milliseconds(1000), value: "data" },
+        {
+          channelKey: 1,
+          timestamp: TimeStamp.milliseconds(1000),
+          value: "",
+          continuation: true,
+        },
+      ];
+      const { log } = setupWithContext(entries, REGION_500, {
+        showChannelNames: true,
+        showReceiptTimestamp: false,
+        channels: [{ channel: 1 }],
+        channelNames: { "1": "log" },
+        selectionStart: 0,
+        selectionEnd: 1,
+      });
+      log.render();
+      const lines = log.state.selectedLines.map((l) => l.text);
+      expect(lines[0]).toContain("[log]");
+      expect(lines[0]).toContain("data");
+      expect(lines[1]).not.toContain("[log]");
+      expect(lines[1]).toMatch(/^\s*$/);
+      expect(lines[1].length).toBe(lines[0].indexOf("data"));
+    });
   });
 
   describe("selectedText and selectedLines", () => {

--- a/pluto/src/log/aether/Log.ts
+++ b/pluto/src/log/aether/Log.ts
@@ -453,6 +453,8 @@ export class Log extends aether.Leaf<typeof logState, InternalState> {
     else if (showReceiptTimestamp) prefix = `${ts}  `;
     else if (showChannelNames) prefix = `[${name}]${pad}  `;
     else prefix = "";
+    // Continuation lines (\n) keep the prefix's alignment width as whitespace.
+    if (entry.continuation) prefix = " ".repeat(prefix.length);
     return { prefix, value, line: prefix + value, channelKey: chKeyStr };
   }
 

--- a/pluto/src/log/aether/telem/sources.spec.ts
+++ b/pluto/src/log/aether/telem/sources.spec.ts
@@ -393,6 +393,22 @@ describe("StreamMultiChannelLog", () => {
       expect(entries.every((e) => e.timestamp === ts)).toBe(true);
     });
 
+    it("should split on Windows-style \\r\\n without leaving a stray \\r", async () => {
+      c.channelA = new channel.Channel({
+        ...c.channelA,
+        dataType: DataType.STRING,
+      });
+      const props: StreamMultiChannelLogProps = {
+        channels: [c.channelA.key],
+        timeSpan: TimeSpan.seconds(30),
+      };
+      const log = new StreamMultiChannelLog(c, props);
+      await waitForResolve(log);
+      const series = new Series({ data: ["line1\r\nline2"] });
+      c.streamHandler?.(new Map([[c.channelA.key, new MultiSeries([series])]]));
+      expect(log.value().map((e) => e.value)).toEqual(["line1", "line2"]);
+    });
+
     it("should preserve consecutive newlines as blank entries", async () => {
       c.channelA = new channel.Channel({
         ...c.channelA,
@@ -462,6 +478,26 @@ describe("StreamMultiChannelLog", () => {
       const entries = log.value();
       expect(entries).toHaveLength(1);
       expect(entries[0].value).toBe(JSON.stringify({ msg: "hi\nthere" }));
+    });
+
+    it("should not leave orphan continuation entries at the head when MAX_ENTRIES eviction cuts mid-group", async () => {
+      c.channelA = new channel.Channel({
+        ...c.channelA,
+        dataType: DataType.STRING,
+      });
+      const props: StreamMultiChannelLogProps = {
+        channels: [c.channelA.key],
+        timeSpan: TimeSpan.seconds(30),
+      };
+      const log = new StreamMultiChannelLog(c, props);
+      await waitForResolve(log);
+      // 33,335 three-line samples = 100,005 entries; excess of 5 cuts mid-group.
+      const data = new Array(33_335).fill("a\nb\nc");
+      const series = new Series({ data });
+      c.streamHandler?.(new Map([[c.channelA.key, new MultiSeries([series])]]));
+      const entries = log.value();
+      expect(entries.length).toBeGreaterThan(0);
+      expect(entries[0].continuation === true).toBe(false);
     });
   });
 

--- a/pluto/src/log/aether/telem/sources.spec.ts
+++ b/pluto/src/log/aether/telem/sources.spec.ts
@@ -500,6 +500,48 @@ describe("StreamMultiChannelLog", () => {
       expect(entries[0].value).toBe('{"user_id":1,"first_name":"alice"}');
     });
 
+    it("should produce a single non-continuation entry for an empty string sample", async () => {
+      c.channelA = new channel.Channel({
+        ...c.channelA,
+        dataType: DataType.STRING,
+      });
+      const props: StreamMultiChannelLogProps = {
+        channels: [c.channelA.key],
+        timeSpan: TimeSpan.seconds(30),
+      };
+      const log = new StreamMultiChannelLog(c, props);
+      await waitForResolve(log);
+      const series = new Series({ data: [""] });
+      c.streamHandler?.(new Map([[c.channelA.key, new MultiSeries([series])]]));
+      const entries = log.value();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].value).toBe("");
+      expect(entries[0].continuation === true).toBe(false);
+    });
+
+    it("should not split BYTES channel values that contain \\n", async () => {
+      c.channelA = new channel.Channel({
+        ...c.channelA,
+        dataType: DataType.BYTES,
+      });
+      const props: StreamMultiChannelLogProps = {
+        channels: [c.channelA.key],
+        timeSpan: TimeSpan.seconds(30),
+      };
+      const log = new StreamMultiChannelLog(c, props);
+      await waitForResolve(log);
+      const payload = new TextEncoder().encode("line1\nline2");
+      const buf = new ArrayBuffer(4 + payload.byteLength);
+      new DataView(buf).setUint32(0, payload.byteLength, true);
+      new Uint8Array(buf).set(payload, 4);
+      const series = new Series({ data: buf, dataType: DataType.BYTES });
+      c.streamHandler?.(new Map([[c.channelA.key, new MultiSeries([series])]]));
+      const entries = log.value();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].value).toBe("line1\nline2");
+      expect(entries[0].continuation === true).toBe(false);
+    });
+
     it("should not leave orphan continuation entries at the head when maxEntries eviction cuts mid-group", async () => {
       c.channelA = new channel.Channel({
         ...c.channelA,

--- a/pluto/src/log/aether/telem/sources.spec.ts
+++ b/pluto/src/log/aether/telem/sources.spec.ts
@@ -370,6 +370,101 @@ describe("StreamMultiChannelLog", () => {
     expect(log.evictedCount).toBe(0);
   });
 
+  describe("newline handling", () => {
+    it("should split a string sample on \\n into multiple entries", async () => {
+      c.channelA = new channel.Channel({
+        ...c.channelA,
+        dataType: DataType.STRING,
+      });
+      const props: StreamMultiChannelLogProps = {
+        channels: [c.channelA.key],
+        timeSpan: TimeSpan.seconds(30),
+      };
+      const log = new StreamMultiChannelLog(c, props);
+      await waitForResolve(log);
+      const series = new Series({ data: ["line1\nline2\n"] });
+      c.streamHandler?.(new Map([[c.channelA.key, new MultiSeries([series])]]));
+      const entries = log.value();
+      expect(entries).toHaveLength(3);
+      expect(entries.map((e) => e.value)).toEqual(["line1", "line2", ""]);
+      expect(entries.map((e) => e.continuation === true)).toEqual([false, true, true]);
+      expect(entries.every((e) => e.channelKey === c.channelA.key)).toBe(true);
+      const ts = entries[0].timestamp;
+      expect(entries.every((e) => e.timestamp === ts)).toBe(true);
+    });
+
+    it("should preserve consecutive newlines as blank entries", async () => {
+      c.channelA = new channel.Channel({
+        ...c.channelA,
+        dataType: DataType.STRING,
+      });
+      const props: StreamMultiChannelLogProps = {
+        channels: [c.channelA.key],
+        timeSpan: TimeSpan.seconds(30),
+      };
+      const log = new StreamMultiChannelLog(c, props);
+      await waitForResolve(log);
+      const series = new Series({ data: ["a\n\nb"] });
+      c.streamHandler?.(new Map([[c.channelA.key, new MultiSeries([series])]]));
+      expect(log.value().map((e) => e.value)).toEqual(["a", "", "b"]);
+    });
+
+    it("should produce a single non-continuation entry for a string with no \\n", async () => {
+      c.channelA = new channel.Channel({
+        ...c.channelA,
+        dataType: DataType.STRING,
+      });
+      const props: StreamMultiChannelLogProps = {
+        channels: [c.channelA.key],
+        timeSpan: TimeSpan.seconds(30),
+      };
+      const log = new StreamMultiChannelLog(c, props);
+      await waitForResolve(log);
+      const series = new Series({ data: ["hello world", ""] });
+      c.streamHandler?.(new Map([[c.channelA.key, new MultiSeries([series])]]));
+      const entries = log.value();
+      expect(entries).toHaveLength(2);
+      expect(entries[0].value).toBe("hello world");
+      expect(entries[0].continuation === true).toBe(false);
+      // An explicit empty write is NOT a continuation — the prefix should still
+      // render. Only entries produced by a \n split are continuations.
+      expect(entries[1].value).toBe("");
+      expect(entries[1].continuation === true).toBe(false);
+    });
+
+    it("should not split numeric channel values", async () => {
+      const props: StreamMultiChannelLogProps = {
+        channels: [c.channelA.key],
+        timeSpan: TimeSpan.seconds(30),
+      };
+      const log = new StreamMultiChannelLog(c, props);
+      await waitForResolve(log);
+      const series = new Series({ data: new Float32Array([1, 2, 3]) });
+      c.streamHandler?.(new Map([[c.channelA.key, new MultiSeries([series])]]));
+      const entries = log.value();
+      expect(entries).toHaveLength(3);
+      expect(entries.map((e) => e.value)).toEqual(["1", "2", "3"]);
+    });
+
+    it("should not split JSON channel values that contain \\n", async () => {
+      c.channelA = new channel.Channel({
+        ...c.channelA,
+        dataType: DataType.JSON,
+      });
+      const props: StreamMultiChannelLogProps = {
+        channels: [c.channelA.key],
+        timeSpan: TimeSpan.seconds(30),
+      };
+      const log = new StreamMultiChannelLog(c, props);
+      await waitForResolve(log);
+      const series = new Series({ data: [{ msg: "hi\nthere" }] });
+      c.streamHandler?.(new Map([[c.channelA.key, new MultiSeries([series])]]));
+      const entries = log.value();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].value).toBe(JSON.stringify({ msg: "hi\nthere" }));
+    });
+  });
+
   describe("setChannels", () => {
     it("should be a no-op when channels have not changed", async () => {
       const props: StreamMultiChannelLogProps = {

--- a/pluto/src/log/aether/telem/sources.spec.ts
+++ b/pluto/src/log/aether/telem/sources.spec.ts
@@ -497,9 +497,7 @@ describe("StreamMultiChannelLog", () => {
       c.streamHandler?.(new Map([[c.channelA.key, new MultiSeries([series])]]));
       const entries = log.value();
       expect(entries).toHaveLength(1);
-      expect(entries[0].value).toBe(
-        '{"user_id":1,"first_name":"alice"}',
-      );
+      expect(entries[0].value).toBe('{"user_id":1,"first_name":"alice"}');
     });
 
     it("should not leave orphan continuation entries at the head when maxEntries eviction cuts mid-group", async () => {

--- a/pluto/src/log/aether/telem/sources.spec.ts
+++ b/pluto/src/log/aether/telem/sources.spec.ts
@@ -480,7 +480,7 @@ describe("StreamMultiChannelLog", () => {
       expect(entries[0].value).toBe(JSON.stringify({ msg: "hi\nthere" }));
     });
 
-    it("should not leave orphan continuation entries at the head when MAX_ENTRIES eviction cuts mid-group", async () => {
+    it("should not leave orphan continuation entries at the head when maxEntries eviction cuts mid-group", async () => {
       c.channelA = new channel.Channel({
         ...c.channelA,
         dataType: DataType.STRING,
@@ -489,10 +489,10 @@ describe("StreamMultiChannelLog", () => {
         channels: [c.channelA.key],
         timeSpan: TimeSpan.seconds(30),
       };
-      const log = new StreamMultiChannelLog(c, props);
+      const log = new StreamMultiChannelLog(c, props, undefined, undefined, 100);
       await waitForResolve(log);
-      // 33,335 three-line samples = 100,005 entries; excess of 5 cuts mid-group.
-      const data = new Array(33_335).fill("a\nb\nc");
+      // 35 three-line samples = 105 entries; excess of 5 cuts mid-group.
+      const data = new Array(35).fill("a\nb\nc");
       const series = new Series({ data });
       c.streamHandler?.(new Map([[c.channelA.key, new MultiSeries([series])]]));
       const entries = log.value();

--- a/pluto/src/log/aether/telem/sources.spec.ts
+++ b/pluto/src/log/aether/telem/sources.spec.ts
@@ -480,6 +480,28 @@ describe("StreamMultiChannelLog", () => {
       expect(entries[0].value).toBe(JSON.stringify({ msg: "hi\nthere" }));
     });
 
+    it("should preserve raw snake_case keys in JSON channel values", async () => {
+      c.channelA = new channel.Channel({
+        ...c.channelA,
+        dataType: DataType.JSON,
+      });
+      const props: StreamMultiChannelLogProps = {
+        channels: [c.channelA.key],
+        timeSpan: TimeSpan.seconds(30),
+      };
+      const log = new StreamMultiChannelLog(c, props);
+      await waitForResolve(log);
+      const series = new Series({
+        data: [{ user_id: 1, first_name: "alice" }],
+      });
+      c.streamHandler?.(new Map([[c.channelA.key, new MultiSeries([series])]]));
+      const entries = log.value();
+      expect(entries).toHaveLength(1);
+      expect(entries[0].value).toBe(
+        '{"user_id":1,"first_name":"alice"}',
+      );
+    });
+
     it("should not leave orphan continuation entries at the head when maxEntries eviction cuts mid-group", async () => {
       c.channelA = new channel.Channel({
         ...c.channelA,

--- a/pluto/src/log/aether/telem/sources.ts
+++ b/pluto/src/log/aether/telem/sources.ts
@@ -157,7 +157,7 @@ export class StreamMultiChannelLog
                 pushed++;
                 continue;
               }
-              const lines = value.split("\n");
+              const lines = value.split(/\r?\n/);
               for (let j = 0; j < lines.length; j++)
                 this.entries.push({
                   channelKey: chMeta.key,
@@ -223,7 +223,10 @@ export class StreamMultiChannelLog
       evicted += cutoff;
     }
     if (this.entries.length > MAX_ENTRIES) {
-      const excess = this.entries.length - MAX_ENTRIES;
+      let excess = this.entries.length - MAX_ENTRIES;
+      // Skip leading continuations so the new head isn't an orphan.
+      while (excess < this.entries.length && this.entries[excess].continuation)
+        excess++;
       this.entries.splice(0, excess);
       evicted += excess;
     }

--- a/pluto/src/log/aether/telem/sources.ts
+++ b/pluto/src/log/aether/telem/sources.ts
@@ -146,15 +146,26 @@ export class StreamMultiChannelLog
         for (const [key, chMeta] of this.channelMeta) {
           const allocated = res.get(key);
           const isJSON = chMeta.dataType.equals(DataType.JSON);
+          const isString = chMeta.dataType.equals(DataType.STRING);
           const pushSamples = (buf: Series, start: number): void => {
             for (let i = start; i < buf.length; i++) {
-              const raw = buf.at(i, true);
-              this.entries.push({
-                channelKey: chMeta.key,
-                timestamp: now,
-                value: isJSON ? JSON.stringify(raw) : String(raw),
-              });
-              pushed++;
+              const value = isJSON
+                ? JSON.stringify(buf.at(i, true))
+                : String(buf.at(i, true));
+              if (!isString || !value.includes("\n")) {
+                this.entries.push({ channelKey: chMeta.key, timestamp: now, value });
+                pushed++;
+                continue;
+              }
+              const lines = value.split("\n");
+              for (let j = 0; j < lines.length; j++)
+                this.entries.push({
+                  channelKey: chMeta.key,
+                  timestamp: now,
+                  value: lines[j],
+                  continuation: j > 0,
+                });
+              pushed += lines.length;
             }
           };
           if (allocated != null && allocated.series.length > 0) {

--- a/pluto/src/log/aether/telem/sources.ts
+++ b/pluto/src/log/aether/telem/sources.ts
@@ -57,6 +57,7 @@ export class StreamMultiChannelLog
   private readonly client: client.Client;
   private readonly onStatusChange?: status.Adder;
   private readonly now: () => TimeStamp;
+  private readonly maxEntries: number;
   private channelMeta: Map<channel.Key, ChannelMeta> = new Map();
   private entries: LogEntry[] = [];
   private stopStreaming?: destructor.Destructor;
@@ -74,11 +75,13 @@ export class StreamMultiChannelLog
     props: unknown,
     options?: CreateOptions,
     now: () => TimeStamp = () => TimeStamp.now(),
+    maxEntries: number = MAX_ENTRIES,
   ) {
     super(props);
     this.client = client;
     this.onStatusChange = options?.onStatusChange;
     this.now = now;
+    this.maxEntries = maxEntries;
     this._channels = this.props.channels.filter(
       (ch): ch is number => typeof ch === "number",
     );
@@ -222,8 +225,8 @@ export class StreamMultiChannelLog
       this.entries.splice(0, cutoff);
       evicted += cutoff;
     }
-    if (this.entries.length > MAX_ENTRIES) {
-      let excess = this.entries.length - MAX_ENTRIES;
+    if (this.entries.length > this.maxEntries) {
+      let excess = this.entries.length - this.maxEntries;
       // Skip leading continuations so the new head isn't an orphan.
       while (excess < this.entries.length && this.entries[excess].continuation)
         excess++;

--- a/pluto/src/log/aether/telem/sources.ts
+++ b/pluto/src/log/aether/telem/sources.ts
@@ -148,13 +148,10 @@ export class StreamMultiChannelLog
         let pushed = 0;
         for (const [key, chMeta] of this.channelMeta) {
           const allocated = res.get(key);
-          const isJSON = chMeta.dataType.equals(DataType.JSON);
           const isString = chMeta.dataType.equals(DataType.STRING);
           const pushSamples = (buf: Series, start: number): void => {
             for (let i = start; i < buf.length; i++) {
-              const value = isJSON
-                ? JSON.stringify(buf.at(i, true))
-                : String(buf.at(i, true));
+              const value = buf.asString(i, true);
               if (!isString || !value.includes("\n")) {
                 this.entries.push({ channelKey: chMeta.key, timestamp: now, value });
                 pushed++;

--- a/pluto/src/log/aether/telem/types.ts
+++ b/pluto/src/log/aether/telem/types.ts
@@ -16,6 +16,8 @@ export interface LogEntry {
   channelKey: channel.Key;
   timestamp: TimeStamp;
   value: string;
+  // True when this entry was produced by splitting a sample on \n;
+  continuation?: boolean;
 }
 
 export interface LogSource extends Source<LogEntry[]> {

--- a/x/ts/src/telem/series.spec.ts
+++ b/x/ts/src/telem/series.spec.ts
@@ -369,6 +369,56 @@ describe("Series", () => {
     });
   });
 
+  describe("asString", () => {
+    it("should return the string value for a string series", () => {
+      const series = new Series({
+        data: ["apple", "banana"],
+        dataType: DataType.STRING,
+      });
+      expect(series.asString(0, true)).toEqual("apple");
+      expect(series.asString(1, true)).toEqual("banana");
+    });
+
+    it("should return the raw JSON string without parsing for a JSON series", () => {
+      const series = new Series({
+        data: [{ a_b: 1, c_d: "apple" }],
+        dataType: DataType.JSON,
+      });
+      const result = series.asString(0, true);
+      expect(result).toEqual('{"a_b":1,"c_d":"apple"}');
+    });
+
+    it("should return a string representation for a numeric series", () => {
+      const series = new Series({
+        data: new Float32Array([3.5, 7]),
+        dataType: DataType.FLOAT32,
+      });
+      expect(series.asString(0, true)).toEqual("3.5");
+      expect(series.asString(1, true)).toEqual("7");
+    });
+
+    it("should return undefined when index is out of bounds", () => {
+      const series = new Series({
+        data: ["apple"],
+        dataType: DataType.STRING,
+      });
+      expect(series.asString(5)).toBeUndefined();
+    });
+
+    it("should throw when index is out of bounds and required is true", () => {
+      const series = new Series({
+        data: ["apple"],
+        dataType: DataType.STRING,
+      });
+      expect(() => series.asString(5, true)).toThrow();
+    });
+
+    it("should return the UUID string for a UUID series", () => {
+      const series = new Series({ data: SAMPLE_UUID_BYTES, dataType: DataType.UUID });
+      expect(series.asString(0, true)).toEqual("123e4567-e89b-40d3-8056-426614174000");
+    });
+  });
+
   describe("atAlignment", () => {
     it("should return the value at a particular alignment", () => {
       const series = new Series({

--- a/x/ts/src/telem/series.spec.ts
+++ b/x/ts/src/telem/series.spec.ts
@@ -388,6 +388,33 @@ describe("Series", () => {
       expect(result).toEqual('{"a_b":1,"c_d":"apple"}');
     });
 
+    it("should preserve raw snake_case keys while at() converts them to camelCase", () => {
+      const series = new Series({
+        data: [{ user_id: 1, first_name: "alice" }],
+        dataType: DataType.JSON,
+      });
+      expect(series.asString(0, true)).toEqual('{"user_id":1,"first_name":"alice"}');
+      expect(series.at(0, true)).toEqual({ userId: 1, firstName: "alice" });
+    });
+
+    it("should decode UTF-8 bytes for a BYTES series", () => {
+      const payload = new TextEncoder().encode("hello world");
+      const buf = new ArrayBuffer(4 + payload.byteLength);
+      new DataView(buf).setUint32(0, payload.byteLength, true);
+      new Uint8Array(buf).set(payload, 4);
+      const series = new Series({ data: buf, dataType: DataType.BYTES });
+      expect(series.asString(0, true)).toEqual("hello world");
+    });
+
+    it("should emit the U+FFFD replacement character for invalid UTF-8 in a BYTES series", () => {
+      const payload = new Uint8Array([0xff, 0xfe]);
+      const buf = new ArrayBuffer(4 + payload.byteLength);
+      new DataView(buf).setUint32(0, payload.byteLength, true);
+      new Uint8Array(buf).set(payload, 4);
+      const series = new Series({ data: buf, dataType: DataType.BYTES });
+      expect(series.asString(0, true)).toEqual("��");
+    });
+
     it("should return a string representation for a numeric series", () => {
       const series = new Series({
         data: new Float32Array([3.5, 7]),

--- a/x/ts/src/telem/series.ts
+++ b/x/ts/src/telem/series.ts
@@ -809,7 +809,24 @@ export class Series<T extends TelemValue = TelemValue>
     return uuidString;
   }
 
-  private atVariable(index: number, required: boolean): T | undefined {
+  asString(index: number, required: true): string;
+
+  asString(index: number, required?: false): string | undefined;
+
+  asString(index: number, required: boolean = false): string | undefined {
+    if (this.dataType.isVariable)
+      return this.atVariable(index, required, true) as string | undefined;
+    if (this.dataType.equals(DataType.UUID)) return this.atUUID(index, required);
+    const v = this.at(index, required as true);
+    if (v == null) return undefined;
+    return String(v);
+  }
+
+  private atVariable(
+    index: number,
+    required: boolean,
+    asString: boolean = false,
+  ): T | undefined {
     let start = 0;
     let len = 0;
     const buf = this.buffer;
@@ -845,9 +862,9 @@ export class Series<T extends TelemValue = TelemValue>
       }
     }
     const slice = new Uint8Array(buf, start, len);
-    if (this.dataType.equals(DataType.STRING))
-      return new TextDecoder().decode(slice) as T;
-    return caseconv.snakeToCamel(JSON.parse(new TextDecoder().decode(slice))) as T;
+    const str = new TextDecoder().decode(slice);
+    if (asString || this.dataType.equals(DataType.STRING)) return str as T;
+    return caseconv.snakeToCamel(JSON.parse(str)) as T;
   }
 
   /**

--- a/x/ts/src/telem/series.ts
+++ b/x/ts/src/telem/series.ts
@@ -777,7 +777,12 @@ export class Series<T extends TelemValue = TelemValue>
   at(index: number, required?: false): T | undefined;
 
   at(index: number, required: boolean = false): T | undefined {
-    if (this.dataType.isVariable) return this.atVariable(index, required ?? false);
+    if (this.dataType.isVariable) {
+      const str = this.atVariable(index, required);
+      if (str == null) return undefined;
+      if (this.dataType.equals(DataType.STRING)) return str as T;
+      return caseconv.snakeToCamel(JSON.parse(str)) as T;
+    }
     if (this.dataType.equals(DataType.UUID)) return this.atUUID(index, required) as T;
     if (index < 0) index = this.length + index;
     const v = this.data[index];
@@ -814,19 +819,14 @@ export class Series<T extends TelemValue = TelemValue>
   asString(index: number, required?: false): string | undefined;
 
   asString(index: number, required: boolean = false): string | undefined {
-    if (this.dataType.isVariable)
-      return this.atVariable(index, required, true) as string | undefined;
+    if (this.dataType.isVariable) return this.atVariable(index, required);
     if (this.dataType.equals(DataType.UUID)) return this.atUUID(index, required);
     const v = this.at(index, required as true);
     if (v == null) return undefined;
     return String(v);
   }
 
-  private atVariable(
-    index: number,
-    required: boolean,
-    asString: boolean = false,
-  ): T | undefined {
+  private atVariable(index: number, required: boolean): string | undefined {
     let start = 0;
     let len = 0;
     const buf = this.buffer;
@@ -862,9 +862,7 @@ export class Series<T extends TelemValue = TelemValue>
       }
     }
     const slice = new Uint8Array(buf, start, len);
-    const str = new TextDecoder().decode(slice);
-    if (asString || this.dataType.equals(DataType.STRING)) return str as T;
-    return caseconv.snakeToCamel(JSON.parse(str)) as T;
+    return new TextDecoder().decode(slice);
   }
 
   /**


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4155](https://linear.app/synnax/issue/SY-4155/render-line-breaks-in-logs)

## Description

`\n` in a log channel's string value did not produce a visible line break in the Console.

Canvas2D `fillText` renders `\n` as an unknown glyph. Fixed in the log telem source by splitting each string sample on `\n` and pushing one `LogEntry` per piece, leaving the renderer's "one entry = one line" invariant intact. Continuation entries drop the `timestamp`/`[name]` prefix but keep its width as whitespace so values stay column-aligned. Numeric and JSON channels take a single-push fast path with no split.

JSON log entries now display raw stored keys (`user_id`) instead of the previous JS-transformed camelCase (`userId`)

<img width="1176" height="507" alt="image" src="https://github.com/user-attachments/assets/7847aa03-b651-4985-bd72-88b4b573cf2e" />


## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes `
` characters in log channel string values not rendering as visible line breaks in the Console. The approach splits each STRING sample on `/
?
/` at the telem source layer, pushing one `LogEntry` per segment with continuation entries carrying a whitespace-only prefix to preserve column alignment.

- **`asString()` on `Series`** — new method returning raw stored bytes without camelCase conversion, giving JSON log entries their original `snake_case` keys.
- **GC orphan fix in `gcEntries`** — MAX_ENTRIES eviction now advances past leading continuation entries before splicing so the log head is always a non-orphan line.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all three previously flagged concerns are addressed with tests and the atVariable refactor preserves at() behavior.

The split logic lives entirely in the telem source layer, the renderer needs only a one-line guard, and time-based GC cannot produce orphan continuations because all segments of a multi-line sample share the same timestamp.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| pluto/src/log/aether/telem/sources.ts | Core fix: STRING samples split on /\r?\n/ pushed as continuation entries; MAX_ENTRIES GC advances past orphaned continuations before splicing. |
| x/ts/src/telem/series.ts | Adds asString() returning raw bytes; refactors atVariable() to string | undefined with type branching moved to at(). |
| pluto/src/log/aether/Log.ts | Continuation entries get whitespace-only prefix matching the normal prefix length for column alignment. |
| pluto/src/log/aether/telem/types.ts | Adds optional continuation?: boolean to LogEntry; backward-compatible. |
| pluto/src/log/aether/telem/sources.spec.ts | Covers \n, \r\n, consecutive newlines, no-split fast paths, and MAX_ENTRIES orphan eviction edge case. |
| x/ts/src/telem/series.spec.ts | asString suite covering STRING, JSON raw keys, BYTES, numeric, UUID, and out-of-bounds cases. |
| pluto/src/log/aether/Log.spec.ts | Six renderer tests for continuation alignment across prefix combinations, multi-group, and interleaved channels. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `pluto/src/log/aether/telem/sources.ts`, line 225-228 ([link](https://github.com/synnaxlabs/synnax/blob/203a7f3894cfe9a7f7d75782e02ed619950d6851/pluto/src/log/aether/telem/sources.ts#L225-L228)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **MAX_ENTRIES GC can leave orphaned continuation entries**

   `gcEntries` evicts entries with a blind `splice(0, excess)` when the array exceeds `MAX_ENTRIES` (100 000). That cut is agnostic to the `continuation` flag, so if the eviction boundary falls mid-group (e.g. the first non-continuation entry of a multi-line sample is removed but its continuation siblings are not), the surviving continuation entries become the new head of `this.entries`. They render with a whitespace-only prefix and no label or timestamp, making the top of the log appear to start in the middle of a sentence with no attribution.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (7): Last reviewed commit: ["SY-4155: tests"](https://github.com/synnaxlabs/synnax/commit/5f5912411ad4c82c62dcda30dc9f6396b170e994) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31135293)</sub>

<!-- /greptile_comment -->