### PR TITLE
SY-4145: Fix Keyboard Triggering - Attempt 2

### DIFF
--- a/console/src/schematic/Schematic.tsx
+++ b/console/src/schematic/Schematic.tsx
@@ -365,6 +365,7 @@ export const Loaded: Layout.Renderer = ({ layoutKey, visible }) => {
     [dispatch, layoutKey],
   );
 
+  const modals = Layout.useSelectWindowModals();
   Diagram.useTriggers({
     onCopy: handleCopySelection,
     onPaste: handlePasteSelection,
@@ -373,6 +374,7 @@ export const Loaded: Layout.Renderer = ({ layoutKey, visible }) => {
     onUndo: undo,
     onRedo: redo,
     region: ref,
+    disabled: modals.length > 0,
   });
 
   return (

--- a/pluto/src/triggers/Triggers.spec.tsx
+++ b/pluto/src/triggers/Triggers.spec.tsx
@@ -439,53 +439,6 @@ describe("Triggers", () => {
       fireEvent.keyUp(document.body, { code: "KeyA" });
     });
 
-    it("should not trigger when target is in a sibling subtree of the region", async () => {
-      Element.prototype.getBoundingClientRect = mockBoundingClientRect(0, 0, 100, 100);
-      const callback = vi.fn();
-      const regionRef = { current: document.createElement("div") };
-      const C = () => {
-        Triggers.use({
-          callback,
-          triggers: [["Control", "V"]],
-          region: regionRef,
-          loose: true,
-        });
-        return <div ref={regionRef}>Target Region</div>;
-      };
-      const { container } = render(
-        <Triggers.Provider>
-          <C />
-          <input data-testid="modal-input" />
-        </Triggers.Provider>,
-      );
-      const modalInput = container.querySelector("input")!;
-
-      // Move cursor into region
-      fireEvent.mouseMove(regionRef.current, { clientX: 10, clientY: 10 });
-
-      // Keyboard event targeting the sibling input should NOT fire "start"
-      fireEvent.keyDown(modalInput, { code: "ControlLeft" });
-      fireEvent.keyDown(modalInput, { code: "KeyV", ctrlKey: true });
-      const startCalls = callback.mock.calls.filter(
-        (args) => (args[0] as Triggers.UseEvent).stage === "start",
-      );
-      expect(startCalls).toHaveLength(0);
-
-      fireEvent.keyUp(modalInput, { code: "KeyV" });
-      fireEvent.keyUp(modalInput, { code: "ControlLeft" });
-
-      // Same shortcut targeting body (normal case) SHOULD fire "start"
-      fireEvent.keyDown(document.body, { code: "ControlLeft" });
-      fireEvent.keyDown(document.body, { code: "KeyV", ctrlKey: true });
-      const startCalls2 = callback.mock.calls.filter(
-        (args) => (args[0] as Triggers.UseEvent).stage === "start",
-      );
-      expect(startCalls2).toHaveLength(1);
-
-      fireEvent.keyUp(document.body, { code: "KeyV" });
-      fireEvent.keyUp(document.body, { code: "ControlLeft" });
-    });
-
     it("should handle regionMustBeElement correctly", async () => {
       vi.useFakeTimers();
       const callback = vi.fn();
@@ -506,19 +459,18 @@ describe("Triggers", () => {
         </Triggers.Provider>,
       );
 
-      // Move cursor into region but trigger on body — both start and end
-      // should be suppressed since body !== regionRef.current
+      // // Move cursor into region but trigger on body
       fireEvent.mouseMove(regionRef.current, { clientX: 10, clientY: 10 });
       fireEvent.keyDown(document.body, { code: "KeyA" });
       fireEvent.keyUp(document.body, { code: "KeyA" });
-      expect(callback).not.toHaveBeenCalled();
+      expect(callback).toHaveBeenCalledTimes(1);
       fireEvent.mouseMove(regionRef.current, { clientX: 10, clientY: 10 });
 
       vi.advanceTimersByTime(500);
 
       // Trigger directly on region element
       fireEvent.keyDown(regionRef.current, { code: "KeyA" });
-      expect(callback).toHaveBeenCalledOnce();
+      expect(callback).toHaveBeenCalledTimes(2);
       expect(callback).toHaveBeenLastCalledWith({
         target: regionRef.current,
         triggers: [["A"]],
@@ -549,11 +501,11 @@ describe("Triggers", () => {
         </Triggers.Provider>,
       );
 
-      // Mouse click outside region — both start and end should be suppressed
+      // // Mouse click outside region
       fireEvent.mouseMove(document.body, { clientX: -10, clientY: -10 });
       fireEvent.mouseDown(document.body, { button: 0 });
       fireEvent.mouseUp(document.body, { button: 0 });
-      expect(callback).not.toHaveBeenCalled();
+      expect(callback).toHaveBeenCalledOnce();
 
       vi.advanceTimersByTime(500);
 

--- a/pluto/src/triggers/hooks.ts
+++ b/pluto/src/triggers/hooks.ts
@@ -70,18 +70,11 @@ export const use = ({
       const removed = res[1];
       if (added.length === 0 && removed.length === 0) return;
       added = filterInRegion(e.target, e.cursor, added, region, regionMustBeElement);
-      const filteredRemoved = filterInRegion(
-        e.target,
-        e.cursor,
-        removed,
-        region,
-        regionMustBeElement,
-      );
       const base = { target: e.target, cursor: e.cursor };
       if (added.length > 0)
         f?.({ ...base, stage: "start", triggers: added, prevTriggers: e.prev });
-      if (filteredRemoved.length > 0)
-        f?.({ ...base, stage: "end", triggers: filteredRemoved, prevTriggers: e.prev });
+      if (removed.length > 0)
+        f?.({ ...base, stage: "end", triggers: removed, prevTriggers: e.prev });
     });
   }, [f, memoTriggers, listen, loose, region, double, regionMustBeElement]);
 };
@@ -99,10 +92,7 @@ const filterInRegion = (
   return added.filter((t) => {
     const rg = regionMustBeElement ?? t.some((v) => v.includes("Mouse"));
     if (rg) return box.contains(b, cursor) && target === region.current;
-    return (
-      box.contains(b, cursor) &&
-      (region.current!.contains(target) || target.contains(region.current))
-    );
+    return box.contains(b, cursor);
   });
 };
 

--- a/pluto/src/vis/diagram/useTriggers.spec.tsx
+++ b/pluto/src/vis/diagram/useTriggers.spec.tsx
@@ -1,0 +1,250 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { fireEvent, render } from "@testing-library/react";
+import { type ReactElement, useRef } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { mockBoundingClientRect } from "@/testutil/dom";
+import { Triggers } from "@/triggers";
+import { useTriggers, type UseTriggersProps } from "@/vis/diagram/useTriggers";
+
+interface TestComponentProps extends Omit<UseTriggersProps, "region"> {}
+
+const TestComponent = (props: TestComponentProps): ReactElement => {
+  const regionRef = useRef<HTMLDivElement>(null);
+  useTriggers({ ...props, region: regionRef });
+  return <div ref={regionRef}>Canvas</div>;
+};
+
+const noop = () => {};
+const noopCursor = () => {};
+
+const defaultProps: TestComponentProps = {
+  onUndo: noop,
+  onRedo: noop,
+  onCopy: noopCursor,
+  onPaste: noopCursor,
+  onClear: noop,
+  onSelectAll: noop,
+};
+
+describe("Diagram.useTriggers", () => {
+  it("should call onUndo when Control+Z is pressed", () => {
+    Element.prototype.getBoundingClientRect = mockBoundingClientRect(0, 0, 100, 100);
+    const onUndo = vi.fn();
+    render(
+      <Triggers.Provider>
+        <TestComponent {...defaultProps} onUndo={onUndo} />
+      </Triggers.Provider>,
+    );
+    fireEvent.mouseMove(document.body, { clientX: 10, clientY: 10 });
+    fireEvent.keyDown(document.body, { code: "ControlLeft" });
+    fireEvent.keyDown(document.body, { code: "KeyZ", ctrlKey: true });
+    expect(onUndo).toHaveBeenCalledOnce();
+    fireEvent.keyUp(document.body, { code: "KeyZ" });
+    fireEvent.keyUp(document.body, { code: "ControlLeft" });
+  });
+
+  it("should call onRedo when Control+Shift+Z is pressed", () => {
+    Element.prototype.getBoundingClientRect = mockBoundingClientRect(0, 0, 100, 100);
+    const onRedo = vi.fn();
+    render(
+      <Triggers.Provider>
+        <TestComponent {...defaultProps} onRedo={onRedo} />
+      </Triggers.Provider>,
+    );
+    fireEvent.mouseMove(document.body, { clientX: 10, clientY: 10 });
+    fireEvent.keyDown(document.body, { code: "ShiftLeft", shiftKey: true });
+    fireEvent.keyDown(document.body, { code: "ControlLeft", shiftKey: true });
+    fireEvent.keyDown(document.body, {
+      code: "KeyZ",
+      ctrlKey: true,
+      shiftKey: true,
+    });
+    expect(onRedo).toHaveBeenCalledOnce();
+    fireEvent.keyUp(document.body, { code: "KeyZ" });
+    fireEvent.keyUp(document.body, { code: "ControlLeft" });
+    fireEvent.keyUp(document.body, { code: "ShiftLeft" });
+  });
+
+  it("should call onCopy when Control+C is pressed", () => {
+    Element.prototype.getBoundingClientRect = mockBoundingClientRect(0, 0, 100, 100);
+    const onCopy = vi.fn();
+    render(
+      <Triggers.Provider>
+        <TestComponent {...defaultProps} onCopy={onCopy} />
+      </Triggers.Provider>,
+    );
+    fireEvent.mouseMove(document.body, { clientX: 10, clientY: 10 });
+    fireEvent.keyDown(document.body, { code: "ControlLeft" });
+    fireEvent.keyDown(document.body, { code: "KeyC", ctrlKey: true });
+    expect(onCopy).toHaveBeenCalledOnce();
+    fireEvent.keyUp(document.body, { code: "KeyC" });
+    fireEvent.keyUp(document.body, { code: "ControlLeft" });
+  });
+
+  it("should call onPaste when Control+V is pressed", () => {
+    Element.prototype.getBoundingClientRect = mockBoundingClientRect(0, 0, 100, 100);
+    const onPaste = vi.fn();
+    render(
+      <Triggers.Provider>
+        <TestComponent {...defaultProps} onPaste={onPaste} />
+      </Triggers.Provider>,
+    );
+    fireEvent.mouseMove(document.body, { clientX: 10, clientY: 10 });
+    fireEvent.keyDown(document.body, { code: "ControlLeft" });
+    fireEvent.keyDown(document.body, { code: "KeyV", ctrlKey: true });
+    expect(onPaste).toHaveBeenCalledOnce();
+    fireEvent.keyUp(document.body, { code: "KeyV" });
+    fireEvent.keyUp(document.body, { code: "ControlLeft" });
+  });
+
+  it("should call onClear when Escape is pressed", () => {
+    Element.prototype.getBoundingClientRect = mockBoundingClientRect(0, 0, 100, 100);
+    const onClear = vi.fn();
+    render(
+      <Triggers.Provider>
+        <TestComponent {...defaultProps} onClear={onClear} />
+      </Triggers.Provider>,
+    );
+    fireEvent.mouseMove(document.body, { clientX: 10, clientY: 10 });
+    fireEvent.keyDown(document.body, { code: "Escape" });
+    expect(onClear).toHaveBeenCalledOnce();
+    fireEvent.keyUp(document.body, { code: "Escape" });
+  });
+
+  it("should call onSelectAll when Control+A is pressed", () => {
+    Element.prototype.getBoundingClientRect = mockBoundingClientRect(0, 0, 100, 100);
+    const onSelectAll = vi.fn();
+    render(
+      <Triggers.Provider>
+        <TestComponent {...defaultProps} onSelectAll={onSelectAll} />
+      </Triggers.Provider>,
+    );
+    fireEvent.mouseMove(document.body, { clientX: 10, clientY: 10 });
+    fireEvent.keyDown(document.body, { code: "ControlLeft" });
+    fireEvent.keyDown(document.body, { code: "KeyA", ctrlKey: true });
+    expect(onSelectAll).toHaveBeenCalledOnce();
+    fireEvent.keyUp(document.body, { code: "KeyA" });
+    fireEvent.keyUp(document.body, { code: "ControlLeft" });
+  });
+
+  describe("disabled", () => {
+    it("should not call any callbacks when disabled is true", () => {
+      Element.prototype.getBoundingClientRect = mockBoundingClientRect(0, 0, 100, 100);
+      const onUndo = vi.fn();
+      const onCopy = vi.fn();
+      const onPaste = vi.fn();
+      const onClear = vi.fn();
+      const onSelectAll = vi.fn();
+      render(
+        <Triggers.Provider>
+          <TestComponent
+            {...defaultProps}
+            onUndo={onUndo}
+            onCopy={onCopy}
+            onPaste={onPaste}
+            onClear={onClear}
+            onSelectAll={onSelectAll}
+            disabled
+          />
+        </Triggers.Provider>,
+      );
+      fireEvent.mouseMove(document.body, { clientX: 10, clientY: 10 });
+
+      fireEvent.keyDown(document.body, { code: "ControlLeft" });
+      fireEvent.keyDown(document.body, { code: "KeyZ", ctrlKey: true });
+      fireEvent.keyUp(document.body, { code: "KeyZ" });
+      fireEvent.keyUp(document.body, { code: "ControlLeft" });
+
+      fireEvent.keyDown(document.body, { code: "ControlLeft" });
+      fireEvent.keyDown(document.body, { code: "KeyC", ctrlKey: true });
+      fireEvent.keyUp(document.body, { code: "KeyC" });
+      fireEvent.keyUp(document.body, { code: "ControlLeft" });
+
+      fireEvent.keyDown(document.body, { code: "ControlLeft" });
+      fireEvent.keyDown(document.body, { code: "KeyV", ctrlKey: true });
+      fireEvent.keyUp(document.body, { code: "KeyV" });
+      fireEvent.keyUp(document.body, { code: "ControlLeft" });
+
+      fireEvent.keyDown(document.body, { code: "Escape" });
+      fireEvent.keyUp(document.body, { code: "Escape" });
+
+      fireEvent.keyDown(document.body, { code: "ControlLeft" });
+      fireEvent.keyDown(document.body, { code: "KeyA", ctrlKey: true });
+      fireEvent.keyUp(document.body, { code: "KeyA" });
+      fireEvent.keyUp(document.body, { code: "ControlLeft" });
+
+      expect(onUndo).not.toHaveBeenCalled();
+      expect(onCopy).not.toHaveBeenCalled();
+      expect(onPaste).not.toHaveBeenCalled();
+      expect(onClear).not.toHaveBeenCalled();
+      expect(onSelectAll).not.toHaveBeenCalled();
+    });
+
+    it("should not fire when disabled is initially false then becomes true", () => {
+      Element.prototype.getBoundingClientRect = mockBoundingClientRect(0, 0, 100, 100);
+      const onUndo = vi.fn();
+      const { rerender } = render(
+        <Triggers.Provider>
+          <TestComponent {...defaultProps} onUndo={onUndo} />
+        </Triggers.Provider>,
+      );
+      fireEvent.mouseMove(document.body, { clientX: 10, clientY: 10 });
+
+      fireEvent.keyDown(document.body, { code: "ControlLeft" });
+      fireEvent.keyDown(document.body, { code: "KeyZ", ctrlKey: true });
+      expect(onUndo).toHaveBeenCalledOnce();
+      fireEvent.keyUp(document.body, { code: "KeyZ" });
+      fireEvent.keyUp(document.body, { code: "ControlLeft" });
+
+      rerender(
+        <Triggers.Provider>
+          <TestComponent {...defaultProps} onUndo={onUndo} disabled />
+        </Triggers.Provider>,
+      );
+
+      fireEvent.keyDown(document.body, { code: "ControlLeft" });
+      fireEvent.keyDown(document.body, { code: "KeyZ", ctrlKey: true });
+      expect(onUndo).toHaveBeenCalledOnce();
+      fireEvent.keyUp(document.body, { code: "KeyZ" });
+      fireEvent.keyUp(document.body, { code: "ControlLeft" });
+    });
+
+    it("should resume firing when disabled changes from true to false", () => {
+      Element.prototype.getBoundingClientRect = mockBoundingClientRect(0, 0, 100, 100);
+      const onUndo = vi.fn();
+      const { rerender } = render(
+        <Triggers.Provider>
+          <TestComponent {...defaultProps} onUndo={onUndo} disabled />
+        </Triggers.Provider>,
+      );
+      fireEvent.mouseMove(document.body, { clientX: 10, clientY: 10 });
+
+      fireEvent.keyDown(document.body, { code: "ControlLeft" });
+      fireEvent.keyDown(document.body, { code: "KeyZ", ctrlKey: true });
+      expect(onUndo).not.toHaveBeenCalled();
+      fireEvent.keyUp(document.body, { code: "KeyZ" });
+      fireEvent.keyUp(document.body, { code: "ControlLeft" });
+
+      rerender(
+        <Triggers.Provider>
+          <TestComponent {...defaultProps} onUndo={onUndo} disabled={false} />
+        </Triggers.Provider>,
+      );
+
+      fireEvent.keyDown(document.body, { code: "ControlLeft" });
+      fireEvent.keyDown(document.body, { code: "KeyZ", ctrlKey: true });
+      expect(onUndo).toHaveBeenCalledOnce();
+      fireEvent.keyUp(document.body, { code: "KeyZ" });
+      fireEvent.keyUp(document.body, { code: "ControlLeft" });
+    });
+  });
+});

--- a/pluto/src/vis/diagram/useTriggers.ts
+++ b/pluto/src/vis/diagram/useTriggers.ts
@@ -34,6 +34,7 @@ export interface UseTriggersProps extends Pick<Triggers.UseProps, "region"> {
   onPaste: (cursor: xy.XY) => void;
   onClear: () => void;
   onSelectAll: () => void;
+  disabled?: boolean;
 }
 
 export const useTriggers = ({
@@ -44,6 +45,7 @@ export const useTriggers = ({
   onUndo,
   onRedo,
   region,
+  disabled,
 }: UseTriggersProps) => {
   Triggers.use({
     triggers: FLATTENED_CONFIG,
@@ -51,7 +53,7 @@ export const useTriggers = ({
     region,
     callback: useCallback(
       ({ triggers, cursor, stage }: Triggers.UseEvent) => {
-        if (region?.current == null || stage !== "start") return;
+        if (region?.current == null || stage !== "start" || disabled) return;
         const mode = Triggers.determineMode(CONFIG, triggers);
         if (mode == "undo") return onUndo();
         if (mode == "redo") return onRedo();
@@ -60,7 +62,7 @@ export const useTriggers = ({
         if (mode == "clear") return onClear();
         if (mode == "all") return onSelectAll();
       },
-      [onUndo, onRedo, onCopy, onPaste, onClear, onSelectAll],
+      [onUndo, onRedo, onCopy, onPaste, onClear, onSelectAll, disabled],
     ),
   });
 };


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4145](https://linear.app/synnax/issue/SY-4145/fix-schematic-keyboard-triggering)

## Description
Check for blocking modal.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes schematic keyboard shortcut triggering (SY-4145) by relaxing the trigger region filter to use cursor position instead of DOM event-target containment, and disabling all shortcuts when a modal layout is open.

- `filterInRegion` in `hooks.ts` drops the `target.contains / region.contains` DOM check for keyboard triggers; shortcuts now fire whenever the cursor is inside the region's bounding box, regardless of which element dispatched the keyboard event. This fixes the case where `document.body` (the default target when nothing is focused) was rejected by the old containment check.
- `Diagram.useTriggers` gains a `disabled` prop (plumbed through `Schematic.tsx` via `useSelectWindowModals`) that short-circuits all callbacks when any modal is registered in the window, preventing shortcuts from leaking through modal UIs.
- A new `useTriggers.spec.tsx` covers all six trigger actions and three `disabled` lifecycle transitions; `Triggers.spec.tsx` removes and updates tests to reflect the new cursor-only filtering semantics.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the specific schematic-modal scenario it targets; the global relaxation of filterInRegion warrants a closer look at other consumers before landing on rc.

The fix correctly resolves keyboard-shortcut dead-zones caused by document.body receiving events when nothing is focused, and the modal guard is cleanly implemented. The main area of caution is that filterInRegion's cursor-only logic now applies to every caller of Triggers.use with a region, and end events are no longer region-filtered at all — both changes are globally visible but their blast radius appears limited given how those consumers use triggers today.

pluto/src/triggers/hooks.ts deserves a second look — the filterInRegion change and the unfiltered end events affect all callers, not just the schematic path.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pluto/src/triggers/hooks.ts | Removes DOM target-containment check from filterInRegion (keyboard triggers now fire on cursor position alone) and stops filtering "end" events by region — both are global changes affecting all callers of Triggers.use with a region prop. |
| pluto/src/vis/diagram/useTriggers.ts | Adds optional disabled prop; callback now early-returns when disabled is true, and disabled is correctly included in the useCallback dependency array. |
| console/src/schematic/Schematic.tsx | Wires useSelectWindowModals into useTriggers disabled prop to block keyboard shortcuts when a modal is open; useSelectWindowModals may not cover all blocking UI overlays. |
| pluto/src/vis/diagram/useTriggers.spec.tsx | New test file covering all six trigger actions plus three disabled-lifecycle scenarios (initially disabled, toggle to disabled, toggle back to enabled). |
| pluto/src/triggers/Triggers.spec.tsx | Removes the sibling-subtree suppression test (no longer applicable after filterInRegion change) and updates regionMustBeElement / mouseClick tests to match the new permissive cursor-only filtering. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    KE[Keyboard Event fires] --> LP[Triggers.Provider listener]
    LP --> FT[filter + diff triggers]
    FT --> FIR{filterInRegion}
    FIR -->|Mouse trigger| MC["cursor in box AND target === region"]
    FIR -->|Keyboard trigger cursor-only| KC["cursor in box"]
    MC --> SA[stage: start - added]
    KC --> SA
    FT -->|removed - unfiltered| SE[stage: end - always fires]
    SA --> CB[Triggers.use callback]
    SE --> CB
    CB --> DIS{useTriggers: disabled?}
    DIS -->|true - modal open| NOP[no-op]
    DIS -->|false| MODE[determineMode]
    MODE --> ACT["onUndo / onRedo / onCopy / onPaste / onClear / onSelectAll"]
```

<sub>Reviews (1): Last reviewed commit: ["SY-4145: Check for blocking modals"](https://github.com/synnaxlabs/synnax/commit/516da5a3eaeef2ce0d2e31f0c00d6e66ef5a56e7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31368674)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->