### PR TITLE
SY-4164: Use Key Aliases Instead of Primitive Types in Core

### DIFF
--- a/client/cpp/device/json.gen.h
+++ b/client/cpp/device/json.gen.h
@@ -24,7 +24,7 @@ namespace synnax::device {
 inline StatusDetails StatusDetails::parse(x::json::Parser parser) {
     return StatusDetails{
         .rack = parser.field<::synnax::rack::Key>("rack"),
-        .device = parser.field<std::string>("device"),
+        .device = parser.field<Key>("device"),
     };
 }
 

--- a/client/cpp/device/types.gen.h
+++ b/client/cpp/device/types.gen.h
@@ -36,7 +36,7 @@ struct StatusDetails {
     /// @brief rack is the key of the rack this device belongs to.
     ::synnax::rack::Key rack = 0;
     /// @brief device is the device identifier.
-    std::string device;
+    Key device;
 
     static StatusDetails parse(x::json::Parser parser);
     [[nodiscard]] x::json::json to_json() const;

--- a/client/py/synnax/device/types_gen.py
+++ b/client/py/synnax/device/types_gen.py
@@ -32,7 +32,7 @@ class StatusDetails(BaseModel):
     """
 
     rack: rack_.Key = Field(ge=0, le=4294967295)
-    device: str
+    device: Key
 
 
 Status: TypeAlias = status_.Status[StatusDetails]

--- a/client/ts/src/device/types.gen.ts
+++ b/client/ts/src/device/types.gen.ts
@@ -15,17 +15,17 @@ import { z } from "zod";
 import { ontology } from "@/ontology";
 import { rack } from "@/rack";
 
+export const keyZ = z.string();
+export type Key = z.infer<typeof keyZ>;
+
 /** StatusDetails contains device-specific status details identifying the device and its associated rack. */
 export const statusDetailsZ = z.object({
   /** rack is the key of the rack this device belongs to. */
   rack: rack.keyZ,
   /** device is the device identifier. */
-  device: z.string(),
+  device: keyZ,
 });
 export interface StatusDetails extends z.infer<typeof statusDetailsZ> {}
-
-export const keyZ = z.string();
-export type Key = z.infer<typeof keyZ>;
 
 export const statusZ = status.statusZ({ details: statusDetailsZ });
 export type Status = z.infer<typeof statusZ>;

--- a/client/ts/src/workspace/types.gen.ts
+++ b/client/ts/src/workspace/types.gen.ts
@@ -13,6 +13,7 @@ import { caseconv, record } from "@synnaxlabs/x";
 import { z } from "zod";
 
 import { ontology } from "@/ontology";
+import { user } from "@/user";
 
 export const keyZ = z.uuid();
 export type Key = z.infer<typeof keyZ>;
@@ -28,7 +29,7 @@ export const workspaceZ = z.object({
   /** name is a human-readable name for the workspace. */
   name: z.string().min(1, "Name is required"),
   /** author is the UUID of the user who created this workspace. */
-  author: z.uuid().optional(),
+  author: user.keyZ.optional(),
   /**
    * layout is the mosaic tree structure that defines how visualizations are
    * arranged. Contains tab layout, split configurations, and window

--- a/core/pkg/api/access/access.go
+++ b/core/pkg/api/access/access.go
@@ -82,7 +82,7 @@ func (s *Service) CreatePolicy(
 type RetrievePolicyRequest struct {
 	Internal *bool         `json:"internal" msgpack:"internal"`
 	Subjects []ontology.ID `json:"subjects" msgpack:"subjects"`
-	Keys     []uuid.UUID   `json:"keys" msgpack:"keys"`
+	Keys     []policy.Key  `json:"keys" msgpack:"keys"`
 	Limit    int           `json:"limit" msgpack:"limit"`
 	Offset   int           `json:"offset" msgpack:"offset"`
 }
@@ -131,7 +131,7 @@ func (s *Service) RetrievePolicy(
 }
 
 type DeletePolicyRequest struct {
-	Keys []uuid.UUID `json:"keys" msgpack:"keys"`
+	Keys []policy.Key `json:"keys" msgpack:"keys"`
 }
 
 func (s *Service) DeletePolicy(ctx context.Context, req DeletePolicyRequest) (types.Nil, error) {
@@ -189,10 +189,10 @@ func (s *Service) CreateRole(
 
 type (
 	RetrieveRoleRequest struct {
-		Internal *bool       `json:"internal" msgpack:"internal"`
-		Keys     []uuid.UUID `json:"keys" msgpack:"keys"`
-		Limit    int         `json:"limit" msgpack:"limit"`
-		Offset   int         `json:"offset" msgpack:"offset"`
+		Internal *bool      `json:"internal" msgpack:"internal"`
+		Keys     []role.Key `json:"keys" msgpack:"keys"`
+		Limit    int        `json:"limit" msgpack:"limit"`
+		Offset   int        `json:"offset" msgpack:"offset"`
 	}
 	RetrieveRoleResponse struct {
 		Roles []role.Role `json:"roles" msgpack:"roles"`
@@ -232,7 +232,7 @@ func (s *Service) RetrieveRole(
 }
 
 type DeleteRoleRequest struct {
-	Keys []uuid.UUID `json:"keys" msgpack:"keys"`
+	Keys []role.Key `json:"keys" msgpack:"keys"`
 }
 
 func (s *Service) DeleteRole(ctx context.Context, req DeleteRoleRequest) (types.Nil, error) {
@@ -259,8 +259,8 @@ func (s *Service) DeleteRole(ctx context.Context, req DeleteRoleRequest) (types.
 }
 
 type AssignRoleRequest struct {
-	User uuid.UUID `json:"user" msgpack:"user"`
-	Role uuid.UUID `json:"role" msgpack:"role"`
+	User user.Key `json:"user" msgpack:"user"`
+	Role role.Key `json:"role" msgpack:"role"`
 }
 
 func (s *Service) AssignRole(
@@ -281,8 +281,8 @@ func (s *Service) AssignRole(
 }
 
 type UnassignRoleRequest struct {
-	User uuid.UUID `json:"user" msgpack:"user"`
-	Role uuid.UUID `json:"role" msgpack:"role"`
+	User user.Key `json:"user" msgpack:"user"`
+	Role role.Key `json:"role" msgpack:"role"`
 }
 
 func (s *Service) UnassignRole(ctx context.Context, req UnassignRoleRequest) (types.Nil, error) {

--- a/core/pkg/api/arc/arc.go
+++ b/core/pkg/api/arc/arc.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"go/types"
 
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/alamos"
 	"github.com/synnaxlabs/arc/compiler"
 	arctransport "github.com/synnaxlabs/arc/lsp/transport"
@@ -82,7 +81,7 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (res CreateResp
 }
 
 type DeleteRequest struct {
-	Keys []uuid.UUID `json:"keys" msgpack:"keys"`
+	Keys []arc.Key `json:"keys" msgpack:"keys"`
 }
 
 func (s *Service) Delete(ctx context.Context, req DeleteRequest) (res types.Nil, err error) {
@@ -100,13 +99,13 @@ func (s *Service) Delete(ctx context.Context, req DeleteRequest) (res types.Nil,
 
 type (
 	RetrieveRequest struct {
-		SearchTerm    string      `json:"search_term" msgpack:"search_term"`
-		Keys          []uuid.UUID `json:"keys" msgpack:"keys"`
-		Names         []string    `json:"names" msgpack:"names"`
-		Limit         int         `json:"limit" msgpack:"limit"`
-		Offset        int         `json:"offset" msgpack:"offset"`
-		IncludeStatus bool        `json:"include_status" msgpack:"include_status"`
-		Compile       bool        `json:"compile" msgpack:"compile"`
+		SearchTerm    string    `json:"search_term" msgpack:"search_term"`
+		Keys          []arc.Key `json:"keys" msgpack:"keys"`
+		Names         []string  `json:"names" msgpack:"names"`
+		Limit         int       `json:"limit" msgpack:"limit"`
+		Offset        int       `json:"offset" msgpack:"offset"`
+		IncludeStatus bool      `json:"include_status" msgpack:"include_status"`
+		Compile       bool      `json:"compile" msgpack:"compile"`
 	}
 	RetrieveResponse struct {
 		Arcs []Arc `json:"arcs" msgpack:"arcs"`

--- a/core/pkg/api/channel/channel.go
+++ b/core/pkg/api/channel/channel.go
@@ -139,7 +139,7 @@ type RetrieveRequest struct {
 	// Name.
 	NodeKey node.Key `json:"node_key" msgpack:"node_key"`
 	// RangeKey is used for fetching aliases.
-	RangeKey uuid.UUID `json:"range_key" msgpack:"range_key"`
+	RangeKey ranger.Key `json:"range_key" msgpack:"range_key"`
 }
 
 // RetrieveResponse is the response for a RetrieveRequest.

--- a/core/pkg/api/device/device.go
+++ b/core/pkg/api/device/device.go
@@ -82,18 +82,18 @@ func (s *Service) Create(
 }
 
 type RetrieveRequest struct {
-	SearchTerm     string     `json:"search_term" msgpack:"search_term"`
-	Keys           []string   `json:"keys" msgpack:"keys"`
-	Names          []string   `json:"names" msgpack:"names"`
-	Makes          []string   `json:"makes" msgpack:"makes"`
-	Models         []string   `json:"models" msgpack:"models"`
-	Locations      []string   `json:"locations" msgpack:"locations"`
-	Racks          []rack.Key `json:"racks" msgpack:"racks"`
-	Limit          int        `json:"limit" msgpack:"limit"`
-	Offset         int        `json:"offset" msgpack:"offset"`
-	IgnoreNotFound bool       `json:"ignore_not_found" msgpack:"ignore_not_found"`
-	IncludeStatus  bool       `json:"include_status" msgpack:"include_status"`
-	IncludeParent  bool       `json:"include_parent" msgpack:"include_parent"`
+	SearchTerm     string       `json:"search_term" msgpack:"search_term"`
+	Keys           []device.Key `json:"keys" msgpack:"keys"`
+	Names          []string     `json:"names" msgpack:"names"`
+	Makes          []string     `json:"makes" msgpack:"makes"`
+	Models         []string     `json:"models" msgpack:"models"`
+	Locations      []string     `json:"locations" msgpack:"locations"`
+	Racks          []rack.Key   `json:"racks" msgpack:"racks"`
+	Limit          int          `json:"limit" msgpack:"limit"`
+	Offset         int          `json:"offset" msgpack:"offset"`
+	IgnoreNotFound bool         `json:"ignore_not_found" msgpack:"ignore_not_found"`
+	IncludeStatus  bool         `json:"include_status" msgpack:"include_status"`
+	IncludeParent  bool         `json:"include_parent" msgpack:"include_parent"`
 }
 
 type RetrieveResponse struct {
@@ -192,7 +192,7 @@ func (s *Service) Retrieve(
 }
 
 type DeleteRequest struct {
-	Keys []string `json:"keys" msgpack:"keys"`
+	Keys []device.Key `json:"keys" msgpack:"keys"`
 }
 
 func (s *Service) Delete(

--- a/core/pkg/api/group/group.go
+++ b/core/pkg/api/group/group.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"go/types"
 
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/synnax/pkg/api/auth"
 	"github.com/synnaxlabs/synnax/pkg/api/config"
 	"github.com/synnaxlabs/synnax/pkg/distribution/group"
@@ -46,7 +45,7 @@ type (
 	CreateRequest struct {
 		Parent ontology.ID `json:"parent" msgpack:"parent"`
 		Name   string      `json:"name" msgpack:"name" validate:"required"`
-		Key    uuid.UUID   `json:"key" msgpack:"key"`
+		Key    group.Key   `json:"key" msgpack:"key"`
 	}
 	CreateResponse struct {
 		Group group.Group `json:"group" msgpack:"group"`
@@ -80,7 +79,7 @@ func (s *Service) Create(
 }
 
 type DeleteRequest struct {
-	Keys []uuid.UUID `json:"keys" msgpack:"keys" validate:"required"`
+	Keys []group.Key `json:"keys" msgpack:"keys" validate:"required"`
 }
 
 func (s *Service) Delete(
@@ -101,7 +100,7 @@ func (s *Service) Delete(
 
 type RenameRequest struct {
 	Name string    `json:"name" msgpack:"name" validate:"required"`
-	Key  uuid.UUID `json:"key" msgpack:"key" validate:"required"`
+	Key  group.Key `json:"key" msgpack:"key" validate:"required"`
 }
 
 func (s *Service) Rename(

--- a/core/pkg/api/grpc/arc/handler.go
+++ b/core/pkg/api/grpc/arc/handler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/synnaxlabs/freighter/grpc"
 	"github.com/synnaxlabs/synnax/pkg/api"
 	apiarc "github.com/synnaxlabs/synnax/pkg/api/arc"
+	svcarc "github.com/synnaxlabs/synnax/pkg/service/arc"
 	"github.com/synnaxlabs/synnax/pkg/service/arc/pb"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
@@ -104,7 +105,7 @@ func (t retrieveRequestTranslator) Forward(
 	_ context.Context,
 	msg apiarc.RetrieveRequest,
 ) (*RetrieveRequest, error) {
-	keys := lo.Map(msg.Keys, func(k uuid.UUID, _ int) string { return k.String() })
+	keys := lo.Map(msg.Keys, func(k svcarc.Key, _ int) string { return k.String() })
 	return &RetrieveRequest{
 		Keys:          keys,
 		Names:         msg.Names,
@@ -120,7 +121,7 @@ func (t retrieveRequestTranslator) Backward(
 	_ context.Context,
 	msg *RetrieveRequest,
 ) (apiarc.RetrieveRequest, error) {
-	keys := make([]uuid.UUID, 0, len(msg.Keys))
+	keys := make([]svcarc.Key, 0, len(msg.Keys))
 	for _, keyStr := range msg.Keys {
 		key, err := uuid.Parse(keyStr)
 		if err != nil {
@@ -165,7 +166,7 @@ func (t deleteRequestTranslator) Forward(
 	_ context.Context,
 	msg apiarc.DeleteRequest,
 ) (*DeleteRequest, error) {
-	keys := lo.Map(msg.Keys, func(k uuid.UUID, _ int) string { return k.String() })
+	keys := lo.Map(msg.Keys, func(k svcarc.Key, _ int) string { return k.String() })
 	return &DeleteRequest{Keys: keys}, nil
 }
 
@@ -173,7 +174,7 @@ func (t deleteRequestTranslator) Backward(
 	_ context.Context,
 	msg *DeleteRequest,
 ) (apiarc.DeleteRequest, error) {
-	keys := make([]uuid.UUID, 0, len(msg.Keys))
+	keys := make([]svcarc.Key, 0, len(msg.Keys))
 	for _, keyStr := range msg.Keys {
 		key, err := uuid.Parse(keyStr)
 		if err != nil {

--- a/core/pkg/api/grpc/ranger/handler.go
+++ b/core/pkg/api/grpc/ranger/handler.go
@@ -18,6 +18,7 @@ import (
 	"github.com/synnaxlabs/synnax/pkg/api"
 	apiranger "github.com/synnaxlabs/synnax/pkg/api/ranger"
 	"github.com/synnaxlabs/synnax/pkg/api/ranger/pb"
+	"github.com/synnaxlabs/synnax/pkg/service/ranger"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
 
@@ -125,7 +126,7 @@ func (t retrieveRequestTranslator) Backward(
 	_ context.Context,
 	r *RetrieveRequest,
 ) (apiranger.RetrieveRequest, error) {
-	keys := make([]uuid.UUID, len(r.Keys))
+	keys := make([]ranger.Key, len(r.Keys))
 	for i := range r.Keys {
 		key, err := uuid.Parse(r.Keys[i])
 		if err != nil {
@@ -173,7 +174,7 @@ func (t deleteRequestTranslator) Backward(
 	_ context.Context,
 	r *DeleteRequest,
 ) (apiranger.DeleteRequest, error) {
-	keys := make([]uuid.UUID, len(r.Keys))
+	keys := make([]ranger.Key, len(r.Keys))
 	for i := range r.Keys {
 		key, err := uuid.Parse(r.Keys[i])
 		if err != nil {

--- a/core/pkg/api/grpc/view/handler.go
+++ b/core/pkg/api/grpc/view/handler.go
@@ -17,6 +17,7 @@ import (
 	"github.com/synnaxlabs/freighter/grpc"
 	"github.com/synnaxlabs/synnax/pkg/api"
 	"github.com/synnaxlabs/synnax/pkg/api/view"
+	svcview "github.com/synnaxlabs/synnax/pkg/service/view"
 	"github.com/synnaxlabs/synnax/pkg/service/view/pb"
 	"google.golang.org/protobuf/types/known/emptypb"
 )
@@ -105,7 +106,7 @@ func (retrieveRequestTranslator) Forward(_ context.Context, req view.RetrieveReq
 }
 
 func (retrieveRequestTranslator) Backward(_ context.Context, req *RetrieveRequest) (view.RetrieveRequest, error) {
-	keys := make([]uuid.UUID, len(req.Keys))
+	keys := make([]svcview.Key, len(req.Keys))
 	for i, k := range req.Keys {
 		parsed, err := uuid.Parse(k)
 		if err != nil {
@@ -147,7 +148,7 @@ func (deleteRequestTranslator) Forward(_ context.Context, req view.DeleteRequest
 }
 
 func (deleteRequestTranslator) Backward(_ context.Context, req *DeleteRequest) (view.DeleteRequest, error) {
-	keys := make([]uuid.UUID, len(req.Keys))
+	keys := make([]svcview.Key, len(req.Keys))
 	for i, k := range req.Keys {
 		parsed, err := uuid.Parse(k)
 		if err != nil {

--- a/core/pkg/api/lineplot/lineplot.go
+++ b/core/pkg/api/lineplot/lineplot.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"go/types"
 
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/synnax/pkg/api/auth"
 	"github.com/synnaxlabs/synnax/pkg/api/config"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
@@ -44,7 +43,7 @@ func NewService(cfgs ...config.LayerConfig) (*Service, error) {
 
 type CreateRequest struct {
 	LinePlots []lineplot.LinePlot `json:"line_plots" msgpack:"line_plots"`
-	Workspace uuid.UUID           `json:"workspace" msgpack:"workspace"`
+	Workspace lineplot.Key        `json:"workspace" msgpack:"workspace"`
 }
 
 type CreateResponse struct {
@@ -72,8 +71,8 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (res CreateResp
 }
 
 type RenameRequest struct {
-	Name string    `json:"name" msgpack:"name"`
-	Key  uuid.UUID `json:"key" msgpack:"key"`
+	Name string       `json:"name" msgpack:"name"`
+	Key  lineplot.Key `json:"key" msgpack:"key"`
 }
 
 func (s *Service) Rename(ctx context.Context, req RenameRequest) (res types.Nil, err error) {
@@ -91,7 +90,7 @@ func (s *Service) Rename(ctx context.Context, req RenameRequest) (res types.Nil,
 
 type SetDataRequest struct {
 	Data map[string]any `json:"data" msgpack:"data"`
-	Key  uuid.UUID      `json:"key" msgpack:"key"`
+	Key  lineplot.Key   `json:"key" msgpack:"key"`
 }
 
 func (s *Service) SetData(ctx context.Context, req SetDataRequest) (res types.Nil, err error) {
@@ -109,7 +108,7 @@ func (s *Service) SetData(ctx context.Context, req SetDataRequest) (res types.Ni
 
 type (
 	RetrieveRequest struct {
-		Keys []uuid.UUID `json:"keys" msgpack:"keys"`
+		Keys []lineplot.Key `json:"keys" msgpack:"keys"`
 	}
 	RetrieveResponse struct {
 		LinePlots []lineplot.LinePlot `json:"line_plots" msgpack:"line_plots"`
@@ -132,7 +131,7 @@ func (s *Service) Retrieve(ctx context.Context, req RetrieveRequest) (res Retrie
 }
 
 type DeleteRequest struct {
-	Keys []uuid.UUID `json:"keys" msgpack:"keys"`
+	Keys []lineplot.Key `json:"keys" msgpack:"keys"`
 }
 
 func (s *Service) Delete(ctx context.Context, req DeleteRequest) (res types.Nil, err error) {

--- a/core/pkg/api/lineplot/lineplot.go
+++ b/core/pkg/api/lineplot/lineplot.go
@@ -19,6 +19,7 @@ import (
 	"github.com/synnaxlabs/synnax/pkg/service/access"
 	"github.com/synnaxlabs/synnax/pkg/service/access/rbac"
 	"github.com/synnaxlabs/synnax/pkg/service/lineplot"
+	"github.com/synnaxlabs/synnax/pkg/service/workspace"
 	xconfig "github.com/synnaxlabs/x/config"
 	"github.com/synnaxlabs/x/gorp"
 )
@@ -43,7 +44,7 @@ func NewService(cfgs ...config.LayerConfig) (*Service, error) {
 
 type CreateRequest struct {
 	LinePlots []lineplot.LinePlot `json:"line_plots" msgpack:"line_plots"`
-	Workspace lineplot.Key        `json:"workspace" msgpack:"workspace"`
+	Workspace workspace.Key       `json:"workspace" msgpack:"workspace"`
 }
 
 type CreateResponse struct {

--- a/core/pkg/api/log/log.go
+++ b/core/pkg/api/log/log.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"go/types"
 
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/synnax/pkg/api/auth"
 	"github.com/synnaxlabs/synnax/pkg/api/config"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
@@ -45,7 +44,7 @@ func NewService(cfgs ...config.LayerConfig) (*Service, error) {
 type (
 	CreateRequest struct {
 		Logs      []log.Log `json:"logs" msgpack:"logs"`
-		Workspace uuid.UUID `json:"workspace" msgpack:"workspace"`
+		Workspace log.Key   `json:"workspace" msgpack:"workspace"`
 	}
 	CreateResponse struct {
 		Logs []log.Log `json:"logs" msgpack:"logs"`
@@ -73,8 +72,8 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (res CreateResp
 }
 
 type RenameRequest struct {
-	Name string    `json:"name" msgpack:"name"`
-	Key  uuid.UUID `json:"key" msgpack:"key"`
+	Name string  `json:"name" msgpack:"name"`
+	Key  log.Key `json:"key" msgpack:"key"`
 }
 
 func (s *Service) Rename(ctx context.Context, req RenameRequest) (res types.Nil, err error) {
@@ -92,7 +91,7 @@ func (s *Service) Rename(ctx context.Context, req RenameRequest) (res types.Nil,
 
 type SetDataRequest struct {
 	Data map[string]any `json:"data" msgpack:"data"`
-	Key  uuid.UUID      `json:"key" msgpack:"key"`
+	Key  log.Key        `json:"key" msgpack:"key"`
 }
 
 func (s *Service) SetData(ctx context.Context, req SetDataRequest) (res types.Nil, err error) {
@@ -110,7 +109,7 @@ func (s *Service) SetData(ctx context.Context, req SetDataRequest) (res types.Ni
 
 type (
 	RetrieveRequest struct {
-		Keys []uuid.UUID `json:"keys" msgpack:"keys"`
+		Keys []log.Key `json:"keys" msgpack:"keys"`
 	}
 	RetrieveResponse struct {
 		Logs []log.Log `json:"logs" msgpack:"logs"`
@@ -134,7 +133,7 @@ func (s *Service) Retrieve(ctx context.Context, req RetrieveRequest) (res Retrie
 }
 
 type DeleteRequest struct {
-	Keys []uuid.UUID `json:"keys" msgpack:"keys"`
+	Keys []log.Key `json:"keys" msgpack:"keys"`
 }
 
 func (s *Service) Delete(ctx context.Context, req DeleteRequest) (res types.Nil, err error) {

--- a/core/pkg/api/log/log.go
+++ b/core/pkg/api/log/log.go
@@ -19,6 +19,7 @@ import (
 	"github.com/synnaxlabs/synnax/pkg/service/access"
 	"github.com/synnaxlabs/synnax/pkg/service/access/rbac"
 	"github.com/synnaxlabs/synnax/pkg/service/log"
+	"github.com/synnaxlabs/synnax/pkg/service/workspace"
 	xconfig "github.com/synnaxlabs/x/config"
 	"github.com/synnaxlabs/x/gorp"
 )
@@ -43,8 +44,8 @@ func NewService(cfgs ...config.LayerConfig) (*Service, error) {
 
 type (
 	CreateRequest struct {
-		Logs      []log.Log `json:"logs" msgpack:"logs"`
-		Workspace log.Key   `json:"workspace" msgpack:"workspace"`
+		Logs      []log.Log     `json:"logs" msgpack:"logs"`
+		Workspace workspace.Key `json:"workspace" msgpack:"workspace"`
 	}
 	CreateResponse struct {
 		Logs []log.Log `json:"logs" msgpack:"logs"`

--- a/core/pkg/api/ranger/alias/alias.go
+++ b/core/pkg/api/ranger/alias/alias.go
@@ -13,13 +13,13 @@ import (
 	"context"
 	"go/types"
 
-	"github.com/google/uuid"
 	"github.com/samber/lo"
 	"github.com/synnaxlabs/synnax/pkg/api/auth"
 	"github.com/synnaxlabs/synnax/pkg/api/config"
 	"github.com/synnaxlabs/synnax/pkg/distribution/channel"
 	"github.com/synnaxlabs/synnax/pkg/service/access"
 	"github.com/synnaxlabs/synnax/pkg/service/access/rbac"
+	"github.com/synnaxlabs/synnax/pkg/service/ranger"
 	"github.com/synnaxlabs/synnax/pkg/service/ranger/alias"
 	xconfig "github.com/synnaxlabs/x/config"
 	"github.com/synnaxlabs/x/errors"
@@ -47,7 +47,7 @@ func NewService(cfgs ...config.LayerConfig) (*Service, error) {
 
 type SetRequest struct {
 	Aliases map[channel.Key]string `json:"aliases" msgpack:"aliases"`
-	Range   uuid.UUID              `json:"range" msgpack:"range"`
+	Range   ranger.Key             `json:"range" msgpack:"range"`
 }
 
 func (s *Service) Set(
@@ -75,8 +75,8 @@ func (s *Service) Set(
 
 type (
 	ResolveRequest struct {
-		Aliases []string  `json:"aliases" msgpack:"aliases"`
-		Range   uuid.UUID `json:"range" msgpack:"range"`
+		Aliases []string   `json:"aliases" msgpack:"aliases"`
+		Range   ranger.Key `json:"range" msgpack:"range"`
 	}
 	ResolveResponse struct {
 		Aliases map[string]channel.Key `json:"aliases" msgpack:"aliases"`
@@ -111,7 +111,7 @@ func (s *Service) Resolve(
 
 type DeleteRequest struct {
 	Channels []channel.Key `json:"channels" msgpack:"channels"`
-	Range    uuid.UUID     `json:"range" msgpack:"range"`
+	Range    ranger.Key    `json:"range" msgpack:"range"`
 }
 
 func (s *Service) Delete(
@@ -138,7 +138,7 @@ func (s *Service) Delete(
 
 type (
 	ListRequest struct {
-		Range uuid.UUID `json:"range" msgpack:"range"`
+		Range ranger.Key `json:"range" msgpack:"range"`
 	}
 	ListResponse struct {
 		Aliases map[channel.Key]string `json:"aliases" msgpack:"aliases"`
@@ -168,7 +168,7 @@ func (s *Service) List(
 type (
 	RetrieveRequest struct {
 		Channels []channel.Key `json:"channels" msgpack:"channels"`
-		Range    uuid.UUID     `json:"range" msgpack:"range"`
+		Range    ranger.Key    `json:"range" msgpack:"range"`
 	}
 	RetrieveResponse struct {
 		Aliases map[channel.Key]string `json:"aliases" msgpack:"aliases"`

--- a/core/pkg/api/ranger/kv/kv.go
+++ b/core/pkg/api/ranger/kv/kv.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"go/types"
 
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/synnax/pkg/api/auth"
 	"github.com/synnaxlabs/synnax/pkg/api/config"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
@@ -47,8 +46,8 @@ func NewService(cfgs ...config.LayerConfig) (*Service, error) {
 
 type (
 	GetRequest struct {
-		Keys  []string  `json:"keys" msgpack:"keys"`
-		Range uuid.UUID `json:"range" msgpack:"range"`
+		Keys  []string   `json:"keys" msgpack:"keys"`
+		Range ranger.Key `json:"range" msgpack:"range"`
 	}
 	GetResponse struct {
 		Pairs []kv.Pair `json:"pairs" msgpack:"pairs"`
@@ -86,8 +85,8 @@ func (s *Service) Get(
 }
 
 type SetRequest struct {
-	Pairs []kv.Pair `json:"pairs" msgpack:"pairs"`
-	Range uuid.UUID `json:"range" msgpack:"range"`
+	Pairs []kv.Pair  `json:"pairs" msgpack:"pairs"`
+	Range ranger.Key `json:"range" msgpack:"range"`
 }
 
 func (s *Service) Set(
@@ -108,8 +107,8 @@ func (s *Service) Set(
 }
 
 type DeleteRequest struct {
-	Keys  []string  `json:"keys" msgpack:"keys"`
-	Range uuid.UUID `json:"range" msgpack:"range"`
+	Keys  []string   `json:"keys" msgpack:"keys"`
+	Range ranger.Key `json:"range" msgpack:"range"`
 }
 
 func (s *Service) Delete(

--- a/core/pkg/api/ranger/ranger.go
+++ b/core/pkg/api/ranger/ranger.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"go/types"
 
-	"github.com/google/uuid"
 	"github.com/samber/lo"
 	"github.com/synnaxlabs/synnax/pkg/api/auth"
 	"github.com/synnaxlabs/synnax/pkg/api/config"
@@ -114,7 +113,7 @@ func (s *Service) Create(
 
 type (
 	RetrieveRequest struct {
-		Keys          []uuid.UUID     `json:"keys" msgpack:"keys"`
+		Keys          []ranger.Key    `json:"keys" msgpack:"keys"`
 		Names         []string        `json:"names" msgpack:"names"`
 		SearchTerm    string          `json:"search_term" msgpack:"search_term"`
 		HasLabels     []label.Key     `json:"has_labels" msgpack:"has_labels"`
@@ -204,8 +203,8 @@ func (s *Service) Retrieve(
 }
 
 type RenameRequest struct {
-	Name string    `json:"name" msgpack:"name"`
-	Key  uuid.UUID `json:"key" msgpack:"key"`
+	Name string     `json:"name" msgpack:"name"`
+	Key  ranger.Key `json:"key" msgpack:"key"`
 }
 
 func (s *Service) Rename(
@@ -225,7 +224,7 @@ func (s *Service) Rename(
 }
 
 type DeleteRequest struct {
-	Keys []uuid.UUID `json:"keys" msgpack:"keys"`
+	Keys []ranger.Key `json:"keys" msgpack:"keys"`
 }
 
 func (s *Service) Delete(

--- a/core/pkg/api/schematic/schematic.go
+++ b/core/pkg/api/schematic/schematic.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"go/types"
 
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/synnax/pkg/api/auth"
 	"github.com/synnaxlabs/synnax/pkg/api/config"
 	"github.com/synnaxlabs/synnax/pkg/distribution/group"
@@ -22,6 +21,7 @@ import (
 	"github.com/synnaxlabs/synnax/pkg/service/access/rbac"
 	"github.com/synnaxlabs/synnax/pkg/service/schematic"
 	"github.com/synnaxlabs/synnax/pkg/service/schematic/symbol"
+	"github.com/synnaxlabs/synnax/pkg/service/workspace"
 	xconfig "github.com/synnaxlabs/x/config"
 	"github.com/synnaxlabs/x/gorp"
 )
@@ -47,7 +47,7 @@ func NewService(cfgs ...config.LayerConfig) (*Service, error) {
 type (
 	CreateRequest struct {
 		Schematics []schematic.Schematic `json:"schematics" msgpack:"schematics"`
-		Workspace  uuid.UUID             `json:"workspace" msgpack:"workspace"`
+		Workspace  workspace.Key         `json:"workspace" msgpack:"workspace"`
 	}
 	CreateResponse struct {
 		Schematics []schematic.Schematic `json:"schematics" msgpack:"schematics"`
@@ -75,8 +75,8 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (res CreateResp
 }
 
 type RenameRequest struct {
-	Name string    `json:"name" msgpack:"name"`
-	Key  uuid.UUID `json:"key" msgpack:"key"`
+	Name string        `json:"name" msgpack:"name"`
+	Key  schematic.Key `json:"key" msgpack:"key"`
 }
 
 func (s *Service) Rename(ctx context.Context, req RenameRequest) (res types.Nil, err error) {
@@ -94,7 +94,7 @@ func (s *Service) Rename(ctx context.Context, req RenameRequest) (res types.Nil,
 
 type SetDataRequest struct {
 	Data schematic.Schematic `json:"data" msgpack:"data"`
-	Key  uuid.UUID           `json:"key" msgpack:"key"`
+	Key  schematic.Key       `json:"key" msgpack:"key"`
 }
 
 func (s *Service) SetData(ctx context.Context, req SetDataRequest) (res types.Nil, err error) {
@@ -114,7 +114,7 @@ func (s *Service) SetData(ctx context.Context, req SetDataRequest) (res types.Ni
 // SessionKey identifies the originating client so cluster broadcasts can be
 // deduplicated against the local optimistic update.
 type DispatchRequest struct {
-	Key        uuid.UUID          `json:"key" msgpack:"key"`
+	Key        schematic.Key      `json:"key" msgpack:"key"`
 	SessionKey string             `json:"session_key" msgpack:"session_key"`
 	Actions    []schematic.Action `json:"actions" msgpack:"actions"`
 }
@@ -137,7 +137,7 @@ func (s *Service) Dispatch(ctx context.Context, req DispatchRequest) (res types.
 
 type (
 	RetrieveRequest struct {
-		Keys []uuid.UUID `json:"keys" msgpack:"keys"`
+		Keys []schematic.Key `json:"keys" msgpack:"keys"`
 	}
 	RetrieveResponse struct {
 		Schematics []schematic.Schematic `json:"schematics" msgpack:"schematics"`
@@ -161,7 +161,7 @@ func (s *Service) Retrieve(ctx context.Context, req RetrieveRequest) (res Retrie
 }
 
 type DeleteRequest struct {
-	Keys []uuid.UUID `json:"keys" msgpack:"keys"`
+	Keys []schematic.Key `json:"keys" msgpack:"keys"`
 }
 
 func (s *Service) Delete(ctx context.Context, req DeleteRequest) (res types.Nil, err error) {
@@ -179,9 +179,9 @@ func (s *Service) Delete(ctx context.Context, req DeleteRequest) (res types.Nil,
 
 type (
 	CopyRequest struct {
-		Name     string    `json:"name" msgpack:"name"`
-		Key      uuid.UUID `json:"key" msgpack:"key"`
-		Snapshot bool      `json:"snapshot" msgpack:"snapshot"`
+		Name     string        `json:"name" msgpack:"name"`
+		Key      schematic.Key `json:"key" msgpack:"key"`
+		Snapshot bool          `json:"snapshot" msgpack:"snapshot"`
 	}
 	CopyResponse struct {
 		Schematic schematic.Schematic `json:"schematic" msgpack:"schematic"`
@@ -244,8 +244,8 @@ func (s *Service) CreateSymbol(ctx context.Context, req CreateSymbolRequest) (re
 
 type (
 	RetrieveSymbolRequest struct {
-		SearchTerm string      `json:"search_term" msgpack:"search_term"`
-		Keys       []uuid.UUID `json:"keys" msgpack:"keys"`
+		SearchTerm string          `json:"search_term" msgpack:"search_term"`
+		Keys       []schematic.Key `json:"keys" msgpack:"keys"`
 	}
 	RetrieveSymbolResponse struct {
 		Symbols []symbol.Symbol `json:"symbols" msgpack:"symbols"`
@@ -275,8 +275,8 @@ func (s *Service) RetrieveSymbol(ctx context.Context, req RetrieveSymbolRequest)
 }
 
 type RenameSymbolRequest struct {
-	Name string    `json:"name" msgpack:"name"`
-	Key  uuid.UUID `json:"key" msgpack:"key"`
+	Name string        `json:"name" msgpack:"name"`
+	Key  schematic.Key `json:"key" msgpack:"key"`
 }
 
 func (s *Service) RenameSymbol(ctx context.Context, req RenameSymbolRequest) (res types.Nil, err error) {
@@ -293,7 +293,7 @@ func (s *Service) RenameSymbol(ctx context.Context, req RenameSymbolRequest) (re
 }
 
 type DeleteSymbolRequest struct {
-	Keys []uuid.UUID `json:"keys" msgpack:"keys"`
+	Keys []schematic.Key `json:"keys" msgpack:"keys"`
 }
 
 func (s *Service) DeleteSymbol(ctx context.Context, req DeleteSymbolRequest) (res types.Nil, err error) {

--- a/core/pkg/api/table/table.go
+++ b/core/pkg/api/table/table.go
@@ -19,6 +19,7 @@ import (
 	"github.com/synnaxlabs/synnax/pkg/service/access"
 	"github.com/synnaxlabs/synnax/pkg/service/access/rbac"
 	"github.com/synnaxlabs/synnax/pkg/service/table"
+	"github.com/synnaxlabs/synnax/pkg/service/workspace"
 	xconfig "github.com/synnaxlabs/x/config"
 	"github.com/synnaxlabs/x/gorp"
 )
@@ -44,7 +45,7 @@ func NewService(cfgs ...config.LayerConfig) (*Service, error) {
 type (
 	CreateRequest struct {
 		Tables    []table.Table `json:"tables" msgpack:"tables"`
-		Workspace table.Key     `json:"workspace" msgpack:"workspace"`
+		Workspace workspace.Key `json:"workspace" msgpack:"workspace"`
 	}
 	CreateResponse struct {
 		Tables []table.Table `json:"tables" msgpack:"tables"`

--- a/core/pkg/api/table/table.go
+++ b/core/pkg/api/table/table.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"go/types"
 
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/synnax/pkg/api/auth"
 	"github.com/synnaxlabs/synnax/pkg/api/config"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
@@ -45,7 +44,7 @@ func NewService(cfgs ...config.LayerConfig) (*Service, error) {
 type (
 	CreateRequest struct {
 		Tables    []table.Table `json:"tables" msgpack:"tables"`
-		Workspace uuid.UUID     `json:"workspace" msgpack:"workspace"`
+		Workspace table.Key     `json:"workspace" msgpack:"workspace"`
 	}
 	CreateResponse struct {
 		Tables []table.Table `json:"tables" msgpack:"tables"`
@@ -74,7 +73,7 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (res CreateResp
 
 type RenameRequest struct {
 	Name string    `json:"name" msgpack:"name"`
-	Key  uuid.UUID `json:"key" msgpack:"key"`
+	Key  table.Key `json:"key" msgpack:"key"`
 }
 
 func (s *Service) Rename(ctx context.Context, req RenameRequest) (res types.Nil, err error) {
@@ -92,7 +91,7 @@ func (s *Service) Rename(ctx context.Context, req RenameRequest) (res types.Nil,
 
 type SetDataRequest struct {
 	Data map[string]any `json:"data" msgpack:"data"`
-	Key  uuid.UUID      `json:"key" msgpack:"key"`
+	Key  table.Key      `json:"key" msgpack:"key"`
 }
 
 func (s *Service) SetData(ctx context.Context, req SetDataRequest) (res types.Nil, err error) {
@@ -110,7 +109,7 @@ func (s *Service) SetData(ctx context.Context, req SetDataRequest) (res types.Ni
 
 type (
 	RetrieveRequest struct {
-		Keys []uuid.UUID `json:"keys" msgpack:"keys"`
+		Keys []table.Key `json:"keys" msgpack:"keys"`
 	}
 	RetrieveResponse struct {
 		Tables []table.Table `json:"tables" msgpack:"tables"`
@@ -134,7 +133,7 @@ func (s *Service) Retrieve(ctx context.Context, req RetrieveRequest) (res Retrie
 }
 
 type DeleteRequest struct {
-	Keys []uuid.UUID `json:"keys" msgpack:"keys"`
+	Keys []table.Key `json:"keys" msgpack:"keys"`
 }
 
 func (s *Service) Delete(ctx context.Context, req DeleteRequest) (res types.Nil, err error) {

--- a/core/pkg/api/user/user.go
+++ b/core/pkg/api/user/user.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"go/types"
 
-	"github.com/google/uuid"
 	"github.com/samber/lo"
 	"github.com/synnaxlabs/synnax/pkg/api/auth"
 	"github.com/synnaxlabs/synnax/pkg/api/config"
@@ -55,9 +54,9 @@ func NewService(cfgs ...config.LayerConfig) (*Service, error) {
 // and password are required, and the first and last name are optional.
 type NewUser struct {
 	svcauth.InsecureCredentials
-	FirstName string    `json:"first_name" msgpack:"first_name"`
-	LastName  string    `json:"last_name" msgpack:"last_name"`
-	Key       uuid.UUID `json:"key" msgpack:"key"`
+	FirstName string   `json:"first_name" msgpack:"first_name"`
+	LastName  string   `json:"last_name" msgpack:"last_name"`
+	Key       user.Key `json:"key" msgpack:"key"`
 }
 
 type (
@@ -102,8 +101,8 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (CreateResponse
 }
 
 type ChangeUsernameRequest struct {
-	Username string    `json:"username" msgpack:"username"`
-	Key      uuid.UUID `json:"key" msgpack:"key"`
+	Username string   `json:"username" msgpack:"username"`
+	Key      user.Key `json:"key" msgpack:"key"`
 }
 
 // ChangeUsername changes the username for the user with the given key.
@@ -139,9 +138,9 @@ func (s *Service) ChangeUsername(ctx context.Context, req ChangeUsernameRequest)
 }
 
 type RenameRequest struct {
-	FirstName string    `json:"first_name" msgpack:"first_name"`
-	LastName  string    `json:"last_name" msgpack:"last_name"`
-	Key       uuid.UUID `json:"key" msgpack:"key"`
+	FirstName string   `json:"first_name" msgpack:"first_name"`
+	LastName  string   `json:"last_name" msgpack:"last_name"`
+	Key       user.Key `json:"key" msgpack:"key"`
 }
 
 // Rename changes the name for the user with the provided key. If either the first
@@ -161,8 +160,8 @@ func (s *Service) Rename(ctx context.Context, req RenameRequest) (types.Nil, err
 
 type (
 	RetrieveRequest struct {
-		Keys      []uuid.UUID `json:"keys" msgpack:"keys"`
-		Usernames []string    `json:"usernames" msgpack:"usernames"`
+		Keys      []user.Key `json:"keys" msgpack:"keys"`
+		Usernames []string   `json:"usernames" msgpack:"usernames"`
 	}
 	RetrieveResponse struct {
 		Users []user.User `json:"users" msgpack:"users"`
@@ -194,7 +193,7 @@ func (s *Service) Retrieve(ctx context.Context, req RetrieveRequest) (RetrieveRe
 }
 
 type DeleteRequest struct {
-	Keys []uuid.UUID `json:"keys" msgpack:"keys"`
+	Keys []user.Key `json:"keys" msgpack:"keys"`
 }
 
 // Delete removes the users with the provided keys from the Synnax cluster.

--- a/core/pkg/api/view/view.go
+++ b/core/pkg/api/view/view.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"go/types"
 
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/synnax/pkg/api/auth"
 	"github.com/synnaxlabs/synnax/pkg/api/config"
 	"github.com/synnaxlabs/synnax/pkg/service/access"
@@ -76,11 +75,11 @@ func (s *Service) Create(
 }
 
 type RetrieveRequest struct {
-	SearchTerm string      `json:"search_term" msgpack:"search_term"`
-	Keys       []uuid.UUID `json:"keys" msgpack:"keys"`
-	Types      []string    `json:"types" msgpack:"types"`
-	Limit      int         `json:"limit" msgpack:"limit"`
-	Offset     int         `json:"offset" msgpack:"offset"`
+	SearchTerm string     `json:"search_term" msgpack:"search_term"`
+	Keys       []view.Key `json:"keys" msgpack:"keys"`
+	Types      []string   `json:"types" msgpack:"types"`
+	Limit      int        `json:"limit" msgpack:"limit"`
+	Offset     int        `json:"offset" msgpack:"offset"`
 }
 
 type RetrieveResponse struct {
@@ -123,7 +122,7 @@ func (s *Service) Retrieve(
 }
 
 type DeleteRequest struct {
-	Keys []uuid.UUID `json:"keys" msgpack:"keys"`
+	Keys []view.Key `json:"keys" msgpack:"keys"`
 }
 
 func (s *Service) Delete(

--- a/core/pkg/api/workspace/workspace.go
+++ b/core/pkg/api/workspace/workspace.go
@@ -78,8 +78,8 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (res CreateResp
 }
 
 type RenameRequest struct {
-	Name string    `json:"name" msgpack:"name"`
-	Key  uuid.UUID `json:"key" msgpack:"key"`
+	Name string        `json:"name" msgpack:"name"`
+	Key  workspace.Key `json:"key" msgpack:"key"`
 }
 
 func (s *Service) Rename(ctx context.Context, req RenameRequest) (res types.Nil, err error) {
@@ -97,7 +97,7 @@ func (s *Service) Rename(ctx context.Context, req RenameRequest) (res types.Nil,
 
 type SetLayoutRequest struct {
 	Layout map[string]any `json:"layout" msgpack:"layout"`
-	Key    uuid.UUID      `json:"key" msgpack:"key"`
+	Key    workspace.Key  `json:"key" msgpack:"key"`
 }
 
 func (s *Service) SetLayout(ctx context.Context, req SetLayoutRequest) (res types.Nil, err error) {
@@ -115,11 +115,11 @@ func (s *Service) SetLayout(ctx context.Context, req SetLayoutRequest) (res type
 
 type (
 	RetrieveRequest struct {
-		SearchTerm string      `json:"search_term" msgpack:"search_term"`
-		Keys       []uuid.UUID `json:"keys" msgpack:"keys"`
-		Limit      int         `json:"limit" msgpack:"limit"`
-		Offset     int         `json:"offset" msgpack:"offset"`
-		Author     uuid.UUID   `json:"author" msgpack:"author"`
+		SearchTerm string          `json:"search_term" msgpack:"search_term"`
+		Keys       []workspace.Key `json:"keys" msgpack:"keys"`
+		Limit      int             `json:"limit" msgpack:"limit"`
+		Offset     int             `json:"offset" msgpack:"offset"`
+		Author     workspace.Key   `json:"author" msgpack:"author"`
 	}
 	RetrieveResponse struct {
 		Workspaces []workspace.Workspace `json:"workspaces" msgpack:"workspaces"`
@@ -155,7 +155,7 @@ func (s *Service) Retrieve(
 }
 
 type DeleteRequest struct {
-	Keys []uuid.UUID `json:"keys" msgpack:"keys"`
+	Keys []workspace.Key `json:"keys" msgpack:"keys"`
 }
 
 func (s *Service) Delete(ctx context.Context, req DeleteRequest) (res types.Nil, err error) {

--- a/core/pkg/api/workspace/workspace.go
+++ b/core/pkg/api/workspace/workspace.go
@@ -119,7 +119,7 @@ type (
 		Keys       []workspace.Key `json:"keys" msgpack:"keys"`
 		Limit      int             `json:"limit" msgpack:"limit"`
 		Offset     int             `json:"offset" msgpack:"offset"`
-		Author     workspace.Key   `json:"author" msgpack:"author"`
+		Author     user.Key        `json:"author" msgpack:"author"`
 	}
 	RetrieveResponse struct {
 		Workspaces []workspace.Workspace `json:"workspaces" msgpack:"workspaces"`

--- a/core/pkg/distribution/group/helpers.go
+++ b/core/pkg/distribution/group/helpers.go
@@ -21,10 +21,10 @@ var schema = zyn.Object(map[string]zyn.Schema{
 	"name": zyn.String(),
 })
 
-var _ gorp.Entry[uuid.UUID] = Group{}
+var _ gorp.Entry[Key] = Group{}
 
 // GorpKey implements gorp.Entry.
-func (g Group) GorpKey() uuid.UUID { return g.Key }
+func (g Group) GorpKey() Key { return g.Key }
 
 // SetOptions implements gorp.Entry.
 func (g Group) SetOptions() []any { return nil }

--- a/core/pkg/distribution/group/ontology.go
+++ b/core/pkg/distribution/group/ontology.go
@@ -25,19 +25,19 @@ import (
 	"github.com/synnaxlabs/x/zyn"
 )
 
-func OntologyID(key uuid.UUID) ontology.ID {
+func OntologyID(key Key) ontology.ID {
 	return ontology.ID{Type: ontology.ResourceTypeGroup, Key: key.String()}
 }
 
-func OntologyIDs(keys []uuid.UUID) []ontology.ID {
-	return lo.Map(keys, func(k uuid.UUID, _ int) ontology.ID { return OntologyID(k) })
+func OntologyIDs(keys []Key) []ontology.ID {
+	return lo.Map(keys, func(k Key, _ int) ontology.ID { return OntologyID(k) })
 }
 
 func newResource(g Group) ontology.Resource {
 	return ontology.NewResource(schema, OntologyID(g.Key), g.Name, g)
 }
 
-type change = xchange.Change[uuid.UUID, Group]
+type change = xchange.Change[Key, Group]
 
 var (
 	_ ontology.Service = (*Service)(nil)
@@ -75,7 +75,7 @@ func translateChange(c change) ontology.Change {
 func (s *Service) OnChange(
 	f func(context.Context, iter.Seq[ontology.Change]),
 ) observe.Disconnect {
-	handleChange := func(ctx context.Context, reader gorp.TxReader[uuid.UUID, Group]) {
+	handleChange := func(ctx context.Context, reader gorp.TxReader[Key, Group]) {
 		f(ctx, xiter.Map(reader, translateChange))
 	}
 	return s.table.Observe().OnChange(handleChange)

--- a/core/pkg/distribution/group/service.go
+++ b/core/pkg/distribution/group/service.go
@@ -61,7 +61,7 @@ func (c ServiceConfig) Validate() error {
 type Service struct {
 	cfg     ServiceConfig
 	signals io.Closer
-	table   *gorp.Table[uuid.UUID, Group]
+	table   *gorp.Table[Key, Group]
 }
 
 func OpenService(ctx context.Context, configs ...ServiceConfig) (*Service, error) {
@@ -69,9 +69,9 @@ func OpenService(ctx context.Context, configs ...ServiceConfig) (*Service, error
 	if err != nil {
 		return nil, err
 	}
-	table, err := gorp.OpenTable[uuid.UUID, Group](ctx, gorp.TableConfig[Group]{
+	table, err := gorp.OpenTable[Key, Group](ctx, gorp.TableConfig[Group]{
 		DB:              cfg.DB,
-		Migrations:      []migrate.Migration{gorp.CodecMigration[uuid.UUID, Group]("msgpack_to_orc")},
+		Migrations:      []migrate.Migration{gorp.CodecMigration[Key, Group]("msgpack_to_orc")},
 		Instrumentation: cfg.Instrumentation,
 	})
 	if err != nil {
@@ -97,7 +97,7 @@ func (s *Service) CreateOrRetrieve(ctx context.Context, groupName string, parent
 }
 
 // Observe returns an observable that notifies callers of changes to group entries.
-func (s *Service) Observe() observe.Observable[gorp.TxReader[uuid.UUID, Group]] {
+func (s *Service) Observe() observe.Observable[gorp.TxReader[Key, Group]] {
 	return s.table.Observe()
 }
 
@@ -119,7 +119,7 @@ func (s *Service) Close() error {
 type Writer struct {
 	tx    gorp.Tx
 	otg   ontology.Writer
-	table *gorp.Table[uuid.UUID, Group]
+	table *gorp.Table[Key, Group]
 }
 
 // Create creates a new Group with the given name and parent.
@@ -145,7 +145,7 @@ func (w Writer) Create(
 
 func (w Writer) CreateWithKey(
 	ctx context.Context,
-	key uuid.UUID,
+	key Key,
 	name string,
 	parent ontology.ID,
 ) (g Group, err error) {
@@ -168,8 +168,8 @@ func (w Writer) CreateWithKey(
 }
 
 // Delete deletes the Groups with the given keys.
-func (w Writer) Delete(ctx context.Context, keys ...uuid.UUID) error {
-	keyStrings := lo.Map(keys, func(item uuid.UUID, _ int) string {
+func (w Writer) Delete(ctx context.Context, keys ...Key) error {
+	keyStrings := lo.Map(keys, func(item Key, _ int) string {
 		return item.String()
 	})
 	for _, key := range keys {
@@ -192,13 +192,13 @@ func (w Writer) Delete(ctx context.Context, keys ...uuid.UUID) error {
 			return err
 		}
 	}
-	return w.table.NewDelete().Where(gorp.MatchKeys[uuid.UUID, Group](keys...)).Exec(ctx, w.tx)
+	return w.table.NewDelete().Where(gorp.MatchKeys[Key, Group](keys...)).Exec(ctx, w.tx)
 }
 
 // Rename renames the Group with the given key.
-func (w Writer) Rename(ctx context.Context, key uuid.UUID, name string) error {
+func (w Writer) Rename(ctx context.Context, key Key, name string) error {
 	return w.table.NewUpdate().
-		Where(gorp.MatchKeys[uuid.UUID, Group](key)).
+		Where(gorp.MatchKeys[Key, Group](key)).
 		Change(func(_ gorp.Context, g Group) Group {
 			g.Name = name
 			return g

--- a/core/pkg/distribution/group/signals/signals.go
+++ b/core/pkg/distribution/group/signals/signals.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"io"
 
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/synnax/pkg/distribution/group"
 	"github.com/synnaxlabs/synnax/pkg/distribution/signals"
 	"github.com/synnaxlabs/x/gorp"
@@ -24,7 +23,7 @@ import (
 func Publish(
 	ctx context.Context,
 	prov *signals.Provider,
-	obs observe.Observable[gorp.TxReader[uuid.UUID, group.Group]],
+	obs observe.Observable[gorp.TxReader[group.Key, group.Group]],
 ) (io.Closer, error) {
 	return signals.PublishFromGorp(
 		ctx,

--- a/core/pkg/service/access/rbac/builtin/provision.go
+++ b/core/pkg/service/access/rbac/builtin/provision.go
@@ -22,10 +22,10 @@ import (
 
 // ProvisionResult contains the keys of all provisioned built-in roles.
 type ProvisionResult struct {
-	OwnerKey    uuid.UUID
-	EngineerKey uuid.UUID
-	OperatorKey uuid.UUID
-	ViewerKey   uuid.UUID
+	OwnerKey    role.Key
+	EngineerKey role.Key
+	OperatorKey role.Key
+	ViewerKey   role.Key
 }
 
 // Provision creates or updates all built-in roles and their associated policies.
@@ -62,8 +62,8 @@ func provisionRole(
 	tx gorp.Tx,
 	policySvc *policy.Service,
 	roleSvc *role.Service,
-) (uuid.UUID, error) {
-	policyKeys := make([]uuid.UUID, 0, len(policies))
+) (role.Key, error) {
+	policyKeys := make([]policy.Key, 0, len(policies))
 	for i := range policies {
 		pol := &policies[i]
 		desiredObjects := pol.Objects

--- a/core/pkg/service/access/rbac/policy/ontology.go
+++ b/core/pkg/service/access/rbac/policy/ontology.go
@@ -25,14 +25,14 @@ import (
 )
 
 // OntologyID constructs a unique ontology.ID for the Policy with the given key.
-func OntologyID(k uuid.UUID) ontology.ID {
+func OntologyID(k Key) ontology.ID {
 	return ontology.ID{Type: ontology.ResourceTypePolicy, Key: k.String()}
 }
 
 // OntologyIDs constructs a slice of unique ontology.IDs for the Policys with the given
 // keys.
-func OntologyIDs(keys []uuid.UUID) []ontology.ID {
-	return lo.Map(keys, func(k uuid.UUID, _ int) ontology.ID { return OntologyID(k) })
+func OntologyIDs(keys []Key) []ontology.ID {
+	return lo.Map(keys, func(k Key, _ int) ontology.ID { return OntologyID(k) })
 }
 
 // OntologyIDsFromPolicies constructs a slice of unique ontology.IDs for the given Policys.
@@ -41,8 +41,8 @@ func OntologyIDsFromPolicies(policies []Policy) []ontology.ID {
 }
 
 // KeysFromOntologyIDs extracts the Policy keys from the given ontology.IDs.
-func KeysFromOntologyIDs(ids []ontology.ID) ([]uuid.UUID, error) {
-	keys := make([]uuid.UUID, len(ids))
+func KeysFromOntologyIDs(ids []ontology.ID) ([]Key, error) {
+	keys := make([]Key, len(ids))
 	var err error
 	for i, id := range ids {
 		keys[i], err = uuid.Parse(id.Key)
@@ -63,7 +63,7 @@ func newResource(p Policy) ontology.Resource {
 	return ontology.NewResource(schema, OntologyID(p.Key), p.Name, p)
 }
 
-type change = xchange.Change[uuid.UUID, Policy]
+type change = xchange.Change[Key, Policy]
 
 func (s *Service) Type() ontology.ResourceType { return ontology.ResourceTypePolicy }
 
@@ -97,7 +97,7 @@ func translateChange(c change) ontology.Change {
 
 // OnChange implements ontology.Service.
 func (s *Service) OnChange(f func(context.Context, iter.Seq[ontology.Change])) observe.Disconnect {
-	handleChange := func(ctx context.Context, reader gorp.TxReader[uuid.UUID, Policy]) {
+	handleChange := func(ctx context.Context, reader gorp.TxReader[Key, Policy]) {
 		f(ctx, xiter.Map(reader, translateChange))
 	}
 	return s.table.Observe().OnChange(handleChange)

--- a/core/pkg/service/access/rbac/policy/policy.go
+++ b/core/pkg/service/access/rbac/policy/policy.go
@@ -10,14 +10,13 @@
 package policy
 
 import (
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/x/gorp"
 )
 
-var _ gorp.Entry[uuid.UUID] = Policy{}
+var _ gorp.Entry[Key] = Policy{}
 
 // GorpKey implements the gorp.Entry interface.
-func (p Policy) GorpKey() uuid.UUID { return p.Key }
+func (p Policy) GorpKey() Key { return p.Key }
 
 // SetOptions implements the gorp.Entry interface.
 func (p Policy) SetOptions() []any { return nil }

--- a/core/pkg/service/access/rbac/policy/retriever.go
+++ b/core/pkg/service/access/rbac/policy/retriever.go
@@ -12,14 +12,13 @@ package policy
 import (
 	"context"
 
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
 	"github.com/synnaxlabs/x/gorp"
 )
 
 type Retrieve struct {
 	baseTX   gorp.Tx
-	gorp     gorp.Retrieve[uuid.UUID, Policy]
+	gorp     gorp.Retrieve[Key, Policy]
 	ontology *ontology.Ontology
 }
 
@@ -32,7 +31,7 @@ func (s *Service) ResolveSubjects(
 	ctx context.Context,
 	tx gorp.Tx,
 	subjects ...ontology.ID,
-) ([]uuid.UUID, error) {
+) ([]Key, error) {
 	tx = gorp.OverrideTx(s.cfg.DB, tx)
 	var policyResources []ontology.Resource
 	if err := s.cfg.Ontology.NewRetrieve().WhereIDs(subjects...).

--- a/core/pkg/service/access/rbac/policy/service.go
+++ b/core/pkg/service/access/rbac/policy/service.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"io"
 
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/alamos"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
 	"github.com/synnaxlabs/synnax/pkg/distribution/search"
@@ -63,7 +62,7 @@ func (c ServiceConfig) Validate() error {
 type Service struct {
 	cfg    ServiceConfig
 	closer xio.MultiCloser
-	table  *gorp.Table[uuid.UUID, Policy]
+	table  *gorp.Table[Key, Policy]
 }
 
 func OpenService(ctx context.Context, configs ...ServiceConfig) (s *Service, err error) {
@@ -80,7 +79,7 @@ func OpenService(ctx context.Context, configs ...ServiceConfig) (s *Service, err
 		Instrumentation: cfg.Instrumentation,
 		Migrations: []migrate.Migration{
 			v0Mig,
-			gorp.CodecMigration[uuid.UUID, Policy]("msgpack_to_orc", v0Mig.Key()),
+			gorp.CodecMigration[Key, Policy]("msgpack_to_orc", v0Mig.Key()),
 		},
 	}); err != nil {
 		return nil, err

--- a/core/pkg/service/access/rbac/policy/writer.go
+++ b/core/pkg/service/access/rbac/policy/writer.go
@@ -24,7 +24,7 @@ type Writer struct {
 	tx            gorp.Tx
 	otg           ontology.Writer
 	allowInternal bool
-	table         *gorp.Table[uuid.UUID, Policy]
+	table         *gorp.Table[Key, Policy]
 }
 
 // Create creates a new policy in the database.
@@ -47,15 +47,15 @@ func (w Writer) Create(
 // Delete removes policies with the given keys from the database.
 func (w Writer) Delete(
 	ctx context.Context,
-	keys ...uuid.UUID,
+	keys ...Key,
 ) error {
-	return w.table.NewDelete().Where(gorp.MatchKeys[uuid.UUID, Policy](keys...)).Exec(ctx, w.tx)
+	return w.table.NewDelete().Where(gorp.MatchKeys[Key, Policy](keys...)).Exec(ctx, w.tx)
 }
 
 func (w Writer) SetOnRole(
 	ctx context.Context,
-	roleKey uuid.UUID,
-	policyKeys ...uuid.UUID,
+	roleKey Key,
+	policyKeys ...Key,
 ) error {
 	policyIDs := OntologyIDs(policyKeys)
 	for _, p := range policyIDs {

--- a/core/pkg/service/access/rbac/policy/writer.go
+++ b/core/pkg/service/access/rbac/policy/writer.go
@@ -54,7 +54,7 @@ func (w Writer) Delete(
 
 func (w Writer) SetOnRole(
 	ctx context.Context,
-	roleKey Key,
+	roleKey role.Key,
 	policyKeys ...Key,
 ) error {
 	policyIDs := OntologyIDs(policyKeys)

--- a/core/pkg/service/access/rbac/role/ontology.go
+++ b/core/pkg/service/access/rbac/role/ontology.go
@@ -24,7 +24,7 @@ import (
 )
 
 // OntologyID constructs a unique ontology.ID for the Role with the given key.
-func OntologyID(k uuid.UUID) ontology.ID {
+func OntologyID(k Key) ontology.ID {
 	return ontology.ID{Type: ontology.ResourceTypeRole, Key: k.String()}
 }
 
@@ -38,7 +38,7 @@ func newResource(r Role) ontology.Resource {
 	return ontology.NewResource(schema, OntologyID(r.Key), r.Name, r)
 }
 
-type change = xchange.Change[uuid.UUID, Role]
+type change = xchange.Change[Key, Role]
 
 func (s *Service) Type() ontology.ResourceType { return ontology.ResourceTypeRole }
 
@@ -72,7 +72,7 @@ func translateChange(c change) ontology.Change {
 
 // OnChange implements ontology.Service.
 func (s *Service) OnChange(f func(context.Context, iter.Seq[ontology.Change])) observe.Disconnect {
-	handleChange := func(ctx context.Context, reader gorp.TxReader[uuid.UUID, Role]) {
+	handleChange := func(ctx context.Context, reader gorp.TxReader[Key, Role]) {
 		f(ctx, xiter.Map(reader, translateChange))
 	}
 	return s.table.Observe().OnChange(handleChange)

--- a/core/pkg/service/access/rbac/role/role.go
+++ b/core/pkg/service/access/rbac/role/role.go
@@ -10,15 +10,14 @@
 package role
 
 import (
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
 	"github.com/synnaxlabs/x/gorp"
 )
 
-var _ gorp.Entry[uuid.UUID] = Role{}
+var _ gorp.Entry[Key] = Role{}
 
 // GorpKey implements the gorp.Entry interface.
-func (r Role) GorpKey() uuid.UUID { return r.Key }
+func (r Role) GorpKey() Key { return r.Key }
 
 // SetOptions implements the gorp.Entry interface.
 func (r Role) SetOptions() []any { return nil }

--- a/core/pkg/service/access/rbac/role/service.go
+++ b/core/pkg/service/access/rbac/role/service.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"io"
 
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/alamos"
 	"github.com/synnaxlabs/synnax/pkg/distribution/group"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
@@ -67,7 +66,7 @@ type Service struct {
 	cfg    ServiceConfig
 	closer xio.MultiCloser
 	group  group.Group
-	table  *gorp.Table[uuid.UUID, Role]
+	table  *gorp.Table[Key, Role]
 }
 
 func (s *Service) Close() error { return s.closer.Close() }
@@ -82,7 +81,7 @@ func OpenService(ctx context.Context, configs ...ServiceConfig) (s *Service, err
 	defer func() { err = cleanup(err) }()
 	if s.table, err = gorp.OpenTable(ctx, gorp.TableConfig[Role]{
 		DB:              cfg.DB,
-		Migrations:      []migrate.Migration{gorp.CodecMigration[uuid.UUID, Role]("msgpack_to_orc")},
+		Migrations:      []migrate.Migration{gorp.CodecMigration[Key, Role]("msgpack_to_orc")},
 		Instrumentation: cfg.Instrumentation,
 	}); !ok(err, s.table) {
 		return nil, err

--- a/core/pkg/service/access/rbac/role/writer.go
+++ b/core/pkg/service/access/rbac/role/writer.go
@@ -25,7 +25,7 @@ type Writer struct {
 	otg           ontology.Writer
 	group         group.Group
 	allowInternal bool
-	table         *gorp.Table[uuid.UUID, Role]
+	table         *gorp.Table[Key, Role]
 }
 
 // Create creates a new role in the database.
@@ -50,8 +50,8 @@ func (w Writer) Create(
 
 // Delete removes a role from the database. It will fail if the role is builtin
 // or if any users are assigned to the role.
-func (w Writer) Delete(ctx context.Context, key uuid.UUID) error {
-	return w.table.NewDelete().Where(gorp.MatchKeys[uuid.UUID, Role](key)).Guard(func(_ gorp.Context, r Role) error {
+func (w Writer) Delete(ctx context.Context, key Key) error {
+	return w.table.NewDelete().Where(gorp.MatchKeys[Key, Role](key)).Guard(func(_ gorp.Context, r Role) error {
 		if r.Internal && !w.allowInternal {
 			return errors.Wrap(validate.ErrValidation, "cannot delete builtin role")
 		}
@@ -65,7 +65,7 @@ func (w Writer) Delete(ctx context.Context, key uuid.UUID) error {
 func (w Writer) AssignRole(
 	ctx context.Context,
 	subject ontology.ID,
-	roleKey uuid.UUID,
+	roleKey Key,
 ) error {
 	return w.otg.DefineRelationship(ctx, OntologyID(roleKey), ontology.RelationshipTypeParentOf, subject)
 }
@@ -75,7 +75,7 @@ func (w Writer) AssignRole(
 func (w Writer) UnassignRole(
 	ctx context.Context,
 	subject ontology.ID,
-	roleKey uuid.UUID,
+	roleKey Key,
 ) error {
 	return w.otg.DeleteRelationship(ctx, OntologyID(roleKey), ontology.RelationshipTypeParentOf, subject)
 }

--- a/core/pkg/service/arc/arc.go
+++ b/core/pkg/service/arc/arc.go
@@ -10,15 +10,14 @@
 package arc
 
 import (
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/x/gorp"
 	"github.com/vmihailenco/msgpack/v5"
 )
 
-var _ gorp.Entry[uuid.UUID] = Arc{}
+var _ gorp.Entry[Key] = Arc{}
 
 // GorpKey implements gorp.Entry.
-func (s Arc) GorpKey() uuid.UUID { return s.Key }
+func (s Arc) GorpKey() Key { return s.Key }
 
 // SetOptions implements gorp.Entry.
 func (s Arc) SetOptions() []any { return nil }

--- a/core/pkg/service/arc/ontology.go
+++ b/core/pkg/service/arc/ontology.go
@@ -26,20 +26,20 @@ import (
 )
 
 // OntologyID returns unique identifier for the Arc within the ontology.
-func OntologyID(k uuid.UUID) ontology.ID {
+func OntologyID(k Key) ontology.ID {
 	return ontology.ID{Type: ontology.ResourceTypeArc, Key: k.String()}
 }
 
 // OntologyIDs returns unique identifiers for the arcs within the ontology.
-func OntologyIDs(keys []uuid.UUID) []ontology.ID {
-	return lo.Map(keys, func(key uuid.UUID, _ int) ontology.ID {
+func OntologyIDs(keys []Key) []ontology.ID {
+	return lo.Map(keys, func(key Key, _ int) ontology.ID {
 		return OntologyID(key)
 	})
 }
 
 // KeysFromOntologyIDs extracts the keys of the arcs from the ontology IDs.
-func KeysFromOntologyIDs(ids []ontology.ID) ([]uuid.UUID, error) {
-	keys := make([]uuid.UUID, len(ids))
+func KeysFromOntologyIDs(ids []ontology.ID) ([]Key, error) {
+	keys := make([]Key, len(ids))
 	var err error
 	for i, id := range ids {
 		if keys[i], err = uuid.Parse(id.Key); err != nil {
@@ -65,7 +65,7 @@ var (
 	_ search.Service   = (*Service)(nil)
 )
 
-type change = xchange.Change[uuid.UUID, Arc]
+type change = xchange.Change[Key, Arc]
 
 func (s *Service) Type() ontology.ResourceType { return ontology.ResourceTypeArc }
 
@@ -95,7 +95,7 @@ func translateChange(c change) ontology.Change {
 
 // OnChange implements ontology.Service.
 func (s *Service) OnChange(f func(context.Context, iter.Seq[ontology.Change])) observe.Disconnect {
-	handleChange := func(ctx context.Context, reader gorp.TxReader[uuid.UUID, Arc]) {
+	handleChange := func(ctx context.Context, reader gorp.TxReader[Key, Arc]) {
 		f(ctx, xiter.Map(reader, translateChange))
 	}
 	return s.table.Observe().OnChange(handleChange)

--- a/core/pkg/service/arc/runtime/factory.go
+++ b/core/pkg/service/arc/runtime/factory.go
@@ -12,7 +12,6 @@ package runtime
 import (
 	"context"
 
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/alamos"
 	"github.com/synnaxlabs/synnax/pkg/distribution/framer"
 	"github.com/synnaxlabs/synnax/pkg/service/arc"
@@ -35,7 +34,7 @@ const TaskType = "arc"
 type TaskConfig struct {
 	alamos.Instrumentation
 	// ArcKey is the UUID of the Arc program to execute.
-	ArcKey uuid.UUID `json:"arc_key"`
+	ArcKey arc.Key `json:"arc_key"`
 	// AutoStart sets whether the taskImpl should start automatically when configured.
 	AutoStart bool `json:"auto_start"`
 }

--- a/core/pkg/service/arc/service.go
+++ b/core/pkg/service/arc/service.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"io"
 
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/alamos"
 	"github.com/synnaxlabs/arc"
 	"github.com/synnaxlabs/arc/lsp"
@@ -95,7 +94,7 @@ func (c ServiceConfig) Validate() error {
 
 // Service is the primary service for retrieving and modifying arcs from Synnax.
 type Service struct {
-	table  *gorp.Table[uuid.UUID, Arc]
+	table  *gorp.Table[Key, Arc]
 	closer xio.MultiCloser
 	cfg    ServiceConfig
 }
@@ -124,7 +123,7 @@ func (s *Service) Close() error { return s.closer.Close() }
 
 // CompileProgram retrieves an Arc program by key and compiles its Module.
 // The returned Arc has its Module field populated with the compiled module.
-func (s *Service) CompileProgram(ctx context.Context, key uuid.UUID) (Arc, error) {
+func (s *Service) CompileProgram(ctx context.Context, key Key) (Arc, error) {
 	var entry Arc
 	err := s.NewRetrieve().Where(MatchKeys(key)).Entry(&entry).Exec(ctx, nil)
 	if err != nil {
@@ -155,12 +154,12 @@ func OpenService(ctx context.Context, configs ...ServiceConfig) (s *Service, err
 	s = &Service{cfg: cfg}
 	cleanup, ok := service.NewOpener(ctx, &s.closer)
 	defer func() { err = cleanup(err) }()
-	if s.table, err = gorp.OpenTable[uuid.UUID, Arc](ctx, gorp.TableConfig[Arc]{
+	if s.table, err = gorp.OpenTable[Key, Arc](ctx, gorp.TableConfig[Arc]{
 		DB: cfg.DB,
 		Migrations: []migrate.Migration{
-			gorp.CodecMigration[uuid.UUID, arcv54.Arc]("msgpack_to_orc"),
+			gorp.CodecMigration[Key, arcv54.Arc]("msgpack_to_orc"),
 			migrate.WithAddedDeps(
-				gorp.NewEntryMigration[uuid.UUID, uuid.UUID, arcv54.Arc, Arc](
+				gorp.NewEntryMigration[Key, Key, arcv54.Arc, Arc](
 					"v54_drop_program_status",
 					MigrateArc,
 				),

--- a/core/pkg/service/arc/writer.go
+++ b/core/pkg/service/arc/writer.go
@@ -28,7 +28,7 @@ type Writer struct {
 	tx    gorp.Tx
 	otg   ontology.Writer
 	task  task.Writer
-	table *gorp.Table[uuid.UUID, Arc]
+	table *gorp.Table[Key, Arc]
 }
 
 // Create creates the given Arc. If the Arc does not have a key,
@@ -44,7 +44,7 @@ func (w Writer) Create(
 	if a.Key == uuid.Nil {
 		a.Key = uuid.New()
 	} else {
-		exists, err = w.table.NewRetrieve().Where(gorp.MatchKeys[uuid.UUID, Arc](a.Key)).Exists(ctx, w.tx)
+		exists, err = w.table.NewRetrieve().Where(gorp.MatchKeys[Key, Arc](a.Key)).Exists(ctx, w.tx)
 		if err != nil {
 			return err
 		}
@@ -65,14 +65,14 @@ func (w Writer) Create(
 // tasks will also be deleted.
 func (w Writer) Delete(
 	ctx context.Context,
-	keys ...uuid.UUID,
+	keys ...Key,
 ) error {
 	for _, key := range keys {
 		if err := w.deleteChildTasks(ctx, key); err != nil {
 			return err
 		}
 	}
-	if err := w.table.NewDelete().Where(gorp.MatchKeys[uuid.UUID, Arc](keys...)).Exec(ctx, w.tx); err != nil {
+	if err := w.table.NewDelete().Where(gorp.MatchKeys[Key, Arc](keys...)).Exec(ctx, w.tx); err != nil {
 		return err
 	}
 	for _, key := range keys {
@@ -83,7 +83,7 @@ func (w Writer) Delete(
 	return nil
 }
 
-func (w Writer) deleteChildTasks(ctx context.Context, key uuid.UUID) error {
+func (w Writer) deleteChildTasks(ctx context.Context, key Key) error {
 	var children []ontology.Resource
 	if err := w.otg.NewRetrieve().
 		WhereIDs(OntologyID(key)).

--- a/core/pkg/service/auth/token/token.go
+++ b/core/pkg/service/auth/token/token.go
@@ -20,6 +20,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/synnaxlabs/synnax/pkg/security"
 	"github.com/synnaxlabs/synnax/pkg/service/auth"
+	"github.com/synnaxlabs/synnax/pkg/service/user"
 	"github.com/synnaxlabs/x/config"
 	"github.com/synnaxlabs/x/errors"
 	"github.com/synnaxlabs/x/override"
@@ -101,7 +102,7 @@ func NewService(cfgs ...ServiceConfig) (*Service, error) {
 
 // New issues a new token for the given issuer. Returns the token as a string, and
 // any errors encountered during signing.
-func (s *Service) New(issuer uuid.UUID) (string, error) {
+func (s *Service) New(issuer user.Key) (string, error) {
 	method, key := s.signingMethodAndKey()
 	now := s.cfg.Now().UTC()
 	claims := jwt.NewWithClaims(method, jwt.RegisteredClaims{
@@ -118,14 +119,14 @@ func (s *Service) New(issuer uuid.UUID) (string, error) {
 
 // Validate validates the given token. Returns the UUID of the issuer along with any
 // errors encountered.
-func (s *Service) Validate(token string) (uuid.UUID, error) {
+func (s *Service) Validate(token string) (user.Key, error) {
 	id, _, err := s.validate(token)
 	return id, err
 }
 
 // ValidateMaybeRefresh validates the given token. If the token is close to expiration
 // (as defined by the RefreshThreshold), a new token will be issued and returned as well.
-func (s *Service) ValidateMaybeRefresh(token string) (uuid.UUID, string, error) {
+func (s *Service) ValidateMaybeRefresh(token string) (user.Key, string, error) {
 	id, claims, err := s.validate(token)
 	if err != nil {
 		return id, "", err
@@ -137,7 +138,7 @@ func (s *Service) ValidateMaybeRefresh(token string) (uuid.UUID, string, error) 
 	return id, "", nil
 }
 
-func (s *Service) validate(token string) (uuid.UUID, *jwt.RegisteredClaims, error) {
+func (s *Service) validate(token string) (user.Key, *jwt.RegisteredClaims, error) {
 	claims := &jwt.RegisteredClaims{}
 	_, err := jwt.ParseWithClaims(token, claims, func(token *jwt.Token) (any, error) {
 		return s.publicKey(), nil

--- a/core/pkg/service/device/device.go
+++ b/core/pkg/service/device/device.go
@@ -17,10 +17,10 @@ import (
 	"github.com/synnaxlabs/x/validate"
 )
 
-var _ gorp.Entry[string] = Device{}
+var _ gorp.Entry[Key] = Device{}
 
 // GorpKey gives a unique key for the device for use in gorp.
-func (d Device) GorpKey() string { return d.Key }
+func (d Device) GorpKey() Key { return d.Key }
 
 // SetOptions returns nil.
 func (d Device) SetOptions() []any { return nil }

--- a/core/pkg/service/device/ontology.go
+++ b/core/pkg/service/device/ontology.go
@@ -25,7 +25,7 @@ import (
 )
 
 // OntologyID returns the unique ID for the device within the ontology.
-func OntologyID(key string) ontology.ID {
+func OntologyID(key Key) ontology.ID {
 	return ontology.ID{Type: ontology.ResourceTypeDevice, Key: key}
 }
 
@@ -37,13 +37,13 @@ func OntologyIDsFromDevices(devices []Device) []ontology.ID {
 }
 
 // OntologyIDs returns the ontology IDs for the given keys.
-func OntologyIDs(keys []string) []ontology.ID {
-	return lo.Map(keys, func(k string, _ int) ontology.ID { return OntologyID(k) })
+func OntologyIDs(keys []Key) []ontology.ID {
+	return lo.Map(keys, func(k Key, _ int) ontology.ID { return OntologyID(k) })
 }
 
 // KeysFromOntologyIDs returns the keys for the given ontology IDs.
-func KeysFromOntologyIDs(ids []ontology.ID) []string {
-	keys := make([]string, len(ids))
+func KeysFromOntologyIDs(ids []ontology.ID) []Key {
+	keys := make([]Key, len(ids))
 	for i, id := range ids {
 		keys[i] = id.Key
 	}
@@ -70,7 +70,7 @@ var (
 	_ search.FieldsProvider = (*Service)(nil)
 )
 
-type change = xchange.Change[string, Device]
+type change = xchange.Change[Key, Device]
 
 // Type returns the type of the device ontology service.
 func (s *Service) Type() ontology.ResourceType { return ontology.ResourceTypeDevice }
@@ -107,7 +107,7 @@ func translateChange(c change) ontology.Change {
 // OnChange implements determines what should happen in the ontology when a change is
 // made to a device.
 func (s *Service) OnChange(f func(context.Context, iter.Seq[ontology.Change])) observe.Disconnect {
-	handleChange := func(ctx context.Context, reader gorp.TxReader[string, Device]) {
+	handleChange := func(ctx context.Context, reader gorp.TxReader[Key, Device]) {
 		f(ctx, xiter.Map(reader, translateChange))
 	}
 	return s.table.Observe().OnChange(handleChange)

--- a/core/pkg/service/device/pb/translator.gen.go
+++ b/core/pkg/service/device/pb/translator.gen.go
@@ -27,7 +27,7 @@ import (
 func StatusDetailsToPB(r device.StatusDetails) (*StatusDetails, error) {
 	pb := &StatusDetails{
 		Rack:   uint32(r.Rack),
-		Device: r.Device,
+		Device: string(r.Device),
 	}
 	return pb, nil
 }
@@ -39,7 +39,7 @@ func StatusDetailsFromPB(pb *StatusDetails) (device.StatusDetails, error) {
 		return r, nil
 	}
 	r.Rack = rack.Key(pb.Rack)
-	r.Device = pb.Device
+	r.Device = device.Key(pb.Device)
 	return r, nil
 }
 

--- a/core/pkg/service/device/service.go
+++ b/core/pkg/service/device/service.go
@@ -99,7 +99,7 @@ var DefaultServiceConfig = ServiceConfig{}
 type Service struct {
 	cfg    ServiceConfig
 	closer xio.MultiCloser
-	table  *gorp.Table[string, Device]
+	table  *gorp.Table[Key, Device]
 	group  group.Group
 }
 
@@ -115,13 +115,13 @@ func OpenService(ctx context.Context, cfgs ...ServiceConfig) (s *Service, err er
 	cleanup, ok := service.NewOpener(ctx, &s.closer)
 	defer func() { err = cleanup(err) }()
 	v0Mig := v0.Migration(v0.MigrationConfig{Status: cfg.Status})
-	if s.table, err = gorp.OpenTable[string, Device](ctx, gorp.TableConfig[Device]{
+	if s.table, err = gorp.OpenTable[Key, Device](ctx, gorp.TableConfig[Device]{
 		DB: cfg.DB,
 		Migrations: []migrate.Migration{
 			v0Mig,
-			gorp.CodecMigration[string, v54.Device]("msgpack_to_orc", v0Mig.Key()),
+			gorp.CodecMigration[Key, v54.Device]("msgpack_to_orc", v0Mig.Key()),
 			migrate.WithAddedDeps(
-				gorp.NewEntryMigration[string, string, v54.Device, Device](
+				gorp.NewEntryMigration[Key, Key, v54.Device, Device](
 					"v54_drop_status_parent",
 					MigrateDevice,
 				),

--- a/core/pkg/service/device/types.gen.go
+++ b/core/pkg/service/device/types.gen.go
@@ -18,12 +18,12 @@ import (
 	"github.com/synnaxlabs/x/status"
 )
 
+// Key is a unique identifier for the device
+type Key = string
+
 // Status is device-specific status information including operational state and device
 // identification.
 type Status = status.Status[StatusDetails]
-
-// Key is the device's serial number, used as its unique identifier.
-type Key = string
 
 // StatusDetails contains device-specific status details identifying the device and its
 // associated rack.
@@ -31,7 +31,7 @@ type StatusDetails struct {
 	// Rack is the key of the rack this device belongs to.
 	Rack rack.Key `json:"rack" msgpack:"rack"`
 	// Device is the device identifier.
-	Device string `json:"device" msgpack:"device"`
+	Device Key `json:"device" msgpack:"device"`
 }
 
 // Device is a physical piece of hardware connected to Synnax through the Driver system.

--- a/core/pkg/service/device/writer.go
+++ b/core/pkg/service/device/writer.go
@@ -32,7 +32,7 @@ type Writer struct {
 	otg    ontology.Writer
 	group  group.Group
 	status status.Writer[StatusDetails]
-	table  *gorp.Table[string, Device]
+	table  *gorp.Table[Key, Device]
 }
 
 func resolveStatus(d *Device, provided *Status) *status.Status[StatusDetails] {
@@ -76,7 +76,7 @@ func (w Writer) Create(ctx context.Context, device *Device) error {
 	var existing Device
 	err := w.table.
 		NewRetrieve().
-		Where(gorp.MatchKeys[string, Device](device.Key)).
+		Where(gorp.MatchKeys[Key, Device](device.Key)).
 		Entry(&existing).
 		Exec(ctx, w.tx)
 	isNotFound := errors.Is(err, query.ErrNotFound)
@@ -128,12 +128,12 @@ func (w Writer) Create(ctx context.Context, device *Device) error {
 }
 
 // Delete deletes the device with the given key and its associated status.
-func (w Writer) Delete(ctx context.Context, key string) error {
+func (w Writer) Delete(ctx context.Context, key Key) error {
 	if err := w.otg.DeleteResource(ctx, OntologyID(key)); err != nil {
 		return err
 	}
 	if err := w.status.Delete(ctx, OntologyID(key).String()); err != nil {
 		return err
 	}
-	return w.table.NewDelete().Where(gorp.MatchKeys[string, Device](key)).Exec(ctx, w.tx)
+	return w.table.NewDelete().Where(gorp.MatchKeys[Key, Device](key)).Exec(ctx, w.tx)
 }

--- a/core/pkg/service/label/writer.go
+++ b/core/pkg/service/label/writer.go
@@ -21,7 +21,7 @@ import (
 type Writer struct {
 	tx    gorp.Tx
 	otg   ontology.Writer
-	table *gorp.Table[uuid.UUID, Label]
+	table *gorp.Table[Key, Label]
 }
 
 // Create creates a new label, assigning it a unique key if one is not provided. If

--- a/core/pkg/service/lineplot/helpers.go
+++ b/core/pkg/service/lineplot/helpers.go
@@ -10,14 +10,13 @@
 package lineplot
 
 import (
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/x/gorp"
 )
 
-var _ gorp.Entry[uuid.UUID] = LinePlot{}
+var _ gorp.Entry[Key] = LinePlot{}
 
 // GorpKey implements gorp.Entry.
-func (p LinePlot) GorpKey() uuid.UUID { return p.Key }
+func (p LinePlot) GorpKey() Key { return p.Key }
 
 // SetOptions implements gorp.Entry.
 func (p LinePlot) SetOptions() []any { return nil }

--- a/core/pkg/service/lineplot/ontology.go
+++ b/core/pkg/service/lineplot/ontology.go
@@ -26,13 +26,13 @@ import (
 )
 
 // OntologyID returns unique identifier for the lineplot within the ontology.
-func OntologyID(k uuid.UUID) ontology.ID {
+func OntologyID(k Key) ontology.ID {
 	return ontology.ID{Type: ontology.ResourceTypeLineplot, Key: k.String()}
 }
 
 // OntologyIDs returns unique identifiers for the schematics within the ontology.
-func OntologyIDs(keys []uuid.UUID) []ontology.ID {
-	return lo.Map(keys, func(k uuid.UUID, _ int) ontology.ID { return OntologyID(k) })
+func OntologyIDs(keys []Key) []ontology.ID {
+	return lo.Map(keys, func(k Key, _ int) ontology.ID { return OntologyID(k) })
 }
 
 // OntologyIDsFromLinePlots returns the ontology IDs of the schematics.
@@ -58,7 +58,7 @@ var (
 	_ search.Service   = (*Service)(nil)
 )
 
-type change = xchange.Change[uuid.UUID, LinePlot]
+type change = xchange.Change[Key, LinePlot]
 
 func (s *Service) Type() ontology.ResourceType { return ontology.ResourceTypeLineplot }
 
@@ -88,7 +88,7 @@ func translateChange(c change) ontology.Change {
 
 // OnChange implements ontology.Service.
 func (s *Service) OnChange(f func(context.Context, iter.Seq[ontology.Change])) observe.Disconnect {
-	handleChange := func(ctx context.Context, reader gorp.TxReader[uuid.UUID, LinePlot]) {
+	handleChange := func(ctx context.Context, reader gorp.TxReader[Key, LinePlot]) {
 		f(ctx, xiter.Map(reader, translateChange))
 	}
 	return s.table.Observe().OnChange(handleChange)

--- a/core/pkg/service/lineplot/service.go
+++ b/core/pkg/service/lineplot/service.go
@@ -12,7 +12,6 @@ package lineplot
 import (
 	"context"
 
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/alamos"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
 	"github.com/synnaxlabs/synnax/pkg/distribution/search"
@@ -67,7 +66,7 @@ func (c ServiceConfig) Validate() error {
 // Service is the primary service for retrieving and modifying line plots from Synnax.
 type Service struct {
 	ServiceConfig
-	table *gorp.Table[uuid.UUID, LinePlot]
+	table *gorp.Table[Key, LinePlot]
 }
 
 // OpenService instantiates a new line plot service using the provided configurations.
@@ -78,9 +77,9 @@ func OpenService(ctx context.Context, cfgs ...ServiceConfig) (*Service, error) {
 	if err != nil {
 		return nil, err
 	}
-	table, err := gorp.OpenTable[uuid.UUID, LinePlot](ctx, gorp.TableConfig[LinePlot]{
+	table, err := gorp.OpenTable[Key, LinePlot](ctx, gorp.TableConfig[LinePlot]{
 		DB:              cfg.DB,
-		Migrations:      []migrate.Migration{gorp.CodecMigration[uuid.UUID, LinePlot]("msgpack_to_orc")},
+		Migrations:      []migrate.Migration{gorp.CodecMigration[Key, LinePlot]("msgpack_to_orc")},
 		Instrumentation: cfg.Instrumentation,
 	})
 	if err != nil {

--- a/core/pkg/service/lineplot/writer.go
+++ b/core/pkg/service/lineplot/writer.go
@@ -26,7 +26,7 @@ type Writer struct {
 
 func (w Writer) Create(
 	ctx context.Context,
-	ws Key,
+	ws workspace.Key,
 	p *LinePlot,
 ) (err error) {
 	var exists bool

--- a/core/pkg/service/lineplot/writer.go
+++ b/core/pkg/service/lineplot/writer.go
@@ -21,19 +21,19 @@ import (
 type Writer struct {
 	tx    gorp.Tx
 	otg   ontology.Writer
-	table *gorp.Table[uuid.UUID, LinePlot]
+	table *gorp.Table[Key, LinePlot]
 }
 
 func (w Writer) Create(
 	ctx context.Context,
-	ws uuid.UUID,
+	ws Key,
 	p *LinePlot,
 ) (err error) {
 	var exists bool
 	if p.Key == uuid.Nil {
 		p.Key = uuid.New()
 	} else {
-		exists, err = w.table.NewRetrieve().Where(gorp.MatchKeys[uuid.UUID, LinePlot](p.Key)).Exists(ctx, w.tx)
+		exists, err = w.table.NewRetrieve().Where(gorp.MatchKeys[Key, LinePlot](p.Key)).Exists(ctx, w.tx)
 		if err != nil {
 			return
 		}
@@ -61,11 +61,11 @@ func (w Writer) Create(
 
 func (w Writer) Rename(
 	ctx context.Context,
-	key uuid.UUID,
+	key Key,
 	name string,
 ) error {
 	return w.table.NewUpdate().
-		Where(gorp.MatchKeys[uuid.UUID, LinePlot](key)).
+		Where(gorp.MatchKeys[Key, LinePlot](key)).
 		Change(func(_ gorp.Context, p LinePlot) LinePlot {
 			p.Name = name
 			return p
@@ -74,11 +74,11 @@ func (w Writer) Rename(
 
 func (w Writer) SetData(
 	ctx context.Context,
-	key uuid.UUID,
+	key Key,
 	data map[string]any,
 ) error {
 	return w.table.NewUpdate().
-		Where(gorp.MatchKeys[uuid.UUID, LinePlot](key)).
+		Where(gorp.MatchKeys[Key, LinePlot](key)).
 		Change(func(_ gorp.Context, p LinePlot) LinePlot {
 			p.Data = data
 			return p
@@ -87,9 +87,9 @@ func (w Writer) SetData(
 
 func (w Writer) Delete(
 	ctx context.Context,
-	keys ...uuid.UUID,
+	keys ...Key,
 ) error {
-	err := w.table.NewDelete().Where(gorp.MatchKeys[uuid.UUID, LinePlot](keys...)).Exec(ctx, w.tx)
+	err := w.table.NewDelete().Where(gorp.MatchKeys[Key, LinePlot](keys...)).Exec(ctx, w.tx)
 	if err != nil {
 		return err
 	}

--- a/core/pkg/service/log/helpers.go
+++ b/core/pkg/service/log/helpers.go
@@ -10,14 +10,13 @@
 package log
 
 import (
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/x/gorp"
 )
 
-var _ gorp.Entry[uuid.UUID] = Log{}
+var _ gorp.Entry[Key] = Log{}
 
 // GorpKey implements gorp.Entry.
-func (l Log) GorpKey() uuid.UUID { return l.Key }
+func (l Log) GorpKey() Key { return l.Key }
 
 // SetOptions implements gorp.Entry.
 func (l Log) SetOptions() []any { return nil }

--- a/core/pkg/service/log/ontology.go
+++ b/core/pkg/service/log/ontology.go
@@ -26,13 +26,13 @@ import (
 )
 
 // OntologyID returns unique identifier for the log within the ontology.
-func OntologyID(k uuid.UUID) ontology.ID {
+func OntologyID(k Key) ontology.ID {
 	return ontology.ID{Type: ontology.ResourceTypeLog, Key: k.String()}
 }
 
 // OntologyIDs returns unique identifiers for the logs within the ontology.
-func OntologyIDs(keys []uuid.UUID) []ontology.ID {
-	return lo.Map(keys, func(key uuid.UUID, _ int) ontology.ID {
+func OntologyIDs(keys []Key) []ontology.ID {
+	return lo.Map(keys, func(key Key, _ int) ontology.ID {
 		return OntologyID(key)
 	})
 }
@@ -48,7 +48,7 @@ func newResource(l Log) ontology.Resource {
 	return ontology.NewResource(schema, OntologyID(l.Key), l.Name, l)
 }
 
-type change = xchange.Change[uuid.UUID, Log]
+type change = xchange.Change[Key, Log]
 
 var (
 	_ ontology.Service = (*Service)(nil)
@@ -83,7 +83,7 @@ func translateChange(c change) ontology.Change {
 
 // OnChange implements ontology.Service.
 func (s *Service) OnChange(f func(context.Context, iter.Seq[ontology.Change])) observe.Disconnect {
-	handleChange := func(ctx context.Context, reader gorp.TxReader[uuid.UUID, Log]) {
+	handleChange := func(ctx context.Context, reader gorp.TxReader[Key, Log]) {
 		f(ctx, xiter.Map(reader, translateChange))
 	}
 	return s.table.Observe().OnChange(handleChange)

--- a/core/pkg/service/log/service.go
+++ b/core/pkg/service/log/service.go
@@ -12,7 +12,6 @@ package log
 import (
 	"context"
 
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/alamos"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
 	"github.com/synnaxlabs/synnax/pkg/distribution/search"
@@ -65,7 +64,7 @@ func (c ServiceConfig) Validate() error {
 // Service is the primary service for retrieving and modifying logs from Synnax.
 type Service struct {
 	ServiceConfig
-	table *gorp.Table[uuid.UUID, Log]
+	table *gorp.Table[Key, Log]
 }
 
 // OpenService instantiates a new log service using the provided configurations. Each
@@ -76,9 +75,9 @@ func OpenService(ctx context.Context, cfgs ...ServiceConfig) (*Service, error) {
 	if err != nil {
 		return nil, err
 	}
-	table, err := gorp.OpenTable[uuid.UUID, Log](ctx, gorp.TableConfig[Log]{
+	table, err := gorp.OpenTable[Key, Log](ctx, gorp.TableConfig[Log]{
 		DB:              cfg.DB,
-		Migrations:      []migrate.Migration{gorp.CodecMigration[uuid.UUID, Log]("msgpack_to_orc")},
+		Migrations:      []migrate.Migration{gorp.CodecMigration[Key, Log]("msgpack_to_orc")},
 		Instrumentation: cfg.Instrumentation,
 	})
 	if err != nil {

--- a/core/pkg/service/log/writer.go
+++ b/core/pkg/service/log/writer.go
@@ -33,7 +33,7 @@ type Writer struct {
 // have a key, a new key will be generated.
 func (w Writer) Create(
 	ctx context.Context,
-	ws Key,
+	ws workspace.Key,
 	s *Log,
 ) (err error) {
 	var exists bool

--- a/core/pkg/service/log/writer.go
+++ b/core/pkg/service/log/writer.go
@@ -26,21 +26,21 @@ type Writer struct {
 	tx        gorp.Tx
 	otgWriter ontology.Writer
 	otg       *ontology.Ontology
-	table     *gorp.Table[uuid.UUID, Log]
+	table     *gorp.Table[Key, Log]
 }
 
 // Create creates the given log within the workspace provided. If the log does not
 // have a key, a new key will be generated.
 func (w Writer) Create(
 	ctx context.Context,
-	ws uuid.UUID,
+	ws Key,
 	s *Log,
 ) (err error) {
 	var exists bool
 	if s.Key == uuid.Nil {
 		s.Key = uuid.New()
 	} else {
-		exists, err = w.table.NewRetrieve().Where(gorp.MatchKeys[uuid.UUID, Log](s.Key)).Exists(ctx, w.tx)
+		exists, err = w.table.NewRetrieve().Where(gorp.MatchKeys[Key, Log](s.Key)).Exists(ctx, w.tx)
 		if err != nil {
 			return
 		}
@@ -66,11 +66,11 @@ func (w Writer) Create(
 // Rename renames the log with the given key to the provided name.
 func (w Writer) Rename(
 	ctx context.Context,
-	key uuid.UUID,
+	key Key,
 	name string,
 ) error {
 	return w.table.NewUpdate().
-		Where(gorp.MatchKeys[uuid.UUID, Log](key)).
+		Where(gorp.MatchKeys[Key, Log](key)).
 		Change(func(_ gorp.Context, l Log) Log {
 			l.Name = name
 			return l
@@ -80,11 +80,11 @@ func (w Writer) Rename(
 // SetData sets the data of the log with the given key to the provided data.
 func (w Writer) SetData(
 	ctx context.Context,
-	key uuid.UUID,
+	key Key,
 	data map[string]any,
 ) error {
 	return w.table.NewUpdate().
-		Where(gorp.MatchKeys[uuid.UUID, Log](key)).
+		Where(gorp.MatchKeys[Key, Log](key)).
 		Change(func(ctx gorp.Context, l Log) Log {
 			l.Data = data
 			return l
@@ -94,9 +94,9 @@ func (w Writer) SetData(
 // Delete deletes the logs with the given keys.
 func (w Writer) Delete(
 	ctx context.Context,
-	keys ...uuid.UUID,
+	keys ...Key,
 ) (err error) {
-	if err = w.table.NewDelete().Where(gorp.MatchKeys[uuid.UUID, Log](keys...)).Exec(ctx, w.tx); err != nil {
+	if err = w.table.NewDelete().Where(gorp.MatchKeys[Key, Log](keys...)).Exec(ctx, w.tx); err != nil {
 		return
 	}
 	for _, key := range keys {

--- a/core/pkg/service/ranger/alias/alias.go
+++ b/core/pkg/service/ranger/alias/alias.go
@@ -18,6 +18,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/synnaxlabs/synnax/pkg/distribution/channel"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
+	"github.com/synnaxlabs/synnax/pkg/service/ranger"
 	"github.com/synnaxlabs/x/errors"
 	"github.com/synnaxlabs/x/gorp"
 	"github.com/synnaxlabs/x/zyn"
@@ -25,11 +26,11 @@ import (
 
 const keySeparator = "---"
 
-func gorpKey(r uuid.UUID, ch channel.Key) string {
+func gorpKey(r ranger.Key, ch channel.Key) string {
 	return fmt.Sprintf("%s%s%s", r, keySeparator, ch)
 }
 
-func parseGorpKey(key string) (uuid.UUID, channel.Key, error) {
+func parseGorpKey(key string) (ranger.Key, channel.Key, error) {
 	split := strings.Split(key, keySeparator)
 	if len(split) != 2 {
 		return uuid.Nil, 0, errors.Newf("[alias] - invalid key")
@@ -54,12 +55,12 @@ func (a Alias) GorpKey() string { return gorpKey(a.Range, a.Channel) }
 func (a Alias) SetOptions() []any { return nil }
 
 // OntologyID returns the ontology ID for an alias.
-func OntologyID(r uuid.UUID, ch channel.Key) ontology.ID {
+func OntologyID(r ranger.Key, ch channel.Key) ontology.ID {
 	return ontology.ID{Type: ontology.ResourceTypeRangeAlias, Key: gorpKey(r, ch)}
 }
 
 // OntologyIDs returns ontology IDs for multiple aliases.
-func OntologyIDs(r uuid.UUID, chs []channel.Key) []ontology.ID {
+func OntologyIDs(r ranger.Key, chs []channel.Key) []ontology.ID {
 	return lo.Map(chs, func(ch channel.Key, _ int) ontology.ID {
 		return OntologyID(r, ch)
 	})

--- a/core/pkg/service/ranger/alias/reader.go
+++ b/core/pkg/service/ranger/alias/reader.go
@@ -13,10 +13,10 @@ import (
 	"context"
 	"regexp"
 
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/synnax/pkg/distribution/channel"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
 	"github.com/synnaxlabs/synnax/pkg/distribution/search"
+	"github.com/synnaxlabs/synnax/pkg/service/ranger"
 	"github.com/synnaxlabs/x/errors"
 	"github.com/synnaxlabs/x/gorp"
 	"github.com/synnaxlabs/x/query"
@@ -35,7 +35,7 @@ type Reader struct {
 // ranges.
 func (r Reader) Retrieve(
 	ctx context.Context,
-	rng uuid.UUID,
+	rng ranger.Key,
 	ch channel.Key,
 ) (string, error) {
 	var res Alias
@@ -64,7 +64,7 @@ func (r Reader) Retrieve(
 // recursively check parent ranges.
 func (r Reader) Resolve(
 	ctx context.Context,
-	rng uuid.UUID,
+	rng ranger.Key,
 	alias string,
 ) (channel.Key, error) {
 	var res Alias
@@ -105,7 +105,7 @@ func (r Reader) Resolve(
 // ones.
 func (r Reader) List(
 	ctx context.Context,
-	rng uuid.UUID,
+	rng ranger.Key,
 ) (map[channel.Key]string, error) {
 	res := make(map[channel.Key]string)
 	if err := r.listAliases(ctx, rng, res); err != nil {
@@ -116,7 +116,7 @@ func (r Reader) List(
 
 func (r Reader) listAliases(
 	ctx context.Context,
-	rng uuid.UUID,
+	rng ranger.Key,
 	accumulated map[channel.Key]string,
 ) error {
 	var aliases []Alias
@@ -147,7 +147,7 @@ func (r Reader) listAliases(
 // specified range.
 func (r Reader) Search(
 	ctx context.Context,
-	rng uuid.UUID,
+	rng ranger.Key,
 	term string,
 ) ([]channel.Key, error) {
 	ids, err := r.search.Search(

--- a/core/pkg/service/ranger/alias/service.go
+++ b/core/pkg/service/ranger/alias/service.go
@@ -14,12 +14,12 @@ import (
 	"io"
 	"iter"
 
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/alamos"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
 	"github.com/synnaxlabs/synnax/pkg/distribution/search"
 	"github.com/synnaxlabs/synnax/pkg/distribution/signals"
 	"github.com/synnaxlabs/synnax/pkg/service/channel"
+	"github.com/synnaxlabs/synnax/pkg/service/ranger"
 	xchange "github.com/synnaxlabs/x/change"
 	"github.com/synnaxlabs/x/config"
 	"github.com/synnaxlabs/x/gorp"
@@ -34,9 +34,9 @@ import (
 
 // ParentRetriever is an interface for retrieving the parent range key for a
 // given range. This allows the alias service to implement inheritance without
-// a direct dependency on the ranger service.
+// a direct dependency on the ranger service implementation.
 type ParentRetriever interface {
-	RetrieveParentKey(ctx context.Context, key uuid.UUID, tx gorp.Tx) (uuid.UUID, error)
+	RetrieveParentKey(ctx context.Context, key ranger.Key, tx gorp.Tx) (ranger.Key, error)
 }
 
 // ServiceConfig is the configuration for opening the alias.Service.

--- a/core/pkg/service/ranger/alias/writer.go
+++ b/core/pkg/service/ranger/alias/writer.go
@@ -12,9 +12,9 @@ package alias
 import (
 	"context"
 
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
 	"github.com/synnaxlabs/synnax/pkg/service/channel"
+	"github.com/synnaxlabs/synnax/pkg/service/ranger"
 	"github.com/synnaxlabs/x/errors"
 	"github.com/synnaxlabs/x/gorp"
 	"github.com/synnaxlabs/x/query"
@@ -32,7 +32,7 @@ type Writer struct {
 // Set sets an alias for the given channel on the specified range.
 func (w Writer) Set(
 	ctx context.Context,
-	rng uuid.UUID,
+	rng ranger.Key,
 	ch channel.Key,
 	al string,
 ) error {
@@ -61,7 +61,7 @@ func (w Writer) Set(
 // exist.
 func (w Writer) Delete(
 	ctx context.Context,
-	rng uuid.UUID,
+	rng ranger.Key,
 	ch channel.Key,
 ) error {
 	return w.table.

--- a/core/pkg/service/ranger/kv/reader.go
+++ b/core/pkg/service/ranger/kv/reader.go
@@ -12,8 +12,8 @@ package kv
 import (
 	"context"
 
-	"github.com/google/uuid"
 	"github.com/samber/lo"
+	"github.com/synnaxlabs/synnax/pkg/service/ranger"
 	"github.com/synnaxlabs/x/errors"
 	"github.com/synnaxlabs/x/gorp"
 	"github.com/synnaxlabs/x/query"
@@ -26,7 +26,7 @@ type Reader struct {
 }
 
 // Get retrieves a single key-value pair from the specified range.
-func (r Reader) Get(ctx context.Context, rng uuid.UUID, key string) (string, error) {
+func (r Reader) Get(ctx context.Context, rng ranger.Key, key string) (string, error) {
 	var (
 		res = Pair{Range: rng, Key: key}
 		err = r.table.NewRetrieve().
@@ -43,7 +43,7 @@ func (r Reader) Get(ctx context.Context, rng uuid.UUID, key string) (string, err
 // GetMany retrieves multiple key-value pairs from the specified range.
 func (r Reader) GetMany(
 	ctx context.Context,
-	rng uuid.UUID,
+	rng ranger.Key,
 	keys []string,
 ) ([]Pair, error) {
 	res := make([]Pair, 0, len(keys))
@@ -58,7 +58,7 @@ func (r Reader) GetMany(
 }
 
 // List retrieves all key-value pairs on the specified range.
-func (r Reader) List(ctx context.Context, rng uuid.UUID) ([]Pair, error) {
+func (r Reader) List(ctx context.Context, rng ranger.Key) ([]Pair, error) {
 	var res []Pair
 	err := r.table.NewRetrieve().
 		Where(gorp.Match(func(_ gorp.Context, kv *Pair) (bool, error) {

--- a/core/pkg/service/ranger/kv/writer.go
+++ b/core/pkg/service/ranger/kv/writer.go
@@ -12,7 +12,7 @@ package kv
 import (
 	"context"
 
-	"github.com/google/uuid"
+	"github.com/synnaxlabs/synnax/pkg/service/ranger"
 	"github.com/synnaxlabs/x/gorp"
 )
 
@@ -23,7 +23,7 @@ type Writer struct {
 }
 
 // Set sets a key-value pair on the specified range.
-func (w Writer) Set(ctx context.Context, rng uuid.UUID, key, value string) error {
+func (w Writer) Set(ctx context.Context, rng ranger.Key, key, value string) error {
 	return w.table.NewCreate().
 		Entry(&Pair{Range: rng, Key: key, Value: value}).
 		Exec(ctx, w.tx)
@@ -36,7 +36,7 @@ func (w Writer) SetMany(ctx context.Context, pairs []Pair) error {
 
 // Delete deletes a key-value pair from the specified range. Delete is
 // idempotent and will not return an error if the key does not exist.
-func (w Writer) Delete(ctx context.Context, rng uuid.UUID, key string) error {
+func (w Writer) Delete(ctx context.Context, rng ranger.Key, key string) error {
 	return w.table.NewDelete().
 		Where(gorp.MatchKeys[string, Pair](Pair{Range: rng, Key: key}.GorpKey())).
 		Exec(ctx, w.tx)

--- a/core/pkg/service/ranger/ontology.go
+++ b/core/pkg/service/ranger/ontology.go
@@ -28,21 +28,21 @@ import (
 )
 
 // OntologyID returns the unique ID to identify the range within the Synnax ontology.
-func OntologyID(k uuid.UUID) ontology.ID {
+func OntologyID(k Key) ontology.ID {
 	return ontology.ID{Type: ontology.ResourceTypeRange, Key: k.String()}
 }
 
 // OntologyIDs converts a slice of keys to a slice of ontology IDs.
-func OntologyIDs(keys []uuid.UUID) []ontology.ID {
-	return lo.Map(keys, func(k uuid.UUID, _ int) ontology.ID { return OntologyID(k) })
+func OntologyIDs(keys []Key) []ontology.ID {
+	return lo.Map(keys, func(k Key, _ int) ontology.ID { return OntologyID(k) })
 }
 
-func KeyFromOntologyID(id ontology.ID) (uuid.UUID, error) { return uuid.Parse(id.Key) }
+func KeyFromOntologyID(id ontology.ID) (Key, error) { return uuid.Parse(id.Key) }
 
 // KeysFromOntologyIDs converts a slice of ontology IDs to a slice of keys, returning an
 // error if any of the IDs are invalid.
-func KeysFromOntologyIDs(ids []ontology.ID) ([]uuid.UUID, error) {
-	keys := make([]uuid.UUID, len(ids))
+func KeysFromOntologyIDs(ids []ontology.ID) ([]Key, error) {
+	keys := make([]Key, len(ids))
 	var err error
 	for i, id := range ids {
 		keys[i], err = KeyFromOntologyID(id)
@@ -69,7 +69,7 @@ var (
 	_ search.Service   = (*Service)(nil)
 )
 
-type change = xchange.Change[uuid.UUID, Range]
+type change = xchange.Change[Key, Range]
 
 func (s *Service) Type() ontology.ResourceType { return ontology.ResourceTypeRange }
 
@@ -105,7 +105,7 @@ func translateChange(c change) ontology.Change {
 func (s *Service) OnChange(
 	f func(context.Context, iter.Seq[ontology.Change]),
 ) observe.Disconnect {
-	handleChange := func(ctx context.Context, reader gorp.TxReader[uuid.UUID, Range]) {
+	handleChange := func(ctx context.Context, reader gorp.TxReader[Key, Range]) {
 		f(ctx, xiter.Map(reader, translateChange))
 	}
 	return s.table.Observe().OnChange(handleChange)

--- a/core/pkg/service/ranger/range.go
+++ b/core/pkg/service/ranger/range.go
@@ -13,15 +13,14 @@
 package ranger
 
 import (
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
 	"github.com/synnaxlabs/x/gorp"
 )
 
-var _ gorp.Entry[uuid.UUID] = Range{}
+var _ gorp.Entry[Key] = Range{}
 
 // GorpKey implements gorp.Entry.
-func (r Range) GorpKey() uuid.UUID { return r.Key }
+func (r Range) GorpKey() Key { return r.Key }
 
 // SetOptions implements gorp.Entry.
 func (r Range) SetOptions() []any { return nil }

--- a/core/pkg/service/ranger/retrieve.go
+++ b/core/pkg/service/ranger/retrieve.go
@@ -10,7 +10,6 @@
 package ranger
 
 import (
-	"github.com/google/uuid"
 	"github.com/samber/lo"
 	"github.com/synnaxlabs/synnax/pkg/distribution/search"
 	"github.com/synnaxlabs/synnax/pkg/service/label"
@@ -21,7 +20,7 @@ import (
 // Retrieve is used to retrieve ranges from the cluster using a builder pattern.
 type Retrieve struct {
 	baseTX     gorp.Tx
-	gorp       gorp.Retrieve[uuid.UUID, Range]
+	gorp       gorp.Retrieve[Key, Range]
 	search     *search.Index
 	label      *label.Service
 	searchTerm string
@@ -30,7 +29,7 @@ type Retrieve struct {
 // MatchOverlap returns a filter that matches ranges whose TimeRange overlaps
 // with the provided range.
 func MatchOverlap(tr telem.TimeRange) Filter {
-	return func(_ Retrieve) gorp.Filter[uuid.UUID, Range] {
+	return func(_ Retrieve) gorp.Filter[Key, Range] {
 		return gorp.Match(func(_ gorp.Context, rng *Range) (bool, error) {
 			return rng.TimeRange.OverlapsWith(tr), nil
 		})

--- a/core/pkg/service/ranger/service.go
+++ b/core/pkg/service/ranger/service.go
@@ -93,7 +93,7 @@ func (c ServiceConfig) Override(other ServiceConfig) ServiceConfig {
 // mechanisms for creating, deleting, and listening to changes in ranges.
 type Service struct {
 	closer xio.MultiCloser
-	table  *gorp.Table[uuid.UUID, Range]
+	table  *gorp.Table[Key, Range]
 	cfg    ServiceConfig
 }
 
@@ -113,11 +113,11 @@ func OpenService(ctx context.Context, cfgs ...ServiceConfig) (s *Service, err er
 		Group:           cfg.Group,
 		Instrumentation: cfg.Instrumentation,
 	})
-	if s.table, err = gorp.OpenTable[uuid.UUID, Range](ctx, gorp.TableConfig[Range]{
+	if s.table, err = gorp.OpenTable[Key, Range](ctx, gorp.TableConfig[Range]{
 		DB: cfg.DB,
 		Migrations: []migrate.Migration{
 			v0Mig,
-			gorp.CodecMigration[uuid.UUID, Range]("msgpack_to_orc", v0Mig.Key()),
+			gorp.CodecMigration[Key, Range]("msgpack_to_orc", v0Mig.Key()),
 		},
 		Instrumentation: cfg.Instrumentation,
 	}); !ok(err, s.table) {
@@ -170,9 +170,9 @@ func (s *Service) NewRetrieve() Retrieve {
 // Returns query.ErrNotFound if the range has no parent.
 func (s *Service) RetrieveParentKey(
 	ctx context.Context,
-	key uuid.UUID,
+	key Key,
 	tx gorp.Tx,
-) (uuid.UUID, error) {
+) (Key, error) {
 	tx = gorp.OverrideTx(s.cfg.DB, tx)
 	var resources []ontology.Resource
 	if err := s.cfg.Ontology.NewRetrieve().

--- a/core/pkg/service/ranger/writer.go
+++ b/core/pkg/service/ranger/writer.go
@@ -26,7 +26,7 @@ type Writer struct {
 	tx        gorp.Tx
 	otgWriter ontology.Writer
 	otg       *ontology.Ontology
-	table     *gorp.Table[uuid.UUID, Range]
+	table     *gorp.Table[Key, Range]
 }
 
 // Create creates a new range within the DB, assigning it a unique key if it does not
@@ -56,7 +56,7 @@ func (w Writer) CreateWithParent(
 	}
 	exists, err := w.table.
 		NewRetrieve().
-		Where(gorp.MatchKeys[uuid.UUID, Range](r.Key)).
+		Where(gorp.MatchKeys[Key, Range](r.Key)).
 		Exists(ctx, w.tx)
 	if err != nil && !errors.Is(err, query.ErrNotFound) {
 		return err
@@ -137,17 +137,17 @@ func (w Writer) CreateManyWithParent(
 }
 
 // Rename renames the range with the given key.
-func (w Writer) Rename(ctx context.Context, key uuid.UUID, name string) error {
+func (w Writer) Rename(ctx context.Context, key Key, name string) error {
 	return w.table.
 		NewUpdate().
-		Where(gorp.MatchKeys[uuid.UUID, Range](key)).
+		Where(gorp.MatchKeys[Key, Range](key)).
 		Change(func(_ gorp.Context, r Range) Range { r.Name = name; return r }).
 		Exec(ctx, w.tx)
 }
 
 // Delete deletes the range with the given key. Delete will also delete all children of
 // the range. Delete is idempotent.
-func (w Writer) Delete(ctx context.Context, key uuid.UUID) error {
+func (w Writer) Delete(ctx context.Context, key Key) error {
 	// Query the ontology to find all children of the range and delete them as well
 	var children []ontology.Resource
 	if err := w.
@@ -180,7 +180,7 @@ func (w Writer) Delete(ctx context.Context, key uuid.UUID) error {
 	}
 	if err := w.table.
 		NewDelete().
-		Where(gorp.MatchKeys[uuid.UUID, Range](key)).
+		Where(gorp.MatchKeys[Key, Range](key)).
 		Exec(ctx, w.tx); err != nil {
 		return err
 	}

--- a/core/pkg/service/schematic/actions.go
+++ b/core/pkg/service/schematic/actions.go
@@ -10,7 +10,6 @@
 package schematic
 
 import (
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/x/encoding/msgpack"
 )
 
@@ -19,9 +18,9 @@ import (
 // compare SessionKey against their own client key to skip self-originated
 // updates (optimistic-UI dedup).
 type ScopedAction struct {
-	Key        uuid.UUID `json:"key" msgpack:"key"`
-	SessionKey string    `json:"session_key" msgpack:"session_key"`
-	Actions    []Action  `json:"actions" msgpack:"actions"`
+	Key        Key      `json:"key" msgpack:"key"`
+	SessionKey string   `json:"session_key" msgpack:"session_key"`
+	Actions    []Action `json:"actions" msgpack:"actions"`
 }
 
 // Handle moves the named node to the given position. No-op if no node matches.

--- a/core/pkg/service/schematic/helpers.go
+++ b/core/pkg/service/schematic/helpers.go
@@ -10,14 +10,13 @@
 package schematic
 
 import (
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/x/gorp"
 )
 
-var _ gorp.Entry[uuid.UUID] = Schematic{}
+var _ gorp.Entry[Key] = Schematic{}
 
 // GorpKey implements gorp.Entry.
-func (s Schematic) GorpKey() uuid.UUID { return s.Key }
+func (s Schematic) GorpKey() Key { return s.Key }
 
 // SetOptions implements gorp.Entry.
 func (s Schematic) SetOptions() []any { return nil }

--- a/core/pkg/service/schematic/ontology.go
+++ b/core/pkg/service/schematic/ontology.go
@@ -26,13 +26,13 @@ import (
 )
 
 // OntologyID returns unique identifier for the schematic within the ontology.
-func OntologyID(k uuid.UUID) ontology.ID {
+func OntologyID(k Key) ontology.ID {
 	return ontology.ID{Type: ontology.ResourceTypeSchematic, Key: k.String()}
 }
 
 // OntologyIDs returns unique identifiers for the schematics within the ontology.
-func OntologyIDs(keys []uuid.UUID) []ontology.ID {
-	return lo.Map(keys, func(key uuid.UUID, _ int) ontology.ID {
+func OntologyIDs(keys []Key) []ontology.ID {
+	return lo.Map(keys, func(key Key, _ int) ontology.ID {
 		return OntologyID(key)
 	})
 }
@@ -54,7 +54,7 @@ func newResource(s Schematic) ontology.Resource {
 	return ontology.NewResource(schema, OntologyID(s.Key), s.Name, s)
 }
 
-type change = xchange.Change[uuid.UUID, Schematic]
+type change = xchange.Change[Key, Schematic]
 
 var (
 	_ ontology.Service = (*Service)(nil)
@@ -89,7 +89,7 @@ func translateChange(c change) ontology.Change {
 
 // OnChange implements ontology.Service.
 func (s *Service) OnChange(f func(context.Context, iter.Seq[ontology.Change])) observe.Disconnect {
-	handleChange := func(ctx context.Context, reader gorp.TxReader[uuid.UUID, Schematic]) {
+	handleChange := func(ctx context.Context, reader gorp.TxReader[Key, Schematic]) {
 		f(ctx, xiter.Map(reader, translateChange))
 	}
 	return s.table.Observe().OnChange(handleChange)

--- a/core/pkg/service/schematic/service.go
+++ b/core/pkg/service/schematic/service.go
@@ -14,7 +14,6 @@ import (
 	"encoding/json"
 	stdio "io"
 
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/alamos"
 	"github.com/synnaxlabs/synnax/pkg/distribution/group"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
@@ -88,7 +87,7 @@ type Service struct {
 	ServiceConfig
 	Symbol *symbol.Service
 	closer io.MultiCloser
-	table  *gorp.Table[uuid.UUID, Schematic]
+	table  *gorp.Table[Key, Schematic]
 	// actionObserver fans out ScopedActions emitted by Writer.Dispatch to any
 	// subscribers (notably the cluster signals translator). Nil when the
 	// service is opened without a Signals provider.
@@ -106,12 +105,12 @@ func OpenService(ctx context.Context, cfgs ...ServiceConfig) (s *Service, err er
 	s = &Service{ServiceConfig: cfg, actionObserver: observe.New[ScopedAction]()}
 	cleanup, ok := service.NewOpener(ctx, &s.closer)
 	defer func() { err = cleanup(err) }()
-	if s.table, err = gorp.OpenTable[uuid.UUID, Schematic](ctx, gorp.TableConfig[Schematic]{
+	if s.table, err = gorp.OpenTable[Key, Schematic](ctx, gorp.TableConfig[Schematic]{
 		DB: cfg.DB,
 		Migrations: []migrate.Migration{
-			gorp.CodecMigration[uuid.UUID, v55.Schematic]("msgpack_to_orc"),
+			gorp.CodecMigration[Key, v55.Schematic]("msgpack_to_orc"),
 			migrate.WithAddedDeps(
-				gorp.NewEntryMigration[uuid.UUID, uuid.UUID, v55.Schematic, Schematic](
+				gorp.NewEntryMigration[Key, Key, v55.Schematic, Schematic](
 					"v55_lift_typed_schematic",
 					MigrateSchematic,
 				),

--- a/core/pkg/service/schematic/writer.go
+++ b/core/pkg/service/schematic/writer.go
@@ -29,7 +29,7 @@ type Writer struct {
 	tx        gorp.Tx
 	otgWriter ontology.Writer
 	otg       *ontology.Ontology
-	table     *gorp.Table[uuid.UUID, Schematic]
+	table     *gorp.Table[Key, Schematic]
 	// actionObserver is notified after a successful Dispatch so the cluster
 	// signals subsystem can broadcast the action sequence on the schematic
 	// channels. Nil when the service is opened without a Signals provider.
@@ -40,14 +40,14 @@ type Writer struct {
 // schematic does not have a key, a new key will be generated.
 func (w Writer) Create(
 	ctx context.Context,
-	ws uuid.UUID,
+	ws Key,
 	s *Schematic,
 ) (err error) {
 	var exists bool
 	if s.Key == uuid.Nil {
 		s.Key = uuid.New()
 	} else {
-		exists, err = w.table.NewRetrieve().Where(gorp.MatchKeys[uuid.UUID, Schematic](s.Key)).Exists(ctx, w.tx)
+		exists, err = w.table.NewRetrieve().Where(gorp.MatchKeys[Key, Schematic](s.Key)).Exists(ctx, w.tx)
 		if err != nil {
 			return
 		}
@@ -70,7 +70,7 @@ func (w Writer) Create(
 	)
 }
 
-func (w Writer) findParentWorkspace(ctx context.Context, key uuid.UUID) (uuid.UUID, bool, error) {
+func (w Writer) findParentWorkspace(ctx context.Context, key Key) (workspace.Key, bool, error) {
 	var res []ontology.Resource
 	if err := w.otg.NewRetrieve().
 		WhereIDs(OntologyID(key)).
@@ -90,10 +90,10 @@ func (w Writer) findParentWorkspace(ctx context.Context, key uuid.UUID) (uuid.UU
 // Rename renames the schematic with the given key to the provided name.
 func (w Writer) Rename(
 	ctx context.Context,
-	key uuid.UUID,
+	key Key,
 	name string,
 ) error {
-	return w.table.NewUpdate().Where(gorp.MatchKeys[uuid.UUID, Schematic](key)).
+	return w.table.NewUpdate().Where(gorp.MatchKeys[Key, Schematic](key)).
 		Change(func(_ gorp.Context, s Schematic) Schematic {
 			s.Name = name
 			return s
@@ -106,14 +106,14 @@ func (w Writer) Rename(
 // parameter.
 func (w Writer) Copy(
 	ctx context.Context,
-	key uuid.UUID,
+	key Key,
 	name string,
 	snapshot bool,
 	result *Schematic,
 ) error {
 	newKey := uuid.New()
 	if err := w.table.NewUpdate().
-		Where(gorp.MatchKeys[uuid.UUID, Schematic](key)).
+		Where(gorp.MatchKeys[Key, Schematic](key)).
 		Change(func(_ gorp.Context, s Schematic) Schematic {
 			s.Key = newKey
 			s.Name = name
@@ -149,10 +149,10 @@ func (w Writer) Copy(
 // since snapshots are immutable.
 func (w Writer) SetData(
 	ctx context.Context,
-	key uuid.UUID,
+	key Key,
 	data Schematic,
 ) error {
-	return w.table.NewUpdate().Where(gorp.MatchKeys[uuid.UUID, Schematic](key)).
+	return w.table.NewUpdate().Where(gorp.MatchKeys[Key, Schematic](key)).
 		ChangeErr(func(_ gorp.Context, s Schematic) (Schematic, error) {
 			if s.Snapshot {
 				return s, errors.Wrapf(validate.ErrValidation, "[Schematic] - cannot set data on snapshot %s:%s", key, s.Name)
@@ -172,11 +172,11 @@ func (w Writer) SetData(
 // snapshots are immutable.
 func (w Writer) Dispatch(
 	ctx context.Context,
-	key uuid.UUID,
+	key Key,
 	sessionKey string,
 	actions []Action,
 ) error {
-	if err := w.table.NewUpdate().Where(gorp.MatchKeys[uuid.UUID, Schematic](key)).
+	if err := w.table.NewUpdate().Where(gorp.MatchKeys[Key, Schematic](key)).
 		ChangeErr(func(_ gorp.Context, s Schematic) (Schematic, error) {
 			if s.Snapshot {
 				return s, errors.Wrapf(
@@ -203,9 +203,9 @@ func (w Writer) Dispatch(
 // Delete deletes the schematics with the given keys.
 func (w Writer) Delete(
 	ctx context.Context,
-	keys ...uuid.UUID,
+	keys ...Key,
 ) error {
-	err := w.table.NewDelete().Where(gorp.MatchKeys[uuid.UUID, Schematic](keys...)).Exec(ctx, w.tx)
+	err := w.table.NewDelete().Where(gorp.MatchKeys[Key, Schematic](keys...)).Exec(ctx, w.tx)
 	if err != nil {
 		return err
 	}

--- a/core/pkg/service/schematic/writer.go
+++ b/core/pkg/service/schematic/writer.go
@@ -40,7 +40,7 @@ type Writer struct {
 // schematic does not have a key, a new key will be generated.
 func (w Writer) Create(
 	ctx context.Context,
-	ws Key,
+	ws workspace.Key,
 	s *Schematic,
 ) (err error) {
 	var exists bool

--- a/core/pkg/service/table/helpers.go
+++ b/core/pkg/service/table/helpers.go
@@ -10,14 +10,13 @@
 package table
 
 import (
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/x/gorp"
 )
 
-var _ gorp.Entry[uuid.UUID] = Table{}
+var _ gorp.Entry[Key] = Table{}
 
 // GorpKey implements gorp.Entry.
-func (t Table) GorpKey() uuid.UUID { return t.Key }
+func (t Table) GorpKey() Key { return t.Key }
 
 // SetOptions implements gorp.Entry.
 func (t Table) SetOptions() []any { return nil }

--- a/core/pkg/service/table/ontology.go
+++ b/core/pkg/service/table/ontology.go
@@ -26,13 +26,13 @@ import (
 )
 
 // OntologyID returns unique identifier for the table within the ontology.
-func OntologyID(k uuid.UUID) ontology.ID {
+func OntologyID(k Key) ontology.ID {
 	return ontology.ID{Type: ontology.ResourceTypeTable, Key: k.String()}
 }
 
 // OntologyIDs returns unique identifiers for the tables within the ontology.
-func OntologyIDs(keys []uuid.UUID) []ontology.ID {
-	return lo.Map(keys, func(key uuid.UUID, _ int) ontology.ID {
+func OntologyIDs(keys []Key) []ontology.ID {
+	return lo.Map(keys, func(key Key, _ int) ontology.ID {
 		return OntologyID(key)
 	})
 }
@@ -53,7 +53,7 @@ var (
 	_ search.Service   = (*Service)(nil)
 )
 
-type change = xchange.Change[uuid.UUID, Table]
+type change = xchange.Change[Key, Table]
 
 func (s *Service) Type() ontology.ResourceType { return ontology.ResourceTypeTable }
 
@@ -83,7 +83,7 @@ func translateChange(c change) ontology.Change {
 
 // OnChange implements ontology.Service.
 func (s *Service) OnChange(f func(context.Context, iter.Seq[ontology.Change])) observe.Disconnect {
-	handleChange := func(ctx context.Context, reader gorp.TxReader[uuid.UUID, Table]) {
+	handleChange := func(ctx context.Context, reader gorp.TxReader[Key, Table]) {
 		f(ctx, xiter.Map(reader, translateChange))
 	}
 	return s.table.Observe().OnChange(handleChange)

--- a/core/pkg/service/table/service.go
+++ b/core/pkg/service/table/service.go
@@ -12,7 +12,6 @@ package table
 import (
 	"context"
 
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/alamos"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
 	"github.com/synnaxlabs/synnax/pkg/distribution/search"
@@ -65,7 +64,7 @@ func (c ServiceConfig) Validate() error {
 // Service is the primary service for retrieving and modifying tables from Synnax.
 type Service struct {
 	ServiceConfig
-	table *gorp.Table[uuid.UUID, Table]
+	table *gorp.Table[Key, Table]
 }
 
 // OpenService instantiates a new table service using the provided configurations. Each
@@ -76,9 +75,9 @@ func OpenService(ctx context.Context, cfgs ...ServiceConfig) (*Service, error) {
 	if err != nil {
 		return nil, err
 	}
-	table, err := gorp.OpenTable[uuid.UUID, Table](ctx, gorp.TableConfig[Table]{
+	table, err := gorp.OpenTable[Key, Table](ctx, gorp.TableConfig[Table]{
 		DB:              cfg.DB,
-		Migrations:      []migrate.Migration{gorp.CodecMigration[uuid.UUID, Table]("msgpack_to_orc")},
+		Migrations:      []migrate.Migration{gorp.CodecMigration[Key, Table]("msgpack_to_orc")},
 		Instrumentation: cfg.Instrumentation,
 	})
 	if err != nil {

--- a/core/pkg/service/table/writer.go
+++ b/core/pkg/service/table/writer.go
@@ -26,21 +26,21 @@ type Writer struct {
 	tx        gorp.Tx
 	otgWriter ontology.Writer
 	otg       *ontology.Ontology
-	tbl       *gorp.Table[uuid.UUID, Table]
+	tbl       *gorp.Table[Key, Table]
 }
 
 // Create creates the given table within the workspace provided. If the table does not
 // have a key, a new key will be generated.
 func (w Writer) Create(
 	ctx context.Context,
-	ws uuid.UUID,
+	ws Key,
 	s *Table,
 ) (err error) {
 	var exists bool
 	if s.Key == uuid.Nil {
 		s.Key = uuid.New()
 	} else {
-		exists, err = w.tbl.NewRetrieve().Where(gorp.MatchKeys[uuid.UUID, Table](s.Key)).Exists(ctx, w.tx)
+		exists, err = w.tbl.NewRetrieve().Where(gorp.MatchKeys[Key, Table](s.Key)).Exists(ctx, w.tx)
 		if err != nil {
 			return
 		}
@@ -66,11 +66,11 @@ func (w Writer) Create(
 // Rename renames the table with the given key to the provided name.
 func (w Writer) Rename(
 	ctx context.Context,
-	key uuid.UUID,
+	key Key,
 	name string,
 ) error {
 	return w.tbl.NewUpdate().
-		Where(gorp.MatchKeys[uuid.UUID, Table](key)).
+		Where(gorp.MatchKeys[Key, Table](key)).
 		Change(func(_ gorp.Context, t Table) Table {
 			t.Name = name
 			return t
@@ -81,11 +81,11 @@ func (w Writer) Rename(
 // SetData sets the data of the table with the given key to the provided data.
 func (w Writer) SetData(
 	ctx context.Context,
-	key uuid.UUID,
+	key Key,
 	data map[string]any,
 ) error {
 	return w.tbl.NewUpdate().
-		Where(gorp.MatchKeys[uuid.UUID, Table](key)).
+		Where(gorp.MatchKeys[Key, Table](key)).
 		Change(func(_ gorp.Context, t Table) Table {
 			t.Data = data
 			return t
@@ -95,9 +95,9 @@ func (w Writer) SetData(
 // Delete deletes the tables with the given keys.
 func (w Writer) Delete(
 	ctx context.Context,
-	keys ...uuid.UUID,
+	keys ...Key,
 ) (err error) {
-	if err = w.tbl.NewDelete().Where(gorp.MatchKeys[uuid.UUID, Table](keys...)).Exec(ctx, w.tx); err != nil {
+	if err = w.tbl.NewDelete().Where(gorp.MatchKeys[Key, Table](keys...)).Exec(ctx, w.tx); err != nil {
 		return
 	}
 	for _, key := range keys {

--- a/core/pkg/service/table/writer.go
+++ b/core/pkg/service/table/writer.go
@@ -33,7 +33,7 @@ type Writer struct {
 // have a key, a new key will be generated.
 func (w Writer) Create(
 	ctx context.Context,
-	ws Key,
+	ws workspace.Key,
 	s *Table,
 ) (err error) {
 	var exists bool

--- a/core/pkg/service/user/ontology.go
+++ b/core/pkg/service/user/ontology.go
@@ -26,13 +26,13 @@ import (
 )
 
 // OntologyID returns a unique identifier for a User for use within a resource ontology.
-func OntologyID(key uuid.UUID) ontology.ID {
+func OntologyID(key Key) ontology.ID {
 	return ontology.ID{Type: ontology.ResourceTypeUser, Key: key.String()}
 }
 
 // OntologyIDsFromKeys returns a slice of unique identifiers from a slice of keys
-func OntologyIDsFromKeys(keys []uuid.UUID) []ontology.ID {
-	return lo.Map(keys, func(key uuid.UUID, _ int) ontology.ID {
+func OntologyIDsFromKeys(keys []Key) []ontology.ID {
+	return lo.Map(keys, func(key Key, _ int) ontology.ID {
 		return OntologyID(key)
 	})
 }
@@ -49,7 +49,7 @@ func OntologyIDsFromUsers(users []User) []ontology.ID {
 	})
 }
 
-func KeyFromOntologyID(id ontology.ID) (uuid.UUID, error) { return uuid.Parse(id.Key) }
+func KeyFromOntologyID(id ontology.ID) (Key, error) { return uuid.Parse(id.Key) }
 
 var schema = zyn.Object(map[string]zyn.Schema{
 	"key":        zyn.UUID(),
@@ -88,7 +88,7 @@ func (s *Service) RetrieveResource(ctx context.Context, key string, tx gorp.Tx) 
 	return newResource(u), nil
 }
 
-type change = xchange.Change[uuid.UUID, User]
+type change = xchange.Change[Key, User]
 
 func translateChange(ch change) ontology.Change {
 	return ontology.Change{
@@ -100,7 +100,7 @@ func translateChange(ch change) ontology.Change {
 
 // OnChange implements ontology.Service.
 func (s *Service) OnChange(f func(context.Context, iter.Seq[ontology.Change])) observe.Disconnect {
-	handleChange := func(ctx context.Context, reader gorp.TxReader[uuid.UUID, User]) {
+	handleChange := func(ctx context.Context, reader gorp.TxReader[Key, User]) {
 		f(ctx, xiter.Map(reader, translateChange))
 	}
 	return s.table.Observe().OnChange(handleChange)

--- a/core/pkg/service/user/service.go
+++ b/core/pkg/service/user/service.go
@@ -90,7 +90,7 @@ func (c ServiceConfig) Validate() error {
 type Service struct {
 	cfg    ServiceConfig
 	closer xio.MultiCloser
-	table  *gorp.Table[uuid.UUID, User]
+	table  *gorp.Table[Key, User]
 }
 
 // OpenService opens a new Service with the given context ctx and configurations configs.
@@ -102,9 +102,9 @@ func OpenService(ctx context.Context, configs ...ServiceConfig) (s *Service, err
 	s = &Service{cfg: cfg}
 	cleanup, ok := service.NewOpener(ctx, &s.closer)
 	defer func() { err = cleanup(err) }()
-	if s.table, err = gorp.OpenTable[uuid.UUID, User](ctx, gorp.TableConfig[User]{
+	if s.table, err = gorp.OpenTable[Key, User](ctx, gorp.TableConfig[User]{
 		DB:              cfg.DB,
-		Migrations:      []migrate.Migration{gorp.CodecMigration[uuid.UUID, User]("msgpack_to_orc")},
+		Migrations:      []migrate.Migration{gorp.CodecMigration[Key, User]("msgpack_to_orc")},
 		Instrumentation: cfg.Instrumentation,
 	}); !ok(err, s.table) {
 		return nil, err
@@ -113,7 +113,7 @@ func OpenService(ctx context.Context, configs ...ServiceConfig) (s *Service, err
 	cfg.Search.RegisterService(s)
 	if cfg.Signals != nil {
 		var sig io.Closer
-		if sig, err = signals.PublishFromGorp[uuid.UUID, User](
+		if sig, err = signals.PublishFromGorp[Key, User](
 			ctx,
 			cfg.Signals,
 			signals.GorpPublisherConfigUUID[User](s.table.Observe()),

--- a/core/pkg/service/user/user.go
+++ b/core/pkg/service/user/user.go
@@ -19,10 +19,10 @@ import (
 	"github.com/vmihailenco/msgpack/v5"
 )
 
-var _ gorp.Entry[uuid.UUID] = User{}
+var _ gorp.Entry[Key] = User{}
 
 // GorpKey implements gorp.Entry.
-func (u User) GorpKey() uuid.UUID { return u.Key }
+func (u User) GorpKey() Key { return u.Key }
 
 // SetOptions implements gorp.Entry.
 func (u User) SetOptions() []any { return nil }

--- a/core/pkg/service/user/writer.go
+++ b/core/pkg/service/user/writer.go
@@ -31,7 +31,7 @@ type Writer struct {
 	// between users and a user group.
 	otg ontology.Writer
 	// table is the gorp table for user entries.
-	table *gorp.Table[uuid.UUID, User]
+	table *gorp.Table[Key, User]
 }
 
 // Create makes a new user in the key-value store. If the username of u already exists,
@@ -56,7 +56,7 @@ func (w Writer) Create(ctx context.Context, u *User) error {
 
 // ChangeUsername updates the username of the user with the given key. If a User with
 // the username newUsername already exists, an error is thrown.
-func (w Writer) ChangeUsername(ctx context.Context, key uuid.UUID, newUsername string) error {
+func (w Writer) ChangeUsername(ctx context.Context, key Key, newUsername string) error {
 	usernameExists, err := w.svc.UsernameExists(ctx, newUsername)
 	if err != nil {
 		return err
@@ -64,7 +64,7 @@ func (w Writer) ChangeUsername(ctx context.Context, key uuid.UUID, newUsername s
 	if usernameExists {
 		return auth.RepeatedUsername
 	}
-	return w.table.NewUpdate().Where(gorp.MatchKeys[uuid.UUID, User](key)).Change(func(_ gorp.Context, u User) User {
+	return w.table.NewUpdate().Where(gorp.MatchKeys[Key, User](key)).Change(func(_ gorp.Context, u User) User {
 		u.Username = newUsername
 		return u
 	}).Exec(ctx, w.tx)
@@ -72,8 +72,8 @@ func (w Writer) ChangeUsername(ctx context.Context, key uuid.UUID, newUsername s
 
 // ChangeName updates the first and last name of the user with the given key. If either
 // first or last is an empty string, the corresponding field will not be updated.
-func (w Writer) ChangeName(ctx context.Context, key uuid.UUID, first string, last string) error {
-	return w.table.NewUpdate().Where(gorp.MatchKeys[uuid.UUID, User](key)).Change(func(_ gorp.Context, u User) User {
+func (w Writer) ChangeName(ctx context.Context, key Key, first string, last string) error {
+	return w.table.NewUpdate().Where(gorp.MatchKeys[Key, User](key)).Change(func(_ gorp.Context, u User) User {
 		if first != "" {
 			u.FirstName = first
 		}
@@ -87,9 +87,9 @@ func (w Writer) ChangeName(ctx context.Context, key uuid.UUID, first string, las
 // Delete removes the users with the given keys from the key-value store.
 func (w Writer) Delete(
 	ctx context.Context,
-	keys ...uuid.UUID,
+	keys ...Key,
 ) error {
-	if err := w.table.NewDelete().Where(gorp.MatchKeys[uuid.UUID, User](keys...)).Guard(func(_ gorp.Context, u User) error {
+	if err := w.table.NewDelete().Where(gorp.MatchKeys[Key, User](keys...)).Guard(func(_ gorp.Context, u User) error {
 		if u.RootUser {
 			return errors.New("cannot delete root user")
 		}

--- a/core/pkg/service/view/helpers.go
+++ b/core/pkg/service/view/helpers.go
@@ -10,14 +10,13 @@
 package view
 
 import (
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/x/gorp"
 )
 
-var _ gorp.Entry[uuid.UUID] = View{}
+var _ gorp.Entry[Key] = View{}
 
 // GorpKey implements gorp.Entry.
-func (v View) GorpKey() uuid.UUID { return v.Key }
+func (v View) GorpKey() Key { return v.Key }
 
 // SetOptions implements gorp.Entry.
 func (v View) SetOptions() []any { return nil }

--- a/core/pkg/service/view/ontology.go
+++ b/core/pkg/service/view/ontology.go
@@ -27,18 +27,18 @@ import (
 
 // OntologyID returns a unique ID for the view with the given key within the Synnax
 // ontology.
-func OntologyID(keys uuid.UUID) ontology.ID {
+func OntologyID(keys Key) ontology.ID {
 	return ontology.ID{Type: ontology.ResourceTypeView, Key: keys.String()}
 }
 
 // OntologyIDs returns the ontology IDs for the given keys.
-func OntologyIDs(keys []uuid.UUID) []ontology.ID {
-	return lo.Map(keys, func(k uuid.UUID, _ int) ontology.ID { return OntologyID(k) })
+func OntologyIDs(keys []Key) []ontology.ID {
+	return lo.Map(keys, func(k Key, _ int) ontology.ID { return OntologyID(k) })
 }
 
 // KeysFromOntologyIDs returns the keys of the views for the given ontology IDs.
-func KeysFromOntologyIDs(ids []ontology.ID) ([]uuid.UUID, error) {
-	keys := make([]uuid.UUID, len(ids))
+func KeysFromOntologyIDs(ids []ontology.ID) ([]Key, error) {
+	keys := make([]Key, len(ids))
 	var err error
 	for i, id := range ids {
 		if keys[i], err = uuid.Parse(id.Key); err != nil {
@@ -68,7 +68,7 @@ var (
 	_ search.Service   = (*Service)(nil)
 )
 
-type change = xchange.Change[uuid.UUID, View]
+type change = xchange.Change[Key, View]
 
 func (s *Service) Type() ontology.ResourceType { return ontology.ResourceTypeView }
 
@@ -101,7 +101,7 @@ func translateChange(c change) ontology.Change {
 func (s *Service) OnChange(
 	f func(context.Context, iter.Seq[ontology.Change]),
 ) observe.Disconnect {
-	handleChange := func(ctx context.Context, reader gorp.TxReader[uuid.UUID, View]) {
+	handleChange := func(ctx context.Context, reader gorp.TxReader[Key, View]) {
 		f(ctx, xiter.Map(reader, translateChange))
 	}
 	return s.table.Observe().OnChange(handleChange)

--- a/core/pkg/service/view/service.go
+++ b/core/pkg/service/view/service.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"io"
 
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/alamos"
 	"github.com/synnaxlabs/synnax/pkg/distribution/group"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
@@ -76,7 +75,7 @@ func (c ServiceConfig) Validate() error {
 type Service struct {
 	cfg    ServiceConfig
 	group  group.Group
-	table  *gorp.Table[uuid.UUID, View]
+	table  *gorp.Table[Key, View]
 	closer xio.MultiCloser
 }
 

--- a/core/pkg/service/view/writer.go
+++ b/core/pkg/service/view/writer.go
@@ -27,7 +27,7 @@ type Writer struct {
 	otgWriter ontology.Writer
 	otg       *ontology.Ontology
 	group     group.Group
-	table     *gorp.Table[uuid.UUID, View]
+	table     *gorp.Table[Key, View]
 }
 
 // Create creates or updates a view within the DB. If the view already has a key and an
@@ -69,8 +69,8 @@ func (w Writer) CreateMany(ctx context.Context, views *[]View) error {
 }
 
 // Delete deletes the view with the given key. Delete is idempotent.
-func (w Writer) Delete(ctx context.Context, key uuid.UUID) error {
-	if err := w.table.NewDelete().Where(gorp.MatchKeys[uuid.UUID, View](key)).
+func (w Writer) Delete(ctx context.Context, key Key) error {
+	if err := w.table.NewDelete().Where(gorp.MatchKeys[Key, View](key)).
 		Exec(ctx, w.tx); err != nil && !errors.Is(err, query.ErrNotFound) {
 		return err
 	}
@@ -78,7 +78,7 @@ func (w Writer) Delete(ctx context.Context, key uuid.UUID) error {
 }
 
 // DeleteMany deletes multiple views with the given keys. DeleteMany is idempotent.
-func (w Writer) DeleteMany(ctx context.Context, keys ...uuid.UUID) error {
+func (w Writer) DeleteMany(ctx context.Context, keys ...Key) error {
 	for _, key := range keys {
 		if err := w.Delete(ctx, key); err != nil {
 			return err

--- a/core/pkg/service/workspace/helpers.go
+++ b/core/pkg/service/workspace/helpers.go
@@ -10,15 +10,14 @@
 package workspace
 
 import (
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
 	"github.com/synnaxlabs/x/gorp"
 )
 
-var _ gorp.Entry[uuid.UUID] = Workspace{}
+var _ gorp.Entry[Key] = Workspace{}
 
 // GorpKey implements gorp.Entry.
-func (w Workspace) GorpKey() uuid.UUID { return w.Key }
+func (w Workspace) GorpKey() Key { return w.Key }
 
 // SetOptions implements gorp.Entry.
 func (w Workspace) SetOptions() []any { return nil }

--- a/core/pkg/service/workspace/ontology.go
+++ b/core/pkg/service/workspace/ontology.go
@@ -25,12 +25,12 @@ import (
 	"github.com/synnaxlabs/x/zyn"
 )
 
-func OntologyID(k uuid.UUID) ontology.ID {
+func OntologyID(k Key) ontology.ID {
 	return ontology.ID{Type: ontology.ResourceTypeWorkspace, Key: k.String()}
 }
 
-func OntologyIDs(keys []uuid.UUID) []ontology.ID {
-	return lo.Map(keys, func(k uuid.UUID, _ int) ontology.ID { return OntologyID(k) })
+func OntologyIDs(keys []Key) []ontology.ID {
+	return lo.Map(keys, func(k Key, _ int) ontology.ID { return OntologyID(k) })
 }
 
 func OntologyIDsFromWorkspaces(workspaces []Workspace) []ontology.ID {
@@ -39,8 +39,8 @@ func OntologyIDsFromWorkspaces(workspaces []Workspace) []ontology.ID {
 	})
 }
 
-func KeysFromOntologyIDs(ids []ontology.ID) ([]uuid.UUID, error) {
-	keys := make([]uuid.UUID, len(ids))
+func KeysFromOntologyIDs(ids []ontology.ID) ([]Key, error) {
+	keys := make([]Key, len(ids))
 	var err error
 	for i, id := range ids {
 		if keys[i], err = uuid.Parse(id.Key); err != nil {
@@ -59,7 +59,7 @@ func newResource(ws Workspace) ontology.Resource {
 	return ontology.NewResource(schema, OntologyID(ws.Key), ws.Name, ws)
 }
 
-type change = xchange.Change[uuid.UUID, Workspace]
+type change = xchange.Change[Key, Workspace]
 
 var (
 	_ ontology.Service = (*Service)(nil)
@@ -94,7 +94,7 @@ func translateChange(c change) ontology.Change {
 
 // OnChange implements ontology.Service.
 func (s *Service) OnChange(f func(context.Context, iter.Seq[ontology.Change])) observe.Disconnect {
-	handleChange := func(ctx context.Context, reader gorp.TxReader[uuid.UUID, Workspace]) {
+	handleChange := func(ctx context.Context, reader gorp.TxReader[Key, Workspace]) {
 		f(ctx, xiter.Map(reader, translateChange))
 	}
 	return s.table.Observe().OnChange(handleChange)

--- a/core/pkg/service/workspace/pb/translator.gen.go
+++ b/core/pkg/service/workspace/pb/translator.gen.go
@@ -13,6 +13,7 @@ package pb
 
 import (
 	"github.com/google/uuid"
+	"github.com/synnaxlabs/synnax/pkg/service/user"
 	"github.com/synnaxlabs/synnax/pkg/service/workspace"
 	"google.golang.org/protobuf/types/known/structpb"
 )
@@ -44,10 +45,11 @@ func WorkspaceFromPB(pb *Workspace) (workspace.Workspace, error) {
 		return workspace.Workspace{}, err
 	}
 	r.Key = workspace.Key(parsedKey)
-	r.Author, err = uuid.Parse(pb.Author)
+	parsedAuthor, err := uuid.Parse(pb.Author)
 	if err != nil {
 		return workspace.Workspace{}, err
 	}
+	r.Author = user.Key(parsedAuthor)
 	r.Layout = pb.Layout.AsMap()
 	r.Name = pb.Name
 	return r, nil

--- a/core/pkg/service/workspace/retrieve.gen.go
+++ b/core/pkg/service/workspace/retrieve.gen.go
@@ -13,9 +13,9 @@ package workspace
 
 import (
 	"context"
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
 	"github.com/synnaxlabs/synnax/pkg/distribution/search"
+	"github.com/synnaxlabs/synnax/pkg/service/user"
 	"github.com/synnaxlabs/x/gorp"
 )
 
@@ -74,7 +74,7 @@ func MatchKeys(keys ...Key) Filter {
 }
 
 // MatchAuthor returns a filter for workspaces whose Author matches the provided value.
-func MatchAuthor(v uuid.UUID) Filter {
+func MatchAuthor(v user.Key) Filter {
 	return func(_ Retrieve) gorp.Filter[Key, Workspace] {
 		return gorp.Match(func(_ gorp.Context, e *Workspace) (bool, error) {
 			return e.Author == v, nil

--- a/core/pkg/service/workspace/service.go
+++ b/core/pkg/service/workspace/service.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"io"
 
-	"github.com/google/uuid"
 	"github.com/synnaxlabs/alamos"
 	"github.com/synnaxlabs/synnax/pkg/distribution/group"
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
@@ -67,7 +66,7 @@ func (c ServiceConfig) Validate() error {
 type Service struct {
 	cfg    ServiceConfig
 	closer xio.MultiCloser
-	table  *gorp.Table[uuid.UUID, Workspace]
+	table  *gorp.Table[Key, Workspace]
 	group  group.Group
 }
 
@@ -79,9 +78,9 @@ func OpenService(ctx context.Context, configs ...ServiceConfig) (s *Service, err
 	s = &Service{cfg: cfg}
 	cleanup, ok := service.NewOpener(ctx, &s.closer)
 	defer func() { err = cleanup(err) }()
-	if s.table, err = gorp.OpenTable[uuid.UUID, Workspace](ctx, gorp.TableConfig[Workspace]{
+	if s.table, err = gorp.OpenTable[Key, Workspace](ctx, gorp.TableConfig[Workspace]{
 		DB:              cfg.DB,
-		Migrations:      []migrate.Migration{gorp.CodecMigration[uuid.UUID, Workspace]("msgpack_to_orc")},
+		Migrations:      []migrate.Migration{gorp.CodecMigration[Key, Workspace]("msgpack_to_orc")},
 		Instrumentation: cfg.Instrumentation,
 	}); !ok(err, s.table) {
 		return nil, err

--- a/core/pkg/service/workspace/types.gen.go
+++ b/core/pkg/service/workspace/types.gen.go
@@ -13,6 +13,7 @@ package workspace
 
 import (
 	"github.com/google/uuid"
+	"github.com/synnaxlabs/synnax/pkg/service/user"
 	"github.com/synnaxlabs/x/encoding/msgpack"
 )
 
@@ -28,7 +29,7 @@ type Workspace struct {
 	// Name is a human-readable name for the workspace.
 	Name string `json:"name" msgpack:"name"`
 	// Author is the UUID of the user who created this workspace.
-	Author uuid.UUID `json:"author" msgpack:"author"`
+	Author user.Key `json:"author" msgpack:"author"`
 	// Layout is the mosaic tree structure that defines how visualizations are arranged.
 	// Contains tab layout, split configurations, and window positions.
 	Layout msgpack.EncodedJSON `json:"layout" msgpack:"layout"`

--- a/core/pkg/service/workspace/writer.go
+++ b/core/pkg/service/workspace/writer.go
@@ -23,7 +23,7 @@ type Writer struct {
 	tx    gorp.Tx
 	otg   ontology.Writer
 	group group.Group
-	table *gorp.Table[uuid.UUID, Workspace]
+	table *gorp.Table[Key, Workspace]
 }
 
 func (w Writer) Create(
@@ -61,10 +61,10 @@ func (w Writer) Create(
 
 func (w Writer) Rename(
 	ctx context.Context,
-	key uuid.UUID,
+	key Key,
 	name string,
 ) error {
-	return w.table.NewUpdate().Where(gorp.MatchKeys[uuid.UUID, Workspace](key)).
+	return w.table.NewUpdate().Where(gorp.MatchKeys[Key, Workspace](key)).
 		Change(func(_ gorp.Context, ws Workspace) Workspace {
 			ws.Name = name
 			return ws
@@ -73,10 +73,10 @@ func (w Writer) Rename(
 
 func (w Writer) SetLayout(
 	ctx context.Context,
-	key uuid.UUID,
+	key Key,
 	layout map[string]any,
 ) error {
-	return w.table.NewUpdate().Where(gorp.MatchKeys[uuid.UUID, Workspace](key)).
+	return w.table.NewUpdate().Where(gorp.MatchKeys[Key, Workspace](key)).
 		Change(func(_ gorp.Context, ws Workspace) Workspace {
 			ws.Layout = layout
 			return ws
@@ -85,9 +85,9 @@ func (w Writer) SetLayout(
 
 func (w Writer) Delete(
 	ctx context.Context,
-	keys ...uuid.UUID,
+	keys ...Key,
 ) error {
-	if err := w.table.NewDelete().Where(gorp.MatchKeys[uuid.UUID, Workspace](keys...)).Exec(ctx, w.tx); err != nil {
+	if err := w.table.NewDelete().Where(gorp.MatchKeys[Key, Workspace](keys...)).Exec(ctx, w.tx); err != nil {
 		return err
 	}
 	for _, key := range keys {

--- a/schemas/device.oracle
+++ b/schemas/device.oracle
@@ -17,11 +17,15 @@ import "schemas/ontology"
 @cpp output "client/cpp/device"
 @pb
 
+Key = string {
+    @doc value "is a unique identifier for the device"
+}
+
 StatusDetails struct {
     rack   rack.Key {
         @doc value "is the key of the rack this device belongs to."
     }
-    device string   {
+    device Key      {
         @doc value "is the device identifier."
     }
 
@@ -33,10 +37,6 @@ Status = status.Status<StatusDetails> {
         is device-specific status information including operational state and
         device identification.
     """
-}
-
-Key = string {
-    @doc value "is the device's serial number, used as its unique identifier."
 }
 
 Device struct<

--- a/schemas/workspace.oracle
+++ b/schemas/workspace.oracle
@@ -7,6 +7,8 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+import "schemas/user"
+
 @ts output "client/ts/src/workspace"
 @go output "core/pkg/service/workspace"
 @pb
@@ -16,15 +18,15 @@ Key = uuid {
 }
 
 Workspace struct {
-    key    Key    {
+    key    Key      {
         @doc value "is the unique identifier for this workspace."
         @key
     }
-    name   string {
+    name   string   {
         @doc value         "is a human-readable name for the workspace."
         @validate required
     }
-    author uuid?  {
+    author user.Key? {
         @doc value     "is the UUID of the user who created this workspace."
         @filter scalar
     }

--- a/schemas/workspace.oracle
+++ b/schemas/workspace.oracle
@@ -18,11 +18,11 @@ Key = uuid {
 }
 
 Workspace struct {
-    key    Key      {
+    key    Key       {
         @doc value "is the unique identifier for this workspace."
         @key
     }
-    name   string   {
+    name   string    {
         @doc value         "is a human-readable name for the workspace."
         @validate required
     }
@@ -30,7 +30,7 @@ Workspace struct {
         @doc value     "is the UUID of the user who created this workspace."
         @filter scalar
     }
-    layout record {
+    layout record    {
         @doc value        """
             is the mosaic tree structure that defines how visualizations are
             arranged. Contains tab layout, split configurations, and window


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4164](https://linear.app/synnax/issue/SY-4164)

## Description

Replaces direct uses of underlying primitive types (`uuid.UUID`, `string`,
`golabel.Key`) with the package-local `Key` alias across the
`core/pkg/distribution/*` and `core/pkg/service/*` packages, and the
matching `core/pkg/api/*` request / response types. Affected packages
include `ranger`, `group`, `arc`, `lineplot`, `log`, `schematic`, `table`,
`user`, `view`, `workspace`, `device`, `label`, `access` (`role` /
`policy`), and `auth/token`.

These are alias-only swaps, so the wire formats and types are byte-for-byte
identical. The motivation is readability and a measure of future-proofing
in case any of these aliases are tightened from `=` aliases to named types
later. Existing `uuid.New`, `uuid.Nil`, and `uuid.Parse` constructor calls
stay as-is; conversion at true wire boundaries (proto reinterpret, msgpack
authority workaround) is unchanged.

Also fixes one real schema leak: `StatusDetails.device` in
`schemas/device.oracle` was typed as `string` instead of `Key`. The
generated Go / TS / Py / C++ types pick this up after `oracle sync`.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces direct uses of `uuid.UUID`, `string`, and `golabel.Key` with package-local `Key` aliases across `distribution/*`, `service/*`, and `api/*` packages, improving readability and preparing for potential future tightening of aliases to named types. It also fixes a schema-level bug where `StatusDetails.device` in `device.oracle` was typed as `string` instead of `Key`, with corresponding generated code updates in Go, TypeScript, Python, and C++.

- **Alias-only substitution across 95 files**: All changes are type-alias swaps; wire formats (JSON/msgpack/protobuf) are byte-for-byte identical at runtime.
- **Schema fix for `device.oracle`**: `StatusDetails.device` is now typed as `Key`, and the `Key` definition is repositioned before `StatusDetails` so forward references resolve correctly; generated clients in all target languages are regenerated to match.
- **Workspace `author` field corrected across the stack**: The Go struct, TypeScript Zod schema, protobuf translator, and `MatchAuthor` filter function all now use `user.Key` instead of `uuid.UUID`, making the semantic intent of the field explicit end-to-end.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are alias-only substitutions that are byte-for-byte identical on the wire, plus a schema-level type correction with consistent generated-code updates.

Every substitution replaces a primitive (`uuid.UUID` / `string`) with a `=`-aliased type, so compiled output is identical. The schema fix in `device.oracle` and the corresponding regen across Go/TS/Py/C++ are internally consistent. All issues from prior review rounds (wrong workspace key type in writers, `Author` typed as `workspace.Key`, `roleKey` typed as `policy.Key`) have been corrected in this revision.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| schemas/device.oracle | Moves `Key` definition before `StatusDetails` so `device: Key` resolves correctly; fixes a real schema bug where the field was typed as bare `string`. |
| schemas/workspace.oracle | Imports `schemas/user` and changes `author` from `uuid?` to `user.Key?`, making the field's semantic identity explicit at the schema level. |
| core/pkg/service/workspace/types.gen.go | Generated: `Workspace.Author` changed from `uuid.UUID` to `user.Key`; imports `user` package accordingly. |
| core/pkg/service/workspace/pb/translator.gen.go | Generated: properly introduces an intermediate `parsedAuthor` variable and casts to `user.Key` after `uuid.Parse`, keeping the wire boundary conversion correct. |
| core/pkg/service/auth/token/token.go | `New`, `Validate`, `ValidateMaybeRefresh`, and internal `validate` now use `user.Key` instead of `uuid.UUID`; semantically correct since tokens are always issued to users. |
| core/pkg/service/access/rbac/policy/writer.go | `SetOnRole` now correctly types `roleKey` as `role.Key` and `policyKeys` as `Key`; previous mismatch (package-local `Key` for a role identifier) is resolved. |
| core/pkg/api/workspace/workspace.go | `RetrieveRequest.Author` now uses `user.Key` and `Keys` uses `workspace.Key`; the previous semantic mismatch on `Author` is fully resolved. |
| core/pkg/service/lineplot/writer.go | `Create` `ws` parameter correctly changed to `workspace.Key`; per-entity key parameters use `Key` (i.e., `lineplot.Key`). |
| client/ts/src/workspace/types.gen.ts | Generated: `workspaceZ.author` now uses `user.keyZ.optional()` matching the schema change; imports `user` module. |
| client/ts/src/device/types.gen.ts | Generated: `keyZ` moved before `statusDetailsZ` so `device: keyZ` resolves; `statusDetailsZ.device` now uses `keyZ` instead of `z.string()`. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["schemas/*.oracle\n(source of truth)"] -->|oracle sync| B["types.gen.go\ntranslator.gen.go\nretrieve.gen.go"]
    A -->|oracle sync| C["types.gen.ts\ntypes.gen.py\ntypes.gen.h"]

    B --> D["service layer\n(writer.go / service.go)"]
    D --> E["api layer\n(CreateRequest / RetrieveRequest etc.)"]

    subgraph "Key alias substitutions"
      F["uuid.UUID → lineplot.Key / log.Key / table.Key\nschematic.Key / view.Key / arc.Key …"]
      G["uuid.UUID → workspace.Key\n(ws parameter in Create calls)"]
      H["uuid.UUID → user.Key\n(Author field, token issuer)"]
      I["uuid.UUID → role.Key\n(roleKey in SetOnRole)"]
      J["string → device.Key\n(StatusDetails.device)"]
    end

    E --> F
    E --> G
    E --> H
    E --> I
    B --> J
```

<sub>Reviews (3): Last reviewed commit: ["SY-4164: Sync workspace.author to user.K..."](https://github.com/synnaxlabs/synnax/commit/9336e85c14fc80240f91f415a83aa99f94c44d05) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31271602)</sub>

<!-- /greptile_comment -->