### PR TITLE
SY-4228: Throw Exceptions in Freighter Python Instead of Returning Tuples

### DIFF
--- a/client/py/synnax/access/policy/client.py
+++ b/client/py/synnax/access/policy/client.py
@@ -13,7 +13,7 @@ from uuid import UUID
 from pydantic import BaseModel
 
 from alamos import NOOP, Instrumentation
-from freighter import Empty, UnaryClient, send_required
+from freighter import Empty, UnaryClient
 from synnax.access.policy.payload import Policy
 from synnax.ontology.payload import ID
 from x.normalize import normalize
@@ -73,7 +73,7 @@ class Client:
     ) -> Policy | list[Policy]:
         is_single = not isinstance(policies, list)
         req = _CreateRequest(policies=normalize(policies))
-        res = send_required(self._client, "/access/policy/create", req, _CreateResponse)
+        res = self._client.send("/access/policy/create", req, _CreateResponse)
         return res.policies[0] if is_single else res.policies
 
     def retrieve(
@@ -82,8 +82,7 @@ class Client:
         subjects: list[ID] | None = None,
         internal: bool | None = None,
     ) -> list[Policy]:
-        res = send_required(
-            self._client,
+        res = self._client.send(
             "/access/policy/retrieve",
             _RetrieveRequest(keys=keys, subjects=subjects, internal=internal),
             _RetrieveResponse,
@@ -92,4 +91,4 @@ class Client:
 
     def delete(self, keys: UUID | list[UUID]) -> None:
         req = _DeleteRequest(keys=normalize(keys))
-        send_required(self._client, "/access/policy/delete", req, Empty)
+        self._client.send("/access/policy/delete", req, Empty)

--- a/client/py/synnax/access/role/client.py
+++ b/client/py/synnax/access/role/client.py
@@ -13,7 +13,7 @@ from uuid import UUID
 from pydantic import BaseModel
 
 from alamos import NOOP, Instrumentation
-from freighter import Empty, UnaryClient, send_required
+from freighter import Empty, UnaryClient
 from synnax.access.role.types_gen import Role
 from x.normalize import normalize
 
@@ -80,7 +80,7 @@ class Client:
     ) -> Role | list[Role]:
         is_single = not isinstance(roles, list)
         req = _CreateRequest(roles=normalize(roles))
-        res = send_required(self._client, "/access/role/create", req, _CreateResponse)
+        res = self._client.send("/access/role/create", req, _CreateResponse)
         return res.roles[0] if is_single else res.roles
 
     @overload
@@ -108,15 +108,13 @@ class Client:
         if is_single and key is not None:
             keys = [key]
         req = _RetrieveRequest(keys=keys, limit=limit, offset=offset, internal=internal)
-        res = send_required(
-            self._client, "/access/role/retrieve", req, _RetrieveResponse
-        )
+        res = self._client.send("/access/role/retrieve", req, _RetrieveResponse)
         roles = [] if res.roles is None else res.roles
         return roles[0] if is_single else roles
 
     def delete(self, keys: UUID | list[UUID]) -> None:
         req = _DeleteRequest(keys=normalize(keys))
-        send_required(self._client, "/access/role/delete", req, Empty)
+        self._client.send("/access/role/delete", req, Empty)
 
     def assign(self, user: UUID, role: UUID) -> None:
         """Assign a role to a user.
@@ -126,7 +124,7 @@ class Client:
             role: The UUID of the role to assign
         """
         req = _AssignRequest(user=user, role=role)
-        send_required(self._client, "/access/role/assign", req, Empty)
+        self._client.send("/access/role/assign", req, Empty)
 
     def unassign(self, user: UUID, role: UUID) -> None:
         """Remove a role from a user.
@@ -136,4 +134,4 @@ class Client:
             role: The UUID of the role to unassign
         """
         req = _UnassignRequest(user=user, role=role)
-        send_required(self._client, "/access/role/unassign", req, Empty)
+        self._client.send("/access/role/unassign", req, Empty)

--- a/client/py/synnax/arc/client.py
+++ b/client/py/synnax/arc/client.py
@@ -14,7 +14,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, PrivateAttr
 
-from freighter import Empty, UnaryClient, send_required
+from freighter import Empty, UnaryClient
 from synnax.arc.payload import (
     Graph,
     Key,
@@ -151,11 +151,8 @@ class Client:
                 )
             ]
 
-        res = send_required(
-            self._client,
-            "/arc/create",
-            _CreateRequest(arcs=to_create),
-            _CreateResponse,
+        res = self._client.send(
+            "/arc/create", _CreateRequest(arcs=to_create), _CreateResponse
         ).arcs
         created = self._sugar(res)
         return created[0] if is_single else created
@@ -194,8 +191,7 @@ class Client:
             names = [name]
 
         is_single = key is not None or name is not None
-        res = send_required(
-            self._client,
+        res = self._client.send(
             "/arc/retrieve",
             _RetrieveRequest(
                 keys=keys,
@@ -219,12 +215,7 @@ class Client:
         return arcs[0]
 
     def delete(self, keys: Key | list[Key]) -> None:
-        send_required(
-            self._client,
-            "/arc/delete",
-            _DeleteRequest(keys=normalize(keys)),
-            Empty,
-        )
+        self._client.send("/arc/delete", _DeleteRequest(keys=normalize(keys)), Empty)
 
     def _sugar(self, payloads: list[Payload]) -> list[Arc]:
         return [

--- a/client/py/synnax/auth.py
+++ b/client/py/synnax/auth.py
@@ -80,38 +80,36 @@ class Client:
         self.authenticated = True
 
     def middleware(self) -> Middleware:
-        def mw(ctx: Context, _next: Next) -> tuple[Context, Exception | None]:
+        def mw(ctx: Context, _next: Next) -> Context:
             if not self.authenticated:
                 self.authenticate()
 
             ctx.set(AUTHORIZATION_HEADER, TOKEN_PREFIX + self.token)
-            out_ctx, exc = _next(ctx)
-
-            if isinstance(exc, RETRY_ON_ERRORS):
+            try:
+                out_ctx = _next(ctx)
+            except RETRY_ON_ERRORS:
                 self.authenticated = False
-                out_ctx, exc = mw(ctx, _next)
+                out_ctx = mw(ctx, _next)
 
             self.maybe_refresh_token(out_ctx)
-            return out_ctx, exc
+            return out_ctx
 
         return mw
 
     def async_middleware(self) -> AsyncMiddleware:
-        async def mw(
-            ctx: Context, _next: AsyncNext
-        ) -> tuple[Context, Exception | None]:
+        async def mw(ctx: Context, _next: AsyncNext) -> Context:
             if not self.authenticated:
                 self.authenticate()
 
             ctx.set(AUTHORIZATION_HEADER, TOKEN_PREFIX + self.token)
-            out_ctx, exc = await _next(ctx)
-
-            if isinstance(exc, RETRY_ON_ERRORS):
+            try:
+                out_ctx = await _next(ctx)
+            except RETRY_ON_ERRORS:
                 self.authenticated = False
-                out_ctx, exc = await mw(ctx, _next)
+                out_ctx = await mw(ctx, _next)
 
             self.maybe_refresh_token(out_ctx)
-            return out_ctx, exc
+            return out_ctx
 
         return mw
 

--- a/client/py/synnax/channel/retrieve.py
+++ b/client/py/synnax/channel/retrieve.py
@@ -14,7 +14,7 @@ from typing import Protocol
 from pydantic import BaseModel
 
 from alamos import NOOP, Instrumentation, trace
-from freighter import UnaryClient, send_required
+from freighter import UnaryClient
 from synnax.channel.payload import (
     Key,
     NormalizedNameResult,
@@ -83,7 +83,7 @@ class ClusterRetriever:
         return channels[0]
 
     def _exec_retrieve(self, req: _Request) -> list[Payload]:
-        return send_required(self._client, "/channel/retrieve", req, _Response).channels
+        return self._client.send("/channel/retrieve", req, _Response).channels
 
 
 class CacheRetriever:

--- a/client/py/synnax/channel/writer.py
+++ b/client/py/synnax/channel/writer.py
@@ -10,7 +10,7 @@
 from pydantic import BaseModel
 
 from alamos import Instrumentation, trace
-from freighter import Empty, UnaryClient, send_required
+from freighter import Empty, UnaryClient
 from synnax.channel.payload import (
     Key,
     NormalizedNameResult,
@@ -61,7 +61,7 @@ class Writer:
         channels: list[Payload | New],
     ) -> list[Payload]:
         req = _CreateRequest(channels=channels)
-        res = send_required(self._client, "/channel/create", req, _Response)
+        res = self._client.send("/channel/create", req, _Response)
         if self._cache is not None:
             self._cache.set(res.channels)
         return res.channels
@@ -73,7 +73,7 @@ class Writer:
             req = _DeleteRequest(names=normal.channels)
         else:
             req = _DeleteRequest(keys=normal.channels)
-        send_required(self._client, "/channel/delete", req, Empty)
+        self._client.send("/channel/delete", req, Empty)
         if self._cache is not None:
             self._cache.delete(normal.channels)
 
@@ -82,6 +82,6 @@ class Writer:
         self, keys: list[Key] | tuple[Key], names: list[str] | tuple[str]
     ) -> None:
         req = _RenameRequest(keys=keys, names=names)
-        send_required(self._client, "/channel/rename", req, Empty)
+        self._client.send("/channel/rename", req, Empty)
         if self._cache is not None:
             self._cache.rename(list(keys), list(names))

--- a/client/py/synnax/device/client.py
+++ b/client/py/synnax/device/client.py
@@ -12,7 +12,7 @@ from typing import Any, Literal, overload
 from pydantic import BaseModel
 
 from alamos import NOOP, Instrumentation
-from freighter import Empty, UnaryClient, send_required
+from freighter import Empty, UnaryClient
 from synnax import rack as rack_
 from synnax.device.types_gen import Device
 from synnax.exceptions import NotFoundError
@@ -117,17 +117,12 @@ class Client:
                 )
             ]
         req = _CreateRequest(devices=normalize(devices))
-        res = send_required(
-            self._client,
-            "/device/create",
-            req,
-            _CreateResponse,
-        )
+        res = self._client.send("/device/create", req, _CreateResponse)
         return res.devices[0] if is_single else res.devices
 
     def delete(self, keys: list[str]) -> None:
         req = _DeleteRequest(keys=keys)
-        send_required(self._client, "/device/delete", req, Empty)
+        self._client.send("/device/delete", req, Empty)
 
     @overload
     def retrieve(
@@ -193,8 +188,7 @@ class Client:
         ignore_not_found: bool = False,
     ) -> list[Device] | Device | None:
         is_single = check_for_none(keys, makes, models, locations, names)
-        res = send_required(
-            self._client,
+        res = self._client.send(
             "/device/retrieve",
             _RetrieveRequest(
                 keys=override(key, keys),

--- a/client/py/synnax/framer/deleter.py
+++ b/client/py/synnax/framer/deleter.py
@@ -11,7 +11,7 @@ from pydantic import BaseModel
 
 import synnax.channel.payload as channel
 from alamos import Instrumentation, trace
-from freighter import UnaryClient, send_required
+from freighter import UnaryClient
 from synnax.telem import TimeRange
 
 
@@ -48,4 +48,4 @@ class Deleter:
             req.keys = normal.channels
         else:
             req.names = normal.channels
-        send_required(self._client, "/frame/delete", req, _Response)
+        self._client.send("/frame/delete", req, _Response)

--- a/client/py/synnax/framer/iterator.py
+++ b/client/py/synnax/framer/iterator.py
@@ -19,7 +19,6 @@ from alamos import NOOP, Instrumentation
 from freighter import EOF, ExceptionPayload, Stream, WebsocketClient
 from freighter.transport import P
 from freighter.websocket import Message
-from synnax.exceptions import UnexpectedError
 from synnax.framer.adapter import ReadFrameAdapter
 from synnax.framer.codec import LOW_PERF_SPECIAL_CHAR, WSFramerCodec
 from synnax.framer.frame import Frame, FramePayload
@@ -218,23 +217,12 @@ class Iterator:
         should probably be placed in a 'finally' block. If the iterator is not closed, it may
         leak resources and threads.
         """
-        exc = self._stream.close_send()
-        if exc is not None:
-            raise exc
+        self._stream.close_send()
         while True:
-            r, exc = self._stream.receive()
-            if r is not None:
-                continue
-            if exc is None:
-                raise UnexpectedError(
-                    f"""Unexpected missing close acknowledgement from server.
-                    Please report this issue to the Synnax team.
-                    Response: {r}
-                    """
-                )
-            if not isinstance(exc, EOF):
-                raise exc
-            break
+            try:
+                self._stream.receive()
+            except EOF:
+                break
 
     def __iter__(self) -> Iterator:
         self.seek_first()
@@ -252,15 +240,10 @@ class Iterator:
         self.close()
 
     def _exec(self, **kwargs: object) -> bool:
-        exc = self._stream.send(_Request(**kwargs))
-        if exc is not None:
-            raise exc
+        self._stream.send(_Request(**kwargs))
         self.value = Frame()
         while True:
-            r, exc = self._stream.receive()
-            if exc is not None:
-                raise exc
-            assert r is not None
+            r = self._stream.receive()
             if r.variant == _ResponseVariant.ACK:
                 return r.ack
             fr = Frame(channels=r.frame.keys, series=r.frame.series)

--- a/client/py/synnax/framer/streamer.py
+++ b/client/py/synnax/framer/streamer.py
@@ -99,9 +99,7 @@ class Streamer:
                 exclude_groups=self._exclude_groups,
             )
         )
-        _, exc = self._stream.receive()
-        if exc is not None:
-            raise exc
+        self._stream.receive()
 
     @overload
     def read(self, timeout: float | int | TimeSpan) -> Frame | None:
@@ -140,12 +138,8 @@ class Streamer:
         timeout.
         """
         try:
-            # mypy does not understand destructured union tuples, so we keep [pld, exc] as
-            # a single tuple.
             res = self._stream.receive(TimeSpan.to_seconds(timeout))
-            if res[1] is not None:
-                raise res[1]
-            return self._adapter.adapt(Frame(res[0].frame))
+            return self._adapter.adapt(Frame(res.frame))
         except TimeoutError:
             return None
 
@@ -174,23 +168,12 @@ class Streamer:
         representing the number of seconds, or a synnax TimeSpan object. If no timeout
         is provided, this method will block until the server acknowledges the closure.
         """
-        exc = self._stream.close_send()
-        if exc is not None:
-            raise exc
+        self._stream.close_send()
         while True:
-            r, exc = self._stream.receive(TimeSpan.to_seconds(timeout))
-            if r is not None:
-                continue
-            if exc is None:
-                raise UnexpectedError(
-                    f"""Unexpected missing close acknowledgement from server.
-                    Please report this issue to the Synnax team.
-                    Response: {r}
-                    """
-                )
-            elif not isinstance(exc, EOF):
-                raise exc
-            break
+            try:
+                self._stream.receive(TimeSpan.to_seconds(timeout))
+            except EOF:
+                break
 
     def __iter__(self) -> Streamer:
         """Returns an iterator object that can be used to iterate over the frames of
@@ -255,20 +238,14 @@ class AsyncStreamer:
                 exclude_groups=self._exclude_groups,
             )
         )
-        _, exc = await self._stream.receive()
-        if exc is not None:
-            raise exc
+        await self._stream.receive()
 
     async def read(self) -> Frame:
         """Reads the next frame of telemetry from the streamer. If an error occurs while
         reading the frame, an exception will be raised.
         """
-        # mypy does not understand destructured union tuples, so we keep [pld, exc] as
-        # a single tuple.
         res = await self._stream.receive()
-        if res[1] is not None:
-            raise res[1]
-        return self._adapter.adapt(Frame(res[0].frame))
+        return self._adapter.adapt(Frame(res.frame))
 
     async def close_loop(self) -> None:
         """Closes the sending end of the streamer, requiring the caller to process all
@@ -282,17 +259,15 @@ class AsyncStreamer:
         """Close the streamer and free all network resources, waiting for the server to
         acknowledge the close request.
         """
-        exc = await self._stream.close_send()
-        if exc is not None:
-            raise exc
-        _, exc = await self._stream.receive()
-        if exc is None:
-            raise UnexpectedError(
-                """Unexpected missing close acknowledgement from server.
-                Please report this issue to the Synnax team."""
-            )
-        elif not isinstance(exc, EOF):
-            raise exc
+        await self._stream.close_send()
+        try:
+            await self._stream.receive()
+        except EOF:
+            return
+        raise UnexpectedError(
+            "Unexpected missing close acknowledgement from server. "
+            "Please report this issue to the Synnax team."
+        )
 
     async def __aenter__(self) -> AsyncStreamer:
         """Returns the async streamer object when used as an async context manager."""

--- a/client/py/synnax/framer/writer.py
+++ b/client/py/synnax/framer/writer.py
@@ -208,14 +208,8 @@ class Writer:
             auto_index_persist_interval=auto_index_persist_interval,
             auto_index=auto_index,
         )
-        exc = self._stream.send(
-            WriterRequest(command=WriterCommand.OPEN, config=config)
-        )
-        if exc is not None:
-            raise exc
-        _, exc = self._stream.receive()
-        if exc is not None:
-            raise exc
+        self._stream.send(WriterRequest(command=WriterCommand.OPEN, config=config))
+        self._stream.receive()
 
     @overload
     def write(
@@ -434,28 +428,32 @@ class Writer:
                 if isinstance(self._close_exc, WriterClosed):
                     return
                 raise self._close_exc
-            res, recv_exc = self._stream.receive()
-            if recv_exc is not None:
-                self._close_exc = (
-                    WriterClosed() if isinstance(recv_exc, EOF) else recv_exc
-                )
-            elif res is not None:
-                self._close_exc = decode_exception(res.err)
+            try:
+                res = self._stream.receive()
+            except EOF:
+                self._close_exc = WriterClosed()
+                continue
+            except Exception as recv_exc:
+                self._close_exc = recv_exc
+                continue
+            self._close_exc = decode_exception(res.err)
 
     def _exec(
         self, req: WriterRequest, timeout: int | None = None
     ) -> WriterResponse | None:
-        send_exc = self._stream.send(req)
-        if send_exc is not None:
+        try:
+            self._stream.send(req)
+        except Exception as send_exc:
             self._close(send_exc)
             return None
         while True:
-            res, recv_exc = self._stream.receive(timeout)
-            if recv_exc is not None:
+            try:
+                res = self._stream.receive(timeout)
+            except TimeoutError:
+                raise
+            except Exception as recv_exc:
                 self._close(recv_exc)
                 return None
-            if res is None:
-                continue
             decoded_exc = decode_exception(res.err)
             if decoded_exc is not None:
                 self._close(decoded_exc)

--- a/client/py/synnax/group/client.py
+++ b/client/py/synnax/group/client.py
@@ -11,7 +11,7 @@ from uuid import UUID
 
 from pydantic import BaseModel
 
-from freighter import Empty, UnaryClient, send_required
+from freighter import Empty, UnaryClient
 from synnax.group.types_gen import Group
 from synnax.ontology.payload import ID, CrudeID
 
@@ -42,25 +42,16 @@ class Client:
         self._client = client
 
     def create(self, parent: CrudeID, name: str, key: str | None = None) -> Group:
-        return send_required(
-            self._client,
+        return self._client.send(
             "/ontology/create-group",
             CreateReq(parent=ID(parent), key=UUID(key) if key else None, name=name),
             CreateRes,
         ).group
 
     def rename(self, key: UUID, name: str) -> Empty:
-        return send_required(
-            self._client,
-            "/ontology/rename-group",
-            RenameReq(key=key, name=name),
-            Empty,
+        return self._client.send(
+            "/ontology/rename-group", RenameReq(key=key, name=name), Empty
         )
 
     def delete(self, keys: list[UUID]) -> Empty:
-        return send_required(
-            self._client,
-            "/ontology/delete-group",
-            DeleteReq(keys=keys),
-            Empty,
-        )
+        return self._client.send("/ontology/delete-group", DeleteReq(keys=keys), Empty)

--- a/client/py/synnax/ontology/client.py
+++ b/client/py/synnax/ontology/client.py
@@ -11,7 +11,7 @@ from typing import overload
 
 from pydantic import BaseModel, Field
 
-from freighter import Empty, UnaryClient, send_required
+from freighter import Empty, UnaryClient
 from synnax.ontology.payload import ID, CrudeID, Resource
 from x.normalize import normalize
 
@@ -114,9 +114,7 @@ class Client:
         )
 
     def _exec_retrieve(self, req: RetrieveReq) -> list[Resource]:
-        return send_required(
-            self._client, "/ontology/retrieve", req, RetrieveRes
-        ).resources
+        return self._client.send("/ontology/retrieve", req, RetrieveRes).resources
 
     def retrieve_parents(
         self,
@@ -129,8 +127,7 @@ class Client:
 
     def move_children(self, from_: CrudeID, to: CrudeID, *children: CrudeID) -> None:
 
-        send_required(
-            self._client,
+        self._client.send(
             "/ontology/move-children",
             MoveChildrenReq.model_validate(
                 {"from": ID(from_), "to": ID(to), "children": [ID(i) for i in children]}
@@ -139,16 +136,14 @@ class Client:
         )
 
     def remove_children(self, id: CrudeID, *children: CrudeID) -> None:
-        send_required(
-            self._client,
+        self._client.send(
             "/ontology/remove-children",
             RemoveChildrenReq(id=ID(id), children=[ID(i) for i in children]),
             Empty,
         )
 
     def add_children(self, id: CrudeID, *children: CrudeID) -> None:
-        send_required(
-            self._client,
+        self._client.send(
             "/ontology/add-children",
             AddChildrenReq(id=ID(id), children=[ID(i) for i in children]),
             Empty,

--- a/client/py/synnax/rack/client.py
+++ b/client/py/synnax/rack/client.py
@@ -12,7 +12,7 @@ from typing import overload
 from pydantic import BaseModel
 
 from alamos import NOOP, Instrumentation
-from freighter import Empty, UnaryClient, send_required
+from freighter import Empty, UnaryClient
 from synnax.exceptions import NotFoundError
 from synnax.rack.types_gen import Rack
 from x.normalize import check_for_none, override
@@ -82,14 +82,14 @@ class Client:
         else:
             is_single = False
         req = _CreateRequest(racks=racks)
-        res = send_required(self._client, "/rack/create", req, _CreateResponse)
+        res = self._client.send("/rack/create", req, _CreateResponse)
         if is_single:
             return res.racks[0]
         return res.racks
 
     def delete(self, keys: list[int]) -> None:
         req = _DeleteRequest(keys=keys)
-        send_required(self._client, "/rack/delete", req, Empty)
+        self._client.send("/rack/delete", req, Empty)
 
     @overload
     def retrieve(
@@ -127,8 +127,7 @@ class Client:
         embedded: bool | None = None,
     ) -> Rack | list[Rack]:
         is_single = check_for_none(keys, names)
-        res = send_required(
-            self._client,
+        res = self._client.send(
             "/rack/retrieve",
             _RetrieveRequest(
                 keys=override(key, keys),

--- a/client/py/synnax/ranger/alias/client.py
+++ b/client/py/synnax/ranger/alias/client.py
@@ -68,13 +68,7 @@ class Client:
             return results
 
         req = _ResolveRequest(range=self._rng, aliases=to_fetch)
-        res, exc = self._client.send("/range/alias/resolve", req, _ResolveResponse)
-        if exc is not None:
-            raise exc
-        if res is None:
-            if is_single:
-                raise KeyError(f"Alias not found: {aliases}")
-            return results
+        res = self._client.send("/range/alias/resolve", req, _ResolveResponse)
 
         for alias, key in res.aliases.items():
             self._cache[alias] = key
@@ -85,6 +79,4 @@ class Client:
 
     def set(self, aliases: dict[channel.Key, str]) -> None:
         req = _SetRequest(range=self._rng, aliases=aliases)
-        res, exc = self._client.send("/range/alias/set", req, _EmptyResponse)
-        if exc is not None:
-            raise exc
+        self._client.send("/range/alias/set", req, _EmptyResponse)

--- a/client/py/synnax/ranger/kv/client.py
+++ b/client/py/synnax/ranger/kv/client.py
@@ -12,7 +12,7 @@ from typing import Any, overload
 
 from pydantic import BaseModel
 
-from freighter import UnaryClient, send_required
+from freighter import UnaryClient
 from synnax.ranger.kv.payload import Pair
 from x.normalize import normalize
 
@@ -55,7 +55,7 @@ class Client:
 
     def get(self, keys: str | list[str]) -> dict[str, str] | str:
         req = _GetRequest(range=self._rng_key, keys=normalize(keys))
-        res = send_required(self._client, "/range/kv/get", req, _GetResponse)
+        res = self._client.send("/range/kv/get", req, _GetResponse)
         if isinstance(keys, str):
             return res.pairs[0].value
         return {pair.key: pair.value for pair in res.pairs}
@@ -74,11 +74,11 @@ class Client:
             for k, v in key.items():
                 pairs.append(Pair(range=self._rng_key, key=k, value=v))
         req = _SetRequest(range=self._rng_key, pairs=pairs)
-        send_required(self._client, "/range/kv/set", req, _EmptyResponse)
+        self._client.send("/range/kv/set", req, _EmptyResponse)
 
     def delete(self, keys: str | list[str]) -> None:
         req = _DeleteRequest(range=self._rng_key, keys=normalize(keys))
-        send_required(self._client, "/range/kv/delete", req, _EmptyResponse)
+        self._client.send("/range/kv/delete", req, _EmptyResponse)
 
     def __getitem__(self, key: str) -> str:
         return self.get(key)

--- a/client/py/synnax/ranger/retrieve.py
+++ b/client/py/synnax/ranger/retrieve.py
@@ -58,9 +58,7 @@ class Retriever:
         return self._execute(_Request(search_term=term))
 
     def _execute(self, req: _Request) -> list[Payload]:
-        res, exc = self._client.send("/range/retrieve", req, _Response)
-        if exc is not None:
-            raise exc
-        if res is None or res.ranges is None:
+        res = self._client.send("/range/retrieve", req, _Response)
+        if res.ranges is None:
             return list()
         return res.ranges

--- a/client/py/synnax/ranger/writer.py
+++ b/client/py/synnax/ranger/writer.py
@@ -10,7 +10,7 @@
 from pydantic import BaseModel
 
 from alamos import NOOP, Instrumentation, trace
-from freighter import Empty, UnaryClient, send_required
+from freighter import Empty, UnaryClient
 from synnax.ontology.payload import ID
 from synnax.ranger.payload import Key, Payload
 
@@ -44,9 +44,9 @@ class Writer:
         self, ranges: list[Payload], *, parent: ID | None = None
     ) -> list[Payload]:
         req = _CreateRequest(ranges=ranges, parent=parent)
-        return send_required(self._client, "/range/create", req, _CreateResponse).ranges
+        return self._client.send("/range/create", req, _CreateResponse).ranges
 
     @trace("debug", "range.delete")
     def delete(self, keys: list[Key]) -> None:
         req = _DeleteRequest(keys=keys)
-        send_required(self._client, "/range/delete", req, Empty)
+        self._client.send("/range/delete", req, Empty)

--- a/client/py/synnax/status/client.py
+++ b/client/py/synnax/status/client.py
@@ -12,7 +12,7 @@ from uuid import UUID
 
 from pydantic import BaseModel
 
-from freighter import Empty, UnaryClient, send_required
+from freighter import Empty, UnaryClient
 from synnax.ontology import ID
 from synnax.status.types_gen import Status, Variant
 from x.normalize import normalize
@@ -129,11 +129,8 @@ class Client:
         single = not isinstance(status, list)
         statuses = [status] if single else status
 
-        res = send_required(
-            self.client,
-            _SET_ENDPOINT,
-            _SetRequest(statuses=statuses, parent=parent),
-            _SetResponse,
+        res = self.client.send(
+            _SET_ENDPOINT, _SetRequest(statuses=statuses, parent=parent), _SetResponse
         ).statuses
 
         if single:
@@ -215,8 +212,7 @@ class Client:
         if single and key is not None:
             keys = [key]
 
-        res = send_required(
-            self.client,
+        res = self.client.send(
             _RETRIEVE_ENDPOINT,
             _RetrieveRequest(
                 keys=keys,
@@ -257,12 +253,7 @@ class Client:
             Delete multiple statuses:
                 >>> client.statuses.delete(["status-1", "status-2", "status-3"])
         """
-        send_required(
-            self.client,
-            _DELETE_ENDPOINT,
-            _DeleteRequest(keys=normalize(keys)),
-            Empty,
-        )
+        self.client.send(_DELETE_ENDPOINT, _DeleteRequest(keys=normalize(keys)), Empty)
 
 
 ONTOLOGY_TYPE = ID(type="status")

--- a/client/py/synnax/task/client.py
+++ b/client/py/synnax/task/client.py
@@ -19,7 +19,7 @@ from uuid import uuid4
 from pydantic import BaseModel, Field, ValidationError, field_validator
 
 from alamos import NOOP, Instrumentation
-from freighter import Empty, UnaryClient, send_required
+from freighter import Empty, UnaryClient
 from synnax.device import Client as DeviceClient
 from synnax.device import Device
 from synnax.exceptions import ConfigurationError
@@ -416,7 +416,7 @@ class Client:
         return sugared[0] if is_single else sugared
 
     def _exec_create(self, req: _CreateRequest) -> list[Payload]:
-        res = send_required(self._client, "/task/create", req, _CreateResponse)
+        res = self._client.send("/task/create", req, _CreateResponse)
         return res.tasks
 
     def maybe_assign_def_rack(self, pld: Payload, rack: int = 0) -> Payload:
@@ -469,7 +469,7 @@ class Client:
 
     def delete(self, keys: int | list[int]) -> None:
         req = _DeleteRequest(keys=normalize(keys))
-        send_required(self._client, "/task/delete", req, Empty)
+        self._client.send("/task/delete", req, Empty)
 
     @overload
     def retrieve(
@@ -500,8 +500,7 @@ class Client:
         types: list[str] | None = None,
     ) -> list[Task] | Task:
         is_single = check_for_none(names, keys, types)
-        res = send_required(
-            self._client,
+        res = self._client.send(
             "/task/retrieve",
             _RetrieveRequest(
                 keys=override(key, keys),
@@ -539,8 +538,7 @@ class Client:
                 self._default_rack = self._racks.retrieve_embedded_rack()
             rack = self._default_rack.key
 
-        res = send_required(
-            self._client,
+        res = self._client.send(
             _RETRIEVE_ENDPOINT,
             _RetrieveRequest(rack=rack, internal=False),
             _RetrieveResponse,
@@ -559,5 +557,5 @@ class Client:
         :return: The newly created task.
         """
         req = _CopyRequest(key=key, name=name, snapshot=False)
-        res = send_required(self._client, _COPY_ENDPOINT, req, _CopyResponse)
+        res = self._client.send(_COPY_ENDPOINT, req, _CopyResponse)
         return self.sugar([res.task])[0]

--- a/client/py/synnax/user/client.py
+++ b/client/py/synnax/user/client.py
@@ -12,7 +12,7 @@ from uuid import UUID
 
 from pydantic import BaseModel
 
-from freighter import Empty, UnaryClient, send_required
+from freighter import Empty, UnaryClient
 from synnax.exceptions import NotFoundError
 from synnax.user.payload import New, User
 from x.normalize import normalize
@@ -103,19 +103,15 @@ class Client:
             users = [user]
         if users is None:
             raise ValueError("Either username, user, or users must be provided")
-        res = send_required(
-            self.client,
-            "/user/create",
-            _CreateRequest(users=users),
-            _CreateResponse,
+        res = self.client.send(
+            "/user/create", _CreateRequest(users=users), _CreateResponse
         ).users
         if single:
             return res[0]
         return res
 
     def change_username(self, key: UUID, username: str) -> None:
-        send_required(
-            self.client,
+        self.client.send(
             "/user/change_username",
             _ChangeUsernameRequest(key=key, username=username),
             Empty,
@@ -124,8 +120,7 @@ class Client:
     def change_name(
         self, key: UUID, *, first_name: str = "", last_name: str = ""
     ) -> None:
-        send_required(
-            self.client,
+        self.client.send(
             "/user/change_name",
             _ChangeNameRequest(key=key, first_name=first_name, last_name=last_name),
             Empty,
@@ -157,8 +152,7 @@ class Client:
         if username is not None:
             usernames = normalize(username)
         single = key is not None or username is not None
-        res = send_required(
-            self.client,
+        res = self.client.send(
             "/user/retrieve",
             _RetrieveRequest(keys=keys, usernames=usernames),
             _RetrieveResponse,
@@ -171,9 +165,4 @@ class Client:
         return users[0]
 
     def delete(self, keys: UUID | list[UUID] | None = None) -> None:
-        send_required(
-            self.client,
-            "/user/delete",
-            _DeleteRequest(keys=normalize(keys)),
-            Empty,
-        )
+        self.client.send("/user/delete", _DeleteRequest(keys=normalize(keys)), Empty)

--- a/client/py/synnax/util/send_required.py
+++ b/client/py/synnax/util/send_required.py
@@ -9,17 +9,16 @@
 
 
 from freighter import URL, UnaryClient
-from freighter import send_required as fsend_required
 from freighter.exceptions import Unreachable
 from freighter.transport import RQ, RS
 
 
 def send_required(client: UnaryClient, target: str, req: RQ, res_t: type[RS]) -> RS:
     """Sends a request to a target and returns the response. Raises an exception if the
-    request returns an error.
+    request returns an error, remapping Unreachable to a friendlier cluster message.
     """
     try:
-        return fsend_required(client, target, req, res_t)
+        return client.send(target, req, res_t)
     except Unreachable as exc:
         url = URL.parse(exc.target)
         raise Unreachable(

--- a/client/py/synnax/view/client.py
+++ b/client/py/synnax/view/client.py
@@ -13,7 +13,7 @@ from uuid import UUID
 from pydantic import BaseModel
 
 from alamos import NOOP, Instrumentation
-from freighter import Empty, UnaryClient, send_required
+from freighter import Empty, UnaryClient
 from synnax.exceptions import NotFoundError
 from synnax.view.types_gen import Key, View
 from x.normalize import normalize
@@ -94,18 +94,13 @@ class Client:
                 )
             ]
         req = _CreateRequest(views=normalize(views))
-        res = send_required(
-            self._client,
-            "/view/create",
-            req,
-            _CreateResponse,
-        )
+        res = self._client.send("/view/create", req, _CreateResponse)
         return res.views[0] if is_single else res.views
 
     def delete(self, keys: Key | list[Key]) -> None:
         if not isinstance(keys, list):
             keys = [keys]
-        send_required(self._client, "/view/delete", _DeleteRequest(keys=keys), Empty)
+        self._client.send("/view/delete", _DeleteRequest(keys=keys), Empty)
 
     @overload
     def retrieve(
@@ -138,8 +133,7 @@ class Client:
         is_single = key is not None
         if key is not None:
             keys = [key]
-        res = send_required(
-            self._client,
+        res = self._client.send(
             "/view/retrieve",
             _RetrieveRequest(
                 keys=keys,

--- a/client/py/tests/test_auth.py
+++ b/client/py/tests/test_auth.py
@@ -78,14 +78,12 @@ class TestAuthRetry:
         mock_client = auth_setup
         mock_client.response_errors = [sy.InvalidToken("invalid token"), None]
 
-        response, error = mock_client.send("", 1, int)
-        assert error is None
+        response = mock_client.send("", 1, int)
         assert response == 1
 
     def test_retry_on_expired_token(self, auth_setup):
         """Test that authentication retries when receiving an expired token error."""
         mock_client = auth_setup
         mock_client.response_errors = [sy.ExpiredToken("token expired"), None]
-        response, error = mock_client.send("", 1, int)
-        assert error is None
+        response = mock_client.send("", 1, int)
         assert response == 1

--- a/freighter/py/freighter/__init__.py
+++ b/freighter/py/freighter/__init__.py
@@ -29,7 +29,7 @@ from freighter.transport import (
     Next,
     Transport,
 )
-from freighter.unary import AsyncUnaryClient, UnaryClient, send_required
+from freighter.unary import AsyncUnaryClient, UnaryClient
 from freighter.url import URL
 from freighter.websocket import (
     AsyncWebsocketClient,
@@ -70,7 +70,6 @@ __all__ = [
     "MsgPackCodec",
     "Next",
     "register_exception",
-    "send_required",
     "Stream",
     "StreamClient",
     "StreamClosed",

--- a/freighter/py/freighter/alamos.py
+++ b/freighter/py/freighter/alamos.py
@@ -20,14 +20,21 @@ def instrumentation_middleware(instrumentation: Instrumentation) -> Middleware:
     :param instrumentation: the instrumentation to use for logging and tracing.
     """
 
-    def _middleware(ctx: Context, next_: Next) -> tuple[Context, Exception | None]:
-        with instrumentation.T.debug(ctx.target) as span:
-            if ctx.role == "client":
-                instrumentation.T.propagate(ctx)
-            res, exc = next_(ctx)
-            span.record_exception(exc)
-        _log(ctx, instrumentation, exc)
-        return res, exc
+    def _middleware(ctx: Context, next_: Next) -> Context:
+        exc: Exception | None = None
+        try:
+            with instrumentation.T.debug(ctx.target) as span:
+                if ctx.role == "client":
+                    instrumentation.T.propagate(ctx)
+                try:
+                    return next_(ctx)
+                except Exception as e:
+                    exc = e
+                    raise
+                finally:
+                    span.record_exception(exc)
+        finally:
+            _log(ctx, instrumentation, exc)
 
     return _middleware
 
@@ -42,16 +49,21 @@ def async_instrumentation_middleware(
     :param instrumentation: the instrumentation to use for logging and tracing.
     """
 
-    async def _middleware(
-        context: Context, next_: AsyncNext
-    ) -> tuple[Context, Exception | None]:
+    async def _middleware(context: Context, next_: AsyncNext) -> Context:
         if context.role == "client":
             instrumentation.T.propagate(context)
-        with instrumentation.T.trace(context.target, "debug") as span:
-            res, exc = await next_(context)
-            span.record_exception(exc)
-        _log(context, instrumentation, exc)
-        return res, exc
+        exc: Exception | None = None
+        try:
+            with instrumentation.T.trace(context.target, "debug") as span:
+                try:
+                    return await next_(context)
+                except Exception as e:
+                    exc = e
+                    raise
+                finally:
+                    span.record_exception(exc)
+        finally:
+            _log(context, instrumentation, exc)
 
     return _middleware
 

--- a/freighter/py/freighter/http.py
+++ b/freighter/py/freighter/http.py
@@ -58,9 +58,7 @@ class HTTPClient(MiddlewareCollector):
         self.__pool = PoolManager(cert_reqs="CERT_NONE", **kwargs)
         urllib3.disable_warnings()
 
-    def send(
-        self, target: str, req: RQ, res_t: type[RS]
-    ) -> tuple[RS, None] | tuple[None, Exception]:
+    def send(self, target: str, req: RQ, res_t: type[RS]) -> RS:
         """Implements the UnaryClient protocol."""
         return self.request(
             "POST",
@@ -78,19 +76,14 @@ class HTTPClient(MiddlewareCollector):
         }
 
     def request(
-        self,
-        method: str,
-        url: str,
-        role: Role,
-        request: RQ,
-        res_t: type[RS],
-    ) -> tuple[RS, None] | tuple[None, Exception]:
+        self, method: str, url: str, role: Role, request: RQ, res_t: type[RS]
+    ) -> RS:
         in_ctx = Context(url, self.__endpoint.protocol, role)
 
         res_container: list[RS | None] = [None]
 
-        def finalizer(ctx: Context) -> tuple[Context, Exception | None]:
-            out_meta_data = Context(url, self.__endpoint.protocol, role)
+        def finalizer(ctx: Context) -> Context:
+            out_ctx = Context(url, self.__endpoint.protocol, role)
             data = None
             if request is not None:
                 data = self.__codec.encode(request)
@@ -103,25 +96,24 @@ class HTTPClient(MiddlewareCollector):
                     method=method, url=url, headers=head, body=data
                 )
             except MaxRetryError as e:
-                return out_meta_data, Unreachable(url, e.url or "Unreachable")
-            except HTTPError as e:
-                return out_meta_data, e
+                raise Unreachable(url, e.url or "Unreachable") from e
 
-            out_meta_data.params = http_res.headers
+            out_ctx.params = http_res.headers
 
             if http_res.status < 200 or http_res.status >= 300:
-                err = self.__codec.decode(http_res.data, ExceptionPayload)
-                return out_meta_data, decode_exception(err)
+                payload = self.__codec.decode(http_res.data, ExceptionPayload)
+                exc = decode_exception(payload)
+                if exc is None:
+                    exc = HTTPError(
+                        f"unexpected error response with status {http_res.status}"
+                    )
+                raise exc
 
-            if http_res.data is None:
-                return out_meta_data, None
+            if http_res.data is not None:
+                res_container[0] = self.__codec.decode(http_res.data, res_t)
+            return out_ctx
 
-            res_container[0] = self.__codec.decode(http_res.data, res_t)
-            return out_meta_data, None
-
-        _, exc = self.exec(in_ctx, finalizer)
-        if exc is not None:
-            return None, exc
+        self.exec(in_ctx, finalizer)
         res = res_container[0]
         assert res is not None
-        return res, None
+        return res

--- a/freighter/py/freighter/mock.py
+++ b/freighter/py/freighter/mock.py
@@ -19,13 +19,13 @@ class MockUnaryClient[RQ, RS](Transport):
 
     requests: list[RQ]
     responses: list[RS]
-    response_errors: list[Exception]
+    response_errors: list[Exception | None]
     _mw: MiddlewareCollector
 
     def __init__(
         self,
         responses: list[RS] | None = None,
-        response_errors: list[Exception] | None = None,
+        response_errors: list[Exception | None] | None = None,
     ):
         """
         Initialize a new MockUnaryClient.
@@ -42,16 +42,16 @@ class MockUnaryClient[RQ, RS](Transport):
         """Implements the Transport protocol."""
         self._mw.use(*middleware)
 
-    def send(
-        self, target: str, req: RQ, res_t: type[RS]
-    ) -> tuple[RS, None] | tuple[None, Exception]:
+    def send(self, target: str, req: RQ, res_t: type[RS]) -> RS:
         """
-        Mock implementation of send that returns pre-configured responses or errors.
+        Mock implementation of send that returns pre-configured responses or raises
+        pre-configured errors.
 
         :param target: the target address of the server
         :param req: the request to issue to the server
-        :return: a tuple of (response, error)
+        :return: the next pre-configured response.
         :raises RuntimeError: when no more responses are available
+        :raises Exception: the next pre-configured error, if any.
         """
         self.requests.append(req)
         if not self.responses:
@@ -59,14 +59,13 @@ class MockUnaryClient[RQ, RS](Transport):
 
         ctx = Context(protocol="mock", target=target, role="client")
 
-        def finalizer(ctx: Context) -> tuple[Context, Exception | None]:
-            error = None
+        def finalizer(ctx: Context) -> Context:
             if self.response_errors:
                 error = self.response_errors.pop(0)
-            return ctx, error
+                if error is not None:
+                    raise error
+            return ctx
 
-        _, exc = self._mw.exec(ctx, finalizer)
-        if exc is not None:
-            return None, exc
+        self._mw.exec(ctx, finalizer)
 
-        return self.responses.pop(0), None
+        return self.responses.pop(0)

--- a/freighter/py/freighter/stream.py
+++ b/freighter/py/freighter/stream.py
@@ -15,14 +15,14 @@ from freighter.transport import RQ, RS, AsyncTransport, Transport
 class AsyncStreamReceiver(Protocol[RS]):
     """Protocol for an entity that receives a stream of response asynchronously."""
 
-    async def receive(self) -> tuple[RS, None] | tuple[None, Exception]:
+    async def receive(self) -> RS:
         """
         Receives a response from the stream. It's not safe to call receive concurrently.
 
-        :returns freighter.errors.EOF: if the server closed the stream nominally.
-        :returns Exception: if the server closed the stream abnormally, returns the
-            error the server returned.
-        :raises Exception: if the transport fails.
+        :returns: the next response from the stream.
+        :raises freighter.errors.EOF: if the server closed the stream nominally.
+        :raises Exception: if the server closed the stream abnormally, raises the error
+            the server returned, or if the transport fails.
         """
         ...
 
@@ -30,9 +30,7 @@ class AsyncStreamReceiver(Protocol[RS]):
 class StreamReceiver(Protocol[RS]):
     """Protocol for an entity that receives a stream of responses."""
 
-    def receive(
-        self, timeout: float | None = None
-    ) -> tuple[RS, None] | tuple[None, Exception]:
+    def receive(self, timeout: float | None = None) -> RS:
         """
         Receives a response from the stream. It's not safe to call receive concurrently.
 
@@ -40,11 +38,11 @@ class StreamReceiver(Protocol[RS]):
             method will block indefinitely. Not all implementations support this
             parameter.
 
-        :returns freighter.errors.EOF: if the server closed the stream nominally.
+        :returns: the next response from the stream.
+        :raises freighter.errors.EOF: if the server closed the stream nominally.
         :raises TimeoutError: if the timeout is reached.
-        :returns Exception: if the server closed the stream abnormally, returns the
-            error the server returned.
-        :raises Exception: if the transport fails.
+        :raises Exception: if the server closed the stream abnormally, raises the error
+            the server returned, or if the transport fails.
         """
         ...
 
@@ -56,15 +54,14 @@ class StreamReceiver(Protocol[RS]):
 class AsyncStreamSender(Protocol[RQ]):
     """Protocol for an entity that asynchronously sends a stream of requests."""
 
-    async def send(self, request: RQ) -> Exception | None:
+    async def send(self, request: RQ) -> None:
         """
         Sends a request to the stream. It is not safe to call send concurrently with
         close_send or send.
 
         :param request: the request to send.
-        :returns freighter.errors.EOF: if the server closed the stream. The caller can
+        :raises freighter.errors.EOF: if the server closed the stream. The caller can
             discover the error returned by the server by calling receive().
-        :returns None: if the message was sent successfully.
         :raises freighter.errors.StreamClosed: if the client called close_send()
         :raises Exception: if the transport fails.
         """
@@ -74,15 +71,14 @@ class AsyncStreamSender(Protocol[RQ]):
 class StreamSender(Protocol[RQ]):
     """Protocol for an entity that sends a stream of requests."""
 
-    def send(self, request: RQ) -> Exception | None:
+    def send(self, request: RQ) -> None:
         """
         Sends a request to the stream. It is not safe to call send concurrently with
         close_send or send.
 
         :param request: the request to send.
-        :returns freighter.errors.EOF: if the server closed the stream. The caller can
+        :raises freighter.errors.EOF: if the server closed the stream. The caller can
             discover the error returned by the server by calling receive().
-        :returns None: if the message was sent successfully.
         :raises freighter.errors.StreamClosed: if the client called close_send()
         :raises Exception: if the transport fails.
         """
@@ -96,7 +92,7 @@ class AsyncStreamSenderCloser(AsyncStreamSender[RQ], Protocol):
     requests.
     """
 
-    async def close_send(self) -> Exception | None:
+    async def close_send(self) -> None:
         """
         Lets the server know no more messages will be sent. If the client attempts to
         call send() after calling close_send(), a freighter.errors.StreamClosed
@@ -106,7 +102,7 @@ class AsyncStreamSenderCloser(AsyncStreamSender[RQ], Protocol):
         After calling close_send, the client is responsible for calling receive() to
         successfully receive the server's acknowledgement.
 
-        :return: None
+        :raises Exception: if the transport fails to communicate the closure.
         """
         ...
 
@@ -117,7 +113,7 @@ class StreamSenderCloser(StreamSender[RQ], Protocol):
     sending direction of the stream when finished issuing requests.
     """
 
-    def close_send(self) -> Exception | None:
+    def close_send(self) -> None:
         """
         Lets the server know no more messages will be sent. If the client attempts to
         call send() after calling close_send(), a freighter.errors.StreamClosed
@@ -127,7 +123,7 @@ class StreamSenderCloser(StreamSender[RQ], Protocol):
         After calling close_send, the client is responsible for calling receive() to
         successfully receive the server's acknowledgement.
 
-        :return: None
+        :raises Exception: if the transport fails to communicate the closure.
         """
         ...
 

--- a/freighter/py/freighter/transport.py
+++ b/freighter/py/freighter/transport.py
@@ -56,36 +56,38 @@ class AsyncTransport(Protocol):
         ...
 
 
-Next = Callable[[Context], tuple[Context, Exception | None]]
-"""Executes the next middleware in the chain"""
+Next = Callable[[Context], Context]
+"""Executes the next middleware in the chain, returning the response context. Raises if
+the request fails."""
 
-AsyncNext = Callable[[Context], Awaitable[tuple[Context, Exception | None]]]
-"""Executes the next middleware in the chain"""
+AsyncNext = Callable[[Context], Awaitable[Context]]
+"""Executes the next middleware in the chain, returning the response context. Raises if
+the request fails."""
 
-Middleware = Callable[[Context, Next], tuple[Context, Exception | None]]
+Middleware = Callable[[Context, Next], Context]
 """
 Middleware is a general middleware function that can be used to parse or attach metadata
-to a request or alter its behavior.
+to a request or alter its behavior. It returns the response context and raises if the
+request fails.
 """
 
-AsyncMiddleware = Callable[
-    [Context, AsyncNext], Awaitable[tuple[Context, Exception | None]]
-]
+AsyncMiddleware = Callable[[Context, AsyncNext], Awaitable[Context]]
 """
 AsyncMiddleware is a general middleware function that can be used to parse or attach
-metadata to a request or alter its behavior.
+metadata to a request or alter its behavior. It returns the response context and raises
+if the request fails.
 """
 
-Finalizer = Callable[[Context], tuple[Context, Exception | None]]
+Finalizer = Callable[[Context], Context]
 """
 Finalizer is a middleware that is executed as the last step in a chain. It is used to
-finalize the request and return the response.
+finalize the request and return the response context, raising if the request fails.
 """
 
-AsyncFinalizer = Callable[[Context], Awaitable[tuple[Context, Exception | None]]]
+AsyncFinalizer = Callable[[Context], Awaitable[Context]]
 """
 AsyncFinalizer is a middleware that is executed as the last step in a chain. It is used
-to finalize the request and return the response.
+to finalize the request and return the response context, raising if the request fails.
 """
 
 
@@ -101,21 +103,19 @@ class MiddlewareCollector:
         """Use implements the Transport protocol."""
         self._middleware.extend(args)
 
-    def exec(
-        self,
-        ctx: Context,
-        finalizer: Finalizer,
-    ) -> tuple[Context, Exception | None]:
+    def exec(self, ctx: Context, finalizer: Finalizer) -> Context:
         """
         Executes the middleware in order, passing metadata to each middleware until the
         end of the chain is reached. It then calls the finalizer with the metadata.
 
         :param ctx: the context to pass to the middleware.
         :param finalizer: the finalizer to call at the end of the chain.
+        :returns: the response context.
+        :raises Exception: if any middleware or the finalizer fails.
         """
         middleware = self._middleware.copy()
 
-        def _next(ctx_: Context) -> tuple[Context, Exception | None]:
+        def _next(ctx_: Context) -> Context:
             if len(middleware) == 0:
                 return finalizer(ctx_)
             return middleware.pop()(ctx_, _next)
@@ -135,21 +135,19 @@ class AsyncMiddlewareCollector:
         """Use implements the Transport protocol."""
         self._middleware.extend(args)
 
-    async def exec(
-        self,
-        md: Context,
-        finalizer: AsyncFinalizer,
-    ) -> tuple[Context, Exception | None]:
+    async def exec(self, md: Context, finalizer: AsyncFinalizer) -> Context:
         """
         Executes the middleware in order, passing metadata to each middleware until the
         end of the chain is reached. It then calls the finalizer with the metadata.
 
         :param md: the metadata to pass to the middleware
         :param finalizer: the finalizer to call at the end of the chain
+        :returns: the response context.
+        :raises Exception: if any middleware or the finalizer fails.
         """
         middleware = self._middleware.copy()
 
-        async def _next(_md: Context) -> tuple[Context, Exception | None]:
+        async def _next(_md: Context) -> Context:
             if len(middleware) == 0:
                 return await finalizer(_md)
             return await middleware.pop()(_md, _next)

--- a/freighter/py/freighter/unary.py
+++ b/freighter/py/freighter/unary.py
@@ -18,12 +18,7 @@ class UnaryClient(Transport, Protocol):
     two entities.
     """
 
-    def send(
-        self,
-        target: str,
-        req: RQ,
-        res_t: type[RS],
-    ) -> tuple[RS, None] | tuple[None, Exception]:
+    def send(self, target: str, req: RQ, res_t: type[RS]) -> RS:
         """
         Sends a request to the target server and waits until a response is returned.
 
@@ -31,18 +26,11 @@ class UnaryClient(Transport, Protocol):
         :param req: the request to issue to the server
         :param res_t: the response type expected from the server. Implementations can
             use this to validate the response.
-        :return: any errors encountered
+        :return: the response returned by the server.
         :raises Unreachable: when the provided target cannot be reached
+        :raises Exception: any error returned by the server.
         """
         ...
-
-
-def send_required(client: UnaryClient, target: str, req: RQ, res_t: type[RS]) -> RS:
-    """Utility wrapper that throws an exception if the request returns an error."""
-    res = client.send(target, req, res_t)
-    if res[1] is not None:
-        raise res[1]
-    return res[0]
 
 
 class AsyncUnaryClient(AsyncTransport, Protocol):
@@ -51,12 +39,7 @@ class AsyncUnaryClient(AsyncTransport, Protocol):
     transport between two entities.
     """
 
-    async def send(
-        self,
-        target: str,
-        req: RQ,
-        res_t: type[RS],
-    ) -> tuple[RS, None] | tuple[None, Exception]:
+    async def send(self, target: str, req: RQ, res_t: type[RS]) -> RS:
         """
         Sends a request to the target server and waits until a response is returned.
 
@@ -64,7 +47,8 @@ class AsyncUnaryClient(AsyncTransport, Protocol):
         :param req: the request to issue to the server
         :param res_t: the response from the server. Implementations can use this to
             validate the response.
-        :return: any errors encountered
+        :return: the response returned by the server.
         :raises Unreachable: when the provided target cannot be reached
+        :raises Exception: any error returned by the server.
         """
         ...

--- a/freighter/py/freighter/websocket.py
+++ b/freighter/py/freighter/websocket.py
@@ -149,6 +149,9 @@ class AsyncWebsocketStream(AsyncStream[RQ, RS]):
         exc = decode_exception(decoded_msg.error)
         if exc is not None:
             raise exc
+        raise RuntimeError(
+            f"expected 'open' ack from server, got message type {decoded_msg.type!r}"
+        )
 
     async def close_send(self) -> None:
         """Implements the AsyncStream protocol."""
@@ -225,6 +228,9 @@ class SyncWebsocketStream(Stream[RQ, RS]):
         exc = decode_exception(decoded_msg.error)
         if exc is not None:
             raise exc
+        raise RuntimeError(
+            f"expected 'open' ack from server, got message type {decoded_msg.type!r}"
+        )
 
     def send(self, payload: RQ) -> None:
         if self._server_closed is not None:

--- a/freighter/py/freighter/websocket.py
+++ b/freighter/py/freighter/websocket.py
@@ -104,11 +104,11 @@ class AsyncWebsocketStream(AsyncStream[RQ, RS]):
         self._server_closed = None
         self._res_msg_t = _new_res_msg_t(res_t)
 
-    async def receive(self) -> tuple[RS, None] | tuple[None, Exception]:
+    async def receive(self) -> RS:
         """Implements the AsyncStream protocol."""
         server_closed = self._server_closed
         if server_closed is not None:
-            return None, server_closed
+            raise server_closed
 
         data = await self._internal.recv()
         assert isinstance(data, bytes)
@@ -117,18 +117,17 @@ class AsyncWebsocketStream(AsyncStream[RQ, RS]):
         if msg.type == "close":
             await self._close_server(msg.error)
             assert self._server_closed is not None
-            return None, self._server_closed
+            raise self._server_closed
 
         assert msg.payload is not None
-        return msg.payload, None
+        return msg.payload
 
-    async def send(self, payload: RQ) -> Exception | None:
+    async def send(self, payload: RQ) -> None:
         """Implements the AsyncStream protocol."""
-        # If the server closed with an error, we return freighter.EOF to the
-        # caller, and expect them to discover the close error by calling
-        # receive().
+        # If the server closed with an error, we raise freighter.EOF to the caller, and
+        # expect them to discover the close error by calling receive().
         if self._server_closed is not None:
-            return EOF()
+            raise EOF()
 
         if self._send_closed:
             raise StreamClosed
@@ -136,34 +135,31 @@ class AsyncWebsocketStream(AsyncStream[RQ, RS]):
         msg = Message[RQ](type="data", payload=payload, error=None)
         encoded = self._encoder.encode(msg)
 
-        # If the server closed with an error, we return freighter.EOF to the
-        # caller, and expect them to discover the close error by calling
-        # receive().
         try:
             await self._internal.send(encoded)
-        except ConnectionClosedOK:
-            return EOF()
-        return None
+        except ConnectionClosedOK as e:
+            raise EOF() from e
 
-    async def receive_open_ack(self) -> Exception | None:
+    async def receive_open_ack(self) -> None:
         msg = await self._internal.recv()
         assert isinstance(msg, bytes)
         decoded_msg = self._encoder.decode(msg, Message)
         if decoded_msg.type == "open":
-            return None
-        return decode_exception(decoded_msg.error)
+            return
+        exc = decode_exception(decoded_msg.error)
+        if exc is not None:
+            raise exc
 
-    async def close_send(self) -> Exception | None:
+    async def close_send(self) -> None:
         """Implements the AsyncStream protocol."""
         if self._send_closed or self._server_closed is not None:
-            return None
+            return
 
         msg = Message[RQ](type="close", payload=None, error=None)
         try:
             await self._internal.send(self._encoder.encode(msg))
         finally:
             self._send_closed = True
-        return None
 
     async def _close_server(self, exc_pld: ExceptionPayload | None) -> None:
         if self._server_closed is not None:
@@ -197,42 +193,42 @@ class SyncWebsocketStream(Stream[RQ, RS]):
         self._server_closed = None
         self._res_msg_t = _new_res_msg_t(res_t)
 
-    def receive(
-        self, timeout: float | None = None
-    ) -> tuple[RS, None] | tuple[None, Exception]:
+    def receive(self, timeout: float | None = None) -> RS:
         server_closed = self._server_closed
         if server_closed is not None:
-            return None, server_closed
+            raise server_closed
 
         try:
             data = self._internal.recv(timeout)
         except ConnectionClosedOK as e:
-            return None, handle_close_err(e)
+            raise handle_close_err(e) from e
         assert isinstance(data, bytes)
         msg = self._encoder.decode(data, self._res_msg_t)
 
         if msg.type == "close":
             self._close_server(msg.error)
             assert self._server_closed is not None
-            return None, self._server_closed
+            raise self._server_closed
 
         assert msg.payload is not None
-        return msg.payload, None
+        return msg.payload
 
     def received(self) -> bool:
         return self._internal.recv_bufsize > 0
 
-    def receive_open_ack(self) -> Exception | None:
+    def receive_open_ack(self) -> None:
         msg = self._internal.recv()
         assert isinstance(msg, bytes)
         decoded_msg = self._encoder.decode(msg, self._res_msg_t)
         if decoded_msg.type == "open":
-            return None
-        return decode_exception(decoded_msg.error)
+            return
+        exc = decode_exception(decoded_msg.error)
+        if exc is not None:
+            raise exc
 
-    def send(self, payload: RQ) -> Exception | None:
+    def send(self, payload: RQ) -> None:
         if self._server_closed is not None:
-            return EOF()
+            raise EOF()
 
         if self._send_closed:
             raise StreamClosed
@@ -243,21 +239,19 @@ class SyncWebsocketStream(Stream[RQ, RS]):
         try:
             self._internal.send(encoded)
         except ConnectionClosedOK as e:
-            return handle_close_err(e)
-        return None
+            raise handle_close_err(e) from e
 
-    def close_send(self) -> Exception | None:
+    def close_send(self) -> None:
         if self._send_closed or self._server_closed is not None:
-            return None
+            return
 
         msg = Message[RQ](type="close", payload=None, error=None)
         try:
             self._internal.send(self._encoder.encode(msg))
         except ConnectionClosedOK as e:
-            return handle_close_err(e)
+            raise handle_close_err(e) from e
         finally:
             self._send_closed = True
-        return None
 
     def _close_server(self, exc_pld: ExceptionPayload | None) -> None:
         if self._server_closed is not None:
@@ -319,25 +313,20 @@ class AsyncWebsocketClient(_Base, AsyncMiddlewareCollector, AsyncStreamClient):
         """Implements the AsyncStreamClient protocol."""
         socket_container: list[AsyncWebsocketStream[RQ, RS] | None] = [None]
 
-        async def finalizer(ctx: Context) -> tuple[Context, Exception | None]:
+        async def finalizer(ctx: Context) -> Context:
             out_ctx = Context(target, "websocket", "client")
-            try:
-                ws = await connect(
-                    self._endpoint.child(target).stringify(),
-                    additional_headers=self.additional_headers(ctx.params),
-                    max_size=self._max_message_size,
-                    **self._kwargs,
-                )
-                socket = AsyncWebsocketStream[RQ, RS](self._encoder, ws, res_t)
-                e = await socket.receive_open_ack()
-                socket_container[0] = socket
-                return out_ctx, e
-            except Exception as e:
-                return out_ctx, e
+            ws = await connect(
+                self._endpoint.child(target).stringify(),
+                additional_headers=self.additional_headers(ctx.params),
+                max_size=self._max_message_size,
+                **self._kwargs,
+            )
+            socket = AsyncWebsocketStream[RQ, RS](self._encoder, ws, res_t)
+            await socket.receive_open_ack()
+            socket_container[0] = socket
+            return out_ctx
 
-        _, exc = await self.exec(Context(target, "websocket", "client"), finalizer)
-        if exc is not None:
-            raise exc
+        await self.exec(Context(target, "websocket", "client"), finalizer)
 
         socket = socket_container[0]
         assert socket is not None
@@ -378,25 +367,20 @@ class WebsocketClient(_Base, MiddlewareCollector, StreamClient):
     ) -> SyncWebsocketStream[RQ, RS]:
         socket_container: list[SyncWebsocketStream[RQ, RS] | None] = [None]
 
-        def finalizer(ctx: Context) -> tuple[Context, Exception | None]:
+        def finalizer(ctx: Context) -> Context:
             out_ctx = Context(target, "websocket", "client")
-            try:
-                ws = sync_connect(
-                    self._endpoint.child(target).stringify(),
-                    additional_headers=self.additional_headers(ctx.params),
-                    max_size=self._max_message_size,
-                    **self._kwargs,
-                )
-                socket = SyncWebsocketStream[RQ, RS](self._encoder, ws, res_t)
-                e = socket.receive_open_ack()
-                socket_container[0] = socket
-                return out_ctx, e
-            except Exception as e:
-                return out_ctx, e
+            ws = sync_connect(
+                self._endpoint.child(target).stringify(),
+                additional_headers=self.additional_headers(ctx.params),
+                max_size=self._max_message_size,
+                **self._kwargs,
+            )
+            socket = SyncWebsocketStream[RQ, RS](self._encoder, ws, res_t)
+            socket.receive_open_ack()
+            socket_container[0] = socket
+            return out_ctx
 
-        _, exc = self.exec(Context(target, "websocket", "client"), finalizer)
-        if exc is not None:
-            raise exc
+        self.exec(Context(target, "websocket", "client"), finalizer)
         socket = socket_container[0]
         assert socket is not None
         return socket

--- a/freighter/py/tests/test_http.py
+++ b/freighter/py/tests/test_http.py
@@ -28,26 +28,20 @@ def client(endpoint: URL) -> HTTPClient:
 class TestClient:
     def test_echo(self, client: HTTPClient) -> None:
         """Should echo an incremented ID back to the caller."""
-        res, err = client.send("/echo", Message(id=1, message="hello"), Message)
-        assert err is None
-        assert res is not None
+        res = client.send("/echo", Message(id=1, message="hello"), Message)
         assert res.id == 2
         assert res.message == "hello"
 
     def test_middleware(self, client: HTTPClient) -> None:
         dct = {"called": False}
 
-        def mw(md: Context, next: Next) -> tuple[Context, Exception | None]:
+        def mw(md: Context, next: Next) -> Context:
             md.params["Test"] = "test"
             dct["called"] = True
             return next(md)
 
         client.use(mw)
-        res, err = client.send(
-            "/middlewareCheck", Message(id=1, message="hello"), Message
-        )
-        assert err is None
-        assert res is not None
+        res = client.send("/middlewareCheck", Message(id=1, message="hello"), Message)
         assert res.id == 2
         assert res.message == "hello"
         assert dct["called"]

--- a/freighter/py/tests/test_ws.py
+++ b/freighter/py/tests/test_ws.py
@@ -72,14 +72,12 @@ class TestAsyncWebsocket:
         stream = await async_client.stream("/echo", Message, Message)
         for i in range(10):
             await stream.send(Message(id=i, message="hello"))
-            msg, err = await stream.receive()
-            assert err is None
-            assert msg is not None
+            msg = await stream.receive()
             assert msg.id == i + 1
             assert msg.message == "hello"
         await stream.close_send()
-        msg, err = await stream.receive()
-        assert err is not None
+        with pytest.raises(freighter.EOF):
+            await stream.receive()
 
     async def test_receive_message_after_close(
         self, async_client: AsyncWebsocketClient
@@ -92,28 +90,26 @@ class TestAsyncWebsocket:
         await stream.close_send()
         # calling should be idempotent
         await stream.close_send()
-        msg, err = await stream.receive()
-        assert err is None
-        assert msg is not None
+        msg = await stream.receive()
         assert msg.id == 0
         assert msg.message == "Close Acknowledged"
-        msg, err = await stream.receive()
-        assert isinstance(err, freighter.EOF)
+        with pytest.raises(freighter.EOF):
+            await stream.receive()
 
     async def test_receive_error(self, async_client: AsyncWebsocketClient) -> None:
         """Should correctly decode a custom error from the server."""
         stream = await async_client.stream("/receiveAndExitWithErr", Message, Message)
         await stream.send(Message(id=1, message="hello"))
-        msg, err = await stream.receive()
-        assert isinstance(err, Error)
-        assert err.code == 1
-        assert err.message == "unexpected error"
+        with pytest.raises(Error) as exc_info:
+            await stream.receive()
+        assert exc_info.value.code == 1
+        assert exc_info.value.message == "unexpected error"
         await stream.close_send()
 
     async def test_middleware(self, async_client: AsyncWebsocketClient) -> None:
         dct = {"called": False}
 
-        async def mw(md: Context, next: AsyncNext) -> tuple[Context, Exception | None]:
+        async def mw(md: Context, next: AsyncNext) -> Context:
             md.params["Test"] = "test"
             dct["called"] = True
             return await next(md)
@@ -121,8 +117,8 @@ class TestAsyncWebsocket:
         async_client.use(mw)
         stream = await async_client.stream("/middlewareCheck", Message, Message)
         await stream.close_send()
-        _, err = await stream.receive()
-        assert isinstance(err, freighter.EOF)
+        with pytest.raises(freighter.EOF):
+            await stream.receive()
         assert dct["called"]
 
     async def test_server_timeout(
@@ -133,30 +129,21 @@ class TestAsyncWebsocket:
         msg_str = str(uuid4())
         await stream.send(Message(id=1, message=msg_str))
         time.sleep(2)
-        res, err = unary_client.send(
+        res = unary_client.send(
             "/slamMessagesTimeoutCheck", Message(id=1, message=msg_str), Message
         )
-        assert err is None
-        assert res is not None
         assert res.message == "timeout"
         with pytest.raises(ConnectionClosedError):
             while True:
-                _, err = await stream.receive()
-                if isinstance(err, freighter.EOF):
-                    break
+                await stream.receive()
 
     async def test_with_custom_codec(self, async_client: AsyncWebsocketClient) -> None:
         """Should correctly use a custom codec for the websocket client."""
         async_client = async_client.with_codec(MyVerySpecialCustomCodec())
         stream = await async_client.stream("/echo", Message, Message)
         for i in range(1):
-            err = await stream.send(
-                Message(id=12, message="what we send here is ignored")
-            )
-            assert err is None
-            msg, err = await stream.receive()
-            assert err is None
-            assert msg is not None
+            await stream.send(Message(id=12, message="what we send here is ignored"))
+            msg = await stream.receive()
             assert msg.id == 4201
             assert msg.message == "the key to the universe"
 
@@ -165,39 +152,35 @@ class TestSyncWebsocket:
     def test_basic_exchange(self, sync_client: WebsocketClient) -> None:
         stream = sync_client.stream("/echo", Message, Message)
         for i in range(10):
-            err = stream.send(Message(id=i, message="hello"))
-            assert err is None
-            msg, err = stream.receive()
-            assert err is None
-            assert msg is not None
+            stream.send(Message(id=i, message="hello"))
+            msg = stream.receive()
             assert msg.id == i + 1
             assert msg.message == "hello"
         stream.close_send()
-        msg, err = stream.receive()
-        assert msg is None
-        assert err is not None
+        with pytest.raises(freighter.EOF):
+            stream.receive()
 
     def test_repeated_receive(self, sync_client: WebsocketClient) -> None:
         """Should receive ten messages from the server."""
         stream = sync_client.stream("/respondWithTenMessages", Message, Message)
         c = 0
         while True:
-            msg, err = stream.receive()
-            if isinstance(err, freighter.EOF):
+            try:
+                msg = stream.receive()
+            except freighter.EOF:
                 break
             c += 1
-            assert err is None
-            assert msg is not None
             assert msg.message == "hello"
         stream.close_send()
         assert c == 10
-        _, err = stream.receive()
+        with pytest.raises(freighter.EOF):
+            stream.receive()
 
     def test_middleware(self, sync_client: WebsocketClient) -> None:
         """Should receive ten messages from the server."""
         dct = {"called": False}
 
-        def mw(md: Context, next: Next) -> tuple[Context, Exception | None]:
+        def mw(md: Context, next: Next) -> Context:
             md.params["Test"] = "test"
             dct["called"] = True
             return next(md)
@@ -205,8 +188,8 @@ class TestSyncWebsocket:
         sync_client.use(mw)
         stream = sync_client.stream("/middlewareCheck", Message, Message)
         stream.close_send()
-        _, err = stream.receive()
-        assert isinstance(err, freighter.EOF)
+        with pytest.raises(freighter.EOF):
+            stream.receive()
         assert dct["called"]
 
     def test_middleware_error_on_server(self, sync_client: WebsocketClient) -> None:
@@ -222,8 +205,9 @@ class TestSyncWebsocket:
             stream.receive(timeout=0.1)
         stream.close_send()
         while True:
-            _, err = stream.receive()
-            if isinstance(err, freighter.EOF):
+            try:
+                stream.receive()
+            except freighter.EOF:
                 break
 
     def test_timeout_0(self, sync_client: WebsocketClient) -> None:
@@ -239,9 +223,7 @@ class TestSyncWebsocket:
                 break
             try:
                 time.sleep(sleep)
-                msg, err = stream.receive(timeout=0)
-                assert err is None
-                assert msg is not None
+                msg = stream.receive(timeout=0)
                 assert msg.id == 1
                 break
             except TimeoutError:
@@ -252,23 +234,25 @@ class TestSyncWebsocket:
     def test_receive_error(self, sync_client: WebsocketClient) -> None:
         """Should correctly decode a custom error from the server."""
         stream = sync_client.stream("/receiveAndExitWithErr", Message, Message)
-        err = stream.send(Message(id=1, message="hello"))
-        assert err is None
-        msg, err = stream.receive()
-        assert isinstance(err, Error)
-        assert err.code == 1
-        assert err.message == "unexpected error"
+        stream.send(Message(id=1, message="hello"))
+        with pytest.raises(Error) as exc_info:
+            stream.receive()
+        assert exc_info.value.code == 1
+        assert exc_info.value.message == "unexpected error"
         stream.close_send()
 
     def test_exit_immediately_with_err(self, sync_client: WebsocketClient) -> None:
         """Should correctly return the error to the stream"""
         stream = sync_client.stream("/immediatelyExitWithErr", Message, Message)
         for i in range(100):
-            stream.send(Message(id=1, message="hello"))
-        msg, err = stream.receive()
-        assert isinstance(err, Error)
-        assert err.code == 1
-        assert err.message == "unexpected error"
+            try:
+                stream.send(Message(id=1, message="hello"))
+            except freighter.EOF:
+                break
+        with pytest.raises(Error) as exc_info:
+            stream.receive()
+        assert exc_info.value.code == 1
+        assert exc_info.value.message == "unexpected error"
         stream.close_send()
 
     def test_with_custom_codec(self, sync_client: WebsocketClient) -> None:
@@ -276,10 +260,7 @@ class TestSyncWebsocket:
         sync_client = sync_client.with_codec(MyVerySpecialCustomCodec())
         stream = sync_client.stream("/echo", Message, Message)
         for i in range(1):
-            err = stream.send(Message(id=12, message="what we send here is ignored"))
-            assert err is None
-            msg, err = stream.receive()
-            assert err is None
-            assert msg is not None
+            stream.send(Message(id=12, message="what we send here is ignored"))
+            msg = stream.receive()
             assert msg.id == 4201
             assert msg.message == "the key to the universe"


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4228](https://linear.app/synnax/issue/SY-4228)

## Description

Refactors the Python Freighter library to **raise exceptions** instead of returning errors as the second element of a tuple, bringing it in line with idiomatic Python. This mirrors the TypeScript change in #2366 (SY-4179).

**API changes (`freighter/py`):**

- `UnaryClient.send` / `AsyncUnaryClient.send` now return `RS` and raise on error, instead of `tuple[RS, None] | tuple[None, Exception]`.
- `Stream.receive` / `AsyncStream.receive` now return `RS` and raise. In particular, they raise `freighter.EOF` on nominal stream close (the Pythonic equivalent of `StopIteration`); drain loops become `try/except EOF`.
- `Stream.send` / `close_send` (and async variants) return `None` and raise.
- The middleware chain (`Next` / `Middleware` / `Finalizer` / `MiddlewareCollector.exec`, plus async) now returns `Context` and raises, instead of `tuple[Context, Exception | None]`. The Alamos instrumentation middleware records/logs on both paths via `try/finally` and re-raises.
- `HTTPClient`, `WebsocketClient`/`AsyncWebsocketClient`, and `MockUnaryClient` updated accordingly.
- Removed the now-redundant `freighter.send_required` helper — since `send` raises, `send_required(client, t, r, rt)` is exactly `client.send(t, r, rt)`. All call sites were inlined.

**Consumer updates (`client/py`):**

- The auth middleware's token-retry now uses `try/except RETRY_ON_ERRORS` instead of inspecting a returned error.
- The framer `Streamer`/`Writer`/`Iterator` close/exec/read loops were updated to the raising API (e.g. drain-until-`EOF`). `Writer._exec` still re-raises `TimeoutError` so `write(timeout=0)`'s non-blocking error check keeps working.
- Inlined all `freighter.send_required(...)` calls across the resource clients (channel, task, device, rack, user, status, group, access, ontology, ranger, view, arc, framer/deleter) to `client.send(...)`.

**Behavior note:** because the middleware chain now raises, the response `Context` is unavailable on a hard error, so the auth middleware refreshes the token on success/retry paths but not on hard-error responses (previously untested behavior that self-heals via the existing expired-token retry).

## Verification

- `mypy` clean: `freighter/py` (21 files) and `client/py`'s `synnax/` package (143 files).
- `ruff check` + `ruff format --check` clean across both full packages.
- The full `freighter/py` suite (25 tests) passes against the Freighter integration server, including the rewritten HTTP/WebSocket tests (echo, middleware, error decode, EOF-on-close, timeouts, custom codec).
- `client/py`'s `TestAuthRetry` passes (exercises the raising mock + the `except RETRY_ON_ERRORS` middleware path).

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR refactors the Python Freighter library and its consumers to raise exceptions instead of returning `(payload, error)` tuples, making the API idiomatic Python. All 34 changed files follow the same consistent pattern: callers use `try/except EOF` drain loops and `except RETRY_ON_ERRORS` for auth retries, replacing the old `if exc is not None: raise exc` idiom. The `send_required` helper is removed since `client.send(...)` is now equivalent.

- **`freighter/py`**: `UnaryClient.send`, `Stream.send/receive/close_send`, `Middleware`/`Next`/`Finalizer`, and all implementations (`HTTPClient`, `WebsocketClient`, `AsyncWebsocketClient`) updated to the raising API; `receive_open_ack` now raises `RuntimeError` as a fallback for unexpected message types, closing a previously-noted silent-return gap.
- **`client/py`**: Auth middleware converted to `try/except RETRY_ON_ERRORS`; framer `Writer`/`Streamer`/`Iterator` close/drain loops and `_exec` updated accordingly; all `freighter.send_required(...)` call-sites inlined to `client.send(...)`.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The refactor is mechanically consistent across all 34 files with no correctness regressions found.

All error handling semantics are preserved: EOF drain loops, auth token retry, TimeoutError re-raise in Writer._exec, and non-blocking write semantics all behave identically to the old code. The only structural difference (maybe_refresh_token skipped on hard-error responses) is explicitly acknowledged in the PR description. The one minor observation (double call to maybe_refresh_token on retry-success) has no observable effect.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| freighter/py/freighter/transport.py | Middleware types updated from tuple-returning to raising; MiddlewareCollector.exec and AsyncMiddlewareCollector.exec correctly propagate exceptions through the chain. |
| freighter/py/freighter/http.py | Finalizer now raises instead of returning a tuple; only MaxRetryError is caught (other urllib3 errors now propagate raw — pre-existing concern flagged in prior threads). |
| freighter/py/freighter/websocket.py | Stream send/receive/close_send now raise instead of returning tuples; receive_open_ack now raises RuntimeError as a fallback for unexpected message types, closing the previously noted silent-return gap. |
| freighter/py/freighter/alamos.py | Instrumentation middleware restructured with nested try/finally to record exceptions on the span and log, then re-raise. |
| client/py/synnax/auth.py | Auth middleware updated to use try/except RETRY_ON_ERRORS; recursive retry logic preserved; maybe_refresh_token called redundantly on retry-success but is idempotent. |
| client/py/synnax/framer/writer.py | _close drain loop and _exec updated to raising API; explicit continue in except blocks prevents fall-through to decode_exception; TimeoutError still re-raised for non-blocking write semantics. |
| client/py/synnax/framer/streamer.py | Sync and async streamer close/read loops updated to raising API correctly. |
| client/py/synnax/framer/iterator.py | close() and _exec() updated to raising API; drain-until-EOF loop correctly ignores data frames and propagates non-EOF errors. |

</details>

<sub>Reviews (2): Last reviewed commit: ["Raise on missing open-ack in receive\_ope..."](https://github.com/synnaxlabs/synnax/commit/c3a2451baed9d0aa6ee6449d7e0becfa3c9bd603) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33895691)</sub>

<!-- /greptile_comment -->