### PR TITLE
SY-4169: Fix Arc Formatting for Top-Level Anonymous Config Values

### DIFF
--- a/arc/go/formatter/formatter_test.go
+++ b/arc/go/formatter/formatter_test.go
@@ -294,6 +294,9 @@ var _ = Describe("Formatter", func() {
 		Entry("dotted identifier with anonymous config in flow stays on one line",
 			`time.interval{1s} -> "hello" -> arc_string_test`,
 			"time.interval{1s} -> \"hello\" -> arc_string_test\n"),
+		Entry("plain identifier with anonymous config in flow stays on one line",
+			"interval{1s} -> output",
+			"interval{1s} -> output\n"),
 	)
 
 	DescribeTable("Next Statement",

--- a/arc/go/formatter/formatter_test.go
+++ b/arc/go/formatter/formatter_test.go
@@ -291,6 +291,9 @@ var _ = Describe("Formatter", func() {
 		Entry("flow with multiple config values",
 			"sensor -> filter{threshold=10} -> scale{factor=2} -> output",
 			"sensor -> filter{threshold=10} -> scale{factor=2} -> output\n"),
+		Entry("dotted identifier with anonymous config in flow stays on one line",
+			`time.interval{1s} -> "hello" -> arc_string_test`,
+			"time.interval{1s} -> \"hello\" -> arc_string_test\n"),
 	)
 
 	DescribeTable("Next Statement",

--- a/arc/go/formatter/printer.go
+++ b/arc/go/formatter/printer.go
@@ -398,31 +398,11 @@ func (p *printer) isConfigValuesBlock(idx int, tokens []antlr.Token) bool {
 			return true
 		}
 	}
-	if p.isEmptyBlock(idx, tokens) {
-		return true
-	}
-	return p.hasAssignInBraceBlock(idx, tokens)
-}
-
-func (p *printer) hasAssignInBraceBlock(idx int, tokens []antlr.Token) bool {
-	braceDepth := 1
-	for i := idx + 1; i < len(tokens); i++ {
-		tokType := tokens[i].GetTokenType()
-		switch tokType {
-		case parser.ArcLexerLBRACE:
-			braceDepth++
-		case parser.ArcLexerRBRACE:
-			braceDepth--
-			if braceDepth == 0 {
-				return false
-			}
-		case parser.ArcLexerASSIGN:
-			if braceDepth == 1 {
-				return true
-			}
-		}
-	}
-	return false
+	// Walk exhausted: the brace sits at the start of the token stream with
+	// only an identifier (and possibly a dotted member chain) before it.
+	// Block-body forms (func/stage/sequence bodies) are detected earlier in
+	// detectBraceContext, so this must be a callable's config values block.
+	return true
 }
 
 func (p *printer) shouldInlineConfigValues(idx int, tokens []antlr.Token) bool {


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4169](https://linear.app/synnax/issue/SY-4169)

## Description

The Arc formatter expanded `time.interval{1s} -> "hello" -> arc_string_test` to:

```
time.interval {
    1s
} -> "hello" -> arc_string_test
```

`isConfigValuesBlock` walks back through the token stream from a `{` to determine whether it opens a callable's config values block or a generic code block. When the walk reached the start of the token stream, it fell back to `hasAssignInBraceBlock`, which only returned true for blocks containing `=` (named args). Positional-only invocations at the top of a file with no preceding statement boundary (dotted callable like `time.interval{1s}`, or anything followed by a flow operator with nothing before it) therefore got misclassified as generic blocks and expanded to multi-line.

The fix returns `true` on walk exhaustion. Block-body forms (`func`/`stage`/`sequence` bodies) are detected by separate checks earlier in `detectBraceContext`, so any brace that reaches `isConfigValuesBlock` with only an identifier (and optional dotted member chain) before it must be a callable's config values block. The unused `hasAssignInBraceBlock` helper is removed.

Includes a regression test in `Flow Statements` covering the exact input from the report.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a mis-classification of top-level anonymous positional config-values blocks (e.g. `time.interval{1s}`) as generic code blocks, which caused the Arc formatter to expand them to multi-line. The root cause was that `isConfigValuesBlock` fell back to `hasAssignInBraceBlock` — which only recognised named args (`=`) — when the backward walk exhausted at the start of the token stream.

- **`printer.go`**: Replaces the `isEmptyBlock` + `hasAssignInBraceBlock` fallback chain with an unconditional `return true` on walk exhaustion. This is safe because `func`/`stage`/`sequence` body forms are classified by earlier checks in `detectBraceContext` and never reach `isConfigValuesBlock`.
- **`formatter_test.go`**: Adds two \"Flow Statements\" table entries — the exact dotted-callable case from the bug report (`time.interval{1s} -> …`) and a plain-identifier equivalent (`interval{1s} -> output`) — pinning the corrected behaviour against future regressions.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The change is a narrowly scoped fix to a single fallback branch in the brace-context classifier, and the earlier checks in `detectBraceContext` ensure no block-body form can reach the changed code path.

The backward walk in `isConfigValuesBlock` was already correct for all non-exhausted paths; only the terminal case (top-of-file positional invocation) was wrong. Replacing `hasAssignInBraceBlock` with an unconditional `return true` is sound because `func`/`stage`/`sequence` bodies are fully classified before `isConfigValuesBlock` is ever called. Both the dotted and non-dotted positional cases are now covered by regression tests.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| arc/go/formatter/printer.go | Removes the broken `hasAssignInBraceBlock` fallback and the `isEmptyBlock` check; replaces them with an unconditional `return true` when the backward walk exhausts — correctly classifying any top-level `IDENT{…}` as a callable's config-values block. |
| arc/go/formatter/formatter_test.go | Adds two regression entries to the "Flow Statements" table: the exact dotted-callable case from the bug report (`time.interval{1s}`) and the non-dotted equivalent (`interval{1s}`), both at the top of the file with no preceding statement. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["detectBraceContext(idx)"] --> B{"isFuncConfigBlock?\n(func NAME {)"}
    B -->|yes| C[braceContextConfigBlock]
    B -->|no| D{"isStageBody?\n(stage / stage NAME {)"}
    D -->|yes| E[braceContextStageBody]
    D -->|no| F{"isSequenceBody?\n(sequence / sequence NAME {)"}
    F -->|yes| G[braceContextSequenceBody]
    F -->|no| H["isConfigValuesBlock(idx)"]
    H --> H1{"tokens[idx-1] == IDENTIFIER?"}
    H1 -->|no| I[return false]
    H1 -->|yes| H2["Walk backward through tokens"]
    H2 --> J{"Hit IF/FOR/ELSE/FUNC/STAGE/SEQUENCE?"}
    J -->|yes| K[return false]
    J -->|no| L{"Hit LBRACE/RBRACE/COLON/ARROW/ASSIGN/RETURN?"}
    L -->|yes| M[return true]
    L -->|no| N{"Walk exhausted"}
    N -->|OLD| O_OLD["false - braceContextBlock bug"]
    N -->|NEW| O_NEW["true - braceContextConfigValues fix"]
```

<sub>Reviews (2): Last reviewed commit: ["Add regression test for plain identifier..."](https://github.com/synnaxlabs/synnax/commit/1956849bbdbbd325c8afed6196e7951793052650) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33317604)</sub>

<!-- /greptile_comment -->