### PR TITLE
SY-4185: Fix flakey storage layer test

### DIFF
--- a/core/pkg/storage/layer_test.go
+++ b/core/pkg/storage/layer_test.go
@@ -36,23 +36,21 @@ var _ = Describe("storage", func() {
 		AfterEach(func() { Expect(os.RemoveAll(tempDir)).ToNot(HaveOccurred()) })
 		Describe("Acquiring a lock", func() {
 			It("Should return an error if the lock is already acquired", func(ctx SpecContext) {
-				store := MustSucceed(storage.OpenLayer(ctx, cfg))
+				MustOpen(storage.OpenLayer(ctx, cfg))
 				Expect(storage.OpenLayer(ctx, cfg)).Error().To(HaveOccurred())
-				Expect(store.Close()).To(Succeed())
 			})
 		})
 		Describe("Permissions", func() {
 			// These two tests are failing on Windows because VFS cannot create a
-			// directory on Windows with custom permissions – all directories are created
-			// with 777.
+			// directory on Windows with custom permissions – all directories are
+			// created with 777.
 			if !strings.HasPrefix(runtime.GOOS, "windows") {
 				Describe("Name Directory", func() {
 					It("Should set the correct permissions on the storage directory", func(ctx SpecContext) {
 						cfg.Perm = storage.DefaultLayerConfig.Perm
-						store := MustSucceed(storage.OpenLayer(ctx, cfg))
+						MustOpen(storage.OpenLayer(ctx, cfg))
 						stat := MustSucceed(os.Stat(cfg.Dirname))
 						Expect(stat.Mode().Perm()).To(Equal(cfg.Perm))
-						Expect(store.Close()).To(Succeed())
 					})
 				})
 				Describe("Existing Directory", func() {
@@ -66,8 +64,7 @@ var _ = Describe("storage", func() {
 					It("Should return an error if the directory exists but has insufficient permissions", func(ctx SpecContext) {
 						// use os.Stat to check the dir permissions
 						cfg.Perm = xfs.UserRWX
-						_, err := storage.OpenLayer(ctx, cfg)
-						Expect(err).To(HaveOccurred())
+						Expect(storage.OpenLayer(ctx, cfg)).Error().To(HaveOccurred())
 					})
 				})
 			}
@@ -75,8 +72,7 @@ var _ = Describe("storage", func() {
 		Describe("In-Memory", func() {
 			It("Should open a memory backed version of storage", func(ctx SpecContext) {
 				cfg.InMemory = new(true)
-				store := MustSucceed(storage.OpenLayer(ctx, cfg))
-				Expect(store.Close()).To(Succeed())
+				MustOpen(storage.OpenLayer(ctx, cfg))
 			})
 		})
 	})
@@ -97,7 +93,7 @@ var _ = Describe("storage", func() {
 			Entry("Directory not set",
 				func(cfg storage.LayerConfig) storage.LayerConfig {
 					cfg.Dirname = ""
-					*cfg.InMemory = false
+					cfg.InMemory = new(false)
 					return cfg
 				},
 				"dirname",
@@ -105,7 +101,7 @@ var _ = Describe("storage", func() {
 			Entry("Directory not set, mem-backed",
 				func(cfg storage.LayerConfig) storage.LayerConfig {
 					cfg.Dirname = ""
-					*cfg.InMemory = true
+					cfg.InMemory = new(true)
 					return cfg
 				},
 				"",


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue number and link -->

[SY-4185](https://linear.app/synnax/issue/SY-4185/fix-flakey-corepkgstoragelayer-testgo)

## Description

<!-- Write a description describing the changes. -->

Fix flakey storage layer test caused by directly mutating the default values of the storage layer config.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a race condition in the storage layer tests where `*cfg.InMemory = false` and `*cfg.InMemory = true` were dereferencing and mutating the shared pointer stored in `DefaultLayerConfig.InMemory`, causing cross-test contamination when tests ran in parallel or in sequence.

- The two `ServiceConfig.Validate` table entries now use `cfg.InMemory = new(false)` / `cfg.InMemory = new(true)` to assign fresh pointers, leaving `DefaultLayerConfig.InMemory` untouched.
- Several tests that previously captured the `*Layer` return value solely to call `Close()` at the end have been migrated to `MustOpen(...)`, which uses Ginkgo's `DeferCleanup` to register teardown automatically.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The change is confined to test code and correctly addresses the root cause of the flakiness without introducing new risks.

Both changes are straightforward and correct. Using `new(false)` / `new(true)` instead of dereferencing the shared `DefaultLayerConfig.InMemory` pointer eliminates the cross-test state mutation that caused flakiness. The migration from manual `Close()` calls to `MustOpen` is a well-supported pattern in this codebase and `DeferCleanup` integrates correctly with Ginkgo's scope lifecycle (runs after the It block, before AfterEach), so the directory teardown order is preserved.

No files require special attention. The only changed file is the test file, and the fix is minimal and targeted.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| core/pkg/storage/layer_test.go | Fixes flaky test by replacing `*cfg.InMemory = false/true` (which mutated the shared DefaultLayerConfig pointer) with `cfg.InMemory = new(false/true)`, and replaces manual Close() calls with the MustOpen helper that defers cleanup via Ginkgo's DeferCleanup. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[BeforeEach: create tempDir, cfg with nil InMemory] --> B[It block runs]
    B --> C{Test mutates cfg.InMemory?}
    C -- "OLD: *cfg.InMemory = false\nMutates DefaultLayerConfig!" --> D[DefaultLayerConfig.InMemory corrupted\nFlaky subsequent tests]
    C -- "NEW: cfg.InMemory = new(false)\nFresh pointer" --> E[DefaultLayerConfig.InMemory unchanged\nTests isolated]
    E --> F[storage.OpenLayer or Validate called]
    F --> G{Open or Validate test?}
    G -- "Open test uses MustOpen" --> H[DeferCleanup: Layer.Close registered]
    G -- "Validate test" --> I[Validate returns error, no Layer opened]
    H --> J[It block ends]
    I --> J
    J --> K[DeferCleanup fires: Layer.Close called]
    K --> L[AfterEach: os.RemoveAll tempDir]
```

<sub>Reviews (1): Last reviewed commit: ["Fix flakey storage layer test"](https://github.com/synnaxlabs/synnax/commit/8d4dccacbbdfc75ed502958c980c995f5d3457c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33319607)</sub>

<!-- /greptile_comment -->