### PR TITLE
SY-4174: Make windowKey Optional in Nav Drawer Actions

### DIFF
--- a/console/src/arc/editor/graph/Editor.tsx
+++ b/console/src/arc/editor/graph/Editor.tsx
@@ -8,7 +8,6 @@
 // included in the file licenses/APL.txt.
 
 import { arc } from "@synnaxlabs/client";
-import { useSelectWindowKey } from "@synnaxlabs/drift/react";
 import {
   Access,
   Arc as Base,
@@ -116,7 +115,6 @@ export const ContextMenu: Layout.ContextMenuRenderer = ({ layoutKey }) => (
 );
 
 export const Editor: Layout.Renderer = ({ layoutKey, visible }) => {
-  const windowKey = useSelectWindowKey() as string;
   const state = useSelect(layoutKey);
 
   const dispatch = useDispatch();
@@ -225,14 +223,8 @@ export const Editor: Layout.Renderer = ({ layoutKey, visible }) => {
 
   const handleDoubleClick = useCallback(() => {
     if (!state.graph.editable) return;
-    dispatch(
-      Layout.setNavDrawerVisible({
-        windowKey,
-        key: "visualization",
-        value: true,
-      }),
-    );
-  }, [windowKey, state.graph.editable, dispatch]);
+    dispatch(Layout.setNavDrawerVisible({ key: "visualization", value: true }));
+  }, [state.graph.editable, dispatch]);
 
   const handleViewportModeChange = useCallback(
     (mode: Viewport.Mode) => dispatch(setViewportMode({ mode })),

--- a/console/src/layout/middleware.ts
+++ b/console/src/layout/middleware.ts
@@ -7,6 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+import { type Middleware } from "@reduxjs/toolkit";
 import { Drift, MAIN_WINDOW, selectWindowKey } from "@synnaxlabs/drift";
 import { Mosaic } from "@synnaxlabs/pluto";
 import { runtime } from "@synnaxlabs/x";
@@ -21,6 +22,8 @@ import {
   type PlacePayload,
   remove,
   type RemovePayload,
+  setNavDrawerVisible,
+  type SetNavDrawerVisiblePayload,
   setWorkspace,
   type SetWorkspacePayload,
   type StoreState,
@@ -142,7 +145,28 @@ const deleteLayoutsOnMosaicCloseEffect: MiddlewareEffect<
   store.dispatch(remove({ keys: layoutKeys }));
 };
 
+/**
+ * Injects the current window key into setNavDrawerVisible actions whose payload
+ * omits one. Lets call sites dispatch the action without selecting the window key
+ * themselves; the reducer still requires a windowKey to be present.
+ */
+const injectNavDrawerWindowKey: Middleware<{}, StoreState & Drift.StoreState> =
+  (store) => (next) => (action) => {
+    if (
+      typeof action !== "object" ||
+      action == null ||
+      (action as { type?: unknown }).type !== setNavDrawerVisible.type
+    )
+      return next(action);
+    const payload = (action as { payload: SetNavDrawerVisiblePayload }).payload;
+    if (payload.windowKey != null) return next(action);
+    const windowKey = selectWindowKey(store.getState());
+    if (windowKey == null) return next(action);
+    return next(setNavDrawerVisible({ ...payload, windowKey }));
+  };
+
 export const MIDDLEWARE = [
+  injectNavDrawerWindowKey,
   effectMiddleware(
     [moveMosaicTab.type, remove.type, clearWorkspace.type, setWorkspace.type],
     [closeWindowOnEmptyMosaicEffect],

--- a/console/src/layout/middleware.ts
+++ b/console/src/layout/middleware.ts
@@ -23,7 +23,6 @@ import {
   remove,
   type RemovePayload,
   setNavDrawerVisible,
-  type SetNavDrawerVisiblePayload,
   setWorkspace,
   type SetWorkspacePayload,
   type StoreState,
@@ -152,17 +151,11 @@ const deleteLayoutsOnMosaicCloseEffect: MiddlewareEffect<
  */
 const injectNavDrawerWindowKey: Middleware<{}, StoreState & Drift.StoreState> =
   (store) => (next) => (action) => {
-    if (
-      typeof action !== "object" ||
-      action == null ||
-      (action as { type?: unknown }).type !== setNavDrawerVisible.type
-    )
+    if (!setNavDrawerVisible.match(action) || action.payload.windowKey != null)
       return next(action);
-    const payload = (action as { payload: SetNavDrawerVisiblePayload }).payload;
-    if (payload.windowKey != null) return next(action);
     const windowKey = selectWindowKey(store.getState());
     if (windowKey == null) return next(action);
-    return next(setNavDrawerVisible({ ...payload, windowKey }));
+    return next(setNavDrawerVisible({ ...action.payload, windowKey }));
   };
 
 export const MIDDLEWARE = [

--- a/console/src/layout/slice.spec.ts
+++ b/console/src/layout/slice.spec.ts
@@ -26,11 +26,33 @@ import {
   selectSliceState,
 } from "@/layout/selectors";
 import {
-  actions,
+  clearWorkspace,
+  hideAllNavDrawers,
+  moveMosaicTab,
+  place,
   reducer,
+  remove,
+  rename,
+  resizeMosaicTab,
+  resizeNavDrawer,
+  selectMosaicTab,
+  setActiveTheme,
+  setAltKey,
   setArgs,
+  setColorContext,
+  setFocus,
+  setHauled,
+  setNavDrawer,
+  setNavDrawerVisible,
+  setUnsavedChanges,
+  setWorkspace,
   SLICE_NAME,
+  splitMosaicNode,
+  startNavHover,
   type State,
+  stopNavHover,
+  toggleActiveTheme,
+  toggleNavHover,
   ZERO_SLICE_STATE,
 } from "@/layout/slice";
 
@@ -75,13 +97,13 @@ describe("Layout Slice", () => {
 
   describe("place", () => {
     it("should insert a mosaic tab and select it", () => {
-      store.dispatch(actions.place(mosaicLayout("plot-1")));
+      store.dispatch(place(mosaicLayout("plot-1")));
       expect(select(state(), "plot-1")).toBeDefined();
       expect(selectActiveMosaicTabState(state()).layoutKey).toBe("plot-1");
     });
 
     it("should add a window-located layout without touching the mosaic", () => {
-      store.dispatch(actions.place(windowLayout("popup-1")));
+      store.dispatch(place(windowLayout("popup-1")));
       expect(select(state(), "popup-1")?.location).toBe("window");
       expect(selectActiveMosaicTabState(state()).layoutKey).toBeNull();
     });
@@ -89,21 +111,21 @@ describe("Layout Slice", () => {
 
   describe("remove", () => {
     it("should remove a mosaic layout and clear it from the mosaic", () => {
-      store.dispatch(actions.place(mosaicLayout("plot-1")));
-      store.dispatch(actions.remove({ keys: ["plot-1"] }));
+      store.dispatch(place(mosaicLayout("plot-1")));
+      store.dispatch(remove({ keys: ["plot-1"] }));
       expect(select(state(), "plot-1")).toBeUndefined();
       expect(selectActiveMosaicTabState(state()).layoutKey).toBeNull();
     });
 
     it("should ignore the main layout", () => {
-      store.dispatch(actions.remove({ keys: ["main"] }));
+      store.dispatch(remove({ keys: ["main"] }));
       expect(select(state(), "main")).toBeDefined();
     });
 
     it("should remove multiple layouts in one dispatch", () => {
-      store.dispatch(actions.place(mosaicLayout("a")));
-      store.dispatch(actions.place(mosaicLayout("b")));
-      store.dispatch(actions.remove({ keys: ["a", "b"] }));
+      store.dispatch(place(mosaicLayout("a")));
+      store.dispatch(place(mosaicLayout("b")));
+      store.dispatch(remove({ keys: ["a", "b"] }));
       expect(select(state(), "a")).toBeUndefined();
       expect(select(state(), "b")).toBeUndefined();
     });
@@ -111,8 +133,8 @@ describe("Layout Slice", () => {
 
   describe("rename", () => {
     it("should rename a mosaic layout and its tab", () => {
-      store.dispatch(actions.place(mosaicLayout("plot-1")));
-      store.dispatch(actions.rename({ key: "plot-1", name: "Renamed" }));
+      store.dispatch(place(mosaicLayout("plot-1")));
+      store.dispatch(rename({ key: "plot-1", name: "Renamed" }));
       expect(select(state(), "plot-1")?.name).toBe("Renamed");
       const [, root] = selectMosaic(state());
       const tab = Mosaic.findTabNode(root!, "plot-1")?.tabs?.find(
@@ -122,28 +144,28 @@ describe("Layout Slice", () => {
     });
 
     it("should ignore an unknown key", () => {
-      store.dispatch(actions.rename({ key: "nope", name: "x" }));
+      store.dispatch(rename({ key: "nope", name: "x" }));
       expect(select(state(), "nope")).toBeUndefined();
     });
   });
 
   describe("setAltKey", () => {
     it("should set an alt key for a layout", () => {
-      store.dispatch(actions.setAltKey({ key: "real", altKey: "alt" }));
+      store.dispatch(setAltKey({ key: "real", altKey: "alt" }));
       expect(selectAltKey(state(), "real")).toBe("alt");
     });
 
     it("should resolve a layout via its alt key", () => {
-      store.dispatch(actions.place(mosaicLayout("real")));
-      store.dispatch(actions.setAltKey({ key: "real", altKey: "alt" }));
-      store.dispatch(actions.rename({ key: "alt", name: "Resolved" }));
+      store.dispatch(place(mosaicLayout("real")));
+      store.dispatch(setAltKey({ key: "real", altKey: "alt" }));
+      store.dispatch(rename({ key: "alt", name: "Resolved" }));
       expect(select(state(), "real")?.name).toBe("Resolved");
     });
   });
 
   describe("setArgs", () => {
     it("should set args on an existing layout", () => {
-      store.dispatch(actions.place(mosaicLayout("plot-1")));
+      store.dispatch(place(mosaicLayout("plot-1")));
       store.dispatch(setArgs({ key: "plot-1", args: { foo: 42 } }));
       expect(selectArgs(state(), "plot-1")).toEqual({ foo: 42 });
     });
@@ -151,25 +173,23 @@ describe("Layout Slice", () => {
 
   describe("setFocus", () => {
     it("should focus a layout in its window's mosaic", () => {
-      store.dispatch(actions.place(mosaicLayout("plot-1")));
-      store.dispatch(actions.setFocus({ key: "plot-1", windowKey: MAIN_WINDOW }));
+      store.dispatch(place(mosaicLayout("plot-1")));
+      store.dispatch(setFocus({ key: "plot-1", windowKey: MAIN_WINDOW }));
       expect(selectFocused(state()).focused).toBe("plot-1");
     });
 
     it("should clear focus when key is null", () => {
-      store.dispatch(actions.place(mosaicLayout("plot-1")));
-      store.dispatch(actions.setFocus({ key: "plot-1", windowKey: MAIN_WINDOW }));
-      store.dispatch(actions.setFocus({ key: null, windowKey: MAIN_WINDOW }));
+      store.dispatch(place(mosaicLayout("plot-1")));
+      store.dispatch(setFocus({ key: "plot-1", windowKey: MAIN_WINDOW }));
+      store.dispatch(setFocus({ key: null, windowKey: MAIN_WINDOW }));
       expect(selectFocused(state()).focused).toBeNull();
     });
   });
 
   describe("setUnsavedChanges", () => {
     it("should flag a mosaic layout and propagate to its tab", () => {
-      store.dispatch(actions.place(mosaicLayout("plot-1")));
-      store.dispatch(
-        actions.setUnsavedChanges({ key: "plot-1", unsavedChanges: true }),
-      );
+      store.dispatch(place(mosaicLayout("plot-1")));
+      store.dispatch(setUnsavedChanges({ key: "plot-1", unsavedChanges: true }));
       expect(select(state(), "plot-1")?.unsavedChanges).toBe(true);
       const [, root] = selectMosaic(state());
       const tab = Mosaic.findTabNode(root!, "plot-1")?.tabs?.find(
@@ -185,7 +205,7 @@ describe("Layout Slice", () => {
         source: { key: "src", type: "drag" },
         items: [{ key: "item-1", type: "drag" }],
       };
-      store.dispatch(actions.setHauled(haul));
+      store.dispatch(setHauled(haul));
       expect(selectHauling(state())).toEqual(haul);
     });
   });
@@ -196,45 +216,45 @@ describe("Layout Slice", () => {
         ...Color.ZERO_CONTEXT_STATE,
         frequent: { "#ff0000": { lastUsed: 1, count: 1, relevance: 1 } },
       };
-      store.dispatch(actions.setColorContext({ state: ctx }));
+      store.dispatch(setColorContext({ state: ctx }));
       expect(selectColorContext(state())).toEqual(ctx);
     });
   });
 
   describe("setActiveTheme", () => {
     it("should set the named theme", () => {
-      store.dispatch(actions.setActiveTheme("synnaxLight"));
+      store.dispatch(setActiveTheme("synnaxLight"));
       expect(selectActiveThemeKey(state())).toBe("synnaxLight");
     });
 
     it("should cycle to the next theme when payload is undefined", () => {
-      store.dispatch(actions.setActiveTheme(undefined));
+      store.dispatch(setActiveTheme(undefined));
       expect(selectActiveThemeKey(state())).toBe("synnaxLight");
-      store.dispatch(actions.setActiveTheme(undefined));
+      store.dispatch(setActiveTheme(undefined));
       expect(selectActiveThemeKey(state())).toBe("synnaxDark");
     });
   });
 
   describe("toggleActiveTheme", () => {
     it("should cycle to the next theme", () => {
-      store.dispatch(actions.toggleActiveTheme());
+      store.dispatch(toggleActiveTheme());
       expect(selectActiveThemeKey(state())).toBe("synnaxLight");
     });
   });
 
   describe("moveMosaicTab", () => {
     it("should be a no-op when key is omitted within the same window", () => {
-      store.dispatch(actions.place(mosaicLayout("plot-1")));
+      store.dispatch(place(mosaicLayout("plot-1")));
       const [, before] = selectMosaic(state());
-      store.dispatch(actions.moveMosaicTab({ tabKey: "plot-1", loc: "center" }));
+      store.dispatch(moveMosaicTab({ tabKey: "plot-1", loc: "center" }));
       expect(selectMosaic(state())[1]).toEqual(before);
     });
 
     it("should move a tab to a different window's mosaic", () => {
-      store.dispatch(actions.place(mosaicLayout("mw-2", { type: "mosaicWindow" })));
-      store.dispatch(actions.place(mosaicLayout("plot-1", { windowKey: "mw-2" })));
+      store.dispatch(place(mosaicLayout("mw-2", { type: "mosaicWindow" })));
+      store.dispatch(place(mosaicLayout("plot-1", { windowKey: "mw-2" })));
       store.dispatch(
-        actions.moveMosaicTab({
+        moveMosaicTab({
           tabKey: "plot-1",
           windowKey: MAIN_WINDOW,
           loc: "center",
@@ -248,19 +268,19 @@ describe("Layout Slice", () => {
 
   describe("selectMosaicTab", () => {
     it("should set the active tab on the layout's window", () => {
-      store.dispatch(actions.place(mosaicLayout("plot-1")));
-      store.dispatch(actions.place(mosaicLayout("plot-2")));
-      store.dispatch(actions.selectMosaicTab({ tabKey: "plot-1" }));
+      store.dispatch(place(mosaicLayout("plot-1")));
+      store.dispatch(place(mosaicLayout("plot-2")));
+      store.dispatch(selectMosaicTab({ tabKey: "plot-1" }));
       expect(selectActiveMosaicTabState(state()).layoutKey).toBe("plot-1");
     });
   });
 
   describe("splitMosaicNode", () => {
     it("should split the node containing the tab", () => {
-      store.dispatch(actions.place(mosaicLayout("plot-1")));
-      store.dispatch(actions.place(mosaicLayout("plot-2")));
+      store.dispatch(place(mosaicLayout("plot-1")));
+      store.dispatch(place(mosaicLayout("plot-2")));
       store.dispatch(
-        actions.splitMosaicNode({
+        splitMosaicNode({
           windowKey: MAIN_WINDOW,
           tabKey: "plot-1",
           direction: "x",
@@ -274,10 +294,10 @@ describe("Layout Slice", () => {
 
   describe("resizeMosaicTab", () => {
     it("should set the size on the targeted node", () => {
-      store.dispatch(actions.place(mosaicLayout("plot-1")));
-      store.dispatch(actions.place(mosaicLayout("plot-2")));
+      store.dispatch(place(mosaicLayout("plot-1")));
+      store.dispatch(place(mosaicLayout("plot-2")));
       store.dispatch(
-        actions.splitMosaicNode({
+        splitMosaicNode({
           windowKey: MAIN_WINDOW,
           tabKey: "plot-1",
           direction: "x",
@@ -285,7 +305,7 @@ describe("Layout Slice", () => {
       );
       const [, root] = selectMosaic(state());
       store.dispatch(
-        actions.resizeMosaicTab({
+        resizeMosaicTab({
           windowKey: MAIN_WINDOW,
           key: root!.key,
           size: 0.25,
@@ -298,7 +318,7 @@ describe("Layout Slice", () => {
   describe("setNavDrawer", () => {
     it("should overwrite the drawer entry at a location", () => {
       store.dispatch(
-        actions.setNavDrawer({
+        setNavDrawer({
           windowKey: MAIN_WINDOW,
           location: "left",
           activeItem: "channel",
@@ -315,7 +335,7 @@ describe("Layout Slice", () => {
 
     it("should create nav state for an unknown window", () => {
       store.dispatch(
-        actions.setNavDrawer({
+        setNavDrawer({
           windowKey: "popup",
           location: "right",
           activeItem: null,
@@ -331,7 +351,7 @@ describe("Layout Slice", () => {
   describe("resizeNavDrawer", () => {
     it("should set the size of an existing drawer", () => {
       store.dispatch(
-        actions.resizeNavDrawer({
+        resizeNavDrawer({
           windowKey: MAIN_WINDOW,
           location: "left",
           size: 480,
@@ -342,7 +362,7 @@ describe("Layout Slice", () => {
 
     it("should ignore a window or location without a drawer", () => {
       store.dispatch(
-        actions.resizeNavDrawer({ windowKey: "absent", location: "left", size: 100 }),
+        resizeNavDrawer({ windowKey: "absent", location: "left", size: 100 }),
       );
       expect(selectSliceState(state()).nav.absent).toBeUndefined();
     });
@@ -351,39 +371,39 @@ describe("Layout Slice", () => {
   describe("setNavDrawerVisible", () => {
     it("should throw when windowKey is missing", () => {
       expect(() =>
-        store.dispatch(actions.setNavDrawerVisible({ key: "visualization" })),
+        store.dispatch(setNavDrawerVisible({ key: "visualization" })),
       ).toThrow(/windowKey/);
     });
 
     it("should throw when neither key nor location is provided", () => {
       expect(() =>
-        store.dispatch(actions.setNavDrawerVisible({ windowKey: MAIN_WINDOW })),
+        store.dispatch(setNavDrawerVisible({ windowKey: MAIN_WINDOW })),
       ).toThrow(/key or location/);
     });
 
     it("should activate a menu item by key", () => {
       store.dispatch(
-        actions.setNavDrawerVisible({ windowKey: MAIN_WINDOW, key: "visualization" }),
+        setNavDrawerVisible({ windowKey: MAIN_WINDOW, key: "visualization" }),
       );
       expect(selectNavDrawer(state(), "bottom")?.activeItem).toBe("visualization");
     });
 
     it("should clear the active item when the same key is dispatched again", () => {
       store.dispatch(
-        actions.setNavDrawerVisible({ windowKey: MAIN_WINDOW, key: "visualization" }),
+        setNavDrawerVisible({ windowKey: MAIN_WINDOW, key: "visualization" }),
       );
       store.dispatch(
-        actions.setNavDrawerVisible({ windowKey: MAIN_WINDOW, key: "visualization" }),
+        setNavDrawerVisible({ windowKey: MAIN_WINDOW, key: "visualization" }),
       );
       expect(selectNavDrawer(state(), "bottom")?.activeItem).toBeNull();
     });
 
     it("should respect an explicit value=false", () => {
       store.dispatch(
-        actions.setNavDrawerVisible({ windowKey: MAIN_WINDOW, key: "visualization" }),
+        setNavDrawerVisible({ windowKey: MAIN_WINDOW, key: "visualization" }),
       );
       store.dispatch(
-        actions.setNavDrawerVisible({
+        setNavDrawerVisible({
           windowKey: MAIN_WINDOW,
           location: "bottom",
           value: false,
@@ -394,7 +414,7 @@ describe("Layout Slice", () => {
 
     it("should activate the first menu item when location is provided with value=true", () => {
       store.dispatch(
-        actions.setNavDrawerVisible({
+        setNavDrawerVisible({
           windowKey: MAIN_WINDOW,
           location: "left",
           value: true,
@@ -407,7 +427,7 @@ describe("Layout Slice", () => {
   describe("startNavHover", () => {
     it("should set hover and active item on an empty drawer", () => {
       store.dispatch(
-        actions.startNavHover({
+        startNavHover({
           windowKey: MAIN_WINDOW,
           location: "left",
           key: "channel",
@@ -421,10 +441,10 @@ describe("Layout Slice", () => {
 
     it("should ignore an already-active drawer that is not in hover mode", () => {
       store.dispatch(
-        actions.setNavDrawerVisible({ windowKey: MAIN_WINDOW, key: "visualization" }),
+        setNavDrawerVisible({ windowKey: MAIN_WINDOW, key: "visualization" }),
       );
       store.dispatch(
-        actions.startNavHover({
+        startNavHover({
           windowKey: MAIN_WINDOW,
           location: "bottom",
           key: "channel",
@@ -437,9 +457,7 @@ describe("Layout Slice", () => {
 
   describe("toggleNavHover", () => {
     it("should enter hover mode on an empty drawer that contains the key", () => {
-      store.dispatch(
-        actions.toggleNavHover({ windowKey: MAIN_WINDOW, key: "channel" }),
-      );
+      store.dispatch(toggleNavHover({ windowKey: MAIN_WINDOW, key: "channel" }));
       expect(selectNavDrawer(state(), "left")).toMatchObject({
         hover: true,
         activeItem: "channel",
@@ -450,15 +468,13 @@ describe("Layout Slice", () => {
   describe("stopNavHover", () => {
     it("should clear hover and active item when in hover mode", () => {
       store.dispatch(
-        actions.startNavHover({
+        startNavHover({
           windowKey: MAIN_WINDOW,
           location: "left",
           key: "channel",
         }),
       );
-      store.dispatch(
-        actions.stopNavHover({ windowKey: MAIN_WINDOW, location: "left" }),
-      );
+      store.dispatch(stopNavHover({ windowKey: MAIN_WINDOW, location: "left" }));
       expect(selectNavDrawer(state(), "left")).toMatchObject({
         hover: false,
         activeItem: null,
@@ -469,16 +485,16 @@ describe("Layout Slice", () => {
   describe("hideAllNavDrawers", () => {
     it("should clear active item and hover for every drawer in every window", () => {
       store.dispatch(
-        actions.setNavDrawerVisible({ windowKey: MAIN_WINDOW, key: "visualization" }),
+        setNavDrawerVisible({ windowKey: MAIN_WINDOW, key: "visualization" }),
       );
       store.dispatch(
-        actions.startNavHover({
+        startNavHover({
           windowKey: MAIN_WINDOW,
           location: "left",
           key: "channel",
         }),
       );
-      store.dispatch(actions.hideAllNavDrawers());
+      store.dispatch(hideAllNavDrawers());
       expect(selectNavDrawer(state(), "bottom")?.activeItem).toBeNull();
       expect(selectNavDrawer(state(), "left")?.activeItem).toBeNull();
       expect(selectNavDrawer(state(), "left")?.hover).toBe(false);
@@ -487,12 +503,12 @@ describe("Layout Slice", () => {
 
   describe("setWorkspace", () => {
     it("should preserve window-located layouts when applying a workspace", () => {
-      store.dispatch(actions.place(windowLayout("popup-1")));
+      store.dispatch(place(windowLayout("popup-1")));
       const ws = {
         ...ZERO_SLICE_STATE,
         layouts: { ...ZERO_SLICE_STATE.layouts, "ws-plot": mosaicLayout("ws-plot") },
       };
-      store.dispatch(actions.setWorkspace({ slice: ws }));
+      store.dispatch(setWorkspace({ slice: ws }));
       expect(select(state(), "popup-1")).toBeDefined();
       expect(select(state(), "ws-plot")).toBeDefined();
       expect(select(state(), "main")).toBeDefined();
@@ -514,16 +530,16 @@ describe("Layout Slice", () => {
           },
         },
       };
-      store.dispatch(actions.setWorkspace({ slice: ws, keepNav: false }));
+      store.dispatch(setWorkspace({ slice: ws, keepNav: false }));
       expect(selectNavDrawer(state(), "left")?.activeItem).toBe("task");
     });
   });
 
   describe("clearWorkspace", () => {
     it("should drop mosaic layouts but preserve window-located ones", () => {
-      store.dispatch(actions.place(mosaicLayout("plot-1")));
-      store.dispatch(actions.place(windowLayout("popup-1")));
-      store.dispatch(actions.clearWorkspace());
+      store.dispatch(place(mosaicLayout("plot-1")));
+      store.dispatch(place(windowLayout("popup-1")));
+      store.dispatch(clearWorkspace());
       expect(select(state(), "plot-1")).toBeUndefined();
       expect(select(state(), "popup-1")).toBeDefined();
       expect(select(state(), "main")).toBeDefined();

--- a/console/src/layout/slice.spec.ts
+++ b/console/src/layout/slice.spec.ts
@@ -7,20 +7,39 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { configureStore } from "@reduxjs/toolkit";
-import { MAIN_WINDOW } from "@synnaxlabs/drift";
+import { combineReducers, configureStore } from "@reduxjs/toolkit";
+import { Drift, MAIN_WINDOW } from "@synnaxlabs/drift";
 import { Color, type Haul, Mosaic } from "@synnaxlabs/pluto";
 import { beforeEach, describe, expect, it } from "vitest";
 
+import {
+  select,
+  selectActiveMosaicTabState,
+  selectActiveThemeKey,
+  selectAltKey,
+  selectArgs,
+  selectColorContext,
+  selectFocused,
+  selectHauling,
+  selectMosaic,
+  selectNavDrawer,
+  selectSliceState,
+} from "@/layout/selectors";
 import {
   actions,
   reducer,
   setArgs,
   SLICE_NAME,
   type State,
-  type StoreState,
   ZERO_SLICE_STATE,
 } from "@/layout/slice";
+
+const rootReducer = combineReducers({
+  [SLICE_NAME]: reducer,
+  drift: Drift.reducer,
+});
+
+type TestState = ReturnType<typeof rootReducer>;
 
 const mosaicLayout = (key: string, overrides: Partial<State> = {}): State => ({
   key,
@@ -41,28 +60,30 @@ const windowLayout = (key: string, overrides: Partial<State> = {}): State => ({
 });
 
 describe("Layout Slice", () => {
-  let store: ReturnType<typeof configureStore<StoreState>>;
+  let store: ReturnType<typeof configureStore<TestState>>;
 
   beforeEach(() => {
     store = configureStore({
-      reducer: { [SLICE_NAME]: reducer },
-      preloadedState: { [SLICE_NAME]: ZERO_SLICE_STATE },
+      reducer: rootReducer,
+      preloadedState: {
+        [SLICE_NAME]: ZERO_SLICE_STATE,
+      },
     });
   });
 
-  const slice = () => store.getState()[SLICE_NAME];
+  const state = () => store.getState();
 
   describe("place", () => {
     it("should insert a mosaic tab and select it", () => {
       store.dispatch(actions.place(mosaicLayout("plot-1")));
-      expect(slice().layouts["plot-1"]).toBeDefined();
-      expect(slice().mosaics[MAIN_WINDOW].activeTab).toBe("plot-1");
+      expect(select(state(), "plot-1")).toBeDefined();
+      expect(selectActiveMosaicTabState(state()).layoutKey).toBe("plot-1");
     });
 
     it("should add a window-located layout without touching the mosaic", () => {
       store.dispatch(actions.place(windowLayout("popup-1")));
-      expect(slice().layouts["popup-1"].location).toBe("window");
-      expect(slice().mosaics[MAIN_WINDOW].activeTab).toBeNull();
+      expect(select(state(), "popup-1")?.location).toBe("window");
+      expect(selectActiveMosaicTabState(state()).layoutKey).toBeNull();
     });
   });
 
@@ -70,21 +91,21 @@ describe("Layout Slice", () => {
     it("should remove a mosaic layout and clear it from the mosaic", () => {
       store.dispatch(actions.place(mosaicLayout("plot-1")));
       store.dispatch(actions.remove({ keys: ["plot-1"] }));
-      expect(slice().layouts["plot-1"]).toBeUndefined();
-      expect(slice().mosaics[MAIN_WINDOW].activeTab).toBeNull();
+      expect(select(state(), "plot-1")).toBeUndefined();
+      expect(selectActiveMosaicTabState(state()).layoutKey).toBeNull();
     });
 
     it("should ignore the main layout", () => {
       store.dispatch(actions.remove({ keys: ["main"] }));
-      expect(slice().layouts.main).toBeDefined();
+      expect(select(state(), "main")).toBeDefined();
     });
 
     it("should remove multiple layouts in one dispatch", () => {
       store.dispatch(actions.place(mosaicLayout("a")));
       store.dispatch(actions.place(mosaicLayout("b")));
       store.dispatch(actions.remove({ keys: ["a", "b"] }));
-      expect(slice().layouts.a).toBeUndefined();
-      expect(slice().layouts.b).toBeUndefined();
+      expect(select(state(), "a")).toBeUndefined();
+      expect(select(state(), "b")).toBeUndefined();
     });
   });
 
@@ -92,29 +113,31 @@ describe("Layout Slice", () => {
     it("should rename a mosaic layout and its tab", () => {
       store.dispatch(actions.place(mosaicLayout("plot-1")));
       store.dispatch(actions.rename({ key: "plot-1", name: "Renamed" }));
-      expect(slice().layouts["plot-1"].name).toBe("Renamed");
-      const node = Mosaic.findTabNode(slice().mosaics[MAIN_WINDOW].root, "plot-1");
-      expect(node?.tabs?.find((t) => t.tabKey === "plot-1")?.name).toBe("Renamed");
+      expect(select(state(), "plot-1")?.name).toBe("Renamed");
+      const [, root] = selectMosaic(state());
+      const tab = Mosaic.findTabNode(root!, "plot-1")?.tabs?.find(
+        (t) => t.tabKey === "plot-1",
+      );
+      expect(tab?.name).toBe("Renamed");
     });
 
     it("should ignore an unknown key", () => {
       store.dispatch(actions.rename({ key: "nope", name: "x" }));
-      expect(slice().layouts.nope).toBeUndefined();
+      expect(select(state(), "nope")).toBeUndefined();
     });
   });
 
   describe("setAltKey", () => {
-    it("should map a key to its alt key in both directions", () => {
+    it("should set an alt key for a layout", () => {
       store.dispatch(actions.setAltKey({ key: "real", altKey: "alt" }));
-      expect(slice().keyToAltKey.real).toBe("alt");
-      expect(slice().altKeyToKey.alt).toBe("real");
+      expect(selectAltKey(state(), "real")).toBe("alt");
     });
 
     it("should resolve a layout via its alt key", () => {
       store.dispatch(actions.place(mosaicLayout("real")));
       store.dispatch(actions.setAltKey({ key: "real", altKey: "alt" }));
       store.dispatch(actions.rename({ key: "alt", name: "Resolved" }));
-      expect(slice().layouts.real.name).toBe("Resolved");
+      expect(select(state(), "real")?.name).toBe("Resolved");
     });
   });
 
@@ -122,7 +145,7 @@ describe("Layout Slice", () => {
     it("should set args on an existing layout", () => {
       store.dispatch(actions.place(mosaicLayout("plot-1")));
       store.dispatch(setArgs({ key: "plot-1", args: { foo: 42 } }));
-      expect(slice().layouts["plot-1"].args).toEqual({ foo: 42 });
+      expect(selectArgs(state(), "plot-1")).toEqual({ foo: 42 });
     });
   });
 
@@ -130,14 +153,14 @@ describe("Layout Slice", () => {
     it("should focus a layout in its window's mosaic", () => {
       store.dispatch(actions.place(mosaicLayout("plot-1")));
       store.dispatch(actions.setFocus({ key: "plot-1", windowKey: MAIN_WINDOW }));
-      expect(slice().mosaics[MAIN_WINDOW].focused).toBe("plot-1");
+      expect(selectFocused(state()).focused).toBe("plot-1");
     });
 
     it("should clear focus when key is null", () => {
       store.dispatch(actions.place(mosaicLayout("plot-1")));
       store.dispatch(actions.setFocus({ key: "plot-1", windowKey: MAIN_WINDOW }));
       store.dispatch(actions.setFocus({ key: null, windowKey: MAIN_WINDOW }));
-      expect(slice().mosaics[MAIN_WINDOW].focused).toBeNull();
+      expect(selectFocused(state()).focused).toBeNull();
     });
   });
 
@@ -147,9 +170,12 @@ describe("Layout Slice", () => {
       store.dispatch(
         actions.setUnsavedChanges({ key: "plot-1", unsavedChanges: true }),
       );
-      expect(slice().layouts["plot-1"].unsavedChanges).toBe(true);
-      const node = Mosaic.findTabNode(slice().mosaics[MAIN_WINDOW].root, "plot-1");
-      expect(node?.tabs?.find((t) => t.tabKey === "plot-1")?.unsavedChanges).toBe(true);
+      expect(select(state(), "plot-1")?.unsavedChanges).toBe(true);
+      const [, root] = selectMosaic(state());
+      const tab = Mosaic.findTabNode(root!, "plot-1")?.tabs?.find(
+        (t) => t.tabKey === "plot-1",
+      );
+      expect(tab?.unsavedChanges).toBe(true);
     });
   });
 
@@ -160,7 +186,7 @@ describe("Layout Slice", () => {
         items: [{ key: "item-1", type: "drag" }],
       };
       store.dispatch(actions.setHauled(haul));
-      expect(slice().hauling).toEqual(haul);
+      expect(selectHauling(state())).toEqual(haul);
     });
   });
 
@@ -171,37 +197,37 @@ describe("Layout Slice", () => {
         frequent: { "#ff0000": { lastUsed: 1, count: 1, relevance: 1 } },
       };
       store.dispatch(actions.setColorContext({ state: ctx }));
-      expect(slice().colorContext).toEqual(ctx);
+      expect(selectColorContext(state())).toEqual(ctx);
     });
   });
 
   describe("setActiveTheme", () => {
     it("should set the named theme", () => {
       store.dispatch(actions.setActiveTheme("synnaxLight"));
-      expect(slice().activeTheme).toBe("synnaxLight");
+      expect(selectActiveThemeKey(state())).toBe("synnaxLight");
     });
 
     it("should cycle to the next theme when payload is undefined", () => {
       store.dispatch(actions.setActiveTheme(undefined));
-      expect(slice().activeTheme).toBe("synnaxLight");
+      expect(selectActiveThemeKey(state())).toBe("synnaxLight");
       store.dispatch(actions.setActiveTheme(undefined));
-      expect(slice().activeTheme).toBe("synnaxDark");
+      expect(selectActiveThemeKey(state())).toBe("synnaxDark");
     });
   });
 
   describe("toggleActiveTheme", () => {
     it("should cycle to the next theme", () => {
       store.dispatch(actions.toggleActiveTheme());
-      expect(slice().activeTheme).toBe("synnaxLight");
+      expect(selectActiveThemeKey(state())).toBe("synnaxLight");
     });
   });
 
   describe("moveMosaicTab", () => {
     it("should be a no-op when key is omitted within the same window", () => {
       store.dispatch(actions.place(mosaicLayout("plot-1")));
-      const before = slice().mosaics[MAIN_WINDOW].root;
+      const [, before] = selectMosaic(state());
       store.dispatch(actions.moveMosaicTab({ tabKey: "plot-1", loc: "center" }));
-      expect(slice().mosaics[MAIN_WINDOW].root).toEqual(before);
+      expect(selectMosaic(state())[1]).toEqual(before);
     });
 
     it("should move a tab to a different window's mosaic", () => {
@@ -214,10 +240,9 @@ describe("Layout Slice", () => {
           loc: "center",
         }),
       );
-      expect(slice().layouts["plot-1"].windowKey).toBe(MAIN_WINDOW);
-      expect(
-        Mosaic.findTabNode(slice().mosaics[MAIN_WINDOW].root, "plot-1"),
-      ).toBeDefined();
+      expect(select(state(), "plot-1")?.windowKey).toBe(MAIN_WINDOW);
+      const [, root] = selectMosaic(state());
+      expect(Mosaic.findTabNode(root!, "plot-1")).toBeDefined();
     });
   });
 
@@ -226,7 +251,7 @@ describe("Layout Slice", () => {
       store.dispatch(actions.place(mosaicLayout("plot-1")));
       store.dispatch(actions.place(mosaicLayout("plot-2")));
       store.dispatch(actions.selectMosaicTab({ tabKey: "plot-1" }));
-      expect(slice().mosaics[MAIN_WINDOW].activeTab).toBe("plot-1");
+      expect(selectActiveMosaicTabState(state()).layoutKey).toBe("plot-1");
     });
   });
 
@@ -241,9 +266,9 @@ describe("Layout Slice", () => {
           direction: "x",
         }),
       );
-      const root = slice().mosaics[MAIN_WINDOW].root;
-      expect(root.first).toBeDefined();
-      expect(root.last).toBeDefined();
+      const [, root] = selectMosaic(state());
+      expect(root?.first).toBeDefined();
+      expect(root?.last).toBeDefined();
     });
   });
 
@@ -258,11 +283,15 @@ describe("Layout Slice", () => {
           direction: "x",
         }),
       );
-      const rootKey = slice().mosaics[MAIN_WINDOW].root.key;
+      const [, root] = selectMosaic(state());
       store.dispatch(
-        actions.resizeMosaicTab({ windowKey: MAIN_WINDOW, key: rootKey, size: 0.25 }),
+        actions.resizeMosaicTab({
+          windowKey: MAIN_WINDOW,
+          key: root!.key,
+          size: 0.25,
+        }),
       );
-      expect(slice().mosaics[MAIN_WINDOW].root.size).toBe(0.25);
+      expect(selectMosaic(state())[1]?.size).toBe(0.25);
     });
   });
 
@@ -277,7 +306,7 @@ describe("Layout Slice", () => {
           size: 320,
         }),
       );
-      expect(slice().nav.main.drawers.left).toEqual({
+      expect(selectNavDrawer(state(), "left")).toEqual({
         activeItem: "channel",
         menuItems: ["channel"],
         size: 320,
@@ -293,7 +322,9 @@ describe("Layout Slice", () => {
           menuItems: ["x"],
         }),
       );
-      expect(slice().nav.popup.drawers.right?.menuItems).toEqual(["x"]);
+      expect(selectSliceState(state()).nav.popup.drawers.right?.menuItems).toEqual([
+        "x",
+      ]);
     });
   });
 
@@ -306,14 +337,14 @@ describe("Layout Slice", () => {
           size: 480,
         }),
       );
-      expect(slice().nav.main.drawers.left.size).toBe(480);
+      expect(selectNavDrawer(state(), "left")?.size).toBe(480);
     });
 
     it("should ignore a window or location without a drawer", () => {
       store.dispatch(
         actions.resizeNavDrawer({ windowKey: "absent", location: "left", size: 100 }),
       );
-      expect(slice().nav.absent).toBeUndefined();
+      expect(selectSliceState(state()).nav.absent).toBeUndefined();
     });
   });
 
@@ -334,7 +365,7 @@ describe("Layout Slice", () => {
       store.dispatch(
         actions.setNavDrawerVisible({ windowKey: MAIN_WINDOW, key: "visualization" }),
       );
-      expect(slice().nav.main.drawers.bottom?.activeItem).toBe("visualization");
+      expect(selectNavDrawer(state(), "bottom")?.activeItem).toBe("visualization");
     });
 
     it("should clear the active item when the same key is dispatched again", () => {
@@ -344,7 +375,7 @@ describe("Layout Slice", () => {
       store.dispatch(
         actions.setNavDrawerVisible({ windowKey: MAIN_WINDOW, key: "visualization" }),
       );
-      expect(slice().nav.main.drawers.bottom?.activeItem).toBeNull();
+      expect(selectNavDrawer(state(), "bottom")?.activeItem).toBeNull();
     });
 
     it("should respect an explicit value=false", () => {
@@ -358,7 +389,7 @@ describe("Layout Slice", () => {
           value: false,
         }),
       );
-      expect(slice().nav.main.drawers.bottom?.activeItem).toBeNull();
+      expect(selectNavDrawer(state(), "bottom")?.activeItem).toBeNull();
     });
 
     it("should activate the first menu item when location is provided with value=true", () => {
@@ -369,7 +400,7 @@ describe("Layout Slice", () => {
           value: true,
         }),
       );
-      expect(slice().nav.main.drawers.left.activeItem).toBe("channel");
+      expect(selectNavDrawer(state(), "left")?.activeItem).toBe("channel");
     });
   });
 
@@ -382,7 +413,7 @@ describe("Layout Slice", () => {
           key: "channel",
         }),
       );
-      expect(slice().nav.main.drawers.left).toMatchObject({
+      expect(selectNavDrawer(state(), "left")).toMatchObject({
         hover: true,
         activeItem: "channel",
       });
@@ -399,8 +430,8 @@ describe("Layout Slice", () => {
           key: "channel",
         }),
       );
-      expect(slice().nav.main.drawers.bottom?.activeItem).toBe("visualization");
-      expect(slice().nav.main.drawers.bottom?.hover).toBeFalsy();
+      expect(selectNavDrawer(state(), "bottom")?.activeItem).toBe("visualization");
+      expect(selectNavDrawer(state(), "bottom")?.hover).toBeFalsy();
     });
   });
 
@@ -409,7 +440,7 @@ describe("Layout Slice", () => {
       store.dispatch(
         actions.toggleNavHover({ windowKey: MAIN_WINDOW, key: "channel" }),
       );
-      expect(slice().nav.main.drawers.left).toMatchObject({
+      expect(selectNavDrawer(state(), "left")).toMatchObject({
         hover: true,
         activeItem: "channel",
       });
@@ -428,7 +459,7 @@ describe("Layout Slice", () => {
       store.dispatch(
         actions.stopNavHover({ windowKey: MAIN_WINDOW, location: "left" }),
       );
-      expect(slice().nav.main.drawers.left).toMatchObject({
+      expect(selectNavDrawer(state(), "left")).toMatchObject({
         hover: false,
         activeItem: null,
       });
@@ -448,9 +479,9 @@ describe("Layout Slice", () => {
         }),
       );
       store.dispatch(actions.hideAllNavDrawers());
-      expect(slice().nav.main.drawers.bottom?.activeItem).toBeNull();
-      expect(slice().nav.main.drawers.left.activeItem).toBeNull();
-      expect(slice().nav.main.drawers.left.hover).toBe(false);
+      expect(selectNavDrawer(state(), "bottom")?.activeItem).toBeNull();
+      expect(selectNavDrawer(state(), "left")?.activeItem).toBeNull();
+      expect(selectNavDrawer(state(), "left")?.hover).toBe(false);
     });
   });
 
@@ -462,9 +493,9 @@ describe("Layout Slice", () => {
         layouts: { ...ZERO_SLICE_STATE.layouts, "ws-plot": mosaicLayout("ws-plot") },
       };
       store.dispatch(actions.setWorkspace({ slice: ws }));
-      expect(slice().layouts["popup-1"]).toBeDefined();
-      expect(slice().layouts["ws-plot"]).toBeDefined();
-      expect(slice().layouts.main).toBeDefined();
+      expect(select(state(), "popup-1")).toBeDefined();
+      expect(select(state(), "ws-plot")).toBeDefined();
+      expect(select(state(), "main")).toBeDefined();
     });
 
     it("should adopt the workspace's nav state when keepNav is false", () => {
@@ -484,7 +515,7 @@ describe("Layout Slice", () => {
         },
       };
       store.dispatch(actions.setWorkspace({ slice: ws, keepNav: false }));
-      expect(slice().nav.main.drawers.left.activeItem).toBe("task");
+      expect(selectNavDrawer(state(), "left")?.activeItem).toBe("task");
     });
   });
 
@@ -493,9 +524,9 @@ describe("Layout Slice", () => {
       store.dispatch(actions.place(mosaicLayout("plot-1")));
       store.dispatch(actions.place(windowLayout("popup-1")));
       store.dispatch(actions.clearWorkspace());
-      expect(slice().layouts["plot-1"]).toBeUndefined();
-      expect(slice().layouts["popup-1"]).toBeDefined();
-      expect(slice().layouts.main).toBeDefined();
+      expect(select(state(), "plot-1")).toBeUndefined();
+      expect(select(state(), "popup-1")).toBeDefined();
+      expect(select(state(), "main")).toBeDefined();
     });
   });
 });

--- a/console/src/layout/slice.spec.ts
+++ b/console/src/layout/slice.spec.ts
@@ -1,0 +1,501 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { configureStore } from "@reduxjs/toolkit";
+import { MAIN_WINDOW } from "@synnaxlabs/drift";
+import { Color, type Haul, Mosaic } from "@synnaxlabs/pluto";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  actions,
+  reducer,
+  setArgs,
+  SLICE_NAME,
+  type State,
+  type StoreState,
+  ZERO_SLICE_STATE,
+} from "@/layout/slice";
+
+const mosaicLayout = (key: string, overrides: Partial<State> = {}): State => ({
+  key,
+  windowKey: MAIN_WINDOW,
+  type: "schematic",
+  name: key,
+  location: "mosaic",
+  ...overrides,
+});
+
+const windowLayout = (key: string, overrides: Partial<State> = {}): State => ({
+  key,
+  windowKey: MAIN_WINDOW,
+  type: "schematic",
+  name: key,
+  location: "window",
+  ...overrides,
+});
+
+describe("Layout Slice", () => {
+  let store: ReturnType<typeof configureStore<StoreState>>;
+
+  beforeEach(() => {
+    store = configureStore({
+      reducer: { [SLICE_NAME]: reducer },
+      preloadedState: { [SLICE_NAME]: ZERO_SLICE_STATE },
+    });
+  });
+
+  const slice = () => store.getState()[SLICE_NAME];
+
+  describe("place", () => {
+    it("should insert a mosaic tab and select it", () => {
+      store.dispatch(actions.place(mosaicLayout("plot-1")));
+      expect(slice().layouts["plot-1"]).toBeDefined();
+      expect(slice().mosaics[MAIN_WINDOW].activeTab).toBe("plot-1");
+    });
+
+    it("should add a window-located layout without touching the mosaic", () => {
+      store.dispatch(actions.place(windowLayout("popup-1")));
+      expect(slice().layouts["popup-1"].location).toBe("window");
+      expect(slice().mosaics[MAIN_WINDOW].activeTab).toBeNull();
+    });
+  });
+
+  describe("remove", () => {
+    it("should remove a mosaic layout and clear it from the mosaic", () => {
+      store.dispatch(actions.place(mosaicLayout("plot-1")));
+      store.dispatch(actions.remove({ keys: ["plot-1"] }));
+      expect(slice().layouts["plot-1"]).toBeUndefined();
+      expect(slice().mosaics[MAIN_WINDOW].activeTab).toBeNull();
+    });
+
+    it("should ignore the main layout", () => {
+      store.dispatch(actions.remove({ keys: ["main"] }));
+      expect(slice().layouts.main).toBeDefined();
+    });
+
+    it("should remove multiple layouts in one dispatch", () => {
+      store.dispatch(actions.place(mosaicLayout("a")));
+      store.dispatch(actions.place(mosaicLayout("b")));
+      store.dispatch(actions.remove({ keys: ["a", "b"] }));
+      expect(slice().layouts.a).toBeUndefined();
+      expect(slice().layouts.b).toBeUndefined();
+    });
+  });
+
+  describe("rename", () => {
+    it("should rename a mosaic layout and its tab", () => {
+      store.dispatch(actions.place(mosaicLayout("plot-1")));
+      store.dispatch(actions.rename({ key: "plot-1", name: "Renamed" }));
+      expect(slice().layouts["plot-1"].name).toBe("Renamed");
+      const node = Mosaic.findTabNode(slice().mosaics[MAIN_WINDOW].root, "plot-1");
+      expect(node?.tabs?.find((t) => t.tabKey === "plot-1")?.name).toBe("Renamed");
+    });
+
+    it("should ignore an unknown key", () => {
+      store.dispatch(actions.rename({ key: "nope", name: "x" }));
+      expect(slice().layouts.nope).toBeUndefined();
+    });
+  });
+
+  describe("setAltKey", () => {
+    it("should map a key to its alt key in both directions", () => {
+      store.dispatch(actions.setAltKey({ key: "real", altKey: "alt" }));
+      expect(slice().keyToAltKey.real).toBe("alt");
+      expect(slice().altKeyToKey.alt).toBe("real");
+    });
+
+    it("should resolve a layout via its alt key", () => {
+      store.dispatch(actions.place(mosaicLayout("real")));
+      store.dispatch(actions.setAltKey({ key: "real", altKey: "alt" }));
+      store.dispatch(actions.rename({ key: "alt", name: "Resolved" }));
+      expect(slice().layouts.real.name).toBe("Resolved");
+    });
+  });
+
+  describe("setArgs", () => {
+    it("should set args on an existing layout", () => {
+      store.dispatch(actions.place(mosaicLayout("plot-1")));
+      store.dispatch(setArgs({ key: "plot-1", args: { foo: 42 } }));
+      expect(slice().layouts["plot-1"].args).toEqual({ foo: 42 });
+    });
+  });
+
+  describe("setFocus", () => {
+    it("should focus a layout in its window's mosaic", () => {
+      store.dispatch(actions.place(mosaicLayout("plot-1")));
+      store.dispatch(actions.setFocus({ key: "plot-1", windowKey: MAIN_WINDOW }));
+      expect(slice().mosaics[MAIN_WINDOW].focused).toBe("plot-1");
+    });
+
+    it("should clear focus when key is null", () => {
+      store.dispatch(actions.place(mosaicLayout("plot-1")));
+      store.dispatch(actions.setFocus({ key: "plot-1", windowKey: MAIN_WINDOW }));
+      store.dispatch(actions.setFocus({ key: null, windowKey: MAIN_WINDOW }));
+      expect(slice().mosaics[MAIN_WINDOW].focused).toBeNull();
+    });
+  });
+
+  describe("setUnsavedChanges", () => {
+    it("should flag a mosaic layout and propagate to its tab", () => {
+      store.dispatch(actions.place(mosaicLayout("plot-1")));
+      store.dispatch(
+        actions.setUnsavedChanges({ key: "plot-1", unsavedChanges: true }),
+      );
+      expect(slice().layouts["plot-1"].unsavedChanges).toBe(true);
+      const node = Mosaic.findTabNode(slice().mosaics[MAIN_WINDOW].root, "plot-1");
+      expect(node?.tabs?.find((t) => t.tabKey === "plot-1")?.unsavedChanges).toBe(true);
+    });
+  });
+
+  describe("setHauled", () => {
+    it("should overwrite the hauling state", () => {
+      const haul: Haul.DraggingState = {
+        source: { key: "src", type: "drag" },
+        items: [{ key: "item-1", type: "drag" }],
+      };
+      store.dispatch(actions.setHauled(haul));
+      expect(slice().hauling).toEqual(haul);
+    });
+  });
+
+  describe("setColorContext", () => {
+    it("should overwrite the color context", () => {
+      const ctx: Color.ContextState = {
+        ...Color.ZERO_CONTEXT_STATE,
+        frequent: { "#ff0000": { lastUsed: 1, count: 1, relevance: 1 } },
+      };
+      store.dispatch(actions.setColorContext({ state: ctx }));
+      expect(slice().colorContext).toEqual(ctx);
+    });
+  });
+
+  describe("setActiveTheme", () => {
+    it("should set the named theme", () => {
+      store.dispatch(actions.setActiveTheme("synnaxLight"));
+      expect(slice().activeTheme).toBe("synnaxLight");
+    });
+
+    it("should cycle to the next theme when payload is undefined", () => {
+      store.dispatch(actions.setActiveTheme(undefined));
+      expect(slice().activeTheme).toBe("synnaxLight");
+      store.dispatch(actions.setActiveTheme(undefined));
+      expect(slice().activeTheme).toBe("synnaxDark");
+    });
+  });
+
+  describe("toggleActiveTheme", () => {
+    it("should cycle to the next theme", () => {
+      store.dispatch(actions.toggleActiveTheme());
+      expect(slice().activeTheme).toBe("synnaxLight");
+    });
+  });
+
+  describe("moveMosaicTab", () => {
+    it("should be a no-op when key is omitted within the same window", () => {
+      store.dispatch(actions.place(mosaicLayout("plot-1")));
+      const before = slice().mosaics[MAIN_WINDOW].root;
+      store.dispatch(actions.moveMosaicTab({ tabKey: "plot-1", loc: "center" }));
+      expect(slice().mosaics[MAIN_WINDOW].root).toEqual(before);
+    });
+
+    it("should move a tab to a different window's mosaic", () => {
+      store.dispatch(actions.place(mosaicLayout("mw-2", { type: "mosaicWindow" })));
+      store.dispatch(actions.place(mosaicLayout("plot-1", { windowKey: "mw-2" })));
+      store.dispatch(
+        actions.moveMosaicTab({
+          tabKey: "plot-1",
+          windowKey: MAIN_WINDOW,
+          loc: "center",
+        }),
+      );
+      expect(slice().layouts["plot-1"].windowKey).toBe(MAIN_WINDOW);
+      expect(
+        Mosaic.findTabNode(slice().mosaics[MAIN_WINDOW].root, "plot-1"),
+      ).toBeDefined();
+    });
+  });
+
+  describe("selectMosaicTab", () => {
+    it("should set the active tab on the layout's window", () => {
+      store.dispatch(actions.place(mosaicLayout("plot-1")));
+      store.dispatch(actions.place(mosaicLayout("plot-2")));
+      store.dispatch(actions.selectMosaicTab({ tabKey: "plot-1" }));
+      expect(slice().mosaics[MAIN_WINDOW].activeTab).toBe("plot-1");
+    });
+  });
+
+  describe("splitMosaicNode", () => {
+    it("should split the node containing the tab", () => {
+      store.dispatch(actions.place(mosaicLayout("plot-1")));
+      store.dispatch(actions.place(mosaicLayout("plot-2")));
+      store.dispatch(
+        actions.splitMosaicNode({
+          windowKey: MAIN_WINDOW,
+          tabKey: "plot-1",
+          direction: "x",
+        }),
+      );
+      const root = slice().mosaics[MAIN_WINDOW].root;
+      expect(root.first).toBeDefined();
+      expect(root.last).toBeDefined();
+    });
+  });
+
+  describe("resizeMosaicTab", () => {
+    it("should set the size on the targeted node", () => {
+      store.dispatch(actions.place(mosaicLayout("plot-1")));
+      store.dispatch(actions.place(mosaicLayout("plot-2")));
+      store.dispatch(
+        actions.splitMosaicNode({
+          windowKey: MAIN_WINDOW,
+          tabKey: "plot-1",
+          direction: "x",
+        }),
+      );
+      const rootKey = slice().mosaics[MAIN_WINDOW].root.key;
+      store.dispatch(
+        actions.resizeMosaicTab({ windowKey: MAIN_WINDOW, key: rootKey, size: 0.25 }),
+      );
+      expect(slice().mosaics[MAIN_WINDOW].root.size).toBe(0.25);
+    });
+  });
+
+  describe("setNavDrawer", () => {
+    it("should overwrite the drawer entry at a location", () => {
+      store.dispatch(
+        actions.setNavDrawer({
+          windowKey: MAIN_WINDOW,
+          location: "left",
+          activeItem: "channel",
+          menuItems: ["channel"],
+          size: 320,
+        }),
+      );
+      expect(slice().nav.main.drawers.left).toEqual({
+        activeItem: "channel",
+        menuItems: ["channel"],
+        size: 320,
+      });
+    });
+
+    it("should create nav state for an unknown window", () => {
+      store.dispatch(
+        actions.setNavDrawer({
+          windowKey: "popup",
+          location: "right",
+          activeItem: null,
+          menuItems: ["x"],
+        }),
+      );
+      expect(slice().nav.popup.drawers.right?.menuItems).toEqual(["x"]);
+    });
+  });
+
+  describe("resizeNavDrawer", () => {
+    it("should set the size of an existing drawer", () => {
+      store.dispatch(
+        actions.resizeNavDrawer({
+          windowKey: MAIN_WINDOW,
+          location: "left",
+          size: 480,
+        }),
+      );
+      expect(slice().nav.main.drawers.left.size).toBe(480);
+    });
+
+    it("should ignore a window or location without a drawer", () => {
+      store.dispatch(
+        actions.resizeNavDrawer({ windowKey: "absent", location: "left", size: 100 }),
+      );
+      expect(slice().nav.absent).toBeUndefined();
+    });
+  });
+
+  describe("setNavDrawerVisible", () => {
+    it("should throw when windowKey is missing", () => {
+      expect(() =>
+        store.dispatch(actions.setNavDrawerVisible({ key: "visualization" })),
+      ).toThrow(/windowKey/);
+    });
+
+    it("should throw when neither key nor location is provided", () => {
+      expect(() =>
+        store.dispatch(actions.setNavDrawerVisible({ windowKey: MAIN_WINDOW })),
+      ).toThrow(/key or location/);
+    });
+
+    it("should activate a menu item by key", () => {
+      store.dispatch(
+        actions.setNavDrawerVisible({ windowKey: MAIN_WINDOW, key: "visualization" }),
+      );
+      expect(slice().nav.main.drawers.bottom?.activeItem).toBe("visualization");
+    });
+
+    it("should clear the active item when the same key is dispatched again", () => {
+      store.dispatch(
+        actions.setNavDrawerVisible({ windowKey: MAIN_WINDOW, key: "visualization" }),
+      );
+      store.dispatch(
+        actions.setNavDrawerVisible({ windowKey: MAIN_WINDOW, key: "visualization" }),
+      );
+      expect(slice().nav.main.drawers.bottom?.activeItem).toBeNull();
+    });
+
+    it("should respect an explicit value=false", () => {
+      store.dispatch(
+        actions.setNavDrawerVisible({ windowKey: MAIN_WINDOW, key: "visualization" }),
+      );
+      store.dispatch(
+        actions.setNavDrawerVisible({
+          windowKey: MAIN_WINDOW,
+          location: "bottom",
+          value: false,
+        }),
+      );
+      expect(slice().nav.main.drawers.bottom?.activeItem).toBeNull();
+    });
+
+    it("should activate the first menu item when location is provided with value=true", () => {
+      store.dispatch(
+        actions.setNavDrawerVisible({
+          windowKey: MAIN_WINDOW,
+          location: "left",
+          value: true,
+        }),
+      );
+      expect(slice().nav.main.drawers.left.activeItem).toBe("channel");
+    });
+  });
+
+  describe("startNavHover", () => {
+    it("should set hover and active item on an empty drawer", () => {
+      store.dispatch(
+        actions.startNavHover({
+          windowKey: MAIN_WINDOW,
+          location: "left",
+          key: "channel",
+        }),
+      );
+      expect(slice().nav.main.drawers.left).toMatchObject({
+        hover: true,
+        activeItem: "channel",
+      });
+    });
+
+    it("should ignore an already-active drawer that is not in hover mode", () => {
+      store.dispatch(
+        actions.setNavDrawerVisible({ windowKey: MAIN_WINDOW, key: "visualization" }),
+      );
+      store.dispatch(
+        actions.startNavHover({
+          windowKey: MAIN_WINDOW,
+          location: "bottom",
+          key: "channel",
+        }),
+      );
+      expect(slice().nav.main.drawers.bottom?.activeItem).toBe("visualization");
+      expect(slice().nav.main.drawers.bottom?.hover).toBeFalsy();
+    });
+  });
+
+  describe("toggleNavHover", () => {
+    it("should enter hover mode on an empty drawer that contains the key", () => {
+      store.dispatch(
+        actions.toggleNavHover({ windowKey: MAIN_WINDOW, key: "channel" }),
+      );
+      expect(slice().nav.main.drawers.left).toMatchObject({
+        hover: true,
+        activeItem: "channel",
+      });
+    });
+  });
+
+  describe("stopNavHover", () => {
+    it("should clear hover and active item when in hover mode", () => {
+      store.dispatch(
+        actions.startNavHover({
+          windowKey: MAIN_WINDOW,
+          location: "left",
+          key: "channel",
+        }),
+      );
+      store.dispatch(
+        actions.stopNavHover({ windowKey: MAIN_WINDOW, location: "left" }),
+      );
+      expect(slice().nav.main.drawers.left).toMatchObject({
+        hover: false,
+        activeItem: null,
+      });
+    });
+  });
+
+  describe("hideAllNavDrawers", () => {
+    it("should clear active item and hover for every drawer in every window", () => {
+      store.dispatch(
+        actions.setNavDrawerVisible({ windowKey: MAIN_WINDOW, key: "visualization" }),
+      );
+      store.dispatch(
+        actions.startNavHover({
+          windowKey: MAIN_WINDOW,
+          location: "left",
+          key: "channel",
+        }),
+      );
+      store.dispatch(actions.hideAllNavDrawers());
+      expect(slice().nav.main.drawers.bottom?.activeItem).toBeNull();
+      expect(slice().nav.main.drawers.left.activeItem).toBeNull();
+      expect(slice().nav.main.drawers.left.hover).toBe(false);
+    });
+  });
+
+  describe("setWorkspace", () => {
+    it("should preserve window-located layouts when applying a workspace", () => {
+      store.dispatch(actions.place(windowLayout("popup-1")));
+      const ws = {
+        ...ZERO_SLICE_STATE,
+        layouts: { ...ZERO_SLICE_STATE.layouts, "ws-plot": mosaicLayout("ws-plot") },
+      };
+      store.dispatch(actions.setWorkspace({ slice: ws }));
+      expect(slice().layouts["popup-1"]).toBeDefined();
+      expect(slice().layouts["ws-plot"]).toBeDefined();
+      expect(slice().layouts.main).toBeDefined();
+    });
+
+    it("should adopt the workspace's nav state when keepNav is false", () => {
+      const ws = {
+        ...ZERO_SLICE_STATE,
+        nav: {
+          ...ZERO_SLICE_STATE.nav,
+          main: {
+            drawers: {
+              ...ZERO_SLICE_STATE.nav.main.drawers,
+              left: {
+                ...ZERO_SLICE_STATE.nav.main.drawers.left,
+                activeItem: "task",
+              },
+            },
+          },
+        },
+      };
+      store.dispatch(actions.setWorkspace({ slice: ws, keepNav: false }));
+      expect(slice().nav.main.drawers.left.activeItem).toBe("task");
+    });
+  });
+
+  describe("clearWorkspace", () => {
+    it("should drop mosaic layouts but preserve window-located ones", () => {
+      store.dispatch(actions.place(mosaicLayout("plot-1")));
+      store.dispatch(actions.place(windowLayout("popup-1")));
+      store.dispatch(actions.clearWorkspace());
+      expect(slice().layouts["plot-1"]).toBeUndefined();
+      expect(slice().layouts["popup-1"]).toBeDefined();
+      expect(slice().layouts.main).toBeDefined();
+    });
+  });
+});

--- a/console/src/layout/slice.ts
+++ b/console/src/layout/slice.ts
@@ -13,6 +13,7 @@ import {
   type PayloadAction,
   type UnknownAction,
 } from "@reduxjs/toolkit";
+import { UnexpectedError } from "@synnaxlabs/client";
 import { MAIN_WINDOW } from "@synnaxlabs/drift";
 import { type Color, type Haul, Mosaic, type Tabs } from "@synnaxlabs/pluto";
 import { type deep, type direction, id, type location } from "@synnaxlabs/x";
@@ -125,8 +126,8 @@ export interface SetWorkspacePayload {
   slice: SliceState;
 }
 
-interface SetNavDrawerVisiblePayload {
-  windowKey: string;
+export interface SetNavDrawerVisiblePayload {
+  windowKey?: string;
   key?: string;
   location?: NavDrawerLocation;
   value?: boolean;
@@ -385,6 +386,11 @@ export const { actions, reducer } = createSlice({
         payload: { windowKey, key, location, value },
       }: PayloadAction<SetNavDrawerVisiblePayload>,
     ) => {
+      if (windowKey == null)
+        throw new UnexpectedError(
+          "setNavDrawerVisible requires a windowKey; the layout middleware should " +
+            "have injected one from drift state",
+        );
       let navState = state.nav[windowKey];
       if (navState == null) {
         navState = { drawers: {} };

--- a/console/src/lineplot/LinePlot.tsx
+++ b/console/src/lineplot/LinePlot.tsx
@@ -8,7 +8,6 @@
 // included in the file licenses/APL.txt.
 
 import { type channel, lineplot, type ranger } from "@synnaxlabs/client";
-import { useSelectWindowKey } from "@synnaxlabs/drift/react";
 import {
   Access,
   type axis,
@@ -142,7 +141,6 @@ const RangeAnnotationContextMenu = ({
 };
 
 const Loaded: Layout.Renderer = ({ layoutKey, focused, visible }) => {
-  const windowKey = useSelectWindowKey() as string;
   const { name } = Layout.useSelectRequired(layoutKey);
   const vis = useSelect(layoutKey);
   const prevVis = usePrevious(vis);
@@ -317,11 +315,9 @@ const Loaded: Layout.Renderer = ({ layoutKey, focused, visible }) => {
   );
 
   const handleDoubleClick = useCallback(() => {
-    dispatch(
-      Layout.setNavDrawerVisible({ windowKey, key: "visualization", value: true }),
-    );
+    dispatch(Layout.setNavDrawerVisible({ key: "visualization", value: true }));
     dispatch(setActiveToolbarTab({ key: layoutKey, tab: "data" }));
-  }, [windowKey, dispatch, layoutKey]);
+  }, [dispatch, layoutKey]);
 
   const handleSelectRule = useCallback(
     (ruleKey: string) => {

--- a/console/src/log/Log.tsx
+++ b/console/src/log/Log.tsx
@@ -8,7 +8,6 @@
 // included in the file licenses/APL.txt.
 
 import { log } from "@synnaxlabs/client";
-import { useSelectWindowKey } from "@synnaxlabs/drift/react";
 import { Access, Icon, Log as Base } from "@synnaxlabs/pluto";
 import { deep, primitive, TimeSpan, uuid } from "@synnaxlabs/x";
 import { useCallback } from "react";
@@ -59,7 +58,6 @@ const PRELOAD = TimeSpan.seconds(30);
 const EXTRA_CONTEXT_MENU_ITEMS = <ContextMenu.ReloadConsoleItem />;
 
 const Loaded: Layout.Renderer = ({ layoutKey, visible }) => {
-  const winKey = useSelectWindowKey() as string;
   const log = useSelect(layoutKey);
   const dispatch = useSyncComponent(layoutKey);
 
@@ -73,14 +71,8 @@ const Loaded: Layout.Renderer = ({ layoutKey, visible }) => {
     keepFor: DEFAULT_RETENTION,
   });
   const handleDoubleClick = useCallback(() => {
-    dispatch(
-      Layout.setNavDrawerVisible({
-        windowKey: winKey,
-        key: "visualization",
-        value: true,
-      }),
-    );
-  }, [winKey, dispatch]);
+    dispatch(Layout.setNavDrawerVisible({ key: "visualization", value: true }));
+  }, [dispatch]);
 
   const handleConfigureChannels = useCallback(() => {
     dispatch(setActiveToolbarTab({ key: layoutKey, tab: "channels" }));

--- a/console/src/schematic/Schematic.tsx
+++ b/console/src/schematic/Schematic.tsx
@@ -8,7 +8,6 @@
 // included in the file licenses/APL.txt.
 
 import { schematic } from "@synnaxlabs/client";
-import { useSelectWindowKey } from "@synnaxlabs/drift/react";
 import {
   Access,
   Control,
@@ -173,7 +172,6 @@ export const ContextMenu: Layout.ContextMenuRenderer = ({ layoutKey }) => (
 );
 
 export const Loaded: Layout.Renderer = ({ layoutKey, visible }) => {
-  const windowKey = useSelectWindowKey() as string;
   const state = useSelectRequired(layoutKey);
   const legendVisible = useSelectLegendVisible(layoutKey);
   const dispatch = useDispatch();
@@ -276,14 +274,8 @@ export const Loaded: Layout.Renderer = ({ layoutKey, visible }) => {
 
   const handleDoubleClick = useCallback(() => {
     if (!state.editable) return;
-    syncDispatch(
-      Layout.setNavDrawerVisible({
-        windowKey,
-        key: "visualization",
-        value: true,
-      }),
-    );
-  }, [windowKey, state.editable, syncDispatch]);
+    syncDispatch(Layout.setNavDrawerVisible({ key: "visualization", value: true }));
+  }, [state.editable, syncDispatch]);
 
   const handleNodeClickAction = useHandleNodeClickAction(layoutKey);
 

--- a/console/src/table/Table.tsx
+++ b/console/src/table/Table.tsx
@@ -10,7 +10,6 @@
 import "@/table/Table.css";
 
 import { table } from "@synnaxlabs/client";
-import { useSelectWindowKey } from "@synnaxlabs/drift/react";
 import {
   Access,
   Button,
@@ -203,13 +202,9 @@ const Loaded: Layout.Renderer = ({ layoutKey, visible }) => {
     syncDispatch(resizeCol({ key: layoutKey, index, size: clamp(size, 32) }));
   }, []);
 
-  const windowKey = useSelectWindowKey() as string;
-
   const handleDoubleClick = useCallback(() => {
     if (!canEdit) return;
-    syncDispatch(
-      Layout.setNavDrawerVisible({ windowKey, key: "visualization", value: true }),
-    );
+    syncDispatch(Layout.setNavDrawerVisible({ key: "visualization", value: true }));
   }, [canEdit]);
 
   const colSizes = layout.columns.map((col) => col.size);


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4174](https://linear.app/synnax/issue/SY-4174)

## Description

Removes the boilerplate of selecting `windowKey` at every call site that dispatches `setNavDrawerVisible`. A new `injectNavDrawerWindowKey` layout middleware reads the current window key from drift state and injects it into the action payload when the caller omits one. The reducer still throws if a `windowKey` is missing by the time it runs, so the invariant is preserved.

Cleans up the `useSelectWindowKey()` lookup, the `as string` cast, and the corresponding `useCallback` dep at five consumers: `arc/editor/graph/Editor.tsx`, `lineplot/LinePlot.tsx`, `log/Log.tsx`, `schematic/Schematic.tsx`, and `table/Table.tsx`. Call sites that intentionally target a non-current window (e.g. `useNavDrawer.ts`, `nav/useTriggers.ts`, `layouts/nav/Menu.tsx`) keep their explicit `windowKey` and are unaffected.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR eliminates repetitive `useSelectWindowKey()` boilerplate from five layout renderers by introducing an `injectNavDrawerWindowKey` Redux middleware that reads the current window key from Drift state and injects it into `setNavDrawerVisible` actions that omit one. The reducer retains its guard and throws if a `windowKey` still arrives missing.

- **`console/src/layout/middleware.ts`**: New `injectNavDrawerWindowKey` middleware added as the first entry in `MIDDLEWARE`; it short-circuits on matching actions that already carry a `windowKey`.
- **`console/src/layout/slice.ts`**: `SetNavDrawerVisiblePayload.windowKey` made optional (`?`); reducer throws `UnexpectedError` if the key is absent after middleware runs.
- **`console/src/layout/slice.spec.ts`**: Comprehensive new test file covering the reducer, nav drawer actions, mosaic operations, and workspace management (no middleware integration test included).

<h3>Confidence Score: 5/5</h3>

Safe to merge; the middleware correctly injects window key for the five consumers and call sites that already carry an explicit windowKey are untouched.

The change is well-scoped: a single middleware intercepts one action type, the reducer retains its invariant guard, and five consumers are simplified in a uniform way. Call sites that intentionally target non-current windows keep their explicit windowKey and are unaffected.

No files require special attention beyond the optional middleware integration test gap noted in slice.spec.ts.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| console/src/layout/middleware.ts | Adds injectNavDrawerWindowKey middleware; correctly short-circuits on actions with a windowKey already set and injects from Drift state otherwise. |
| console/src/layout/slice.ts | windowKey made optional in SetNavDrawerVisiblePayload; reducer guard preserved via UnexpectedError throw. |
| console/src/layout/slice.spec.ts | New comprehensive test file covering slice reducer; does not include an integration test for the injectNavDrawerWindowKey middleware itself. |
| console/src/arc/editor/graph/Editor.tsx | Removed useSelectWindowKey hook and simplified handleDoubleClick callback and its dependency array. |
| console/src/lineplot/LinePlot.tsx | Removed useSelectWindowKey hook and windowKey from handleDoubleClick dependency array. |
| console/src/log/Log.tsx | Removed useSelectWindowKey hook and simplified handleDoubleClick callback. |
| console/src/schematic/Schematic.tsx | Removed useSelectWindowKey hook and simplified handleDoubleClick callback and its dependency array. |
| console/src/table/Table.tsx | Removed useSelectWindowKey hook; handleDoubleClick dep array unchanged at [canEdit] (pre-existing). |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Component (e.g. LinePlot)
    participant M as injectNavDrawerWindowKey Middleware
    participant D as Drift State
    participant R as Layout Reducer

    C->>M: dispatch setNavDrawerVisible without windowKey
    M->>M: Check if windowKey is absent
    M->>D: selectWindowKey from store state
    D-->>M: returns current windowKey
    M->>R: forward action with injected windowKey
    R->>R: Update nav drawer state

    note over M,R: If Drift returns null, the unmodified action is forwarded and the reducer throws UnexpectedError
```

<sub>Reviews (5): Last reviewed commit: ["Use exported action creators directly in..."](https://github.com/synnaxlabs/synnax/commit/97aaa8b119a84f3c5e547f18b413e5d35a4eb39e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=31795647)</sub>

<!-- /greptile_comment -->