### PR TITLE
SY-4227: Fix Flakey Distribution Framer Writer Test

### DIFF
--- a/x/go/signal/signal_test.go
+++ b/x/go/signal/signal_test.go
@@ -62,6 +62,53 @@ var _ = Describe("Signal", func() {
 
 		})
 
+		// Regression: when a routine fails with a genuine (non-context) error and
+		// cancels the context, sibling routines return context.Canceled. The
+		// underlying errgroup records only the first returned error, so a sibling's
+		// context.Canceled can win the race and mask the real failure. Wait must still
+		// surface the genuine failure rather than the incidental cancellation.
+		Describe("Genuine failure masked by sibling cancellation", func() {
+			It("Should report the genuine failure when a sibling's context.Canceled is recorded first", func() {
+				ctx, cancel := signal.Isolated()
+				release := make(chan struct{})
+				siblingReturned := make(chan struct{})
+				ctx.Go(func(ctx context.Context) error {
+					<-ctx.Done()
+					close(siblingReturned)
+					return ctx.Err()
+				})
+				ctx.Go(func(context.Context) error {
+					<-release
+					return errRoutineFailed
+				})
+				cancel()
+				Eventually(siblingReturned).Should(BeClosed())
+				close(release)
+				Expect(ctx.Wait()).To(MatchError(errRoutineFailed))
+			})
+
+			It("Should let NewHardShutdown surface the genuine failure instead of skipping it as a cancellation", func() {
+				ctx, cancel := signal.Isolated()
+				release := make(chan struct{})
+				siblingReturned := make(chan struct{})
+				ctx.Go(func(ctx context.Context) error {
+					<-ctx.Done()
+					close(siblingReturned)
+					return ctx.Err()
+				})
+				ctx.Go(func(context.Context) error {
+					<-release
+					return errRoutineFailed
+				})
+				go func() {
+					<-siblingReturned
+					close(release)
+				}()
+				closer := signal.NewHardShutdown(ctx, cancel)
+				Expect(closer.Close()).To(MatchError(errRoutineFailed))
+			})
+		})
+
 	})
 
 	Describe("Go Utilities", func() {

--- a/x/go/signal/wg.go
+++ b/x/go/signal/wg.go
@@ -9,13 +9,22 @@
 
 package signal
 
+import (
+	"context"
+
+	"github.com/synnaxlabs/x/errors"
+)
+
 // WaitGroup provides methods for detecting and waiting for the exit of goroutines
 // managed by a signal.Conductor.
 type WaitGroup interface {
-	// Wait waits for all running goroutines to exit, then proceeds to return
-	// the first non-nil error (returns nil if all errors are nil). Returns nil
-	// if no goroutines are running. WaitOnAll. is NOT safe to call concurrently
-	// with any other wait methods.
+	// Wait waits for all running goroutines to exit and returns the error that caused
+	// the context to stop. If one or more routines failed with a genuine (non-context)
+	// error, the first such failure in routine start order is returned, even when a
+	// sibling routine returned context.Canceled first in response to the cancellation.
+	// If no routine failed, Wait returns the first context cancellation error observed,
+	// or nil if every routine exited cleanly. Returns nil if no goroutines are running.
+	// Wait is NOT safe to call concurrently with any other wait methods.
 	Wait() error
 	// Stopped returns a channel that is closed when the context is canceled AND all
 	// running goroutines have exited.
@@ -23,4 +32,23 @@ type WaitGroup interface {
 }
 
 // Wait implements the WaitGroup interface.
-func (c *core) Wait() error { return c.internal.Wait() }
+func (c *core) Wait() error {
+	err := c.internal.Wait()
+	// errgroup records only the first error returned by any routine. When a routine
+	// fails with a genuine error and cancels the context via CancelOnFail, sibling
+	// routines frequently return context.Canceled and can win the race to be recorded
+	// as that first error, masking the real failure. Recover the genuine failure from
+	// the routine states, which record non-context errors explicitly, so callers (and
+	// NewHardShutdown's context.Canceled filtering) observe the true cause.
+	if errors.IsAny(err, context.Canceled, context.DeadlineExceeded) {
+		c.mu.RLock()
+		defer c.mu.RUnlock()
+		for _, r := range c.mu.routines {
+			if r.state.err != nil &&
+				!errors.IsAny(r.state.err, context.Canceled, context.DeadlineExceeded) {
+				return r.state.err
+			}
+		}
+	}
+	return err
+}


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4227](https://linear.app/synnax/issue/SY-4227)

## Description

`core/pkg/distribution/framer/writer`'s "Should return an error when string series
contains invalid UTF-8" spec (and its sibling JSON / malformed-prefix specs) failed
roughly 1 in 60–70 runs under `ginkgo -p --randomize-all --race --until-it-fails`. The
flake was not in the writer's validation logic — it exposed a latent race in the shared
`x/go/signal` primitive.

When the writer's `validator` routine fails with `validate.ErrValidation`, it runs with
`CancelOnFail()`, so `runPostlude` cancels the signal context **before** the errgroup
records the validator's error. The sibling routines (gateway writer, synchronizer,
translators) immediately wake on the cancelled context and return `context.Canceled`.
The underlying `errgroup.Group` records only the **first** returned error via
`sync.Once`, so a sibling's `context.Canceled` can win the race and become the recorded
error. `signal.NewHardShutdown` then does `errors.Skip(err, context.Canceled)` →
`nil`, and the real validation error vanishes. `Writer.Write` / `Close` return `nil`,
and the test's `Expect(...).Error().To(MatchError(validate.ErrValidation))` fails because
no error surfaced at all.

The fix is in `signal.core.Wait()`: when the errgroup's first recorded error is only a
context cancellation, it now recovers the genuine failure from the per-routine state
(`runPostlude` already records non-context failures in `r.state.err`). This is safe —
all routines have finished by the time `Wait` returns — and only changes behavior in the
masked-error case. It fixes the bug for **every** `CancelOnFail` + `NewHardShutdown`
caller, not just this writer.

Verification:
- New `signal` regression specs fail deterministically against the old `Wait()`
  ("Expected an error, got nil") and pass with the fix.
- Full `signal` suite: 28 specs × 31 runs, all pass.
- `writer` suite under the original repro command: 262 attempts, 0 failures (was ~1/65).

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a latent race in `x/go/signal` where `Wait()` could return `nil` instead of the genuine failure error when a `CancelOnFail` routine triggered a context cancellation before its own error was recorded by the underlying `errgroup`. The fix extends `Wait()` to scan per-routine state for a genuine error whenever `errgroup` recorded only a context cancellation.

- **`x/go/signal/wg.go`**: `Wait()` now scans `c.mu.routines` for the first non-context error (in start order) when `errgroup.Wait()` returns only a context cancellation, recovering the real failure that was masked by the race.
- **`x/go/signal/signal_test.go`**: Two regression specs are added — one verifying `Wait()` directly and one verifying `NewHardShutdown.Close()` — both deterministically reproducing the ordering that triggered the flake.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to the masked-error recovery path in Wait() and only activates when errgroup already returned a context cancellation, leaving all other code paths completely unchanged.

The scan in Wait() is executed only after errgroup.Wait() has returned, at which point every goroutine's runPostlude has already committed its state under the mutex, so there is no new concurrency hazard. The recovery logic mirrors the same errors.IsAny gate already used by runPostlude. The two new regression specs deterministically reproduce the ordering that caused the flake.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| x/go/signal/wg.go | Adds error-recovery scan to Wait(): safe to read routine state after errgroup.Wait() returns, protected by RLock, iterates in start order, and only activates when errgroup recorded a context cancellation. |
| x/go/signal/signal_test.go | Adds two regression specs that deterministically force the sibling-cancel-wins-the-race scenario; both correctly pass with the fix and fail without it. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Surface non-context errors first"](https://github.com/synnaxlabs/synnax/commit/571657490225cda7665759f04b692ab6561f70d7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33877881)</sub>

<!-- /greptile_comment -->