### PR TITLE
Rename Python Internal Methods and Attributes to Single Underscore Prefix

### DIFF
--- a/alamos/py/alamos/trace.py
+++ b/alamos/py/alamos/trace.py
@@ -9,6 +9,7 @@
 
 from collections.abc import Iterator
 from contextlib import contextmanager
+from functools import cached_property
 from typing import Protocol
 
 from opentelemetry.propagators.textmap import Setter, TextMapPropagator
@@ -95,7 +96,6 @@ class Tracer:
     _filter: EnvironmentFilter
     _otel_provider: OtelTraceProvider | None
     _otel_propagator: TextMapPropagator | None
-    __otel_tracer: OtelTracer | None
 
     def _(self) -> Noop:
         return self
@@ -110,16 +110,12 @@ class Tracer:
         self._filter = filter_
         self._otel_provider = otel_provider
         self._otel_propagator = otel_propagator
-        self.__otel_tracer = None
 
-    @property
+    @cached_property
     def _otel_tracer(self) -> OtelTracer | None:
-        if self.__otel_tracer is not None:
-            return self.__otel_tracer
-        if self._otel_provider is not None:
-            self.__otel_tracer = self._otel_provider.get_tracer(self._meta.key)
-            return self.__otel_tracer
-        return None
+        if self._otel_provider is None:
+            return None
+        return self._otel_provider.get_tracer(self._meta.key)
 
     @contextmanager
     def trace(self, key: str, env: Environment) -> Iterator[Span]:

--- a/client/py/synnax/arc/client.py
+++ b/client/py/synnax/arc/client.py
@@ -60,7 +60,7 @@ class Arc(Payload):
     - 'graph': Visual programming using a node-based editor
     """
 
-    __client: Client | None = PrivateAttr(None)
+    _client: Client | None = PrivateAttr(None)
 
     def __init__(
         self,
@@ -81,7 +81,7 @@ class Arc(Payload):
             version=version,
             mode=mode,
         )
-        self.__client = _client
+        self._client = _client
 
     @property
     def ontology_id(self) -> ID:
@@ -157,7 +157,7 @@ class Client:
             _CreateRequest(arcs=to_create),
             _CreateResponse,
         ).arcs
-        created = self.__sugar(res)
+        created = self._sugar(res)
         return created[0] if is_single else created
 
     @overload
@@ -207,7 +207,7 @@ class Client:
             _RetrieveResponse,
         )
 
-        arcs = self.__sugar(res.arcs or [])
+        arcs = self._sugar(res.arcs or [])
         if not is_single:
             return arcs
         if len(arcs) == 0:
@@ -226,7 +226,7 @@ class Client:
             Empty,
         )
 
-    def __sugar(self, payloads: list[Payload]) -> list[Arc]:
+    def _sugar(self, payloads: list[Payload]) -> list[Arc]:
         return [
             Arc(
                 key=p.key,

--- a/client/py/synnax/channel/client.py
+++ b/client/py/synnax/channel/client.py
@@ -49,8 +49,8 @@ class Channel(Payload):
     channels and how they work.
     """
 
-    ___frame_client: framer.Client | None = PrivateAttr(None)
-    __client: Client | None = PrivateAttr(None)
+    _frame_client: framer.Client | None = PrivateAttr(None)
+    _client: Client | None = PrivateAttr(None)
 
     def __init__(
         self,
@@ -114,8 +114,8 @@ class Channel(Payload):
             alias=alias,
             status=status,
         )
-        self.___frame_client = _frame_client
-        self.__client = _client
+        self._frame_client = _frame_client
+        self._client = _client
 
     @overload
     def read(
@@ -145,7 +145,7 @@ class Channel(Payload):
         :raises ContiguityError: If the telemetry between start and end is non-contiguous.
         """
         tr = TimeRange(start_or_range, end)
-        return self.__frame_client.read(tr, self.key)
+        return self._get_frame_client().read(tr, self.key)
 
     def write(self, start: CrudeTimeStamp, data: CrudeSeries) -> None:
         """Writes telemetry to the channel starting at the given timestamp.
@@ -154,7 +154,7 @@ class Channel(Payload):
         :param data: The telemetry to write to the channel.
         :returns: None.
         """
-        self.__frame_client.write(start, self.key, data)
+        self._get_frame_client().write(start, self.key, data)
 
     def rename(self, name: str) -> None:
         """Renames the channel.
@@ -162,21 +162,20 @@ class Channel(Payload):
         :param name: The new name for the channel.
         :returns: None.
         """
-        if self.__client is None:
+        if self._client is None:
             raise ValidationError("Cannot rename a channel that has not been created.")
-        self.__client.rename(self.key, name)
+        self._client.rename(self.key, name)
 
     @property
     def ontology_id(self) -> ID:
         return ontology_id(self.key)
 
-    @property
-    def __frame_client(self) -> framer.Client:
-        if self.___frame_client is None:
+    def _get_frame_client(self) -> framer.Client:
+        if self._frame_client is None:
             raise ValidationError(
                 "Cannot read from or write to channel that has not been created."
             )
-        return self.___frame_client
+        return self._frame_client
 
     def __hash__(self) -> int:
         return hash(self.key)
@@ -320,14 +319,14 @@ class Client:
 
         created = list()
         if retrieve_if_name_exists:
-            created = self.__sugar(
+            created = self._sugar(
                 self._retriever.retrieve([ch.name for ch in _channels])
             )
             _channels = [
                 c for c in _channels if c.name not in [ch.name for ch in created]
             ]
 
-        created.extend(self.__sugar(self._creator.create(_channels)))
+        created.extend(self._sugar(self._creator.create(_channels)))
         return created if isinstance(channels, list) else created[0]
 
     @overload
@@ -354,7 +353,7 @@ class Client:
         """
         normal = normalize_params(channel)
         res = self._retriever.retrieve(channel)
-        sug = self.__sugar(res)
+        sug = self._sugar(res)
         if not normal.single:
             return sug
         if len(res) == 1:
@@ -398,7 +397,7 @@ class Client:
         """
         self._creator.rename(normalize(keys), normalize(names))
 
-    def __sugar(self, channels: list[Payload]) -> list[Channel]:
+    def _sugar(self, channels: list[Payload]) -> list[Channel]:
         return [
             Channel(**c.model_dump(), _frame_client=self._frame_client)
             for c in channels

--- a/client/py/synnax/channel/client.py
+++ b/client/py/synnax/channel/client.py
@@ -145,7 +145,7 @@ class Channel(Payload):
         :raises ContiguityError: If the telemetry between start and end is non-contiguous.
         """
         tr = TimeRange(start_or_range, end)
-        return self._frame_client().read(tr, self.key)
+        return self._frame_client.read(tr, self.key)
 
     def write(self, start: CrudeTimeStamp, data: CrudeSeries) -> None:
         """Writes telemetry to the channel starting at the given timestamp.
@@ -154,7 +154,7 @@ class Channel(Payload):
         :param data: The telemetry to write to the channel.
         :returns: None.
         """
-        self._frame_client().write(start, self.key, data)
+        self._frame_client.write(start, self.key, data)
 
     def rename(self, name: str) -> None:
         """Renames the channel.
@@ -170,6 +170,7 @@ class Channel(Payload):
     def ontology_id(self) -> ID:
         return ontology_id(self.key)
 
+    @property
     def _frame_client(self) -> framer.Client:
         if self._cached_frame_client is None:
             raise ValidationError(

--- a/client/py/synnax/channel/client.py
+++ b/client/py/synnax/channel/client.py
@@ -49,7 +49,7 @@ class Channel(Payload):
     channels and how they work.
     """
 
-    _frame_client: framer.Client | None = PrivateAttr(None)
+    _cached_frame_client: framer.Client | None = PrivateAttr(None)
     _client: Client | None = PrivateAttr(None)
 
     def __init__(
@@ -114,7 +114,7 @@ class Channel(Payload):
             alias=alias,
             status=status,
         )
-        self._frame_client = _frame_client
+        self._cached_frame_client = _frame_client
         self._client = _client
 
     @overload
@@ -145,7 +145,7 @@ class Channel(Payload):
         :raises ContiguityError: If the telemetry between start and end is non-contiguous.
         """
         tr = TimeRange(start_or_range, end)
-        return self._get_frame_client().read(tr, self.key)
+        return self._frame_client().read(tr, self.key)
 
     def write(self, start: CrudeTimeStamp, data: CrudeSeries) -> None:
         """Writes telemetry to the channel starting at the given timestamp.
@@ -154,7 +154,7 @@ class Channel(Payload):
         :param data: The telemetry to write to the channel.
         :returns: None.
         """
-        self._get_frame_client().write(start, self.key, data)
+        self._frame_client().write(start, self.key, data)
 
     def rename(self, name: str) -> None:
         """Renames the channel.
@@ -170,12 +170,12 @@ class Channel(Payload):
     def ontology_id(self) -> ID:
         return ontology_id(self.key)
 
-    def _get_frame_client(self) -> framer.Client:
-        if self._frame_client is None:
+    def _frame_client(self) -> framer.Client:
+        if self._cached_frame_client is None:
             raise ValidationError(
                 "Cannot read from or write to channel that has not been created."
             )
-        return self._frame_client
+        return self._cached_frame_client
 
     def __hash__(self) -> int:
         return hash(self.key)

--- a/client/py/synnax/channel/retrieve.py
+++ b/client/py/synnax/channel/retrieve.py
@@ -68,7 +68,7 @@ class ClusterRetriever:
             req = _Request(names=normal.channels)
         else:
             req = _Request(keys=normal.channels)
-        return self.__exec_retrieve(req)
+        return self._exec_retrieve(req)
 
     @trace("debug")
     def retrieve_one(self, param: Key | str) -> Payload:
@@ -77,12 +77,12 @@ class ClusterRetriever:
             req.keys = [param]
         else:
             req.names = [param]
-        channels = self.__exec_retrieve(req)
+        channels = self._exec_retrieve(req)
         if len(channels) == 0:
             raise NotFoundError(f"Could not find channel matching {param}")
         return channels[0]
 
-    def __exec_retrieve(self, req: _Request) -> list[Payload]:
+    def _exec_retrieve(self, req: _Request) -> list[Payload]:
         return send_required(self._client, "/channel/retrieve", req, _Response).channels
 
 

--- a/client/py/synnax/framer/adapter.py
+++ b/client/py/synnax/framer/adapter.py
@@ -22,14 +22,14 @@ from synnax.telem import CrudeSeries, DataType, Series
 
 
 class ReadFrameAdapter:
-    __adapter: dict[channel.Key, str] | None
+    _adapter: dict[channel.Key, str] | None
     retriever: ChannelRetriever
     keys: list[channel.Key]
     codec: Codec
 
     def __init__(self, retriever: ChannelRetriever):
         self.retriever = retriever
-        self.__adapter = None
+        self._adapter = None
         self.keys = list()
         self.codec = Codec()
 
@@ -41,20 +41,20 @@ class ReadFrameAdapter:
             self.codec.update(new_keys, [ch.data_type for ch in fetched])
 
         if isinstance(normal, channel.NormalizedKeyResult):
-            self.__adapter = None
+            self._adapter = None
             self.keys = list(normal.channels)
             return
 
-        self.__adapter = dict[int, str]()
+        self._adapter = dict[int, str]()
         for name in normal.channels:
             ch = next((c for c in fetched if c.name == name), None)
             if ch is None:
                 raise KeyError(f"Channel {name} not found.")
-            self.__adapter[ch.key] = ch.name
-        self.keys = list(self.__adapter.keys())
+            self._adapter[ch.key] = ch.name
+        self.keys = list(self._adapter.keys())
 
     def adapt(self, fr: Frame) -> Frame:
-        if self.__adapter is None:
+        if self._adapter is None:
             return fr
 
         # In certain cases there can be a slight desync between the channels being sent
@@ -64,7 +64,7 @@ class ReadFrameAdapter:
         for i, k in enumerate(fr.channels):
             try:
                 if isinstance(k, channel.Key):
-                    fr.channels[i] = self.__adapter[k]  # type: ignore[call-overload]
+                    fr.channels[i] = self._adapter[k]  # type: ignore[call-overload]
             except KeyError:
                 if to_purge is None:
                     to_purge = [i]
@@ -119,14 +119,14 @@ class WriteFrameAdapter:
     ) -> dict[channel.Key, Any]:
         out = dict()
         for k in data.keys():
-            out[self.__adapt_to_key(k)] = data[k]
+            out[self._adapt_to_key(k)] = data[k]
         return out
 
     @property
     def keys(self) -> list[channel.Key]:
         return self._keys
 
-    def __adapt_to_key(self, ch: channel.Payload | channel.Key | str) -> channel.Key:
+    def _adapt_to_key(self, ch: channel.Payload | channel.Key | str) -> channel.Key:
         if isinstance(ch, channel.Key):
             return ch
         if isinstance(ch, channel.Payload):
@@ -134,9 +134,9 @@ class WriteFrameAdapter:
         # If it's not a payload or key already, it has to be a name,
         # which means we need to resolve the key from a remote source
         # (either cache or server)
-        return self.__adapt_ch(ch).key
+        return self._adapt_ch(ch).key
 
-    def __adapt_ch(self, ch: channel.Key | str | channel.Payload) -> channel.Payload:
+    def _adapt_ch(self, ch: channel.Key | str | channel.Payload) -> channel.Payload:
         if isinstance(ch, (channel.Key, str)):
             return self.retriever.retrieve_one(ch)
         return ch
@@ -205,7 +205,7 @@ class WriteFrameAdapter:
                     """
                     )
 
-            pld = self.__adapt_ch(channels_or_data)
+            pld = self._adapt_ch(channels_or_data)
             return Frame([pld.key], [Series(cast(CrudeSeries, series))])
 
         if isinstance(channels_or_data, list):
@@ -223,7 +223,7 @@ class WriteFrameAdapter:
             channels: list[channel.Key] = list()
             o_series: list[Series] = list()
             for i, ch in enumerate(channels_or_data):
-                pld = self.__adapt_ch(ch)
+                pld = self._adapt_ch(ch)
                 if i >= len(series_list):
                     raise ValidationError(
                         f"""
@@ -266,7 +266,7 @@ class WriteFrameAdapter:
             dict_channels: list[channel.Key] = list()
             dict_series: list[Series] = list()
             for k, v in channels_or_data.items():
-                pld = self.__adapt_ch(k)
+                pld = self._adapt_ch(k)
                 dict_channels.append(pld.key)
                 dict_series.append(Series(v))
 

--- a/client/py/synnax/framer/client.py
+++ b/client/py/synnax/framer/client.py
@@ -41,11 +41,11 @@ class Client:
     directly, but rather used through the synnax.Synnax class.
     """
 
-    __stream_client: WebsocketClient
-    __async_client: AsyncStreamClient
-    __unary_client: UnaryClient
-    __channels: Retriever
-    __deleter: Deleter
+    _stream_client: WebsocketClient
+    _async_client: AsyncStreamClient
+    _unary_client: UnaryClient
+    _channels: Retriever
+    _deleter: Deleter
     instrumentation: Instrumentation
 
     def __init__(
@@ -57,11 +57,11 @@ class Client:
         deleter: Deleter,
         instrumentation: Instrumentation = NOOP,
     ) -> None:
-        self.__stream_client = stream_client
-        self.__async_client = async_client
-        self.__unary_client = unary_client
-        self.__channels = retriever
-        self.__deleter = deleter
+        self._stream_client = stream_client
+        self._async_client = async_client
+        self._unary_client = unary_client
+        self._channels = retriever
+        self._deleter = deleter
         self.instrumentation = instrumentation
 
     def open_writer(
@@ -110,7 +110,7 @@ class Client:
         auto_index_persist_interval to AlwaysAutoIndexPersist.
         """
         adapter = WriteFrameAdapter(
-            retriever=self.__channels,
+            retriever=self._channels,
             err_on_extra_chans=err_on_extra_chans,
             strict_data_types=strict,
             suppress_warnings=suppress_warnings,
@@ -119,7 +119,7 @@ class Client:
         return Writer(
             start=start,
             adapter=adapter,
-            client=self.__stream_client,
+            client=self._stream_client,
             authorities=authorities,
             name=name,
             group=group,
@@ -148,12 +148,12 @@ class Client:
         :returns: An Iterator over the given channels within the provided time
         range. See the Iterator documentation for more.
         """
-        adapter = ReadFrameAdapter(self.__channels)
+        adapter = ReadFrameAdapter(self._channels)
         adapter.update(channels)
         return Iterator(
             tr=tr,
             adapter=adapter,
-            client=self.__stream_client,
+            client=self._stream_client,
             chunk_size=chunk_size,
             downsample_factor=downsample_factor,
             instrumentation=self.instrumentation,
@@ -313,11 +313,11 @@ class Client:
         :param exclude_groups: Writer group IDs whose frames should be filtered out by
         the Core. Used for telemetry bypass deduplication.
         """
-        adapter = ReadFrameAdapter(self.__channels)
+        adapter = ReadFrameAdapter(self._channels)
         adapter.update(channels)
         return Streamer(
             adapter=adapter,
-            client=self.__stream_client,
+            client=self._stream_client,
             downsample_factor=downsample_factor,
             throttle_rate=throttle_rate,
             exclude_groups=exclude_groups,
@@ -330,11 +330,11 @@ class Client:
         throttle_rate: float = 0,
         exclude_groups: list[int] | None = None,
     ) -> AsyncStreamer:
-        adapter = ReadFrameAdapter(self.__channels)
+        adapter = ReadFrameAdapter(self._channels)
         adapter.update(channels)
         s = AsyncStreamer(
             adapter=adapter,
-            client=self.__async_client,
+            client=self._async_client,
             downsample_factor=downsample_factor,
             throttle_rate=throttle_rate,
             exclude_groups=exclude_groups,
@@ -351,7 +351,7 @@ class Client:
         :param channels: channels to delete data from.
         :param tr: time range to delete data from.
         """
-        self.__deleter.delete(channels, tr)
+        self._deleter.delete(channels, tr)
 
     def _read_frame(
         self,

--- a/client/py/synnax/framer/iterator.py
+++ b/client/py/synnax/framer/iterator.py
@@ -96,8 +96,8 @@ class Iterator:
     between two timestamps, see the segment Client read method instead.
     """
 
-    __stream: Stream[_Request, _Response]
-    __adapter: ReadFrameAdapter
+    _stream: Stream[_Request, _Response]
+    _adapter: ReadFrameAdapter
 
     open: bool
     tr: TimeRange
@@ -117,14 +117,14 @@ class Iterator:
     ) -> None:
         self.tr = tr
         self.instrumentation = instrumentation
-        self.__adapter = adapter
-        client = client.with_codec(WSIteratorCodec(self.__adapter.codec))
-        self.__stream = client.stream("/frame/iterate", _Request, _Response)
+        self._adapter = adapter
+        client = client.with_codec(WSIteratorCodec(self._adapter.codec))
+        self._stream = client.stream("/frame/iterate", _Request, _Response)
         self._chunk_size = chunk_size
         self._downsample_factor = downsample_factor
-        self.__open()
+        self._open()
 
-    def __open(self) -> None:
+    def _open(self) -> None:
         """Opens the iterator, configuring it to iterate over the telemetry in the
         channels with the given keys within the provided time range.
 
@@ -134,7 +134,7 @@ class Iterator:
         self._exec(
             command=_Command.OPEN,
             bounds=self.tr,
-            keys=self.__adapter.keys,
+            keys=self._adapter.keys,
             chunk_size=self._chunk_size,
             downsample_factor=self._downsample_factor,
         )
@@ -218,11 +218,11 @@ class Iterator:
         should probably be placed in a 'finally' block. If the iterator is not closed, it may
         leak resources and threads.
         """
-        exc = self.__stream.close_send()
+        exc = self._stream.close_send()
         if exc is not None:
             raise exc
         while True:
-            r, exc = self.__stream.receive()
+            r, exc = self._stream.receive()
             if r is not None:
                 continue
             if exc is None:
@@ -252,16 +252,16 @@ class Iterator:
         self.close()
 
     def _exec(self, **kwargs: object) -> bool:
-        exc = self.__stream.send(_Request(**kwargs))
+        exc = self._stream.send(_Request(**kwargs))
         if exc is not None:
             raise exc
         self.value = Frame()
         while True:
-            r, exc = self.__stream.receive()
+            r, exc = self._stream.receive()
             if exc is not None:
                 raise exc
             assert r is not None
             if r.variant == _ResponseVariant.ACK:
                 return r.ack
             fr = Frame(channels=r.frame.keys, series=r.frame.series)
-            self.value.append(self.__adapter.adapt(fr))
+            self.value.append(self._adapter.adapt(fr))

--- a/client/py/synnax/io/csv.py
+++ b/client/py/synnax/io/csv.py
@@ -29,7 +29,7 @@ class CSVReader(CSVMatcher):  # type: ignore
     channel_keys: list[str] | None
     chunk_size: int
 
-    __reader: TextFileReader | None
+    _reader: TextFileReader | None
     _path: Path
     _channels: list[ChannelMeta] | None
     _row_count: int | None
@@ -55,9 +55,9 @@ class CSVReader(CSVMatcher):  # type: ignore
         self._row_count = None
         self._skip_rows = 0
         self._calculated_skip_rows = False
-        self.__reader = None
+        self._reader = None
 
-    def __detect_delimiter(self) -> str:
+    def _detect_delimiter(self) -> str:
         with open(self._path, "r") as file:
             sample = file.read(1024)
             dialect = csv.Sniffer().sniff(sample)
@@ -65,16 +65,16 @@ class CSVReader(CSVMatcher):  # type: ignore
 
     def seek_first(self) -> None:
         self.close()
-        self.__reader = pd.read_csv(
+        self._reader = pd.read_csv(
             self._path,
             chunksize=self.chunk_size,
             usecols=self.channel_keys,
             header=0,
-            skiprows=self.__get_skip_rows(),
-            delimiter=self.__detect_delimiter(),
+            skiprows=self._get_skip_rows(),
+            delimiter=self._detect_delimiter(),
         )
 
-    def __get_skip_rows(self) -> int | tuple[int, int]:
+    def _get_skip_rows(self) -> int | tuple[int, int]:
         if self._calculated_skip_rows:
             return self._skip_rows
 
@@ -82,7 +82,7 @@ class CSVReader(CSVMatcher):  # type: ignore
             self._path,
             chunksize=1,
             usecols=self.channel_keys,
-            delimiter=self.__detect_delimiter(),
+            delimiter=self._detect_delimiter(),
         )
         self._skip_rows = 0
 
@@ -108,7 +108,7 @@ class CSVReader(CSVMatcher):  # type: ignore
     def channels(self) -> list[ChannelMeta]:
         if not self._channels:
             cols = pd.read_csv(
-                self._path, nrows=0, delimiter=self.__detect_delimiter()
+                self._path, nrows=0, delimiter=self._detect_delimiter()
             ).columns
             self._channels = [
                 ChannelMeta(name=name.strip(), meta_data=dict()) for name in cols
@@ -119,10 +119,10 @@ class CSVReader(CSVMatcher):  # type: ignore
         self.chunk_size = chunk_size
 
     def read(self) -> pd.DataFrame:
-        return convert_df(next(self._reader))
+        return convert_df(next(self._ensure_reader()))
 
     def __iter__(self) -> Iterator[pd.DataFrame]:
-        return CSVReaderIterator(self._reader)
+        return CSVReaderIterator(self._ensure_reader())
 
     @classmethod
     def type(cls) -> ReaderType:
@@ -136,17 +136,16 @@ class CSVReader(CSVMatcher):  # type: ignore
             self._row_count = estimate_row_count(self._path)
         return self._row_count * len(self.channels())
 
-    @property
-    def _reader(self) -> TextFileReader:
-        if self.__reader is None:
+    def _ensure_reader(self) -> TextFileReader:
+        if self._reader is None:
             self.seek_first()
-        assert self.__reader is not None
-        return self.__reader
+        assert self._reader is not None
+        return self._reader
 
     def close(self) -> None:
-        if self.__reader is not None:
-            self.__reader.close()
-        self.__reader = None
+        if self._reader is not None:
+            self._reader.close()
+        self._reader = None
 
 
 def estimate_row_count(path: Path) -> int:

--- a/client/py/synnax/io/csv.py
+++ b/client/py/synnax/io/csv.py
@@ -29,7 +29,7 @@ class CSVReader(CSVMatcher):  # type: ignore
     channel_keys: list[str] | None
     chunk_size: int
 
-    _reader: TextFileReader | None
+    _cached_reader: TextFileReader | None
     _path: Path
     _channels: list[ChannelMeta] | None
     _row_count: int | None
@@ -55,7 +55,7 @@ class CSVReader(CSVMatcher):  # type: ignore
         self._row_count = None
         self._skip_rows = 0
         self._calculated_skip_rows = False
-        self._reader = None
+        self._cached_reader = None
 
     def _detect_delimiter(self) -> str:
         with open(self._path, "r") as file:
@@ -65,7 +65,7 @@ class CSVReader(CSVMatcher):  # type: ignore
 
     def seek_first(self) -> None:
         self.close()
-        self._reader = pd.read_csv(
+        self._cached_reader = pd.read_csv(
             self._path,
             chunksize=self.chunk_size,
             usecols=self.channel_keys,
@@ -119,10 +119,10 @@ class CSVReader(CSVMatcher):  # type: ignore
         self.chunk_size = chunk_size
 
     def read(self) -> pd.DataFrame:
-        return convert_df(next(self._ensure_reader()))
+        return convert_df(next(self._reader))
 
     def __iter__(self) -> Iterator[pd.DataFrame]:
-        return CSVReaderIterator(self._ensure_reader())
+        return CSVReaderIterator(self._reader)
 
     @classmethod
     def type(cls) -> ReaderType:
@@ -136,16 +136,17 @@ class CSVReader(CSVMatcher):  # type: ignore
             self._row_count = estimate_row_count(self._path)
         return self._row_count * len(self.channels())
 
-    def _ensure_reader(self) -> TextFileReader:
-        if self._reader is None:
+    @property
+    def _reader(self) -> TextFileReader:
+        if self._cached_reader is None:
             self.seek_first()
-        assert self._reader is not None
-        return self._reader
+        assert self._cached_reader is not None
+        return self._cached_reader
 
     def close(self) -> None:
-        if self._reader is not None:
-            self._reader.close()
-        self._reader = None
+        if self._cached_reader is not None:
+            self._cached_reader.close()
+        self._cached_reader = None
 
 
 def estimate_row_count(path: Path) -> int:

--- a/client/py/synnax/ontology/client.py
+++ b/client/py/synnax/ontology/client.py
@@ -99,7 +99,7 @@ class Client:
             include_schema=include_schema,
             exclude_field_data=exclude_field_data,
         )
-        resources = self.__exec_retrieve(req)
+        resources = self._exec_retrieve(req)
         if is_single:
             return resources[0]
         return resources
@@ -109,11 +109,11 @@ class Client:
         id: CrudeID | list[CrudeID],
     ) -> list[Resource]:
         normalized: list[CrudeID] = normalize(id)
-        return self.__exec_retrieve(
+        return self._exec_retrieve(
             RetrieveReq(ids=[ID(i) for i in normalized], children=True)
         )
 
-    def __exec_retrieve(self, req: RetrieveReq) -> list[Resource]:
+    def _exec_retrieve(self, req: RetrieveReq) -> list[Resource]:
         return send_required(
             self._client, "/ontology/retrieve", req, RetrieveRes
         ).resources
@@ -123,7 +123,7 @@ class Client:
         id: CrudeID | list[CrudeID],
     ) -> list[Resource]:
         normalized: list[CrudeID] = normalize(id)
-        return self.__exec_retrieve(
+        return self._exec_retrieve(
             RetrieveReq(ids=[ID(i) for i in normalized], parents=True)
         )
 

--- a/client/py/synnax/ranger/alias/client.py
+++ b/client/py/synnax/ranger/alias/client.py
@@ -35,13 +35,13 @@ class _EmptyResponse(BaseModel): ...
 
 
 class Client:
-    __client: UnaryClient
-    __cache: dict[str, channel.Key]
+    _client: UnaryClient
+    _cache: dict[str, channel.Key]
 
     def __init__(self, rng: uuid.UUID, client: UnaryClient) -> None:
-        self.__client = client
-        self.__rng = rng
-        self.__cache = {}
+        self._client = client
+        self._rng = rng
+        self._cache = {}
 
     @overload
     def resolve(self, aliases: str) -> channel.Key: ...
@@ -56,7 +56,7 @@ class Client:
 
         results: dict[str, channel.Key] = {}
         for alias in normalized_aliases:
-            key = self.__cache.get(alias, None)
+            key = self._cache.get(alias, None)
             if key is not None:
                 results[alias] = key
             else:
@@ -67,8 +67,8 @@ class Client:
                 return results[normalized_aliases[0]]
             return results
 
-        req = _ResolveRequest(range=self.__rng, aliases=to_fetch)
-        res, exc = self.__client.send("/range/alias/resolve", req, _ResolveResponse)
+        req = _ResolveRequest(range=self._rng, aliases=to_fetch)
+        res, exc = self._client.send("/range/alias/resolve", req, _ResolveResponse)
         if exc is not None:
             raise exc
         if res is None:
@@ -77,14 +77,14 @@ class Client:
             return results
 
         for alias, key in res.aliases.items():
-            self.__cache[alias] = key
+            self._cache[alias] = key
 
         if is_single:
             return res.aliases[normalized_aliases[0]]
         return {**results, **res.aliases}
 
     def set(self, aliases: dict[channel.Key, str]) -> None:
-        req = _SetRequest(range=self.__rng, aliases=aliases)
-        res, exc = self.__client.send("/range/alias/set", req, _EmptyResponse)
+        req = _SetRequest(range=self._rng, aliases=aliases)
+        res, exc = self._client.send("/range/alias/set", req, _EmptyResponse)
         if exc is not None:
             raise exc

--- a/client/py/synnax/ranger/client.py
+++ b/client/py/synnax/ranger/client.py
@@ -54,16 +54,16 @@ RANGE_SET_CHANNEL = "sy_range_set"
 
 
 class _InternalScopedChannel(channel.Payload):
-    __range: Range | None = PrivateAttr(None)
+    _range: Range | None = PrivateAttr(None)
     """The range that this channel belongs to."""
-    __frame_client: framer.Client | None = PrivateAttr(None)
+    _frame_client: framer.Client | None = PrivateAttr(None)
     """The frame client for executing read operations."""
-    __aliaser: alias_.Client | None = PrivateAttr(None)
+    _aliaser: alias_.Client | None = PrivateAttr(None)
     """An aliaser for setting the channel's alias."""
-    __cache: MultiSeries | None = PrivateAttr(None)
+    _cache: MultiSeries | None = PrivateAttr(None)
     """An internal cache to prevent repeated reads from the same channel."""
-    __tasks: TaskClient | None = PrivateAttr(None)
-    __ontology: OntologyClient | None = PrivateAttr(None)
+    _tasks: TaskClient | None = PrivateAttr(None)
+    _ontology: OntologyClient | None = PrivateAttr(None)
 
     def __new__(cls, *args: Any, **kwargs: Any) -> _InternalScopedChannel:
         cls = overload_comparison_operators(cls, "__array__")
@@ -79,21 +79,20 @@ class _InternalScopedChannel(channel.Payload):
         _aliaser: alias_.Client | None = None,
     ):
         super().__init__(**payload.model_dump())
-        self.__range = rng
-        self.__frame_client = frame_client
-        self.__aliaser = _aliaser
-        self.__tasks = tasks
-        self.__ontology = ontology
+        self._range = rng
+        self._frame_client = frame_client
+        self._aliaser = _aliaser
+        self._tasks = tasks
+        self._ontology = ontology
 
-    @property
-    def _range(self) -> Range:
-        if self.__range is None:
+    def _get_range(self) -> Range:
+        if self._range is None:
             raise _RANGE_NOT_CREATED
-        return self.__range
+        return self._range
 
     @property
     def time_range(self) -> TimeRange:
-        return self._range.time_range
+        return self._get_range().time_range
 
     def __array__(self, *args: Any, **kwargs: Any) -> np.ndarray:
         """Converts the channel to a numpy array. This method is necessary
@@ -109,19 +108,18 @@ class _InternalScopedChannel(channel.Payload):
         """
         return self.read().to_numpy()
 
-    @property
-    def _frame_client(self) -> framer.Client:
-        if self.__frame_client is None:
+    def _get_frame_client(self) -> framer.Client:
+        if self._frame_client is None:
             raise _RANGE_NOT_CREATED
-        return self.__frame_client
+        return self._frame_client
 
     def read(self) -> MultiSeries:
-        if self.__cache is None:
-            self.__cache = self._frame_client.read(self.time_range, self.key)
-        return self.__cache
+        if self._cache is None:
+            self._cache = self._get_frame_client().read(self.time_range, self.key)
+        return self._cache
 
     def set_alias(self, alias: str) -> None:
-        self._range.set_alias(self.key, alias)
+        self._get_range().set_alias(self.key, alias)
 
     def __str__(self) -> str:
         return f"{super().__str__()} between {self.time_range.start} and {self.time_range.end}"
@@ -143,8 +141,8 @@ class ScopedChannel:
     multiple channels.
     """
 
-    __internal: list[_InternalScopedChannel]
-    __query: str
+    _internal: list[_InternalScopedChannel]
+    _query: str
 
     def __new__(cls, *args: Any, **kwargs: Any) -> ScopedChannel:
         cls = overload_comparison_operators(cls, "__array__")
@@ -155,24 +153,24 @@ class ScopedChannel:
         query: str,
         internal: list[_InternalScopedChannel],
     ):
-        self.__internal = internal
-        self.__query = query
+        self._internal = internal
+        self._query = query
 
-    def __guard(self) -> None:
-        if len(self.__internal) > 1:
-            raise QueryError(f"""Multiple channels found for query '{self.__query}':
-            {[str(ch) for ch in self.__internal]}
+    def _guard(self) -> None:
+        if len(self._internal) > 1:
+            raise QueryError(f"""Multiple channels found for query '{self._query}':
+            {[str(ch) for ch in self._internal]}
             """)
 
     def __array__(self, *args: object, **kwargs: object) -> np.ndarray:
         """Converts the scoped channel to a numpy array. This method is necessary
         for numpy interop."""
-        self.__guard()
-        return self.__internal[0].__array__(*args, **kwargs)
+        self._guard()
+        return self._internal[0].__array__(*args, **kwargs)
 
     def __getitem__(self, index: int) -> SampleValue:
-        self.__guard()
-        return self.__internal[0].__getitem__(index)
+        self._guard()
+        return self._internal[0].__getitem__(index)
 
     def to_numpy(self) -> np.ndarray:
         """Converts the scoped channel to a numpy array. This method is necessary
@@ -181,43 +179,43 @@ class ScopedChannel:
 
     @property
     def key(self) -> channel.Key:
-        self.__guard()
-        return self.__internal[0].key
+        self._guard()
+        return self._internal[0].key
 
     @property
     def name(self) -> str:
-        self.__guard()
-        return self.__internal[0].name
+        self._guard()
+        return self._internal[0].name
 
     @property
     def data_type(self) -> DataType:
-        self.__guard()
-        return self.__internal[0].data_type
+        self._guard()
+        return self._internal[0].data_type
 
     @property
     def is_index(self) -> bool:
-        self.__guard()
-        return self.__internal[0].is_index
+        self._guard()
+        return self._internal[0].is_index
 
     @property
     def index(self) -> channel.Key:
-        self.__guard()
-        return self.__internal[0].index
+        self._guard()
+        return self._internal[0].index
 
     @property
     def leaseholder(self) -> int:
-        self.__guard()
-        return self.__internal[0].leaseholder
+        self._guard()
+        return self._internal[0].leaseholder
 
     def set_alias(self, alias: str) -> None:
-        self.__guard()
-        self.__internal[0].set_alias(alias)
+        self._guard()
+        self._internal[0].set_alias(alias)
 
     def __iter__(self) -> Iterator[_InternalScopedChannel]:
-        return iter(self.__internal)
+        return iter(self._internal)
 
     def __len__(self) -> int:
-        return sum(len(ch) for ch in self.__internal)
+        return sum(len(ch) for ch in self._internal)
 
 
 _RANGE_NOT_CREATED = QueryError("""Cannot read from a range that has not been created.
@@ -231,19 +229,19 @@ class Range(Payload):
     and how they work.
     """
 
-    __frame_client: framer.Client | None = PrivateAttr(None)
+    _frame_client: framer.Client | None = PrivateAttr(None)
     """The frame client for executing read and write operations."""
     _channels: ChannelRetriever | None = PrivateAttr(None)
     """For retrieving channels from the cluster."""
     _kv: kv.Client | None = PrivateAttr(None)
     """Key-value store for storing metadata about the range."""
-    __aliaser: alias_.Client | None = PrivateAttr(None)
+    _aliaser: alias_.Client | None = PrivateAttr(None)
     """For setting and resolving aliases."""
     _cache: dict[channel.Key, _InternalScopedChannel] = PrivateAttr(dict())
     """A writer for creating child ranges"""
-    __client: Client | None = PrivateAttr(None)
-    __tasks: TaskClient | None = PrivateAttr(None)
-    __ontology: OntologyClient | None = PrivateAttr(None)
+    _client: Client | None = PrivateAttr(None)
+    _tasks: TaskClient | None = PrivateAttr(None)
+    _ontology: OntologyClient | None = PrivateAttr(None)
 
     def __init__(
         self,
@@ -280,20 +278,20 @@ class Range(Payload):
             .ranges.create() and .ranges.retrieve(), and should not be set by the user.
         """
         super().__init__(name=name, time_range=time_range, key=key, color=color)
-        self.__frame_client = _frame_client
+        self._frame_client = _frame_client
         self._channels = _channel_retriever
         self._kv = _kv
-        self.__aliaser = _aliaser
-        self.__client = _client
-        self.__tasks = _tasks
-        self.__ontology = _ontology
+        self._aliaser = _aliaser
+        self._client = _client
+        self._tasks = _tasks
+        self._ontology = _ontology
 
     def _get_scoped_channel(
         self, channels: list[channel.Payload], query: str
     ) -> ScopedChannel:
         if len(channels) == 0:
             raise QueryError(f"Channel matching {query} not found")
-        return ScopedChannel(query, self.__splice_cached(channels))
+        return ScopedChannel(query, self._splice_cached(channels))
 
     def __getattr__(self, query: str) -> ScopedChannel:
         try:
@@ -302,7 +300,7 @@ class Range(Payload):
         except AttributeError:
             pass
         channels = self._channel_retriever.retrieve(query)
-        aliases = self._aliaser.resolve([query])
+        aliases = self._get_aliaser().resolve([query])
         channels.extend(self._channel_retriever.retrieve(list(aliases.values())))
         return self._get_scoped_channel(channels, query)
 
@@ -312,7 +310,7 @@ class Range(Payload):
             return self._get_scoped_channel(channels, name.__str__())
         return self.__getattr__(name)
 
-    def __splice_cached(
+    def _splice_cached(
         self, channels: list[channel.Payload]
     ) -> list[_InternalScopedChannel]:
         results = list()
@@ -321,10 +319,10 @@ class Range(Payload):
             if cached is None:
                 cached = _InternalScopedChannel(
                     rng=self,
-                    frame_client=self._frame_client,
+                    frame_client=self._get_frame_client(),
                     payload=pld,
-                    tasks=self._tasks,
-                    ontology=self._ontology,
+                    tasks=self._get_tasks(),
+                    ontology=self._get_ontology(),
                 )
                 self._cache[pld.key] = cached
             results.append(cached)
@@ -340,35 +338,30 @@ class Range(Payload):
             raise _RANGE_NOT_CREATED
         return self._kv
 
-    @property
-    def _aliaser(self) -> alias_.Client:
-        if self.__aliaser is None:
+    def _get_aliaser(self) -> alias_.Client:
+        if self._aliaser is None:
             raise _RANGE_NOT_CREATED
-        return self.__aliaser
+        return self._aliaser
 
-    @property
-    def _frame_client(self) -> framer.Client:
-        if self.__frame_client is None:
+    def _get_frame_client(self) -> framer.Client:
+        if self._frame_client is None:
             raise _RANGE_NOT_CREATED
-        return self.__frame_client
+        return self._frame_client
 
-    @property
-    def _client(self) -> Client:
-        if self.__client is None:
+    def _get_client(self) -> Client:
+        if self._client is None:
             raise _RANGE_NOT_CREATED
-        return self.__client
+        return self._client
 
-    @property
-    def _tasks(self) -> TaskClient:
-        if self.__tasks is None:
+    def _get_tasks(self) -> TaskClient:
+        if self._tasks is None:
             raise _RANGE_NOT_CREATED
-        return self.__tasks
+        return self._tasks
 
-    @property
-    def _ontology(self) -> OntologyClient:
-        if self.__ontology is None:
+    def _get_ontology(self) -> OntologyClient:
+        if self._ontology is None:
             raise _RANGE_NOT_CREATED
-        return self.__ontology
+        return self._ontology
 
     @property
     def _channel_retriever(self) -> ChannelRetriever:
@@ -400,7 +393,7 @@ class Range(Payload):
                 corrected[res[0].key] = alias
             else:
                 corrected[ch] = alias
-        self._aliaser.set(corrected)
+        self._get_aliaser().set(corrected)
 
     def to_payload(self) -> Payload:
         return Payload(name=self.name, time_range=self.time_range, key=self.key)
@@ -420,13 +413,13 @@ class Range(Payload):
     ) -> None:
         start = self.time_range.start
         if series is None:
-            self._frame_client.write(start, cast(framer.CrudeFrame, channels))
+            self._get_frame_client().write(start, cast(framer.CrudeFrame, channels))
             return
         if not isinstance(channels, (int, str, list, tuple, channel.Payload)):
             raise TypeError(
                 "channels must be a channel key, name, or list when series is provided"
             )
-        self._frame_client.write(start, channels, series)
+        self._get_frame_client().write(start, channels, series)
 
     def create_child_range(
         self,
@@ -436,7 +429,7 @@ class Range(Payload):
         color: str = "",
         key: Key = UUID(int=0),
     ) -> Range:
-        return self._client.create(
+        return self._get_client().create(
             name=name,
             time_range=time_range,
             color=color,
@@ -472,19 +465,19 @@ class Range(Payload):
     @property
     def children(self) -> list[Range]:
         """Returns a list of child ranges of this range."""
-        res = self._ontology.retrieve_children(self.ontology_id)
+        res = self._get_ontology().retrieve_children(self.ontology_id)
         range_children = [r for r in res if r.id.type == "range"]
         if len(range_children) == 0:
             return []
         child_keys: list[Key] = [
             r.id.key for r in range_children if r.id.key is not None
         ]
-        return self._client.retrieve(keys=child_keys)
+        return self._get_client().retrieve(keys=child_keys)
 
     def snapshots(self) -> list[Task]:
-        res = self._ontology.retrieve_children(self.ontology_id)
+        res = self._get_ontology().retrieve_children(self.ontology_id)
         tasks = [t for t in res if t.id.type == "task"]
-        return self._tasks.retrieve(
+        return self._get_tasks().retrieve(
             keys=[int(t.id.key) for t in tasks if t.id.key is not None]
         )
 
@@ -626,7 +619,7 @@ class Client:
             existing_names = {r.name for r in res}
             to_create = [r for r in to_create if r.name not in existing_names]
         if len(to_create) > 0:
-            res.extend(self.__sugar(self._writer.create(to_create, parent=parent)))
+            res.extend(self._sugar(self._writer.create(to_create, parent=parent)))
         return res if not is_single else res[0]
 
     @overload
@@ -658,7 +651,7 @@ class Client:
     ) -> Range | list[Range]:
         is_single = check_for_none(keys, names)
         _ranges = self._retriever.retrieve(key=key, name=name, names=names, keys=keys)
-        sug = self.__sugar(_ranges)
+        sug = self._sugar(_ranges)
         if not is_single:
             return sug
         if len(sug) == 0:
@@ -678,9 +671,9 @@ class Client:
         term: str,
     ) -> list[Range]:
         _ranges = self._retriever.search(term)
-        return self.__sugar(_ranges)
+        return self._sugar(_ranges)
 
-    def __sugar(self, ranges: list[Payload]) -> list[Range]:
+    def _sugar(self, ranges: list[Payload]) -> list[Range]:
         return [
             Range(
                 **r.model_dump(),

--- a/client/py/synnax/ranger/client.py
+++ b/client/py/synnax/ranger/client.py
@@ -440,7 +440,7 @@ class Range(Payload):
         color: str = "",
         key: Key = UUID(int=0),
     ) -> Range:
-        return self._client().create(
+        return self._client.create(
             name=name,
             time_range=time_range,
             color=color,
@@ -476,19 +476,19 @@ class Range(Payload):
     @property
     def children(self) -> list[Range]:
         """Returns a list of child ranges of this range."""
-        res = self._ontology().retrieve_children(self.ontology_id)
+        res = self._ontology.retrieve_children(self.ontology_id)
         range_children = [r for r in res if r.id.type == "range"]
         if len(range_children) == 0:
             return []
         child_keys: list[Key] = [
             r.id.key for r in range_children if r.id.key is not None
         ]
-        return self._client().retrieve(keys=child_keys)
+        return self._client.retrieve(keys=child_keys)
 
     def snapshots(self) -> list[Task]:
-        res = self._ontology().retrieve_children(self.ontology_id)
+        res = self._ontology.retrieve_children(self.ontology_id)
         tasks = [t for t in res if t.id.type == "task"]
-        return self._tasks().retrieve(
+        return self._tasks.retrieve(
             keys=[int(t.id.key) for t in tasks if t.id.key is not None]
         )
 

--- a/client/py/synnax/ranger/client.py
+++ b/client/py/synnax/ranger/client.py
@@ -404,7 +404,7 @@ class Range(Payload):
                 corrected[res[0].key] = alias
             else:
                 corrected[ch] = alias
-        self._aliaser().set(corrected)
+        self._aliaser.set(corrected)
 
     def to_payload(self) -> Payload:
         return Payload(name=self.name, time_range=self.time_range, key=self.key)

--- a/client/py/synnax/ranger/client.py
+++ b/client/py/synnax/ranger/client.py
@@ -54,7 +54,7 @@ RANGE_SET_CHANNEL = "sy_range_set"
 
 
 class _InternalScopedChannel(channel.Payload):
-    _range: Range | None = PrivateAttr(None)
+    _cached_range: Range | None = PrivateAttr(None)
     """The range that this channel belongs to."""
     _cached_frame_client: framer.Client | None = PrivateAttr(None)
     """The frame client for executing read operations."""
@@ -79,20 +79,21 @@ class _InternalScopedChannel(channel.Payload):
         _aliaser: alias_.Client | None = None,
     ):
         super().__init__(**payload.model_dump())
-        self._range = rng
+        self._cached_range = rng
         self._cached_frame_client = frame_client
         self._aliaser = _aliaser
         self._tasks = tasks
         self._ontology = ontology
 
-    def _get_range(self) -> Range:
-        if self._range is None:
+    @property
+    def range(self) -> Range:
+        if self._cached_range is None:
             raise _RANGE_NOT_CREATED
-        return self._range
+        return self._cached_range
 
     @property
     def time_range(self) -> TimeRange:
-        return self._get_range().time_range
+        return self.range.time_range
 
     def __array__(self, *args: Any, **kwargs: Any) -> np.ndarray:
         """Converts the channel to a numpy array. This method is necessary
@@ -120,7 +121,7 @@ class _InternalScopedChannel(channel.Payload):
         return self._cache
 
     def set_alias(self, alias: str) -> None:
-        self._get_range().set_alias(self.key, alias)
+        self.range.set_alias(self.key, alias)
 
     def __str__(self) -> str:
         return f"{super().__str__()} between {self.time_range.start} and {self.time_range.end}"

--- a/client/py/synnax/ranger/client.py
+++ b/client/py/synnax/ranger/client.py
@@ -56,7 +56,7 @@ RANGE_SET_CHANNEL = "sy_range_set"
 class _InternalScopedChannel(channel.Payload):
     _range: Range | None = PrivateAttr(None)
     """The range that this channel belongs to."""
-    _frame_client: framer.Client | None = PrivateAttr(None)
+    _cached_frame_client: framer.Client | None = PrivateAttr(None)
     """The frame client for executing read operations."""
     _aliaser: alias_.Client | None = PrivateAttr(None)
     """An aliaser for setting the channel's alias."""
@@ -80,7 +80,7 @@ class _InternalScopedChannel(channel.Payload):
     ):
         super().__init__(**payload.model_dump())
         self._range = rng
-        self._frame_client = frame_client
+        self._cached_frame_client = frame_client
         self._aliaser = _aliaser
         self._tasks = tasks
         self._ontology = ontology
@@ -108,14 +108,14 @@ class _InternalScopedChannel(channel.Payload):
         """
         return self.read().to_numpy()
 
-    def _get_frame_client(self) -> framer.Client:
-        if self._frame_client is None:
+    def _frame_client(self) -> framer.Client:
+        if self._cached_frame_client is None:
             raise _RANGE_NOT_CREATED
-        return self._frame_client
+        return self._cached_frame_client
 
     def read(self) -> MultiSeries:
         if self._cache is None:
-            self._cache = self._get_frame_client().read(self.time_range, self.key)
+            self._cache = self._frame_client().read(self.time_range, self.key)
         return self._cache
 
     def set_alias(self, alias: str) -> None:
@@ -229,7 +229,7 @@ class Range(Payload):
     and how they work.
     """
 
-    _frame_client: framer.Client | None = PrivateAttr(None)
+    _cached_frame_client: framer.Client | None = PrivateAttr(None)
     """The frame client for executing read and write operations."""
     _channels: ChannelRetriever | None = PrivateAttr(None)
     """For retrieving channels from the cluster."""
@@ -278,7 +278,7 @@ class Range(Payload):
             .ranges.create() and .ranges.retrieve(), and should not be set by the user.
         """
         super().__init__(name=name, time_range=time_range, key=key, color=color)
-        self._frame_client = _frame_client
+        self._cached_frame_client = _frame_client
         self._channels = _channel_retriever
         self._kv = _kv
         self._aliaser = _aliaser
@@ -319,7 +319,7 @@ class Range(Payload):
             if cached is None:
                 cached = _InternalScopedChannel(
                     rng=self,
-                    frame_client=self._get_frame_client(),
+                    frame_client=self._frame_client(),
                     payload=pld,
                     tasks=self._get_tasks(),
                     ontology=self._get_ontology(),
@@ -343,10 +343,10 @@ class Range(Payload):
             raise _RANGE_NOT_CREATED
         return self._aliaser
 
-    def _get_frame_client(self) -> framer.Client:
-        if self._frame_client is None:
+    def _frame_client(self) -> framer.Client:
+        if self._cached_frame_client is None:
             raise _RANGE_NOT_CREATED
-        return self._frame_client
+        return self._cached_frame_client
 
     def _get_client(self) -> Client:
         if self._client is None:
@@ -413,13 +413,13 @@ class Range(Payload):
     ) -> None:
         start = self.time_range.start
         if series is None:
-            self._get_frame_client().write(start, cast(framer.CrudeFrame, channels))
+            self._frame_client().write(start, cast(framer.CrudeFrame, channels))
             return
         if not isinstance(channels, (int, str, list, tuple, channel.Payload)):
             raise TypeError(
                 "channels must be a channel key, name, or list when series is provided"
             )
-        self._get_frame_client().write(start, channels, series)
+        self._frame_client().write(start, channels, series)
 
     def create_child_range(
         self,

--- a/client/py/synnax/ranger/client.py
+++ b/client/py/synnax/ranger/client.py
@@ -86,14 +86,14 @@ class _InternalScopedChannel(channel.Payload):
         self._ontology = ontology
 
     @property
-    def range(self) -> Range:
+    def _range(self) -> Range:
         if self._cached_range is None:
             raise _RANGE_NOT_CREATED
         return self._cached_range
 
     @property
     def time_range(self) -> TimeRange:
-        return self.range.time_range
+        return self._range.time_range
 
     def __array__(self, *args: Any, **kwargs: Any) -> np.ndarray:
         """Converts the channel to a numpy array. This method is necessary
@@ -121,7 +121,7 @@ class _InternalScopedChannel(channel.Payload):
         return self._cache
 
     def set_alias(self, alias: str) -> None:
-        self.range.set_alias(self.key, alias)
+        self._range.set_alias(self.key, alias)
 
     def __str__(self) -> str:
         return f"{super().__str__()} between {self.time_range.start} and {self.time_range.end}"

--- a/client/py/synnax/ranger/client.py
+++ b/client/py/synnax/ranger/client.py
@@ -108,6 +108,7 @@ class _InternalScopedChannel(channel.Payload):
         """
         return self.read().to_numpy()
 
+    @property
     def _frame_client(self) -> framer.Client:
         if self._cached_frame_client is None:
             raise _RANGE_NOT_CREATED
@@ -115,7 +116,7 @@ class _InternalScopedChannel(channel.Payload):
 
     def read(self) -> MultiSeries:
         if self._cache is None:
-            self._cache = self._frame_client().read(self.time_range, self.key)
+            self._cache = self._frame_client.read(self.time_range, self.key)
         return self._cache
 
     def set_alias(self, alias: str) -> None:
@@ -319,7 +320,7 @@ class Range(Payload):
             if cached is None:
                 cached = _InternalScopedChannel(
                     rng=self,
-                    frame_client=self._frame_client(),
+                    frame_client=self._frame_client,
                     payload=pld,
                     tasks=self._get_tasks(),
                     ontology=self._get_ontology(),
@@ -343,6 +344,7 @@ class Range(Payload):
             raise _RANGE_NOT_CREATED
         return self._aliaser
 
+    @property
     def _frame_client(self) -> framer.Client:
         if self._cached_frame_client is None:
             raise _RANGE_NOT_CREATED
@@ -413,13 +415,13 @@ class Range(Payload):
     ) -> None:
         start = self.time_range.start
         if series is None:
-            self._frame_client().write(start, cast(framer.CrudeFrame, channels))
+            self._frame_client.write(start, cast(framer.CrudeFrame, channels))
             return
         if not isinstance(channels, (int, str, list, tuple, channel.Payload)):
             raise TypeError(
                 "channels must be a channel key, name, or list when series is provided"
             )
-        self._frame_client().write(start, channels, series)
+        self._frame_client.write(start, channels, series)
 
     def create_child_range(
         self,

--- a/client/py/synnax/ranger/client.py
+++ b/client/py/synnax/ranger/client.py
@@ -160,9 +160,11 @@ class ScopedChannel:
 
     def _guard(self) -> None:
         if len(self._internal) > 1:
-            raise QueryError(f"""Multiple channels found for query '{self._query}':
+            raise QueryError(
+                f"""Multiple channels found for query '{self._query}':
             {[str(ch) for ch in self._internal]}
-            """)
+            """
+            )
 
     def __array__(self, *args: object, **kwargs: object) -> np.ndarray:
         """Converts the scoped channel to a numpy array. This method is necessary
@@ -220,8 +222,10 @@ class ScopedChannel:
         return sum(len(ch) for ch in self._internal)
 
 
-_RANGE_NOT_CREATED = QueryError("""Cannot read from a range that has not been created.
-Please call client.ranges.create(range) before attempting to read from a range.""")
+_RANGE_NOT_CREATED = QueryError(
+    """Cannot read from a range that has not been created.
+Please call client.ranges.create(range) before attempting to read from a range."""
+)
 
 
 class Range(Payload):
@@ -237,13 +241,13 @@ class Range(Payload):
     """For retrieving channels from the cluster."""
     _kv: kv.Client | None = PrivateAttr(None)
     """Key-value store for storing metadata about the range."""
-    _aliaser: alias_.Client | None = PrivateAttr(None)
+    _cached_aliaser: alias_.Client | None = PrivateAttr(None)
     """For setting and resolving aliases."""
     _cache: dict[channel.Key, _InternalScopedChannel] = PrivateAttr(dict())
     """A writer for creating child ranges"""
-    _client: Client | None = PrivateAttr(None)
-    _tasks: TaskClient | None = PrivateAttr(None)
-    _ontology: OntologyClient | None = PrivateAttr(None)
+    _cached_client: Client | None = PrivateAttr(None)
+    _cached_tasks: TaskClient | None = PrivateAttr(None)
+    _cached_ontology: OntologyClient | None = PrivateAttr(None)
 
     def __init__(
         self,
@@ -283,10 +287,10 @@ class Range(Payload):
         self._cached_frame_client = _frame_client
         self._channels = _channel_retriever
         self._kv = _kv
-        self._aliaser = _aliaser
-        self._client = _client
-        self._tasks = _tasks
-        self._ontology = _ontology
+        self._cached_aliaser = _aliaser
+        self._cached_client = _client
+        self._cached_tasks = _tasks
+        self._cached_ontology = _ontology
 
     def _get_scoped_channel(
         self, channels: list[channel.Payload], query: str
@@ -302,7 +306,7 @@ class Range(Payload):
         except AttributeError:
             pass
         channels = self._channel_retriever.retrieve(query)
-        aliases = self._get_aliaser().resolve([query])
+        aliases = self._aliaser.resolve([query])
         channels.extend(self._channel_retriever.retrieve(list(aliases.values())))
         return self._get_scoped_channel(channels, query)
 
@@ -323,8 +327,8 @@ class Range(Payload):
                     rng=self,
                     frame_client=self._frame_client,
                     payload=pld,
-                    tasks=self._get_tasks(),
-                    ontology=self._get_ontology(),
+                    tasks=self._tasks,
+                    ontology=self._ontology,
                 )
                 self._cache[pld.key] = cached
             results.append(cached)
@@ -340,10 +344,11 @@ class Range(Payload):
             raise _RANGE_NOT_CREATED
         return self._kv
 
-    def _get_aliaser(self) -> alias_.Client:
-        if self._aliaser is None:
+    @property
+    def _aliaser(self) -> alias_.Client:
+        if self._cached_aliaser is None:
             raise _RANGE_NOT_CREATED
-        return self._aliaser
+        return self._cached_aliaser
 
     @property
     def _frame_client(self) -> framer.Client:
@@ -351,20 +356,23 @@ class Range(Payload):
             raise _RANGE_NOT_CREATED
         return self._cached_frame_client
 
-    def _get_client(self) -> Client:
-        if self._client is None:
+    @property
+    def _client(self) -> Client:
+        if self._cached_client is None:
             raise _RANGE_NOT_CREATED
-        return self._client
+        return self._cached_client
 
-    def _get_tasks(self) -> TaskClient:
-        if self._tasks is None:
+    @property
+    def _tasks(self) -> TaskClient:
+        if self._cached_tasks is None:
             raise _RANGE_NOT_CREATED
-        return self._tasks
+        return self._cached_tasks
 
-    def _get_ontology(self) -> OntologyClient:
-        if self._ontology is None:
+    @property
+    def _ontology(self) -> OntologyClient:
+        if self._cached_ontology is None:
             raise _RANGE_NOT_CREATED
-        return self._ontology
+        return self._cached_ontology
 
     @property
     def _channel_retriever(self) -> ChannelRetriever:
@@ -396,7 +404,7 @@ class Range(Payload):
                 corrected[res[0].key] = alias
             else:
                 corrected[ch] = alias
-        self._get_aliaser().set(corrected)
+        self._aliaser().set(corrected)
 
     def to_payload(self) -> Payload:
         return Payload(name=self.name, time_range=self.time_range, key=self.key)
@@ -432,7 +440,7 @@ class Range(Payload):
         color: str = "",
         key: Key = UUID(int=0),
     ) -> Range:
-        return self._get_client().create(
+        return self._client().create(
             name=name,
             time_range=time_range,
             color=color,
@@ -468,19 +476,19 @@ class Range(Payload):
     @property
     def children(self) -> list[Range]:
         """Returns a list of child ranges of this range."""
-        res = self._get_ontology().retrieve_children(self.ontology_id)
+        res = self._ontology().retrieve_children(self.ontology_id)
         range_children = [r for r in res if r.id.type == "range"]
         if len(range_children) == 0:
             return []
         child_keys: list[Key] = [
             r.id.key for r in range_children if r.id.key is not None
         ]
-        return self._get_client().retrieve(keys=child_keys)
+        return self._client().retrieve(keys=child_keys)
 
     def snapshots(self) -> list[Task]:
-        res = self._get_ontology().retrieve_children(self.ontology_id)
+        res = self._ontology().retrieve_children(self.ontology_id)
         tasks = [t for t in res if t.id.type == "task"]
-        return self._get_tasks().retrieve(
+        return self._tasks().retrieve(
             keys=[int(t.id.key) for t in tasks if t.id.key is not None]
         )
 
@@ -607,17 +615,21 @@ class Client:
             if is_single and len(res) > 1:
                 filtered = [r for r in res if r.time_range == time_range]
                 if len(filtered) == 0:
-                    raise QueryError(f"""
+                    raise QueryError(
+                        f"""
                         retrieve_if_name_exists was set to true, but {len(res)} ranges
                         were found matching {name} but none had the same time range as
                         passed to create. Synnax can't figure out which one you want!
-                        """)
+                        """
+                    )
                 if len(filtered) > 1:
-                    raise QueryError(f"""
+                    raise QueryError(
+                        f"""
                     retrieve_if_name_exists was set to true, but {len(res)} ranges were
                     found that matched {name} and had time range {time_range}. Synnax
                     can't figure out which one you want!
-                    """)
+                    """
+                    )
                 res = [filtered[0]]
             existing_names = {r.name for r in res}
             to_create = [r for r in to_create if r.name not in existing_names]

--- a/client/py/synnax/ranger/retrieve.py
+++ b/client/py/synnax/ranger/retrieve.py
@@ -28,7 +28,7 @@ class _Response(BaseModel):
 
 
 class Retriever:
-    __client: UnaryClient
+    _client: UnaryClient
     instrumentation: Instrumentation = NOOP
 
     def __init__(
@@ -36,7 +36,7 @@ class Retriever:
         client: UnaryClient,
         instrumentation: Instrumentation = NOOP,
     ) -> None:
-        self.__client = client
+        self._client = client
         self.instrumentation = instrumentation
 
     @trace("debug")
@@ -51,14 +51,14 @@ class Retriever:
             keys = normalize(key)
         if name is not None:
             names = normalize(name)
-        return self.__execute(_Request(keys=keys, names=names))
+        return self._execute(_Request(keys=keys, names=names))
 
     @trace("debug")
     def search(self, term: str) -> list[Payload]:
-        return self.__execute(_Request(search_term=term))
+        return self._execute(_Request(search_term=term))
 
-    def __execute(self, req: _Request) -> list[Payload]:
-        res, exc = self.__client.send("/range/retrieve", req, _Response)
+    def _execute(self, req: _Request) -> list[Payload]:
+        res, exc = self._client.send("/range/retrieve", req, _Response)
         if exc is not None:
             raise exc
         if res is None or res.ranges is None:

--- a/client/py/synnax/task/client.py
+++ b/client/py/synnax/task/client.py
@@ -163,14 +163,14 @@ class Task:
         self.internal = internal
         self.snapshot = snapshot
         self.status = status
-        self._frame_client = _frame_client
+        self._cached_frame_client = _frame_client
 
-    def _get_frame_client(self) -> FrameClient:
-        if self._frame_client is None:
+    def _frame_client(self) -> FrameClient:
+        if self._cached_frame_client is None:
             raise RuntimeError(
                 "Cannot execute commands on a task that has not been created or retrieved from the cluster."
             )
-        return self._frame_client
+        return self._cached_frame_client
 
     def to_payload(self) -> Payload:
         return Payload(
@@ -186,7 +186,7 @@ class Task:
         self.type = task.type
         self.config = task.config
         self.snapshot = task.snapshot
-        self._frame_client = task._frame_client
+        self._cached_frame_client = task._cached_frame_client
 
     @property
     def ontology_id(self) -> ID:
@@ -212,7 +212,7 @@ class Task:
         :param args: The arguments to pass to the command.
         :return: The unique key assigned to the command.
         """
-        w = self._get_frame_client().open_writer(TimeStamp.now(), _TASK_CMD_CHANNEL)
+        w = self._frame_client().open_writer(TimeStamp.now(), _TASK_CMD_CHANNEL)
         key = str(uuid4())
         w.write(
             _TASK_CMD_CHANNEL,
@@ -235,7 +235,7 @@ class Task:
         :param timeout: The maximum time to wait for the driver to acknowledge the
         command before a timeout occurs.
         """
-        with self._get_frame_client().open_streamer([_TASK_STATE_CHANNEL]) as s:
+        with self._frame_client().open_streamer([_TASK_STATE_CHANNEL]) as s:
             key = self.execute_command(type_, args)
             while True:
                 frame = s.read(TimeSpan.from_seconds(timeout).seconds)

--- a/client/py/synnax/task/client.py
+++ b/client/py/synnax/task/client.py
@@ -139,7 +139,7 @@ class Task:
     config: dict[str, Any] = {}
     snapshot: bool = False
     status: Status | None = None
-    __frame_client: FrameClient | None = None
+    _frame_client: FrameClient | None = None
 
     def __init__(
         self,
@@ -163,15 +163,14 @@ class Task:
         self.internal = internal
         self.snapshot = snapshot
         self.status = status
-        self.__frame_client = _frame_client
+        self._frame_client = _frame_client
 
-    @property
-    def _frame_client(self) -> FrameClient:
-        if self.__frame_client is None:
+    def _get_frame_client(self) -> FrameClient:
+        if self._frame_client is None:
             raise RuntimeError(
                 "Cannot execute commands on a task that has not been created or retrieved from the cluster."
             )
-        return self.__frame_client
+        return self._frame_client
 
     def to_payload(self) -> Payload:
         return Payload(
@@ -187,7 +186,7 @@ class Task:
         self.type = task.type
         self.config = task.config
         self.snapshot = task.snapshot
-        self.__frame_client = task.__frame_client
+        self._frame_client = task._frame_client
 
     @property
     def ontology_id(self) -> ID:
@@ -213,7 +212,7 @@ class Task:
         :param args: The arguments to pass to the command.
         :return: The unique key assigned to the command.
         """
-        w = self._frame_client.open_writer(TimeStamp.now(), _TASK_CMD_CHANNEL)
+        w = self._get_frame_client().open_writer(TimeStamp.now(), _TASK_CMD_CHANNEL)
         key = str(uuid4())
         w.write(
             _TASK_CMD_CHANNEL,
@@ -236,7 +235,7 @@ class Task:
         :param timeout: The maximum time to wait for the driver to acknowledge the
         command before a timeout occurs.
         """
-        with self._frame_client.open_streamer([_TASK_STATE_CHANNEL]) as s:
+        with self._get_frame_client().open_streamer([_TASK_STATE_CHANNEL]) as s:
             key = self.execute_command(type_, args)
             while True:
                 frame = s.read(TimeSpan.from_seconds(timeout).seconds)
@@ -411,11 +410,11 @@ class Client:
         for pld in payloads:
             self.maybe_assign_def_rack(pld, rack)
         req = _CreateRequest(tasks=payloads)
-        created = self.__exec_create(req)
+        created = self._exec_create(req)
         sugared = self.sugar(created)
         return sugared[0] if is_single else sugared
 
-    def __exec_create(self, req: _CreateRequest) -> list[Payload]:
+    def _exec_create(self, req: _CreateRequest) -> list[Payload]:
         res = send_required(self._client, "/task/create", req, _CreateResponse)
         return res.tasks
 
@@ -438,7 +437,7 @@ class Client:
         with self._frame_client.open_streamer([_TASK_STATE_CHANNEL]) as streamer:
             pld = self.maybe_assign_def_rack(task.to_payload())
             req = _CreateRequest(tasks=[pld])
-            tasks = self.__exec_create(req)
+            tasks = self._exec_create(req)
             task.set_internal(self.sugar(tasks)[0])
             while True:
                 frame = streamer.read(timeout)

--- a/client/py/synnax/task/client.py
+++ b/client/py/synnax/task/client.py
@@ -165,6 +165,7 @@ class Task:
         self.status = status
         self._cached_frame_client = _frame_client
 
+    @property
     def _frame_client(self) -> FrameClient:
         if self._cached_frame_client is None:
             raise RuntimeError(
@@ -212,7 +213,7 @@ class Task:
         :param args: The arguments to pass to the command.
         :return: The unique key assigned to the command.
         """
-        w = self._frame_client().open_writer(TimeStamp.now(), _TASK_CMD_CHANNEL)
+        w = self._frame_client.open_writer(TimeStamp.now(), _TASK_CMD_CHANNEL)
         key = str(uuid4())
         w.write(
             _TASK_CMD_CHANNEL,
@@ -235,7 +236,7 @@ class Task:
         :param timeout: The maximum time to wait for the driver to acknowledge the
         command before a timeout occurs.
         """
-        with self._frame_client().open_streamer([_TASK_STATE_CHANNEL]) as s:
+        with self._frame_client.open_streamer([_TASK_STATE_CHANNEL]) as s:
             key = self.execute_command(type_, args)
             while True:
                 frame = s.read(TimeSpan.from_seconds(timeout).seconds)

--- a/client/py/synnax/task/client.py
+++ b/client/py/synnax/task/client.py
@@ -139,7 +139,7 @@ class Task:
     config: dict[str, Any] = {}
     snapshot: bool = False
     status: Status | None = None
-    _frame_client: FrameClient | None = None
+    _cached_frame_client: FrameClient | None = None
 
     def __init__(
         self,

--- a/freighter/py/freighter/http.py
+++ b/freighter/py/freighter/http.py
@@ -59,9 +59,6 @@ class HTTPClient(MiddlewareCollector):
         self.__pool = PoolManager(cert_reqs="CERT_NONE", **kwargs)
         urllib3.disable_warnings()
 
-    def __(self) -> UnaryClient:
-        return self
-
     def send(
         self, target: str, req: RQ, res_t: type[RS]
     ) -> tuple[RS, None] | tuple[None, Exception]:

--- a/freighter/py/freighter/http.py
+++ b/freighter/py/freighter/http.py
@@ -20,7 +20,6 @@ from freighter.codec import Codec
 from freighter.context import Context, Role
 from freighter.exceptions import Unreachable
 from freighter.transport import RQ, RS, MiddlewareCollector
-from freighter.unary import UnaryClient
 from freighter.url import URL
 from x.exceptions import ExceptionPayload, decode_exception
 

--- a/freighter/py/freighter/transport.py
+++ b/freighter/py/freighter/transport.py
@@ -115,12 +115,12 @@ class MiddlewareCollector:
         """
         middleware = self._middleware.copy()
 
-        def __next(ctx_: Context) -> tuple[Context, Exception | None]:
+        def _next(ctx_: Context) -> tuple[Context, Exception | None]:
             if len(middleware) == 0:
                 return finalizer(ctx_)
-            return middleware.pop()(ctx_, __next)
+            return middleware.pop()(ctx_, _next)
 
-        return __next(ctx)
+        return _next(ctx)
 
 
 class AsyncMiddlewareCollector:
@@ -149,9 +149,9 @@ class AsyncMiddlewareCollector:
         """
         middleware = self._middleware.copy()
 
-        async def __next(_md: Context) -> tuple[Context, Exception | None]:
+        async def _next(_md: Context) -> tuple[Context, Exception | None]:
             if len(middleware) == 0:
                 return await finalizer(_md)
-            return await middleware.pop()(_md, __next)
+            return await middleware.pop()(_md, _next)
 
-        return await __next(md)
+        return await _next(md)

--- a/freighter/py/freighter/url.py
+++ b/freighter/py/freighter/url.py
@@ -65,13 +65,13 @@ class URL:
 
     def child(self, path: str) -> URL:
         """Creates a new URL with the given path appended to the current path."""
-        return URL(self.host, self.port, self.__child_prefix(path), self.protocol)
+        return URL(self.host, self.port, self._child_prefix(path), self.protocol)
 
     def stringify(self) -> str:
         """Returns the URL as a string."""
         return f"{self.protocol}://{self.host}:{self.port}/{self.path}"
 
-    def __child_prefix(self, path: str) -> str:
+    def _child_prefix(self, path: str) -> str:
         return reduce(urljoin, [self.path, format_path(path)])
 
     def __str__(self) -> str:

--- a/freighter/py/freighter/websocket.py
+++ b/freighter/py/freighter/websocket.py
@@ -91,33 +91,33 @@ def _new_res_msg_t(res_t: type[RS]) -> type[Message[RS]]:
 class AsyncWebsocketStream(AsyncStream[RQ, RS]):
     """An implementation of AsyncStream that is backed by a websocket."""
 
-    __encoder: Codec
-    __internal: AsyncClientConnection
-    __server_closed: Exception | None
-    __send_closed: bool
-    __res_msg_t: type[Message[RS]]
+    _encoder: Codec
+    _internal: AsyncClientConnection
+    _server_closed: Exception | None
+    _send_closed: bool
+    _res_msg_t: type[Message[RS]]
 
     def __init__(self, encoder: Codec, ws: AsyncClientConnection, res_t: type[RS]):
-        self.__encoder = encoder
-        self.__internal = ws
-        self.__send_closed = False
-        self.__server_closed = None
-        self.__res_msg_t = _new_res_msg_t(res_t)
+        self._encoder = encoder
+        self._internal = ws
+        self._send_closed = False
+        self._server_closed = None
+        self._res_msg_t = _new_res_msg_t(res_t)
 
     async def receive(self) -> tuple[RS, None] | tuple[None, Exception]:
         """Implements the AsyncStream protocol."""
-        server_closed = self.__server_closed
+        server_closed = self._server_closed
         if server_closed is not None:
             return None, server_closed
 
-        data = await self.__internal.recv()
+        data = await self._internal.recv()
         assert isinstance(data, bytes)
-        msg = self.__encoder.decode(data, self.__res_msg_t)
+        msg = self._encoder.decode(data, self._res_msg_t)
 
         if msg.type == "close":
-            await self.__close_server(msg.error)
-            assert self.__server_closed is not None
-            return None, self.__server_closed
+            await self._close_server(msg.error)
+            assert self._server_closed is not None
+            return None, self._server_closed
 
         assert msg.payload is not None
         return msg.payload, None
@@ -127,63 +127,63 @@ class AsyncWebsocketStream(AsyncStream[RQ, RS]):
         # If the server closed with an error, we return freighter.EOF to the
         # caller, and expect them to discover the close error by calling
         # receive().
-        if self.__server_closed is not None:
+        if self._server_closed is not None:
             return EOF()
 
-        if self.__send_closed:
+        if self._send_closed:
             raise StreamClosed
 
         msg = Message[RQ](type="data", payload=payload, error=None)
-        encoded = self.__encoder.encode(msg)
+        encoded = self._encoder.encode(msg)
 
         # If the server closed with an error, we return freighter.EOF to the
         # caller, and expect them to discover the close error by calling
         # receive().
         try:
-            await self.__internal.send(encoded)
+            await self._internal.send(encoded)
         except ConnectionClosedOK:
             return EOF()
         return None
 
     async def receive_open_ack(self) -> Exception | None:
-        msg = await self.__internal.recv()
+        msg = await self._internal.recv()
         assert isinstance(msg, bytes)
-        decoded_msg = self.__encoder.decode(msg, Message)
+        decoded_msg = self._encoder.decode(msg, Message)
         if decoded_msg.type == "open":
             return None
         return decode_exception(decoded_msg.error)
 
     async def close_send(self) -> Exception | None:
         """Implements the AsyncStream protocol."""
-        if self.__send_closed or self.__server_closed is not None:
+        if self._send_closed or self._server_closed is not None:
             return None
 
         msg = Message[RQ](type="close", payload=None, error=None)
         try:
-            await self.__internal.send(self.__encoder.encode(msg))
+            await self._internal.send(self._encoder.encode(msg))
         finally:
-            self.__send_closed = True
+            self._send_closed = True
         return None
 
-    async def __close_server(self, exc_pld: ExceptionPayload | None) -> None:
-        if self.__server_closed is not None:
+    async def _close_server(self, exc_pld: ExceptionPayload | None) -> None:
+        if self._server_closed is not None:
             return
         try:
             assert exc_pld is not None
-            self.__server_closed = decode_exception(exc_pld)
+            self._server_closed = decode_exception(exc_pld)
         finally:
-            await self.__internal.close()
+            await self._internal.close()
 
 
 DEFAULT_MAX_SIZE = 2**20
 
 
 class SyncWebsocketStream(Stream[RQ, RS]):
-    __encoder: Codec
-    __internal: SyncClientProtocol
-    __server_closed: Exception | None
-    __send_closed: bool
-    __res_msg_t: type[Message[RS]]
+    _encoder: Codec
+    _internal: SyncClientProtocol
+    _server_closed: Exception | None
+    _send_closed: bool
+    _res_msg_t: type[Message[RS]]
 
     def __init__(
         self,
@@ -191,82 +191,82 @@ class SyncWebsocketStream(Stream[RQ, RS]):
         ws: SyncClientProtocol,
         res_t: type[RS],
     ):
-        self.__encoder = encoder
-        self.__internal = ws
-        self.__send_closed = False
-        self.__server_closed = None
-        self.__res_msg_t = _new_res_msg_t(res_t)
+        self._encoder = encoder
+        self._internal = ws
+        self._send_closed = False
+        self._server_closed = None
+        self._res_msg_t = _new_res_msg_t(res_t)
 
     def receive(
         self, timeout: float | None = None
     ) -> tuple[RS, None] | tuple[None, Exception]:
-        server_closed = self.__server_closed
+        server_closed = self._server_closed
         if server_closed is not None:
             return None, server_closed
 
         try:
-            data = self.__internal.recv(timeout)
+            data = self._internal.recv(timeout)
         except ConnectionClosedOK as e:
             return None, handle_close_err(e)
         assert isinstance(data, bytes)
-        msg = self.__encoder.decode(data, self.__res_msg_t)
+        msg = self._encoder.decode(data, self._res_msg_t)
 
         if msg.type == "close":
-            self.__close_server(msg.error)
-            assert self.__server_closed is not None
-            return None, self.__server_closed
+            self._close_server(msg.error)
+            assert self._server_closed is not None
+            return None, self._server_closed
 
         assert msg.payload is not None
         return msg.payload, None
 
     def received(self) -> bool:
-        return self.__internal.recv_bufsize > 0
+        return self._internal.recv_bufsize > 0
 
     def receive_open_ack(self) -> Exception | None:
-        msg = self.__internal.recv()
+        msg = self._internal.recv()
         assert isinstance(msg, bytes)
-        decoded_msg = self.__encoder.decode(msg, self.__res_msg_t)
+        decoded_msg = self._encoder.decode(msg, self._res_msg_t)
         if decoded_msg.type == "open":
             return None
         return decode_exception(decoded_msg.error)
 
     def send(self, payload: RQ) -> Exception | None:
-        if self.__server_closed is not None:
+        if self._server_closed is not None:
             return EOF()
 
-        if self.__send_closed:
+        if self._send_closed:
             raise StreamClosed
 
         msg = Message[RQ](type="data", payload=payload, error=None)
-        encoded = self.__encoder.encode(msg)
+        encoded = self._encoder.encode(msg)
 
         try:
-            self.__internal.send(encoded)
+            self._internal.send(encoded)
         except ConnectionClosedOK as e:
             return handle_close_err(e)
         return None
 
     def close_send(self) -> Exception | None:
-        if self.__send_closed or self.__server_closed is not None:
+        if self._send_closed or self._server_closed is not None:
             return None
 
         msg = Message[RQ](type="close", payload=None, error=None)
         try:
-            self.__internal.send(self.__encoder.encode(msg))
+            self._internal.send(self._encoder.encode(msg))
         except ConnectionClosedOK as e:
             return handle_close_err(e)
         finally:
-            self.__send_closed = True
+            self._send_closed = True
         return None
 
-    def __close_server(self, exc_pld: ExceptionPayload | None) -> None:
-        if self.__server_closed is not None:
+    def _close_server(self, exc_pld: ExceptionPayload | None) -> None:
+        if self._server_closed is not None:
             return
         try:
             assert exc_pld is not None
-            self.__server_closed = decode_exception(exc_pld)
+            self._server_closed = decode_exception(exc_pld)
         finally:
-            self.__internal.close()
+            self._internal.close()
 
 
 class _Base:
@@ -309,9 +309,6 @@ class AsyncWebsocketClient(_Base, AsyncMiddlewareCollector, AsyncStreamClient):
         """
         AsyncMiddlewareCollector.__init__(self)
         _Base.__init__(self, **kwargs)
-
-    def __(self) -> AsyncStreamClient:
-        return self
 
     async def stream(
         self,
@@ -372,9 +369,6 @@ class WebsocketClient(_Base, MiddlewareCollector, StreamClient):
     def __init__(self, **kwargs: Any) -> None:
         MiddlewareCollector.__init__(self)
         _Base.__init__(self, **kwargs)
-
-    def __(self) -> StreamClient:
-        return self
 
     def stream(
         self,

--- a/x/py/x/telem/series.py
+++ b/x/py/x/telem/series.py
@@ -63,12 +63,12 @@ class Series(BaseModel):
     """The underlying buffer"""
     alignment: Alignment = Alignment(0, 0)
     """The alignment of the Series, representing the position within an array of arrays"""
-    __len_cache: int | None = PrivateAttr(None)
+    _len_cache: int | None = PrivateAttr(None)
 
     def __len__(self) -> int:
         if not self.data_type.is_variable:
             return self.data_type.density.sample_count(len(self.data))
-        if self.__len_cache is None:
+        if self._len_cache is None:
             count = 0
             offset = 0
             d = self.data
@@ -78,8 +78,8 @@ class Series(BaseModel):
                 )
                 offset += VARIABLE_LENGTH_PREFIX_SIZE + length
                 count += 1
-            self.__len_cache = count
-        return self.__len_cache
+            self._len_cache = count
+        return self._len_cache
 
     def __init__(
         self,
@@ -166,7 +166,7 @@ class Series(BaseModel):
             time_range=time_range,
             alignment=alignment,
         )
-        self.__len_cache = None
+        self._len_cache = None
 
     def __array__(
         self, dtype: np.dtype | None = None, copy: bool | None = None
@@ -234,15 +234,15 @@ class Series(BaseModel):
         if self.data_type == DataType.UUID:
             yield from [self[i] for i in range(len(self))]
         elif self.data_type == DataType.JSON:
-            for v in self.__iter__variable():
+            for v in self._iter_variable():
                 yield json.loads(v)
         elif self.data_type == DataType.STRING:
-            for v in self.__iter__variable():
+            for v in self._iter_variable():
                 yield v.decode("utf-8")
         else:
             yield from self.__array__()
 
-    def __iter__variable(self) -> Iterator[bytes]:
+    def _iter_variable(self) -> Iterator[bytes]:
         offset = 0
         d = self.data
         while offset + VARIABLE_LENGTH_PREFIX_SIZE <= len(d):


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

N/A — convention cleanup extracted from the SY-4130 branch.

## Description

The Python client, freighter, alamos, and `x` packages had an inconsistent mix of single- and double-underscore prefixes on non-public attributes, methods, and local closures. Double-underscore prefixes trigger Python's name-mangling, which produces surprising behavior when subclasses or other in-module code try to access the same attribute — and there is no case in any of these packages where we actually want that mangling. The single-underscore convention is the standard "internal use" signal and is what the rest of the codebase already uses.

This PR renames the affected identifiers across:

- `alamos/py` (`Tracer._otel_tracer` — the `__`-prefixed memoization attribute is replaced with `functools.cached_property`).
- `client/py/synnax/` — `arc/`, `channel/`, `framer/`, `io/`, `ontology/`, `ranger/`, `task/`.
- `freighter/py/freighter/` — `http.py`, `transport.py`, `url.py`, `websocket.py`.
- `x/py/x/telem/series.py` — including the `Series` length cache and variable-length iterator helper.

A handful of related cleanups ride along, since reverting them would leave broken code after the rename:

- The `HTTPClient.__()` no-op identity method and several unused `__`-prefixed websocket helpers are removed outright.
- A few `Channel` / `Client` properties that previously exposed mangled accessors via `@property` are now plain helper methods (e.g. `Channel._get_frame_client()`), so callers in the same module can call them directly.
- `CSVReader.__reader` becomes `_reader` plus a small `_ensure_reader()` helper that replaces the previous unchecked `next(self._reader)`.

No public API surface changes — every renamed identifier was already an internal one.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR mechanically renames double-underscore-prefixed private attributes and methods to single-underscore throughout the Python `alamos`, `client`, `freighter`, and `x/telem` packages, eliminating unintended name-mangling. As a small accompanying cleanup, the no-op `__()` identity methods on the HTTP and WebSocket client classes are removed, and `Tracer._otel_tracer` is converted from a manually-cached `@property` to `functools.cached_property`.

- **Convention cleanup across 18 files** — replaces `__` prefixes with `_` (e.g. `__sugar` → `_sugar`, `__exec_retrieve` → `_exec_retrieve`, `__stream` → `_stream`) and introduces descriptive backing-store names like `_cached_frame_client` where needed to avoid collisions with public-facing properties.
- **`alamos/trace.py`** — drops the manual `__otel_tracer` backing field and replaces the hand-rolled memoization `@property` with `@cached_property`; the semantics are equivalent since `_otel_provider` is constructor-only.
- **`freighter/` cleanups** — removes three unused `__()` identity methods from `HTTPClient`, `AsyncWebsocketClient`, and `WebsocketClient`, and renames the inner `__next` closures in `transport.py` to `_next` (avoiding the `__next__` dunder look-alike).

<h3>Confidence Score: 5/5</h3>

Safe to merge — every change is a mechanical rename with no public API surface affected.

All 18 files contain purely mechanical renames from double- to single-underscore prefixes, with a small handful of accompanying cleanups (removing dead `__()` identity methods, switching to `cached_property`). Each changed call site was updated consistently, the backing-store/property naming collisions introduced by the rename are resolved with `_cached_*` prefixes, and no external interfaces are modified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| alamos/py/alamos/trace.py | Replaces manual `__otel_tracer` memoization with `functools.cached_property`; semantically equivalent since `_otel_provider` is constructor-only. |
| client/py/synnax/task/client.py | Renames `__frame_client` backing store to `_cached_frame_client` and `__exec_create` to `_exec_create`; resolves the pre-existing annotation/property name collision. |
| client/py/synnax/ranger/client.py | Large batch rename of `__`-prefixed PrivateAttrs across `_InternalScopedChannel`, `ScopedChannel`, and `Range`; introduces distinct `_cached_*` names for backing stores to avoid collision with guarded property accessors. |
| freighter/py/freighter/websocket.py | Renames all `__`-prefixed instance attributes in `AsyncWebsocketStream` and `SyncWebsocketStream` to `_`; removes the unused `__()` identity methods from both client classes. |
| freighter/py/freighter/transport.py | Renames inner closure `__next` to `_next` in both `MiddlewareCollector` and `AsyncMiddlewareCollector`, eliminating the confusing `__next__` lookalike. |
| client/py/synnax/channel/client.py | Renames the triple-underscore `___frame_client` backing store to `_cached_frame_client`, `__client` to `_client`, and `__sugar` to `_sugar`; all call sites updated consistently. |
| client/py/synnax/io/csv.py | Renames `__reader`, `__detect_delimiter`, and `__get_skip_rows` to single-underscore equivalents; the lazy-initialization pattern in the `_reader` property is preserved unchanged. |
| x/py/x/telem/series.py | Renames `__len_cache` PrivateAttr to `_len_cache` and `__iter__variable` to `_iter_variable`; cleans up the confusing `__iter__` lookalike name. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph alamos
        A["Tracer.__otel_tracer\n(manual @property cache)"] -->|replaced by| B["Tracer._otel_tracer\n(@cached_property)"]
    end
    subgraph freighter
        C["HTTPClient.__()"] -->|removed| D["(no-op deleted)"]
        E["WebsocketClient.__()"] -->|removed| F["(no-op deleted)"]
        G["MiddlewareCollector.__next closure"] -->|renamed| H["_next closure"]
    end
    subgraph client
        I["Channel.___frame_client\n__client, __sugar"] -->|renamed| J["_cached_frame_client\n_client, _sugar"]
        K["framer.Client.__stream_client\n__channels, __deleter"] -->|renamed| L["_stream_client\n_channels, _deleter"]
        M["ranger.Range.__aliaser\n__frame_client, __client"] -->|renamed| N["_cached_aliaser\n_cached_frame_client, _cached_client"]
        O["Task.__frame_client"] -->|renamed| P["_cached_frame_client"]
    end
    subgraph x_telem
        Q["Series.__len_cache\n__iter__variable"] -->|renamed| R["_len_cache\n_iter_variable"]
    end
```

<sub>Reviews (5): Last reviewed commit: ["Remove unnecessary function call"](https://github.com/synnaxlabs/synnax/commit/86c233cf249c79cde8c7bb412e35dc0f16e4fd59) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32837482)</sub>

<!-- /greptile_comment -->