### PR TITLE
SY-4091: Upgrade GitHub Actions

### DIFF
--- a/.github/actions/test-typescript/action.yaml
+++ b/.github/actions/test-typescript/action.yaml
@@ -34,7 +34,7 @@ runs:
   using: composite
   steps:
     - name: Set up pnpm
-      uses: pnpm/action-setup@v5
+      uses: pnpm/action-setup@v6
 
     - name: Set up Node.js
       uses: actions/setup-node@v6

--- a/.github/scripts/audit_actions.sh
+++ b/.github/scripts/audit_actions.sh
@@ -31,12 +31,12 @@ find "$GITHUB_DIR/workflows" "$GITHUB_DIR/actions" \
     | while IFS= read -r file; do
         rel=${file#"$REPO_DIR"/}
         grep -nE '^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*' "$file" \
-            | awk -v rel="$rel" '
+            | awk -v rel="$rel" -v sq="'" '
             {
                 line = $0
                 sub(/^[0-9]+:/, "", line)
                 sub(/^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*/, "", line)
-                gsub(/["\x27]/, "", line)
+                gsub("[\"" sq "]", "", line)
                 sub(/[[:space:]]+#.*$/, "", line)
                 sub(/[[:space:]]+$/, "", line)
                 if (line == "" || line ~ /^#/) next

--- a/.github/scripts/audit_actions.sh
+++ b/.github/scripts/audit_actions.sh
@@ -1,4 +1,14 @@
 #!/bin/sh
+
+# Copyright 2026 Synnax Labs, Inc.
+#
+# Use of this software is governed by the Business Source License included in the file
+# licenses/BSL.txt.
+#
+# As of the Change Date specified in that file, in accordance with the Business Source
+# License, use of this software will be governed by the Apache License, Version 2.0,
+# included in the file licenses/APL.txt.
+
 # Audit every `uses:` reference across .github/workflows and .github/actions.
 # Prints, for each distinct action, the versions/refs it is pinned to and the
 # number of occurrences. Local `./...` action references are skipped. Actions
@@ -16,12 +26,12 @@ trap 'rm -f "$TMP"' EXIT
 
 # Extract `uses:` references as TAB-separated: name<TAB>version<TAB>file:line
 find "$GITHUB_DIR/workflows" "$GITHUB_DIR/actions" \
-    \( -name '*.yaml' -o -name '*.yml' \) -type f 2>/dev/null |
-    sort |
-    while IFS= read -r file; do
+    \( -name '*.yaml' -o -name '*.yml' \) -type f 2> /dev/null \
+    | sort \
+    | while IFS= read -r file; do
         rel=${file#"$REPO_DIR"/}
-        grep -nE '^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*' "$file" |
-            awk -v rel="$rel" '
+        grep -nE '^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*' "$file" \
+            | awk -v rel="$rel" '
             {
                 line = $0
                 sub(/^[0-9]+:/, "", line)
@@ -45,9 +55,9 @@ find "$GITHUB_DIR/workflows" "$GITHUB_DIR/actions" \
                 }
                 printf "%s\t%s\t%s:%s\n", name, version, rel, lineno
             }'
-    done >"$TMP"
+    done > "$TMP"
 
-total=$(wc -l <"$TMP" | tr -d ' ')
+total=$(wc -l < "$TMP" | tr -d ' ')
 files=$(cut -f3 "$TMP" | cut -d: -f1 | sort -u | wc -l | tr -d ' ')
 
 if [ "$total" -eq 0 ]; then
@@ -64,11 +74,11 @@ printf "%s  %s\n" \
     "$(printf '%*s' 40 '' | tr ' ' '-')"
 
 # Per-name summary: collapse versions into "v1 (3), v2 (1)" form.
-cut -f1,2 "$TMP" | sort | uniq -c |
-    awk '{ count = $1; name = $2; version = $3;
-           printf "%s\t%s (%d)\n", name, version, count }' |
-    sort |
-    awk -F'\t' -v w="$name_w" '
+cut -f1,2 "$TMP" | sort | uniq -c \
+    | awk '{ count = $1; name = $2; version = $3;
+           printf "%s\t%s (%d)\n", name, version, count }' \
+    | sort \
+    | awk -F'\t' -v w="$name_w" '
     {
         if ($1 != prev && prev != "") {
             marker = (n > 1) ? "*" : " "
@@ -88,17 +98,17 @@ cut -f1,2 "$TMP" | sort | uniq -c |
     }'
 
 # Detail block for any action pinned to more than one version.
-multi=$(cut -f1,2 "$TMP" | sort -u | cut -f1 | uniq -c |
-    awk '$1 > 1 { print $2 }')
+multi=$(cut -f1,2 "$TMP" | sort -u | cut -f1 | uniq -c \
+    | awk '$1 > 1 { print $2 }')
 
 if [ -n "$multi" ]; then
     printf "\nActions with multiple pinned versions (marked with *):\n"
     echo "$multi" | while IFS= read -r name; do
         [ -z "$name" ] && continue
         printf "\n  %s\n" "$name"
-        awk -F'\t' -v target="$name" '$1 == target { print $2 "\t" $3 }' "$TMP" |
-            sort |
-            awk -F'\t' '
+        awk -F'\t' -v target="$name" '$1 == target { print $2 "\t" $3 }' "$TMP" \
+            | sort \
+            | awk -F'\t' '
             {
                 if ($1 != prev) {
                     printf "    %s\n", $1

--- a/.github/scripts/audit_actions.sh
+++ b/.github/scripts/audit_actions.sh
@@ -1,0 +1,110 @@
+#!/bin/sh
+# Audit every `uses:` reference across .github/workflows and .github/actions.
+# Prints, for each distinct action, the versions/refs it is pinned to and the
+# number of occurrences. Local `./...` action references are skipped. Actions
+# pinned to more than one version are listed in a detail block with file:line
+# locations.
+
+set -eu
+
+SCRIPT_DIR=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+GITHUB_DIR=$(dirname "$SCRIPT_DIR")
+REPO_DIR=$(dirname "$GITHUB_DIR")
+
+TMP=$(mktemp -t audit_actions.XXXXXX)
+trap 'rm -f "$TMP"' EXIT
+
+# Extract `uses:` references as TAB-separated: name<TAB>version<TAB>file:line
+find "$GITHUB_DIR/workflows" "$GITHUB_DIR/actions" \
+    \( -name '*.yaml' -o -name '*.yml' \) -type f 2>/dev/null |
+    sort |
+    while IFS= read -r file; do
+        rel=${file#"$REPO_DIR"/}
+        grep -nE '^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*' "$file" |
+            awk -v rel="$rel" '
+            {
+                line = $0
+                sub(/^[0-9]+:/, "", line)
+                sub(/^[[:space:]]*-?[[:space:]]*uses:[[:space:]]*/, "", line)
+                gsub(/["\x27]/, "", line)
+                sub(/[[:space:]]+#.*$/, "", line)
+                sub(/[[:space:]]+$/, "", line)
+                if (line == "" || line ~ /^#/) next
+
+                match($0, /^[0-9]+/)
+                lineno = substr($0, RSTART, RLENGTH)
+
+                if (line ~ /^\.\.?\//) {
+                    next
+                } else if (index(line, "@") > 0) {
+                    at = index(line, "@")
+                    name = substr(line, 1, at - 1)
+                    version = substr(line, at + 1)
+                } else {
+                    name = line; version = "(unpinned)"
+                }
+                printf "%s\t%s\t%s:%s\n", name, version, rel, lineno
+            }'
+    done >"$TMP"
+
+total=$(wc -l <"$TMP" | tr -d ' ')
+files=$(cut -f3 "$TMP" | cut -d: -f1 | sort -u | wc -l | tr -d ' ')
+
+if [ "$total" -eq 0 ]; then
+    echo "No \`uses:\` references found."
+    exit 0
+fi
+
+name_w=$(cut -f1 "$TMP" | awk '{ if (length > m) m = length } END { print m }')
+
+printf "Found %s \`uses:\` references across %s files.\n\n" "$total" "$files"
+printf "%-*s  VERSIONS\n" "$name_w" "ACTION"
+printf "%s  %s\n" \
+    "$(printf '%*s' "$name_w" '' | tr ' ' '-')" \
+    "$(printf '%*s' 40 '' | tr ' ' '-')"
+
+# Per-name summary: collapse versions into "v1 (3), v2 (1)" form.
+cut -f1,2 "$TMP" | sort | uniq -c |
+    awk '{ count = $1; name = $2; version = $3;
+           printf "%s\t%s (%d)\n", name, version, count }' |
+    sort |
+    awk -F'\t' -v w="$name_w" '
+    {
+        if ($1 != prev && prev != "") {
+            marker = (n > 1) ? "*" : " "
+            printf "%-*s %s%s\n", w, prev, marker, joined
+            joined = ""
+            n = 0
+        }
+        prev = $1
+        joined = (joined == "") ? $2 : joined ", " $2
+        n++
+    }
+    END {
+        if (prev != "") {
+            marker = (n > 1) ? "*" : " "
+            printf "%-*s %s%s\n", w, prev, marker, joined
+        }
+    }'
+
+# Detail block for any action pinned to more than one version.
+multi=$(cut -f1,2 "$TMP" | sort -u | cut -f1 | uniq -c |
+    awk '$1 > 1 { print $2 }')
+
+if [ -n "$multi" ]; then
+    printf "\nActions with multiple pinned versions (marked with *):\n"
+    echo "$multi" | while IFS= read -r name; do
+        [ -z "$name" ] && continue
+        printf "\n  %s\n" "$name"
+        awk -F'\t' -v target="$name" '$1 == target { print $2 "\t" $3 }' "$TMP" |
+            sort |
+            awk -F'\t' '
+            {
+                if ($1 != prev) {
+                    printf "    %s\n", $1
+                    prev = $1
+                }
+                printf "      %s\n", $2
+            }'
+    done
+fi

--- a/.github/workflows/build.synnax.yaml
+++ b/.github/workflows/build.synnax.yaml
@@ -506,7 +506,7 @@ jobs:
 
       - name: Set up pnpm
         if: inputs.console
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
 
       - name: Set up Node.js
         if: inputs.console
@@ -824,7 +824,7 @@ jobs:
           fi
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/check.oracle.yaml
+++ b/.github/workflows/check.oracle.yaml
@@ -85,7 +85,7 @@ jobs:
             oracle/go.sum
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
 
       - name: Set up Node
         uses: actions/setup-node@v6
@@ -139,7 +139,7 @@ jobs:
 
       - name: Archive JSON report
         if: failure() && steps.check.conclusion == 'failure'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: oracle-check-report
           path: oracle-check.json

--- a/.github/workflows/deploy.docs.yaml
+++ b/.github/workflows/deploy.docs.yaml
@@ -33,7 +33,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/deploy.synnax.yaml
+++ b/.github/workflows/deploy.synnax.yaml
@@ -288,7 +288,7 @@ jobs:
           echo "CONSOLE_VERSION=${CONSOLE_VERSION}" >> $GITHUB_OUTPUT
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
         if: github.ref == 'refs/heads/main'
 
       - name: Set up Node.js

--- a/.github/workflows/deploy.ts.yaml
+++ b/.github/workflows/deploy.ts.yaml
@@ -30,7 +30,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Set up pnpm
-        uses: pnpm/action-setup@v5
+        uses: pnpm/action-setup@v6
 
       - name: Set up Node.js
         uses: actions/setup-node@v6

--- a/.github/workflows/test.format.yaml
+++ b/.github/workflows/test.format.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6
-      - uses: pnpm/action-setup@v5
+      - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:
           node-version-file: package.json


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue number and link -->

[SY-4091](https://linear.app/synnax/issue/SY-4091/upgrade-github-actions)

## Description

<!-- Write a description describing the changes. -->

Upgrade GitHub actions and add a script for auditing them.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR upgrades `pnpm/action-setup` from v5 to v6 across all workflows and composite actions, upgrades the last remaining `actions/upload-artifact@v4` reference in `check.oracle.yaml` to v7 (matching every other workflow), and introduces a new POSIX-sh audit script for detecting version inconsistencies going forward.

- **`pnpm/action-setup` v5 → v6**: Updated consistently across 7 files (`.github/actions/test-typescript/action.yaml` and 6 workflows), bringing all references to the latest major version.
- **`actions/upload-artifact` v4 → v7** (`check.oracle.yaml`): Closes the last v4 straggler; all upload-artifact references are now on v7, paired with the existing `actions/download-artifact@v8` used elsewhere.
- **`audit_actions.sh`**: New POSIX sh script that scans every `uses:` line under `.github/`, extracts action name and version, and flags any action pinned to more than one version — useful for catching future drift.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are version upgrades to well-established actions with no functional logic changes.

The PR is purely a set of version pin bumps for `pnpm/action-setup` and `actions/upload-artifact`, plus a new read-only shell audit script. All upgrades are to current major releases; the `upload-artifact` v7 upgrade is already consistent with every other workflow in the repo. No workflow logic is modified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/scripts/audit_actions.sh | New POSIX sh audit script that scans all workflow/action YAML files, extracts `uses:` references, and reports actions pinned to multiple versions; uses portable `awk -v sq="'"` for single-quote handling. |
| .github/workflows/check.oracle.yaml | Upgrades both `pnpm/action-setup` (v5→v6) and `actions/upload-artifact` (v4→v7), making it consistent with all other workflows already on v7. |
| .github/workflows/build.synnax.yaml | Two occurrences of `pnpm/action-setup` bumped from v5 to v6; `actions/upload-artifact` and `actions/download-artifact` were already on v7/v8. |
| .github/actions/test-typescript/action.yaml | Single `pnpm/action-setup` bump from v5 to v6 in the shared TypeScript test composite action. |
| .github/workflows/deploy.docs.yaml | `pnpm/action-setup` bumped from v5 to v6; no other changes. |
| .github/workflows/deploy.synnax.yaml | `pnpm/action-setup` bumped from v5 to v6; no other changes. |
| .github/workflows/deploy.ts.yaml | `pnpm/action-setup` bumped from v5 to v6; no other changes. |
| .github/workflows/test.format.yaml | `pnpm/action-setup` bumped from v5 to v6; no other changes. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[audit_actions.sh] --> B[find .github/workflows\n.github/actions *.yaml/*.yml]
    B --> C[grep uses: lines]
    C --> D[awk: extract name, version, file:line\nskip local ./.. refs]
    D --> E[TMP file\nname TAB version TAB file:lineno]
    E --> F[Summary table\nper-action version counts]
    E --> G{Any action with\nmultiple versions?}
    G -- Yes --> H[Detail block\nfile:line per version]
    G -- No --> I[Clean output]
```

<sub>Reviews (2): Last reviewed commit: ["Improve shell script"](https://github.com/synnaxlabs/synnax/commit/c708203877f02f4aa3ec9def9bcede90f4ff2936) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32531767)</sub>

<!-- /greptile_comment -->