### PR TITLE
SY-4215: Fix Arc Analyzer Type Substitution Staleness

### DIFF
--- a/arc/go/analyzer/context/context.go
+++ b/arc/go/analyzer/context/context.go
@@ -192,7 +192,7 @@ func NewRoot[ASTNode antlr.ParserRuleContext](
 	root *symbol.Symbol,
 ) Context[ASTNode] {
 	if root == nil {
-		root = symbol.NewRoot(nil)
+		root = symbol.NewRoot(nil, nil)
 	}
 	return Context[ASTNode]{
 		Context:     ctx,

--- a/arc/go/analyzer/expression/expression_suite_test.go
+++ b/arc/go/analyzer/expression/expression_suite_test.go
@@ -29,7 +29,7 @@ func TestExpression(t *testing.T) {
 }
 
 func buildExpressionRoot(extras []symbol.Symbol) *symbol.Symbol {
-	root := symbol.NewRoot(nil, stl.Symbols...)
+	root := symbol.NewRoot(nil, stl.NewSymbols())
 	for i := range extras {
 		s := extras[i]
 		root.Parent.AddChild(&s)

--- a/arc/go/analyzer/flow/flow.go
+++ b/arc/go/analyzer/flow/flow.go
@@ -210,7 +210,6 @@ func parseFunction(ctx context.Context[parser.IFunctionContext], prevNode parser
 	}
 }
 
-
 func analyzeIdentifier(
 	ctx context.Context[parser.IIdentifierContext],
 	prevNode parser.IFlowNodeContext,

--- a/arc/go/analyzer/flow/flow.go
+++ b/arc/go/analyzer/flow/flow.go
@@ -12,6 +12,8 @@
 package flow
 
 import (
+	"fmt"
+
 	"github.com/antlr4-go/antlr/v4"
 	"github.com/synnaxlabs/arc/analyzer/context"
 	"github.com/synnaxlabs/arc/analyzer/expression"
@@ -24,13 +26,23 @@ import (
 	"github.com/synnaxlabs/x/set"
 )
 
+// freshenKey derives a unique freshening prefix from a call site's AST node so
+// each invocation of a polymorphic function gets its own set of type variables.
+// Without this, two calls to math.avg with different concrete types would unify
+// against a single shared T and conflict.
+func freshenKey(node antlr.ParserRuleContext, name string) string {
+	tok := node.GetStart()
+	return fmt.Sprintf("%s_%d_%d", name, tok.GetLine(), tok.GetColumn())
+}
+
 func AnalyzeSingleFunction(ctx context.Context[parser.IFunctionContext]) {
 	funcType, name := resolveFunc(ctx, ctx.AST)
 	if funcType == nil {
 		return
 	}
-	validateFuncConfig(ctx, name, funcType.Type, ctx.AST.ConfigValues(), ctx.AST)
-	for _, input := range funcType.Type.Inputs {
+	freshType := types.Freshen(funcType.Type, freshenKey(ctx.AST, name))
+	validateFuncConfig(ctx, name, freshType, ctx.AST.ConfigValues(), ctx.AST)
+	for _, input := range freshType.Inputs {
 		if input.Value == nil {
 			ctx.Diagnostics.Add(diagnostics.Errorf(ctx.AST,
 				"standalone function '%s' has required input '%s' with no source; "+
@@ -79,10 +91,12 @@ func parseFunction(ctx context.Context[parser.IFunctionContext], prevNode parser
 		return
 	}
 
+	freshType := types.Freshen(funcType.Type, freshenKey(ctx.AST, name))
+
 	validateFuncConfig(
 		ctx,
 		name,
-		funcType.Type,
+		freshType,
 		ctx.AST.ConfigValues(),
 		ctx.AST,
 	)
@@ -92,7 +106,7 @@ func parseFunction(ctx context.Context[parser.IFunctionContext], prevNode parser
 
 	// Dual-shape ExecBoth (see symbol.ExecBoth): upstream is a trigger, not
 	// a typed input.
-	upstreamIsTrigger := funcType.Exec == symbol.ExecBoth && len(funcType.Type.Config) > 0
+	upstreamIsTrigger := funcType.Exec == symbol.ExecBoth && len(freshType.Config) > 0
 
 	if prevIDNode := prevNode.Identifier(); prevIDNode != nil {
 		idName := prevIDNode.IDENTIFIER().GetText()
@@ -106,8 +120,8 @@ func parseFunction(ctx context.Context[parser.IFunctionContext], prevNode parser
 			ctx.Diagnostics.Add(diagnostics.Errorf(prevIDNode, "%s is not a channel", idName))
 			return
 		}
-		if !upstreamIsTrigger && len(funcType.Type.Inputs) > 0 {
-			param := funcType.Type.Inputs[0]
+		if !upstreamIsTrigger && len(freshType.Inputs) > 0 {
+			param := freshType.Inputs[0]
 			if idSym.Type.Kind != types.KindChan {
 				ctx.Diagnostics.Add(diagnostics.Errorf(ctx.AST,
 					"%s is not a valid channel",
@@ -128,15 +142,15 @@ func parseFunction(ctx context.Context[parser.IFunctionContext], prevNode parser
 					idName,
 					chanValueType,
 					name,
-					param,
+					funcType.Type.Inputs[0],
 				))
 				return
 			}
 		}
 	} else if prevExpr := prevNode.Expression(); prevExpr != nil {
 		exprType := atypes.InferFromExpression(context.Child(ctx, prevExpr)).Unwrap()
-		if !upstreamIsTrigger && len(funcType.Type.Inputs) > 0 {
-			param := funcType.Type.Inputs[0]
+		if !upstreamIsTrigger && len(freshType.Inputs) > 0 {
+			param := freshType.Inputs[0]
 			if err := atypes.Check(
 				ctx.Constraints,
 				exprType,
@@ -148,7 +162,7 @@ func parseFunction(ctx context.Context[parser.IFunctionContext], prevNode parser
 					"expression type %s does not match func %s parameter type %s",
 					exprType,
 					name,
-					param.Type,
+					funcType.Type.Inputs[0].Type,
 				))
 				return
 			}
@@ -169,13 +183,14 @@ func parseFunction(ctx context.Context[parser.IFunctionContext], prevNode parser
 			}
 		}
 
-		if !upstreamIsTrigger && !hasRoutingTableBetween && len(funcType.Type.Inputs) > 1 {
+		if !upstreamIsTrigger && !hasRoutingTableBetween && len(freshType.Inputs) > 1 {
 			ctx.Diagnostics.Add(diagnostics.Errorf(ctx.AST, "%s has more than one parameter", name))
 			return
 		}
-		if !upstreamIsTrigger && !hasRoutingTableBetween && len(funcType.Type.Inputs) > 0 {
-			t := funcType.Type.Inputs[0].Type
-			prevOutputType := resolveFuncOutput(ctx, prevFuncType.Type, prevFuncName,
+		if !upstreamIsTrigger && !hasRoutingTableBetween && len(freshType.Inputs) > 0 {
+			t := freshType.Inputs[0].Type
+			prevFreshType := types.Freshen(prevFuncType.Type, freshenKey(prevFuncNode, prevFuncName))
+			prevOutputType := resolveFuncOutput(ctx, prevFreshType, prevFuncName,
 				"'"+name+"' expects an input parameter")
 			if !prevOutputType.IsValid() {
 				return
@@ -186,7 +201,7 @@ func parseFunction(ctx context.Context[parser.IFunctionContext], prevNode parser
 					"return type %s of %s is not equal to argument type %s of %s",
 					prevOutputType,
 					prevFuncName,
-					t,
+					funcType.Type.Inputs[0].Type,
 					name,
 				))
 				return
@@ -194,6 +209,7 @@ func parseFunction(ctx context.Context[parser.IFunctionContext], prevNode parser
 		}
 	}
 }
+
 
 func analyzeIdentifier(
 	ctx context.Context[parser.IIdentifierContext],

--- a/arc/go/analyzer/imports_test.go
+++ b/arc/go/analyzer/imports_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/synnaxlabs/arc/symbol"
 	. "github.com/synnaxlabs/arc/symbol/testutil"
 	"github.com/synnaxlabs/arc/types"
-	"github.com/synnaxlabs/x/lsp/doc"
 	. "github.com/synnaxlabs/x/testutil"
 )
 
@@ -30,7 +29,8 @@ var _ = Describe("Import Pass", func() {
 		dynChannels := StaticResolver{
 			{Name: "ch", Kind: symbol.KindChannel, Type: types.Chan(types.U8()), ID: 10},
 		}
-		timeModule := symbol.NewModule("time", doc.Doc{}, symbol.Symbol{
+		timeModule := &symbol.Symbol{Name: "time", Kind: symbol.KindModule}
+		timeModule.AddChild(&symbol.Symbol{
 			Name: "now",
 			Kind: symbol.KindFunction,
 			Type: types.Function(types.FunctionProperties{

--- a/arc/go/analyzer/polymorphic_test.go
+++ b/arc/go/analyzer/polymorphic_test.go
@@ -88,6 +88,25 @@ sensor_i64 -> simple{} -> out_i64`
 		analyzer.AnalyzeProgram(ctx)
 		Expect(ctx.Diagnostics.Ok()).To(BeTrue(), ctx.Diagnostics.String())
 	})
+
+	// Pins the prev-freshening contract: at each func→func boundary, the
+	// previous function is re-freshened with the same position-derived key
+	// used when it was the current function, so its solved type variables
+	// resolve through the constraint store from the earlier node analysis.
+	// A chain of three polymorphic functions hits this path twice and would
+	// silently mis-propagate types if constraint retention regressed.
+	It("Should propagate types through a chain of three polymorphic funcs", func(sCtx SpecContext) {
+		chainExtras := []symbol.Symbol{
+			{Name: "out_f32", Kind: symbol.KindChannel, Type: types.Chan(types.F32())},
+		}
+		root = NewRoot(nil, append(extras, chainExtras...)...)
+		src := `sensor_f32 -> simple{} -> simple{} -> simple{} -> out_f32`
+		ast := MustSucceed(parser.Parse(src))
+		ctx := acontext.NewRoot(sCtx, ast, root)
+		analyzer.AnalyzeProgram(ctx)
+		Expect(ctx.Diagnostics.Ok()).To(BeTrue(), ctx.Diagnostics.String())
+		Expect(ctx.Constraints.Substitutions).To(ContainElement(types.F32()))
+	})
 })
 
 var _ = Describe("Polymorphic func in module - cross-analysis", func() {

--- a/arc/go/analyzer/polymorphic_test.go
+++ b/arc/go/analyzer/polymorphic_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/synnaxlabs/arc/symbol"
 	. "github.com/synnaxlabs/arc/symbol/testutil"
 	"github.com/synnaxlabs/arc/types"
+	"github.com/synnaxlabs/x/lsp/doc"
 	. "github.com/synnaxlabs/x/testutil"
 )
 
@@ -60,14 +61,7 @@ var _ = Describe("Polymorphic func Analysis", func() {
 			ctx := acontext.NewRoot(sCtx, ast, root)
 			analyzer.AnalyzeProgram(ctx)
 			Expect(ctx.Diagnostics.Ok()).To(BeTrue(), ctx.Diagnostics.String())
-
-			simpleSymbol := MustSucceed(ctx.Scope.Resolve(ctx, "simple"))
-			aType := MustBeOk(simpleSymbol.Type.Inputs.Get("a"))
-			resolvedParam := ctx.Constraints.ApplySubstitutions(aType.Type)
-			returnType := MustBeOk(simpleSymbol.Type.Outputs.Get(ir.DefaultOutputParam))
-			resolvedReturn := ctx.Constraints.ApplySubstitutions(returnType.Type)
-			Expect(resolvedParam).To(Equal(tc.expectedType))
-			Expect(resolvedReturn).To(Equal(tc.expectedType))
+			Expect(ctx.Constraints.Substitutions).To(ContainElement(tc.expectedType))
 		},
 		Entry("infers types from channel inputs",
 			polymorphicCase{
@@ -80,4 +74,61 @@ var _ = Describe("Polymorphic func Analysis", func() {
 				expectedType: types.F32(),
 			}),
 	)
+
+	It("Should accept two calls to the same polymorphic func with different concrete types", func(sCtx SpecContext) {
+		i64Extras := []symbol.Symbol{
+			{Name: "sensor_i64", Kind: symbol.KindChannel, Type: types.Chan(types.I64())},
+			{Name: "out_f32", Kind: symbol.KindChannel, Type: types.Chan(types.F32())},
+			{Name: "out_i64", Kind: symbol.KindChannel, Type: types.Chan(types.I64())},
+		}
+		root = NewRoot(nil, append(extras, i64Extras...)...)
+		src := `sensor_f32 -> simple{} -> out_f32
+sensor_i64 -> simple{} -> out_i64`
+		ast := MustSucceed(parser.Parse(src))
+		ctx := acontext.NewRoot(sCtx, ast, root)
+		analyzer.AnalyzeProgram(ctx)
+		Expect(ctx.Diagnostics.Ok()).To(BeTrue(), ctx.Diagnostics.String())
+	})
+})
+
+var _ = Describe("Polymorphic func in module - cross-analysis", func() {
+	buildExtras := func() []symbol.Symbol {
+		c := types.NumericConstraint()
+		simple := symbol.Symbol{
+			Name: "simple",
+			Kind: symbol.KindFunction,
+			Type: types.Function(types.FunctionProperties{
+				Inputs: types.Params{{Name: "a", Type: types.Variable("T", &c)}},
+				Outputs: types.Params{
+					{Name: ir.DefaultOutputParam, Type: types.Variable("T", &c)},
+				},
+			}),
+		}
+		mod := symbol.NewModule("mymod", doc.Doc{}, simple)
+		return []symbol.Symbol{
+			*mod,
+			{Name: "sensor_f32", Kind: symbol.KindChannel, Type: types.Chan(types.F32())},
+			{Name: "sensor_i64", Kind: symbol.KindChannel, Type: types.Chan(types.I64())},
+			{Name: "out_f32", Kind: symbol.KindChannel, Type: types.Chan(types.F32())},
+			{Name: "out_i64", Kind: symbol.KindChannel, Type: types.Chan(types.I64())},
+		}
+	}
+
+	It("Should not corrupt a module's polymorphic function type across analyses", func(sCtx SpecContext) {
+		extras := buildExtras()
+
+		root1 := NewRoot(nil, extras...)
+		ast1 := MustSucceed(parser.Parse(`import mymod
+sensor_f32 -> mymod.simple{} -> out_f32`))
+		ctx1 := acontext.NewRoot(sCtx, ast1, root1)
+		analyzer.AnalyzeProgram(ctx1)
+		Expect(ctx1.Diagnostics.Ok()).To(BeTrue(), ctx1.Diagnostics.String())
+
+		root2 := NewRoot(nil, extras...)
+		ast2 := MustSucceed(parser.Parse(`import mymod
+sensor_i64 -> mymod.simple{} -> out_i64`))
+		ctx2 := acontext.NewRoot(sCtx, ast2, root2)
+		analyzer.AnalyzeProgram(ctx2)
+		Expect(ctx2.Diagnostics.Ok()).To(BeTrue(), ctx2.Diagnostics.String())
+	})
 })

--- a/arc/go/analyzer/polymorphic_test.go
+++ b/arc/go/analyzer/polymorphic_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/synnaxlabs/arc/symbol"
 	. "github.com/synnaxlabs/arc/symbol/testutil"
 	"github.com/synnaxlabs/arc/types"
-	"github.com/synnaxlabs/x/lsp/doc"
 	. "github.com/synnaxlabs/x/testutil"
 )
 
@@ -94,7 +93,7 @@ sensor_i64 -> simple{} -> out_i64`
 var _ = Describe("Polymorphic func in module - cross-analysis", func() {
 	buildExtras := func() []symbol.Symbol {
 		c := types.NumericConstraint()
-		simple := symbol.Symbol{
+		simple := &symbol.Symbol{
 			Name: "simple",
 			Kind: symbol.KindFunction,
 			Type: types.Function(types.FunctionProperties{
@@ -104,7 +103,8 @@ var _ = Describe("Polymorphic func in module - cross-analysis", func() {
 				},
 			}),
 		}
-		mod := symbol.NewModule("mymod", doc.Doc{}, simple)
+		mod := &symbol.Symbol{Name: "mymod", Kind: symbol.KindModule}
+		mod.AddChild(simple)
 		return []symbol.Symbol{
 			*mod,
 			{Name: "sensor_f32", Kind: symbol.KindChannel, Type: types.Chan(types.F32())},

--- a/arc/go/arc.go
+++ b/arc/go/arc.go
@@ -42,18 +42,20 @@ type (
 // any extras attached to the ambient prelude, and resolver installed as
 // the GlobalResolver. This is the canonical entry point for production
 // compilation: callers pass any additional static symbols (e.g. status
-// types) as extras alongside the resolver.
+// types) as extras alongside the resolver. STL symbols are freshly
+// allocated per call so no analysis can corrupt another's view of the
+// standard library.
 func NewRoot(resolver SymbolResolver, extras ...*symbol.Symbol) *symbol.Symbol {
-	syms := make([]*symbol.Symbol, 0, len(stl.Symbols)+len(extras))
-	syms = append(syms, stl.Symbols...)
+	stlSyms := stl.NewSymbols()
+	syms := make([]*symbol.Symbol, 0, len(stlSyms)+len(extras))
+	syms = append(syms, stlSyms...)
 	syms = append(syms, extras...)
-	return symbol.NewRoot(resolver, syms...)
+	return symbol.NewRoot(resolver, syms)
 }
 
 // CompileGraph parses, analyzes, and compiles a graph-mode program
 // against root. root must have its ambient prelude populated by the
-// caller (typically with stl.Symbols and any cluster channels). Graph
-// mode auto-imports modules; callers do not need to call
+// caller. Graph mode auto-imports modules; callers do not need to call
 // symbol.AutoImportModules themselves — CompileGraph does it.
 func CompileGraph(ctx context.Context, g Graph, root *symbol.Symbol) (Program, error) {
 	graphWithAST, err := graph.Parse(g)
@@ -73,8 +75,7 @@ func CompileGraph(ctx context.Context, g Graph, root *symbol.Symbol) (Program, e
 }
 
 // CompileText parses, analyzes, and compiles a text-mode program against
-// root. root must have its ambient prelude populated by the caller
-// (typically with stl.Symbols and any cluster channels).
+// root. root must have its ambient prelude populated by the caller.
 func CompileText(ctx context.Context, t Text, root *symbol.Symbol) (Program, error) {
 	textWithAST, err := text.Parse(t)
 	if err != nil {

--- a/arc/go/arc_test.go
+++ b/arc/go/arc_test.go
@@ -28,7 +28,7 @@ var _ = Describe("Arc", func() {
 	compile := func(ctx SpecContext, code string, channels ...arc.Symbol) arc.Program {
 		t := arc.Text{Raw: code}
 		Expect(t.Raw).ToNot(BeEmpty())
-		root := symbol.NewRoot(nil, stl.Symbols...)
+		root := symbol.NewRoot(nil, stl.NewSymbols())
 		for i := range channels {
 			s := channels[i]
 			root.Parent.AddChild(&s)
@@ -455,7 +455,7 @@ trigger -> counter{} -> output_b
 	})
 
 	It("Should return a compile error when () is used instead of {} in a flow", func(ctx SpecContext) {
-		root := symbol.NewRoot(nil, stl.Symbols...)
+		root := symbol.NewRoot(nil, stl.NewSymbols())
 		some := symbol.Symbol{
 			Name: "some_ch",
 			Kind: symbol.KindChannel,

--- a/arc/go/compiler/context/context_test.go
+++ b/arc/go/compiler/context/context_test.go
@@ -27,7 +27,7 @@ var _ = Describe("Context", func() {
 	)
 
 	BeforeEach(func() {
-		scope = symbol.NewRoot(nil)
+		scope = symbol.NewRoot(nil, nil)
 		typeMap = make(map[antlr.ParserRuleContext]types.Type)
 	})
 
@@ -82,14 +82,14 @@ var _ = Describe("Context", func() {
 	Describe("WithScope", func() {
 		It("Should return a context with the scope replaced", func(ctx SpecContext) {
 			root := ccontext.NewRoot(ctx, scope, typeMap, nil)
-			newScope := symbol.NewRoot(nil)
+			newScope := symbol.NewRoot(nil, nil)
 			withScope := root.WithScope(newScope)
 			Expect(withScope.Scope).To(Equal(newScope))
 		})
 
 		It("Should not modify the original context", func(ctx SpecContext) {
 			root := ccontext.NewRoot(ctx, scope, typeMap, nil)
-			newScope := symbol.NewRoot(nil)
+			newScope := symbol.NewRoot(nil, nil)
 			root.WithScope(newScope)
 			Expect(root.Scope).To(Equal(scope))
 		})

--- a/arc/go/compiler/expression/expression_suite_test.go
+++ b/arc/go/compiler/expression/expression_suite_test.go
@@ -77,7 +77,7 @@ func autoImportSTL(bCtx context.Context, root *symbol.Symbol) {
 
 func compileWithAnalyzer(bCtx context.Context, exprSource string, channels []symbol.Symbol) ([]byte, types.Type) {
 	expr := MustSucceed(parser.ParseExpression(exprSource))
-	root := symbol.NewRoot(nil, stl.Symbols...)
+	root := symbol.NewRoot(nil, stl.NewSymbols())
 	for i := range channels {
 		s := channels[i]
 		root.Parent.AddChild(&s)
@@ -157,7 +157,7 @@ func expectSeriesLiteralWithHint(
 	expectedOpcodes ...any,
 ) {
 	parsedExpr := MustSucceed(parser.ParseExpression(expr))
-	root := symbol.NewRoot(nil, stl.Symbols...)
+	root := symbol.NewRoot(nil, stl.NewSymbols())
 	for i := range extras {
 		s := extras[i]
 		root.Parent.AddChild(&s)

--- a/arc/go/compiler/resolve/emit_test.go
+++ b/arc/go/compiler/resolve/emit_test.go
@@ -23,8 +23,8 @@ import (
 // root so qualified lookups like "string.from_i32" resolve through the
 // same scope-tree walk the real compiler uses.
 func stringScope() *symbol.Symbol {
-	root := symbol.NewRoot(nil)
-	for _, s := range stlstrings.Symbols {
+	root := symbol.NewRoot(nil, nil)
+	for _, s := range stlstrings.NewSymbols() {
 		root.AddChild(s)
 	}
 	return root

--- a/arc/go/compiler/resolve/resolver_test.go
+++ b/arc/go/compiler/resolve/resolver_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/synnaxlabs/arc/compiler/wasm"
 	"github.com/synnaxlabs/arc/symbol"
 	"github.com/synnaxlabs/arc/types"
-	"github.com/synnaxlabs/x/lsp/doc"
 )
 
 // mathModuleWithAbs returns a sealed math module with an abs(T) -> T entry
@@ -24,7 +23,8 @@ import (
 // exercise polymorphic suffix derivation.
 func mathModuleWithAbs() *symbol.Symbol {
 	numConstraint := types.NumericConstraint()
-	return symbol.NewModule("math", doc.Doc{}, symbol.Symbol{
+	mod := &symbol.Symbol{Name: "math", Kind: symbol.KindModule}
+	mod.AddChild(&symbol.Symbol{
 		Name: "abs",
 		Kind: symbol.KindFunction,
 		Type: types.Function(types.FunctionProperties{
@@ -32,11 +32,13 @@ func mathModuleWithAbs() *symbol.Symbol {
 			Outputs: types.Params{{Name: "result", Type: types.Variable("T", &numConstraint)}},
 		}),
 	})
+	return mod
 }
 
 // monoMathAbs returns a math module with a monomorphic f64 abs entry.
 func monoMathAbs() *symbol.Symbol {
-	return symbol.NewModule("math", doc.Doc{}, symbol.Symbol{
+	mod := &symbol.Symbol{Name: "math", Kind: symbol.KindModule}
+	mod.AddChild(&symbol.Symbol{
 		Name: "abs",
 		Kind: symbol.KindFunction,
 		Type: types.Function(types.FunctionProperties{
@@ -44,6 +46,7 @@ func monoMathAbs() *symbol.Symbol {
 			Outputs: types.Params{{Name: "result", Type: types.F64()}},
 		}),
 	})
+	return mod
 }
 
 var _ = Describe("Resolver", func() {

--- a/arc/go/compiler/testutil/testutil.go
+++ b/arc/go/compiler/testutil/testutil.go
@@ -30,7 +30,7 @@ import (
 // STL-populated root, suitable for compiler unit tests that exercise
 // expressions referencing host functions (channels.write, series.add, ...).
 func FunctionScope(ctx context.Context) *symbol.Symbol {
-	root := symbol.NewRoot(nil, stl.Symbols...)
+	root := symbol.NewRoot(nil, stl.NewSymbols())
 	s := testutil.MustSucceed(root.Add(ctx, symbol.Symbol{Name: "func", Kind: symbol.KindFunction, Type: arctypes.I32()}))
 	return testutil.MustSucceed(s.Add(ctx, symbol.Symbol{Kind: symbol.KindBlock}))
 }

--- a/arc/go/graph/graph_test.go
+++ b/arc/go/graph/graph_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/synnaxlabs/arc/symbol"
 	. "github.com/synnaxlabs/arc/symbol/testutil"
 	"github.com/synnaxlabs/arc/types"
-	"github.com/synnaxlabs/x/lsp/doc"
 	"github.com/synnaxlabs/x/telem"
 	. "github.com/synnaxlabs/x/testutil"
 )
@@ -1250,7 +1249,8 @@ var _ = Describe("Graph", func() {
 					{Name: ir.DefaultOutputParam, Type: types.U8()},
 				},
 			})
-			statusModule := symbol.NewModule("status", doc.Doc{}, symbol.Symbol{
+			statusModule := &symbol.Symbol{Name: "status", Kind: symbol.KindModule}
+			statusModule.AddChild(&symbol.Symbol{
 				Name: "set",
 				Kind: symbol.KindFunction,
 				Exec: symbol.ExecFlow,

--- a/arc/go/graph/graph_test.go
+++ b/arc/go/graph/graph_test.go
@@ -140,7 +140,7 @@ var _ = Describe("Graph", func() {
 					},
 				},
 			}
-			root := symbol.NewRoot(nil, stl.Symbols...)
+			root := symbol.NewRoot(nil, stl.NewSymbols())
 			root.Parent.AddChild(&symbol.Symbol{
 				Name: "ox_pt_1",
 				Type: types.Chan(types.F32()),
@@ -1259,7 +1259,7 @@ var _ = Describe("Graph", func() {
 			channels := []symbol.Symbol{
 				{Name: "sensor", Type: types.Chan(types.U8()), Kind: symbol.KindChannel, ID: 100},
 			}
-			root := symbol.NewRoot(nil, stl.Symbols...)
+			root := symbol.NewRoot(nil, stl.NewSymbols())
 			for i := range channels {
 				s := channels[i]
 				root.Parent.AddChild(&s)

--- a/arc/go/import_test.go
+++ b/arc/go/import_test.go
@@ -32,7 +32,7 @@ func analyze(source string, extras ...[]symbol.Symbol) *diagnostics.Diagnostics 
 	if parseDiag != nil && !parseDiag.Ok() {
 		return parseDiag
 	}
-	root := symbol.NewRoot(nil, stl.Symbols...)
+	root := symbol.NewRoot(nil, stl.NewSymbols())
 	for _, set := range extras {
 		for i := range set {
 			s := set[i]
@@ -151,7 +151,7 @@ trig -> t.now{} -> now_out
 			if parseDiag != nil {
 				Expect(parseDiag.Ok()).To(BeTrue())
 			}
-			root := symbol.NewRoot(nil, stl.Symbols...)
+			root := symbol.NewRoot(nil, stl.NewSymbols())
 			for i := range chans {
 				s := chans[i]
 				root.Parent.AddChild(&s)

--- a/arc/go/ir/ir_test.go
+++ b/arc/go/ir/ir_test.go
@@ -56,7 +56,7 @@ var _ = Describe("IR", func() {
 		})
 
 		It("Should return false when Symbols is set", func() {
-			program := &ir.IR{Symbols: symbol.NewRoot(nil)}
+			program := &ir.IR{Symbols: symbol.NewRoot(nil, nil)}
 			Expect(program.IsZero()).To(BeFalse())
 		})
 	})
@@ -155,7 +155,7 @@ var _ = Describe("IR", func() {
 		})
 
 		It("Should exclude Symbols and TypeMap from JSON (json:\"-\" tag)", func() {
-			original := &ir.IR{Symbols: symbol.NewRoot(nil)}
+			original := &ir.IR{Symbols: symbol.NewRoot(nil, nil)}
 			data := MustSucceed(json.Marshal(original))
 			jsonStr := string(data)
 			Expect(jsonStr).ToNot(ContainSubstring("\"symbols\""))

--- a/arc/go/lsp/testutil/helpers.go
+++ b/arc/go/lsp/testutil/helpers.go
@@ -23,7 +23,7 @@ import (
 // defaultNewRoot builds an STL-populated root with no dynamic resolver.
 // Used as the default for test servers that don't override NewRoot.
 func defaultNewRoot() *symbol.Symbol {
-	root := symbol.NewRoot(nil, stl.Symbols...)
+	root := symbol.NewRoot(nil, stl.NewSymbols())
 	return root
 }
 

--- a/arc/go/runtime/node/node_test.go
+++ b/arc/go/runtime/node/node_test.go
@@ -56,7 +56,7 @@ func newTestConfig(ctx context.Context, nodeType string) node.Config {
 		Nodes:     []graph.Node{{Key: "n1", Type: nodeType}},
 		Functions: []graph.Function{{Key: nodeType}},
 	}
-	analyzed, _ := graph.Analyze(ctx, g, symbol.NewRoot(nil))
+	analyzed, _ := graph.Analyze(ctx, g, symbol.NewRoot(nil, nil))
 	s := node.New(analyzed)
 	return node.Config{
 		Node:  ir.Node{Type: nodeType},

--- a/arc/go/runtime_test.go
+++ b/arc/go/runtime_test.go
@@ -55,13 +55,14 @@ func newRuntimeHarness(
 	channelSyms []symbol.Symbol,
 	channelDigests ...channels.Digest,
 ) *runtimeHarness {
-	ambient := make([]*symbol.Symbol, 0, len(stl.Symbols)+len(channelSyms))
-	ambient = append(ambient, stl.Symbols...)
+	stlSyms := stl.NewSymbols()
+	ambient := make([]*symbol.Symbol, 0, len(stlSyms)+len(channelSyms))
+	ambient = append(ambient, stlSyms...)
 	for i := range channelSyms {
 		s := channelSyms[i]
 		ambient = append(ambient, &s)
 	}
-	root := symbol.NewRoot(nil, ambient...)
+	root := symbol.NewRoot(nil, ambient)
 	prog := MustSucceed(arc.CompileText(ctx, arc.Text{Raw: source}, root))
 
 	nodeState := node.New(prog.IR)

--- a/arc/go/stl/channels/channels.go
+++ b/arc/go/stl/channels/channels.go
@@ -26,55 +26,57 @@ import (
 
 var numConstraint = types.NumericConstraint()
 
-// userOnSymbol and userWriteSymbol are the user-facing flow-mode builtins
-// `on{}` and `write{}` installed at root scope so programs can reference
-// them without an import.
-var userOnSymbol = symbol.Symbol{
-	Name: "on",
-	Kind: symbol.KindFunction,
-	Exec: symbol.ExecFlow,
-	Type: types.Function(types.FunctionProperties{
-		Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.Variable("T", nil)}},
-		Config:  types.Params{{Name: "channel", Type: types.ReadChan(types.Variable("T", nil))}},
-	}),
-}
-
-var userWriteSymbol = symbol.Symbol{
-	Name: "write",
-	Kind: symbol.KindFunction,
-	Exec: symbol.ExecFlow,
-	Type: types.Function(types.FunctionProperties{
-		Inputs:  types.Params{{Name: ir.DefaultInputParam, Type: types.Variable("T", nil)}},
-		Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.U8()}},
-		Config:  types.Params{{Name: "channel", Type: types.WriteChan(types.Variable("T", nil))}},
-	}),
-}
-
 // Name is the module name.
 const Name = "channels"
 
-var module = symbol.NewModule(
-	Name,
-	doc.Doc{},
-	symbol.InternalHostFunc(
-		"read",
-		types.Params{{Name: "ch", Type: types.I32()}},
-		types.Params{{Name: "value", Type: types.Variable("T", &numConstraint)}},
-	),
-	symbol.InternalHostFunc(
-		"write",
-		types.Params{
-			{Name: "ch", Type: types.I32()},
-			{Name: "value", Type: types.Variable("T", &numConstraint)},
-		},
-		nil,
-	),
-).MarkInternal()
+func newUserOnSymbol() *symbol.Symbol {
+	return &symbol.Symbol{
+		Name: "on",
+		Kind: symbol.KindFunction,
+		Exec: symbol.ExecFlow,
+		Type: types.Function(types.FunctionProperties{
+			Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.Variable("T", nil)}},
+			Config:  types.Params{{Name: "channel", Type: types.ReadChan(types.Variable("T", nil))}},
+		}),
+	}
+}
 
-// Symbols are the symbols this package contributes to a program's ambient
-// prelude: the channels module plus `on` and `write` as bare globals so
+func newUserWriteSymbol() *symbol.Symbol {
+	return &symbol.Symbol{
+		Name: "write",
+		Kind: symbol.KindFunction,
+		Exec: symbol.ExecFlow,
+		Type: types.Function(types.FunctionProperties{
+			Inputs:  types.Params{{Name: ir.DefaultInputParam, Type: types.Variable("T", nil)}},
+			Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.U8()}},
+			Config:  types.Params{{Name: "channel", Type: types.WriteChan(types.Variable("T", nil))}},
+		}),
+	}
+}
+
+// NewSymbols returns a fresh slice of ambient prelude symbols this package
+// contributes: the channels module plus `on` and `write` as bare globals so
 // flow-mode programs can reference them without an import.
-var Symbols = []*symbol.Symbol{module, &userOnSymbol, &userWriteSymbol}
+func NewSymbols() []*symbol.Symbol {
+	mod := symbol.NewModule(
+		Name,
+		doc.Doc{},
+		symbol.InternalHostFunc(
+			"read",
+			types.Params{{Name: "ch", Type: types.I32()}},
+			types.Params{{Name: "value", Type: types.Variable("T", &numConstraint)}},
+		),
+		symbol.InternalHostFunc(
+			"write",
+			types.Params{
+				{Name: "ch", Type: types.I32()},
+				{Name: "value", Type: types.Variable("T", &numConstraint)},
+			},
+			nil,
+		),
+	).MarkInternal()
+	return []*symbol.Symbol{mod, newUserOnSymbol(), newUserWriteSymbol()}
+}
 
 // Host is the runtime host-side support for the channels module: it
 // registers WASM host bindings (read/write per type) and acts as the node

--- a/arc/go/stl/channels/channels.go
+++ b/arc/go/stl/channels/channels.go
@@ -17,65 +17,58 @@ import (
 	"github.com/synnaxlabs/arc/stl/strings"
 	"github.com/synnaxlabs/arc/symbol"
 	"github.com/synnaxlabs/arc/types"
-	"github.com/synnaxlabs/x/lsp/doc"
 	"github.com/synnaxlabs/x/query"
 	"github.com/synnaxlabs/x/telem"
 	"github.com/synnaxlabs/x/zyn"
 	"github.com/tetratelabs/wazero"
 )
 
-var numConstraint = types.NumericConstraint()
-
 // Name is the module name.
 const Name = "channels"
-
-func newUserOnSymbol() *symbol.Symbol {
-	return &symbol.Symbol{
-		Name: "on",
-		Kind: symbol.KindFunction,
-		Exec: symbol.ExecFlow,
-		Type: types.Function(types.FunctionProperties{
-			Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.Variable("T", nil)}},
-			Config:  types.Params{{Name: "channel", Type: types.ReadChan(types.Variable("T", nil))}},
-		}),
-	}
-}
-
-func newUserWriteSymbol() *symbol.Symbol {
-	return &symbol.Symbol{
-		Name: "write",
-		Kind: symbol.KindFunction,
-		Exec: symbol.ExecFlow,
-		Type: types.Function(types.FunctionProperties{
-			Inputs:  types.Params{{Name: ir.DefaultInputParam, Type: types.Variable("T", nil)}},
-			Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.U8()}},
-			Config:  types.Params{{Name: "channel", Type: types.WriteChan(types.Variable("T", nil))}},
-		}),
-	}
-}
 
 // NewSymbols returns a fresh slice of ambient prelude symbols this package
 // contributes: the channels module plus `on` and `write` as bare globals so
 // flow-mode programs can reference them without an import.
 func NewSymbols() []*symbol.Symbol {
-	mod := symbol.NewModule(
-		Name,
-		doc.Doc{},
+	numConstraint := new(types.NumericConstraint())
+	mod := &symbol.Symbol{Name: Name, Kind: symbol.KindModule, Internal: true}
+	mod.AddChild(
 		symbol.InternalHostFunc(
 			"read",
 			types.Params{{Name: "ch", Type: types.I32()}},
-			types.Params{{Name: "value", Type: types.Variable("T", &numConstraint)}},
+			types.Params{{Name: "value", Type: types.Variable("T", numConstraint)}},
 		),
 		symbol.InternalHostFunc(
 			"write",
 			types.Params{
 				{Name: "ch", Type: types.I32()},
-				{Name: "value", Type: types.Variable("T", &numConstraint)},
+				{Name: "value", Type: types.Variable("T", numConstraint)},
 			},
 			nil,
 		),
-	).MarkInternal()
-	return []*symbol.Symbol{mod, newUserOnSymbol(), newUserWriteSymbol()}
+	)
+	return []*symbol.Symbol{
+		mod,
+		{
+			Name: "on",
+			Kind: symbol.KindFunction,
+			Exec: symbol.ExecFlow,
+			Type: types.Function(types.FunctionProperties{
+				Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.Variable("T", nil)}},
+				Config:  types.Params{{Name: "channel", Type: types.ReadChan(types.Variable("T", nil))}},
+			}),
+		},
+		{
+			Name: "write",
+			Kind: symbol.KindFunction,
+			Exec: symbol.ExecFlow,
+			Type: types.Function(types.FunctionProperties{
+				Inputs:  types.Params{{Name: ir.DefaultInputParam, Type: types.Variable("T", nil)}},
+				Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.U8()}},
+				Config:  types.Params{{Name: "channel", Type: types.WriteChan(types.Variable("T", nil))}},
+			}),
+		},
+	}
 }
 
 // Host is the runtime host-side support for the channels module: it

--- a/arc/go/stl/constant/constant.go
+++ b/arc/go/stl/constant/constant.go
@@ -24,7 +24,10 @@ var (
 	symName    = "constant"
 	constraint = types.NumericConstraint()
 	typeVar    = types.Variable("T", &constraint)
-	sym        = symbol.Symbol{
+)
+
+func newSymbol() *symbol.Symbol {
+	return &symbol.Symbol{
 		Name:     symName,
 		Kind:     symbol.KindFunction,
 		Exec:     symbol.ExecFlow,
@@ -34,13 +37,13 @@ var (
 			Config:  types.Params{{Name: "value", Type: typeVar}},
 		}),
 	}
-)
+}
 
-// Symbols are the symbols this package contributes to a program's ambient
-// prelude: the `constant` builtin installed at root scope. The symbol is
-// Internal — it is emitted by graph-mode lowering of literal flow nodes,
+// NewSymbols returns a fresh slice of ambient prelude symbols this package
+// contributes: the `constant` builtin installed at root scope. The symbol
+// is Internal — it is emitted by graph-mode lowering of literal flow nodes,
 // not called directly from user source.
-var Symbols = []*symbol.Symbol{&sym}
+func NewSymbols() []*symbol.Symbol { return []*symbol.Symbol{newSymbol()} }
 
 // Host is the runtime host-side support for the constant builtin: a node
 // factory only. No WASM bindings, no per-program state.

--- a/arc/go/stl/constant/constant.go
+++ b/arc/go/stl/constant/constant.go
@@ -20,30 +20,28 @@ import (
 	"github.com/synnaxlabs/x/telem"
 )
 
-var (
-	symName    = "constant"
-	constraint = types.NumericConstraint()
-	typeVar    = types.Variable("T", &constraint)
-)
-
-func newSymbol() *symbol.Symbol {
-	return &symbol.Symbol{
-		Name:     symName,
-		Kind:     symbol.KindFunction,
-		Exec:     symbol.ExecFlow,
-		Internal: true,
-		Type: types.Function(types.FunctionProperties{
-			Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: typeVar}},
-			Config:  types.Params{{Name: "value", Type: typeVar}},
-		}),
-	}
-}
+var symbolName = "constant"
 
 // NewSymbols returns a fresh slice of ambient prelude symbols this package
 // contributes: the `constant` builtin installed at root scope. The symbol
 // is Internal — it is emitted by graph-mode lowering of literal flow nodes,
 // not called directly from user source.
-func NewSymbols() []*symbol.Symbol { return []*symbol.Symbol{newSymbol()} }
+func NewSymbols() []*symbol.Symbol {
+	constraint := new(types.NumericConstraint())
+	typeVar := types.Variable("T", constraint)
+	return []*symbol.Symbol{
+		{
+			Name:     symbolName,
+			Kind:     symbol.KindFunction,
+			Exec:     symbol.ExecFlow,
+			Internal: true,
+			Type: types.Function(types.FunctionProperties{
+				Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: typeVar}},
+				Config:  types.Params{{Name: "value", Type: typeVar}},
+			}),
+		},
+	}
+}
 
 // Host is the runtime host-side support for the constant builtin: a node
 // factory only. No WASM bindings, no per-program state.
@@ -53,7 +51,7 @@ type Host struct{}
 func NewHost() *Host { return &Host{} }
 
 func (h *Host) Create(_ context.Context, cfg node.Config) (node.Node, error) {
-	if cfg.Node.Type != symName {
+	if cfg.Node.Type != symbolName {
 		return nil, query.ErrNotFound
 	}
 	return &constant{State: cfg.State, value: cfg.Node.Config[0].Value}, nil

--- a/arc/go/stl/constant/constant_test.go
+++ b/arc/go/stl/constant/constant_test.go
@@ -327,7 +327,7 @@ var _ = Describe("Constant", func() {
 	Describe("Symbols", func() {
 		It("Should expose constant symbol", func() {
 			var sym *symbol.Symbol
-			for _, s := range constant.Symbols {
+			for _, s := range constant.NewSymbols() {
 				if s.Name == "constant" {
 					sym = s
 					break

--- a/arc/go/stl/control/control.go
+++ b/arc/go/stl/control/control.go
@@ -23,9 +23,8 @@ import (
 )
 
 const (
-	bareSymbolName      = "set_authority"
-	qualifiedMemberName = "set_authority"
-	name                = "control"
+	symbolName = "set_authority"
+	name       = "control"
 )
 
 var (
@@ -61,22 +60,19 @@ func newSymbolProps() types.Type {
 // contributes: the control module plus the deprecated bare alias
 // (set_authority) whose Deprecated field points at the canonical member.
 func NewSymbols() []*symbol.Symbol {
-	member := symbol.Symbol{
-		Name: qualifiedMemberName,
+	member := &symbol.Symbol{
+		Name: symbolName,
 		Kind: symbol.KindFunction,
 		Exec: symbol.ExecFlow,
 		Type: newSymbolProps(),
 		Doc:  memberDoc,
 	}
-	mod := symbol.NewModule(name, moduleDoc, member)
-	bare := &symbol.Symbol{
-		Name:       bareSymbolName,
-		Kind:       symbol.KindFunction,
-		Exec:       symbol.ExecFlow,
-		Type:       newSymbolProps(),
-		Deprecated: mod.FindChild(qualifiedMemberName),
-	}
-	return []*symbol.Symbol{mod, bare}
+	mod := &symbol.Symbol{Name: name, Kind: symbol.KindModule, Doc: moduleDoc}
+	mod.AddChild(member)
+	bare := *member
+	bare.Parent = nil
+	bare.Deprecated = mod.FindChild(symbolName)
+	return []*symbol.Symbol{mod, &bare}
 }
 
 // Host is the runtime host-side support for the control module: it acts as
@@ -92,7 +88,7 @@ type Host struct {
 func NewHost(ab *ProgramState) *Host { return &Host{auth: ab} }
 
 func (h *Host) Create(_ context.Context, cfg node.Config) (node.Node, error) {
-	if cfg.Node.Type != bareSymbolName && cfg.Node.Type != qualifiedMemberName {
+	if cfg.Node.Type != symbolName && cfg.Node.Type != symbolName {
 		return nil, query.ErrNotFound
 	}
 	var nodeCfg nodeConfig

--- a/arc/go/stl/control/control.go
+++ b/arc/go/stl/control/control.go
@@ -29,7 +29,24 @@ const (
 )
 
 var (
-	symbolProps = types.Function(types.FunctionProperties{
+	memberDoc = doc.New(
+		doc.Paragraph("Dynamically changes the control authority of write channels at runtime."),
+		doc.Divider(),
+		doc.Code("arc", "control.set_authority{value=255}"),
+		doc.Divider(),
+		doc.Paragraph("Set authority for a specific channel:"),
+		doc.Divider(),
+		doc.Code("arc", "control.set_authority{value=255, channel=valve_cmd}"),
+		doc.Divider(),
+		doc.Paragraph("Authority is a u8 (0-255). Higher values take priority. Setting authority to 0 releases control of the channel."),
+	)
+	moduleDoc = doc.New(
+		doc.Paragraph("Runtime control over write authority — promote or release writes targeting shared channels."),
+	)
+)
+
+func newSymbolProps() types.Type {
+	return types.Function(types.FunctionProperties{
 		Config: types.Params{
 			{Name: "value", Type: types.U8()},
 			{Name: "channel", Type: types.WriteChan(types.Variable("T", nil)), Value: uint32(0)},
@@ -38,43 +55,29 @@ var (
 			{Name: ir.DefaultOutputParam, Type: types.U8(), Value: uint8(0)},
 		},
 	})
-	memberSymbol = symbol.Symbol{
+}
+
+// NewSymbols returns a fresh slice of ambient prelude symbols this package
+// contributes: the control module plus the deprecated bare alias
+// (set_authority) whose Deprecated field points at the canonical member.
+func NewSymbols() []*symbol.Symbol {
+	member := symbol.Symbol{
 		Name: qualifiedMemberName,
 		Kind: symbol.KindFunction,
 		Exec: symbol.ExecFlow,
-		Type: symbolProps,
-		Doc: doc.New(
-			doc.Paragraph("Dynamically changes the control authority of write channels at runtime."),
-			doc.Divider(),
-			doc.Code("arc", "control.set_authority{value=255}"),
-			doc.Divider(),
-			doc.Paragraph("Set authority for a specific channel:"),
-			doc.Divider(),
-			doc.Code("arc", "control.set_authority{value=255, channel=valve_cmd}"),
-			doc.Divider(),
-			doc.Paragraph("Authority is a u8 (0-255). Higher values take priority. Setting authority to 0 releases control of the channel."),
-		),
+		Type: newSymbolProps(),
+		Doc:  memberDoc,
 	}
-	module = symbol.NewModule(
-		name,
-		doc.New(
-			doc.Paragraph("Runtime control over write authority — promote or release writes targeting shared channels."),
-		),
-		memberSymbol,
-	)
-	bareSymbol = symbol.Symbol{
+	mod := symbol.NewModule(name, moduleDoc, member)
+	bare := &symbol.Symbol{
 		Name:       bareSymbolName,
 		Kind:       symbol.KindFunction,
 		Exec:       symbol.ExecFlow,
-		Type:       symbolProps,
-		Deprecated: module.FindChild(qualifiedMemberName),
+		Type:       newSymbolProps(),
+		Deprecated: mod.FindChild(qualifiedMemberName),
 	}
-)
-
-// Symbols are the symbols this package contributes to a program's ambient
-// prelude: the control module plus the deprecated bare alias
-// (set_authority) whose Deprecated field points at the canonical member.
-var Symbols = []*symbol.Symbol{module, &bareSymbol}
+	return []*symbol.Symbol{mod, bare}
+}
 
 // Host is the runtime host-side support for the control module: it acts as
 // the node factory for set_authority. There are no WASM bindings for

--- a/arc/go/stl/control/control.go
+++ b/arc/go/stl/control/control.go
@@ -88,7 +88,7 @@ type Host struct {
 func NewHost(ab *ProgramState) *Host { return &Host{auth: ab} }
 
 func (h *Host) Create(_ context.Context, cfg node.Config) (node.Node, error) {
-	if cfg.Node.Type != symbolName && cfg.Node.Type != symbolName {
+	if cfg.Node.Type != symbolName {
 		return nil, query.ErrNotFound
 	}
 	var nodeCfg nodeConfig

--- a/arc/go/stl/control/control_test.go
+++ b/arc/go/stl/control/control_test.go
@@ -338,7 +338,7 @@ var _ = Describe("Control", func() {
 
 	Describe("Symbols", func() {
 		var root *symbol.Symbol
-		BeforeEach(func() { root = symbol.NewRoot(nil, control.Symbols...) })
+		BeforeEach(func() { root = symbol.NewRoot(nil, control.NewSymbols()) })
 		bare := func(ctx context.Context, name string) *symbol.Symbol {
 			return MustSucceed(root.Resolve(ctx, name, symbol.IncludeInternal))
 		}

--- a/arc/go/stl/errors/error.go
+++ b/arc/go/stl/errors/error.go
@@ -21,23 +21,26 @@ import (
 
 const name = "error"
 
-var panicSymbol = symbol.Symbol{
-	Name:     "panic",
-	Kind:     symbol.KindFunction,
-	Exec:     symbol.ExecWASM,
-	Internal: true,
-	Type: types.Function(types.FunctionProperties{
-		Inputs: types.Params{{Name: "ptr", Type: types.I32()}, {Name: "len", Type: types.I32()}},
-	}),
+func newPanicSymbol() symbol.Symbol {
+	return symbol.Symbol{
+		Name:     "panic",
+		Kind:     symbol.KindFunction,
+		Exec:     symbol.ExecWASM,
+		Internal: true,
+		Type: types.Function(types.FunctionProperties{
+			Inputs: types.Params{{Name: "ptr", Type: types.I32()}, {Name: "len", Type: types.I32()}},
+		}),
+	}
 }
 
-var module = symbol.NewModule(name, doc.Doc{}, panicSymbol).MarkInternal()
-
-// Symbols are the symbols this package contributes to a program's ambient
-// prelude: the error module containing panic. Both module and member are
-// Internal — panic is emitted by lowering passes (e.g., out-of-bounds
+// NewSymbols returns a fresh slice of ambient prelude symbols this package
+// contributes: the error module containing panic. Both module and member
+// are Internal — panic is emitted by lowering passes (e.g., out-of-bounds
 // checks), not called from user source.
-var Symbols = []*symbol.Symbol{module}
+func NewSymbols() []*symbol.Symbol {
+	mod := symbol.NewModule(name, doc.Doc{}, newPanicSymbol()).MarkInternal()
+	return []*symbol.Symbol{mod}
+}
 
 // Host is the runtime host-side support for the error module: it registers
 // the panic host function and holds a reference to the WASM guest's

--- a/arc/go/stl/errors/error.go
+++ b/arc/go/stl/errors/error.go
@@ -14,15 +14,19 @@ import (
 
 	"github.com/synnaxlabs/arc/symbol"
 	"github.com/synnaxlabs/arc/types"
-	"github.com/synnaxlabs/x/lsp/doc"
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
 )
 
 const name = "error"
 
-func newPanicSymbol() symbol.Symbol {
-	return symbol.Symbol{
+// NewSymbols returns a fresh slice of ambient prelude symbols this package
+// contributes: the error module containing panic. Both module and member
+// are Internal — panic is emitted by lowering passes (e.g., out-of-bounds
+// checks), not called from user source.
+func NewSymbols() []*symbol.Symbol {
+	mod := &symbol.Symbol{Name: name, Kind: symbol.KindModule, Internal: true}
+	mod.AddChild(&symbol.Symbol{
 		Name:     "panic",
 		Kind:     symbol.KindFunction,
 		Exec:     symbol.ExecWASM,
@@ -30,15 +34,7 @@ func newPanicSymbol() symbol.Symbol {
 		Type: types.Function(types.FunctionProperties{
 			Inputs: types.Params{{Name: "ptr", Type: types.I32()}, {Name: "len", Type: types.I32()}},
 		}),
-	}
-}
-
-// NewSymbols returns a fresh slice of ambient prelude symbols this package
-// contributes: the error module containing panic. Both module and member
-// are Internal — panic is emitted by lowering passes (e.g., out-of-bounds
-// checks), not called from user source.
-func NewSymbols() []*symbol.Symbol {
-	mod := symbol.NewModule(name, doc.Doc{}, newPanicSymbol()).MarkInternal()
+	})
 	return []*symbol.Symbol{mod}
 }
 

--- a/arc/go/stl/math/math.go
+++ b/arc/go/stl/math/math.go
@@ -53,8 +53,8 @@ type (
 	)
 )
 
-func createBaseSymbol(name string) symbol.Symbol {
-	return symbol.Symbol{
+func createBaseSymbol(name string, doc doc.Doc) *symbol.Symbol {
+	return &symbol.Symbol{
 		Name: name,
 		Kind: symbol.KindFunction,
 		Exec: symbol.ExecFlow,
@@ -71,13 +71,8 @@ func createBaseSymbol(name string) symbol.Symbol {
 				{Name: ir.DefaultOutputParam, Type: types.Variable("T", &numConstraint)},
 			},
 		}),
+		Doc: doc,
 	}
-}
-
-func reductionSymbol(name string, body doc.Doc) symbol.Symbol {
-	s := createBaseSymbol(name)
-	s.Doc = body
-	return s
 }
 
 var (
@@ -122,8 +117,8 @@ var (
 	)
 )
 
-func newPowSymbol() symbol.Symbol {
-	return symbol.Symbol{
+func newPowSymbol() *symbol.Symbol {
+	return &symbol.Symbol{
 		Name:     powSymbolName,
 		Kind:     symbol.KindFunction,
 		Exec:     symbol.ExecWASM,
@@ -135,8 +130,8 @@ func newPowSymbol() symbol.Symbol {
 	}
 }
 
-func newDerivativeSymbol() symbol.Symbol {
-	return symbol.Symbol{
+func newDerivativeSymbol() *symbol.Symbol {
+	return &symbol.Symbol{
 		Name: derivativeSymbolName,
 		Kind: symbol.KindFunction,
 		Exec: symbol.ExecFlow,
@@ -160,26 +155,21 @@ const name = "math"
 // member. Every call allocates new Symbol values so analyses can mutate
 // them (e.g. apply type substitutions) without corrupting other analyses.
 func NewSymbols() []*symbol.Symbol {
-	avg := reductionSymbol(avgSymbolName, avgDoc)
-	min := reductionSymbol(minSymbolName, minDoc)
-	max := reductionSymbol(maxSymbolName, maxDoc)
+	avg := createBaseSymbol(avgSymbolName, avgDoc)
+	min := createBaseSymbol(minSymbolName, minDoc)
+	max := createBaseSymbol(maxSymbolName, maxDoc)
 	derivative := newDerivativeSymbol()
-	mod := symbol.NewModule(
-		name,
-		moduleDoc,
-		newPowSymbol(),
-		avg,
-		min,
-		max,
-		derivative,
-	)
-	return []*symbol.Symbol{
-		mod,
-		avg.Deprecate(mod.FindChild(avgSymbolName)),
-		min.Deprecate(mod.FindChild(minSymbolName)),
-		max.Deprecate(mod.FindChild(maxSymbolName)),
-		derivative.Deprecate(mod.FindChild(derivativeSymbolName)),
-	}
+	mod := &symbol.Symbol{Name: name, Kind: symbol.KindModule, Doc: moduleDoc}
+	mod.AddChild(newPowSymbol(), avg, min, max, derivative)
+	avgBare := *avg
+	avgBare.Deprecated = avg
+	minBare := *min
+	minBare.Deprecated = min
+	maxBare := *max
+	maxBare.Deprecated = max
+	derivativeBare := *derivative
+	derivativeBare.Deprecated = derivative
+	return []*symbol.Symbol{mod, &avgBare, &minBare, &maxBare, &derivativeBare}
 }
 
 // Host is the runtime host-side support for math: it registers the WASM

--- a/arc/go/stl/math/math.go
+++ b/arc/go/stl/math/math.go
@@ -81,17 +81,7 @@ func reductionSymbol(name string, body doc.Doc) symbol.Symbol {
 }
 
 var (
-	powSymbol = symbol.Symbol{
-		Name:     powSymbolName,
-		Kind:     symbol.KindFunction,
-		Exec:     symbol.ExecWASM,
-		Internal: true,
-		Type: types.Function(types.FunctionProperties{
-			Inputs:  types.Params{{Name: "base", Type: types.Variable("T", &numConstraint)}, {Name: "exp", Type: types.Variable("T", &numConstraint)}},
-			Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.Variable("T", &numConstraint)}},
-		}),
-	}
-	avgSymbol = reductionSymbol(avgSymbolName, doc.New(
+	avgDoc = doc.New(
 		doc.Paragraph("Computes a running average of input values."),
 		doc.Divider(),
 		doc.Code("arc", "sensor -> math.avg{} -> output"),
@@ -103,8 +93,8 @@ var (
 		doc.Paragraph("An optional reset input clears the accumulated average:"),
 		doc.Divider(),
 		doc.Code("arc", "sensor -> math.avg{} -> output\nreset_signal -> math.avg{}.reset"),
-	))
-	minSymbol = reductionSymbol(minSymbolName, doc.New(
+	)
+	minDoc = doc.New(
 		doc.Paragraph("Tracks the running minimum of input values."),
 		doc.Divider(),
 		doc.Code("arc", "sensor -> math.min{} -> output"),
@@ -112,8 +102,8 @@ var (
 		doc.Paragraph("Reset after a fixed number of samples or a time window:"),
 		doc.Divider(),
 		doc.Code("arc", "sensor -> math.min{count=100} -> output\nsensor -> math.min{duration=5s} -> output"),
-	))
-	maxSymbol = reductionSymbol(maxSymbolName, doc.New(
+	)
+	maxDoc = doc.New(
 		doc.Paragraph("Tracks the running maximum of input values."),
 		doc.Divider(),
 		doc.Code("arc", "sensor -> math.max{} -> output"),
@@ -121,8 +111,32 @@ var (
 		doc.Paragraph("Reset after a fixed number of samples or a time window:"),
 		doc.Divider(),
 		doc.Code("arc", "sensor -> math.max{count=100} -> output\nsensor -> math.max{duration=5s} -> output"),
-	))
-	derivativeSymbol = symbol.Symbol{
+	)
+	derivativeDoc = doc.New(
+		doc.Paragraph("Computes the rate of change (derivative) of input values. Output is always f64."),
+		doc.Divider(),
+		doc.Code("arc", "sensor -> math.derivative{} -> rate_output"),
+	)
+	moduleDoc = doc.New(
+		doc.Paragraph("Numerical primitives: running averages, running min/max, derivatives, and arithmetic helpers."),
+	)
+)
+
+func newPowSymbol() symbol.Symbol {
+	return symbol.Symbol{
+		Name:     powSymbolName,
+		Kind:     symbol.KindFunction,
+		Exec:     symbol.ExecWASM,
+		Internal: true,
+		Type: types.Function(types.FunctionProperties{
+			Inputs:  types.Params{{Name: "base", Type: types.Variable("T", &numConstraint)}, {Name: "exp", Type: types.Variable("T", &numConstraint)}},
+			Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.Variable("T", &numConstraint)}},
+		}),
+	}
+}
+
+func newDerivativeSymbol() symbol.Symbol {
+	return symbol.Symbol{
 		Name: derivativeSymbolName,
 		Kind: symbol.KindFunction,
 		Exec: symbol.ExecFlow,
@@ -134,41 +148,38 @@ var (
 				{Name: ir.DefaultOutputParam, Type: types.F64()},
 			},
 		}),
-		Doc: doc.New(
-			doc.Paragraph("Computes the rate of change (derivative) of input values. Output is always f64."),
-			doc.Divider(),
-			doc.Code("arc", "sensor -> math.derivative{} -> rate_output"),
-		),
+		Doc: derivativeDoc,
 	}
-)
+}
 
 const name = "math"
 
-// module is the math module, built once at package init. Its children are
-// the canonical math.<name> functions and are the targets of the deprecated
-// bare globals' Deprecated field.
-var module = symbol.NewModule(
-	name,
-	doc.New(
-		doc.Paragraph("Numerical primitives: running averages, running min/max, derivatives, and arithmetic helpers."),
-	),
-	powSymbol,
-	avgSymbol,
-	minSymbol,
-	maxSymbol,
-	derivativeSymbol,
-)
-
-// Symbols are the symbols this package contributes to a program's ambient
-// prelude: the math module itself and the deprecated bare aliases
-// (avg, min, max, derivative) whose Deprecated field points at the
-// canonical module member.
-var Symbols = []*symbol.Symbol{
-	module,
-	avgSymbol.Deprecate(module.FindChild(avgSymbolName)),
-	minSymbol.Deprecate(module.FindChild(minSymbolName)),
-	maxSymbol.Deprecate(module.FindChild(maxSymbolName)),
-	derivativeSymbol.Deprecate(module.FindChild(derivativeSymbolName)),
+// NewSymbols returns a fresh slice of ambient prelude symbols this package
+// contributes: the math module and the deprecated bare aliases (avg, min,
+// max, derivative) whose Deprecated field points at the canonical module
+// member. Every call allocates new Symbol values so analyses can mutate
+// them (e.g. apply type substitutions) without corrupting other analyses.
+func NewSymbols() []*symbol.Symbol {
+	avg := reductionSymbol(avgSymbolName, avgDoc)
+	min := reductionSymbol(minSymbolName, minDoc)
+	max := reductionSymbol(maxSymbolName, maxDoc)
+	derivative := newDerivativeSymbol()
+	mod := symbol.NewModule(
+		name,
+		moduleDoc,
+		newPowSymbol(),
+		avg,
+		min,
+		max,
+		derivative,
+	)
+	return []*symbol.Symbol{
+		mod,
+		avg.Deprecate(mod.FindChild(avgSymbolName)),
+		min.Deprecate(mod.FindChild(minSymbolName)),
+		max.Deprecate(mod.FindChild(maxSymbolName)),
+		derivative.Deprecate(mod.FindChild(derivativeSymbolName)),
+	}
 }
 
 // Host is the runtime host-side support for math: it registers the WASM

--- a/arc/go/stl/math/math_test.go
+++ b/arc/go/stl/math/math_test.go
@@ -258,7 +258,7 @@ var _ = Describe("Math", func() {
 
 	Describe("Symbols", func() {
 		var root *symbol.Symbol
-		BeforeEach(func() { root = symbol.NewRoot(nil, stlmath.Symbols...) })
+		BeforeEach(func() { root = symbol.NewRoot(nil, stlmath.NewSymbols()) })
 		math := func(ctx context.Context, member string) *symbol.Symbol {
 			mod := MustSucceed(root.Resolve(ctx, "math", symbol.IncludeInternal))
 			return MustSucceed(mod.Resolve(ctx, member, symbol.IncludeInternal))

--- a/arc/go/stl/op/symbol.go
+++ b/arc/go/stl/op/symbol.go
@@ -71,53 +71,31 @@ const (
 	notSymbolName = "not"
 )
 
-// Symbols are the symbols this package contributes to a program's ambient
-// prelude. Operators are root-level (no module) — they install directly at
-// the root scope so lowering passes can emit calls without imports.
-var Symbols = []*symbol.Symbol{
-	comparison(geSymbolName, doc.New(
-		doc.Paragraph("Greater-than-or-equal comparison. Returns 1 if `a >= b`, 0 otherwise."),
-		doc.Divider(),
-		doc.Code("arc", "ge(a, b)  // equivalent to: a >= b"),
-	)),
-	comparison(gtSymbolName, doc.New(
-		doc.Paragraph("Greater-than comparison. Returns 1 if `a > b`, 0 otherwise."),
-		doc.Divider(),
-		doc.Code("arc", "gt(a, b)  // equivalent to: a > b"),
-	)),
-	comparison(leSymbolName, doc.New(
-		doc.Paragraph("Less-than-or-equal comparison. Returns 1 if `a <= b`, 0 otherwise."),
-		doc.Divider(),
-		doc.Code("arc", "le(a, b)  // equivalent to: a <= b"),
-	)),
-	comparison(ltSymbolName, doc.New(
-		doc.Paragraph("Less-than comparison. Returns 1 if `a < b`, 0 otherwise."),
-		doc.Divider(),
-		doc.Code("arc", "lt(a, b)  // equivalent to: a < b"),
-	)),
-	comparison(eqSymbolName, doc.New(
-		doc.Paragraph("Equality comparison. Returns 1 if `a == b`, 0 otherwise."),
-		doc.Divider(),
-		doc.Code("arc", "eq(a, b)  // equivalent to: a == b"),
-	)),
-	comparison(neSymbolName, doc.New(
-		doc.Paragraph("Inequality comparison. Returns 1 if `a != b`, 0 otherwise."),
-		doc.Divider(),
-		doc.Code("arc", "ne(a, b)  // equivalent to: a != b"),
-	)),
-	logical(andSymbolName, doc.New(
-		doc.Paragraph("Logical AND. Returns a nonzero value if both inputs are nonzero, 0 otherwise."),
-		doc.Divider(),
-		doc.Code("arc", "and(a, b)  // equivalent to: a && b"),
-	)),
-	logical(orSymbolName, doc.New(
-		doc.Paragraph("Logical OR. Returns a nonzero value if either input is nonzero, 0 otherwise."),
-		doc.Divider(),
-		doc.Code("arc", "or(a, b)  // equivalent to: a || b"),
-	)),
-	not(notSymbolName, doc.New(
-		doc.Paragraph("Logical NOT. Returns 1 if the input is 0, 0 otherwise."),
-		doc.Divider(),
-		doc.Code("arc", "not(a)  // equivalent to: !a"),
-	)),
+var (
+	geDoc  = doc.New(doc.Paragraph("Greater-than-or-equal comparison. Returns 1 if `a >= b`, 0 otherwise."), doc.Divider(), doc.Code("arc", "ge(a, b)  // equivalent to: a >= b"))
+	gtDoc  = doc.New(doc.Paragraph("Greater-than comparison. Returns 1 if `a > b`, 0 otherwise."), doc.Divider(), doc.Code("arc", "gt(a, b)  // equivalent to: a > b"))
+	leDoc  = doc.New(doc.Paragraph("Less-than-or-equal comparison. Returns 1 if `a <= b`, 0 otherwise."), doc.Divider(), doc.Code("arc", "le(a, b)  // equivalent to: a <= b"))
+	ltDoc  = doc.New(doc.Paragraph("Less-than comparison. Returns 1 if `a < b`, 0 otherwise."), doc.Divider(), doc.Code("arc", "lt(a, b)  // equivalent to: a < b"))
+	eqDoc  = doc.New(doc.Paragraph("Equality comparison. Returns 1 if `a == b`, 0 otherwise."), doc.Divider(), doc.Code("arc", "eq(a, b)  // equivalent to: a == b"))
+	neDoc  = doc.New(doc.Paragraph("Inequality comparison. Returns 1 if `a != b`, 0 otherwise."), doc.Divider(), doc.Code("arc", "ne(a, b)  // equivalent to: a != b"))
+	andDoc = doc.New(doc.Paragraph("Logical AND. Returns a nonzero value if both inputs are nonzero, 0 otherwise."), doc.Divider(), doc.Code("arc", "and(a, b)  // equivalent to: a && b"))
+	orDoc  = doc.New(doc.Paragraph("Logical OR. Returns a nonzero value if either input is nonzero, 0 otherwise."), doc.Divider(), doc.Code("arc", "or(a, b)  // equivalent to: a || b"))
+	notDoc = doc.New(doc.Paragraph("Logical NOT. Returns 1 if the input is 0, 0 otherwise."), doc.Divider(), doc.Code("arc", "not(a)  // equivalent to: !a"))
+)
+
+// NewSymbols returns a fresh slice of ambient prelude symbols this package
+// contributes. Operators are root-level (no module) — they install directly
+// at the root scope so lowering passes can emit calls without imports.
+func NewSymbols() []*symbol.Symbol {
+	return []*symbol.Symbol{
+		comparison(geSymbolName, geDoc),
+		comparison(gtSymbolName, gtDoc),
+		comparison(leSymbolName, leDoc),
+		comparison(ltSymbolName, ltDoc),
+		comparison(eqSymbolName, eqDoc),
+		comparison(neSymbolName, neDoc),
+		logical(andSymbolName, andDoc),
+		logical(orSymbolName, orDoc),
+		not(notSymbolName, notDoc),
+	}
 }

--- a/arc/go/stl/selector/selector.go
+++ b/arc/go/stl/selector/selector.go
@@ -40,8 +40,16 @@ const (
 )
 
 var (
-	symbolName   = "select"
-	symbolSelect = symbol.Symbol{
+	symbolName = "select"
+	symbolDoc  = doc.New(
+		doc.Paragraph("Routes input values to 'true' or 'false' outputs. Values equal to 1 are routed to the true output; all others to false."),
+		doc.Divider(),
+		doc.Code("arc", "flag -> select{} -> {\n    true: open_valve,\n    false: shut_valve\n}"),
+	)
+)
+
+func newSymbol() *symbol.Symbol {
+	return &symbol.Symbol{
 		Name: symbolName,
 		Kind: symbol.KindFunction,
 		Exec: symbol.ExecFlow,
@@ -54,17 +62,13 @@ var (
 				{Name: FalseOutputParam, Type: types.U8()},
 			},
 		}),
-		Doc: doc.New(
-			doc.Paragraph("Routes input values to 'true' or 'false' outputs. Values equal to 1 are routed to the true output; all others to false."),
-			doc.Divider(),
-			doc.Code("arc", "flag -> select{} -> {\n    true: open_valve,\n    false: shut_valve\n}"),
-		),
+		Doc: symbolDoc,
 	}
-)
+}
 
-// Symbols are the symbols this package contributes to a program's ambient
-// prelude: the `select` builtin installed at root scope.
-var Symbols = []*symbol.Symbol{&symbolSelect}
+// NewSymbols returns a fresh slice of ambient prelude symbols this package
+// contributes: the `select` builtin installed at root scope.
+func NewSymbols() []*symbol.Symbol { return []*symbol.Symbol{newSymbol()} }
 
 // Host is the runtime host-side support for `select`: a node factory only.
 // No WASM bindings, no per-program state.

--- a/arc/go/stl/selector/selector.go
+++ b/arc/go/stl/selector/selector.go
@@ -48,27 +48,27 @@ var (
 	)
 )
 
-func newSymbol() *symbol.Symbol {
-	return &symbol.Symbol{
-		Name: symbolName,
-		Kind: symbol.KindFunction,
-		Exec: symbol.ExecFlow,
-		Type: types.Function(types.FunctionProperties{
-			Inputs: types.Params{
-				{Name: ir.DefaultOutputParam, Type: types.U8()},
-			},
-			Outputs: types.Params{
-				{Name: TrueOutputParam, Type: types.U8()},
-				{Name: FalseOutputParam, Type: types.U8()},
-			},
-		}),
-		Doc: symbolDoc,
-	}
-}
-
 // NewSymbols returns a fresh slice of ambient prelude symbols this package
 // contributes: the `select` builtin installed at root scope.
-func NewSymbols() []*symbol.Symbol { return []*symbol.Symbol{newSymbol()} }
+func NewSymbols() []*symbol.Symbol {
+	return []*symbol.Symbol{
+		{
+			Name: symbolName,
+			Kind: symbol.KindFunction,
+			Exec: symbol.ExecFlow,
+			Type: types.Function(types.FunctionProperties{
+				Inputs: types.Params{
+					{Name: ir.DefaultOutputParam, Type: types.U8()},
+				},
+				Outputs: types.Params{
+					{Name: TrueOutputParam, Type: types.U8()},
+					{Name: FalseOutputParam, Type: types.U8()},
+				},
+			}),
+			Doc: symbolDoc,
+		},
+	}
+}
 
 // Host is the runtime host-side support for `select`: a node factory only.
 // No WASM bindings, no per-program state.

--- a/arc/go/stl/selector/selector_test.go
+++ b/arc/go/stl/selector/selector_test.go
@@ -360,7 +360,7 @@ var _ = Describe("Select", func() {
 	Describe("Symbols", func() {
 		It("Should expose bare select symbol", func() {
 			var sym *symbol.Symbol
-			for _, s := range selector.Symbols {
+			for _, s := range selector.NewSymbols() {
 				if s.Name == "select" {
 					sym = s
 					break
@@ -371,7 +371,7 @@ var _ = Describe("Select", func() {
 			Expect(sym.Kind).To(Equal(symbol.KindFunction))
 		})
 		It("Should not expose qualified selector.select symbol", func() {
-			for _, s := range selector.Symbols {
+			for _, s := range selector.NewSymbols() {
 				Expect(s.Kind).ToNot(Equal(symbol.KindModule))
 			}
 		})

--- a/arc/go/stl/series/series.go
+++ b/arc/go/stl/series/series.go
@@ -59,9 +59,8 @@ func NewSymbols() []*symbol.Symbol {
 	rScalarIn := types.Params{{Name: "scalar", Type: tv()}, {Name: "handle", Type: i32}}
 	seriesBinIn := types.Params{{Name: "a", Type: i32}, {Name: "b", Type: i32}}
 	resultOut := types.Params{{Name: "result", Type: i32}}
-	mod := symbol.NewModule(
-		Name,
-		doc.Doc{},
+	mod := &symbol.Symbol{Name: Name, Kind: symbol.KindModule, Internal: true}
+	mod.AddChild(
 		symbol.InternalHostFunc("element_add", scalarArithIn, resultOut),
 		symbol.InternalHostFunc("element_sub", scalarArithIn, resultOut),
 		symbol.InternalHostFunc("element_mul", scalarArithIn, resultOut),
@@ -124,7 +123,7 @@ func NewSymbols() []*symbol.Symbol {
 			types.Params{{Name: "handle", Type: i32}, {Name: "start", Type: i32}, {Name: "end", Type: i32}},
 			resultOut,
 		),
-	).MarkInternal()
+	)
 	return []*symbol.Symbol{mod, newUserLenSymbol()}
 }
 

--- a/arc/go/stl/series/series.go
+++ b/arc/go/stl/series/series.go
@@ -29,104 +29,104 @@ func tv() types.Type { return types.Variable("T", &numConstraint) }
 var i32 = types.I32()
 var i64 = types.I64()
 
-// userLenSymbol is the user-facing `len(series) i64` builtin installed at
-// root scope so programs can use it without an import.
-var userLenSymbol = symbol.Symbol{
-	Name: "len",
-	Kind: symbol.KindFunction,
-	Exec: symbol.ExecWASM,
-	Type: types.Function(types.FunctionProperties{
-		Inputs:  types.Params{{Name: ir.DefaultInputParam, Type: types.Variable("T", nil)}},
-		Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.I64()}},
-	}),
-	Doc: doc.New(
-		doc.Paragraph("Returns the length of a series or string as i64."),
-		doc.Divider(),
-		doc.Code("arc", "length := len(data)"),
-	),
-}
-
-var (
-	scalarArithIn = types.Params{{Name: "handle", Type: i32}, {Name: "scalar", Type: tv()}}
-	rScalarIn     = types.Params{{Name: "scalar", Type: tv()}, {Name: "handle", Type: i32}}
-	seriesBinIn   = types.Params{{Name: "a", Type: i32}, {Name: "b", Type: i32}}
-	resultOut     = types.Params{{Name: "result", Type: i32}}
+var lenDoc = doc.New(
+	doc.Paragraph("Returns the length of a series or string as i64."),
+	doc.Divider(),
+	doc.Code("arc", "length := len(data)"),
 )
+
+func newUserLenSymbol() *symbol.Symbol {
+	return &symbol.Symbol{
+		Name: "len",
+		Kind: symbol.KindFunction,
+		Exec: symbol.ExecWASM,
+		Type: types.Function(types.FunctionProperties{
+			Inputs:  types.Params{{Name: ir.DefaultInputParam, Type: types.Variable("T", nil)}},
+			Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.I64()}},
+		}),
+		Doc: lenDoc,
+	}
+}
 
 // Name is the module name.
 const Name = "series"
 
-var module = symbol.NewModule(
-	Name,
-	doc.Doc{},
-	symbol.InternalHostFunc("element_add", scalarArithIn, resultOut),
-	symbol.InternalHostFunc("element_sub", scalarArithIn, resultOut),
-	symbol.InternalHostFunc("element_mul", scalarArithIn, resultOut),
-	symbol.InternalHostFunc("element_div", scalarArithIn, resultOut),
-	symbol.InternalHostFunc("element_mod", scalarArithIn, resultOut),
-	symbol.InternalHostFunc("element_radd", rScalarIn, resultOut),
-	symbol.InternalHostFunc("element_rsub", rScalarIn, resultOut),
-	symbol.InternalHostFunc("element_rmul", rScalarIn, resultOut),
-	symbol.InternalHostFunc("element_rdiv", rScalarIn, resultOut),
-	symbol.InternalHostFunc("element_rmod", rScalarIn, resultOut),
-	symbol.InternalHostFunc("series_add", seriesBinIn, resultOut),
-	symbol.InternalHostFunc("series_sub", seriesBinIn, resultOut),
-	symbol.InternalHostFunc("series_mul", seriesBinIn, resultOut),
-	symbol.InternalHostFunc("series_div", seriesBinIn, resultOut),
-	symbol.InternalHostFunc("series_mod", seriesBinIn, resultOut),
-	symbol.InternalHostFunc("compare_gt", seriesBinIn, resultOut),
-	symbol.InternalHostFunc("compare_lt", seriesBinIn, resultOut),
-	symbol.InternalHostFunc("compare_ge", seriesBinIn, resultOut),
-	symbol.InternalHostFunc("compare_le", seriesBinIn, resultOut),
-	symbol.InternalHostFunc("compare_eq", seriesBinIn, resultOut),
-	symbol.InternalHostFunc("compare_ne", seriesBinIn, resultOut),
-	symbol.InternalHostFunc("compare_gt_scalar", scalarArithIn, resultOut),
-	symbol.InternalHostFunc("compare_lt_scalar", scalarArithIn, resultOut),
-	symbol.InternalHostFunc("compare_ge_scalar", scalarArithIn, resultOut),
-	symbol.InternalHostFunc("compare_le_scalar", scalarArithIn, resultOut),
-	symbol.InternalHostFunc("compare_eq_scalar", scalarArithIn, resultOut),
-	symbol.InternalHostFunc("compare_ne_scalar", scalarArithIn, resultOut),
-	symbol.InternalHostFunc(
-		"create_empty",
-		types.Params{{Name: "len", Type: i32}},
-		types.Params{{Name: "handle", Type: i32}},
-	),
-	symbol.InternalHostFunc(
-		"set_element",
-		types.Params{{Name: "handle", Type: i32}, {Name: "idx", Type: i32}, {Name: "value", Type: tv()}},
-		resultOut,
-	),
-	symbol.InternalHostFunc(
-		"index",
-		types.Params{{Name: "handle", Type: i32}, {Name: "idx", Type: i32}},
-		types.Params{{Name: "value", Type: tv()}},
-	),
-	symbol.InternalHostFunc(
-		"negate",
-		types.Params{{Name: "handle", Type: i32}},
-		resultOut,
-	),
-	symbol.InternalHostFunc(
-		"not_u8",
-		types.Params{{Name: "handle", Type: i32}},
-		resultOut,
-	),
-	symbol.InternalHostFunc(
-		"len",
-		types.Params{{Name: "handle", Type: i32}},
-		types.Params{{Name: "length", Type: i64}},
-	),
-	symbol.InternalHostFunc(
-		"slice",
-		types.Params{{Name: "handle", Type: i32}, {Name: "start", Type: i32}, {Name: "end", Type: i32}},
-		resultOut,
-	),
-).MarkInternal()
-
-// Symbols are the symbols this package contributes to a program's ambient
-// prelude: the series module plus the bare `len` global (a user-facing
+// NewSymbols returns a fresh slice of ambient prelude symbols this package
+// contributes: the series module plus the bare `len` global (a user-facing
 // builtin reachable without an import).
-var Symbols = []*symbol.Symbol{module, &userLenSymbol}
+func NewSymbols() []*symbol.Symbol {
+	scalarArithIn := types.Params{{Name: "handle", Type: i32}, {Name: "scalar", Type: tv()}}
+	rScalarIn := types.Params{{Name: "scalar", Type: tv()}, {Name: "handle", Type: i32}}
+	seriesBinIn := types.Params{{Name: "a", Type: i32}, {Name: "b", Type: i32}}
+	resultOut := types.Params{{Name: "result", Type: i32}}
+	mod := symbol.NewModule(
+		Name,
+		doc.Doc{},
+		symbol.InternalHostFunc("element_add", scalarArithIn, resultOut),
+		symbol.InternalHostFunc("element_sub", scalarArithIn, resultOut),
+		symbol.InternalHostFunc("element_mul", scalarArithIn, resultOut),
+		symbol.InternalHostFunc("element_div", scalarArithIn, resultOut),
+		symbol.InternalHostFunc("element_mod", scalarArithIn, resultOut),
+		symbol.InternalHostFunc("element_radd", rScalarIn, resultOut),
+		symbol.InternalHostFunc("element_rsub", rScalarIn, resultOut),
+		symbol.InternalHostFunc("element_rmul", rScalarIn, resultOut),
+		symbol.InternalHostFunc("element_rdiv", rScalarIn, resultOut),
+		symbol.InternalHostFunc("element_rmod", rScalarIn, resultOut),
+		symbol.InternalHostFunc("series_add", seriesBinIn, resultOut),
+		symbol.InternalHostFunc("series_sub", seriesBinIn, resultOut),
+		symbol.InternalHostFunc("series_mul", seriesBinIn, resultOut),
+		symbol.InternalHostFunc("series_div", seriesBinIn, resultOut),
+		symbol.InternalHostFunc("series_mod", seriesBinIn, resultOut),
+		symbol.InternalHostFunc("compare_gt", seriesBinIn, resultOut),
+		symbol.InternalHostFunc("compare_lt", seriesBinIn, resultOut),
+		symbol.InternalHostFunc("compare_ge", seriesBinIn, resultOut),
+		symbol.InternalHostFunc("compare_le", seriesBinIn, resultOut),
+		symbol.InternalHostFunc("compare_eq", seriesBinIn, resultOut),
+		symbol.InternalHostFunc("compare_ne", seriesBinIn, resultOut),
+		symbol.InternalHostFunc("compare_gt_scalar", scalarArithIn, resultOut),
+		symbol.InternalHostFunc("compare_lt_scalar", scalarArithIn, resultOut),
+		symbol.InternalHostFunc("compare_ge_scalar", scalarArithIn, resultOut),
+		symbol.InternalHostFunc("compare_le_scalar", scalarArithIn, resultOut),
+		symbol.InternalHostFunc("compare_eq_scalar", scalarArithIn, resultOut),
+		symbol.InternalHostFunc("compare_ne_scalar", scalarArithIn, resultOut),
+		symbol.InternalHostFunc(
+			"create_empty",
+			types.Params{{Name: "len", Type: i32}},
+			types.Params{{Name: "handle", Type: i32}},
+		),
+		symbol.InternalHostFunc(
+			"set_element",
+			types.Params{{Name: "handle", Type: i32}, {Name: "idx", Type: i32}, {Name: "value", Type: tv()}},
+			resultOut,
+		),
+		symbol.InternalHostFunc(
+			"index",
+			types.Params{{Name: "handle", Type: i32}, {Name: "idx", Type: i32}},
+			types.Params{{Name: "value", Type: tv()}},
+		),
+		symbol.InternalHostFunc(
+			"negate",
+			types.Params{{Name: "handle", Type: i32}},
+			resultOut,
+		),
+		symbol.InternalHostFunc(
+			"not_u8",
+			types.Params{{Name: "handle", Type: i32}},
+			resultOut,
+		),
+		symbol.InternalHostFunc(
+			"len",
+			types.Params{{Name: "handle", Type: i32}},
+			types.Params{{Name: "length", Type: i64}},
+		),
+		symbol.InternalHostFunc(
+			"slice",
+			types.Params{{Name: "handle", Type: i32}, {Name: "start", Type: i32}, {Name: "end", Type: i32}},
+			resultOut,
+		),
+	).MarkInternal()
+	return []*symbol.Symbol{mod, newUserLenSymbol()}
+}
 
 // Host is the runtime host-side support for the series module: it
 // registers the WASM host bindings that allocate and manipulate series

--- a/arc/go/stl/stable/stable.go
+++ b/arc/go/stl/stable/stable.go
@@ -29,7 +29,18 @@ const (
 )
 
 var (
-	symbolType = types.Function(types.FunctionProperties{
+	memberDoc = doc.New(
+		doc.Paragraph("Emits a value only after it has remained stable for a specified duration. Prevents spurious signals from transient fluctuations."),
+		doc.Divider(),
+		doc.Code("arc", "sensor -> stable.for{duration=5s} -> output"),
+	)
+	moduleDoc = doc.New(
+		doc.Paragraph("Debouncing helpers that emit only after values remain stable for a duration."),
+	)
+)
+
+func newSymbolType() types.Type {
+	return types.Function(types.FunctionProperties{
 		Config: types.Params{
 			{Name: "duration", Type: types.TimeSpan()},
 		},
@@ -40,37 +51,29 @@ var (
 			{Name: ir.DefaultOutputParam, Type: types.Variable("T", nil)},
 		},
 	})
-	memberSymbol = symbol.Symbol{
+}
+
+// NewSymbols returns a fresh slice of ambient prelude symbols this package
+// contributes: the stable module plus the deprecated `stable_for` bare
+// alias whose Deprecated field points at the canonical stable.for member.
+func NewSymbols() []*symbol.Symbol {
+	member := symbol.Symbol{
 		Name: qualifiedMemberName,
 		Kind: symbol.KindFunction,
 		Exec: symbol.ExecFlow,
-		Type: symbolType,
-		Doc: doc.New(
-			doc.Paragraph("Emits a value only after it has remained stable for a specified duration. Prevents spurious signals from transient fluctuations."),
-			doc.Divider(),
-			doc.Code("arc", "sensor -> stable.for{duration=5s} -> output"),
-		),
+		Type: newSymbolType(),
+		Doc:  memberDoc,
 	}
-	module = symbol.NewModule(
-		name,
-		doc.New(
-			doc.Paragraph("Debouncing helpers that emit only after values remain stable for a duration."),
-		),
-		memberSymbol,
-	)
-	bareSymbol = symbol.Symbol{
+	mod := symbol.NewModule(name, moduleDoc, member)
+	bare := &symbol.Symbol{
 		Name:       bareSymbolName,
 		Kind:       symbol.KindFunction,
 		Exec:       symbol.ExecFlow,
-		Type:       symbolType,
-		Deprecated: module.FindChild(qualifiedMemberName),
+		Type:       newSymbolType(),
+		Deprecated: mod.FindChild(qualifiedMemberName),
 	}
-)
-
-// Symbols are the symbols this package contributes to a program's ambient
-// prelude: the stable module plus the deprecated `stable_for` bare alias
-// whose Deprecated field points at the canonical stable.for member.
-var Symbols = []*symbol.Symbol{module, &bareSymbol}
+	return []*symbol.Symbol{mod, bare}
+}
 
 // Host is the runtime host-side support for the stable module: a node
 // factory for stable.for. Stable has no WASM host bindings.

--- a/arc/go/stl/stable/stable.go
+++ b/arc/go/stl/stable/stable.go
@@ -57,22 +57,20 @@ func newSymbolType() types.Type {
 // contributes: the stable module plus the deprecated `stable_for` bare
 // alias whose Deprecated field points at the canonical stable.for member.
 func NewSymbols() []*symbol.Symbol {
-	member := symbol.Symbol{
+	member := &symbol.Symbol{
 		Name: qualifiedMemberName,
 		Kind: symbol.KindFunction,
 		Exec: symbol.ExecFlow,
 		Type: newSymbolType(),
 		Doc:  memberDoc,
 	}
-	mod := symbol.NewModule(name, moduleDoc, member)
-	bare := &symbol.Symbol{
-		Name:       bareSymbolName,
-		Kind:       symbol.KindFunction,
-		Exec:       symbol.ExecFlow,
-		Type:       newSymbolType(),
-		Deprecated: mod.FindChild(qualifiedMemberName),
-	}
-	return []*symbol.Symbol{mod, bare}
+	mod := &symbol.Symbol{Name: name, Kind: symbol.KindModule, Doc: moduleDoc}
+	mod.AddChild(member)
+	bare := *member
+	bare.Parent = nil
+	bare.Name = bareSymbolName
+	bare.Deprecated = mod.FindChild(qualifiedMemberName)
+	return []*symbol.Symbol{mod, &bare}
 }
 
 // Host is the runtime host-side support for the stable module: a node

--- a/arc/go/stl/stable/stable_test.go
+++ b/arc/go/stl/stable/stable_test.go
@@ -378,7 +378,7 @@ var _ = Describe("StableFor", func() {
 
 	Describe("Symbols", func() {
 		var root *symbol.Symbol
-		BeforeEach(func() { root = symbol.NewRoot(nil, stable.Symbols...) })
+		BeforeEach(func() { root = symbol.NewRoot(nil, stable.NewSymbols()) })
 		It("Should expose bare stable_for symbol", func(ctx SpecContext) {
 			sym := MustSucceed(root.Resolve(ctx, "stable_for", symbol.IncludeInternal))
 			Expect(sym.Name).To(Equal("stable_for"))

--- a/arc/go/stl/stateful/stateful.go
+++ b/arc/go/stl/stateful/stateful.go
@@ -17,7 +17,6 @@ import (
 	"github.com/synnaxlabs/arc/stl/strings"
 	"github.com/synnaxlabs/arc/symbol"
 	"github.com/synnaxlabs/arc/types"
-	"github.com/synnaxlabs/x/lsp/doc"
 	"github.com/synnaxlabs/x/query"
 	"github.com/synnaxlabs/x/telem"
 	"github.com/tetratelabs/wazero"
@@ -118,9 +117,8 @@ const Name = "stateful"
 // NewSymbols returns a fresh slice of ambient prelude symbols this package
 // contributes: the stateful module only (no bare globals).
 func NewSymbols() []*symbol.Symbol {
-	mod := symbol.NewModule(
-		Name,
-		doc.Doc{},
+	mod := &symbol.Symbol{Name: Name, Kind: symbol.KindModule, Internal: true}
+	mod.AddChild(
 		symbol.InternalHostFunc(
 			"load",
 			types.Params{{Name: "id", Type: types.I32()}, {Name: "init", Type: types.Variable("T", &numConstraint)}},
@@ -141,7 +139,7 @@ func NewSymbols() []*symbol.Symbol {
 			types.Params{{Name: "id", Type: types.I32()}, {Name: "handle", Type: types.I32()}},
 			nil,
 		),
-	).MarkInternal()
+	)
 	return []*symbol.Symbol{mod}
 }
 

--- a/arc/go/stl/stateful/stateful.go
+++ b/arc/go/stl/stateful/stateful.go
@@ -115,34 +115,35 @@ var numConstraint = types.NumericConstraint()
 // Name is the module name.
 const Name = "stateful"
 
-var module = symbol.NewModule(
-	Name,
-	doc.Doc{},
-	symbol.InternalHostFunc(
-		"load",
-		types.Params{{Name: "id", Type: types.I32()}, {Name: "init", Type: types.Variable("T", &numConstraint)}},
-		types.Params{{Name: "value", Type: types.Variable("T", &numConstraint)}},
-	),
-	symbol.InternalHostFunc(
-		"store",
-		types.Params{{Name: "id", Type: types.I32()}, {Name: "value", Type: types.Variable("T", &numConstraint)}},
-		nil,
-	),
-	symbol.InternalHostFunc(
-		"load_series",
-		types.Params{{Name: "id", Type: types.I32()}, {Name: "init", Type: types.I32()}},
-		types.Params{{Name: "handle", Type: types.I32()}},
-	),
-	symbol.InternalHostFunc(
-		"store_series",
-		types.Params{{Name: "id", Type: types.I32()}, {Name: "handle", Type: types.I32()}},
-		nil,
-	),
-).MarkInternal()
-
-// Symbols are the symbols this package contributes to a program's ambient
-// prelude: the state module only (no bare globals).
-var Symbols = []*symbol.Symbol{module}
+// NewSymbols returns a fresh slice of ambient prelude symbols this package
+// contributes: the stateful module only (no bare globals).
+func NewSymbols() []*symbol.Symbol {
+	mod := symbol.NewModule(
+		Name,
+		doc.Doc{},
+		symbol.InternalHostFunc(
+			"load",
+			types.Params{{Name: "id", Type: types.I32()}, {Name: "init", Type: types.Variable("T", &numConstraint)}},
+			types.Params{{Name: "value", Type: types.Variable("T", &numConstraint)}},
+		),
+		symbol.InternalHostFunc(
+			"store",
+			types.Params{{Name: "id", Type: types.I32()}, {Name: "value", Type: types.Variable("T", &numConstraint)}},
+			nil,
+		),
+		symbol.InternalHostFunc(
+			"load_series",
+			types.Params{{Name: "id", Type: types.I32()}, {Name: "init", Type: types.I32()}},
+			types.Params{{Name: "handle", Type: types.I32()}},
+		),
+		symbol.InternalHostFunc(
+			"store_series",
+			types.Params{{Name: "id", Type: types.I32()}, {Name: "handle", Type: types.I32()}},
+			nil,
+		),
+	).MarkInternal()
+	return []*symbol.Symbol{mod}
+}
 
 func (h *Host) Create(_ context.Context, _ node.Config) (node.Node, error) {
 	return nil, query.ErrNotFound

--- a/arc/go/stl/stl.go
+++ b/arc/go/stl/stl.go
@@ -28,21 +28,26 @@ import (
 	"github.com/synnaxlabs/arc/stl/stateful"
 	"github.com/synnaxlabs/arc/stl/strings"
 	"github.com/synnaxlabs/arc/stl/time"
+	"github.com/synnaxlabs/arc/symbol"
 )
 
-// Symbols is the flattened set of symbols every STL package contributes
-// to a program's ambient prelude.
-var Symbols = slices.Concat(
-	channels.Symbols,
-	constant.Symbols,
-	control.Symbols,
-	errors.Symbols,
-	math.Symbols,
-	op.Symbols,
-	selector.Symbols,
-	series.Symbols,
-	stable.Symbols,
-	stateful.Symbols,
-	strings.Symbols,
-	time.Symbols,
-)
+// NewSymbols returns a fresh slice of every STL package's ambient prelude
+// symbols. Each call allocates a new tree so concurrent analyses (e.g. the
+// LSP serving multiple documents) and successive analyses on the same
+// process never share mutable symbol state.
+func NewSymbols() []*symbol.Symbol {
+	return slices.Concat(
+		channels.NewSymbols(),
+		constant.NewSymbols(),
+		control.NewSymbols(),
+		errors.NewSymbols(),
+		math.NewSymbols(),
+		op.NewSymbols(),
+		selector.NewSymbols(),
+		series.NewSymbols(),
+		stable.NewSymbols(),
+		stateful.NewSymbols(),
+		strings.NewSymbols(),
+		time.NewSymbols(),
+	)
+}

--- a/arc/go/stl/stl_test.go
+++ b/arc/go/stl/stl_test.go
@@ -23,7 +23,7 @@ import (
 
 func allModules() []*symbol.Symbol {
 	var mods []*symbol.Symbol
-	for _, s := range stl.Symbols {
+	for _, s := range stl.NewSymbols() {
 		if s.Kind == symbol.KindModule {
 			mods = append(mods, s)
 		}

--- a/arc/go/stl/strings/string.go
+++ b/arc/go/stl/strings/string.go
@@ -17,7 +17,6 @@ import (
 	"github.com/synnaxlabs/arc/ir"
 	"github.com/synnaxlabs/arc/symbol"
 	"github.com/synnaxlabs/arc/types"
-	"github.com/synnaxlabs/x/lsp/doc"
 	"github.com/tetratelabs/wazero"
 	"github.com/tetratelabs/wazero/api"
 )
@@ -25,7 +24,7 @@ import (
 // Name is the module name.
 const Name = "strings"
 
-func formatHostFunc(t types.Type) symbol.Symbol {
+func formatHostFunc(t types.Type) *symbol.Symbol {
 	return symbol.InternalHostFunc(
 		"format_"+t.String(),
 		types.Params{
@@ -40,9 +39,8 @@ func formatHostFunc(t types.Type) symbol.Symbol {
 // NewSymbols returns a fresh slice of ambient prelude symbols this package
 // contributes. Strings contributes only its module (no bare globals).
 func NewSymbols() []*symbol.Symbol {
-	mod := symbol.NewModule(
-		Name,
-		doc.Doc{},
+	mod := &symbol.Symbol{Name: Name, Kind: symbol.KindModule, Internal: true}
+	mod.AddChild(
 		symbol.InternalHostFunc(
 			"from_literal",
 			types.Params{{Name: "ptr", Type: types.I32()}, {Name: "len", Type: types.I32()}},
@@ -100,7 +98,7 @@ func NewSymbols() []*symbol.Symbol {
 		formatHostFunc(types.F32()),
 		formatHostFunc(types.F64()),
 		formatHostFunc(types.String()),
-	).MarkInternal()
+	)
 	return []*symbol.Symbol{mod}
 }
 

--- a/arc/go/stl/strings/string.go
+++ b/arc/go/stl/strings/string.go
@@ -37,71 +37,72 @@ func formatHostFunc(t types.Type) symbol.Symbol {
 	)
 }
 
-var module = symbol.NewModule(
-	Name,
-	doc.Doc{},
-	symbol.InternalHostFunc(
-		"from_literal",
-		types.Params{{Name: "ptr", Type: types.I32()}, {Name: "len", Type: types.I32()}},
-		types.Params{{Name: "handle", Type: types.I32()}},
-	),
-	symbol.InternalHostFunc(
-		"concat",
-		types.Params{{Name: "a", Type: types.String()}, {Name: "b", Type: types.String()}},
-		types.Params{{Name: ir.DefaultOutputParam, Type: types.String()}},
-	),
-	symbol.InternalHostFunc(
-		"equal",
-		types.Params{{Name: "a", Type: types.String()}, {Name: "b", Type: types.String()}},
-		types.Params{{Name: ir.DefaultOutputParam, Type: types.I32()}},
-	),
-	symbol.InternalHostFunc(
-		"len",
-		types.Params{{Name: "handle", Type: types.String()}},
-		types.Params{{Name: ir.DefaultOutputParam, Type: types.I64()}},
-	),
-	symbol.InternalHostFunc(
-		"from_i32",
-		types.Params{{Name: "value", Type: types.I32()}},
-		types.Params{{Name: ir.DefaultOutputParam, Type: types.String()}},
-	),
-	symbol.InternalHostFunc(
-		"from_u32",
-		types.Params{{Name: "value", Type: types.U32()}},
-		types.Params{{Name: ir.DefaultOutputParam, Type: types.String()}},
-	),
-	symbol.InternalHostFunc(
-		"from_i64",
-		types.Params{{Name: "value", Type: types.I64()}},
-		types.Params{{Name: ir.DefaultOutputParam, Type: types.String()}},
-	),
-	symbol.InternalHostFunc(
-		"from_u64",
-		types.Params{{Name: "value", Type: types.U64()}},
-		types.Params{{Name: ir.DefaultOutputParam, Type: types.String()}},
-	),
-	symbol.InternalHostFunc(
-		"from_f32",
-		types.Params{{Name: "value", Type: types.F32()}},
-		types.Params{{Name: ir.DefaultOutputParam, Type: types.String()}},
-	),
-	symbol.InternalHostFunc(
-		"from_f64",
-		types.Params{{Name: "value", Type: types.F64()}},
-		types.Params{{Name: ir.DefaultOutputParam, Type: types.String()}},
-	),
-	formatHostFunc(types.I32()),
-	formatHostFunc(types.U32()),
-	formatHostFunc(types.I64()),
-	formatHostFunc(types.U64()),
-	formatHostFunc(types.F32()),
-	formatHostFunc(types.F64()),
-	formatHostFunc(types.String()),
-).MarkInternal()
-
-// Symbols are the symbols this package contributes to a program's ambient
-// prelude. Strings contributes only its module (no bare globals).
-var Symbols = []*symbol.Symbol{module}
+// NewSymbols returns a fresh slice of ambient prelude symbols this package
+// contributes. Strings contributes only its module (no bare globals).
+func NewSymbols() []*symbol.Symbol {
+	mod := symbol.NewModule(
+		Name,
+		doc.Doc{},
+		symbol.InternalHostFunc(
+			"from_literal",
+			types.Params{{Name: "ptr", Type: types.I32()}, {Name: "len", Type: types.I32()}},
+			types.Params{{Name: "handle", Type: types.I32()}},
+		),
+		symbol.InternalHostFunc(
+			"concat",
+			types.Params{{Name: "a", Type: types.String()}, {Name: "b", Type: types.String()}},
+			types.Params{{Name: ir.DefaultOutputParam, Type: types.String()}},
+		),
+		symbol.InternalHostFunc(
+			"equal",
+			types.Params{{Name: "a", Type: types.String()}, {Name: "b", Type: types.String()}},
+			types.Params{{Name: ir.DefaultOutputParam, Type: types.I32()}},
+		),
+		symbol.InternalHostFunc(
+			"len",
+			types.Params{{Name: "handle", Type: types.String()}},
+			types.Params{{Name: ir.DefaultOutputParam, Type: types.I64()}},
+		),
+		symbol.InternalHostFunc(
+			"from_i32",
+			types.Params{{Name: "value", Type: types.I32()}},
+			types.Params{{Name: ir.DefaultOutputParam, Type: types.String()}},
+		),
+		symbol.InternalHostFunc(
+			"from_u32",
+			types.Params{{Name: "value", Type: types.U32()}},
+			types.Params{{Name: ir.DefaultOutputParam, Type: types.String()}},
+		),
+		symbol.InternalHostFunc(
+			"from_i64",
+			types.Params{{Name: "value", Type: types.I64()}},
+			types.Params{{Name: ir.DefaultOutputParam, Type: types.String()}},
+		),
+		symbol.InternalHostFunc(
+			"from_u64",
+			types.Params{{Name: "value", Type: types.U64()}},
+			types.Params{{Name: ir.DefaultOutputParam, Type: types.String()}},
+		),
+		symbol.InternalHostFunc(
+			"from_f32",
+			types.Params{{Name: "value", Type: types.F32()}},
+			types.Params{{Name: ir.DefaultOutputParam, Type: types.String()}},
+		),
+		symbol.InternalHostFunc(
+			"from_f64",
+			types.Params{{Name: "value", Type: types.F64()}},
+			types.Params{{Name: ir.DefaultOutputParam, Type: types.String()}},
+		),
+		formatHostFunc(types.I32()),
+		formatHostFunc(types.U32()),
+		formatHostFunc(types.I64()),
+		formatHostFunc(types.U64()),
+		formatHostFunc(types.F32()),
+		formatHostFunc(types.F64()),
+		formatHostFunc(types.String()),
+	).MarkInternal()
+	return []*symbol.Symbol{mod}
+}
 
 func registerFrom[T any](
 	builder wazero.HostModuleBuilder,

--- a/arc/go/stl/time/time.go
+++ b/arc/go/stl/time/time.go
@@ -42,7 +42,28 @@ const MinTolerance = 5 * telem.Millisecond
 const unsetBaseInterval = telem.TimeSpanMax
 
 var (
-	intervalSymbol = symbol.Symbol{
+	intervalDoc = doc.New(
+		doc.Paragraph("Fires repeatedly at a specified period."),
+		doc.Divider(),
+		doc.Code("arc", "time.interval{period=1s} -> tick"),
+	)
+	waitDoc = doc.New(
+		doc.Paragraph("Fires once after a specified duration."),
+		doc.Divider(),
+		doc.Code("arc", "time.wait{duration=500ms} -> done"),
+	)
+	nowDoc = doc.New(
+		doc.Paragraph("Returns the current timestamp."),
+		doc.Divider(),
+		doc.Code("arc", "t := time.now()"),
+	)
+	moduleDoc = doc.New(
+		doc.Paragraph("Time-related primitives: reading the current timestamp, firing periodic intervals, and waiting fixed durations."),
+	)
+)
+
+func newIntervalSymbol() symbol.Symbol {
+	return symbol.Symbol{
 		Name: intervalSymbolName,
 		Kind: symbol.KindFunction,
 		Exec: symbol.ExecFlow,
@@ -50,13 +71,12 @@ var (
 			Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.U8()}},
 			Config:  types.Params{{Name: periodConfigParam, Type: types.TimeSpan()}},
 		}),
-		Doc: doc.New(
-			doc.Paragraph("Fires repeatedly at a specified period."),
-			doc.Divider(),
-			doc.Code("arc", "time.interval{period=1s} -> tick"),
-		),
+		Doc: intervalDoc,
 	}
-	waitSymbol = symbol.Symbol{
+}
+
+func newWaitSymbol() symbol.Symbol {
+	return symbol.Symbol{
 		Name: waitSymbolName,
 		Kind: symbol.KindFunction,
 		Exec: symbol.ExecFlow,
@@ -64,48 +84,36 @@ var (
 			Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.U8()}},
 			Config:  types.Params{{Name: durationConfigParam, Type: types.TimeSpan()}},
 		}),
-		Doc: doc.New(
-			doc.Paragraph("Fires once after a specified duration."),
-			doc.Divider(),
-			doc.Code("arc", "time.wait{duration=500ms} -> done"),
-		),
+		Doc: waitDoc,
 	}
-	nowSymbol = symbol.Symbol{
+}
+
+func newNowSymbol() symbol.Symbol {
+	return symbol.Symbol{
 		Name: nowSymbolName,
 		Kind: symbol.KindFunction,
 		Exec: symbol.ExecBoth,
 		Type: types.Function(types.FunctionProperties{
 			Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.TimeStamp()}},
 		}),
-		Doc: doc.New(
-			doc.Paragraph("Returns the current timestamp."),
-			doc.Divider(),
-			doc.Code("arc", "t := time.now()"),
-		),
+		Doc: nowDoc,
 	}
-)
+}
 
-// module is the time module, built once at package init. Its children are
-// the canonical time.<name> functions and serve as Deprecated targets for
-// the bare globals below.
-var module = symbol.NewModule(
-	name,
-	doc.New(
-		doc.Paragraph("Time-related primitives: reading the current timestamp, firing periodic intervals, and waiting fixed durations."),
-	),
-	intervalSymbol,
-	waitSymbol,
-	nowSymbol,
-)
-
-// Symbols are the symbols this package contributes to a program's ambient
-// prelude: the time module plus the deprecated bare aliases (interval,
+// NewSymbols returns a fresh slice of ambient prelude symbols this package
+// contributes: the time module plus the deprecated bare aliases (interval,
 // wait, now) whose Deprecated fields point at the canonical members.
-var Symbols = []*symbol.Symbol{
-	module,
-	intervalSymbol.Deprecate(module.FindChild(intervalSymbolName)),
-	waitSymbol.Deprecate(module.FindChild(waitSymbolName)),
-	nowSymbol.Deprecate(module.FindChild(nowSymbolName)),
+func NewSymbols() []*symbol.Symbol {
+	interval := newIntervalSymbol()
+	wait := newWaitSymbol()
+	now := newNowSymbol()
+	mod := symbol.NewModule(name, moduleDoc, interval, wait, now)
+	return []*symbol.Symbol{
+		mod,
+		interval.Deprecate(mod.FindChild(intervalSymbolName)),
+		wait.Deprecate(mod.FindChild(waitSymbolName)),
+		now.Deprecate(mod.FindChild(nowSymbolName)),
+	}
 }
 
 // Host is the runtime host-side support for the time module: it registers

--- a/arc/go/stl/time/time.go
+++ b/arc/go/stl/time/time.go
@@ -62,8 +62,11 @@ var (
 	)
 )
 
-func newIntervalSymbol() symbol.Symbol {
-	return symbol.Symbol{
+// NewSymbols returns a fresh slice of ambient prelude symbols this package
+// contributes: the time module plus the deprecated bare aliases (interval,
+// wait, now) whose Deprecated fields point at the canonical members.
+func NewSymbols() []*symbol.Symbol {
+	interval := &symbol.Symbol{
 		Name: intervalSymbolName,
 		Kind: symbol.KindFunction,
 		Exec: symbol.ExecFlow,
@@ -73,10 +76,7 @@ func newIntervalSymbol() symbol.Symbol {
 		}),
 		Doc: intervalDoc,
 	}
-}
-
-func newWaitSymbol() symbol.Symbol {
-	return symbol.Symbol{
+	wait := &symbol.Symbol{
 		Name: waitSymbolName,
 		Kind: symbol.KindFunction,
 		Exec: symbol.ExecFlow,
@@ -86,10 +86,7 @@ func newWaitSymbol() symbol.Symbol {
 		}),
 		Doc: waitDoc,
 	}
-}
-
-func newNowSymbol() symbol.Symbol {
-	return symbol.Symbol{
+	now := &symbol.Symbol{
 		Name: nowSymbolName,
 		Kind: symbol.KindFunction,
 		Exec: symbol.ExecBoth,
@@ -98,22 +95,15 @@ func newNowSymbol() symbol.Symbol {
 		}),
 		Doc: nowDoc,
 	}
-}
-
-// NewSymbols returns a fresh slice of ambient prelude symbols this package
-// contributes: the time module plus the deprecated bare aliases (interval,
-// wait, now) whose Deprecated fields point at the canonical members.
-func NewSymbols() []*symbol.Symbol {
-	interval := newIntervalSymbol()
-	wait := newWaitSymbol()
-	now := newNowSymbol()
-	mod := symbol.NewModule(name, moduleDoc, interval, wait, now)
-	return []*symbol.Symbol{
-		mod,
-		interval.Deprecate(mod.FindChild(intervalSymbolName)),
-		wait.Deprecate(mod.FindChild(waitSymbolName)),
-		now.Deprecate(mod.FindChild(nowSymbolName)),
-	}
+	mod := &symbol.Symbol{Name: name, Kind: symbol.KindModule, Doc: moduleDoc}
+	mod.AddChild(interval, wait, now)
+	intervalBare := *interval
+	intervalBare.Deprecated = interval
+	waitBare := *wait
+	waitBare.Deprecated = wait
+	nowBare := *now
+	nowBare.Deprecated = now
+	return []*symbol.Symbol{mod, &intervalBare, &waitBare, &nowBare}
 }
 
 // Host is the runtime host-side support for the time module: it registers

--- a/arc/go/stl/time/time_test.go
+++ b/arc/go/stl/time/time_test.go
@@ -910,7 +910,7 @@ var _ = Describe("Time", func() {
 	})
 	Describe("Symbols", func() {
 		var root *symbol.Symbol
-		BeforeEach(func() { root = symbol.NewRoot(nil, time.Symbols...) })
+		BeforeEach(func() { root = symbol.NewRoot(nil, time.NewSymbols()) })
 		bare := func(ctx context.Context, name string) *symbol.Symbol {
 			return MustSucceed(root.Resolve(ctx, name, symbol.IncludeInternal))
 		}

--- a/arc/go/stl/wasm/wasm_test.go
+++ b/arc/go/stl/wasm/wasm_test.go
@@ -189,7 +189,7 @@ func newTextHarness(
 	channelDigests ...channels.Digest,
 ) *testHarness {
 	parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
-	root := symbol.NewRoot(nil, stl.Symbols...)
+	root := symbol.NewRoot(nil, stl.NewSymbols())
 	for i := range chans {
 		s := chans[i]
 		root.Parent.AddChild(&s)

--- a/arc/go/symbol/factory_test.go
+++ b/arc/go/symbol/factory_test.go
@@ -17,44 +17,11 @@ import (
 	"github.com/synnaxlabs/arc/symbol"
 	"github.com/synnaxlabs/arc/types"
 	"github.com/synnaxlabs/x/errors"
-	"github.com/synnaxlabs/x/lsp/doc"
 	"github.com/synnaxlabs/x/query"
 	. "github.com/synnaxlabs/x/testutil"
 )
 
 var _ = Describe("Factories", func() {
-	Describe("NewModule", func() {
-		It("Should construct a sealed module with the given name", func() {
-			mod := symbol.NewModule("time", doc.Doc{})
-			Expect(mod.Name).To(Equal("time"))
-			Expect(mod.Kind).To(Equal(symbol.KindModule))
-			Expect(mod.Parent).To(BeNil())
-		})
-
-		It("Should set each member's Parent to the module", func() {
-			mod := symbol.NewModule("time", doc.Doc{},
-				symbol.Symbol{Name: "now", Kind: symbol.KindFunction, Type: types.F64()},
-				symbol.Symbol{Name: "sleep", Kind: symbol.KindFunction, Type: types.F64()},
-			)
-			Expect(mod.Children()).To(HaveLen(2))
-			for _, child := range mod.Children() {
-				Expect(child.Parent).To(Equal(mod))
-			}
-		})
-
-		It("Should copy each member so caller mutations do not leak", func() {
-			member := symbol.Symbol{Name: "now", Kind: symbol.KindFunction, Type: types.F64()}
-			mod := symbol.NewModule("time", doc.Doc{}, member)
-			member.Name = "mutated"
-			Expect(mod.Children()[0].Name).To(Equal("now"))
-		})
-
-		It("Should permit construction with no members", func() {
-			mod := symbol.NewModule("empty", doc.Doc{})
-			Expect(mod.Children()).To(BeEmpty())
-		})
-	})
-
 	Describe("InternalHostFunc", func() {
 		It("Should build a KindFunction symbol flagged Internal and Exec=WASM", func() {
 			sym := symbol.InternalHostFunc(
@@ -84,37 +51,10 @@ var _ = Describe("Factories", func() {
 		})
 	})
 
-	Describe("Deprecate", func() {
-		It("Should return a copy with Deprecated set to the replacement", func() {
-			replacement := &symbol.Symbol{Name: "math.avg", Kind: symbol.KindFunction}
-			deprecated := symbol.Symbol{
-				Name: "avg", Kind: symbol.KindFunction, Type: types.F64(),
-			}.Deprecate(replacement)
-			Expect(deprecated.Name).To(Equal("avg"))
-			Expect(deprecated.Deprecated).To(Equal(replacement))
-		})
-
-		It("Should not mutate the input symbol", func() {
-			input := symbol.Symbol{Name: "avg", Kind: symbol.KindFunction, Type: types.F64()}
-			input.Deprecate(&symbol.Symbol{Name: "math.avg"})
-			Expect(input.Deprecated).To(BeNil())
-		})
-
-		It("Should return a heap-allocated pointer the caller can mutate independently", func() {
-			input := symbol.Symbol{Name: "avg", Kind: symbol.KindFunction}
-			first := input.Deprecate(&symbol.Symbol{Name: "math.avg"})
-			second := input.Deprecate(&symbol.Symbol{Name: "stats.avg"})
-			Expect(first).ToNot(Equal(second))
-			Expect(first.Deprecated.Name).To(Equal("math.avg"))
-			Expect(second.Deprecated.Name).To(Equal("stats.avg"))
-		})
-	})
-
 	Describe("QualifiedName", func() {
 		It("Should prefix the module name for a module member", func() {
-			mod := symbol.NewModule("math", doc.Doc{},
-				symbol.Symbol{Name: "avg", Kind: symbol.KindFunction},
-			)
+			mod := &symbol.Symbol{Name: "math", Kind: symbol.KindModule}
+			mod.AddChild(&symbol.Symbol{Name: "avg", Kind: symbol.KindFunction})
 			Expect(mod.FindChild("avg").QualifiedName()).To(Equal("math.avg"))
 		})
 
@@ -148,12 +88,10 @@ var _ = Describe("Factories", func() {
 
 	Describe("AutoImportModules", func() {
 		It("Should install a KindModuleAlias child for each module in the ambient prelude", func() {
-			timeMod := symbol.NewModule("time", doc.Doc{},
-				symbol.Symbol{Name: "now", Kind: symbol.KindFunction, Type: types.F64()},
-			)
-			mathMod := symbol.NewModule("math", doc.Doc{},
-				symbol.Symbol{Name: "avg", Kind: symbol.KindFunction, Type: types.F64()},
-			)
+			timeMod := &symbol.Symbol{Name: "time", Kind: symbol.KindModule}
+			timeMod.AddChild(&symbol.Symbol{Name: "now", Kind: symbol.KindFunction, Type: types.F64()})
+			mathMod := &symbol.Symbol{Name: "math", Kind: symbol.KindModule}
+			mathMod.AddChild(&symbol.Symbol{Name: "avg", Kind: symbol.KindFunction, Type: types.F64()})
 			ambient := &symbol.Symbol{Kind: symbol.KindAmbient}
 			ambient.AddChild(timeMod)
 			ambient.AddChild(mathMod)
@@ -180,7 +118,7 @@ var _ = Describe("Factories", func() {
 		It("Should skip non-module children of the ambient prelude", func() {
 			ambient := &symbol.Symbol{Kind: symbol.KindAmbient}
 			ambient.AddChild(&symbol.Symbol{Name: "global_const", Kind: symbol.KindGlobalConstant})
-			ambient.AddChild(symbol.NewModule("time", doc.Doc{}))
+			ambient.AddChild(&symbol.Symbol{Name: "time", Kind: symbol.KindModule})
 			root := symbol.NewRoot(nil, nil)
 			ambient.AddChild(root)
 

--- a/arc/go/symbol/factory_test.go
+++ b/arc/go/symbol/factory_test.go
@@ -119,7 +119,7 @@ var _ = Describe("Factories", func() {
 		})
 
 		It("Should return the bare name for a top-level symbol", func(bCtx SpecContext) {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			sym := MustSucceed(rootScope.Add(
 				bCtx,
 				symbol.Symbol{Name: "x", Kind: symbol.KindVariable, Type: types.I32()},
@@ -128,7 +128,7 @@ var _ = Describe("Factories", func() {
 		})
 
 		It("Should return the bare name when the parent is not a module", func(bCtx SpecContext) {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			funcScope := MustSucceed(rootScope.Add(
 				bCtx,
 				symbol.Symbol{Name: "f", Kind: symbol.KindFunction},
@@ -157,7 +157,7 @@ var _ = Describe("Factories", func() {
 			ambient := &symbol.Symbol{Kind: symbol.KindAmbient}
 			ambient.AddChild(timeMod)
 			ambient.AddChild(mathMod)
-			root := symbol.NewRoot(nil)
+			root := symbol.NewRoot(nil, nil)
 			ambient.AddChild(root)
 
 			symbol.AutoImportModules(root)
@@ -181,7 +181,7 @@ var _ = Describe("Factories", func() {
 			ambient := &symbol.Symbol{Kind: symbol.KindAmbient}
 			ambient.AddChild(&symbol.Symbol{Name: "global_const", Kind: symbol.KindGlobalConstant})
 			ambient.AddChild(symbol.NewModule("time", doc.Doc{}))
-			root := symbol.NewRoot(nil)
+			root := symbol.NewRoot(nil, nil)
 			ambient.AddChild(root)
 
 			symbol.AutoImportModules(root)
@@ -194,7 +194,7 @@ var _ = Describe("Factories", func() {
 	Describe("NewRoot", func() {
 		It("Should attach ambient globals as siblings of the root", func() {
 			channel := &symbol.Symbol{Name: "sensor", Kind: symbol.KindChannel, Type: types.Chan(types.F32())}
-			root := symbol.NewRoot(nil, channel)
+			root := symbol.NewRoot(nil, []*symbol.Symbol{channel})
 			Expect(root.Parent).ToNot(BeNil())
 			Expect(root.Parent.Kind).To(Equal(symbol.KindAmbient))
 			Expect(root.Parent.FindChild("sensor")).ToNot(BeNil())
@@ -202,7 +202,7 @@ var _ = Describe("Factories", func() {
 
 		It("Should shallow-copy each ambient global so callers can reuse them across roots", func() {
 			original := &symbol.Symbol{Name: "sensor", Kind: symbol.KindChannel, Type: types.Chan(types.F32())}
-			root := symbol.NewRoot(nil, original)
+			root := symbol.NewRoot(nil, []*symbol.Symbol{original})
 			attached := root.Parent.FindChild("sensor")
 			Expect(attached.Parent).To(Equal(root.Parent))
 			Expect(original.Parent).To(BeNil())
@@ -210,8 +210,8 @@ var _ = Describe("Factories", func() {
 
 		It("Should isolate Parent assignment between concurrent roots", func() {
 			shared := &symbol.Symbol{Name: "shared", Kind: symbol.KindChannel, Type: types.Chan(types.F32())}
-			rootA := symbol.NewRoot(nil, shared)
-			rootB := symbol.NewRoot(nil, shared)
+			rootA := symbol.NewRoot(nil, []*symbol.Symbol{shared})
+			rootB := symbol.NewRoot(nil, []*symbol.Symbol{shared})
 			attachedA := rootA.Parent.FindChild("shared")
 			attachedB := rootB.Parent.FindChild("shared")
 			Expect(attachedA).ToNot(BeIdenticalTo(attachedB))
@@ -221,7 +221,7 @@ var _ = Describe("Factories", func() {
 
 		It("Should install the given dynamic resolver on the root", func(bCtx SpecContext) {
 			resolver := &recordingResolver{}
-			root := symbol.NewRoot(resolver)
+			root := symbol.NewRoot(resolver, nil)
 			Expect(root.GlobalResolver).To(Equal(resolver))
 			_, _ = root.Resolve(bCtx, "missing")
 			Expect(resolver.resolveCalls).To(Equal(1))

--- a/arc/go/symbol/scope_test.go
+++ b/arc/go/symbol/scope_test.go
@@ -24,7 +24,7 @@ import (
 var _ = Describe("Scope", func() {
 	Describe("Root", func() {
 		It("Should create a new root scope", func() {
-			s := symbol.NewRoot(nil)
+			s := symbol.NewRoot(nil, nil)
 			Expect(s.GlobalResolver).To(BeNil())
 			Expect(s.Children()).To(BeEmpty())
 			Expect(s.Counter).ToNot(BeNil())
@@ -32,14 +32,14 @@ var _ = Describe("Scope", func() {
 		})
 
 		It("Should create a new root scope with a global resolver", func() {
-			s := symbol.NewRoot(StaticResolver{})
+			s := symbol.NewRoot(StaticResolver{}, nil)
 			Expect(s.GlobalResolver).ToNot(BeNil())
 		})
 	})
 
 	Describe("Add", func() {
 		It("Should add a new variable scope", func(bCtx SpecContext) {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			varScope := MustSucceed(rootScope.Add(
 				bCtx,
 				symbol.Symbol{Name: "x", Kind: symbol.KindVariable, Type: types.I32()},
@@ -55,7 +55,7 @@ var _ = Describe("Scope", func() {
 		})
 
 		It("Should add a new function scope", func(bCtx SpecContext) {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			funcScope := MustSucceed(rootScope.Add(
 				bCtx,
 				symbol.Symbol{Name: "my_func", Kind: symbol.KindFunction},
@@ -67,7 +67,7 @@ var _ = Describe("Scope", func() {
 		})
 
 		It("Should add a new func scope", func(bCtx SpecContext) {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			stageScope := MustSucceed(rootScope.Add(
 				bCtx,
 				symbol.Symbol{Name: "my_task", Kind: symbol.KindBlock},
@@ -77,7 +77,7 @@ var _ = Describe("Scope", func() {
 
 		DescribeTable("Should assign IDs to slot-allocating kinds",
 			func(bCtx SpecContext, kind symbol.Kind) {
-				rootScope := symbol.NewRoot(nil)
+				rootScope := symbol.NewRoot(nil, nil)
 				scope1 := MustSucceed(rootScope.Add(
 					bCtx,
 					symbol.Symbol{Name: "var1", Kind: kind, Type: types.I32()},
@@ -98,7 +98,7 @@ var _ = Describe("Scope", func() {
 		)
 
 		It("Should give KindSequence its own Counter", func(bCtx SpecContext) {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			seqScope := MustSucceed(rootScope.Add(
 				bCtx,
 				symbol.Symbol{Name: "my_seq", Kind: symbol.KindSequence},
@@ -113,7 +113,7 @@ var _ = Describe("Scope", func() {
 		})
 
 		It("Should give KindFunction a Channels container", func(bCtx SpecContext) {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			funcScope := MustSucceed(rootScope.Add(
 				bCtx,
 				symbol.Symbol{Name: "f", Kind: symbol.KindFunction},
@@ -123,7 +123,7 @@ var _ = Describe("Scope", func() {
 		})
 
 		It("Should not give KindSequence a Channels container", func(bCtx SpecContext) {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			seqScope := MustSucceed(rootScope.Add(
 				bCtx,
 				symbol.Symbol{Name: "s", Kind: symbol.KindSequence},
@@ -132,7 +132,7 @@ var _ = Describe("Scope", func() {
 		})
 
 		It("Should correctly increment IDs for variables within function scopes", func(bCtx SpecContext) {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			funcScope := MustSucceed(rootScope.Add(
 				bCtx,
 				symbol.Symbol{Name: "my_func", Kind: symbol.KindFunction},
@@ -156,7 +156,7 @@ var _ = Describe("Scope", func() {
 		})
 
 		It("Should not return error when adding duplicate symbol that shadows a global", func(bCtx SpecContext) {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			scope1 := MustSucceed(rootScope.Add(
 				bCtx,
 				symbol.Symbol{Name: "x", Kind: symbol.KindVariable, Type: types.I32()},
@@ -171,7 +171,7 @@ var _ = Describe("Scope", func() {
 			globalResolver := StaticResolver{
 				{Name: "x", Kind: symbol.KindConfig, Type: types.F64()},
 			}
-			rootScope := symbol.NewRoot(globalResolver)
+			rootScope := symbol.NewRoot(globalResolver, nil)
 			scope := MustSucceed(rootScope.Add(bCtx, symbol.Symbol{Name: "x", Kind: symbol.KindVariable, Type: types.I32()}))
 			Expect(scope).ToNot(BeNil())
 		})
@@ -179,7 +179,7 @@ var _ = Describe("Scope", func() {
 			globalResolver := StaticResolver{
 				{Name: "x", Kind: symbol.KindConfig, Type: types.F64()},
 			}
-			rootScope := symbol.NewRoot(globalResolver)
+			rootScope := symbol.NewRoot(globalResolver, nil)
 			localScope := MustSucceed(rootScope.Add(bCtx, symbol.Symbol{Name: "x", Kind: symbol.KindVariable, Type: types.I32()}))
 			resolved := MustSucceed(rootScope.Resolve(bCtx, "x"))
 			Expect(resolved).To(Equal(localScope))
@@ -190,7 +190,7 @@ var _ = Describe("Scope", func() {
 			globalResolver := StaticResolver{
 				{Name: "x", Kind: symbol.KindConfig, Type: types.F64()},
 			}
-			rootScope := symbol.NewRoot(globalResolver)
+			rootScope := symbol.NewRoot(globalResolver, nil)
 			funcScope := MustSucceed(rootScope.Add(bCtx, symbol.Symbol{Name: "f", Kind: symbol.KindFunction}))
 			localScope := MustSucceed(funcScope.Add(bCtx, symbol.Symbol{Name: "x", Kind: symbol.KindVariable, Type: types.I32()}))
 			resolved := MustSucceed(funcScope.Resolve(bCtx, "x"))
@@ -198,7 +198,7 @@ var _ = Describe("Scope", func() {
 			Expect(resolved.Type).To(Equal(types.I32()))
 		})
 		It("Should allow symbols with empty names", func(bCtx SpecContext) {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			child := MustSucceed(rootScope.Add(bCtx, symbol.Symbol{Name: "", Kind: symbol.KindBlock}))
 			Expect(child.Name).To(Equal(""))
 		})
@@ -206,7 +206,7 @@ var _ = Describe("Scope", func() {
 
 	Describe("GetChildByParserRule", func() {
 		It("Should find child by parser rule", func(bCtx SpecContext) {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			rule := antlr.NewBaseParserRuleContext(nil, 0)
 			child := MustSucceed(rootScope.Add(
 				bCtx,
@@ -217,7 +217,7 @@ var _ = Describe("Scope", func() {
 		})
 
 		It("Should return error when parser rule not found", func(bCtx SpecContext) {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			scope := MustSucceed(rootScope.Add(
 				bCtx,
 				symbol.Symbol{Name: "x", Kind: symbol.KindVariable, Type: types.I32()},
@@ -229,7 +229,7 @@ var _ = Describe("Scope", func() {
 
 	Describe("FindChild", func() {
 		It("Should find child by name", func(bCtx SpecContext) {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			child := MustSucceed(rootScope.Add(
 				bCtx,
 				symbol.Symbol{Name: "x", Kind: symbol.KindVariable, Type: types.I32()},
@@ -239,7 +239,7 @@ var _ = Describe("Scope", func() {
 		})
 
 		It("Should return nil when name not found", func() {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			found := rootScope.FindChild("nonexistent")
 			Expect(found).To(BeNil())
 		})
@@ -247,7 +247,7 @@ var _ = Describe("Scope", func() {
 
 	Describe("AddChild", func() {
 		It("Should append the child and set its Parent", func() {
-			parent := symbol.NewRoot(nil)
+			parent := symbol.NewRoot(nil, nil)
 			child := &symbol.Symbol{Name: "host_fn", Kind: symbol.KindFunction}
 			parent.AddChild(child)
 			Expect(child.Parent).To(Equal(parent))
@@ -255,13 +255,13 @@ var _ = Describe("Scope", func() {
 		})
 
 		It("Should return the child for chaining", func() {
-			parent := symbol.NewRoot(nil)
+			parent := symbol.NewRoot(nil, nil)
 			child := &symbol.Symbol{Name: "host_fn", Kind: symbol.KindFunction}
 			Expect(parent.AddChild(child)).To(Equal(child))
 		})
 
 		It("Should append in insertion order", func() {
-			parent := symbol.NewRoot(nil)
+			parent := symbol.NewRoot(nil, nil)
 			first := &symbol.Symbol{Name: "first", Kind: symbol.KindFunction}
 			second := &symbol.Symbol{Name: "second", Kind: symbol.KindFunction}
 			parent.AddChild(first)
@@ -272,7 +272,7 @@ var _ = Describe("Scope", func() {
 		})
 
 		It("Should not check for naming conflicts", func() {
-			parent := symbol.NewRoot(nil)
+			parent := symbol.NewRoot(nil, nil)
 			parent.AddChild(&symbol.Symbol{Name: "dup", Kind: symbol.KindFunction})
 			parent.AddChild(&symbol.Symbol{Name: "dup", Kind: symbol.KindFunction})
 			conflicts := 0
@@ -285,7 +285,7 @@ var _ = Describe("Scope", func() {
 		})
 
 		It("Should not assign an ID", func() {
-			parent := symbol.NewRoot(nil)
+			parent := symbol.NewRoot(nil, nil)
 			child := &symbol.Symbol{Name: "x", Kind: symbol.KindVariable}
 			parent.AddChild(child)
 			Expect(child.ID).To(Equal(0))
@@ -294,7 +294,7 @@ var _ = Describe("Scope", func() {
 
 	Describe("Root", func() {
 		It("Should return root scope from any depth", func(bCtx SpecContext) {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			funcScope := MustSucceed(rootScope.Add(bCtx, symbol.Symbol{Name: "f", Kind: symbol.KindFunction}))
 			varScope := MustSucceed(funcScope.Add(bCtx, symbol.Symbol{Name: "x", Kind: symbol.KindVariable, Type: types.I32()}))
 			Expect(varScope.Root()).To(Equal(rootScope))
@@ -305,13 +305,13 @@ var _ = Describe("Scope", func() {
 
 	Describe("Resolve", func() {
 		It("Should resolve symbol in current scope", func(bCtx SpecContext) {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			child := MustSucceed(rootScope.Add(bCtx, symbol.Symbol{Name: "x", Kind: symbol.KindVariable, Type: types.I32()}))
 			resolved := MustSucceed(rootScope.Resolve(bCtx, "x"))
 			Expect(resolved).To(Equal(child))
 		})
 		It("Should resolve symbol from parent scope", func(bCtx SpecContext) {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			global := MustSucceed(rootScope.Add(bCtx, symbol.Symbol{Name: "global", Kind: symbol.KindVariable, Type: types.I32()}))
 			funcScope := MustSucceed(rootScope.Add(bCtx, symbol.Symbol{Name: "f", Kind: symbol.KindFunction}))
 			resolved := MustSucceed(funcScope.Resolve(bCtx, "global"))
@@ -321,20 +321,20 @@ var _ = Describe("Scope", func() {
 			globalResolver := StaticResolver{
 				{Name: "pi", Kind: symbol.KindConfig, Type: types.F64()},
 			}
-			rootScope := symbol.NewRoot(globalResolver)
+			rootScope := symbol.NewRoot(globalResolver, nil)
 			resolved := MustSucceed(rootScope.Resolve(bCtx, "pi"))
 			Expect(resolved.Name).To(Equal("pi"))
 			Expect(resolved.Kind).To(Equal(symbol.KindConfig))
 		})
 		It("Should prioritize local over parent scope", func(bCtx SpecContext) {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			rootX := MustSucceed(rootScope.Add(bCtx, symbol.Symbol{Name: "x", Kind: symbol.KindVariable, Type: types.I32()}))
 			funcScope := MustSucceed(rootScope.Add(bCtx, symbol.Symbol{Name: "f", Kind: symbol.KindFunction}))
 			resolvedFromFunc := MustSucceed(funcScope.Resolve(bCtx, "x"))
 			Expect(resolvedFromFunc).To(Equal(rootX))
 		})
 		It("Should return error for undefined symbol", func(bCtx SpecContext) {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			Expect(rootScope.Resolve(bCtx, "undefined")).Error().To(
 				MatchError(ContainSubstring("undefined symbol: undefined")),
 			)
@@ -343,7 +343,7 @@ var _ = Describe("Scope", func() {
 			globalResolver := StaticResolver{
 				{Name: "host_fn", Kind: symbol.KindFunction, Type: types.F64(), Internal: true},
 			}
-			rootScope := symbol.NewRoot(globalResolver)
+			rootScope := symbol.NewRoot(globalResolver, nil)
 			Expect(rootScope.Resolve(bCtx, "host_fn")).Error().To(MatchError(ContainSubstring("undefined symbol: host_fn")))
 		})
 		It("Should resolve non-internal symbols from global resolver alongside internal ones", func(bCtx SpecContext) {
@@ -351,7 +351,7 @@ var _ = Describe("Scope", func() {
 				{Name: "host_fn", Kind: symbol.KindFunction, Type: types.F64(), Internal: true},
 				{Name: "user_fn", Kind: symbol.KindFunction, Type: types.F64()},
 			}
-			rootScope := symbol.NewRoot(globalResolver)
+			rootScope := symbol.NewRoot(globalResolver, nil)
 			resolved := MustSucceed(rootScope.Resolve(bCtx, "user_fn"))
 			Expect(resolved.Name).To(Equal("user_fn"))
 		})
@@ -359,13 +359,13 @@ var _ = Describe("Scope", func() {
 			globalResolver := StaticResolver{
 				{Name: "host_fn", Kind: symbol.KindFunction, Type: types.F64(), Internal: true},
 			}
-			rootScope := symbol.NewRoot(globalResolver)
+			rootScope := symbol.NewRoot(globalResolver, nil)
 			resolved := MustSucceed(rootScope.Resolve(bCtx, "host_fn", symbol.IncludeInternal))
 			Expect(resolved.Name).To(Equal("host_fn"))
 			Expect(resolved.Internal).To(BeTrue())
 		})
 		It("Should match a numeric name by ID rather than by Name", func(bCtx SpecContext) {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			first := MustSucceed(rootScope.Add(
 				bCtx,
 				symbol.Symbol{Name: "a", Kind: symbol.KindVariable, Type: types.I32()},
@@ -380,7 +380,7 @@ var _ = Describe("Scope", func() {
 			Expect(byID).To(Equal(second))
 		})
 		It("Should report the origin scope on undefined-symbol error after a multi-level walk", func(bCtx SpecContext) {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			funcScope := MustSucceed(rootScope.Add(
 				bCtx,
 				symbol.Symbol{Name: "f", Kind: symbol.KindFunction},
@@ -404,7 +404,7 @@ var _ = Describe("Scope", func() {
 				})
 				ambient := &symbol.Symbol{Kind: symbol.KindAmbient}
 				ambient.AddChild(timeMod)
-				root := symbol.NewRoot(nil)
+				root := symbol.NewRoot(nil, nil)
 				ambient.AddChild(root)
 				return root
 			}
@@ -484,7 +484,7 @@ var _ = Describe("Scope", func() {
 
 	Describe("Search", func() {
 		It("Should resolve symbols from children", func(bCtx SpecContext) {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			fooScope := MustSucceed(rootScope.Add(bCtx, symbol.Symbol{Name: "foo", Kind: symbol.KindVariable, Type: types.I32()}))
 			Expect(fooScope).ToNot(BeNil())
 			foobarScope := MustSucceed(rootScope.Add(bCtx, symbol.Symbol{Name: "foobar", Kind: symbol.KindVariable, Type: types.I64()}))
@@ -501,14 +501,14 @@ var _ = Describe("Scope", func() {
 				{Name: "pi", Kind: symbol.KindConfig, Type: types.F64()},
 				{Name: "print", Kind: symbol.KindFunction},
 			}
-			rootScope := symbol.NewRoot(globalResolver)
+			rootScope := symbol.NewRoot(globalResolver, nil)
 			scopes := MustSucceed(rootScope.Search(bCtx, "p"))
 			Expect(scopes).To(HaveLen(2))
 			names := []string{scopes[0].Name, scopes[1].Name}
 			Expect(names).To(ContainElements("pi", "print"))
 		})
 		It("Should resolve symbols from parent scope", func(bCtx SpecContext) {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			globalScope := MustSucceed(rootScope.Add(bCtx, symbol.Symbol{Name: "global", Kind: symbol.KindVariable, Type: types.I32()}))
 			Expect(globalScope).ToNot(BeNil())
 			globalTwoScope := MustSucceed(rootScope.Add(bCtx, symbol.Symbol{Name: "globalTwo", Kind: symbol.KindVariable, Type: types.I32()}))
@@ -523,7 +523,7 @@ var _ = Describe("Scope", func() {
 			globalResolver := StaticResolver{
 				{Name: "x", Kind: symbol.KindConfig, Type: types.F64()},
 			}
-			rootScope := symbol.NewRoot(globalResolver)
+			rootScope := symbol.NewRoot(globalResolver, nil)
 			rootX := MustSucceed(rootScope.Add(bCtx, symbol.Symbol{Name: "x", Kind: symbol.KindVariable, Type: types.I32()}))
 			Expect(rootX).ToNot(BeNil())
 			funcScope := MustSucceed(rootScope.Add(bCtx, symbol.Symbol{Name: "f", Kind: symbol.KindFunction}))
@@ -534,14 +534,14 @@ var _ = Describe("Scope", func() {
 			Expect(scopes[0].Type).To(Equal(types.I64()))
 		})
 		It("Should return empty slice for non-matching prefix", func(bCtx SpecContext) {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			scope := MustSucceed(rootScope.Add(bCtx, symbol.Symbol{Name: "foo", Kind: symbol.KindVariable, Type: types.I32()}))
 			Expect(scope).ToNot(BeNil())
 			scopes := MustSucceed(rootScope.Search(bCtx, "xyz"))
 			Expect(scopes).To(BeEmpty())
 		})
 		It("Should return all symbols for empty prefix", func(bCtx SpecContext) {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			fooScope := MustSucceed(rootScope.Add(bCtx, symbol.Symbol{Name: "foo", Kind: symbol.KindVariable, Type: types.I32()}))
 			Expect(fooScope).ToNot(BeNil())
 			barScope := MustSucceed(rootScope.Add(bCtx, symbol.Symbol{Name: "bar", Kind: symbol.KindVariable, Type: types.I32()}))
@@ -554,7 +554,7 @@ var _ = Describe("Scope", func() {
 				{Name: "element_add", Kind: symbol.KindFunction, Type: types.F64(), Internal: true},
 				{Name: "len", Kind: symbol.KindFunction, Type: types.F64()},
 			}
-			rootScope := symbol.NewRoot(globalResolver)
+			rootScope := symbol.NewRoot(globalResolver, nil)
 			scopes := MustSucceed(rootScope.Search(bCtx, ""))
 			Expect(scopes).To(HaveLen(1))
 			Expect(scopes[0].Name).To(Equal("len"))
@@ -565,7 +565,7 @@ var _ = Describe("Scope", func() {
 				{Name: "element_sub", Kind: symbol.KindFunction, Type: types.F64(), Internal: true},
 				{Name: "element_len", Kind: symbol.KindFunction, Type: types.F64()},
 			}
-			rootScope := symbol.NewRoot(globalResolver)
+			rootScope := symbol.NewRoot(globalResolver, nil)
 			scopes := MustSucceed(rootScope.Search(bCtx, "element"))
 			Expect(scopes).To(HaveLen(1))
 			Expect(scopes[0].Name).To(Equal("element_len"))
@@ -574,7 +574,7 @@ var _ = Describe("Scope", func() {
 
 	Describe("ClosestAncestorOfKind", func() {
 		It("Should find closest ancestor of kind", func(bCtx SpecContext) {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			funcScope := MustSucceed(rootScope.Add(bCtx, symbol.Symbol{Name: "f", Kind: symbol.KindFunction}))
 			blockScope := MustSucceed(funcScope.Add(bCtx, symbol.Symbol{Name: "block", Kind: symbol.KindBlock}))
 			varScope := MustSucceed(blockScope.Add(bCtx, symbol.Symbol{Name: "x", Kind: symbol.KindVariable, Type: types.I32()}))
@@ -583,14 +583,14 @@ var _ = Describe("Scope", func() {
 		})
 
 		It("Should return self if matching kind", func(bCtx SpecContext) {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			funcScope := MustSucceed(rootScope.Add(bCtx, symbol.Symbol{Name: "f", Kind: symbol.KindFunction}))
 			ancestor := MustSucceed(funcScope.ClosestAncestorOfKind(symbol.KindFunction))
 			Expect(ancestor).To(Equal(funcScope))
 		})
 
 		It("Should return error when no ancestor found", func() {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			Expect(rootScope.ClosestAncestorOfKind(symbol.KindChannel)).Error().To(
 				MatchError(ContainSubstring("undefined symbol")),
 			)
@@ -599,7 +599,7 @@ var _ = Describe("Scope", func() {
 
 	Describe("String", func() {
 		It("Should format scope as string", func(bCtx SpecContext) {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			funcScope := MustSucceed(rootScope.Add(bCtx, symbol.Symbol{Name: "myFunc", Kind: symbol.KindFunction}))
 			varScope := MustSucceed(funcScope.Add(bCtx, symbol.Symbol{Name: "x", Kind: symbol.KindVariable, Type: types.I32()}))
 			Expect(varScope).ToNot(BeNil())
@@ -614,7 +614,7 @@ var _ = Describe("Scope", func() {
 
 	Describe("FilterChildrenByKind", func() {
 		It("Should filter children by kind", func(bCtx SpecContext) {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			var1 := MustSucceed(rootScope.Add(bCtx, symbol.Symbol{Name: "x", Kind: symbol.KindVariable, Type: types.I32()}))
 			funcScope := MustSucceed(rootScope.Add(bCtx, symbol.Symbol{Name: "f", Kind: symbol.KindFunction}))
 			Expect(funcScope).ToNot(BeNil())
@@ -624,7 +624,7 @@ var _ = Describe("Scope", func() {
 			Expect(filtered).To(ContainElements(var1, var2))
 		})
 		It("Should return empty when no matches", func(bCtx SpecContext) {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			scope := MustSucceed(rootScope.Add(bCtx, symbol.Symbol{Name: "x", Kind: symbol.KindVariable, Type: types.I32()}))
 			Expect(scope).ToNot(BeNil())
 			filtered := rootScope.FilterChildrenByKind(symbol.KindChannel)
@@ -634,7 +634,7 @@ var _ = Describe("Scope", func() {
 
 	Describe("AutoName", func() {
 		It("Should generate name with prefix and incremented index", func() {
-			rootScope := symbol.NewRoot(nil)
+			rootScope := symbol.NewRoot(nil, nil)
 			child1 := &symbol.Symbol{Parent: rootScope, Kind: symbol.KindBlock}
 			child1.AutoName("stage_")
 			Expect(child1.Name).To(Equal("stage_0"))
@@ -679,7 +679,7 @@ var _ = Describe("Scope", func() {
 			})
 
 			It("Should replace internal Read ID with actual channel ID for user-defined functions", func(bCtx SpecContext) {
-				fnSym := symbol.NewRoot(nil)
+				fnSym := symbol.NewRoot(nil, nil)
 				fnSym.Kind = symbol.KindFunction
 				fnSym.Channels = types.NewChannels()
 				configParam := MustSucceed(fnSym.Add(bCtx, symbol.Symbol{
@@ -698,7 +698,7 @@ var _ = Describe("Scope", func() {
 			})
 
 			It("Should replace internal Write ID with actual channel ID for user-defined functions", func(bCtx SpecContext) {
-				fnSym := symbol.NewRoot(nil)
+				fnSym := symbol.NewRoot(nil, nil)
 				fnSym.Kind = symbol.KindFunction
 				fnSym.Channels = types.NewChannels()
 				configParam := MustSucceed(fnSym.Add(bCtx, symbol.Symbol{
@@ -718,7 +718,7 @@ var _ = Describe("Scope", func() {
 			})
 
 			It("Should handle param that is both read and written", func(bCtx SpecContext) {
-				fnSym := symbol.NewRoot(nil)
+				fnSym := symbol.NewRoot(nil, nil)
 				fnSym.Kind = symbol.KindFunction
 				fnSym.Channels = types.NewChannels()
 				configParam := MustSucceed(fnSym.Add(bCtx, symbol.Symbol{

--- a/arc/go/symbol/scope_test.go
+++ b/arc/go/symbol/scope_test.go
@@ -17,7 +17,6 @@ import (
 	. "github.com/synnaxlabs/arc/symbol/testutil"
 	"github.com/synnaxlabs/arc/types"
 	"github.com/synnaxlabs/x/errors"
-	"github.com/synnaxlabs/x/lsp/doc"
 	. "github.com/synnaxlabs/x/testutil"
 )
 
@@ -254,10 +253,21 @@ var _ = Describe("Scope", func() {
 			Expect(parent.FindChild("host_fn")).To(Equal(child))
 		})
 
-		It("Should return the child for chaining", func() {
+		It("Should return the receiver for chaining", func() {
 			parent := symbol.NewRoot(nil, nil)
 			child := &symbol.Symbol{Name: "host_fn", Kind: symbol.KindFunction}
-			Expect(parent.AddChild(child)).To(Equal(child))
+			Expect(parent.AddChild(child)).To(Equal(parent))
+		})
+
+		It("Should append every child when called variadically", func() {
+			parent := symbol.NewRoot(nil, nil)
+			first := &symbol.Symbol{Name: "first", Kind: symbol.KindFunction}
+			second := &symbol.Symbol{Name: "second", Kind: symbol.KindFunction}
+			parent.AddChild(first, second)
+			Expect(first.Parent).To(Equal(parent))
+			Expect(second.Parent).To(Equal(parent))
+			Expect(parent.FindChild("first")).To(Equal(first))
+			Expect(parent.FindChild("second")).To(Equal(second))
 		})
 
 		It("Should append in insertion order", func() {
@@ -399,7 +409,8 @@ var _ = Describe("Scope", func() {
 			// buildAmbientRoot constructs a root with a synthetic ambient
 			// prelude that has a single "time" module containing "now".
 			buildAmbientRoot := func(bCtx SpecContext) *symbol.Symbol {
-				timeMod := symbol.NewModule("time", doc.Doc{}, symbol.Symbol{
+				timeMod := &symbol.Symbol{Name: "time", Kind: symbol.KindModule}
+				timeMod.AddChild(&symbol.Symbol{
 					Name: "now", Kind: symbol.KindFunction, Type: types.F64(),
 				})
 				ambient := &symbol.Symbol{Kind: symbol.KindAmbient}

--- a/arc/go/symbol/suggest_test.go
+++ b/arc/go/symbol/suggest_test.go
@@ -65,7 +65,7 @@ var _ = Describe("Symbol Suggestions", func() {
 
 	Describe("SuggestSimilar", func() {
 		It("should suggest similar symbol names", func(bCtx SpecContext) {
-			root := symbol.NewRoot(nil)
+			root := symbol.NewRoot(nil, nil)
 			MustSucceed(root.Add(bCtx, symbol.Symbol{Name: "temperature", Kind: symbol.KindVariable}))
 			MustSucceed(root.Add(bCtx, symbol.Symbol{Name: "pressure", Kind: symbol.KindVariable}))
 			MustSucceed(root.Add(bCtx, symbol.Symbol{Name: "humidity", Kind: symbol.KindVariable}))
@@ -75,7 +75,7 @@ var _ = Describe("Symbol Suggestions", func() {
 		})
 
 		It("should return empty slice when no similar symbols exist", func(bCtx SpecContext) {
-			root := symbol.NewRoot(nil)
+			root := symbol.NewRoot(nil, nil)
 			MustSucceed(root.Add(bCtx, symbol.Symbol{Name: "x", Kind: symbol.KindVariable}))
 
 			suggestions := root.SuggestSimilar(bCtx, "temperature", 2)
@@ -83,7 +83,7 @@ var _ = Describe("Symbol Suggestions", func() {
 		})
 
 		It("should respect maxSuggestions limit", func(bCtx SpecContext) {
-			root := symbol.NewRoot(nil)
+			root := symbol.NewRoot(nil, nil)
 			MustSucceed(root.Add(bCtx, symbol.Symbol{Name: "cat", Kind: symbol.KindVariable}))
 			MustSucceed(root.Add(bCtx, symbol.Symbol{Name: "bat", Kind: symbol.KindVariable}))
 			MustSucceed(root.Add(bCtx, symbol.Symbol{Name: "rat", Kind: symbol.KindVariable}))
@@ -94,7 +94,7 @@ var _ = Describe("Symbol Suggestions", func() {
 		})
 
 		It("should search parent scopes", func(bCtx SpecContext) {
-			root := symbol.NewRoot(nil)
+			root := symbol.NewRoot(nil, nil)
 			MustSucceed(root.Add(bCtx, symbol.Symbol{Name: "globalVar", Kind: symbol.KindVariable}))
 
 			child := MustSucceed(root.Add(bCtx, symbol.Symbol{Name: "block", Kind: symbol.KindBlock}))
@@ -104,7 +104,7 @@ var _ = Describe("Symbol Suggestions", func() {
 		})
 
 		It("should sort suggestions by distance", func(bCtx SpecContext) {
-			root := symbol.NewRoot(nil)
+			root := symbol.NewRoot(nil, nil)
 			MustSucceed(root.Add(bCtx, symbol.Symbol{Name: "test", Kind: symbol.KindVariable}))
 			MustSucceed(root.Add(bCtx, symbol.Symbol{Name: "tests", Kind: symbol.KindVariable}))
 			MustSucceed(root.Add(bCtx, symbol.Symbol{Name: "testing", Kind: symbol.KindVariable}))
@@ -115,7 +115,7 @@ var _ = Describe("Symbol Suggestions", func() {
 		})
 
 		It("should not include exact matches", func(bCtx SpecContext) {
-			root := symbol.NewRoot(nil)
+			root := symbol.NewRoot(nil, nil)
 			MustSucceed(root.Add(bCtx, symbol.Symbol{Name: "temperature", Kind: symbol.KindVariable}))
 
 			suggestions := root.SuggestSimilar(bCtx, "temperature", 2)
@@ -125,7 +125,7 @@ var _ = Describe("Symbol Suggestions", func() {
 
 	Describe("Resolve with suggestions", func() {
 		It("should return UndefinedSymbolError with lazy hint", func(bCtx SpecContext) {
-			root := symbol.NewRoot(nil)
+			root := symbol.NewRoot(nil, nil)
 			MustSucceed(root.Add(bCtx, symbol.Symbol{Name: "temperature", Kind: symbol.KindVariable}))
 
 			Expect(root.Resolve(bCtx, "temperatur")).Error().
@@ -137,7 +137,7 @@ var _ = Describe("Symbol Suggestions", func() {
 		})
 
 		It("should not include suggestions when none are close enough", func(bCtx SpecContext) {
-			root := symbol.NewRoot(nil)
+			root := symbol.NewRoot(nil, nil)
 			MustSucceed(root.Add(bCtx, symbol.Symbol{Name: "x", Kind: symbol.KindVariable}))
 
 			Expect(root.Resolve(bCtx, "unknownSymbol")).Error().
@@ -156,7 +156,7 @@ var _ = Describe("Symbol Suggestions", func() {
 					{Name: "builtin_fn", Kind: symbol.KindFunction},
 				},
 			}
-			root := symbol.NewRoot(tracker)
+			root := symbol.NewRoot(tracker, nil)
 			MustSucceed(root.Add(bCtx, symbol.Symbol{Name: "alpha", Kind: symbol.KindVariable}))
 			MustSucceed(root.Add(bCtx, symbol.Symbol{Name: "beta", Kind: symbol.KindVariable}))
 			MustSucceed(root.Add(bCtx, symbol.Symbol{Name: "gamma", Kind: symbol.KindVariable}))
@@ -164,7 +164,7 @@ var _ = Describe("Symbol Suggestions", func() {
 		})
 
 		It("should provide suggestions via diagnostics.Error with HintProvider", func(bCtx SpecContext) {
-			root := symbol.NewRoot(nil)
+			root := symbol.NewRoot(nil, nil)
 			MustSucceed(root.Add(bCtx, symbol.Symbol{Name: "temperature", Kind: symbol.KindVariable}))
 
 			d := diagnostics.Error(resolveErr(bCtx, root, "temperatur"), nil)
@@ -174,7 +174,7 @@ var _ = Describe("Symbol Suggestions", func() {
 		})
 
 		It("should not add notes via diagnostics.Error when no suggestions exist", func(bCtx SpecContext) {
-			root := symbol.NewRoot(nil)
+			root := symbol.NewRoot(nil, nil)
 			MustSucceed(root.Add(bCtx, symbol.Symbol{Name: "x", Kind: symbol.KindVariable}))
 
 			d := diagnostics.Error(resolveErr(bCtx, root, "unknownSymbol"), nil)

--- a/arc/go/symbol/symbol.go
+++ b/arc/go/symbol/symbol.go
@@ -227,14 +227,11 @@ type Symbol struct {
 // where STL symbols, test channels, and custom modules belong.
 //
 // Each ambient global is shallow-copied before being attached so the
-// per-root Parent assignment does not mutate the caller's symbol. STL
-// packages expose their modules as package-level singletons, and
-// concurrent NewRoot calls (e.g. an LSP server analyzing two documents
-// at once) would otherwise race on those shared Parent fields. Module
-// children stay shared across roots — they are read-only after
-// construction and the seal at KindModule means Parent-walks inside a
-// module never observe the per-root Parent of the wrapper.
-func NewRoot(dynamicResolver Resolver, ambientGlobals ...*Symbol) *Symbol {
+// per-root Parent assignment does not mutate the caller's symbol. This
+// matters when a caller reuses the same slice across multiple roots:
+// without the copy, the second NewRoot call would re-parent symbols
+// away from the first root's ambient.
+func NewRoot(dynamicResolver Resolver, ambientGlobals []*Symbol) *Symbol {
 	ambient := &Symbol{Kind: KindAmbient}
 	root := &Symbol{
 		Kind:           KindBlock,

--- a/arc/go/symbol/symbol.go
+++ b/arc/go/symbol/symbol.go
@@ -338,15 +338,18 @@ func (s *Symbol) Add(ctx context.Context, sym Symbol) (*Symbol, error) {
 	return child, nil
 }
 
-// AddChild appends an already-constructed child to s.children and sets its
-// Parent. Used by builders (e.g., STL module construction) that prepare
-// children before attaching them. Does not check for naming conflicts and
-// does not assign IDs; callers are responsible for these when constructing
-// tree fragments directly.
-func (s *Symbol) AddChild(child *Symbol) *Symbol {
-	child.Parent = s
-	s.children = append(s.children, child)
-	return child
+// AddChild appends each already-constructed child to s.children and sets
+// its Parent to s. Used by builders (e.g., STL module construction) that
+// prepare children before attaching them. Does not check for naming
+// conflicts and does not assign IDs; callers are responsible for these
+// when constructing tree fragments directly. Returns s so calls can be
+// chained.
+func (s *Symbol) AddChild(children ...*Symbol) *Symbol {
+	for _, child := range children {
+		child.Parent = s
+		s.children = append(s.children, child)
+	}
+	return s
 }
 
 // AutoImportModules aliases each non-Internal KindModule in root's
@@ -379,8 +382,8 @@ func AutoImportModules(root *Symbol) {
 // is hidden from user code. Used by STL packages to declare host bindings
 // (channels.read, state.load, etc.) with the common shape factored out:
 // every WASM host shim is Kind=KindFunction, Exec=ExecWASM, Internal=true.
-func InternalHostFunc(name string, inputs, outputs types.Params) Symbol {
-	return Symbol{
+func InternalHostFunc(name string, inputs, outputs types.Params) *Symbol {
+	return &Symbol{
 		Name:     name,
 		Kind:     KindFunction,
 		Exec:     ExecWASM,
@@ -390,44 +393,6 @@ func InternalHostFunc(name string, inputs, outputs types.Params) Symbol {
 			Outputs: outputs,
 		}),
 	}
-}
-
-// NewModule constructs a sealed module symbol with the given name, hover
-// documentation, and the supplied members as children. Parent is nil so
-// name resolution from outside cannot see the module's siblings, and
-// lookup from inside cannot escape the module's namespace. Pass a zero
-// doc.Doc{} when the module is Internal (compiler-only) and has no
-// user-facing hover.
-func NewModule(name string, body doc.Doc, members ...Symbol) *Symbol {
-	mod := &Symbol{Name: name, Kind: KindModule, Doc: body}
-	for i := range members {
-		child := members[i]
-		child.Parent = mod
-		mod.children = append(mod.children, &child)
-	}
-	return mod
-}
-
-// MarkInternal sets Internal=true on s and returns s for chaining. Used
-// to hide a symbol from user code while keeping it reachable from the
-// compiler via IncludeInternal. Applied to STL modules whose surface is
-// meant for the compiler only (channels, strings, series, stateful) —
-// host shims that user code is not allowed to call directly.
-func (s *Symbol) MarkInternal() *Symbol {
-	s.Internal = true
-	return s
-}
-
-// Deprecate returns a heap-allocated copy of s with Deprecated set to
-// replacement. Used by STL packages to build the bare-name aliases
-// (`avg`, `interval`, ...) that point at their canonical module members
-// (`math.avg`, `time.interval`, ...). The copy's Doc is cleared because
-// the hover renderer reads the canonical's Doc through Deprecated; keeping
-// a second copy on the alias would let the two drift.
-func (s Symbol) Deprecate(replacement *Symbol) *Symbol {
-	s.Deprecated = replacement
-	s.Doc = doc.Doc{}
-	return &s
 }
 
 func (s *Symbol) addIndex() int {

--- a/arc/go/symbol/testutil/testutil.go
+++ b/arc/go/symbol/testutil/testutil.go
@@ -28,13 +28,14 @@ import (
 // internally) so tests can pass their per-test []symbol.Symbol resolver
 // slices directly without a conversion loop.
 func NewRoot(resolver symbol.Resolver, extras ...symbol.Symbol) *symbol.Symbol {
-	syms := make([]*symbol.Symbol, 0, len(stl.Symbols)+len(extras))
-	syms = append(syms, stl.Symbols...)
+	stlSyms := stl.NewSymbols()
+	syms := make([]*symbol.Symbol, 0, len(stlSyms)+len(extras))
+	syms = append(syms, stlSyms...)
 	for i := range extras {
 		s := extras[i]
 		syms = append(syms, &s)
 	}
-	return symbol.NewRoot(resolver, syms...)
+	return symbol.NewRoot(resolver, syms)
 }
 
 // NewGraphRoot is NewRoot plus symbol.AutoImportModules. Graph-mode tests

--- a/arc/go/text/text_test.go
+++ b/arc/go/text/text_test.go
@@ -260,7 +260,7 @@ var _ = Describe("Text", func() {
 			DescribeTable("Literal constant generation",
 				func(ctx SpecContext, source string, chans []symbol.Symbol, expectConstant bool, expectedType types.Type) {
 					parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
-					root := symbol.NewRoot(nil, stl.Symbols...)
+					root := symbol.NewRoot(nil, stl.NewSymbols())
 					for i := range chans {
 						s := chans[i]
 						root.Parent.AddChild(&s)
@@ -2210,7 +2210,7 @@ time.wait{duration=500ms} -> output`
 			DescribeTable("next keyword error cases",
 				func(ctx SpecContext, source string, chans []symbol.Symbol, expectedError string) {
 					parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
-					root := symbol.NewRoot(nil, stl.Symbols...)
+					root := symbol.NewRoot(nil, stl.NewSymbols())
 					for i := range chans {
 						s := chans[i]
 						root.Parent.AddChild(&s)

--- a/arc/go/text/text_test.go
+++ b/arc/go/text/text_test.go
@@ -22,7 +22,6 @@ import (
 	. "github.com/synnaxlabs/arc/symbol/testutil"
 	"github.com/synnaxlabs/arc/text"
 	"github.com/synnaxlabs/arc/types"
-	"github.com/synnaxlabs/x/lsp/doc"
 	"github.com/synnaxlabs/x/set"
 	"github.com/synnaxlabs/x/telem"
 	. "github.com/synnaxlabs/x/testutil"
@@ -690,7 +689,8 @@ sensor -> stable.for{duration=1s} -> output`
 						{Name: ir.DefaultOutputParam, Type: types.U8()},
 					},
 				})
-				statusModule := symbol.NewModule("status", doc.Doc{}, symbol.Symbol{
+				statusModule := &symbol.Symbol{Name: "status", Kind: symbol.KindModule}
+				statusModule.AddChild(&symbol.Symbol{
 					Name: "set",
 					Kind: symbol.KindFunction,
 					Exec: symbol.ExecFlow,
@@ -726,7 +726,8 @@ sensor -> stable.for{duration=1s} -> output`
 						{Name: ir.DefaultOutputParam, Type: types.U8()},
 					},
 				})
-				statusModule := symbol.NewModule("status", doc.Doc{}, symbol.Symbol{
+				statusModule := &symbol.Symbol{Name: "status", Kind: symbol.KindModule}
+				statusModule.AddChild(&symbol.Symbol{
 					Name: "set",
 					Kind: symbol.KindFunction,
 					Exec: symbol.ExecFlow,

--- a/core/pkg/service/arc/runtime/task_test.go
+++ b/core/pkg/service/arc/runtime/task_test.go
@@ -85,7 +85,7 @@ var _ = Describe("Task", Ordered, func() {
 	newGraphFactory := func(g graph.Graph) driver.Factory {
 		return newFactoryWith(func(ctx context.Context, key uuid.UUID) (svcarc.Arc, error) {
 			resolver := symbol.NewChannelResolver(dist.Channel, nil)
-			root := arc.NewRoot(resolver, arcstatus.Symbols...)
+			root := arc.NewRoot(resolver, arcstatus.NewSymbols()...)
 			module, err := arc.CompileGraph(ctx, g, root)
 			if err != nil {
 				return svcarc.Arc{}, err
@@ -97,7 +97,7 @@ var _ = Describe("Task", Ordered, func() {
 	newTextFactory := func(ctx context.Context, prof arc.Text) driver.Factory {
 		return newFactoryWith(func(_ context.Context, _ uuid.UUID) (svcarc.Arc, error) {
 			resolver := symbol.NewChannelResolver(dist.Channel, nil)
-			root := arc.NewRoot(resolver, arcstatus.Symbols...)
+			root := arc.NewRoot(resolver, arcstatus.NewSymbols()...)
 			module, err := arc.CompileText(ctx, prof, root)
 			if err != nil {
 				return svcarc.Arc{}, err

--- a/core/pkg/service/arc/service.go
+++ b/core/pkg/service/arc/service.go
@@ -121,10 +121,12 @@ func (s *Service) NewSymbolResolver(tx gorp.Tx) arc.SymbolResolver {
 // is the production analysis root: tx is consulted for channel lookups,
 // nil means "use the service DB directly."
 func (s *Service) NewRoot(tx gorp.Tx) *arcsymbol.Symbol {
-	syms := make([]*arcsymbol.Symbol, 0, len(stl.Symbols)+len(arcstatus.Symbols))
-	syms = append(syms, stl.Symbols...)
-	syms = append(syms, arcstatus.Symbols...)
-	return arcsymbol.NewRoot(s.NewChannelResolver(tx), syms...)
+	stlSyms := stl.NewSymbols()
+	statusSyms := arcstatus.NewSymbols()
+	syms := make([]*arcsymbol.Symbol, 0, len(stlSyms)+len(statusSyms))
+	syms = append(syms, stlSyms...)
+	syms = append(syms, statusSyms...)
+	return arcsymbol.NewRoot(s.NewChannelResolver(tx), syms)
 }
 
 func (s *Service) NewLSP() (*lsp.Server, error) {

--- a/core/pkg/service/arc/status/set.go
+++ b/core/pkg/service/arc/status/set.go
@@ -34,59 +34,54 @@ const (
 	moduleName          = "status"
 )
 
-var symbolProps = types.Function(types.FunctionProperties{
-	Config: types.Params{
-		{Name: "status_key", Type: types.String()},
-		{Name: "variant", Type: types.String()},
-		{Name: "message", Type: types.String()},
-		{Name: "name", Type: types.String(), Value: ""},
-	},
-	Inputs: types.Params{
-		{Name: ir.DefaultOutputParam, Type: types.U8()},
-	},
-})
-
-// memberSymbol is the canonical status.set symbol that lives inside the
-// status module. The deprecated bare global below points at it via
-// Deprecated so analyzer hints can name the replacement.
-var memberSymbol = symbol.Symbol{
-	Name: qualifiedMemberName,
-	Kind: symbol.KindFunction,
-	Exec: symbol.ExecFlow,
-	Type: symbolProps,
-	Doc: doc.New(
+var (
+	memberDoc = doc.New(
 		doc.Paragraph("Sets a status notification on the cluster. Used to report alarms, warnings, or operational state."),
 		doc.Divider(),
 		doc.Code("arc", "sensor -> status.set{status_key=\"ox_alarm\", variant=\"error\", message=\"Overpressure\"}"),
 		doc.Divider(),
 		doc.Paragraph("Accepted variants: success, error, warning, info."),
-	),
-}
-
-// module is the status module, built once at package init. Its sole child
-// is the `set` function above.
-var module = symbol.NewModule(
-	moduleName,
-	doc.New(
+	)
+	moduleDoc = doc.New(
 		doc.Paragraph("Publishes status notifications (alarms, warnings, operational state) to the cluster."),
-	),
-	memberSymbol,
+	)
 )
 
-// bareSymbolPtr is the deprecated `set_status` bare global. Its
-// Deprecated field points at the module's `set` member so warnings name
-// the qualified replacement.
-var bareSymbolPtr = &symbol.Symbol{
-	Name:       bareSymbolName,
-	Kind:       symbol.KindFunction,
-	Exec:       symbol.ExecFlow,
-	Type:       symbolProps,
-	Deprecated: module.FindChild(qualifiedMemberName),
+func newSymbolProps() types.Type {
+	return types.Function(types.FunctionProperties{
+		Config: types.Params{
+			{Name: "status_key", Type: types.String()},
+			{Name: "variant", Type: types.String()},
+			{Name: "message", Type: types.String()},
+			{Name: "name", Type: types.String(), Value: ""},
+		},
+		Inputs: types.Params{
+			{Name: ir.DefaultOutputParam, Type: types.U8()},
+		},
+	})
 }
 
-// Symbols are the symbols this package contributes to a program's
-// ambient prelude: the status module plus the deprecated bare global.
-var Symbols = []*symbol.Symbol{module, bareSymbolPtr}
+// NewSymbols returns a fresh slice of ambient prelude symbols this package
+// contributes: the status module plus the deprecated `set_status` bare
+// global whose Deprecated field points at the canonical status.set member.
+func NewSymbols() []*symbol.Symbol {
+	member := symbol.Symbol{
+		Name: qualifiedMemberName,
+		Kind: symbol.KindFunction,
+		Exec: symbol.ExecFlow,
+		Type: newSymbolProps(),
+		Doc:  memberDoc,
+	}
+	mod := symbol.NewModule(moduleName, moduleDoc, member)
+	bare := &symbol.Symbol{
+		Name:       bareSymbolName,
+		Kind:       symbol.KindFunction,
+		Exec:       symbol.ExecFlow,
+		Type:       newSymbolProps(),
+		Deprecated: mod.FindChild(qualifiedMemberName),
+	}
+	return []*symbol.Symbol{mod, bare}
+}
 
 type Module struct {
 	stat *status.Service

--- a/core/pkg/service/arc/status/set.go
+++ b/core/pkg/service/arc/status/set.go
@@ -65,14 +65,15 @@ func newSymbolProps() types.Type {
 // contributes: the status module plus the deprecated `set_status` bare
 // global whose Deprecated field points at the canonical status.set member.
 func NewSymbols() []*symbol.Symbol {
-	member := symbol.Symbol{
+	member := &symbol.Symbol{
 		Name: qualifiedMemberName,
 		Kind: symbol.KindFunction,
 		Exec: symbol.ExecFlow,
 		Type: newSymbolProps(),
 		Doc:  memberDoc,
 	}
-	mod := symbol.NewModule(moduleName, moduleDoc, member)
+	mod := &symbol.Symbol{Name: moduleName, Kind: symbol.KindModule, Doc: moduleDoc}
+	mod.AddChild(member)
 	bare := &symbol.Symbol{
 		Name:       bareSymbolName,
 		Kind:       symbol.KindFunction,

--- a/core/pkg/service/arc/status/set_test.go
+++ b/core/pkg/service/arc/status/set_test.go
@@ -28,7 +28,7 @@ import (
 
 var _ = Describe("Symbols", func() {
 	findByName := func(name string) *symbol.Symbol {
-		for _, s := range arcstatus.Symbols {
+		for _, s := range arcstatus.NewSymbols() {
 			if s.Name == name {
 				return s
 			}


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4215](https://linear.app/synnax/issue/SY-4215)

## Description

The Arc analyzer had two related bugs that surfaced when editing polymorphic STL function calls in the LSP. Each is independently fixable, both are fixed here.

**Bug A — cross-analysis corruption.** `applyTypeSubstitutionsToSymbols` walked through \`KindModuleAlias\` children (\`Symbol.Children()\` follows aliases transparently) and rewrote each scope's \`Type\` field in place. Because \`stl.Symbols\` was a package-level \`var\`, the math/time/control/etc. modules were shared across every analysis in the LSP process. Once one analysis bound a type variable to a concrete type, the shared \`avgSymbol.Type.Inputs[0].Type\` was permanently \`f32\` (or whatever it resolved to first), and every later analysis failed against the corrupted symbol. Reproduced as: \`sensor_f32 -> math.avg{...}\` analyzes fine, edit the channel to one with a different type, get \`{input f32 <nil>}\` mismatch.

**Bug B — multi-call within one analysis.** \`flow.go:parseFunction\` pulled \`funcType.Type.Inputs[0]\` directly (unfreshened) for inline type checks. Two calls to the same polymorphic function with different concrete types unified against a single shared \`T\` and the second conflicted.

### Fixes

- \`flow.go:parseFunction\` and \`AnalyzeSingleFunction\` now \`Freshen\` the function type per call site (keyed by AST source position) so each invocation gets its own \`T\`. Three flow branches updated (identifier, expression, function-output).
- Every STL package (\`math\`, \`time\`, \`control\`, \`channels\`, \`series\`, \`stateful\`, \`strings\`, \`op\`, \`selector\`, \`errors\`, \`constant\`, \`stable\`) replaced \`var Symbols\` with \`func NewSymbols()\`. Same for \`core/pkg/service/arc/status\`. Each call returns a freshly-allocated tree; concurrent and sequential analyses no longer share any mutable symbol state. Doc strings stay package-level constants since they are immutable.
- \`stl.Symbols\` is now \`stl.NewSymbols()\`. All call sites (\`arc.NewRoot\`, \`testutil.NewRoot\`, \`compiler/testutil\`, \`lsp/testutil\`, \`core/pkg/service/arc/service.go\`, tests) updated.
- \`symbol.NewRoot\` signature changed from variadic \`...*Symbol\` to slice \`[]*Symbol\`. Only ~4 call sites in symbol-package tests used the true-variadic form; every production caller already passed a slice with \`...\`.

### Regression tests

\`arc/go/analyzer/polymorphic_test.go\` gains two scenarios:
- \"Should accept two calls to the same polymorphic func with different concrete types\" — covers Bug B.
- \"Should not corrupt a module's polymorphic function type across analyses\" — covers Bug A.

Both fail on the prior \`main\` and pass after these changes.

### Verification

- All 53 \`arc/go\` ginkgo suites pass.
- All 5 \`core/pkg/service/arc/...\` suites pass (including \`Alarm Flow\`).

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two related LSP analysis bugs: shared mutable symbol state caused type-variable corruption across analyses (Bug A), and missing per-call type freshening caused conflicts when the same polymorphic function appeared twice in one program (Bug B).

- All STL packages replace `var Symbols` singletons with `func NewSymbols()` constructors so each analysis gets its own freshly-allocated symbol tree, eliminating cross-analysis state corruption.
- `flow.go` and `AnalyzeSingleFunction` now call `types.Freshen` keyed by AST position before each invocation of a polymorphic function, giving each call site its own type-variable namespace.
- `symbol.NewRoot` signature changed from variadic `...*Symbol` to slice `[]*Symbol`; `symbol.NewModule` and `symbol.Deprecate` helpers were removed in favour of inline construction inside each `NewSymbols` function.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The core fix is mechanically sound, well-tested with two targeted regression tests that directly reproduce both bugs.

All substantive changes address clearly identified root causes. The remaining observations are style inconsistencies with no runtime impact.

arc/go/stl/channels/channels.go and arc/go/stl/constant/constant.go use an unusual constraint-allocation idiom; arc/go/stl/math/math.go and arc/go/stl/time/time.go copy bare aliases without resetting Parent.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| arc/go/analyzer/flow/flow.go | Adds position-keyed Freshen calls for every polymorphic function invocation; error messages intentionally keep the original unfreshened type name. |
| arc/go/stl/channels/channels.go | Converts var Symbols to NewSymbols(); uses unusual new(types.NumericConstraint()) idiom. |
| arc/go/stl/constant/constant.go | Same unusual new(types.NumericConstraint()) pattern as channels.go. |
| arc/go/symbol/symbol.go | NewRoot takes a slice, AddChild made variadic, NewModule/Deprecate removed, InternalHostFunc returns *Symbol. |
| arc/go/stl/stl.go | Replaces global var Symbols with func NewSymbols() delegating to all package constructors. |
| arc/go/stl/math/math.go | Converts to NewSymbols(); bare aliases copy Parent from canonical child without resetting it. |
| arc/go/analyzer/polymorphic_test.go | Adds regression tests for both Bug A (cross-analysis corruption) and Bug B (two calls to same polymorphic func). |
| core/pkg/service/arc/service.go | Updates NewRoot to call fresh NewSymbols() per invocation. |
| core/pkg/service/arc/status/set.go | Converts to NewSymbols() factory with fresh type allocation per call. |

</details>

<sub>Reviews (2): Last reviewed commit: ["fixed linting issues and added relevant ..."](https://github.com/synnaxlabs/synnax/commit/a3b6e6e531fce230eaf170b5ab30236a6c770fd0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33524135)</sub>

<!-- /greptile_comment -->