### PR TITLE
SY-4176: Fix Arc Task Failure on TimeSpan Config Values

### DIFF
--- a/arc/go/stl/wasm/wasm.go
+++ b/arc/go/stl/wasm/wasm.go
@@ -129,6 +129,8 @@ func ConvertConfigValue(v any) (uint64, error) {
 		return math.Float64bits(val), nil
 	case telem.TimeStamp:
 		return uint64(val), nil
+	case telem.TimeSpan:
+		return uint64(val), nil
 	default:
 		err := errors.Newf("unsupported config value type: %T", v)
 		zap.S().DPanic(err.Error())

--- a/arc/go/stl/wasm/wasm_test.go
+++ b/arc/go/stl/wasm/wasm_test.go
@@ -57,6 +57,7 @@ var _ = Describe("ConvertConfigValue", func() {
 		Entry("float32", float32(1.5), uint64(math.Float32bits(1.5))),
 		Entry("float64", float64(2.5), math.Float64bits(2.5)),
 		Entry("telem.TimeStamp", telem.TimeStamp(9), uint64(9)),
+		Entry("telem.TimeSpan", telem.TimeSpan(10), uint64(10)),
 	)
 
 	DescribeTable("unsupported types return an error instead of panicking",
@@ -611,6 +612,34 @@ var _ = Describe("WASM", func() {
 			h.SetInput("y", 0, telem.NewSeriesV[int64](100), telem.NewSeriesSecondsTSV(1))
 			h.Execute(ctx, "add")
 			Expect(telem.UnmarshalSeries[int64](h.Output("add", 0))).To(Equal([]int64{105}))
+		})
+	})
+
+	Describe("TimeSpan Config Values", func() {
+		It("Should thread duration literal config values through the analyzer, compiler, and runtime", func(ctx SpecContext) {
+			resolver := symbol.MapResolver{
+				"trigger_ch": {
+					Name: "trigger_ch",
+					Kind: symbol.KindChannel,
+					Type: types.Chan(types.F32()),
+					ID:   100,
+				},
+			}
+			source := `
+func emit_period{period i64 ns} (trigger f32) i64 {
+    return period
+}
+
+trigger_ch -> emit_period{period=1s}
+`
+			h := newTextHarness(ctx, source, resolver,
+				channel.Digest{Key: 100, DataType: telem.Float32T},
+			)
+			defer h.Close(ctx)
+
+			h.SetInput("on_trigger_ch_0", 0, telem.NewSeriesV[float32](1.0), telem.NewSeriesSecondsTSV(1))
+			h.Execute(ctx, "emit_period_0")
+			Expect(telem.UnmarshalSeries[int64](h.Output("emit_period_0", 0))).To(Equal([]int64{int64(telem.Second)}))
 		})
 	})
 


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4176](https://linear.app/synnax/issue/SY-4176/fix-arc-time-configuration-bug)

## Description

Fixes a bug where user-defined Arc functions failed to start with `unsupported config value type: telem.TimeSpan` when a duration literal (e.g. `2s`) was passed as a config argument.

The WASM config-value bridge (`arc/go/stl/wasm/wasm.go:ConvertConfigValue`) handled `telem.TimeStamp` but was missing `telem.TimeSpan`. Both are `int64` underneath. Added the case clause and a test entry.

```go
func get_time_passed{length i64}() u8 {
    start i64 $= 0
    if (start == 0){
        return 0
    }
    passed := time.now() - start
    return passed > length
}

// Can now pass `2s` as an input 
trigger -> get_time_passed{2s} -> sink 
```

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `telem.TimeSpan` support to the WASM config-value bridge (`ConvertConfigValue`) so that duration literals (e.g. `2s`) no longer cause Arc task failures at startup.

- **`wasm.go`**: Adds a single `case telem.TimeSpan:` clause that casts to `uint64`, exactly mirroring the existing `telem.TimeStamp` handling — valid because both are `int64` aliases.
- **`wasm_test.go`**: Adds a unit-test table entry and a full end-to-end integration test confirming the value flows correctly through the analyzer, compiler, and runtime.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single targeted case clause in an exhaustive type switch, backed by a unit test and a full pipeline integration test.

The fix is minimal: one new case in a type switch for a type that is a direct alias of `int64`, identical in behaviour to the already-handled `telem.TimeStamp`. The new integration test exercises the full analyzer-compiler-runtime path, giving confidence the fix works end-to-end with no unintended side effects.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| arc/go/stl/wasm/wasm.go | Added `telem.TimeSpan` case to `ConvertConfigValue`, converting it to `uint64` via direct cast — mirrors the existing `telem.TimeStamp` handling since both are `int64` underneath. |
| arc/go/stl/wasm/wasm_test.go | Adds a unit test entry for `telem.TimeSpan` in the `ConvertConfigValue` table and a new integration test that validates duration literals flow through the full analyzer-compiler-runtime pipeline. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User as Arc DSL
    participant Analyzer
    participant Compiler
    participant WASM Runtime
    participant ConvertConfigValue

    User->>Analyzer: "emit_period{period=1s}"
    Analyzer->>Compiler: Resolve telem.TimeSpan config value
    Compiler->>WASM Runtime: Pass config values
    WASM Runtime->>ConvertConfigValue: ConvertConfigValue(telem.TimeSpan(1e9))
    Note over ConvertConfigValue: case telem.TimeSpan (NEW)<br/>return uint64(val), nil
    ConvertConfigValue-->>WASM Runtime: uint64(1000000000)
    WASM Runtime-->>User: Function executes successfully
```

<sub>Reviews (1): Last reviewed commit: ["SY-4176: Enable TimeSpan conversion to u..."](https://github.com/synnaxlabs/synnax/commit/07a964644c38668ca5730c626997f9105f74a466) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32038943)</sub>

<!-- /greptile_comment -->