### PR TITLE
SY-4216: Fix Flakey Gorp Notify Test

### DIFF
--- a/x/go/gorp/key_codec_test.go
+++ b/x/go/gorp/key_codec_test.go
@@ -16,6 +16,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/synnaxlabs/x/gorp"
+	"github.com/synnaxlabs/x/kv/memkv"
 	. "github.com/synnaxlabs/x/testutil"
 )
 
@@ -376,16 +377,19 @@ var _ = Describe("KeyCodec", func() {
 	})
 
 	Describe("Observe with non-int32 keys", func() {
+		// Each spec opens its own *gorp.DB so that committed entries don't leak into
+		// the suite-wide db and pollute other specs (e.g. the iteration tests above,
+		// which scan all entries of a given type).
 		It("Should decode uint64 keys on delete notifications", func(ctx SpecContext) {
-			uint64Table := MustSucceed(gorp.OpenTable(ctx, gorp.TableConfig[uint64, uint64Entry]{DB: db}))
+			localDB := DeferClose(gorp.Wrap(memkv.New()))
+			uint64Table := MustSucceed(gorp.OpenTable(ctx, gorp.TableConfig[uint64, uint64Entry]{DB: localDB}))
 			defer func() { Expect(uint64Table.Close()).To(Succeed()) }()
 
 			Expect(gorp.NewCreate[uint64, uint64Entry]().
 				Entry(&uint64Entry{ID: math.MaxUint64, Data: "data"}).
-				Exec(ctx, db)).To(Succeed())
+				Exec(ctx, localDB)).To(Succeed())
 
-			tx := db.OpenTx()
-			defer func() { Expect(tx.Close()).To(Succeed()) }()
+			tx := DeferClose(localDB.OpenTx())
 			Expect(gorp.NewDelete[uint64, uint64Entry]().
 				Where(gorp.MatchKeys[uint64, uint64Entry](math.MaxUint64)).Exec(ctx, tx)).To(Succeed())
 
@@ -403,11 +407,11 @@ var _ = Describe("KeyCodec", func() {
 		})
 
 		It("Should decode int16 keys on set notifications", func(ctx SpecContext) {
-			int16Table := MustSucceed(gorp.OpenTable(ctx, gorp.TableConfig[int16, int16Entry]{DB: db}))
+			localDB := DeferClose(gorp.Wrap(memkv.New()))
+			int16Table := MustSucceed(gorp.OpenTable(ctx, gorp.TableConfig[int16, int16Entry]{DB: localDB}))
 			defer func() { Expect(int16Table.Close()).To(Succeed()) }()
 
-			tx := db.OpenTx()
-			defer func() { Expect(tx.Close()).To(Succeed()) }()
+			tx := DeferClose(localDB.OpenTx())
 			Expect(gorp.NewCreate[int16, int16Entry]().
 				Entry(&int16Entry{ID: -500, Data: "data"}).
 				Exec(ctx, tx)).To(Succeed())

--- a/x/go/gorp/key_codec_test.go
+++ b/x/go/gorp/key_codec_test.go
@@ -377,19 +377,20 @@ var _ = Describe("KeyCodec", func() {
 	})
 
 	Describe("Observe with non-int32 keys", func() {
-		// Each spec opens its own *gorp.DB so that committed entries don't leak into
-		// the suite-wide db and pollute other specs (e.g. the iteration tests above,
-		// which scan all entries of a given type).
+		var notifyDB *gorp.DB
+		BeforeEach(func() {
+			notifyDB = DeferClose(gorp.Wrap(memkv.New()))
+			tx = DeferClose(notifyDB.OpenTx())
+		})
+
 		It("Should decode uint64 keys on delete notifications", func(ctx SpecContext) {
-			localDB := DeferClose(gorp.Wrap(memkv.New()))
-			uint64Table := MustSucceed(gorp.OpenTable(ctx, gorp.TableConfig[uint64, uint64Entry]{DB: localDB}))
+			uint64Table := MustSucceed(gorp.OpenTable(ctx, gorp.TableConfig[uint64, uint64Entry]{DB: notifyDB}))
 			defer func() { Expect(uint64Table.Close()).To(Succeed()) }()
 
 			Expect(gorp.NewCreate[uint64, uint64Entry]().
 				Entry(&uint64Entry{ID: math.MaxUint64, Data: "data"}).
-				Exec(ctx, localDB)).To(Succeed())
+				Exec(ctx, notifyDB)).To(Succeed())
 
-			tx := DeferClose(localDB.OpenTx())
 			Expect(gorp.NewDelete[uint64, uint64Entry]().
 				Where(gorp.MatchKeys[uint64, uint64Entry](math.MaxUint64)).Exec(ctx, tx)).To(Succeed())
 
@@ -407,11 +408,9 @@ var _ = Describe("KeyCodec", func() {
 		})
 
 		It("Should decode int16 keys on set notifications", func(ctx SpecContext) {
-			localDB := DeferClose(gorp.Wrap(memkv.New()))
-			int16Table := MustSucceed(gorp.OpenTable(ctx, gorp.TableConfig[int16, int16Entry]{DB: localDB}))
+			int16Table := MustSucceed(gorp.OpenTable(ctx, gorp.TableConfig[int16, int16Entry]{DB: notifyDB}))
 			defer func() { Expect(int16Table.Close()).To(Succeed()) }()
 
-			tx := DeferClose(localDB.OpenTx())
 			Expect(gorp.NewCreate[int16, int16Entry]().
 				Entry(&int16Entry{ID: -500, Data: "data"}).
 				Exec(ctx, tx)).To(Succeed())


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4216](https://linear.app/synnax/issue/SY-4216)

## Description

The two `Observe with non-int32 keys` specs in `x/go/gorp/key_codec_test.go` called `tx.Commit(ctx)` against the suite-wide `*gorp.DB` created in `BeforeSuite`. The `int16` notify spec in particular committed an `int16Entry{ID: -500}` and never deleted it, so the row leaked into every subsequent spec in the same proc.

Whenever Ginkgo's randomization happened to schedule that spec before `Should iterate int16 entries in big-endian byte order`, the iteration spec did a full `iter.First()`/`iter.Next()` scan, picked up the orphan `-500`, and failed `HaveLen(3)` with `[1, 300, -500, -1]`. The byte ordering itself was correct (`0x0001 < 0x012C < 0xFE0C < 0xFFFF`) — only the count was wrong.

Fix: give each notify spec its own in-memory `*gorp.DB` (`gorp.Wrap(memkv.New())`) so its `Commit` can no longer pollute the shared store. Verified with five `ginkgo --randomize-all` runs on different seeds (313/313 passing each time).

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a test isolation bug where two "Observe with non-int32 keys" specs in `key_codec_test.go` shared the suite-wide `*gorp.DB`, allowing committed data from one spec to leak into others when Ginkgo randomized execution order.

- Each notify spec now gets its own ephemeral `*gorp.DB` (via `gorp.Wrap(memkv.New())`) created in a nested `BeforeEach`, ensuring `tx.Commit` can never pollute the shared store.
- The outer `BeforeEach` still opens a `db.OpenTx()` for every spec in the top-level `Describe`, including these two — that transaction is registered with `DeferClose` but immediately superseded by the inner `BeforeEach`, resulting in a harmless extra allocation that is still properly cleaned up.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is confined to test isolation and does not touch any production code paths.

The fix correctly scopes each flaky notify spec to its own ephemeral in-memory DB, eliminating cross-spec state leakage. The outer BeforeEach still fires and opens an extra transaction against the shared DB, but DeferClose registers it for cleanup so it is discarded without side effects. No production logic is modified.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| x/go/gorp/key_codec_test.go | Added a nested BeforeEach that creates an isolated in-memory DB and tx for each notify spec, eliminating state leakage into the shared suite DB. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Ginkgo
    participant OuterBeforeEach
    participant InnerBeforeEach
    participant Spec
    participant DeferClose

    Ginkgo->>OuterBeforeEach: run (each spec)
    OuterBeforeEach->>DeferClose: register db.OpenTx() for cleanup
    OuterBeforeEach-->>Ginkgo: "tx = db.OpenTx()"

    Ginkgo->>InnerBeforeEach: run (notify specs only)
    InnerBeforeEach->>DeferClose: register gorp.Wrap(memkv.New()) for cleanup
    InnerBeforeEach->>DeferClose: register notifyDB.OpenTx() for cleanup
    InnerBeforeEach-->>Ginkgo: "tx = notifyDB.OpenTx() [reassigned]"

    Ginkgo->>Spec: run It block
    Spec->>Spec: Create/Delete via notifyDB / tx
    Spec->>Spec: tx.Commit(ctx)

    Ginkgo->>DeferClose: cleanup LIFO
    DeferClose->>DeferClose: Close notifyDB tx
    DeferClose->>DeferClose: Close notifyDB
    DeferClose->>DeferClose: Close outer db.OpenTx() (unused)
```

<sub>Reviews (2): Last reviewed commit: ["Pull local DB setup into BeforeEach"](https://github.com/synnaxlabs/synnax/commit/d8e2f2262202446884cad7358499ce86204b46f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33519083)</sub>

<!-- /greptile_comment -->