### PR TITLE
SY-4160: Fix flakey x/go/testutil leak test

### DIFF
--- a/x/go/testutil/leak_test.go
+++ b/x/go/testutil/leak_test.go
@@ -23,6 +23,8 @@ import (
 // fully qualified name.
 func holdUntilSignal(done <-chan struct{}) { <-done }
 
+const holdUntilSignalName = "github.com/synnaxlabs/x/testutil.holdUntilSignal"
+
 var _ = Describe("Leak", func() {
 	Describe("buildLeakConfig", func() {
 		It("returns a zero config when no options are supplied", func() {
@@ -82,7 +84,9 @@ var _ = Describe("Leak", func() {
 			done := make(chan struct{})
 			defer close(done)
 			go holdUntilSignal(done)
-			Eventually(gleak.Goroutines).Should(HaveLen(len(snapshot) + 1))
+			Eventually(gleak.Goroutines).Should(ContainElement(
+				HaveField("TopFunction", holdUntilSignalName),
+			))
 
 			failures := InterceptGomegaFailures(func() {
 				assertNoLeakedGoroutines(snapshot, leakConfig{
@@ -98,13 +102,13 @@ var _ = Describe("Leak", func() {
 			done := make(chan struct{})
 			defer close(done)
 			go holdUntilSignal(done)
-			Eventually(gleak.Goroutines).Should(HaveLen(len(snapshot) + 1))
+			Eventually(gleak.Goroutines).Should(ContainElement(
+				HaveField("TopFunction", holdUntilSignalName),
+			))
 
 			cfg := buildLeakConfig([]LeakOption{
 				LeakWithin(100 * time.Millisecond),
-				LeakIgnoring(gleak.IgnoringTopFunction(
-					"github.com/synnaxlabs/x/testutil.holdUntilSignal",
-				)),
+				LeakIgnoring(gleak.IgnoringTopFunction(holdUntilSignalName)),
 			})
 			assertNoLeakedGoroutines(snapshot, cfg)
 		})
@@ -116,8 +120,10 @@ var _ = Describe("Leak", func() {
 				time.Sleep(50 * time.Millisecond)
 				close(done)
 			}()
-			go func() { <-done }()
-			Eventually(gleak.Goroutines).Should(HaveLen(len(snapshot) + 2))
+			go holdUntilSignal(done)
+			Eventually(gleak.Goroutines).Should(ContainElement(
+				HaveField("TopFunction", holdUntilSignalName),
+			))
 
 			assertNoLeakedGoroutines(snapshot, leakConfig{
 				timeout: 1 * time.Second,
@@ -130,8 +136,7 @@ var _ = Describe("Leak", func() {
 		It("does not fail a clean spec", func() {
 			ShouldNotLeakGoroutines()
 			var wg sync.WaitGroup
-			wg.Add(1)
-			go func() { defer wg.Done() }()
+			wg.Go(func() {})
 			wg.Wait()
 		})
 


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue number and link -->

[SY-3140](https://linear.app/synnax/issue/SY-4160/fix-flakey-xgotestutil-leak-test)

## Description

<!-- Write a description describing the changes. -->

Fix a flakey test in `x/go/testutil` by making sure the leak checkers match against a specific goroutine.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes flaky goroutine leak tests in `x/go/testutil` by replacing count-based goroutine assertions (`HaveLen(len(snapshot) + N)`) with identity-based assertions that target the specific `holdUntilSignal` goroutine by name. A shared constant is introduced for the fully qualified function name, and one anonymous goroutine is replaced with the named `holdUntilSignal` helper to make it trackable.

- **Root cause of flakiness fixed**: `HaveLen` checked the total goroutine count, which was sensitive to transient runtime or test-runner goroutines appearing at the wrong moment; `ContainElement(HaveField(\"TopFunction\", ...))` pins the assertion to the exact goroutine under test.
- **Minor cleanup**: `wg.Add(1); go func() { defer wg.Done() }()` is replaced with the idiomatic `wg.Go(func() {})` now available in Go 1.26.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the single changed file is a test file with no production logic, and the fix correctly addresses the flakiness root cause.

Only the test file changes, the fix is narrowly targeted, and the new assertion strategy (checking for a specific goroutine by name rather than total count) is strictly more robust than what it replaces. The package path in holdUntilSignalName matches the module and directory layout, and wg.Go is valid under Go 1.26.2.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| x/go/testutil/leak_test.go | Replaces flaky count-based goroutine assertions with identity-based checks on the named holdUntilSignal goroutine; introduces a shared constant and uses wg.Go for cleaner WaitGroup usage |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test
    participant Goroutine as holdUntilSignal goroutine
    participant Gomega as Eventually / gleak

    Test->>Goroutine: go holdUntilSignal(done)
    Test->>Gomega: Eventually(gleak.Goroutines).Should(ContainElement(HaveField("TopFunction", name)))
    Gomega-->>Test: goroutine confirmed running by name

    alt OLD behaviour (removed)
        Test->>Gomega: HaveLen(len(snapshot) + N)
        note over Gomega: Flaky — other runtime goroutines can change the total count
    end

    Test->>Goroutine: close(done) / defer close(done)
    Goroutine-->>Test: goroutine exits

    Test->>Gomega: assertNoLeakedGoroutines(snapshot, cfg)
    Gomega-->>Test: no leaks detected
```

<sub>Reviews (1): Last reviewed commit: ["Fix flakey x/go/testutil leak test"](https://github.com/synnaxlabs/synnax/commit/1ea77e762f69998781d2e1e8ed35c4a55a152d76) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31406623)</sub>

<!-- /greptile_comment -->