### PR TITLE
SY-4194: Configure pnpm Build Script Approvals

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,9 +12,9 @@ packages:
   - x/ts
 
 allowBuilds:
-  core-js: true
+  core-js: false
   esbuild: true
-  protobufjs: true
+  protobufjs: false
   sharp: true
 
 catalog:


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4194](https://linear.app/synnax/issue/SY-4194)

## Description

pnpm 11 default-denies install-time scripts and emits a warning on every install for each unreviewed package. The `sy-4092-upgrade-typescript-dependencies` base branch silenced this by approving every package (`core-js`, `esbuild`, `protobufjs`, `sharp`) in `pnpm-workspace.yaml`'s `allowBuilds` block. That makes the warning go away, but it also grants build-script execution to packages that don't need it — the opposite of what pnpm 11's default-deny posture is designed for.

This commit narrows the trust surface to only the packages whose postinstalls are functionally required:

- `esbuild`, `sharp`: kept at `true`. Both need their postinstall to resolve / install platform-specific native binaries; Vite builds and Astro image optimization break otherwise.
- `core-js`, `protobufjs`: flipped to `false`. Both postinstalls are purely cosmetic (donation / funding messages); neither library needs the script to function. Explicit `false` keeps the warning silenced without granting execution.

Every entry left at `true` in `allowBuilds` is a script we explicitly trust to execute on every contributor machine and in CI, so we keep it minimal.

Note: pnpm 11 removed `pnpm.onlyBuiltDependencies` / `pnpm.ignoredBuiltDependencies` from `package.json` — all build-script configuration now lives exclusively in `pnpm-workspace.yaml` under `allowBuilds`.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR tightens the pnpm 10/11 build-script allowlist in `pnpm-workspace.yaml` by explicitly setting `core-js` and `protobufjs` to `false` (suppress postinstall) while keeping `esbuild` and `sharp` at `true` (allow postinstall for native binary resolution).

- `esbuild: true` and `sharp: true` remain approved so Vite builds and Astro image optimization continue to work.
- `core-js: false` and `protobufjs: false` suppress the purely cosmetic donation/funding postinstall messages those packages emit, with no functional impact.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is two boolean flips in a config file with well-understood, low-risk effects.

The two changed values suppress postinstall scripts for `core-js` and `protobufjs` that are documented to be cosmetic-only (donation/funding messages). Neither library requires its postinstall to function. `esbuild` and `sharp` are left at `true` as they genuinely need their scripts. No application logic is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pnpm-workspace.yaml | Sets `core-js` and `protobufjs` to `false` in `allowBuilds`, suppressing their cosmetic postinstall scripts; `esbuild` and `sharp` remain `true` to allow native binary resolution. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[pnpm install] --> B{allowBuilds check}
    B -->|core-js: false| C[Postinstall SKIPPED\nno donation message]
    B -->|protobufjs: false| D[Postinstall SKIPPED\nno funding message]
    B -->|esbuild: true| E[Postinstall ALLOWED\nresolves native binaries]
    B -->|sharp: true| F[Postinstall ALLOWED\nAstro image optimization]
```

<sub>Reviews (3): Last reviewed commit: ["SY-4194: Configure pnpm build script app..."](https://github.com/synnaxlabs/synnax/commit/3cbc79ce3bbe7caa54dd72fba2b91ba828a91e47) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32712244)</sub>

<!-- /greptile_comment -->