### PR TITLE
SY-4179: Throw Exceptions in Freighter TypeScript Instead of Returning Tuples

### DIFF
--- a/client/ts/src/access/policy/client.ts
+++ b/client/ts/src/access/policy/client.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { sendRequired, type UnaryClient } from "@synnaxlabs/freighter";
+import { type UnaryClient } from "@synnaxlabs/freighter";
 import { array } from "@synnaxlabs/x";
 import { z } from "zod";
 
@@ -78,8 +78,7 @@ export class Client {
   async create(policies: New[]): Promise<Policy[]>;
   async create(policies: CreateArgs): Promise<Policy | Policy[]> {
     const isMany = Array.isArray(policies);
-    const res = await sendRequired<typeof createArgsZ, typeof createResZ>(
-      this.client,
+    const res = await this.client.send(
       "/access/policy/create",
       policies,
       createArgsZ,
@@ -92,8 +91,7 @@ export class Client {
   async retrieve(args: RetrieveMultipleParams): Promise<Policy[]>;
   async retrieve(args: RetrieveArgs): Promise<Policy | Policy[]> {
     const isSingle = "key" in args;
-    const res = await sendRequired<typeof retrieveArgsZ, typeof retrieveResZ>(
-      this.client,
+    const res = await this.client.send(
       "/access/policy/retrieve",
       args,
       retrieveArgsZ,
@@ -105,8 +103,7 @@ export class Client {
   async delete(key: Key): Promise<void>;
   async delete(keys: Key[]): Promise<void>;
   async delete(keys: Key | Key[]): Promise<void> {
-    await sendRequired<typeof deleteReqZ, typeof deleteResZ>(
-      this.client,
+    await this.client.send(
       "/access/policy/delete",
       { keys: array.toArray(keys) },
       deleteReqZ,

--- a/client/ts/src/access/role/client.ts
+++ b/client/ts/src/access/role/client.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { sendRequired, type UnaryClient } from "@synnaxlabs/freighter";
+import { type UnaryClient } from "@synnaxlabs/freighter";
 import { array } from "@synnaxlabs/x";
 import { z } from "zod";
 
@@ -79,8 +79,7 @@ export class Client {
   async create(roles: New[]): Promise<Role[]>;
   async create(roles: New | New[]): Promise<Role | Role[]> {
     const isMany = Array.isArray(roles);
-    const res = await sendRequired<typeof createArgsZ, typeof createResZ>(
-      this.client,
+    const res = await this.client.send(
       "/access/role/create",
       roles,
       createArgsZ,
@@ -93,8 +92,7 @@ export class Client {
   async retrieve(args: RetrieveMultipleParams): Promise<Role[]>;
   async retrieve(args: RetrieveArgs): Promise<Role | Role[]> {
     const isSingle = "key" in args;
-    const res = await sendRequired<typeof retrieveArgsZ, typeof retrieveResZ>(
-      this.client,
+    const res = await this.client.send(
       "/access/role/retrieve",
       args,
       retrieveArgsZ,
@@ -104,32 +102,14 @@ export class Client {
   }
 
   async delete(args: DeleteArgs): Promise<void> {
-    await sendRequired<typeof deleteArgsZ, typeof deleteResZ>(
-      this.client,
-      "/access/role/delete",
-      args,
-      deleteArgsZ,
-      deleteResZ,
-    );
+    await this.client.send("/access/role/delete", args, deleteArgsZ, deleteResZ);
   }
 
   async assign(args: AssignArgs): Promise<void> {
-    await sendRequired<typeof assignReqZ, typeof assignResZ>(
-      this.client,
-      "/access/role/assign",
-      args,
-      assignReqZ,
-      assignResZ,
-    );
+    await this.client.send("/access/role/assign", args, assignReqZ, assignResZ);
   }
 
   async unassign(args: UnassignArgs): Promise<void> {
-    await sendRequired<typeof unassignReqZ, typeof unassignResZ>(
-      this.client,
-      "/access/role/unassign",
-      args,
-      unassignReqZ,
-      unassignResZ,
-    );
+    await this.client.send("/access/role/unassign", args, unassignReqZ, unassignResZ);
   }
 }

--- a/client/ts/src/arc/client.ts
+++ b/client/ts/src/arc/client.ts
@@ -8,7 +8,6 @@
 // included in the file licenses/APL.txt.
 
 import {
-  sendRequired,
   type Stream,
   type StreamClient,
   type UnaryClient,
@@ -77,8 +76,7 @@ export class Client {
   async create(arcs: New[]): Promise<Arc[]>;
   async create(arcs: New | New[]): Promise<Arc | Arc[]> {
     const isMany = Array.isArray(arcs);
-    const res = await sendRequired(
-      this.client,
+    const res = await this.client.send(
       "/arc/create",
       { arcs: array.toArray(arcs) },
       createReqZ,
@@ -91,8 +89,7 @@ export class Client {
   async retrieve(args: RetrieveArgs): Promise<Arc[]>;
   async retrieve(args: RetrieveArgs): Promise<Arc | Arc[]> {
     const isSingle = "key" in args || "name" in args;
-    const res = await sendRequired(
-      this.client,
+    const res = await this.client.send(
       "/arc/retrieve",
       args,
       retrieveArgsZ,
@@ -103,8 +100,7 @@ export class Client {
   }
 
   async delete(keys: Key | Key[]): Promise<void> {
-    await sendRequired(
-      this.client,
+    await this.client.send(
       "/arc/delete",
       { keys: array.toArray(keys) },
       deleteReqZ,

--- a/client/ts/src/arc/lsp.spec.ts
+++ b/client/ts/src/arc/lsp.spec.ts
@@ -27,7 +27,7 @@ type JSONRPCResponse =
     };
 
 type LSPReceiver = {
-  receive: () => Promise<[{ content: string }, null] | [null, Error]>;
+  receive: () => Promise<{ content: string }>;
 };
 
 const MAX_DRAIN = 50;
@@ -38,9 +38,7 @@ const receiveResponse = async (
   expectedId: number,
 ): Promise<JSONRPCResponse> => {
   for (let i = 0; i < MAX_DRAIN; i++) {
-    const [res, err] = await stream.receive();
-    if (err != null) throw err;
-    if (res == null) throw new Error("Expected response");
+    const res = await stream.receive();
     const msg = JSON.parse(res.content);
     if (!("method" in msg) && "id" in msg && msg.id === expectedId)
       return msg as JSONRPCResponse;
@@ -56,9 +54,7 @@ const receiveNotification = async (
   expectedMethod: string,
 ): Promise<JSONRPCRequest> => {
   for (let i = 0; i < MAX_DRAIN; i++) {
-    const [res, err] = await stream.receive();
-    if (err != null) throw err;
-    if (res == null) throw new Error("Expected message");
+    const res = await stream.receive();
     const msg = JSON.parse(res.content);
     if ("method" in msg && msg.method === expectedMethod) return msg as JSONRPCRequest;
   }

--- a/client/ts/src/auth/auth.spec.ts
+++ b/client/ts/src/auth/auth.spec.ts
@@ -33,8 +33,8 @@ describe("auth", () => {
     );
     const client = new auth.Client(transport.unary, TEST_CLIENT_PARAMS);
     const mw = client.middleware();
-    const res = await mw(DUMMY_CTX, async () => [DUMMY_CTX, null]);
-    expect(res).toEqual([DUMMY_CTX, null]);
+    const res = await mw(DUMMY_CTX, async () => DUMMY_CTX);
+    expect(res).toEqual(DUMMY_CTX);
   });
 
   test("invalid credentials", async () => {
@@ -49,8 +49,7 @@ describe("auth", () => {
       password: "wrong",
     });
     const mw = client.middleware();
-    const [, err] = await mw(DUMMY_CTX, async () => [DUMMY_CTX, null]);
-    expect(err).toBeInstanceOf(AuthError);
+    await expect(mw(DUMMY_CTX, async () => DUMMY_CTX)).rejects.toThrow(AuthError);
   });
 
   describe("token retry", () => {
@@ -68,16 +67,16 @@ describe("auth", () => {
         let isFirst = true;
         let tkOne: string | undefined;
         let tkTwo: string | undefined;
-        const [, err] = await mw(DUMMY_CTX, async () => {
+        const res = await mw(DUMMY_CTX, async () => {
           if (isFirst) {
             isFirst = false;
             tkOne = client.token;
-            return [DUMMY_CTX, new ErrorType()];
+            throw new ErrorType();
           }
           tkTwo = client.token;
-          return [DUMMY_CTX, null];
+          return DUMMY_CTX;
         });
-        expect(err).toBeNull();
+        expect(res).toEqual(DUMMY_CTX);
         expect(tkOne).toBeDefined();
         expect(tkTwo).toBeDefined();
       });
@@ -92,11 +91,11 @@ describe("auth", () => {
       );
       const client = new auth.Client(transport.unary, TEST_CLIENT_PARAMS);
       const mw = client.middleware();
-      const [, err] = await mw(DUMMY_CTX, async () => [
-        DUMMY_CTX,
-        new InvalidTokenError(),
-      ]);
-      expect(err).toBeInstanceOf(InvalidTokenError);
+      await expect(
+        mw(DUMMY_CTX, async () => {
+          throw new InvalidTokenError();
+        }),
+      ).rejects.toThrow(InvalidTokenError);
     });
   });
 });

--- a/client/ts/src/auth/auth.ts
+++ b/client/ts/src/auth/auth.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { type Middleware, sendRequired, type UnaryClient } from "@synnaxlabs/freighter";
+import { type Middleware, type UnaryClient } from "@synnaxlabs/freighter";
 import { TimeStamp } from "@synnaxlabs/x";
 import { z } from "zod";
 
@@ -82,8 +82,7 @@ export class Client {
 
   async changePassword(newPassword: string): Promise<void> {
     if (!this.authenticated) throw new Error("Not authenticated");
-    await sendRequired<typeof changePasswordReqZ, typeof changePasswordResZ>(
-      this.client,
+    await this.client.send(
       "/auth/change-password",
       {
         username: this.credentials.username,
@@ -99,34 +98,42 @@ export class Client {
   middleware(): Middleware {
     const mw: Middleware = async (reqCtx, next) => {
       if (!this.authenticated && !reqCtx.target.endsWith(LOGIN_ENDPOINT)) {
-        this.authenticating ??= new Promise((resolve, reject) => {
-          this.client
-            .send(LOGIN_ENDPOINT, this.credentials, credentialsZ, tokenResponseZ)
-            .then(([res, err]) => {
-              if (err != null) return resolve(err);
-              if (res == null) return resolve(new Error("No response from login"));
-              this.authState = {
-                authenticated: true,
-                user: res.user,
-                token: res.token,
-              };
-              resolve(null);
-            })
-            .catch(reject);
-        });
+        this.authenticating ??= (async (): Promise<Error | null> => {
+          try {
+            const res = await this.client.send(
+              LOGIN_ENDPOINT,
+              this.credentials,
+              credentialsZ,
+              tokenResponseZ,
+            );
+            this.authState = {
+              authenticated: true,
+              user: res.user,
+              token: res.token,
+            };
+            return null;
+          } catch (err) {
+            return err instanceof Error ? err : new Error(String(err));
+          }
+        })();
         const err = await this.authenticating;
-        if (err != null) return [reqCtx, err];
+        if (err != null) throw err;
       }
       reqCtx.params.Authorization = `Bearer ${this.token}`;
-      const [resCtx, err] = await next(reqCtx);
-      if (RETRY_ON.some((e) => e.matches(err)) && this.retryCount < MAX_RETRIES) {
-        this.authState = { authenticated: false };
-        this.authenticating = undefined;
-        this.retryCount += 1;
-        return mw(reqCtx, next);
+      try {
+        const resCtx = await next(reqCtx);
+        this.retryCount = 0;
+        return resCtx;
+      } catch (err) {
+        if (RETRY_ON.some((e) => e.matches(err)) && this.retryCount < MAX_RETRIES) {
+          this.authState = { authenticated: false };
+          this.authenticating = undefined;
+          this.retryCount += 1;
+          return mw(reqCtx, next);
+        }
+        this.retryCount = 0;
+        throw err;
       }
-      this.retryCount = 0;
-      return [resCtx, err];
     };
     return mw;
   }

--- a/client/ts/src/channel/client.ts
+++ b/client/ts/src/channel/client.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { sendRequired, type UnaryClient } from "@synnaxlabs/freighter";
+import { type UnaryClient } from "@synnaxlabs/freighter";
 import {
   array,
   type CrudeDensity,
@@ -417,8 +417,7 @@ export class Client {
   }
 
   async retrieveGroup(): Promise<group.Group> {
-    const res = await sendRequired(
-      this.client,
+    const res = await this.client.send(
       "/channel/retrieve-group",
       {},
       retrieveGroupReqZ,

--- a/client/ts/src/channel/retriever.ts
+++ b/client/ts/src/channel/retriever.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { sendRequired, type UnaryClient } from "@synnaxlabs/freighter";
+import { type UnaryClient } from "@synnaxlabs/freighter";
 import { array, type CrudeTimeSpan, DataType, debounce, zod } from "@synnaxlabs/x";
 import { Mutex } from "async-mutex";
 import { z } from "zod";
@@ -83,13 +83,7 @@ export class ClusterRetriever implements Retriever {
   }
 
   private async execute(request: RetrieveRequest): Promise<Payload[]> {
-    const res = await sendRequired(
-      this.client,
-      "/channel/retrieve",
-      request,
-      reqZ,
-      resZ,
-    );
+    const res = await this.client.send("/channel/retrieve", request, reqZ, resZ);
     return res.channels;
   }
 }

--- a/client/ts/src/channel/writer.ts
+++ b/client/ts/src/channel/writer.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { sendRequired, type UnaryClient } from "@synnaxlabs/freighter";
+import { type UnaryClient } from "@synnaxlabs/freighter";
 import { type DataType } from "@synnaxlabs/x";
 import { z } from "zod";
 
@@ -47,11 +47,7 @@ export class Writer {
   }
 
   async create(channels: New[]): Promise<Payload[]> {
-    const { channels: created } = await sendRequired<
-      typeof createReqZ,
-      typeof createResZ
-    >(
-      this.client,
+    const { channels: created } = await this.client.send(
       "/channel/create",
       {
         channels: channels.map((c) => ({
@@ -68,25 +64,13 @@ export class Writer {
 
   async delete(props: DeleteProps): Promise<void> {
     const keys = keyZ.array().parse(props.keys ?? []);
-    await sendRequired<typeof deleteReqZ, typeof deleteResZ>(
-      this.client,
-      "/channel/delete",
-      props,
-      deleteReqZ,
-      deleteResZ,
-    );
+    await this.client.send("/channel/delete", props, deleteReqZ, deleteResZ);
     if (keys.length > 0) this.cache.delete(keys);
     if (props.names != null) this.cache.delete(props.names);
   }
 
   async rename(keys: Key[], names: string[]): Promise<void> {
-    await sendRequired<typeof renameReqZ, typeof renameResZ>(
-      this.client,
-      "/channel/rename",
-      { keys, names },
-      renameReqZ,
-      renameResZ,
-    );
+    await this.client.send("/channel/rename", { keys, names }, renameReqZ, renameResZ);
     this.cache.rename(keys, names);
   }
 }

--- a/client/ts/src/connection/checker.ts
+++ b/client/ts/src/connection/checker.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { sendRequired, type UnaryClient } from "@synnaxlabs/freighter";
+import { type UnaryClient } from "@synnaxlabs/freighter";
 import {
   ClockSkewCalculator,
   type CrudeTimeSpan,
@@ -117,8 +117,7 @@ export class Checker {
     this.checking = true;
     try {
       if (measureSkew) this.skewCalc.start();
-      const res = await sendRequired(
-        this.client,
+      const res = await this.client.send(
         "/connectivity/check",
         undefined,
         requestZ,

--- a/client/ts/src/connection/connection.spec.ts
+++ b/client/ts/src/connection/connection.spec.ts
@@ -90,14 +90,11 @@ describe("connectivity", () => {
   });
   describe("clock skew", () => {
     const createMockClient = (nodeTime: TimeStamp): UnaryClient => ({
-      send: vi.fn().mockResolvedValue([
-        {
-          clusterKey: "test-cluster",
-          nodeVersion: __VERSION__,
-          nodeTime,
-        },
-        null,
-      ]) as UnaryClient["send"],
+      send: vi.fn().mockResolvedValue({
+        clusterKey: "test-cluster",
+        nodeVersion: __VERSION__,
+        nodeTime,
+      }),
       use: vi.fn(),
     });
 

--- a/client/ts/src/device/client.ts
+++ b/client/ts/src/device/client.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { sendRequired, type UnaryClient } from "@synnaxlabs/freighter";
+import { type UnaryClient } from "@synnaxlabs/freighter";
 import { array, type record, zod } from "@synnaxlabs/x";
 import { z } from "zod";
 
@@ -124,8 +124,7 @@ export class Client {
   ): Promise<Device | Array<Device>> {
     const { schemas, ...rest } = args;
     const isSingle = typeof rest === "object" && "key" in rest;
-    const res = await sendRequired(
-      this.client,
+    const res = await this.client.send(
       "/device/retrieve",
       rest,
       retrieveArgsZ,
@@ -166,8 +165,7 @@ export class Client {
     schemas?: DeviceSchemas,
   ): Promise<Device | Device[]> {
     const isSingle = !Array.isArray(devices);
-    const res = await sendRequired(
-      this.client,
+    const res = await this.client.send(
       "/device/create",
       { devices: array.toArray(devices) },
       createReqZ(schemas),
@@ -177,8 +175,7 @@ export class Client {
   }
 
   async delete(keys: Key | Key[]): Promise<void> {
-    await sendRequired(
-      this.client,
+    await this.client.send(
       "/device/delete",
       { keys: array.toArray(keys) },
       deleteReqZ,

--- a/client/ts/src/errors.ts
+++ b/client/ts/src/errors.ts
@@ -157,15 +157,14 @@ export const validateFieldNotNull = (
 };
 
 export const errorsMiddleware: Middleware = async (ctx, next) => {
-  const [res, err] = await next(ctx);
-  if (err == null) return [res, err];
-  if (err instanceof Unreachable)
-    return [
-      res,
-      new Unreachable({
+  try {
+    return await next(ctx);
+  } catch (err) {
+    if (err instanceof Unreachable)
+      throw new Unreachable({
         message: `Cannot reach Core at ${err.url.host}:${err.url.port}`,
         url: err.url,
-      }),
-    ];
-  return [res, err];
+      });
+    throw err;
+  }
 };

--- a/client/ts/src/framer/deleter.ts
+++ b/client/ts/src/framer/deleter.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { sendRequired, type UnaryClient } from "@synnaxlabs/freighter";
+import { type UnaryClient } from "@synnaxlabs/freighter";
 import { TimeRange } from "@synnaxlabs/x";
 import { z } from "zod";
 
@@ -33,12 +33,6 @@ export class Deleter {
   }
 
   async delete(props: Request): Promise<void> {
-    await sendRequired<typeof reqZ, typeof resZ>(
-      this.client,
-      "/frame/delete",
-      props,
-      reqZ,
-      resZ,
-    );
+    await this.client.send("/frame/delete", props, reqZ, resZ);
   }
 }

--- a/client/ts/src/framer/streamProxy.ts
+++ b/client/ts/src/framer/streamProxy.ts
@@ -10,6 +10,8 @@
 import { EOF, type Stream } from "@synnaxlabs/freighter";
 import { type z } from "zod";
 
+import { UnexpectedError } from "@/errors";
+
 export class StreamProxy<RQ extends z.ZodType, RS extends z.ZodType> {
   readonly name: string;
   private readonly stream: Stream<RQ, RS>;
@@ -20,9 +22,7 @@ export class StreamProxy<RQ extends z.ZodType, RS extends z.ZodType> {
   }
 
   async receive(): Promise<z.infer<RS>> {
-    const [res, err] = await this.stream.receive();
-    if (err != null) throw err;
-    return res;
+    return await this.stream.receive();
   }
 
   received(): boolean {
@@ -32,16 +32,16 @@ export class StreamProxy<RQ extends z.ZodType, RS extends z.ZodType> {
   async closeAndAck(): Promise<void> {
     this.stream.closeSend();
     while (true) {
-      const [res, err] = await this.stream.receive();
-      if (res != null)
-        console.warn(
-          `${this.name} received unexpected response on ${JSON.stringify(res)} closure.
-        Please report this error to the Synnax team.`,
-        );
-      if (err != null) {
+      let res: z.infer<RS>;
+      try {
+        res = await this.stream.receive();
+      } catch (err) {
         if (EOF.matches(err)) return;
         throw err;
       }
+      throw new UnexpectedError(
+        `${this.name} received unexpected response ${JSON.stringify(res)} on closure.`,
+      );
     }
   }
 
@@ -50,7 +50,6 @@ export class StreamProxy<RQ extends z.ZodType, RS extends z.ZodType> {
   }
 
   send(req: z.input<RQ>): void {
-    const err = this.stream.send(req);
-    if (err != null) throw err;
+    this.stream.send(req);
   }
 }

--- a/client/ts/src/framer/streamer.ts
+++ b/client/ts/src/framer/streamer.ts
@@ -124,8 +124,7 @@ export const createStreamOpener =
       throttleRate: cfg.throttleRate,
       excludeGroups: cfg.excludeGroups,
     });
-    const [, err] = await stream.receive();
-    if (err != null) throw err;
+    await stream.receive();
     return streamer;
   };
 

--- a/client/ts/src/framer/writer.ts
+++ b/client/ts/src/framer/writer.ts
@@ -248,13 +248,14 @@ export class Writer {
    * @param frame - The frame to write to the database. The frame must:
    *
    *    1. Have exactly one array for each key in the list of keys provided to the
-   *    writer's open method.
+   *       writer's open method.
    *    2. Have equal length arrays for each key.
    *    3. When writing to an index (i.e. TimeStamp) channel, the values must be
-   *    monotonically increasing.
+   *       monotonically increasing.
    *
-   * @returns false if the writer has accumulated an error. In this case, the caller
-   * should acknowledge the error by calling the error method or closing the writer.
+   * @throws if the writer has accumulated an error. Once write throws, all subsequent
+   * calls to write and commit will also throw, and the writer must be closed and
+   * re-opened to continue writing.
    */
   async write(
     channelsOrData:
@@ -290,9 +291,9 @@ export class Writer {
    * Commits the written frames to the database. Commit is synchronous, meaning that it
    * will not return until all frames have been committed to the database.
    *
-   * @returns false if the commit failed due to an error. In this case, the caller
-   * should acknowledge the error by calling the error method or closing the writer.
-   * After the caller acknowledges the error, they can attempt to commit again.
+   * @returns the timestamp of the last sample written to the writer.
+   * @throws if the commit fails or any previous writer method has thrown. Once commit
+   * throws, the writer must be closed and re-opened to continue use.
    */
   async commit(): Promise<TimeStamp> {
     if (this.closeErr != null) throw this.closeErr;
@@ -337,6 +338,9 @@ export class Writer {
       this.stream.send(req);
     } catch (err) {
       if (!(err instanceof Error)) throw err;
+      // A send failure is always EOF or StreamClosed, never WriterClosedError, so
+      // closeInternal re-throws here and the receive loop below is reached only when
+      // the send succeeds.
       await this.closeInternal(err);
     }
     while (true) {

--- a/client/ts/src/framer/writer.ts
+++ b/client/ts/src/framer/writer.ts
@@ -266,7 +266,11 @@ export class Writer {
     if (this.closeErr != null) throw this.closeErr;
     if (this.stream.received()) return await this.close();
     const frame = await this.adapter.adapt(channelsOrData, series);
-    this.stream.send({ command: WriterCommand.Write, frame: frame.toPayload() });
+    try {
+      this.stream.send({ command: WriterCommand.Write, frame: frame.toPayload() });
+    } catch (err) {
+      if (!EOF.matches(err)) throw err;
+    }
   }
 
   async setAuthority(
@@ -318,18 +322,32 @@ export class Writer {
         if (WriterClosedError.matches(this.closeErr)) return null;
         throw this.closeErr;
       }
-      const [res, err] = await this.stream.receive();
-      if (err != null) this.closeErr = EOF.matches(err) ? new WriterClosedError() : err;
-      else this.closeErr = errors.decode(res?.err);
+      try {
+        const res = await this.stream.receive();
+        this.closeErr = errors.decode(res?.err);
+      } catch (err) {
+        if (!(err instanceof Error)) throw err;
+        this.closeErr = EOF.matches(err) ? new WriterClosedError() : err;
+      }
     }
   }
 
   private async execute(req: WriteRequest): Promise<Response> {
-    const err = this.stream.send(req);
-    if (err != null) await this.closeInternal(err);
+    try {
+      this.stream.send(req);
+    } catch (err) {
+      if (!(err instanceof Error)) throw err;
+      await this.closeInternal(err);
+    }
     while (true) {
-      const [res, err] = await this.stream.receive();
-      if (err != null) await this.closeInternal(err);
+      let res: Response;
+      try {
+        res = await this.stream.receive();
+      } catch (err) {
+        if (!(err instanceof Error)) throw err;
+        await this.closeInternal(err);
+        continue;
+      }
       const resErr = errors.decode(res?.err);
       if (resErr != null) await this.closeInternal(resErr);
       if (res?.command == req.command) return res;

--- a/client/ts/src/group/client.ts
+++ b/client/ts/src/group/client.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { sendRequired, type UnaryClient } from "@synnaxlabs/freighter";
+import { type UnaryClient } from "@synnaxlabs/freighter";
 import { array } from "@synnaxlabs/x";
 import z from "zod";
 
@@ -39,8 +39,7 @@ export class Client {
   }
 
   async create(args: CreateArgs): Promise<Group> {
-    const res = await sendRequired(
-      this.client,
+    const res = await this.client.send(
       "/ontology/create-group",
       args,
       createReqZ,
@@ -50,8 +49,7 @@ export class Client {
   }
 
   async rename(key: Key, name: string): Promise<void> {
-    await sendRequired(
-      this.client,
+    await this.client.send(
       "/ontology/rename-group",
       { key, name },
       renameReqZ,
@@ -60,8 +58,7 @@ export class Client {
   }
 
   async delete(keys: Key | Key[]): Promise<void> {
-    await sendRequired(
-      this.client,
+    await this.client.send(
       "/ontology/delete-group",
       { keys: array.toArray(keys) },
       deleteReqZ,

--- a/client/ts/src/label/client.ts
+++ b/client/ts/src/label/client.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { sendRequired, type UnaryClient } from "@synnaxlabs/freighter";
+import { type UnaryClient } from "@synnaxlabs/freighter";
 import { array } from "@synnaxlabs/x";
 import z from "zod";
 
@@ -66,8 +66,7 @@ export class Client {
   async retrieve(args: RetrieveMultipleParams): Promise<Label[]>;
   async retrieve(args: RetrieveArgs): Promise<Label | Label[]> {
     const isSingle = "key" in args;
-    const res = await sendRequired(
-      this.client,
+    const res = await this.client.send(
       "/label/retrieve",
       args,
       retrieveArgsZ,
@@ -78,8 +77,7 @@ export class Client {
   }
 
   async label(id: ontology.ID, labels: Key[], opts: SetOptions = {}): Promise<void> {
-    await sendRequired<typeof setReqZ, typeof emptyResZ>(
-      this.client,
+    await this.client.send(
       "/label/set",
       { id, labels, replace: opts.replace },
       setReqZ,
@@ -88,21 +86,14 @@ export class Client {
   }
 
   async remove(id: ontology.ID, labels: Key[]): Promise<void> {
-    await sendRequired<typeof removeReqZ, typeof emptyResZ>(
-      this.client,
-      "/label/remove",
-      { id, labels },
-      removeReqZ,
-      emptyResZ,
-    );
+    await this.client.send("/label/remove", { id, labels }, removeReqZ, emptyResZ);
   }
 
   async create(label: New): Promise<Label>;
   async create(labels: New[]): Promise<Label[]>;
   async create(labels: New | New[]): Promise<Label | Label[]> {
     const isMany = Array.isArray(labels);
-    const res = await sendRequired<typeof createReqZ, typeof createResZ>(
-      this.client,
+    const res = await this.client.send(
       "/label/create",
       { labels: array.toArray(labels) },
       createReqZ,
@@ -112,8 +103,7 @@ export class Client {
   }
 
   async delete(keys: Key | Key[]): Promise<void> {
-    await sendRequired<typeof deleteReqZ, typeof emptyResZ>(
-      this.client,
+    await this.client.send(
       "/label/delete",
       { keys: array.toArray(keys) },
       deleteReqZ,

--- a/client/ts/src/lineplot/client.ts
+++ b/client/ts/src/lineplot/client.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { sendRequired, type UnaryClient } from "@synnaxlabs/freighter";
+import { type UnaryClient } from "@synnaxlabs/freighter";
 import { array, caseconv, record } from "@synnaxlabs/x";
 import { z } from "zod";
 
@@ -61,8 +61,7 @@ export class Client {
     linePlots: New | New[],
   ): Promise<LinePlot | LinePlot[]> {
     const isMany = Array.isArray(linePlots);
-    const res = await sendRequired(
-      this.client,
+    const res = await this.client.send(
       "/lineplot/create",
       { workspace, linePlots: array.toArray(linePlots) },
       createReqZ,
@@ -72,23 +71,11 @@ export class Client {
   }
 
   async rename(key: Key, name: string): Promise<void> {
-    await sendRequired(
-      this.client,
-      "/lineplot/rename",
-      { key, name },
-      renameReqZ,
-      emptyResZ,
-    );
+    await this.client.send("/lineplot/rename", { key, name }, renameReqZ, emptyResZ);
   }
 
   async setData(key: Key, data: record.Unknown): Promise<void> {
-    await sendRequired(
-      this.client,
-      "/lineplot/set-data",
-      { key, data },
-      setDataReqZ,
-      emptyResZ,
-    );
+    await this.client.send("/lineplot/set-data", { key, data }, setDataReqZ, emptyResZ);
   }
 
   async retrieve(args: RetrieveSingleParams): Promise<LinePlot>;
@@ -97,8 +84,7 @@ export class Client {
     args: RetrieveSingleParams | RetrieveMultipleParams,
   ): Promise<LinePlot | LinePlot[]> {
     const isSingle = singleRetrieveArgsZ.safeParse(args).success;
-    const res = await sendRequired(
-      this.client,
+    const res = await this.client.send(
       "/lineplot/retrieve",
       args,
       retrieveArgsZ,
@@ -109,8 +95,7 @@ export class Client {
   }
 
   async delete(keys: Key | Key[]): Promise<void> {
-    await sendRequired(
-      this.client,
+    await this.client.send(
       "/lineplot/delete",
       { keys: array.toArray(keys) },
       deleteReqZ,

--- a/client/ts/src/log/client.ts
+++ b/client/ts/src/log/client.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { sendRequired, type UnaryClient } from "@synnaxlabs/freighter";
+import { type UnaryClient } from "@synnaxlabs/freighter";
 import { array, caseconv, record } from "@synnaxlabs/x";
 import { z } from "zod";
 
@@ -51,8 +51,7 @@ export class Client {
   async create(workspace: workspace.Key, logs: New[]): Promise<Log[]>;
   async create(workspace: workspace.Key, logs: New | New[]): Promise<Log | Log[]> {
     const isMany = Array.isArray(logs);
-    const res = await sendRequired(
-      this.client,
+    const res = await this.client.send(
       "/log/create",
       { workspace, logs: array.toArray(logs) },
       createReqZ,
@@ -62,23 +61,11 @@ export class Client {
   }
 
   async rename(key: Key, name: string): Promise<void> {
-    await sendRequired(
-      this.client,
-      "/log/rename",
-      { key, name },
-      renameReqZ,
-      emptyResZ,
-    );
+    await this.client.send("/log/rename", { key, name }, renameReqZ, emptyResZ);
   }
 
   async setData(key: Key, data: record.Unknown): Promise<void> {
-    await sendRequired(
-      this.client,
-      "/log/set-data",
-      { key, data },
-      setDataReqZ,
-      emptyResZ,
-    );
+    await this.client.send("/log/set-data", { key, data }, setDataReqZ, emptyResZ);
   }
 
   async retrieve(args: RetrieveSingleParams): Promise<Log>;
@@ -87,8 +74,7 @@ export class Client {
     args: RetrieveSingleParams | RetrieveMultipleParams,
   ): Promise<Log | Log[]> {
     const isSingle = singleRetrieveArgsZ.safeParse(args).success;
-    const res = await sendRequired(
-      this.client,
+    const res = await this.client.send(
       "/log/retrieve",
       args,
       retrieveArgsZ,
@@ -99,8 +85,7 @@ export class Client {
   }
 
   async delete(keys: Key | Key[]): Promise<void> {
-    await sendRequired(
-      this.client,
+    await this.client.send(
       "/log/delete",
       { keys: array.toArray(keys) },
       deleteReqZ,

--- a/client/ts/src/ontology/client.ts
+++ b/client/ts/src/ontology/client.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { sendRequired, type UnaryClient } from "@synnaxlabs/freighter";
+import { type UnaryClient } from "@synnaxlabs/freighter";
 import { array, strings } from "@synnaxlabs/x";
 import { z } from "zod";
 
@@ -163,8 +163,7 @@ export class Client {
   }
 
   private async execRetrieve(request: RetrieveRequest): Promise<Resource[]> {
-    const { resources } = await sendRequired(
-      this.client,
+    const { resources } = await this.client.send(
       "/ontology/retrieve",
       request,
       retrieveReqZ,

--- a/client/ts/src/ontology/writer.ts
+++ b/client/ts/src/ontology/writer.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { sendRequired, type UnaryClient } from "@synnaxlabs/freighter";
+import { type UnaryClient } from "@synnaxlabs/freighter";
 import { z } from "zod";
 
 import { type ID, idZ } from "@/ontology/payload";
@@ -24,8 +24,7 @@ export class Writer {
   }
 
   async addChildren(id: ID, ...children: ID[]): Promise<void> {
-    await sendRequired<typeof addRemoveChildrenReqZ, typeof emptyResZ>(
-      this.client,
+    await this.client.send(
       "/ontology/add-children",
       { id, children },
       addRemoveChildrenReqZ,
@@ -34,8 +33,7 @@ export class Writer {
   }
 
   async removeChildren(id: ID, ...children: ID[]): Promise<void> {
-    await sendRequired<typeof addRemoveChildrenReqZ, typeof emptyResZ>(
-      this.client,
+    await this.client.send(
       "/ontology/remove-children",
       { id, children },
       addRemoveChildrenReqZ,
@@ -44,8 +42,7 @@ export class Writer {
   }
 
   async moveChildren(from: ID, to: ID, ...children: ID[]): Promise<void> {
-    await sendRequired<typeof moveChildrenReqZ, typeof emptyResZ>(
-      this.client,
+    await this.client.send(
       "/ontology/move-children",
       { from, to, children },
       moveChildrenReqZ,

--- a/client/ts/src/rack/client.ts
+++ b/client/ts/src/rack/client.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { sendRequired, type UnaryClient } from "@synnaxlabs/freighter";
+import { type UnaryClient } from "@synnaxlabs/freighter";
 import { array } from "@synnaxlabs/x";
 import { z } from "zod";
 
@@ -82,8 +82,7 @@ export class Client {
   }
 
   async delete(keys: Key | Key[]): Promise<void> {
-    await sendRequired<typeof deleteReqZ, typeof deleteResZ>(
-      this.client,
+    await this.client.send(
       "/rack/delete",
       { keys: array.toArray(keys) },
       deleteReqZ,
@@ -95,8 +94,7 @@ export class Client {
   async create(racks: New[]): Promise<Rack[]>;
   async create(rack: New | New[]): Promise<Rack | Rack[]> {
     const isSingle = !Array.isArray(rack);
-    const res = await sendRequired<typeof createReqZ, typeof createResZ>(
-      this.client,
+    const res = await this.client.send(
       "/rack/create",
       { racks: array.toArray(rack) },
       createReqZ,
@@ -110,8 +108,7 @@ export class Client {
   async retrieve(args: RetrieveMultipleParams): Promise<Rack[]>;
   async retrieve(args: RetrieveArgs): Promise<Rack | Rack[]> {
     const isSingle = "key" in args || "name" in args;
-    const res = await sendRequired(
-      this.client,
+    const res = await this.client.send(
       "/rack/retrieve",
       args,
       retrieveArgsZ,

--- a/client/ts/src/ranger/alias/client.ts
+++ b/client/ts/src/ranger/alias/client.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { sendRequired, type UnaryClient } from "@synnaxlabs/freighter";
+import { type UnaryClient } from "@synnaxlabs/freighter";
 import { array } from "@synnaxlabs/x";
 import { z } from "zod";
 
@@ -64,8 +64,7 @@ export class Client {
         else toFetch.push(alias);
       });
     if (toFetch.length === 0) return cached;
-    const res = await sendRequired<typeof resolveReqZ, typeof resolveResZ>(
-      this.client,
+    const res = await this.client.send(
       "/range/alias/resolve",
       { range: this.rangeKey, aliases: toFetch },
       resolveReqZ,
@@ -76,8 +75,7 @@ export class Client {
   }
 
   async set(aliases: Record<channel.Key, string>): Promise<void> {
-    await sendRequired<typeof setReqZ, typeof setResZ>(
-      this.client,
+    await this.client.send(
       "/range/alias/set",
       { range: this.rangeKey, aliases },
       setReqZ,
@@ -87,8 +85,7 @@ export class Client {
 
   async list(): Promise<Record<channel.Key, string>> {
     return (
-      await sendRequired<typeof listReqZ, typeof listResZ>(
-        this.client,
+      await this.client.send(
         "/range/alias/list",
         { range: this.rangeKey },
         listReqZ,
@@ -104,8 +101,7 @@ export class Client {
     alias: channel.Key | channel.Key[],
   ): Promise<string | Record<channel.Key, string>> {
     const isSingle = typeof alias === "number";
-    const res = await sendRequired<typeof retrieveReqZ, typeof retrieveResZ>(
-      this.client,
+    const res = await this.client.send(
       "/range/alias/retrieve",
       { range: this.rangeKey, channels: array.toArray(alias) },
       retrieveReqZ,
@@ -115,8 +111,7 @@ export class Client {
   }
 
   async delete(aliases: channel.Key | channel.Key[]): Promise<void> {
-    await sendRequired<typeof deleteReqZ, typeof deleteResZ>(
-      this.client,
+    await this.client.send(
       "/range/alias/delete",
       { range: this.rangeKey, channels: array.toArray(aliases) },
       deleteReqZ,

--- a/client/ts/src/ranger/client.ts
+++ b/client/ts/src/ranger/client.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { sendRequired, type UnaryClient } from "@synnaxlabs/freighter";
+import { type UnaryClient } from "@synnaxlabs/freighter";
 import {
   array,
   color,
@@ -249,8 +249,7 @@ export class Client {
   async retrieve(params: RetrieveRequest): Promise<Range[]>;
   async retrieve(params: RetrieveArgs): Promise<Range | Range[]> {
     const isSingle = typeof params === "string";
-    const { ranges } = await sendRequired(
-      this.unaryClient,
+    const { ranges } = await this.unaryClient.send(
       "/range/retrieve",
       params,
       retrieveArgsZ,

--- a/client/ts/src/ranger/kv/client.ts
+++ b/client/ts/src/ranger/kv/client.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { sendRequired, type UnaryClient } from "@synnaxlabs/freighter";
+import { type UnaryClient } from "@synnaxlabs/freighter";
 import { array } from "@synnaxlabs/x";
 import { z } from "zod";
 
@@ -31,8 +31,7 @@ export class Client {
   async get(key: string): Promise<string>;
   async get(keys: string[]): Promise<Record<string, string>>;
   async get(keys: string | string[]): Promise<string | Record<string, string>> {
-    const res = await sendRequired(
-      this.client,
+    const res = await this.client.send(
       "/range/kv/get",
       { range: this.rangeKey, keys: array.toArray(keys) },
       getReqZ,
@@ -58,8 +57,7 @@ export class Client {
         value: v,
       }));
 
-    await sendRequired(
-      this.client,
+    await this.client.send(
       "/range/kv/set",
       { range: this.rangeKey, pairs },
       setReqZ,
@@ -68,8 +66,7 @@ export class Client {
   }
 
   async delete(key: string | string[]): Promise<void> {
-    await sendRequired(
-      this.client,
+    await this.client.send(
       "/range/kv/delete",
       { range: this.rangeKey, keys: array.toArray(key) },
       deleteReqZ,

--- a/client/ts/src/ranger/writer.ts
+++ b/client/ts/src/ranger/writer.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { sendRequired, type UnaryClient } from "@synnaxlabs/freighter";
+import { type UnaryClient } from "@synnaxlabs/freighter";
 import { z } from "zod";
 
 import { ontology } from "@/ontology";
@@ -35,18 +35,11 @@ export class Writer {
   }
 
   async rename(key: string, name: string): Promise<void> {
-    await sendRequired<typeof renameReqZ, typeof renameResZ>(
-      this.client,
-      "/range/rename",
-      { key, name },
-      renameReqZ,
-      renameResZ,
-    );
+    await this.client.send("/range/rename", { key, name }, renameReqZ, renameResZ);
   }
 
   async create(ranges: New[], options?: CreateOptions): Promise<Payload[]> {
-    const res = await sendRequired<typeof createReqZ, typeof createResZ>(
-      this.client,
+    const res = await this.client.send(
       "/range/create",
       { ranges, ...options },
       createReqZ,
@@ -56,12 +49,6 @@ export class Writer {
   }
 
   async delete(keys: string[]): Promise<void> {
-    await sendRequired<typeof deleteReqZ, typeof deleteResZ>(
-      this.client,
-      "/range/delete",
-      { keys },
-      deleteReqZ,
-      deleteResZ,
-    );
+    await this.client.send("/range/delete", { keys }, deleteReqZ, deleteResZ);
   }
 }

--- a/client/ts/src/schematic/client.ts
+++ b/client/ts/src/schematic/client.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { sendRequired, type UnaryClient } from "@synnaxlabs/freighter";
+import { type UnaryClient } from "@synnaxlabs/freighter";
 import { array } from "@synnaxlabs/x";
 import { z } from "zod";
 
@@ -97,8 +97,7 @@ export class Client {
     schematics: New | New[],
   ): Promise<Schematic | Schematic[]> {
     const isMany = Array.isArray(schematics);
-    const res = await sendRequired(
-      this.client,
+    const res = await this.client.send(
       "/schematic/create",
       { workspace, schematics: array.toArray(schematics) },
       createReqZ,
@@ -112,8 +111,7 @@ export class Client {
   }
 
   async setData(key: Key, data: SetDataBody): Promise<void> {
-    await sendRequired(
-      this.client,
+    await this.client.send(
       "/schematic/set-data",
       { key, data },
       setDataReqZ,
@@ -122,8 +120,7 @@ export class Client {
   }
 
   async dispatch(key: Key, dispatchKey: string, actions: Action[]): Promise<void> {
-    await sendRequired(
-      this.client,
+    await this.client.send(
       "/schematic/dispatch",
       { key, dispatch_key: dispatchKey, actions },
       dispatchReqZ,
@@ -137,8 +134,7 @@ export class Client {
     args: RetrieveSingleParams | RetrieveMultipleParams,
   ): Promise<Schematic | Schematic[]> {
     const isSingle = singleRetrieveArgsZ.safeParse(args).success;
-    const res = await sendRequired(
-      this.client,
+    const res = await this.client.send(
       "/schematic/retrieve",
       args,
       retrieveArgsZ,
@@ -149,8 +145,7 @@ export class Client {
   }
 
   async delete(keys: Key | Key[]): Promise<void> {
-    await sendRequired(
-      this.client,
+    await this.client.send(
       "/schematic/delete",
       { keys: array.toArray(keys) },
       deleteReqZ,
@@ -159,13 +154,7 @@ export class Client {
   }
 
   async copy(args: CopyArgs): Promise<Schematic> {
-    const res = await sendRequired(
-      this.client,
-      "/schematic/copy",
-      args,
-      copyReqZ,
-      copyResZ,
-    );
+    const res = await this.client.send("/schematic/copy", args, copyReqZ, copyResZ);
     return res.schematic;
   }
 }

--- a/client/ts/src/schematic/symbol/client.ts
+++ b/client/ts/src/schematic/symbol/client.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { sendRequired, type UnaryClient } from "@synnaxlabs/freighter";
+import { type UnaryClient } from "@synnaxlabs/freighter";
 import { array } from "@synnaxlabs/x";
 import { z } from "zod";
 
@@ -72,8 +72,7 @@ export class Client {
   async create(options: CreateArgs | CreateMultipleArgs): Promise<Symbol | Symbol[]> {
     const isMany = "symbols" in options;
     const symbols = isMany ? options.symbols : [options];
-    const res = await sendRequired(
-      this.client,
+    const res = await this.client.send(
       "/schematic/symbol/create",
       { symbols, parent: options.parent },
       createReqZ,
@@ -83,8 +82,7 @@ export class Client {
   }
 
   async rename(key: Key, name: string): Promise<void> {
-    await sendRequired(
-      this.client,
+    await this.client.send(
       "/schematic/symbol/rename",
       { key, name },
       renameReqZ,
@@ -96,8 +94,7 @@ export class Client {
   async retrieve(args: RetrieveMultipleParams): Promise<Symbol[]>;
   async retrieve(args: RetrieveArgs): Promise<Symbol | Symbol[]> {
     const isSingle = "key" in args;
-    const res = await sendRequired(
-      this.client,
+    const res = await this.client.send(
       "/schematic/symbol/retrieve",
       args,
       retrieveArgsZ,
@@ -108,8 +105,7 @@ export class Client {
   }
 
   async delete(keys: Key | Key[]): Promise<void> {
-    await sendRequired(
-      this.client,
+    await this.client.send(
       "/schematic/symbol/delete",
       { keys: array.toArray(keys) },
       deleteReqZ,
@@ -118,8 +114,7 @@ export class Client {
   }
 
   async retrieveGroup(): Promise<group.Group> {
-    const res = await sendRequired(
-      this.client,
+    const res = await this.client.send(
       "/schematic/symbol/retrieve-group",
       {},
       retrieveGroupReqZ,

--- a/client/ts/src/status/client.ts
+++ b/client/ts/src/status/client.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { sendRequired, type UnaryClient } from "@synnaxlabs/freighter";
+import { type UnaryClient } from "@synnaxlabs/freighter";
 import { array } from "@synnaxlabs/x";
 import z from "zod";
 
@@ -74,8 +74,7 @@ export class Client {
     args: RetrieveArgs & { detailsSchema?: DetailsSchema },
   ): Promise<Status<DetailsSchema> | Status<DetailsSchema>[]> {
     const isSingle = "key" in args;
-    const res = await sendRequired(
-      this.client,
+    const res = await this.client.send(
       "/status/retrieve",
       args,
       retrieveArgsZ,
@@ -97,11 +96,7 @@ export class Client {
     opts: SetOptions & { detailsSchema?: DetailsSchema } = {},
   ): Promise<Status<DetailsSchema> | Status<DetailsSchema>[]> {
     const isMany = Array.isArray(statuses);
-    const res = await sendRequired<
-      ReturnType<typeof setReqZ<DetailsSchema>>,
-      ReturnType<typeof setResZ<DetailsSchema>>
-    >(
-      this.client,
+    const res = await this.client.send(
       "/status/set",
       {
         statuses: array.toArray(statuses),
@@ -115,8 +110,7 @@ export class Client {
   }
 
   async delete(keys: Key | Key[]): Promise<void> {
-    await sendRequired<typeof deleteReqZ, typeof emptyResZ>(
-      this.client,
+    await this.client.send(
       "/status/delete",
       { keys: array.toArray(keys) },
       deleteReqZ,

--- a/client/ts/src/table/client.ts
+++ b/client/ts/src/table/client.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { sendRequired, type UnaryClient } from "@synnaxlabs/freighter";
+import { type UnaryClient } from "@synnaxlabs/freighter";
 import { array, caseconv, record } from "@synnaxlabs/x";
 import { z } from "zod";
 
@@ -54,8 +54,7 @@ export class Client {
     tables: New | New[],
   ): Promise<Table | Table[]> {
     const isMany = Array.isArray(tables);
-    const res = await sendRequired(
-      this.client,
+    const res = await this.client.send(
       "/table/create",
       { workspace, tables: array.toArray(tables) },
       createReqZ,
@@ -65,23 +64,11 @@ export class Client {
   }
 
   async rename(key: Key, name: string): Promise<void> {
-    await sendRequired(
-      this.client,
-      "/table/rename",
-      { key, name },
-      renameReqZ,
-      emptyResZ,
-    );
+    await this.client.send("/table/rename", { key, name }, renameReqZ, emptyResZ);
   }
 
   async setData(key: Key, data: record.Unknown): Promise<void> {
-    await sendRequired(
-      this.client,
-      "/table/set-data",
-      { key, data },
-      setDataReqZ,
-      emptyResZ,
-    );
+    await this.client.send("/table/set-data", { key, data }, setDataReqZ, emptyResZ);
   }
 
   async retrieve(args: RetrieveSingleParams): Promise<Table>;
@@ -90,8 +77,7 @@ export class Client {
     args: RetrieveSingleParams | RetrieveMultipleParams,
   ): Promise<Table | Table[]> {
     const isSingle = singleRetrieveArgsZ.safeParse(args).success;
-    const res = await sendRequired(
-      this.client,
+    const res = await this.client.send(
       "/table/retrieve",
       args,
       retrieveArgsZ,
@@ -102,8 +88,7 @@ export class Client {
   }
 
   async delete(keys: Key | Key[]): Promise<void> {
-    await sendRequired(
-      this.client,
+    await this.client.send(
       "/table/delete",
       { keys: array.toArray(keys) },
       deleteReqZ,

--- a/client/ts/src/task/client.ts
+++ b/client/ts/src/task/client.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { sendRequired, type UnaryClient } from "@synnaxlabs/freighter";
+import { type UnaryClient } from "@synnaxlabs/freighter";
 import {
   array,
   caseconv,
@@ -279,8 +279,7 @@ export class Client {
     const isSingle = !Array.isArray(task);
     const createReq = createReqZ(schemas);
     const createRes = createResZ(schemas);
-    const res = await sendRequired(
-      this.client,
+    const res = await this.client.send(
       "/task/create",
       { tasks: array.toArray(task) },
       createReq,
@@ -291,8 +290,7 @@ export class Client {
   }
 
   async delete(keys: Key | Key[]): Promise<void> {
-    await sendRequired<typeof deleteReqZ, typeof deleteResZ>(
-      this.client,
+    await this.client.send(
       "/task/delete",
       { keys: array.toArray(keys) },
       deleteReqZ,
@@ -313,8 +311,7 @@ export class Client {
     ...args
   }: RetrieveArgs & RetrieveSchemas<S>): Promise<Task<S> | Task<S>[]> {
     const isSingle = singleRetrieveArgsZ.safeParse(args).success;
-    const res = await sendRequired(
-      this.client,
+    const res = await this.client.send(
       "/task/retrieve",
       args,
       retrieveArgsZ,
@@ -328,8 +325,7 @@ export class Client {
 
   async copy(key: Key, name: string, snapshot: boolean): Promise<Task> {
     const copyRes = copyResZ();
-    const response = await sendRequired(
-      this.client,
+    const response = await this.client.send(
       "/task/copy",
       { key, name, snapshot },
       copyReqZ,

--- a/client/ts/src/user/client.ts
+++ b/client/ts/src/user/client.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { sendRequired, type UnaryClient } from "@synnaxlabs/freighter";
+import { type UnaryClient } from "@synnaxlabs/freighter";
 import { array } from "@synnaxlabs/x";
 import { z } from "zod";
 
@@ -82,8 +82,7 @@ export class Client {
   async create(users: New[]): Promise<User[]>;
   async create(users: New | New[]): Promise<User | User[]> {
     const isMany = Array.isArray(users);
-    const res = await sendRequired<typeof createReqZ, typeof createResZ>(
-      this.client,
+    const res = await this.client.send(
       "/user/create",
       { users: array.toArray(users) },
       createReqZ,
@@ -93,8 +92,7 @@ export class Client {
   }
 
   async changeUsername(key: Key, newUsername: string): Promise<void> {
-    await sendRequired<typeof changeUsernameReqZ, typeof changeUsernameResZ>(
-      this.client,
+    await this.client.send(
       "/user/change-username",
       { key, username: newUsername },
       changeUsernameReqZ,
@@ -107,8 +105,7 @@ export class Client {
   async retrieve(args: RetrieveArgs): Promise<User[]>;
   async retrieve(args: RetrieveArgs): Promise<User | User[]> {
     const isSingle = "key" in args || "username" in args;
-    const res = await sendRequired<typeof retrieveArgsZ, typeof retrieveResZ>(
-      this.client,
+    const res = await this.client.send(
       "/user/retrieve",
       args,
       retrieveArgsZ,
@@ -131,8 +128,7 @@ export class Client {
   }
 
   async rename(key: Key, firstName?: string, lastName?: string): Promise<void> {
-    await sendRequired<typeof renameReqZ, typeof renameResZ>(
-      this.client,
+    await this.client.send(
       "/user/rename",
       { key, firstName, lastName },
       renameReqZ,
@@ -143,8 +139,7 @@ export class Client {
   async delete(key: Key): Promise<void>;
   async delete(keys: Key[]): Promise<void>;
   async delete(keys: Key | Key[]): Promise<void> {
-    await sendRequired<typeof deleteReqZ, typeof deleteResZ>(
-      this.client,
+    await this.client.send(
       "/user/delete",
       { keys: array.toArray(keys) },
       deleteReqZ,

--- a/client/ts/src/view/client.ts
+++ b/client/ts/src/view/client.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { sendRequired, type UnaryClient } from "@synnaxlabs/freighter";
+import { type UnaryClient } from "@synnaxlabs/freighter";
 import { array } from "@synnaxlabs/x";
 import { z } from "zod";
 
@@ -54,8 +54,7 @@ export class Client {
     args: RetrieveSingleParams | RetrieveMultipleParams,
   ): Promise<View | View[]> {
     const isSingle = "key" in args;
-    const res = await sendRequired(
-      this.client,
+    const res = await this.client.send(
       "/view/retrieve",
       args,
       retrieveArgsZ,
@@ -69,8 +68,7 @@ export class Client {
   async create(views: New[]): Promise<View[]>;
   async create(views: New | New[]): Promise<View | View[]> {
     const isMany = Array.isArray(views);
-    const res = await sendRequired<typeof createReqZ, typeof createResZ>(
-      this.client,
+    const res = await this.client.send(
       "/view/create",
       { views: array.toArray(views) },
       createReqZ,
@@ -80,8 +78,7 @@ export class Client {
   }
 
   async delete(keys: Key | Key[]): Promise<void> {
-    await sendRequired<typeof deleteReqZ, typeof emptyResZ>(
-      this.client,
+    await this.client.send(
       "/view/delete",
       { keys: array.toArray(keys) },
       deleteReqZ,

--- a/client/ts/src/workspace/client.ts
+++ b/client/ts/src/workspace/client.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { sendRequired, type UnaryClient } from "@synnaxlabs/freighter";
+import { type UnaryClient } from "@synnaxlabs/freighter";
 import { array, caseconv, record } from "@synnaxlabs/x";
 import { z } from "zod";
 
@@ -57,8 +57,7 @@ export class Client {
   async create(workspaces: New[]): Promise<Workspace[]>;
   async create(workspaces: New | New[]): Promise<Workspace | Workspace[]> {
     const isMany = Array.isArray(workspaces);
-    const res = await sendRequired(
-      this.client,
+    const res = await this.client.send(
       "/workspace/create",
       { workspaces: array.toArray(workspaces) },
       createReqZ,
@@ -68,18 +67,11 @@ export class Client {
   }
 
   async rename(key: Key, name: string): Promise<void> {
-    await sendRequired(
-      this.client,
-      "/workspace/rename",
-      { key, name },
-      renameReqZ,
-      emptyResZ,
-    );
+    await this.client.send("/workspace/rename", { key, name }, renameReqZ, emptyResZ);
   }
 
   async setLayout(key: Key, layout: record.Unknown): Promise<void> {
-    await sendRequired(
-      this.client,
+    await this.client.send(
       "/workspace/set-layout",
       { key, layout },
       setLayoutReqZ,
@@ -98,8 +90,7 @@ export class Client {
     if (typeof keys === "string" || Array.isArray(keys))
       req = { keys: array.toArray(keys) };
     else req = keys;
-    const res = await sendRequired(
-      this.client,
+    const res = await this.client.send(
       "/workspace/retrieve",
       req,
       retrieveReqZ,
@@ -111,8 +102,7 @@ export class Client {
   async delete(key: Key): Promise<void>;
   async delete(keys: Key[]): Promise<void>;
   async delete(keys: Key | Key[]): Promise<void> {
-    await sendRequired(
-      this.client,
+    await this.client.send(
       "/workspace/delete",
       { keys: array.toArray(keys) },
       deleteReqZ,

--- a/console/src/arc/lsp/lsp.ts
+++ b/console/src/arc/lsp/lsp.ts
@@ -14,7 +14,7 @@ import {
 import * as vscodeExtensionApi from "@codingame/monaco-vscode-extension-api";
 import { grammarRaw as arcGrammarRaw } from "@synnaxlabs/arc";
 import { type arc, type Synnax } from "@synnaxlabs/client";
-import { type Stream } from "@synnaxlabs/freighter";
+import { EOF, type Stream } from "@synnaxlabs/freighter";
 import { breaker, type destructor, TimeSpan } from "@synnaxlabs/x";
 import { useEffect } from "react";
 import { type Message, type MessageReader, type MessageWriter } from "vscode-jsonrpc";
@@ -232,12 +232,14 @@ const createFreighterTransport = ({
   const receiveLoop = async () => {
     try {
       while (!isClosed) {
-        const [msg, err] = await stream.receive();
-        if (err != null) {
-          onErrorCallback?.(err);
+        let msg: arc.LSPMessage;
+        try {
+          msg = await stream.receive();
+        } catch (err) {
+          if (!EOF.matches(err))
+            onErrorCallback?.(err instanceof Error ? err : new Error(String(err)));
           break;
         }
-        if (msg == null) break;
         try {
           const parsed = JSON.parse(msg.content);
           onMessageCallback?.(parsed);

--- a/freighter/ts/src/alamos.ts
+++ b/freighter/ts/src/alamos.ts
@@ -15,18 +15,29 @@ export const middleware =
   (instrumentation: Instrumentation): Middleware =>
   async (context, next) => {
     if (context.role === "client") instrumentation.T.propagate(context.params);
-
-    const [res, exc] = await instrumentation.T.trace(
-      context.target,
-      "debug",
-      async (span): Promise<[Context, Error | null]> => {
-        const [ctx, err] = await next(context);
-        if (err != null) span.recordError(err);
-        return [ctx, err];
-      },
-    );
-    log(context, instrumentation, exc);
-    return [res, exc];
+    try {
+      const res = await instrumentation.T.trace(
+        context.target,
+        "debug",
+        async (span): Promise<Context> => {
+          try {
+            return await next(context);
+          } catch (err) {
+            if (err instanceof Error) span.recordError(err);
+            throw err;
+          }
+        },
+      );
+      log(context, instrumentation, null);
+      return res;
+    } catch (err) {
+      log(
+        context,
+        instrumentation,
+        err instanceof Error ? err : new Error(String(err)),
+      );
+      throw err;
+    }
   };
 
 const log = (

--- a/freighter/ts/src/http.spec.ts
+++ b/freighter/ts/src/http.spec.ts
@@ -30,28 +30,19 @@ const messageZ = z.object({
 
 describe("http", () => {
   test("echo", async () => {
-    const [response, error] = await client.send<typeof messageZ>(
+    const response = await client.send(
       "/echo",
-      {
-        id: 1,
-        message: "hello",
-      },
+      { id: 1, message: "hello" },
       messageZ,
       messageZ,
     );
-    expect(error).toBeNull();
     expect(response).toEqual({ id: 2, message: "hello" });
   });
 
   test("not found", async () => {
-    const [response, error] = await client.send<typeof messageZ>(
-      "/not-found",
-      {},
-      messageZ,
-      messageZ,
+    await expect(client.send("/not-found", {}, messageZ, messageZ)).rejects.toThrow(
+      "Not Found",
     );
-    expect(error?.message).toEqual("Not Found");
-    expect(response).toBeNull();
   });
 
   test("middleware", async () => {
@@ -59,34 +50,17 @@ describe("http", () => {
       md.params.Test = "test";
       return await next(md);
     });
-    const [response, error] = await client.send<typeof messageZ>(
-      "/middlewareCheck",
-      {},
-      messageZ,
-      messageZ,
-    );
-    expect(error).toBeNull();
-    expect(response?.message).toEqual("");
+    const response = await client.send("/middlewareCheck", {}, messageZ, messageZ);
+    expect(response.message).toEqual("");
   });
 
   test("unreachable", async () => {
     const c = new HTTPClient(
-      new URL({
-        host: "127.0.0.1",
-        protocol: "http",
-        port: 9999,
-        pathPrefix: "unary",
-      }),
+      new URL({ host: "127.0.0.1", protocol: "http", port: 9999, pathPrefix: "unary" }),
       new binary.JSONCodec(),
     );
-    const [response, error] = await c.send<typeof messageZ>(
-      "/unreachable",
-      {},
-      messageZ,
-      messageZ,
-    );
-    expect(error).toBeInstanceOf(Unreachable);
-    expect(error?.message).toEqual("Unreachable");
-    expect(response).toBeNull();
+    const send = c.send("/unreachable", {}, messageZ, messageZ);
+    await expect(send).rejects.toThrow(Unreachable);
+    await expect(send).rejects.toThrow("Unreachable");
   });
 });

--- a/freighter/ts/src/http.ts
+++ b/freighter/ts/src/http.ts
@@ -86,20 +86,20 @@ export class HTTPClient extends MiddlewareCollector implements UnaryClient {
     req: z.input<RQ> | z.infer<RQ>,
     reqSchema: RQ,
     resSchema: RS,
-  ): Promise<[z.infer<RS>, null] | [null, Error]> {
+  ): Promise<z.infer<RS>> {
     let res: z.infer<RS> | null = null;
     const url = this.endpoint.child(target);
     const request: RequestInit = {};
     request.method = "POST";
     request.body = this.encoder.encode(req, reqSchema) as BodyInit;
-    const [, err] = await this.executeMiddleware(
+    await this.executeMiddleware(
       {
         target: url.toString(),
         protocol: this.endpoint.protocol,
         params: {},
         role: "client",
       },
-      async (ctx: Context): Promise<[Context, Error | null]> => {
+      async (ctx: Context): Promise<Context> => {
         const outCtx: Context = { ...ctx, params: {} };
         request.headers = {
           ...this.headers,
@@ -110,34 +110,30 @@ export class HTTPClient extends MiddlewareCollector implements UnaryClient {
           httpRes = await fetch(ctx.target, request);
         } catch (e) {
           if (!(e instanceof Error)) throw e;
-          return [outCtx, shouldCastToUnreachable(e) ? new Unreachable({ url }) : e];
+          throw shouldCastToUnreachable(e) ? new Unreachable({ url }) : e;
         }
         const data = await httpRes.arrayBuffer();
         if (httpRes?.ok) {
           if (resSchema != null) res = this.encoder.decode<RS>(data, resSchema);
-          return [outCtx, null];
+          return outCtx;
         }
+        if (httpRes.status !== HTTP_STATUS_BAD_REQUEST)
+          throw new Error(httpRes.statusText);
+        let decoded: Error | null;
         try {
-          if (httpRes.status !== HTTP_STATUS_BAD_REQUEST)
-            return [outCtx, new Error(httpRes.statusText)];
-          const err = this.encoder.decode(data, errors.payloadZ);
-          const decoded = errors.decode(err);
-          return [outCtx, decoded];
+          decoded = errors.decode(this.encoder.decode(data, errors.payloadZ));
         } catch (e) {
-          return [
-            outCtx,
-            new Error(
-              `[freighter] - failed to decode error: ${httpRes.statusText}: ${
-                (e as Error).message
-              }`,
-            ),
-          ];
+          if (!(e instanceof Error)) throw e;
+          throw new Error(
+            `[freighter] - failed to decode error: ${httpRes.statusText}: ${e.message}`,
+            { cause: e },
+          );
         }
+        throw decoded ?? new Error(httpRes.statusText);
       },
     );
 
-    if (err != null) return [null, err];
     if (res == null) throw new Error("Response must be defined");
-    return [res, null];
+    return res;
   }
 }

--- a/freighter/ts/src/index.ts
+++ b/freighter/ts/src/index.ts
@@ -11,6 +11,6 @@ export { EOF, StreamClosed, Unreachable } from "@/errors";
 export { HTTPClient } from "@/http";
 export { type Context, type Middleware, type Next } from "@/middleware";
 export { type Stream, type StreamClient } from "@/stream";
-export { sendRequired, type UnaryClient, unaryWithBreaker } from "@/unary";
+export { type UnaryClient, unaryWithBreaker } from "@/unary";
 export { WebSocketClient } from "@/websocket";
 export { type WebsocketMessage } from "@/websocket";

--- a/freighter/ts/src/middleware.ts
+++ b/freighter/ts/src/middleware.ts
@@ -25,24 +25,28 @@ export interface Context {
 export const ROLES = ["client", "server"] as const;
 export type Role = (typeof ROLES)[number];
 
-/** Next executes the next middleware in the chain. */
-export type Next = (ctx: Context) => Promise<[Context, Error | null]>;
-
 /**
- * Middleware represents a general middleware function that can be used to
- * parse/attach metadata to a request or alter its behavior.
+ * Next executes the next middleware in the chain, returning the resulting context. It
+ * throws if any downstream middleware or the finalizer throws.
  */
-export type Middleware = (ctx: Context, next: Next) => Promise<[Context, Error | null]>;
+export type Next = (ctx: Context) => Promise<Context>;
 
 /**
- * Finalizer is a middleware that is executed as the last step in the chain.
- * Finalizer middleware should be used to execute the request.
+ * Middleware represents a general middleware function that can be used to parse/attach
+ * metadata to a request or alter its behavior. It should call next to continue the
+ * chain and may throw to abort the request.
  */
-type Finalizer = (ctx: Context) => Promise<[Context, Error | null]>;
+export type Middleware = (ctx: Context, next: Next) => Promise<Context>;
 
 /**
- * MiddlewareCollector is a class that can be used to collect and execute
- * middleware in order to implement the Transport interface.
+ * Finalizer is a middleware that is executed as the last step in the chain. Finalizer
+ * middleware should be used to execute the request. It throws if the request fails.
+ */
+type Finalizer = (ctx: Context) => Promise<Context>;
+
+/**
+ * MiddlewareCollector is a class that can be used to collect and execute middleware in
+ * order to implement the Transport interface.
  */
 export class MiddlewareCollector {
   middleware: Middleware[] = [];
@@ -53,20 +57,17 @@ export class MiddlewareCollector {
   }
 
   /**
-   * Executes middleware in order, passing the the metadata to each middleware
-   * until the end of the chain is reached. It then calls the finalizer with the
-   * metadata.
+   * Executes middleware in order, passing the the metadata to each middleware until the
+   * end of the chain is reached. It then calls the finalizer with the metadata.
    *
    * @param ctx - The context to pass to the middleware.
    * @param finalizer - The finalizer to call with the metadata.
-   * @returns An error if one was encountered, otherwise undefined.
+   * @returns The context produced by the chain. Throws if any middleware or the
+   * finalizer throws.
    */
-  async executeMiddleware(
-    ctx: Context,
-    finalizer: Finalizer,
-  ): Promise<[Context, Error | null]> {
+  async executeMiddleware(ctx: Context, finalizer: Finalizer): Promise<Context> {
     let i = 0;
-    const next = async (md: Context): Promise<[Context, Error | null]> => {
+    const next = async (md: Context): Promise<Context> => {
       if (i === this.middleware.length) return await finalizer(md);
       const _mw = this.middleware[i];
       i++;

--- a/freighter/ts/src/stream.ts
+++ b/freighter/ts/src/stream.ts
@@ -16,15 +16,14 @@ import { type Transport } from "@/transport";
  */
 export interface StreamReceiver<RS extends z.ZodType> {
   /**
-   * Receives a response from the stream. It's not safe to call receive
-   * concurrently.
+   * Receives a response from the stream. It's not safe to call receive concurrently.
    *
-   *  @returns freighter.EOF: if the server closed the stream nominally.
-   *  @returns Error: if the server closed the stream abnormally,
-   *  returns the error the server returned.
-   *  @raises Error: if the transport fails.
+   *  @returns the next response from the stream.
+   *  @throws freighter.EOF: if the server closed the stream nominally.
+   *  @throws Error: if the server closed the stream abnormally, throws the error the
+   *  server returned, or a transport error if the transport itself failed.
    */
-  receive: () => Promise<[z.infer<RS>, null] | [null, Error]>;
+  receive: () => Promise<z.infer<RS>>;
 
   /**
    * @returns true if the stream has received a response
@@ -37,17 +36,16 @@ export interface StreamReceiver<RS extends z.ZodType> {
  */
 export interface StreamSender<RQ extends z.ZodType> {
   /**
-  * Sends a request to the stream. It is not safe to call send concurrently
-  * with closeSend or send.
+  * Sends a request to the stream. It is not safe to call send concurrently with
+  * closeSend or send.
 
   * @param req -  the request to send.
-  * @returns freighter.EOF: if the server closed the stream. The caller
-  * can discover the error returned by the server by calling receive().
-  * @returns undefined: if the message was sent successfully.
-  * @raises freighter.StreamClosed: if the client called close_send()
-  * @raises Error: if the transport fails.
+  * @throws freighter.EOF: if the server closed the stream. The caller can discover the
+  * error returned by the server by calling receive().
+  * @throws freighter.StreamClosed: if the client called closeSend().
+  * @throws Error: if the transport fails.
   */
-  send: (req: z.input<RQ> | z.infer<RQ>) => Error | null;
+  send: (req: z.input<RQ> | z.infer<RQ>) => void;
 }
 
 /**
@@ -56,13 +54,13 @@ export interface StreamSender<RQ extends z.ZodType> {
  */
 export interface StreamSenderCloser<RQ extends z.ZodType> extends StreamSender<RQ> {
   /**
-  * Lets the server know no more messages will be sent. If the client attempts
-  * to call send() after calling closeSend(), a freighter.StreamClosed
-  * exception will be raised. close_send is idempotent. If the server has
-  * already closed the stream, close_send will do nothing.
+  * Lets the server know no more messages will be sent. If the client attempts to call
+  * send() after calling closeSend(), a freighter.StreamClosed exception will be raised.
+  * close_send is idempotent. If the server has already closed the stream, close_send
+  * will do nothing.
 
-  * After calling close_send, the client is responsible for calling receive()
-  * to successfully receive the server's acknowledgement.
+  * After calling close_send, the client is responsible for calling receive() to
+  * successfully receive the server's acknowledgement.
    */
   closeSend: () => void;
 }
@@ -78,15 +76,15 @@ export interface Stream<RQ extends z.ZodType, RS extends z.ZodType = RQ>
  */
 export interface StreamClient extends Transport {
   /**
-   * Dials the target and returns a stream that can be used to issue requests
-   * and receive responses
+   * Dials the target and returns a stream that can be used to issue requests and
+   * receive responses
    *
-   * @param target - The target to dial. In some implementations, this may be
-   * an endpoint path, or in others, a complete hostname or URL.
-   * @param reqSchema - The schema for the request type. This is used to
-   * validate the request before sending it.
-   * @param resSchema - The schema for the response type. This is used to
-   * validate the response before returning it.
+   * @param target - The target to dial. In some implementations, this may be an
+   * endpoint path, or in others, a complete hostname or URL.
+   * @param reqSchema - The schema for the request type. This is used to validate the
+   * request before sending it.
+   * @param resSchema - The schema for the response type. This is used to validate the
+   * response before returning it.
    */
   stream: <RQ extends z.ZodType, RS extends z.ZodType = RQ>(
     target: string,

--- a/freighter/ts/src/unary.ts
+++ b/freighter/ts/src/unary.ts
@@ -15,8 +15,8 @@ import { type Middleware } from "@/middleware";
 import { type Transport } from "@/transport";
 
 /**
- * An interface for an entity that implements a simple request-response
- * transport between two entities.
+ * An interface for an entity that implements a simple request-response transport
+ * between two entities.
  */
 export interface UnaryClient extends Transport {
   /**
@@ -24,13 +24,15 @@ export interface UnaryClient extends Transport {
    * @param target - The target server to send the request to.
    * @param req - The request to send.
    * @param resSchema - The schema to validate the response against.
+   * @returns the decoded response.
+   * @throws Error: if the server returns an error or the transport fails.
    */
   send: <RQ extends z.ZodType, RS extends z.ZodType = RQ>(
     target: string,
     req: z.input<RQ> | z.infer<RQ>,
     reqSchema: RQ,
     resSchema: RS,
-  ) => Promise<[z.infer<RS>, null] | [null, Error]>;
+  ) => Promise<z.infer<RS>>;
 }
 
 export const unaryWithBreaker = (
@@ -53,28 +55,18 @@ export const unaryWithBreaker = (
       req: z.input<RQ> | z.infer<RQ>,
       reqSchema: RQ,
       resSchema: RS,
-    ): Promise<[z.infer<RS>, null] | [null, Error]> {
+    ): Promise<z.infer<RS>> {
       const brk = new breaker.Breaker(cfg);
-      do {
-        const [res, err] = await this.wrapped.send(target, req, reqSchema, resSchema);
-        if (err == null) return [res, null];
-        if (!Unreachable.matches(err)) return [null, err];
-        console.warn(`[freighter] ${brk.retryMessage}`, err);
-        if (!(await brk.wait())) return [res, err];
-      } while (true);
+      do
+        try {
+          return await this.wrapped.send(target, req, reqSchema, resSchema);
+        } catch (err) {
+          if (!Unreachable.matches(err)) throw err;
+          console.warn(`[freighter] ${brk.retryMessage}`, err);
+          if (!(await brk.wait())) throw err;
+        }
+      while (true);
     }
   }
   return new WithBreaker(base);
-};
-
-export const sendRequired = async <RQ extends z.ZodType, RS extends z.ZodType = RQ>(
-  client: UnaryClient,
-  target: string,
-  req: z.input<RQ> | z.infer<RQ>,
-  reqSchema: RQ,
-  resSchema: RS,
-): Promise<z.infer<RS>> => {
-  const [res, err] = await client.send(target, req, reqSchema, resSchema);
-  if (err != null) throw err;
-  return res;
 };

--- a/freighter/ts/src/websocket.spec.ts
+++ b/freighter/ts/src/websocket.spec.ts
@@ -15,12 +15,9 @@ import { EOF } from "@/errors";
 import { type Context } from "@/middleware";
 import { WebSocketClient } from "@/websocket";
 
-const url = new URL({
-  host: "127.0.0.1",
-  port: 8080,
-});
+const url = new URL({ host: "127.0.0.1", port: 8080 });
 
-const MessageSchema = z.object({
+const messageSchema = z.object({
   id: z.number().optional(),
   message: z.string().optional(),
 });
@@ -47,73 +44,63 @@ const decodeTestError = (encoded: errors.Payload): errors.Typed | null => {
   return new MyCustomError(message, parseInt(code, 10));
 };
 
-errors.register({
-  encode: encodeTestError,
-  decode: decodeTestError,
-});
+errors.register({ encode: encodeTestError, decode: decodeTestError });
 
 describe("websocket", () => {
   test("basic exchange", async () => {
-    const stream = await client.stream("stream/echo", MessageSchema, MessageSchema);
+    const stream = await client.stream("stream/echo", messageSchema, messageSchema);
     for (let i = 0; i < 10; i++) {
       stream.send({ id: i, message: "hello" });
-      const [response, error] = await stream.receive();
-      expect(error).toBeNull();
-      expect(response?.id).toEqual(i + 1);
-      expect(response?.message).toEqual("hello");
+      const response = await stream.receive();
+      expect(response.id).toEqual(i + 1);
+      expect(response.message).toEqual("hello");
     }
     stream.closeSend();
-    const [response, error] = await stream.receive();
-    expect(EOF.matches(error)).toBeTruthy();
-    expect(response).toBeNull();
+    await expect(stream.receive()).rejects.toThrow(EOF);
   });
 
   test("receive message after close", async () => {
     const stream = await client.stream(
       "stream/sendMessageAfterClientClose",
-      MessageSchema,
-      MessageSchema,
+      messageSchema,
+      messageSchema,
     );
     stream.closeSend();
-    const [response, error] = await stream.receive();
-    expect(error).toBeNull();
-    expect(response?.id).toEqual(0);
-    expect(response?.message).toEqual("Close Acknowledged");
-    const [, recvError] = await stream.receive();
-    expect(EOF.matches(recvError)).toBeTruthy();
+    const response = await stream.receive();
+    expect(response.id).toEqual(0);
+    expect(response.message).toEqual("Close Acknowledged");
+    await expect(stream.receive()).rejects.toThrow(EOF);
   });
 
   test("receive error", async () => {
     const stream = await client.stream(
       "stream/receiveAndExitWithErr",
-      MessageSchema,
-      MessageSchema,
+      messageSchema,
+      messageSchema,
     );
     stream.send({ id: 0, message: "hello" });
-    const [response, error] = await stream.receive();
-    expect(MyCustomError.matches(error)).toBeTruthy();
-    expect(response).toBeNull();
+    await expect(stream.receive()).rejects.toThrow(MyCustomError);
   });
 
   describe("middleware", () => {
     test("receive middleware", async () => {
       const myClient = new WebSocketClient(url, new binary.JSONCodec());
       let c = 0;
-      myClient.use(async (md, next): Promise<[Context, Error | null]> => {
+      myClient.use(async (md, next): Promise<Context> => {
         if (md.params !== undefined) {
           c++;
           md.params.Test = "test";
         }
         return await next(md);
       });
-      await myClient.stream("stream/middlewareCheck", MessageSchema, MessageSchema);
+      await myClient.stream("stream/middlewareCheck", messageSchema, messageSchema);
       expect(c).toEqual(1);
     });
 
     test("middleware error on server", async () => {
       const myClient = new WebSocketClient(url, new binary.JSONCodec());
       await expect(
-        myClient.stream("stream/middlewareCheck", MessageSchema, MessageSchema),
+        myClient.stream("stream/middlewareCheck", messageSchema, messageSchema),
       ).rejects.toThrow("test param not found");
     });
   });

--- a/freighter/ts/src/websocket.ts
+++ b/freighter/ts/src/websocket.ts
@@ -56,34 +56,32 @@ class WebSocketStream<
     this.listenForMessages();
   }
 
-  async receiveOpenAck(): Promise<Error | null> {
+  async receiveOpenAck(): Promise<void> {
     const msg = await this.receiveMsg();
-    if (msg.type !== "open") {
-      if (msg.error == null) throw new Error("Message error must be defined");
-      return errors.decode(msg.error);
-    }
-    return null;
+    if (msg.type === "open") return;
+    if (msg.error == null) throw new Error("Message error must be defined");
+    const err = errors.decode(msg.error);
+    if (err != null) throw err;
   }
 
   /** Implements the Stream protocol */
-  send(req: z.input<RQ> | z.infer<RQ>): Error | null {
-    if (this.serverClosed != null) return new EOF();
+  send(req: z.input<RQ> | z.infer<RQ>): void {
+    if (this.serverClosed != null) throw new EOF();
     if (this.sendClosed) throw new StreamClosed();
     this.ws.send(this.codec.encode({ type: "data", payload: req }));
-    return null;
   }
 
   /** Implements the Stream protocol */
-  async receive(): Promise<[z.infer<RS>, null] | [null, Error]> {
-    if (this.serverClosed != null) return [null, this.serverClosed];
+  async receive(): Promise<z.infer<RS>> {
+    if (this.serverClosed != null) throw this.serverClosed;
     const msg = await this.receiveMsg();
     if (msg.type === "close") {
       if (msg.error == null) throw new Error("Message error must be defined");
       this.serverClosed = errors.decode(msg.error);
       if (this.serverClosed == null) throw new Error("Message error must be defined");
-      return [null, this.serverClosed];
+      throw this.serverClosed;
     }
-    return [this.resSchema.parse(msg.payload), null];
+    return this.resSchema.parse(msg.payload);
   }
 
   /** Implements the Stream protocol */
@@ -177,19 +175,16 @@ export class WebSocketClient extends MiddlewareCollector implements StreamClient
     resSchema: RS,
   ): Promise<Stream<RQ, RS>> {
     let stream: Stream<RQ, RS> | undefined;
-    const [, error] = await this.executeMiddleware(
+    await this.executeMiddleware(
       { target, protocol: "websocket", params: {}, role: "client" },
-      async (ctx: Context): Promise<[Context, Error | null]> => {
+      async (ctx: Context): Promise<Context> => {
         const ws = new WebSocket(this.buildURL(target, ctx));
         const outCtx: Context = { ...ctx, params: {} };
         ws.binaryType = WebSocketClient.MESSAGE_TYPE;
-        const streamOrErr = await this.wrapSocket(ws, reqSchema, resSchema);
-        if (streamOrErr instanceof Error) return [outCtx, streamOrErr];
-        stream = streamOrErr;
-        return [outCtx, null];
+        stream = await this.wrapSocket(ws, reqSchema, resSchema);
+        return outCtx;
       },
     );
-    if (error != null) throw error;
     return stream as Stream<RQ, RS>;
   }
 
@@ -208,21 +203,18 @@ export class WebSocketClient extends MiddlewareCollector implements StreamClient
     ws: WebSocket,
     reqSchema: RQ,
     resSchema: RS,
-  ): Promise<WebSocketStream<RQ, RS> | Error> {
-    return await new Promise((resolve) => {
+  ): Promise<WebSocketStream<RQ, RS>> {
+    return await new Promise((resolve, reject) => {
       ws.onopen = () => {
         const oWs = new WebSocketStream<RQ, RS>(ws, this.encoder, reqSchema, resSchema);
         oWs
           .receiveOpenAck()
-          .then((err) => {
-            if (err != null) resolve(err);
-            else resolve(oWs);
-          })
-          .catch((err: Error) => resolve(err));
+          .then(() => resolve(oWs))
+          .catch((err: Error) => reject(err));
       };
       ws.onerror = (ev: Event) => {
         const ev_ = ev as ErrorEvent;
-        resolve(new Error(ev_.message));
+        reject(new Error(ev_.message));
       };
     });
   }

--- a/freighter/ts/src/websocket.ts
+++ b/freighter/ts/src/websocket.ts
@@ -61,7 +61,7 @@ class WebSocketStream<
     if (msg.type === "open") return;
     if (msg.error == null) throw new Error("Message error must be defined");
     const err = errors.decode(msg.error);
-    if (err != null) throw err;
+    throw err ?? new Error(`Unexpected open-ack message type: ${msg.type}`);
   }
 
   /** Implements the Stream protocol */


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4179](https://linear.app/synnax/issue/SY-4179)

## Description

The TypeScript Freighter transport previously signaled errors by **returning** them in a tuple (`[result, null] | [null, Error]`) from `UnaryClient.send`, `Stream.receive`/`send`, and middleware. Every caller had to destructure-and-check, and the codebase had already grown a `sendRequired` helper and a `StreamProxy` wrapper whose only job was to convert those tuples back into thrown exceptions.

This PR pushes throwing down into Freighter itself, so the TypeScript package reads like idiomatic TS:

- `UnaryClient.send` now returns `Promise<RS>` and throws on error.
- `Stream.receive` returns `Promise<RS>` and throws `EOF` (nominal close), the server error (abnormal close), or a transport error.
- `Stream.send` returns `void` and throws `EOF`/`StreamClosed`.
- `Middleware`/`Next`/`Finalizer`/`executeMiddleware` propagate `Context` and throw on failure.
- `unaryWithBreaker` retries via try/catch; the now-redundant `sendRequired` helper is **removed** and all ~94 call sites migrated to `client.send(...)`.

Consumers were updated accordingly: client `auth`, `errors`, and the framer `streamProxy`/`writer`/`streamer`, plus the Console Arc LSP receive loop (which now treats `EOF` as a clean close). HTTP decode-failure errors now attach the original error as `cause`.

This is intentionally a **TypeScript-only** change — the Python Freighter keeps the tuple-return pattern.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR migrates the TypeScript Freighter transport from a tuple-return error convention (`[result, Error|null]`) to idiomatic exception throwing across `UnaryClient.send`, `Stream.receive`/`send`, and the entire middleware chain (`Middleware`/`Next`/`Finalizer`/`executeMiddleware`). The now-redundant `sendRequired` helper is deleted and all ~94 call sites are updated to call `client.send(...)` directly.

- **Freighter core** (`middleware.ts`, `http.ts`, `websocket.ts`, `unary.ts`, `alamos.ts`): All public interfaces and implementations updated; `receiveOpenAck` gains a correct fallback error when `errors.decode` returns `null`; HTTP decode-failure errors now carry the original exception as `cause`.
- **Client layer** (`auth`, `framer`, all resource clients): Boilerplate destructure-and-check code replaced with direct `await`; `StreamProxy.closeAndAck` now throws `UnexpectedError` for residual data messages instead of silently logging.
- **Console LSP** (`lsp.ts`): Receive loop now treats `EOF` as a clean close, suppressing spurious error callbacks on normal server shutdown.

<h3>Confidence Score: 4/5</h3>

The refactoring is mechanically consistent across all 46 files; the one open concern from a prior review thread — write() silently discarding EOF — remains unaddressed and defers stream-closure detection to the next commit() or close().

The transport and middleware changes are solid: receiveOpenAck now correctly falls back to a descriptive error when the decoded payload is null, HTTP decode failures carry the original exception as cause, and the auth retry path resets state correctly before recursing. The outstanding writer.ts concern from the prior review thread (EOF swallowed in write()) is the reason for caution — it changes observable behavior for callers that relied on write() throwing to detect server-side stream closure.

client/ts/src/framer/writer.ts — the EOF-swallow in write() and the structurally unreachable continue in execute() both warrant a second look before merge.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| freighter/ts/src/middleware.ts | Core type change: Next, Middleware, Finalizer, and executeMiddleware now return Promise of Context and throw on error instead of returning [Context, Error|null] tuples. Clean refactor with correct propagation. |
| freighter/ts/src/websocket.ts | send() now throws EOF/StreamClosed, receive() throws on close/error, receiveOpenAck now correctly falls back to a descriptive error when errors.decode returns null for a non-open ACK. |
| freighter/ts/src/http.ts | send() returns Promise of response directly and throws on error; HTTP decode-failure errors now attach the original error as cause; bad-request fallback now correctly surfaces an error when errors.decode returns null. |
| freighter/ts/src/unary.ts | sendRequired helper removed; unaryWithBreaker retry loop converted to try/catch; clean and correct migration. |
| client/ts/src/auth/auth.ts | IIFE-based authenticating promise replaces Promise constructor; auth errors are swallowed into Error|null to keep the shared promise non-rejecting; retry logic correctly resets state before recursing. |
| client/ts/src/framer/writer.ts | execute() and closeInternal() migrated to throw pattern; write() silently swallows EOF (discussed in prior review thread); continue after closeInternal in the receive catch is structurally unreachable (also prior thread). |
| client/ts/src/framer/streamProxy.ts | Simplified by removing tuple-unwrap boilerplate; closeAndAck now correctly throws UnexpectedError for residual data messages instead of silently logging them. |
| freighter/ts/src/alamos.ts | Tracing middleware correctly records errors on span and re-throws; log is called with null on success and with the error on failure; double try-catch structure correctly handles both span-callback errors and instrumentation.T.trace own errors. |
| console/src/arc/lsp/lsp.ts | LSP receive loop now treats EOF as a clean close (onErrorCallback not invoked), and non-EOF errors are wrapped to Error before calling onErrorCallback; intentional behavior change noted in PR description. |
| freighter/ts/src/http.spec.ts | Tests correctly migrated to expect-throws style; unreachable test stores promise then chains two rejects.toThrow assertions on the same promise object. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant MiddlewareCollector
    participant AuthMiddleware
    participant Finalizer
    participant Server

    Caller->>MiddlewareCollector: executeMiddleware(ctx, finalizer)
    MiddlewareCollector->>AuthMiddleware: mw(ctx, next) returns Promise of Context
    AuthMiddleware->>AuthMiddleware: attach Authorization header
    AuthMiddleware->>Finalizer: next(ctx) returns Promise of Context
    Finalizer->>Server: HTTP POST or WS upgrade
    alt success
        Server-->>Finalizer: 200 OK or open ACK
        Finalizer-->>AuthMiddleware: return outCtx
        AuthMiddleware-->>MiddlewareCollector: return ctx
        MiddlewareCollector-->>Caller: return ctx
    else server or transport error
        Server-->>Finalizer: 400 or abnormal close
        Finalizer->>Finalizer: throw decoded Error
        Finalizer-->>AuthMiddleware: propagate throw
        AuthMiddleware->>AuthMiddleware: catch, optionally retry auth
        AuthMiddleware-->>MiddlewareCollector: re-throw
        MiddlewareCollector-->>Caller: throw Error
    end
```

<sub>Reviews (2): Last reviewed commit: ["Add comments"](https://github.com/synnaxlabs/synnax/commit/6b821826b455f89e7a8ca9a10a7fd84f7c0fc077) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33892204)</sub>

<!-- /greptile_comment -->