### PR TITLE
SY-4199: Fix Type Checking for Arc Select Case Body Chains

### DIFF
--- a/arc/go/analyzer/flow/flow.go
+++ b/arc/go/analyzer/flow/flow.go
@@ -174,22 +174,9 @@ func parseFunction(ctx context.Context[parser.IFunctionContext], prevNode parser
 		}
 		if !hasRoutingTableBetween && len(funcType.Type.Inputs) > 0 {
 			t := funcType.Type.Inputs[0].Type
-			var prevOutputType types.Type
-			if outputType, ok := prevFuncType.Type.Outputs.Get(ir.DefaultOutputParam); ok {
-				prevOutputType = outputType.Type
-			} else if len(prevFuncType.Type.Outputs) > 0 {
-				ctx.Diagnostics.Add(diagnostics.Errorf(ctx.AST,
-					"func '%s' has named outputs and requires a routing table",
-					prevFuncName,
-				))
-				return
-			} else {
-				// Void function (no outputs) cannot feed into a function expecting input
-				ctx.Diagnostics.Add(diagnostics.Errorf(ctx.AST,
-					"func '%s' has no return value but '%s' expects an input parameter",
-					prevFuncName,
-					name,
-				))
+			prevOutputType := resolveFuncOutput(ctx, prevFuncType.Type, prevFuncName,
+				"'"+name+"' expects an input parameter")
+			if !prevOutputType.IsValid() {
 				return
 			}
 			if err := atypes.Check(ctx.Constraints, prevOutputType, t, ctx.AST,
@@ -266,6 +253,30 @@ func resolveFunc[T antlr.ParserRuleContext](
 		return nil
 	}
 	return sym
+}
+
+// resolveFuncOutput returns fn's default output type for chained use, emitting
+// a diagnostic when fn has named outputs or no return value. downstreamDesc
+// is embedded in the no-return message to describe the unsatisfied consumer.
+func resolveFuncOutput[T antlr.ParserRuleContext](
+	ctx context.Context[T],
+	fnType types.Type,
+	fnName string,
+	downstreamDesc string,
+) types.Type {
+	if out, ok := fnType.Outputs.Get(ir.DefaultOutputParam); ok {
+		return out.Type
+	}
+	if len(fnType.Outputs) > 0 {
+		ctx.Diagnostics.Add(diagnostics.Errorf(ctx.AST,
+			"func '%s' has named outputs and requires a routing table",
+			fnName))
+	} else {
+		ctx.Diagnostics.Add(diagnostics.Errorf(ctx.AST,
+			"func '%s' has no return value but %s",
+			fnName, downstreamDesc))
+	}
+	return types.Type{}
 }
 
 func validateFuncConfig[T antlr.ParserRuleContext](
@@ -513,32 +524,6 @@ func analyzeOutputRoutingTable(
 	}
 }
 
-// inferFlowNodeOutputType returns the type a flow node emits to the next node
-// in a routing-entry chain, or the zero type if it cannot be resolved.
-func inferFlowNodeOutputType(ctx context.Context[parser.IFlowNodeContext]) types.Type {
-	if expr := ctx.AST.Expression(); expr != nil {
-		return atypes.InferFromExpression(context.Child(ctx, expr))
-	}
-	if fn := ctx.AST.Function(); fn != nil {
-		sym, err := ctx.Resolve(parser.FunctionName(fn))
-		if err != nil || sym.Kind != symbol.KindFunction {
-			return types.Type{}
-		}
-		if out, ok := sym.Type.Outputs.Get(ir.DefaultOutputParam); ok {
-			return out.Type
-		}
-		return types.Type{}
-	}
-	if idNode := ctx.AST.Identifier(); idNode != nil {
-		sym, err := ctx.Resolve(idNode.IDENTIFIER().GetText())
-		if err != nil || sym.Kind != symbol.KindChannel {
-			return types.Type{}
-		}
-		return sym.Type.Unwrap()
-	}
-	return types.Type{}
-}
-
 func analyzeInputRoutingTable(
 	ctx context.Context[parser.IRoutingTableContext],
 	nodes []parser.IFlowNodeContext,
@@ -700,4 +685,29 @@ func analyzeRoutingTargetWithParam(
 	} else if expr := ctx.AST.Expression(); expr != nil {
 		AnalyzeSingleExpression(context.Child(ctx, expr))
 	}
+}
+
+// inferFlowNodeOutputType returns the type a flow node emits to the next node
+// in a routing-entry chain.
+func inferFlowNodeOutputType(ctx context.Context[parser.IFlowNodeContext]) types.Type {
+	if expr := ctx.AST.Expression(); expr != nil {
+		return atypes.InferFromExpression(context.Child(ctx, expr))
+	}
+	if fn := ctx.AST.Function(); fn != nil {
+		fnName := parser.FunctionName(fn)
+		sym, err := ctx.Resolve(fnName)
+		if err != nil || sym.Kind != symbol.KindFunction {
+			return types.Type{}
+		}
+		return resolveFuncOutput(ctx, sym.Type, fnName,
+			"the next node in the chain expects an input")
+	}
+	if idNode := ctx.AST.Identifier(); idNode != nil {
+		sym, err := ctx.Resolve(idNode.IDENTIFIER().GetText())
+		if err != nil || sym.Kind != symbol.KindChannel {
+			return types.Type{}
+		}
+		return sym.Type.Unwrap()
+	}
+	return types.Type{}
 }

--- a/arc/go/analyzer/flow/flow.go
+++ b/arc/go/analyzer/flow/flow.go
@@ -490,8 +490,10 @@ func analyzeOutputRoutingTable(
 			}
 		}
 
-		// Analyze each flow node in the routing entry chain
+		// First node's source is the select-output type; subsequent nodes
+		// chain from the previous node's output.
 		flowNodes := entry.AllFlowNode()
+		nodeSourceType := outputType.Type
 		for i, flowNode := range flowNodes {
 			isLastNode := i == len(flowNodes)-1
 			var targetParam *string
@@ -500,12 +502,41 @@ func analyzeOutputRoutingTable(
 			}
 			analyzeRoutingTargetWithParam(
 				context.Child(ctx, flowNode),
-				outputType.Type,
+				nodeSourceType,
 				nextFuncType,
 				targetParam,
 			)
+			if !isLastNode {
+				nodeSourceType = inferFlowNodeOutputType(context.Child(ctx, flowNode))
+			}
 		}
 	}
+}
+
+// inferFlowNodeOutputType returns the type a flow node emits to the next node
+// in a routing-entry chain, or the zero type if it cannot be resolved.
+func inferFlowNodeOutputType(ctx context.Context[parser.IFlowNodeContext]) types.Type {
+	if expr := ctx.AST.Expression(); expr != nil {
+		return atypes.InferFromExpression(context.Child(ctx, expr))
+	}
+	if fn := ctx.AST.Function(); fn != nil {
+		sym, err := ctx.Resolve(parser.FunctionName(fn))
+		if err != nil || sym.Kind != symbol.KindFunction {
+			return types.Type{}
+		}
+		if out, ok := sym.Type.Outputs.Get(ir.DefaultOutputParam); ok {
+			return out.Type
+		}
+		return types.Type{}
+	}
+	if idNode := ctx.AST.Identifier(); idNode != nil {
+		sym, err := ctx.Resolve(idNode.IDENTIFIER().GetText())
+		if err != nil || sym.Kind != symbol.KindChannel {
+			return types.Type{}
+		}
+		return sym.Type.Unwrap()
+	}
+	return types.Type{}
 }
 
 func analyzeInputRoutingTable(

--- a/arc/go/analyzer/flow/flow_test.go
+++ b/arc/go/analyzer/flow/flow_test.go
@@ -1004,6 +1004,78 @@ sequence main {
 			Expect(ctx.Diagnostics.Ok()).To(BeTrue(), ctx.Diagnostics.String())
 		})
 
+		It("Should infer channel value type for a channel in a non-terminal chain position", func(bCtx SpecContext) {
+			customResolver := symbol.MapResolver{
+				"source_chan": symbol.Symbol{
+					Name: "source_chan",
+					Kind: symbol.KindChannel,
+					Type: types.Chan(types.F64()),
+				},
+				"feed_chan": symbol.Symbol{
+					Name: "feed_chan",
+					Kind: symbol.KindChannel,
+					Type: types.Chan(types.F64()),
+				},
+				"log_num": symbol.Symbol{
+					Name: "log_num",
+					Kind: symbol.KindChannel,
+					Type: types.Chan(types.F64()),
+				},
+			}
+			ast := MustSucceed(parser.Parse(`
+			func demux{} (value f64) (high f64, low f64) {
+			    if (value > 100.0) {
+			        high = value
+			    } else {
+			        low = value
+			    }
+			}
+
+			func pass{} (value f64) f64 {
+			    return value
+			}
+
+			source_chan -> demux{} -> {
+			    high: feed_chan -> pass{} -> log_num,
+			    low: 1 -> log_num
+			}`))
+			ctx := context.CreateRoot(bCtx, ast, customResolver)
+			analyzer.AnalyzeProgram(ctx)
+			Expect(ctx.Diagnostics.Ok()).To(BeTrue(), ctx.Diagnostics.String())
+		})
+
+		It("Should report undefined symbol for an unresolved func in a chain", func(bCtx SpecContext) {
+			customResolver := symbol.MapResolver{
+				"source_chan": symbol.Symbol{
+					Name: "source_chan",
+					Kind: symbol.KindChannel,
+					Type: types.Chan(types.F64()),
+				},
+				"log_num": symbol.Symbol{
+					Name: "log_num",
+					Kind: symbol.KindChannel,
+					Type: types.Chan(types.F64()),
+				},
+			}
+			ast := MustSucceed(parser.Parse(`
+			func demux{} (value f64) (high f64, low f64) {
+			    if (value > 100.0) {
+			        high = value
+			    } else {
+			        low = value
+			    }
+			}
+
+			source_chan -> demux{} -> {
+			    high: unknown_fn{} -> log_num,
+			    low: 1 -> log_num
+			}`))
+			ctx := context.CreateRoot(bCtx, ast, customResolver)
+			analyzer.AnalyzeProgram(ctx)
+			Expect(ctx.Diagnostics.Ok()).To(BeFalse())
+			Expect((*ctx.Diagnostics)[0].Message).To(ContainSubstring("unknown_fn"))
+		})
+
 		It("Should route to channels in routing table", func(bCtx SpecContext) {
 			ast := MustSucceed(parser.Parse(`
 			func demux{} (value f64) (high f64, low f64) {

--- a/arc/go/analyzer/flow/flow_test.go
+++ b/arc/go/analyzer/flow/flow_test.go
@@ -877,6 +877,42 @@ sequence main {
 			Expect(ctx.Diagnostics.Ok()).To(BeTrue(), ctx.Diagnostics.String())
 		})
 
+		It("Should type-check multi-node case body via chain, not select output", func(bCtx SpecContext) {
+			customResolver := symbol.MapResolver{
+				"sensor_chan": symbol.Symbol{
+					Name: "sensor_chan",
+					Kind: symbol.KindChannel,
+					Type: types.Chan(types.F64()),
+				},
+				"log_str": symbol.Symbol{
+					Name: "log_str",
+					Kind: symbol.KindChannel,
+					Type: types.Chan(types.String()),
+				},
+				"log_num": symbol.Symbol{
+					Name: "log_num",
+					Kind: symbol.KindChannel,
+					Type: types.Chan(types.F32()),
+				},
+			}
+			ast := MustSucceed(parser.Parse(`
+			func demux{} (value f64) (high f64, low f64) {
+			    if (value > 100.0) {
+			        high = value
+			    } else {
+			        low = value
+			    }
+			}
+
+			sensor_chan -> demux{} -> {
+			    high: "above" -> log_str,
+			    low: 1 -> log_num
+			}`))
+			ctx := context.CreateRoot(bCtx, ast, customResolver)
+			analyzer.AnalyzeProgram(ctx)
+			Expect(ctx.Diagnostics.Ok()).To(BeTrue(), ctx.Diagnostics.String())
+		})
+
 		It("Should route to channels in routing table", func(bCtx SpecContext) {
 			ast := MustSucceed(parser.Parse(`
 			func demux{} (value f64) (high f64, low f64) {

--- a/arc/go/analyzer/flow/flow_test.go
+++ b/arc/go/analyzer/flow/flow_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/synnaxlabs/arc/analyzer/context"
 	"github.com/synnaxlabs/arc/ir"
 	"github.com/synnaxlabs/arc/parser"
+	"github.com/synnaxlabs/arc/stl/selector"
 	"github.com/synnaxlabs/arc/symbol"
 	"github.com/synnaxlabs/arc/types"
 	"github.com/synnaxlabs/x/diagnostics"
@@ -907,6 +908,96 @@ sequence main {
 			sensor_chan -> demux{} -> {
 			    high: "above" -> log_str,
 			    low: 1 -> log_num
+			}`))
+			ctx := context.CreateRoot(bCtx, ast, customResolver)
+			analyzer.AnalyzeProgram(ctx)
+			Expect(ctx.Diagnostics.Ok()).To(BeTrue(), ctx.Diagnostics.String())
+		})
+
+		It("Should reject type mismatch in a chained case body node", func(bCtx SpecContext) {
+			customResolver := symbol.MapResolver{
+				"sensor_chan": symbol.Symbol{
+					Name: "sensor_chan",
+					Kind: symbol.KindChannel,
+					Type: types.Chan(types.F64()),
+				},
+				"log_str": symbol.Symbol{
+					Name: "log_str",
+					Kind: symbol.KindChannel,
+					Type: types.Chan(types.String()),
+				},
+			}
+			ast := MustSucceed(parser.Parse(`
+			func demux{} (value f64) (high f64, low f64) {
+			    if (value > 100.0) {
+			        high = value
+			    } else {
+			        low = value
+			    }
+			}
+
+			sensor_chan -> demux{} -> {
+			    high: 123 -> log_str,
+			    low: "below" -> log_str
+			}`))
+			ctx := context.CreateRoot(bCtx, ast, customResolver)
+			analyzer.AnalyzeProgram(ctx)
+			Expect(ctx.Diagnostics.Ok()).To(BeFalse())
+			Expect((*ctx.Diagnostics)[0].Message).To(ContainSubstring("type mismatch"))
+		})
+
+		It("Should reject a func with named outputs in a non-terminal chain position", func(bCtx SpecContext) {
+			customResolver := symbol.MapResolver{
+				"sensor_chan": symbol.Symbol{
+					Name: "sensor_chan",
+					Kind: symbol.KindChannel,
+					Type: types.Chan(types.F64()),
+				},
+				"log_num": symbol.Symbol{
+					Name: "log_num",
+					Kind: symbol.KindChannel,
+					Type: types.Chan(types.F32()),
+				},
+			}
+			ast := MustSucceed(parser.Parse(`
+			func demux{} (value f64) (high f64, low f64) {
+			    if (value > 100.0) {
+			        high = value
+			    } else {
+			        low = value
+			    }
+			}
+
+			sensor_chan -> demux{} -> {
+			    high: demux{} -> log_num,
+			    low: 1 -> log_num
+			}`))
+			ctx := context.CreateRoot(bCtx, ast, customResolver)
+			analyzer.AnalyzeProgram(ctx)
+			Expect(ctx.Diagnostics.Ok()).To(BeFalse())
+			Expect((*ctx.Diagnostics)[0].Message).To(ContainSubstring("named outputs and requires a routing table"))
+		})
+
+		It("Should accept select{} with boolean discriminator and string-literal chain bodies", func(bCtx SpecContext) {
+			customResolver := symbol.CompoundResolver{
+				selector.SymbolResolver,
+				symbol.MapResolver{
+					"flag": symbol.Symbol{
+						Name: "flag",
+						Kind: symbol.KindChannel,
+						Type: types.Chan(types.U8()),
+					},
+					"log_str": symbol.Symbol{
+						Name: "log_str",
+						Kind: symbol.KindChannel,
+						Type: types.Chan(types.String()),
+					},
+				},
+			}
+			ast := MustSucceed(parser.Parse(`
+			flag -> select{} -> {
+			    true: "high" -> log_str,
+			    false: "low" -> log_str
 			}`))
 			ctx := context.CreateRoot(bCtx, ast, customResolver)
 			analyzer.AnalyzeProgram(ctx)

--- a/arc/go/text/text_test.go
+++ b/arc/go/text/text_test.go
@@ -1402,10 +1402,8 @@ var _ = Describe("Text", func() {
 				    ch = ch + 1
 				}
 
-				func alarm{} (value f64) {}
-
 				demux{threshold=100.0} -> {
-				    high: increment{ch=counter} -> alarm{}
+				    high: increment{ch=counter}
 				}`
 				parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
 				inter, diagnostics := text.Analyze(ctx, parsedText, resolver)

--- a/integration/tests/arc/stage_routing.py
+++ b/integration/tests/arc/stage_routing.py
@@ -60,6 +60,15 @@ sequence main {
     }
     stage decide_stage_abort {
         "decide_stage_abort" -> routing_stage_log
+        next_cmd => chain_body_hold
+    }
+
+    stage chain_body_hold {
+        "chain_body_hold" -> routing_stage_log
+        routing_flag -> select{} -> {
+            true: "chain_true" -> routing_stage_log,
+            false: "chain_false" -> routing_stage_log
+        }
         next_cmd => done
     }
 
@@ -76,7 +85,10 @@ class StageRouting(ArcConsoleCase):
     Exercises both select{} and a custom multi-output function routing tables
     targeting stages within the same sequence.
     Phase 1 uses select to route based on a boolean flag.
-    Phase 2 uses decide_stage to route to vent/press/abort based on sensor thresholds."""
+    Phase 2 uses decide_stage to route to vent/press/abort based on sensor thresholds.
+    Phase 3 uses select with multi-node case bodies that write string literals
+    to a channel, verifying that case-body chains type-check via chain semantics
+    rather than against the select's discriminator output."""
 
     arc_source = ARC_STAGE_ROUTING
     arc_name_prefix = "StageRouting"
@@ -145,6 +157,18 @@ class StageRouting(ArcConsoleCase):
         self._write_sensor(90.0)
         self.wait_for_eq("routing_stage_log", "decide_stage_abort", is_virtual=True)
 
-        self.log("[decide_stage] Advancing decide_stage_abort -> done")
+        self.log("[decide_stage] Advancing decide_stage_abort -> chain_body_hold")
+        self._advance()
+        self.wait_for_eq("routing_stage_log", "chain_body_hold", is_virtual=True)
+
+        # Phase 3: multi-node case body — `true: "literal" -> str_channel`
+        self.log("[chain_body] flag=1 -> 'chain_true' written to log")
+        self._write_flag(1)
+        self.wait_for_eq("routing_stage_log", "chain_true", is_virtual=True)
+
+        self.log("[chain_body] flag=0 -> 'chain_false' written to log")
+        self._write_flag(0)
+        self.wait_for_eq("routing_stage_log", "chain_false", is_virtual=True)
+
         self._advance()
         self.wait_for_eq("routing_stage_log", "done", is_virtual=True)


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4199](https://linear.app/synnax/issue/SY-4199/arc-select-updates)

## Description

Multi-node case bodies in Arc `select{}` routing tables were rejected by the analyzer. Every node in a case body was validated against the select's discriminator output type instead of threading types through the chain.

Meaning that writing a literal to a channel inside a case (e.g. `true: "text" -> log_str`) failed with a spurious type mismatch.

This now type-checks:

```arc
flag -> select{} -> {
    true:  "on"  -> log_str,
    false: "off" -> log_str
}

sensor -> demux{} -> {
    high: "above" -> log_str,
    low:  1 -> log_num
}

```

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a type-checking bug in the Arc analyzer where every node in a `select{}`/routing-table case body chain was validated against the discriminator's output type instead of threading types through the chain. The fix introduces `inferFlowNodeOutputType` to compute each intermediate node's output type, and refactors the repeated output-resolution logic into `resolveFuncOutput`.

- **`flow.go`**: `analyzeOutputRoutingTable` now initialises `nodeSourceType` from the routing entry's output type and updates it via `inferFlowNodeOutputType` after each non-terminal node; `resolveFuncOutput` is extracted as a shared helper for both `parseFunction` and the new inference path.
- **`flow_test.go`**: Six new table-driven cases cover the happy path (`demux`-chained literals), the negative path (integer literal to a string channel), named-output faults in non-terminal position, the motivating `select{}` scenario from the PR description, channel inference in mid-chain, and unresolved symbol reporting.
- **`stage_routing.py`**: A new `chain_body_hold` stage exercises the end-to-end behavior against a running system.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to the routing-table chain type-checker, covers both positive and negative cases, and does not affect any other analysis paths.

The fix is mechanically straightforward: replace a constant source type with one that is threaded through the chain. All three node kinds (expression, function, identifier) are handled in `inferFlowNodeOutputType`, the extracted `resolveFuncOutput` is exercised by both callers' tests, and the zero-type escape hatch is only reached when a prior diagnostic has already been emitted. No regressions in existing paths are expected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| arc/go/analyzer/flow/flow.go | Core fix: `analyzeOutputRoutingTable` now threads `nodeSourceType` through the chain via the new `inferFlowNodeOutputType` helper; `resolveFuncOutput` is extracted to eliminate duplicate output-resolution logic. Logic is sound. |
| arc/go/analyzer/flow/flow_test.go | Six new `It` blocks cover valid chains, type-mismatch rejection, named-output faults, the motivating `select{}` scenario, mid-chain channel inference, and unresolved symbol reporting. Both positive and negative cases are present. |
| arc/go/text/text_test.go | Removes the now-unnecessary void terminal function (`alarm{}`) from a chain-body test, simplifying it to a single-node entry. |
| integration/tests/arc/stage_routing.py | Adds a new `chain_body_hold` stage and corresponding Phase 3 test steps that verify string-literal chain bodies execute correctly end-to-end. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["analyzeOutputRoutingTable(entry)"] --> B["nodeSourceType = outputType.Type"]
    B --> C{"for each flowNode in entry"}
    C --> D["analyzeRoutingTargetWithParam(nodeSourceType, ...)"]
    D --> E{"isLastNode?"}
    E -- "No" --> F["inferFlowNodeOutputType(flowNode)"]
    F --> G{"node kind?"}
    G -- "Expression" --> H["atypes.InferFromExpression → exprType"]
    G -- "Function" --> I["resolveFuncOutput → fn default output\nor emit diagnostic"]
    G -- "Identifier (channel)" --> J["sym.Type.Unwrap() → channel value type"]
    G -- "Unknown" --> K["types.Type{} (skip check)"]
    H --> L["nodeSourceType = inferred type"]
    I --> L
    J --> L
    K --> L
    L --> C
    E -- "Yes" --> M["Done: last node type-checked\nagainst nodeSourceType"]
```

<sub>Reviews (3): Last reviewed commit: ["SY-4199: Add tests"](https://github.com/synnaxlabs/synnax/commit/cfd857338eec4d5e5fde1021163f1fa3e9404958) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=32922390)</sub>

<!-- /greptile_comment -->