### PR TITLE
SY-4183: Fix Tab Not Found When Re-opening Orphaned Mosaic Layouts

### DIFF
--- a/console/src/layout/slice.spec.ts
+++ b/console/src/layout/slice.spec.ts
@@ -128,6 +128,61 @@ describe("Layout Slice", () => {
       expect(Mosaic.findTabNode(root!, "orphan-arc")).toBeDefined();
       expect(selectActiveMosaicTabState(state()).layoutKey).toBe("orphan-arc");
     });
+
+    it("should not throw when re-placing a layout whose tab lives in another window's mosaic", () => {
+      // Cross-window placement is the most likely live trigger for the
+      // "Tab not found" report: a layout already lives in window A's mosaic,
+      // but the user re-opens it (e.g., from the search palette) while
+      // focused on window B. usePlacer fires `place` with the current
+      // window's key, so prev.windowKey !== layout.windowKey and the new
+      // window's mosaic does not yet contain the tab. The reducer must
+      // move the tab without throwing and must not leave an orphan copy in
+      // the source mosaic.
+      const subWindowKey = "sub-window-1";
+      const subWindowLayout: State = {
+        key: "cross-arc",
+        windowKey: subWindowKey,
+        type: "arc",
+        name: "cross-arc",
+        location: "mosaic",
+      };
+      store = configureStore({
+        reducer: rootReducer,
+        preloadedState: {
+          [SLICE_NAME]: {
+            ...ZERO_SLICE_STATE,
+            layouts: {
+              ...ZERO_SLICE_STATE.layouts,
+              "cross-arc": subWindowLayout,
+            },
+            mosaics: {
+              ...ZERO_SLICE_STATE.mosaics,
+              [subWindowKey]: {
+                activeTab: "cross-arc",
+                focused: null,
+                root: {
+                  key: 1,
+                  tabs: [{ tabKey: "cross-arc", name: "cross-arc", closable: true }],
+                  selected: "cross-arc",
+                },
+              },
+            },
+          },
+        },
+      });
+      expect(() =>
+        store.dispatch(place({ ...subWindowLayout, windowKey: MAIN_WINDOW })),
+      ).not.toThrow();
+      const sliceState = selectSliceState(state());
+      const mainRoot = sliceState.mosaics[MAIN_WINDOW].root;
+      expect(Mosaic.findTabNode(mainRoot, "cross-arc")).toBeDefined();
+      expect(selectActiveMosaicTabState(state()).layoutKey).toBe("cross-arc");
+      const subMosaic = sliceState.mosaics[subWindowKey];
+      // purgeEmptyMosaics may delete the now-empty source mosaic entirely;
+      // either way, the tab must not remain in it.
+      if (subMosaic != null)
+        expect(Mosaic.findTabNode(subMosaic.root, "cross-arc")).toBeUndefined();
+    });
   });
 
   describe("remove", () => {
@@ -533,6 +588,44 @@ describe("Layout Slice", () => {
       expect(select(state(), "popup-1")).toBeDefined();
       expect(select(state(), "ws-plot")).toBeDefined();
       expect(select(state(), "main")).toBeDefined();
+    });
+
+    it("should resurrect orphan mosaic layouts that the workspace's mosaics map omits", () => {
+      // Persisted workspaces can carry direction-B divergence: a layout entry
+      // with location "mosaic" whose tab is absent from the mosaics map.
+      // setWorkspace must reconcile by inserting the tab back into its claimed
+      // mosaic so the user can see and interact with it on load.
+      const ws = {
+        ...ZERO_SLICE_STATE,
+        layouts: {
+          ...ZERO_SLICE_STATE.layouts,
+          "ws-orphan": mosaicLayout("ws-orphan"),
+        },
+      };
+      store.dispatch(setWorkspace({ slice: ws }));
+      expect(select(state(), "ws-orphan")).toBeDefined();
+      const [, root] = selectMosaic(state());
+      expect(Mosaic.findTabNode(root!, "ws-orphan")).toBeDefined();
+    });
+
+    it("should fall back to the main mosaic when an orphan layout points at a missing window", () => {
+      // If the workspace's saved mosaics map has no entry for a layout's
+      // windowKey (e.g., a sub-window that no longer exists), reconciliation
+      // must place the tab in the main mosaic and rewrite the layout's
+      // windowKey so subsequent operations target a real mosaic.
+      const ws = {
+        ...ZERO_SLICE_STATE,
+        layouts: {
+          ...ZERO_SLICE_STATE.layouts,
+          "stale-window-tab": mosaicLayout("stale-window-tab", {
+            windowKey: "ghost-window",
+          }),
+        },
+      };
+      store.dispatch(setWorkspace({ slice: ws }));
+      expect(select(state(), "stale-window-tab")?.windowKey).toBe(MAIN_WINDOW);
+      const [, root] = selectMosaic(state());
+      expect(Mosaic.findTabNode(root!, "stale-window-tab")).toBeDefined();
     });
 
     it("should adopt the workspace's nav state when keepNav is false", () => {

--- a/console/src/layout/slice.spec.ts
+++ b/console/src/layout/slice.spec.ts
@@ -107,6 +107,27 @@ describe("Layout Slice", () => {
       expect(select(state(), "popup-1")?.location).toBe("window");
       expect(selectActiveMosaicTabState(state()).layoutKey).toBeNull();
     });
+
+    it("should recover when a layout claims location mosaic but is absent from the mosaic tree", () => {
+      // Persisted state from another Console can leave a layout entry whose
+      // location is "mosaic" while the matching tab is missing from the mosaic
+      // tree. Re-placing the layout (e.g., via the search palette) must
+      // resurrect the tab instead of throwing "Tab not found".
+      const layout = mosaicLayout("orphan-arc");
+      store = configureStore({
+        reducer: rootReducer,
+        preloadedState: {
+          [SLICE_NAME]: {
+            ...ZERO_SLICE_STATE,
+            layouts: { ...ZERO_SLICE_STATE.layouts, "orphan-arc": layout },
+          },
+        },
+      });
+      expect(() => store.dispatch(place(layout))).not.toThrow();
+      const [, root] = selectMosaic(state());
+      expect(Mosaic.findTabNode(root!, "orphan-arc")).toBeDefined();
+      expect(selectActiveMosaicTabState(state()).layoutKey).toBe("orphan-arc");
+    });
   });
 
   describe("remove", () => {

--- a/console/src/layout/slice.spec.ts
+++ b/console/src/layout/slice.spec.ts
@@ -109,10 +109,6 @@ describe("Layout Slice", () => {
     });
 
     it("should recover when a layout claims location mosaic but is absent from the mosaic tree", () => {
-      // Persisted state from another Console can leave a layout entry whose
-      // location is "mosaic" while the matching tab is missing from the mosaic
-      // tree. Re-placing the layout (e.g., via the search palette) must
-      // resurrect the tab instead of throwing "Tab not found".
       const layout = mosaicLayout("orphan-arc");
       store = configureStore({
         reducer: rootReducer,
@@ -129,15 +125,7 @@ describe("Layout Slice", () => {
       expect(selectActiveMosaicTabState(state()).layoutKey).toBe("orphan-arc");
     });
 
-    it("should not throw when re-placing a layout whose tab lives in another window's mosaic", () => {
-      // Cross-window placement is the most likely live trigger for the
-      // "Tab not found" report: a layout already lives in window A's mosaic,
-      // but the user re-opens it (e.g., from the search palette) while
-      // focused on window B. usePlacer fires `place` with the current
-      // window's key, so prev.windowKey !== layout.windowKey and the new
-      // window's mosaic does not yet contain the tab. The reducer must
-      // move the tab without throwing and must not leave an orphan copy in
-      // the source mosaic.
+    it("should move the tab to the new window without throwing or leaving an orphan when prev.windowKey differs", () => {
       const subWindowKey = "sub-window-1";
       const subWindowLayout: State = {
         key: "cross-arc",
@@ -178,8 +166,6 @@ describe("Layout Slice", () => {
       expect(Mosaic.findTabNode(mainRoot, "cross-arc")).toBeDefined();
       expect(selectActiveMosaicTabState(state()).layoutKey).toBe("cross-arc");
       const subMosaic = sliceState.mosaics[subWindowKey];
-      // purgeEmptyMosaics may delete the now-empty source mosaic entirely;
-      // either way, the tab must not remain in it.
       if (subMosaic != null)
         expect(Mosaic.findTabNode(subMosaic.root, "cross-arc")).toBeUndefined();
     });
@@ -591,10 +577,6 @@ describe("Layout Slice", () => {
     });
 
     it("should resurrect orphan mosaic layouts that the workspace's mosaics map omits", () => {
-      // Persisted workspaces can carry direction-B divergence: a layout entry
-      // with location "mosaic" whose tab is absent from the mosaics map.
-      // setWorkspace must reconcile by inserting the tab back into its claimed
-      // mosaic so the user can see and interact with it on load.
       const ws = {
         ...ZERO_SLICE_STATE,
         layouts: {
@@ -609,10 +591,6 @@ describe("Layout Slice", () => {
     });
 
     it("should fall back to the main mosaic when an orphan layout points at a missing window", () => {
-      // If the workspace's saved mosaics map has no entry for a layout's
-      // windowKey (e.g., a sub-window that no longer exists), reconciliation
-      // must place the tab in the main mosaic and rewrite the layout's
-      // windowKey so subsequent operations target a real mosaic.
       const ws = {
         ...ZERO_SLICE_STATE,
         layouts: {

--- a/console/src/layout/slice.ts
+++ b/console/src/layout/slice.ts
@@ -194,11 +194,11 @@ const tabFromLayout = (layout: State): Tabs.Spec => ({
   tabKey: layout.key,
 });
 
-// Reconcile direction-B divergence: layout entries that claim location
-// "mosaic" but whose tab is absent from the mosaic tree. Persisted workspaces
-// can carry this divergence in from older Console versions or cross-Console
-// edits; reconciling on load lets the user see and interact with the tab
-// instead of triggering "Tab not found" on first re-open.
+// Inserts a tab for every location:"mosaic" layout whose tab is missing
+// from its claimed mosaic, falling back to the main mosaic when the window
+// is gone. Persisted state can carry this shape of inconsistency, and
+// without reconciliation the next attempt to re-open the layout throws
+// "Tab not found" in place().
 const reconcileMosaicLayouts = (state: SliceState) => {
   Object.values(state.layouts).forEach((layout) => {
     if (layout.location !== "mosaic") return;
@@ -229,11 +229,9 @@ export const { actions, reducer } = createSlice({
 
       if (layout.type === MOSAIC_WINDOW_TYPE) state.mosaics[key] = ZERO_MOSAIC_STATE;
 
-      // Remove the tab from its previous mosaic when leaving the mosaic
-      // location entirely or when moving across windows. The previous mosaic
-      // is keyed by prev.windowKey (where the tab actually lives), not by the
-      // incoming layout.windowKey, so cross-window placements clean up the
-      // source.
+      // Clean up the source mosaic when leaving the mosaic location or
+      // moving across windows. The source is keyed by prev.windowKey, not
+      // by the incoming layout.windowKey.
       if (
         prev != null &&
         prev.location === "mosaic" &&
@@ -254,10 +252,9 @@ export const { actions, reducer } = createSlice({
       if (mosaic?.activeTab != null && mosaicKey == null)
         mosaicKey = Mosaic.findTabNode(mosaic.root, mosaic.activeTab)?.key;
 
-      // Use mosaic membership rather than prev.location: a layout entry can
-      // claim location "mosaic" without a matching node in the mosaic tree
-      // when the persisted state is inconsistent (e.g., a workspace saved
-      // from another Console where layouts and mosaic state diverged).
+      // Decide insert vs. select/update by mosaic membership: a layout can
+      // claim location "mosaic" without a matching mosaic node when
+      // persisted state is inconsistent.
       if (location === "mosaic" && mosaic != null) {
         if (Mosaic.findTabNode(mosaic.root, key) != null)
           mosaic.root = Mosaic.updateTab(
@@ -503,8 +500,9 @@ export const { actions, reducer } = createSlice({
       state,
       { payload: { slice, keepNav = true } }: PayloadAction<SetWorkspacePayload>,
     ) => {
-      // migrateSlice returns a frozen object via its zod parse; clone before
-      // reconciliation so the helper can mutate layouts and mosaic trees.
+      // Mosaic.insertTab mutates tabs arrays in place; clone before
+      // reconciling so the helper does not fight frozen nested objects
+      // carried over from the previous store snapshot.
       const next = deep.copy(
         migrateSlice({
           ...slice,

--- a/console/src/layout/slice.ts
+++ b/console/src/layout/slice.ts
@@ -16,7 +16,7 @@ import {
 import { UnexpectedError } from "@synnaxlabs/client";
 import { MAIN_WINDOW } from "@synnaxlabs/drift";
 import { type Color, type Haul, Mosaic, type Tabs } from "@synnaxlabs/pluto";
-import { type deep, type direction, id, type location } from "@synnaxlabs/x";
+import { deep, type direction, id, type location } from "@synnaxlabs/x";
 import { type ComponentType } from "react";
 
 import * as latest from "@/layout/types";
@@ -194,6 +194,25 @@ const tabFromLayout = (layout: State): Tabs.Spec => ({
   tabKey: layout.key,
 });
 
+// Reconcile direction-B divergence: layout entries that claim location
+// "mosaic" but whose tab is absent from the mosaic tree. Persisted workspaces
+// can carry this divergence in from older Console versions or cross-Console
+// edits; reconciling on load lets the user see and interact with the tab
+// instead of triggering "Tab not found" on first re-open.
+const reconcileMosaicLayouts = (state: SliceState) => {
+  Object.values(state.layouts).forEach((layout) => {
+    if (layout.location !== "mosaic") return;
+    let target = state.mosaics[layout.windowKey];
+    if (target == null) {
+      layout.windowKey = MAIN_WINDOW;
+      target = state.mosaics[MAIN_WINDOW];
+      if (target == null) return;
+    }
+    if (Mosaic.findTabNode(target.root, layout.key) != null) return;
+    target.root = Mosaic.insertTab(target.root, tabFromLayout(layout));
+  });
+};
+
 export const { actions, reducer } = createSlice({
   name: SLICE_NAME,
   initialState: ZERO_SLICE_STATE,
@@ -203,7 +222,6 @@ export const { actions, reducer } = createSlice({
       let key = layout.key;
 
       const prev = select(state, key);
-      const mosaic = state.mosaics[layout.windowKey];
       if (prev != null) {
         key = prev.key;
         layout.key = prev.key;
@@ -211,24 +229,36 @@ export const { actions, reducer } = createSlice({
 
       if (layout.type === MOSAIC_WINDOW_TYPE) state.mosaics[key] = ZERO_MOSAIC_STATE;
 
-      // If we're moving from a mosaic, remove the tab.
-      if (prev != null && prev.location === "mosaic" && location !== "mosaic")
-        [mosaic.root] = Mosaic.removeTab(mosaic.root, key);
+      // Remove the tab from its previous mosaic when leaving the mosaic
+      // location entirely or when moving across windows. The previous mosaic
+      // is keyed by prev.windowKey (where the tab actually lives), not by the
+      // incoming layout.windowKey, so cross-window placements clean up the
+      // source.
+      if (
+        prev != null &&
+        prev.location === "mosaic" &&
+        (location !== "mosaic" || prev.windowKey !== layout.windowKey)
+      ) {
+        const prevMosaic = state.mosaics[prev.windowKey];
+        if (prevMosaic != null)
+          [prevMosaic.root] = Mosaic.removeTab(prevMosaic.root, key);
+      }
 
+      const mosaic = state.mosaics[layout.windowKey];
       const mosaicTab = tabFromLayout(layout);
 
       let mosaicKey = tab?.mosaicKey;
       // If we didn't explicitly specify a mosaic node to put the new tab in, and
       // the user has selected an active tab, we'll put the new tab in the same node
       // that the user has selected.
-      if (mosaic.activeTab != null && mosaicKey == null)
+      if (mosaic?.activeTab != null && mosaicKey == null)
         mosaicKey = Mosaic.findTabNode(mosaic.root, mosaic.activeTab)?.key;
 
       // Use mosaic membership rather than prev.location: a layout entry can
       // claim location "mosaic" without a matching node in the mosaic tree
       // when the persisted state is inconsistent (e.g., a workspace saved
       // from another Console where layouts and mosaic state diverged).
-      if (location === "mosaic") {
+      if (location === "mosaic" && mosaic != null) {
         if (Mosaic.findTabNode(mosaic.root, key) != null)
           mosaic.root = Mosaic.updateTab(
             Mosaic.selectTab(mosaic.root, key),
@@ -246,7 +276,6 @@ export const { actions, reducer } = createSlice({
       }
 
       state.layouts[key] = layout;
-      state.mosaics[layout.windowKey] = mosaic;
       if (layout.type !== MOSAIC_WINDOW_TYPE) purgeEmptyMosaics(state);
     },
     setHauled: (state, { payload }: PayloadAction<SetHaulingPayload>) => {
@@ -473,19 +502,26 @@ export const { actions, reducer } = createSlice({
     setWorkspace: (
       state,
       { payload: { slice, keepNav = true } }: PayloadAction<SetWorkspacePayload>,
-    ) =>
-      migrateSlice({
-        ...slice,
-        layouts: {
-          ...layoutsToPreserve(state.layouts),
-          ...slice.layouts,
-          main: MAIN_LAYOUT,
-        },
-        hauling: state.hauling,
-        themes: state.themes,
-        activeTheme: state.activeTheme,
-        nav: keepNav ? state.nav : slice.nav,
-      }),
+    ) => {
+      // migrateSlice returns a frozen object via its zod parse; clone before
+      // reconciliation so the helper can mutate layouts and mosaic trees.
+      const next = deep.copy(
+        migrateSlice({
+          ...slice,
+          layouts: {
+            ...layoutsToPreserve(state.layouts),
+            ...slice.layouts,
+            main: MAIN_LAYOUT,
+          },
+          hauling: state.hauling,
+          themes: state.themes,
+          activeTheme: state.activeTheme,
+          nav: keepNav ? state.nav : slice.nav,
+        }),
+      );
+      reconcileMosaicLayouts(next);
+      return next;
+    },
     clearWorkspace: (state) => ({
       ...ZERO_SLICE_STATE,
       layouts: {

--- a/console/src/layout/slice.ts
+++ b/console/src/layout/slice.ts
@@ -224,26 +224,25 @@ export const { actions, reducer } = createSlice({
       if (mosaic.activeTab != null && mosaicKey == null)
         mosaicKey = Mosaic.findTabNode(mosaic.root, mosaic.activeTab)?.key;
 
-      // If we're moving to a mosaic, insert a tab.
-      if (prev?.location !== "mosaic" && location === "mosaic") {
-        mosaic.root = Mosaic.insertTab(
-          mosaic.root,
-          mosaicTab,
-          tab?.location,
-          mosaicKey,
-        );
+      // Use mosaic membership rather than prev.location: a layout entry can
+      // claim location "mosaic" without a matching node in the mosaic tree
+      // when the persisted state is inconsistent (e.g., a workspace saved
+      // from another Console where layouts and mosaic state diverged).
+      if (location === "mosaic") {
+        if (Mosaic.findTabNode(mosaic.root, key) != null)
+          mosaic.root = Mosaic.updateTab(
+            Mosaic.selectTab(mosaic.root, key),
+            key,
+            () => mosaicTab,
+          );
+        else
+          mosaic.root = Mosaic.insertTab(
+            mosaic.root,
+            mosaicTab,
+            tab?.location,
+            mosaicKey,
+          );
         mosaic.activeTab = key;
-      }
-
-      // If the tab already exists and its in the mosaic, make it the active tab
-      // and select it. Also rename it.
-      if (prev?.location === "mosaic" && location === "mosaic") {
-        mosaic.activeTab = key;
-        mosaic.root = Mosaic.updateTab(
-          Mosaic.selectTab(mosaic.root, key),
-          key,
-          () => mosaicTab,
-        );
       }
 
       state.layouts[key] = layout;


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4183](https://linear.app/synnax/issue/SY-4183)

## Description

The Console threw `Error: Tab not found` from `place` (`console/src/layout/slice.ts`) when a layout entry with `location: "mosaic"` no longer had a matching node in the corresponding mosaic tree. The user's only recovery was to switch to an empty workspace, which left a confusing `Failed to load arc … Tab not found` status in the aggregator and prevented the Arc from opening.

Investigation produced one verified live reproducer and one plausible-but-unverified write path:

1. **Verified — cross-window placement.** A layout already lives in window A's mosaic. The user opens it via the search palette while focused on window B. `usePlacer` fires `place` with `windowKey: B`, but `prev.windowKey === A`. The original reducer called `Mosaic.selectTab` on B's mosaic tree (which never contained the tab) and threw. Reproduced deterministically as a Vitest spec.
2. **Plausible — sub-window-close race.** If a Drift mosaic sub-window is OS-closed and the resulting `remove` cleanup chain doesn't complete before the next persist (250 ms debounce), `state.layouts.X` can survive with `windowKey` pointing at a now-deleted mosaic. The Console then ships divergent state to disk and re-loads it on the next launch. Not reproduced; treated as one of several possible producers of the same bug shape.

### Changes

- **`place` (cross-window fix).** Removes the tab from `prev.windowKey`'s mosaic (not the incoming window's) and triggers the removal whenever the windows differ, not only when leaving the mosaic location. Closes the verified reproducer cleanly: the tab moves to the new window instead of leaking into both mosaics.
- **`place` (defensive).** Decides insert vs. select/update by `Mosaic.findTabNode` membership rather than `prev.location`. Layout entries that claim `location: "mosaic"` without a matching mosaic node now get resurrected instead of triggering "Tab not found." Adds `mosaic == null` / `mosaic?.activeTab` guards so missing mosaics no longer crash the reducer.
- **`setWorkspace` reconciliation.** On workspace load, walks `layouts` and inserts any `location: "mosaic"` entry whose tab is missing from its claimed mosaic, falling back to the main mosaic when the window is gone. Makes the divergent-saved-state class of the bug self-healing on load, independent of which write path produced it.

### Tests

Five new specs in `console/src/layout/slice.spec.ts`:

- `place` recovers from a layout that claims mosaic but is absent from the mosaic tree (the original reporter's symptom).
- `place` does not throw and does not leak a duplicate tab when re-placing a layout whose tab lives in another window's mosaic.
- `setWorkspace` resurrects orphan mosaic layouts that the workspace's mosaics map omits.
- `setWorkspace` falls back to the main mosaic and rewrites `windowKey` when an orphan layout points at a missing window.
- Pre-existing 41 specs continue to pass.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a `Tab not found` crash that occurred when re-opening a layout whose `location: "mosaic"` entry had no corresponding node in the mosaic tree. The root cause was that `place` used `prev.location` — rather than actual mosaic membership — to decide between insert and select, and cleaned up the wrong window's mosaic in cross-window scenarios.

- **`place` fix**: Tab removal now targets `prev.windowKey` (not the incoming `layout.windowKey`), and the insert-vs-select branch is guarded by `Mosaic.findTabNode` membership instead of `prev.location`, so orphaned layouts are resurrected rather than crashing.
- **`setWorkspace` reconciliation**: A new `reconcileMosaicLayouts` helper walks all `location: "mosaic"` layouts after workspace load and inserts any whose tabs are absent from their claimed mosaic (falling back to the main window when the claimed window is gone). The state is deep-copied before reconciliation to avoid mutating Immer-frozen objects.
- **Tests**: Five new specs cover the orphan-recovery path in `place`, the cross-window tab migration, and both variants of `setWorkspace` orphan resurrection.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The three coordinated fixes are internally consistent, all new code paths are guarded against null mosaics, and the Mosaic helpers used (removeTab, insertTab) handle missing-tab cases gracefully.

The logic changes are well-scoped to the layout reducer, the new reconciliation helper only runs at workspace load (not on hot paths), and five new regression specs directly cover the failure modes described in the PR. No unsafe mutations or uncovered branches were found.

No files require special attention. The one test assertion worth tightening is the conditional sub-mosaic check in the cross-window spec, but it does not affect correctness of the production code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| console/src/layout/slice.ts | Three complementary fixes: cross-window removal now targets prev.windowKey; insert/select branches guarded by findTabNode membership; new reconcileMosaicLayouts heals orphaned tabs on setWorkspace; deep.copy prevents mutations on frozen Immer objects. |
| console/src/layout/slice.spec.ts | Five new specs cover orphan recovery in place, cross-window tab migration, and setWorkspace resurrection with missing-window fallback. All pre-existing specs preserved. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[place dispatched] --> B{prev layout found?}
    B -- No --> E
    B -- Yes --> C{prev in mosaic AND leaving mosaic\nOR crossing windows?}
    C -- Yes --> D[removeTab from prev window mosaic]
    D --> E[resolve target mosaic]
    C -- No --> E
    E --> F{location is mosaic AND mosaic exists?}
    F -- No --> I[write layout to state]
    F -- Yes --> G{findTabNode returns result?}
    G -- Yes --> H[selectTab then updateTab]
    G -- No --> J[insertTab]
    H --> K[set activeTab]
    J --> K
    K --> I
    I --> L[purgeEmptyMosaics]

    subgraph setWorkspace reconciliation
        M[migrateSlice result] --> N[deep.copy]
        N --> O[reconcileMosaicLayouts]
        O --> P{layout.location is mosaic?}
        P -- No --> Q[skip]
        P -- Yes --> R{window mosaic exists?}
        R -- No --> S[fallback to main window]
        R -- Yes --> T{tab in mosaic tree?}
        S --> T
        T -- Yes --> U[no-op]
        T -- No --> V[insertTab into target]
    end
```

<sub>Reviews (3): Last reviewed commit: ["SY-4183: Tighten comments, drop invented..."](https://github.com/synnaxlabs/synnax/commit/d6350dcb8f41c45d9a9ae15b580661dc852b5270) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32680572)</sub>

<!-- /greptile_comment -->