### PR TITLE
SY-4225: Fix Migration Clients CI Failure from pnpm 10/11 Mismatch

### DIFF
--- a/.github/actions/test-typescript/action.yaml
+++ b/.github/actions/test-typescript/action.yaml
@@ -29,12 +29,21 @@ inputs:
     description: Additional arguments to pass to the test command
     required: false
     default: ""
+  pnpm_dest:
+    description:
+      Directory pnpm is installed into (pnpm/action-setup `dest`). Override when a
+      single job sets up more than one pnpm major version so the installs don't share a
+      PNPM_HOME and clobber each other's store.
+    required: false
+    default: ~/setup-pnpm
 
 runs:
   using: composite
   steps:
     - name: Set up pnpm
       uses: pnpm/action-setup@v6
+      with:
+        dest: ${{ inputs.pnpm_dest }}
 
     - name: Set up Node.js
       uses: actions/setup-node@v6

--- a/.github/workflows/test.migration.clients.yaml
+++ b/.github/workflows/test.migration.clients.yaml
@@ -169,6 +169,12 @@ jobs:
         with:
           package: client
           lint: false
+          # The "on main" run above installs pnpm 10 into the default ~/setup-pnpm.
+          # Install the current branch's pnpm (11+) into a separate dest so it doesn't
+          # refresh that PNPM_HOME and delete the v10 store, which the main run's
+          # setup-node cache-save still points at (otherwise its post step fails the
+          # job). Remove once main and rc are on the same pnpm major.
+          pnpm_dest: ~/setup-pnpm-current
 
       - name: Stop Core on current branch
         if: always() && steps.start_current.outcome == 'success'


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4225](https://linear.app/synnax/issue/SY-4225/fix-migration-clients-ci-failure-from-pnpm-1011-mismatch)

## Description

The `Test - Migration (Clients)` job fails on every PR into `rc` during the post-job cache-save for the "Test TypeScript with Core on main" step:

```
##[error]Path Validation Error: Path(s) specified in the action for caching do(es) not exist, hence no cache is being saved.
```

All actual tests pass — only the post (cache-save) step fails, which then fails the whole job.

**Root cause:** This job runs the `test-typescript` action twice in one job — once after `Checkout main` (pnpm 10.33.0) and once after `Checkout current branch` (pnpm 11.1.3). Both `pnpm/action-setup` invocations share one `PNPM_HOME` (`~/setup-pnpm`), with the pnpm store inside it.

1. The "on main" run installs pnpm 10; `setup-node` records `~/setup-pnpm/node_modules/.bin/store/v10` for its post-job cache-save (cache miss → save armed).
2. The "on current" run installs pnpm 11 into the same `PNPM_HOME` (`[WARN] Detected a pnpm v10 installation layout at PNPM_HOME. The pnpm shims at PNPM_HOME have been refreshed...`). pnpm 11 uses `store/v11`; the `store/v10` directory is gone.
3. At job end (LIFO), the "on main" post step tries to save `store/v10`, which no longer exists → `@actions/cache` throws `ValidationError`, which `setup-node` re-throws → the job fails.

(Local `./` actions resolve from the checked-out workspace, so the "on main" step runs `main`'s copy of the action with `pnpm/action-setup@v5`, while the current run uses `v6`.) This only affects PRs into `rc` (main pnpm 10 vs current pnpm 11) and would self-resolve once `main` also moves to pnpm 11 — but it blocks all `rc` PRs until then.

**Fix:** Add a `pnpm_dest` input to the `test-typescript` action (default `~/setup-pnpm`, matching `pnpm/action-setup`'s own default so all other consumers are unchanged) and pass `~/setup-pnpm-current` for the current-branch run only. pnpm 11 then installs into a separate directory, never refreshes pnpm 10's `PNPM_HOME`, the `store/v10` directory survives, and the main run's cache-save succeeds. The workflow comment notes the override can be removed once `main` and `rc` share a pnpm major.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a CI failure in the `Test - Migration (Clients)` job caused by two sequential `pnpm/action-setup` invocations sharing the same `PNPM_HOME`: pnpm 11 would overwrite pnpm 10's store directory, then the main-run's `setup-node` post-step would fail trying to cache a path that no longer existed.

- Adds an optional `pnpm_dest` input to the `test-typescript` composite action (defaulting to `~/setup-pnpm` to preserve existing behavior) and forwards it to `pnpm/action-setup`'s `dest` parameter.
- Passes `~/setup-pnpm-current` for the current-branch TypeScript test run in the migration workflow, isolating pnpm 11's install from pnpm 10's, with a comment to remove it once `main` and `rc` share the same pnpm major.

<h3>Confidence Score: 5/5</h3>

Safe to merge — targeted two-file change that isolates pnpm 11 into its own directory and leaves all other callers of the composite action completely unaffected.

Both changes are minimal and surgical: the action gains an opt-in override with a backward-compatible default, and only the one problematic workflow step uses the override. The fix directly addresses the documented root cause and includes a comment reminding the team to clean it up once the version skew is gone.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/actions/test-typescript/action.yaml | Adds optional pnpm_dest input (default ~/setup-pnpm) and forwards it to pnpm/action-setup@v6's dest param; no behavior change for existing callers. |
| .github/workflows/test.migration.clients.yaml | Passes pnpm_dest: ~/setup-pnpm-current for the current branch TypeScript test step to isolate pnpm 11's install from the main-branch pnpm 10 install, with a comment explaining it's temporary. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Job as CI Job
    participant MA as test-typescript (main)
    participant CA as test-typescript (current)
    participant SN1 as setup-node post (main)
    participant SN2 as setup-node post (current)

    Job->>MA: "pnpm/action-setup@v5 (pnpm 10) PNPM_HOME = ~/setup-pnpm"
    Note over MA: store/v10 created at ~/setup-pnpm/store/v10
    MA->>MA: setup-node records cache path: ~/setup-pnpm/store/v10

    Job->>CA: "pnpm/action-setup@v6 (pnpm 11) dest = ~/setup-pnpm-current (NEW)"
    Note over CA: PNPM_HOME = ~/setup-pnpm-current store/v11 at ~/setup-pnpm-current/store/v11 ~/setup-pnpm/store/v10 remains intact

    Note over Job: Post-steps run LIFO
    Job->>SN2: cache-save ~/setup-pnpm-current/store/v11 success
    Job->>SN1: cache-save ~/setup-pnpm/store/v10 success (no longer deleted)
```

<sub>Reviews (1): Last reviewed commit: ["SY-4225: Fix Migration Clients CI Failur..."](https://github.com/synnaxlabs/synnax/commit/dc661b790dd84c981baddb058c5da11116d3eeac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33811381)</sub>

<!-- /greptile_comment -->