### PR TITLE
SY-4041: Fix Horizontal Scrollbar for Arc Sequences

### DIFF
--- a/console/src/arc/editor/Controls.css
+++ b/console/src/arc/editor/Controls.css
@@ -47,3 +47,15 @@
         }
     }
 }
+
+@container (max-width: 600px) {
+    .console-arc .console-editor {
+        padding-bottom: 21rem;
+    }
+}
+
+.console-arc:has(.console-task-controls--expanded) {
+    .console-editor {
+        padding-bottom: 19rem;
+    }
+}


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4041](https://linear.app/synnax/issue/SY-4041)

## Description

In Arc text sequences, the Task.Controls panel could visually cover Monaco's horizontal scrollbar in two states:

- When the Arc editor container is narrow (`@container (max-width: 600px)`), the Controls stacks vertically and grows taller than the default `padding-bottom: 11rem` accounts for.
- When the user expands the Controls (`.console-task-controls--expanded`) to view the full status / description, it grows further.

In both cases the scrollbar ended up behind the Controls panel and disappeared as soon as the cursor approached it.

The fix grows `.console-editor`'s `padding-bottom` in those two states (`21rem` for narrow, `19rem` for expanded), keeping Monaco's scrollbar above the Controls in all layouts. Monaco's native scrollbar position is left alone.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes Monaco's horizontal scrollbar being obscured by the `Task.Controls` panel in Arc sequences by increasing `.console-editor`'s `padding-bottom` in two layout states. Two new CSS rules are added: `21rem` for narrow containers (≤600px, where Controls stack vertically) and `19rem` for the expanded-controls state.

- Narrow container (`@container max-width: 600px`): `padding-bottom` raised from `11rem` to `21rem` to accommodate the taller vertically-stacked Controls.
- Expanded controls (`:has(.console-task-controls--expanded)`): `padding-bottom` raised to `19rem` to accommodate the taller expanded panel in normal-width layouts.

<h3>Confidence Score: 3/5</h3>

The fix partially addresses the scrollbar occlusion but leaves a gap: when the container is both narrow and expanded simultaneously, the wrong padding value wins and the scrollbar can still be hidden.

The two new rules don't compose correctly — CSS source order causes the expanded :has() rule (19rem) to override the narrow @container rule (21rem) when both conditions are active at the same time. A user in a narrow Arc panel who also expands the Controls will get 19rem of bottom padding, less than the 21rem needed for the non-expanded narrow layout, meaning the scrollbar regression can reappear in that combined state.

console/src/arc/editor/Controls.css — specifically the interaction between the @container and :has() rules when both conditions hold.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| console/src/arc/editor/Controls.css | Adds two new padding-bottom overrides for the editor in narrow-container and expanded-controls states; cascade ordering means the expanded rule (19rem) wins over the narrow rule (21rem) when both are active simultaneously, potentially leaving the scrollbar hidden again. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Arc Editor renders] --> B{container width ≤ 600px?}
    B -- Yes --> C[Controls stack vertically\npadding-bottom: 21rem]
    B -- No --> D{.console-task-controls--expanded?}
    D -- Yes --> E[Controls show full status\npadding-bottom: 19rem]
    D -- No --> F[Default layout\npadding-bottom: 11rem]
    C --> G{Also expanded?}
    G -- Yes --> H[⚠️ :has rule wins → 19rem\nmay be insufficient for\nnarrow + expanded layout]
    G -- No --> I[21rem applies ✓]
    E --> J[19rem applies ✓]
    F --> K[11rem applies ✓]
```

<sub>Reviews (1): Last reviewed commit: ["SY-4041: Fix horizontal scrollbar for Ar..."](https://github.com/synnaxlabs/synnax/commit/0c35383018932f6c2c9abf7513cf99a5d26b2abc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32671636)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->