### PR TITLE
SY-4210: Fix Flakey Aspen KV Observable Dedup Test

### DIFF
--- a/aspen/internal/kv/filter_persist.go
+++ b/aspen/internal/kv/filter_persist.go
@@ -1,0 +1,126 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+package kv
+
+import (
+	"context"
+
+	"github.com/synnaxlabs/x/address"
+	"github.com/synnaxlabs/x/confluence"
+	"github.com/synnaxlabs/x/errors"
+	xkv "github.com/synnaxlabs/x/kv"
+	"github.com/synnaxlabs/x/query"
+)
+
+// filterPersist fuses version filtering and persistence into a single segment
+// for the gossip-ingress path. It opens one transaction per inbound TxRequest,
+// reads each digest inside that transaction, and writes accepted ops and their
+// digests through the same transaction before committing. Because reads inside
+// the transaction see prior writes from the same transaction, two duplicate
+// ops in one TxRequest cannot both pass. Because the segment processes one
+// TxRequest at a time on a single goroutine and the engine state cannot change
+// between the digest read and the digest write of any single op, duplicate
+// deliveries across TxRequests are also rejected. This is the structural
+// guarantee that backs the exactly-once observable contract documented on
+// DB.NewObservable.
+//
+// The local write path (versionAssigner -> persist) does not flow through
+// filterPersist: locally-assigned versions are monotonic by construction, so
+// the digest check would always pass and would burden single-node deployments
+// with a Get they cannot benefit from.
+type filterPersist struct {
+	confluence.BatchSwitch[TxRequest, TxRequest]
+	db         xkv.Atomic
+	acceptedTo address.Address
+	rejectedTo address.Address
+	Config
+}
+
+func newFilterPersist(
+	cfg Config,
+	acceptedTo address.Address,
+	rejectedTo address.Address,
+) segment {
+	s := &filterPersist{
+		Config:     cfg,
+		db:         cfg.Engine,
+		acceptedTo: acceptedTo,
+		rejectedTo: rejectedTo,
+	}
+	s.Switch = s._switch
+	return s
+}
+
+func (fp *filterPersist) _switch(
+	_ context.Context,
+	b TxRequest,
+	o map[address.Address]TxRequest,
+) (err error) {
+	ctx, span := fp.T.Debug(b.Context, "tx-filter-persist")
+	defer span.End()
+
+	var (
+		accepted = TxRequest{Sender: b.Sender, doneF: b.doneF, Context: b.Context, span: b.span}
+		rejected = TxRequest{Sender: b.Sender, Context: b.Context, span: b.span}
+	)
+
+	txn := fp.db.OpenTx()
+	defer func() {
+		if err != nil {
+			err = errors.Combine(err, txn.Close())
+		} else if commitErr := txn.Commit(ctx); commitErr != nil {
+			err = errors.Combine(commitErr, txn.Close())
+		}
+		accepted.done(err)
+	}()
+
+	for _, op := range b.Operations {
+		keep, filterErr := fp.filter(ctx, txn, op)
+		if filterErr != nil {
+			err = filterErr
+			return
+		}
+		if !keep {
+			rejected.Operations = append(rejected.Operations, op)
+			continue
+		}
+		if applyErr := op.apply(ctx, txn); applyErr != nil {
+			err = applyErr
+			return
+		}
+		if digestErr := op.Digest().apply(ctx, txn); digestErr != nil {
+			err = digestErr
+			return
+		}
+		accepted.Operations = append(accepted.Operations, op)
+	}
+
+	if len(accepted.Operations) > 0 {
+		o[fp.acceptedTo] = accepted
+	}
+	if len(rejected.Operations) > 0 {
+		o[fp.rejectedTo] = rejected
+	}
+	return nil
+}
+
+func (fp *filterPersist) filter(ctx context.Context, r xkv.Reader, op Operation) (bool, error) {
+	dig, err := getDigestFromKV(ctx, r, op.Key)
+	if err != nil {
+		if errors.Is(err, query.ErrNotFound) {
+			return true, nil
+		}
+		return false, err
+	}
+	if op.Version.EqualTo(dig.Version) {
+		return op.Leaseholder > dig.Leaseholder, nil
+	}
+	return op.Version.NewerThan(dig.Version), nil
+}

--- a/aspen/internal/kv/filter_persist.go
+++ b/aspen/internal/kv/filter_persist.go
@@ -37,7 +37,7 @@ import (
 // with a Get they cannot benefit from.
 type filterPersist struct {
 	confluence.BatchSwitch[TxRequest, TxRequest]
-	db         xkv.Atomic
+	db         xkv.DB
 	acceptedTo address.Address
 	rejectedTo address.Address
 	Config
@@ -62,65 +62,52 @@ func (fp *filterPersist) _switch(
 	_ context.Context,
 	b TxRequest,
 	o map[address.Address]TxRequest,
-) (err error) {
+) error {
 	ctx, span := fp.T.Debug(b.Context, "tx-filter-persist")
 	defer span.End()
 
-	var (
-		accepted = TxRequest{Sender: b.Sender, doneF: b.doneF, Context: b.Context, span: b.span}
-		rejected = TxRequest{Sender: b.Sender, Context: b.Context, span: b.span}
-	)
+	accepted := TxRequest{Sender: b.Sender, doneF: b.doneF, Context: b.Context, span: b.span}
+	rejected := TxRequest{Sender: b.Sender, Context: b.Context, span: b.span}
 
-	txn := fp.db.OpenTx()
-	defer func() {
-		if err != nil {
-			err = errors.Combine(err, txn.Close())
-		} else if commitErr := txn.Commit(ctx); commitErr != nil {
-			err = errors.Combine(commitErr, txn.Close())
+	err := xkv.WithTx(ctx, fp.db, func(txn xkv.Tx) error {
+		for _, op := range b.Operations {
+			if !supersedes(ctx, txn, op) {
+				rejected.Operations = append(rejected.Operations, op)
+				continue
+			}
+			if err := op.apply(ctx, txn); err != nil {
+				return err
+			}
+			if err := op.Digest().apply(ctx, txn); err != nil {
+				return err
+			}
+			accepted.Operations = append(accepted.Operations, op)
 		}
-		accepted.done(err)
-	}()
+		return nil
+	})
+	accepted.done(err)
 
-	for _, op := range b.Operations {
-		keep, filterErr := fp.filter(ctx, txn, op)
-		if filterErr != nil {
-			err = filterErr
-			return
-		}
-		if !keep {
-			rejected.Operations = append(rejected.Operations, op)
-			continue
-		}
-		if applyErr := op.apply(ctx, txn); applyErr != nil {
-			err = applyErr
-			return
-		}
-		if digestErr := op.Digest().apply(ctx, txn); digestErr != nil {
-			err = digestErr
-			return
-		}
-		accepted.Operations = append(accepted.Operations, op)
-	}
-
-	if len(accepted.Operations) > 0 {
+	if err == nil && !accepted.empty() {
 		o[fp.acceptedTo] = accepted
 	}
-	if len(rejected.Operations) > 0 {
+	if !rejected.empty() {
 		o[fp.rejectedTo] = rejected
 	}
 	return nil
 }
 
-func (fp *filterPersist) filter(ctx context.Context, r xkv.Reader, op Operation) (bool, error) {
+// supersedes reports whether op should replace the digest stored for op.Key in
+// r. An op supersedes when its version is strictly newer, or when versions tie
+// and its leaseholder wins the higher-key tiebreak. A missing digest is treated
+// as superseded. Any other read error is treated as not-superseding so a
+// transient read failure cannot cause an op to overwrite stored state.
+func supersedes(ctx context.Context, r xkv.Reader, op Operation) bool {
 	dig, err := getDigestFromKV(ctx, r, op.Key)
 	if err != nil {
-		if errors.Is(err, query.ErrNotFound) {
-			return true, nil
-		}
-		return false, err
+		return errors.Is(err, query.ErrNotFound)
 	}
 	if op.Version.EqualTo(dig.Version) {
-		return op.Leaseholder > dig.Leaseholder, nil
+		return op.Leaseholder > dig.Leaseholder
 	}
-	return op.Version.NewerThan(dig.Version), nil
+	return op.Version.NewerThan(dig.Version)
 }

--- a/aspen/internal/kv/filter_persist.go
+++ b/aspen/internal/kv/filter_persist.go
@@ -17,6 +17,7 @@ import (
 	"github.com/synnaxlabs/x/errors"
 	xkv "github.com/synnaxlabs/x/kv"
 	"github.com/synnaxlabs/x/query"
+	"go.uber.org/zap"
 )
 
 // filterPersist fuses version filtering and persistence into a single segment
@@ -71,7 +72,15 @@ func (fp *filterPersist) _switch(
 
 	err := xkv.WithTx(ctx, fp.db, func(txn xkv.Tx) error {
 		for _, op := range b.Operations {
-			if !supersedes(ctx, txn, op) {
+			sup, supErr := supersedes(ctx, txn, op)
+			if supErr != nil {
+				fp.L.Error(
+					"failed to read digest for gossiped op",
+					zap.Error(supErr),
+					zap.Binary("key", op.Key),
+				)
+			}
+			if !sup {
 				rejected.Operations = append(rejected.Operations, op)
 				continue
 			}
@@ -99,15 +108,19 @@ func (fp *filterPersist) _switch(
 // supersedes reports whether op should replace the digest stored for op.Key in
 // r. An op supersedes when its version is strictly newer, or when versions tie
 // and its leaseholder wins the higher-key tiebreak. A missing digest is treated
-// as superseded. Any other read error is treated as not-superseding so a
-// transient read failure cannot cause an op to overwrite stored state.
-func supersedes(ctx context.Context, r xkv.Reader, op Operation) bool {
+// as superseded. Any other read error is returned and treated as
+// not-superseding by the caller, so a transient read failure cannot cause an op
+// to overwrite stored state.
+func supersedes(ctx context.Context, r xkv.Reader, op Operation) (bool, error) {
 	dig, err := getDigestFromKV(ctx, r, op.Key)
 	if err != nil {
-		return errors.Is(err, query.ErrNotFound)
+		if errors.Is(err, query.ErrNotFound) {
+			return true, nil
+		}
+		return false, err
 	}
 	if op.Version.EqualTo(dig.Version) {
-		return op.Leaseholder > dig.Leaseholder
+		return op.Leaseholder > dig.Leaseholder, nil
 	}
-	return op.Version.NewerThan(dig.Version)
+	return op.Version.NewerThan(dig.Version), nil
 }

--- a/aspen/internal/kv/kv.go
+++ b/aspen/internal/kv/kv.go
@@ -82,7 +82,9 @@ func (d *DB) OpenTx() xkv.Tx {
 
 // OnChange satisfies xkv.Observable: handler receives every persisted
 // TxRequest as a flattened xkv.TxReader, regardless of which node was the
-// leaseholder. For filtered views over the same stream, see NewObservable.
+// leaseholder. Each (key, version) tuple is delivered at most once, even
+// when gossip replicates the same op to this node multiple times. For
+// filtered views over the same stream, see NewObservable.
 func (d *DB) OnChange(handler func(ctx context.Context, reader xkv.TxReader)) observe.Disconnect {
 	return d.NewObservable().OnChange(handler)
 }
@@ -94,6 +96,12 @@ func (d *DB) OnChange(handler func(ctx context.Context, reader xkv.TxReader)) ob
 // Options reshape what subscribers see — for example, IgnoreHostLeaseholder
 // drops TxRequests led by the host node so subscribers only observe writes
 // that originated on a remote node and were replicated here via gossip.
+//
+// Subscribers see each (key, version) tuple at most once. Gossip replication
+// is at-least-once at the wire level, but the ingress pipeline atomically
+// dedupes against the persisted digest so duplicate deliveries do not result
+// in duplicate observer invocations. Subscribers can therefore be written
+// without idempotency wrappers.
 //
 // Each call to NewObservable returns an independent observable; multiple
 // subscribers to the same observable share its filter, while subscribers
@@ -144,7 +152,7 @@ func (d *DB) Report() alamos.Report {
 }
 
 const (
-	versionFilterAddr     = "version_filter"
+	filterPersistAddr     = "filter_persist"
 	versionAssignerAddr   = "version_assigner"
 	persistAddr           = "persist"
 	persistDeltaAddr      = "persist_delta"
@@ -204,8 +212,8 @@ func Open(ctx context.Context, cfgs ...Config) (db *DB, err error) {
 	plumber.SetSource[TxRequest](pipe, operationReceiverAddr, opServer)
 	plumber.SetSegment[TxRequest](
 		pipe,
-		versionFilterAddr,
-		newVersionFilter(cfg, persistAddr, feedbackSenderAddr),
+		filterPersistAddr,
+		newFilterPersist(cfg, persistDeltaAddr, feedbackSenderAddr),
 	)
 	plumber.SetSegment[TxRequest](pipe, versionAssignerAddr, va)
 	plumber.SetSink[TxRequest](pipe, leaseSenderAddr, newLeaseSender(cfg))
@@ -264,26 +272,26 @@ func Open(ctx context.Context, cfgs ...Config) (db *DB, err error) {
 
 	plumber.MultiRouter[TxRequest]{
 		SourceTargets: []address.Address{operationReceiverAddr, operationSenderAddr},
-		SinkTargets:   []address.Address{versionFilterAddr},
-		Stitch:        plumber.StitchUnary,
-		Capacity:      chanBuffer,
-	}.MustRoute(pipe)
-
-	plumber.MultiRouter[TxRequest]{
-		SourceTargets: []address.Address{versionFilterAddr, versionAssignerAddr},
-		SinkTargets:   []address.Address{persistAddr},
+		SinkTargets:   []address.Address{filterPersistAddr},
 		Stitch:        plumber.StitchUnary,
 		Capacity:      chanBuffer,
 	}.MustRoute(pipe)
 
 	plumber.UnaryRouter[TxRequest]{
-		SourceTarget: persistAddr,
-		SinkTarget:   persistDeltaAddr,
+		SourceTarget: versionAssignerAddr,
+		SinkTarget:   persistAddr,
 		Capacity:     chanBuffer,
 	}.MustRoute(pipe)
 
+	plumber.MultiRouter[TxRequest]{
+		SourceTargets: []address.Address{persistAddr, filterPersistAddr},
+		SinkTargets:   []address.Address{persistDeltaAddr},
+		Stitch:        plumber.StitchUnary,
+		Capacity:      chanBuffer,
+	}.MustRoute(pipe)
+
 	plumber.UnaryRouter[TxRequest]{
-		SourceTarget: versionFilterAddr,
+		SourceTarget: filterPersistAddr,
 		SinkTarget:   feedbackSenderAddr,
 		Capacity:     chanBuffer,
 	}.MustRoute(pipe)

--- a/aspen/internal/kv/kv_test.go
+++ b/aspen/internal/kv/kv_test.go
@@ -25,11 +25,13 @@ import (
 	"github.com/synnaxlabs/aspen/internal/kv"
 	"github.com/synnaxlabs/aspen/internal/kv/kvmock"
 	"github.com/synnaxlabs/aspen/internal/node"
+	"github.com/synnaxlabs/x/change"
 	"github.com/synnaxlabs/x/errors"
 	xkv "github.com/synnaxlabs/x/kv"
 	"github.com/synnaxlabs/x/kv/memkv"
 	"github.com/synnaxlabs/x/query"
 	. "github.com/synnaxlabs/x/testutil"
+	"github.com/synnaxlabs/x/version"
 )
 
 var _ = Describe("txn", func() {
@@ -344,6 +346,40 @@ var _ = Describe("txn", func() {
 					}
 				}, "200ms", "20ms").Should(Succeed())
 			})
+		})
+
+		It("Should dedupe replicated writes that arrive at the gossip ingress multiple times", func(ctx SpecContext) {
+			kv1 := MustSucceed(builder.New(ctx, kv.Config{}, cluster.Config{}))
+			MustSucceed(builder.New(ctx, kv.Config{}, cluster.Config{}))
+			waitForClusterStateToConverge(builder)
+
+			var fired atomic.Int64
+			kv1.NewObservable(kv.IgnoreHostLeaseholder).
+				OnChange(func(context.Context, xkv.TxReader) { fired.Add(1) })
+
+			req := kv.TxRequest{
+				Context: ctx,
+				Operations: []kv.Operation{{
+					Change: xkv.Change{
+						Variant: change.VariantSet,
+						Key:     []byte("dedup-test"),
+						Value:   []byte("v1"),
+					},
+					Version:     version.Counter(1_000_000),
+					Leaseholder: node.Key(2),
+				}},
+				Sender:      node.Key(2),
+				Leaseholder: node.Key(2),
+			}
+
+			kv1Addr := builder.ClusterAPIs[node.Key(1)].Host().Address
+			client := builder.OpNet.UnaryClient()
+			for range 5 {
+				MustSucceed(client.Send(ctx, kv1Addr, req))
+			}
+
+			Eventually(fired.Load).Should(Equal(int64(1)))
+			Consistently(fired.Load, "200ms", "20ms").Should(Equal(int64(1)))
 		})
 
 		It("Should deliver every change when no options are passed", func(ctx SpecContext) {

--- a/aspen/internal/kv/version.go
+++ b/aspen/internal/kv/version.go
@@ -12,79 +12,20 @@ package kv
 import (
 	"context"
 
-	"github.com/synnaxlabs/x/address"
 	"github.com/synnaxlabs/x/confluence"
 	"github.com/synnaxlabs/x/errors"
 	xkv "github.com/synnaxlabs/x/kv"
-	"github.com/synnaxlabs/x/query"
 	"github.com/synnaxlabs/x/version"
 	"go.uber.org/zap"
 )
 
-type versionFilter struct {
-	confluence.BatchSwitch[TxRequest, TxRequest]
-	memKV      xkv.DB
-	acceptedTo address.Address
-	rejectedTo address.Address
-	Config
-}
-
-func newVersionFilter(cfg Config, acceptedTo address.Address, rejectedTo address.Address) segment {
-	s := &versionFilter{Config: cfg, acceptedTo: acceptedTo, rejectedTo: rejectedTo, memKV: cfg.Engine}
-	s.Switch = s._switch
-	return s
-}
-
-func (vc *versionFilter) _switch(
-	_ context.Context,
-	b TxRequest,
-	o map[address.Address]TxRequest,
-) error {
-	var (
-		rejected = TxRequest{Sender: b.Sender, doneF: b.doneF, Context: b.Context, span: b.span}
-		accepted = TxRequest{Sender: b.Sender, doneF: b.doneF, Context: b.Context, span: b.span}
-	)
-	ctx, span := vc.T.Debug(b.Context, "tx-filter")
-	defer span.End()
-	for _, op := range b.Operations {
-		if vc.filter(ctx, op) {
-			accepted.Operations = append(accepted.Operations, op)
-		} else {
-			rejected.Operations = append(rejected.Operations, op)
-		}
-	}
-	if len(accepted.Operations) > 0 {
-		o[vc.acceptedTo] = accepted
-	}
-	if len(rejected.Operations) > 0 {
-		o[vc.rejectedTo] = rejected
-	}
-	return nil
-}
-
-func (vc *versionFilter) filter(ctx context.Context, op Operation) bool {
-	dig, err := getDigestFromKV(ctx, vc.memKV, op.Key)
-	if err != nil {
-		dig, err = getDigestFromKV(ctx, vc.Engine, op.Key)
-		if err != nil {
-			return errors.Is(err, query.ErrNotFound)
-		}
-	}
-	// If the versions of the operation are equal, we select a winning operation
-	// based the which leasehold is higher.
-	if op.Version.EqualTo(dig.Version) {
-		return op.Leaseholder > dig.Leaseholder
-	}
-	return op.Version.NewerThan(dig.Version)
-}
-
-func getDigestFromKV(ctx context.Context, kve xkv.DB, key []byte) (Digest, error) {
+func getDigestFromKV(ctx context.Context, r xkv.Reader, key []byte) (Digest, error) {
 	dig := Digest{}
 	key, err := digestKey(key)
 	if err != nil {
 		return dig, err
 	}
-	b, closer, err := kve.Get(ctx, key)
+	b, closer, err := r.Get(ctx, key)
 	if err != nil {
 		return dig, err
 	}


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4210](https://linear.app/synnax/issue/SY-4210)

## Description

The `IgnoreHostLeaseholder` observable test in `aspen/internal/kv/kv_test.go` was flaking in CI because aspen's gossip-ingress pipeline could persist (and observe) the same `(key, version)` tuple more than once. The `versionFilter` segment read a key's digest from the engine and decided accept/reject; the `persist` segment then wrote the op and the digest. The two stages ran on separate goroutines connected by a buffered channel, so two duplicate gossip deliveries could both pass the filter before either committed — both then persisted and the observer fired twice.

Rather than relax the test, this PR fixes the underlying race by fusing the two stages on the gossip-ingress path into a single `filterPersist` segment that opens one pebble transaction per inbound `TxRequest` and performs the digest check + the op/digest write through that transaction. Because reads inside the transaction see prior writes from the same transaction, and the segment processes one `TxRequest` at a time on a single goroutine, the dedup invariant is now structural rather than coordinated through timing.

The local write path is unchanged. `versionAssigner -> persist` still handles locally-originated ops without a digest check, because the assigner already stamps fresh monotonic versions by construction. Single-node clusters do not receive remote ops and therefore pay no overhead for the new logic.

`DB.NewObservable` is now documented as at-most-once per `(key, version)`. A new deterministic test drives duplicate gossip RPCs through the mock `OpNet` and asserts the observer fires exactly once — this catches future regressions of the dedup invariant without depending on CI load to surface the race.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a race condition where two duplicate gossip deliveries could both pass the version filter before either committed a digest, causing the observable to fire more than once for the same `(key, version)` tuple. The fix fuses the version-filter and persist stages for the gossip-ingress path into a single `filterPersist` segment that opens one pebble transaction per inbound `TxRequest`, performing the digest-check and the op/digest write atomically under that transaction.

- **`filter_persist.go`**: New segment that replaces the old two-stage (`versionFilter` → `persist`) gossip-ingress path; the dedup invariant is now structural rather than timing-dependent.
- **`kv.go`**: Pipeline topology updated — `versionAssigner → persistAddr` now routes exclusively to `persistDeltaAddr`, and `filterPersistAddr` is wired directly to `persistDeltaAddr`, bypassing the old `persistAddr` step for gossip ops.
- **`kv_test.go`**: New deterministic dedup test drives 5 identical gossip RPCs through the mock `OpNet` and asserts the observer fires exactly once.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is structurally sound and the new deterministic test directly verifies the corrected invariant.

The race was caused by two pipeline stages running on separate goroutines sharing mutable engine state; fusing them into a single transactional segment eliminates the window entirely. The local write path is untouched. The routing topology changes are minimal and correct: gossip ops bypass persistAddr (they are already persisted by filterPersist), and local ops continue through versionAssigner → persist → persistDelta unchanged. xkv.WithTx correctly defers txn.Close(), so the concern from the previous review thread is already addressed by the helper itself.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| aspen/internal/kv/filter_persist.go | New segment fusing gossip-ingress version-filter and persistence into a single atomic transaction; well-documented and clearly structured with correct use of xkv.WithTx (which defers Close). |
| aspen/internal/kv/kv.go | Pipeline topology correctly updated: gossip-ingress now routes operationReceiver/operationSender → filterPersist → persistDelta, while the local path versionAssigner → persist → persistDelta is unchanged. |
| aspen/internal/kv/kv_test.go | New deterministic dedup test directly drives 5 identical gossip RPCs and asserts exactly-once observer behavior; avoids the timing sensitivity of the original flaky test. |
| aspen/internal/kv/version.go | versionFilter removed; getDigestFromKV signature generalized from xkv.DB to xkv.Reader so it can be called inside a transaction in filterPersist. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph Gossip Ingress ["Gossip-Ingress Path (NEW)"]
        OR[operationReceiverAddr] --> FP[filterPersist]
        OS[operationSenderAddr] --> FP
        FP -- "atomic txn: digest check + op write" --> FP_ACCEPTED{accepted?}
        FP_ACCEPTED -- "yes to persistDelta" --> PD[persistDeltaAddr]
        FP_ACCEPTED -- "no duplicate/stale" --> FS[feedbackSenderAddr]
    end
    subgraph Local Write Path ["Local Write Path (unchanged)"]
        EX[executorAddr] --> LP[leaseProxyAddr]
        LP --> VA[versionAssignerAddr]
        VA --> P[persistAddr]
        P --> PD
    end
    subgraph Fan-out
        PD --> OBS[observableAddr]
        PD --> SS[storeSinkAddr]
    end
```

<sub>Reviews (3): Last reviewed commit: ["Log non-NotFound digest read errors in f..."](https://github.com/synnaxlabs/synnax/commit/ee665ca8a2b8f0ff2ced3d910da6ad1df135a1fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33667096)</sub>

<!-- /greptile_comment -->