### PR TITLE
SY-4186: Improved Schematic Unit Tests

### DIFF
--- a/pluto/src/schematic/Diagram.spec.ts
+++ b/pluto/src/schematic/Diagram.spec.ts
@@ -8,6 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { schematic } from "@synnaxlabs/client";
+import { type record } from "@synnaxlabs/x";
 import { describe, expect, it } from "vitest";
 
 import { edgeChangesToActions, nodeChangesToActions } from "@/schematic/Diagram";
@@ -101,7 +102,7 @@ describe("edgeChangesToActions", () => {
   it("seeds the new edge's config with the pipe variant's default", () => {
     const edge = newEdge("e1");
     const [, setCfg] = edgeChangesToActions([{ type: "add", edge }]);
-    const expected = Edge.REGISTRY.pipe.defaultConfig();
+    const expected = Edge.REGISTRY.pipe.defaultConfig() as unknown as record.Unknown;
     expect(setCfg).toEqual(schematic.setConfig({ key: "e1", config: expected }));
   });
 
@@ -128,7 +129,7 @@ describe("edgeChangesToActions", () => {
       { type: "remove", key: "e2" },
       { type: "add", edge: e3 },
     ];
-    const pipeDefault = Edge.REGISTRY.pipe.defaultConfig();
+    const pipeDefault = Edge.REGISTRY.pipe.defaultConfig() as unknown as record.Unknown;
     expect(edgeChangesToActions(changes)).toEqual([
       schematic.addEdge({ edge: e1 }),
       schematic.setConfig({ key: "e1", config: pipeDefault }),

--- a/pluto/src/schematic/Diagram.spec.ts
+++ b/pluto/src/schematic/Diagram.spec.ts
@@ -1,0 +1,140 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { schematic } from "@synnaxlabs/client";
+import { describe, expect, it } from "vitest";
+
+import { edgeChangesToActions, nodeChangesToActions } from "@/schematic/Diagram";
+import { Edge } from "@/schematic/edge";
+import { type Diagram as Base } from "@/vis/diagram";
+
+describe("nodeChangesToActions", () => {
+  it("returns an empty array for empty input", () => {
+    expect(nodeChangesToActions([])).toEqual([]);
+  });
+
+  it("translates a position change to a setNodePosition action", () => {
+    const change: Base.NodeChange = {
+      type: "position",
+      key: "n1",
+      position: { x: 10, y: 20 },
+      dragging: true,
+    };
+    expect(nodeChangesToActions([change])).toEqual([
+      schematic.setNodePosition({ key: "n1", position: { x: 10, y: 20 } }),
+    ]);
+  });
+
+  it("translates a dimensions change to a setNodeMeasured action", () => {
+    const change: Base.NodeChange = {
+      type: "dimensions",
+      key: "n1",
+      dimensions: { width: 80, height: 40 },
+    };
+    expect(nodeChangesToActions([change])).toEqual([
+      schematic.setNodeMeasured({
+        key: "n1",
+        measured: { width: 80, height: 40 },
+      }),
+    ]);
+  });
+
+  it("translates a remove change to a removeNode action", () => {
+    const change: Base.NodeChange = { type: "remove", key: "n1" };
+    expect(nodeChangesToActions([change])).toEqual([
+      schematic.removeNode({ key: "n1" }),
+    ]);
+  });
+
+  it("silently drops select changes since selection lives outside the schematic", () => {
+    const changes: Base.NodeChange[] = [
+      { type: "select", key: "n1", selected: true },
+      { type: "select", key: "n2", selected: false },
+    ];
+    expect(nodeChangesToActions(changes)).toEqual([]);
+  });
+
+  it("preserves input order across a mixed batch of change types", () => {
+    const changes: Base.NodeChange[] = [
+      { type: "position", key: "n1", position: { x: 1, y: 2 }, dragging: false },
+      { type: "select", key: "n3", selected: true },
+      { type: "remove", key: "n2" },
+      { type: "dimensions", key: "n1", dimensions: { width: 10, height: 20 } },
+    ];
+    expect(nodeChangesToActions(changes)).toEqual([
+      schematic.setNodePosition({ key: "n1", position: { x: 1, y: 2 } }),
+      schematic.removeNode({ key: "n2" }),
+      schematic.setNodeMeasured({
+        key: "n1",
+        measured: { width: 10, height: 20 },
+      }),
+    ]);
+  });
+});
+
+describe("edgeChangesToActions", () => {
+  const newEdge = (key: string): schematic.Edge => ({
+    key,
+    source: { node: "n1", param: "out" },
+    target: { node: "n2", param: "in" },
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(edgeChangesToActions([])).toEqual([]);
+  });
+
+  it("translates an add change into addEdge followed by setConfig", () => {
+    const edge = newEdge("e1");
+    const out = edgeChangesToActions([{ type: "add", edge }]);
+    expect(out).toHaveLength(2);
+    expect(out[0]).toEqual(schematic.addEdge({ edge }));
+    expect(out[1].type).toBe("set_config");
+    expect(out[1].type === "set_config" && out[1].setConfig.key).toBe("e1");
+  });
+
+  it("seeds the new edge's config with the pipe variant's default", () => {
+    const edge = newEdge("e1");
+    const [, setCfg] = edgeChangesToActions([{ type: "add", edge }]);
+    const expected = Edge.REGISTRY.pipe.defaultConfig();
+    expect(setCfg).toEqual(schematic.setConfig({ key: "e1", config: expected }));
+  });
+
+  it("translates a remove change to a removeEdge action", () => {
+    expect(edgeChangesToActions([{ type: "remove", key: "e1" }])).toEqual([
+      schematic.removeEdge({ key: "e1" }),
+    ]);
+  });
+
+  it("silently drops select changes since selection lives outside the schematic", () => {
+    const changes: Base.EdgeChange[] = [
+      { type: "select", key: "e1", selected: true },
+      { type: "select", key: "e2", selected: false },
+    ];
+    expect(edgeChangesToActions(changes)).toEqual([]);
+  });
+
+  it("preserves input order and emits a separate pair for each add", () => {
+    const e1 = newEdge("e1");
+    const e3 = newEdge("e3");
+    const changes: Base.EdgeChange[] = [
+      { type: "add", edge: e1 },
+      { type: "select", key: "e2", selected: true },
+      { type: "remove", key: "e2" },
+      { type: "add", edge: e3 },
+    ];
+    const pipeDefault = Edge.REGISTRY.pipe.defaultConfig();
+    expect(edgeChangesToActions(changes)).toEqual([
+      schematic.addEdge({ edge: e1 }),
+      schematic.setConfig({ key: "e1", config: pipeDefault }),
+      schematic.removeEdge({ key: "e2" }),
+      schematic.addEdge({ edge: e3 }),
+      schematic.setConfig({ key: "e3", config: pipeDefault }),
+    ]);
+  });
+});

--- a/pluto/src/schematic/haul.spec.ts
+++ b/pluto/src/schematic/haul.spec.ts
@@ -1,0 +1,103 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { describe, expect, it } from "vitest";
+
+import { type Haul } from "@/haul";
+import {
+  canDropHaulItem,
+  createHaulItem,
+  filterHaulItems,
+  HAUL_TYPE,
+  type HaulItemData,
+  isHaulItem,
+} from "@/schematic/haul";
+
+const ITEM_DATA: HaulItemData = { key: "n1", variant: "tank" };
+
+const foreignItem = (key: string, type = "other"): Haul.Item => ({ key, type });
+
+describe("HAUL_TYPE", () => {
+  it("is the schematic element type tag", () => {
+    expect(HAUL_TYPE).toBe("schematic-element");
+  });
+});
+
+describe("createHaulItem", () => {
+  it("wraps AddNodeProps into a haul item keyed by the node key", () => {
+    expect(createHaulItem(ITEM_DATA)).toEqual({
+      type: HAUL_TYPE,
+      key: ITEM_DATA.key,
+      data: ITEM_DATA,
+    });
+  });
+
+  it("preserves optional position, specKey, and config on the data payload", () => {
+    const data: HaulItemData = {
+      key: "n2",
+      variant: "valve",
+      position: { x: 5, y: 7 },
+      specKey: "spec-1",
+      config: { variant: "valve" },
+    };
+    expect(createHaulItem(data).data).toEqual(data);
+  });
+});
+
+describe("isHaulItem", () => {
+  it("returns true for items created by createHaulItem", () => {
+    expect(isHaulItem(createHaulItem(ITEM_DATA))).toBe(true);
+  });
+
+  it("returns false for items of any other type", () => {
+    expect(isHaulItem(foreignItem("x"))).toBe(false);
+  });
+});
+
+describe("filterHaulItems", () => {
+  it("keeps only schematic items and preserves their order", () => {
+    const a = createHaulItem({ key: "a", variant: "tank" });
+    const b = foreignItem("b");
+    const c = createHaulItem({ key: "c", variant: "valve" });
+    expect(filterHaulItems([a, b, c])).toEqual([a, c]);
+  });
+
+  it("returns an empty array when no items match", () => {
+    expect(filterHaulItems([foreignItem("a"), foreignItem("b", "another")])).toEqual(
+      [],
+    );
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(filterHaulItems([])).toEqual([]);
+  });
+});
+
+describe("canDropHaulItem", () => {
+  const draggingState = (items: Haul.Item[]): Haul.DraggingState => ({
+    source: items[0] ?? { key: "", type: "" },
+    items,
+  });
+
+  it("accepts a drag containing at least one schematic item", () => {
+    expect(
+      canDropHaulItem(draggingState([foreignItem("a"), createHaulItem(ITEM_DATA)])),
+    ).toBe(true);
+  });
+
+  it("rejects a drag containing only foreign item types", () => {
+    expect(
+      canDropHaulItem(draggingState([foreignItem("a"), foreignItem("b", "another")])),
+    ).toBe(false);
+  });
+
+  it("rejects an empty drag", () => {
+    expect(canDropHaulItem(draggingState([]))).toBe(false);
+  });
+});

--- a/pluto/src/schematic/queries.spec.tsx
+++ b/pluto/src/schematic/queries.spec.tsx
@@ -14,9 +14,9 @@ import {
   type workspace,
 } from "@synnaxlabs/client";
 import { uuid } from "@synnaxlabs/x";
-import { act, render, renderHook, waitFor } from "@testing-library/react";
+import { act, render, renderHook, waitFor, within } from "@testing-library/react";
 import { type FC, type PropsWithChildren, type ReactElement } from "react";
-import { beforeAll, describe, expect, it } from "vitest";
+import { beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 import { Errors } from "@/errors";
 import { Flux } from "@/flux";
@@ -64,7 +64,7 @@ const loadSchematic = async (
       </Wrapper>,
     );
   });
-  await utils.findByTestId("loaded");
+  await within(utils.container).findByTestId("loaded");
 };
 
 describe("schematic queries", () => {
@@ -343,6 +343,214 @@ describe("schematic queries", () => {
           y: 200,
         }),
       );
+    });
+  });
+
+  describe("useDispatch — edge segment preprocess", () => {
+    const SEGMENTS: Schematic.Edge.Segmented.Segment[] = [
+      { direction: "x", length: 50 },
+      { direction: "y", length: 30 },
+      { direction: "x", length: 50 },
+    ];
+
+    interface EdgeCfg {
+      variant?: string;
+      color?: string;
+      segments?: Schematic.Edge.Segmented.Segment[];
+    }
+    const asEdgeCfg = (raw: unknown): EdgeCfg | undefined => raw as EdgeCfg | undefined;
+
+    let schem: schematic.Schematic;
+    let getEdgeCfg: () => EdgeCfg | undefined;
+    let getNode: (k: string) => schematic.Node | undefined;
+    let dispatch: (...actions: schematic.Action[]) => Promise<void>;
+    let undo: () => Promise<void>;
+
+    beforeEach(async () => {
+      schem = await createTestSchematic(ws.key);
+      await loadSchematic(Wrapper, schem.key);
+
+      const edge = renderHook(
+        () => Schematic.useSelectElementConfig({ key: schem.key, elKey: "e1" }),
+        { wrapper: Wrapper },
+      );
+      const all = renderHook(() => Schematic.useSelectAllNodes({ key: schem.key }), {
+        wrapper: Wrapper,
+      });
+      const disp = renderHook(() => Schematic.useDispatch(), {
+        wrapper: Wrapper,
+      });
+      const und = renderHook(() => Schematic.useUndo({ key: schem.key }), {
+        wrapper: Wrapper,
+      });
+
+      getEdgeCfg = () => asEdgeCfg(edge.result.current);
+      getNode = (k) => all.result.current.find((n) => n.key === k);
+      dispatch = async (...actions) =>
+        await act(async () => {
+          await disp.result.current.dispatchAsync({ key: schem.key, actions });
+        });
+      undo = async () =>
+        await act(async () => {
+          und.result.current.undo();
+        });
+    });
+
+    it("adjusts a connected edge's stored segments when its source node moves", async () => {
+      await dispatch(
+        schematic.setConfig({ key: "e1", config: { segments: SEGMENTS } }),
+      );
+      await waitFor(() => expect(getEdgeCfg()?.segments).toEqual(SEGMENTS));
+
+      await dispatch(
+        schematic.setNodePosition({ key: "n1", position: { x: 20, y: 0 } }),
+      );
+      await waitFor(() =>
+        expect(getEdgeCfg()?.segments).toEqual([
+          { direction: "x", length: 30 },
+          { direction: "y", length: 30 },
+          { direction: "x", length: 50 },
+        ]),
+      );
+    });
+
+    it("does not synthesize a setConfig when the edge has no stored segments", async () => {
+      expect(getEdgeCfg()).toBeUndefined();
+
+      await dispatch(
+        schematic.setNodePosition({ key: "n1", position: { x: 20, y: 0 } }),
+      );
+      await waitFor(() => expect(getNode("n1")?.position).toEqual({ x: 20, y: 0 }));
+      expect(getEdgeCfg()).toBeUndefined();
+    });
+
+    it("leaves edge segments alone when source and target move by equal deltas", async () => {
+      await dispatch(
+        schematic.setConfig({ key: "e1", config: { segments: SEGMENTS } }),
+      );
+      await waitFor(() => expect(getEdgeCfg()?.segments).toEqual(SEGMENTS));
+
+      // n1 at (0,0), n2 at (10,10). Shift both by (+20, +5).
+      await dispatch(
+        schematic.setNodePosition({ key: "n1", position: { x: 20, y: 5 } }),
+        schematic.setNodePosition({ key: "n2", position: { x: 30, y: 15 } }),
+      );
+      await waitFor(() => {
+        expect(getNode("n1")?.position).toEqual({ x: 20, y: 5 });
+        expect(getNode("n2")?.position).toEqual({ x: 30, y: 15 });
+      });
+      expect(getEdgeCfg()?.segments).toEqual(SEGMENTS);
+    });
+
+    it("preserves non-segment edge config fields when a connected node moves", async () => {
+      await dispatch(
+        schematic.setConfig({
+          key: "e1",
+          config: { variant: "pipe", color: "#ff00ff", segments: SEGMENTS },
+        }),
+      );
+      await waitFor(() =>
+        expect(getEdgeCfg()).toMatchObject({
+          variant: "pipe",
+          color: "#ff00ff",
+          segments: SEGMENTS,
+        }),
+      );
+
+      await dispatch(
+        schematic.setNodePosition({ key: "n1", position: { x: 20, y: 0 } }),
+      );
+      await waitFor(() => {
+        const cfg = getEdgeCfg();
+        expect(cfg?.variant).toBe("pipe");
+        expect(cfg?.color).toBe("#ff00ff");
+        expect(cfg?.segments?.[0]).toEqual({ direction: "x", length: 30 });
+      });
+    });
+
+    it("propagates dispatched actions to a second Flux store via sy_schematic_set", async () => {
+      const WrapperB = await createAsyncSynnaxWrapper({ client });
+      await loadSchematic(WrapperB, schem.key);
+
+      const { result: nodesB } = renderHook(
+        () => Schematic.useSelectAllNodes({ key: schem.key }),
+        { wrapper: WrapperB },
+      );
+
+      await dispatch(
+        schematic.setNodePosition({ key: "n1", position: { x: 50, y: 50 } }),
+      );
+
+      await waitFor(() => {
+        expect(getNode("n1")?.position).toEqual({ x: 50, y: 50 });
+        expect(nodesB.current.find((n) => n.key === "n1")?.position).toEqual({
+          x: 50,
+          y: 50,
+        });
+      });
+    });
+
+    it("dedups its own echo so undo fully reverts a dispatched action", async () => {
+      const WrapperB = await createAsyncSynnaxWrapper({ client });
+      await loadSchematic(WrapperB, schem.key);
+
+      const { result: nodesB } = renderHook(
+        () => Schematic.useSelectAllNodes({ key: schem.key }),
+        { wrapper: WrapperB },
+      );
+
+      await dispatch(
+        schematic.setNodePosition({ key: "n1", position: { x: 50, y: 50 } }),
+      );
+      await waitFor(() =>
+        expect(nodesB.current.find((n) => n.key === "n1")?.position).toEqual({
+          x: 50,
+          y: 50,
+        }),
+      );
+
+      await undo();
+      await waitFor(() => expect(getNode("n1")?.position).toEqual({ x: 0, y: 0 }));
+    });
+
+    it("coalesces successive moves into a single undo step", async () => {
+      const longSegments: Schematic.Edge.Segmented.Segment[] = [
+        { direction: "x", length: 200 },
+        { direction: "y", length: 30 },
+        { direction: "x", length: 50 },
+      ];
+
+      await dispatch(
+        schematic.setConfig({ key: "e1", config: { segments: longSegments } }),
+      );
+      await waitFor(() => expect(getEdgeCfg()?.segments).toEqual(longSegments));
+
+      await dispatch(
+        schematic.setNodePosition({ key: "n1", position: { x: 20, y: 0 } }),
+      );
+      await waitFor(() =>
+        expect(getEdgeCfg()?.segments?.[0]).toEqual({
+          direction: "x",
+          length: 180,
+        }),
+      );
+
+      await dispatch(
+        schematic.setNodePosition({ key: "n1", position: { x: 40, y: 0 } }),
+      );
+      await waitFor(() =>
+        expect(getEdgeCfg()?.segments?.[0]).toEqual({
+          direction: "x",
+          length: 160,
+        }),
+      );
+
+      await undo();
+
+      await waitFor(() => {
+        expect(getNode("n1")?.position).toEqual({ x: 0, y: 0 });
+        expect(getEdgeCfg()?.segments).toEqual(longSegments);
+      });
     });
   });
 });

--- a/pluto/src/schematic/queries.spec.tsx
+++ b/pluto/src/schematic/queries.spec.tsx
@@ -16,7 +16,7 @@ import {
 import { uuid } from "@synnaxlabs/x";
 import { act, render, renderHook, waitFor, within } from "@testing-library/react";
 import { type FC, type PropsWithChildren, type ReactElement } from "react";
-import { beforeAll, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeAll, beforeEach, describe, expect, it } from "vitest";
 
 import { Errors } from "@/errors";
 import { Flux } from "@/flux";
@@ -49,7 +49,7 @@ const createTestSchematic = async (wsKey: string): Promise<schematic.Schematic> 
 const loadSchematic = async (
   Wrapper: FC<PropsWithChildren>,
   key: string,
-): Promise<void> => {
+): Promise<ReturnType<typeof render>> => {
   const Bootstrap = (): ReactElement => {
     Schematic.useEnsureRetrieved({ key });
     return <div data-testid="loaded" />;
@@ -65,6 +65,7 @@ const loadSchematic = async (
     );
   });
   await within(utils.container).findByTestId("loaded");
+  return utils;
 };
 
 describe("schematic queries", () => {
@@ -365,10 +366,11 @@ describe("schematic queries", () => {
     let getNode: (k: string) => schematic.Node | undefined;
     let dispatch: (...actions: schematic.Action[]) => Promise<void>;
     let undo: () => Promise<void>;
+    let cleanup: () => void;
 
     beforeEach(async () => {
       schem = await createTestSchematic(ws.key);
-      await loadSchematic(Wrapper, schem.key);
+      const loadUtils = await loadSchematic(Wrapper, schem.key);
 
       const edge = renderHook(
         () => Schematic.useSelectElementConfig({ key: schem.key, elKey: "e1" }),
@@ -394,7 +396,16 @@ describe("schematic queries", () => {
         await act(async () => {
           und.result.current.undo();
         });
+      cleanup = () => {
+        edge.unmount();
+        all.unmount();
+        disp.unmount();
+        und.unmount();
+        loadUtils.unmount();
+      };
     });
+
+    afterEach(() => cleanup());
 
     it("adjusts a connected edge's stored segments when its source node moves", async () => {
       await dispatch(
@@ -528,21 +539,8 @@ describe("schematic queries", () => {
       await dispatch(
         schematic.setNodePosition({ key: "n1", position: { x: 20, y: 0 } }),
       );
-      await waitFor(() =>
-        expect(getEdgeCfg()?.segments?.[0]).toEqual({
-          direction: "x",
-          length: 180,
-        }),
-      );
-
       await dispatch(
         schematic.setNodePosition({ key: "n1", position: { x: 40, y: 0 } }),
-      );
-      await waitFor(() =>
-        expect(getEdgeCfg()?.segments?.[0]).toEqual({
-          direction: "x",
-          length: 160,
-        }),
       );
 
       await undo();


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4186](https://linear.app/synnax/issue/SY-4186)

## Description

Adds regression coverage for the schematic seams that shipped with the SY-3833 refactor series but did not have dedicated unit tests. Three files, 47 tests total (24 in the existing queries spec, 12 in a new Diagram spec, 11 in a new haul spec).

The highest-leverage additions:

- **Edge-segment preprocess.** Four tests around `augmentWithEdgeSegments`, including a direct guard for the "color clobber" regression that motivated the recent own-echo dedup fix. Coverage: single-node drag updates connected segments, no-op when the edge has no stored segments, equal-delta multi-node drag is a no-op, and non-segment edge config fields survive a synthesized `setConfig`.

- **Drag-shaped undo coalescing.** Verifies that a `setNodePosition` + augment-synthesized `setConfig` batch produces a single `"move"` undo entry, so one `undo()` reverts the whole gesture rather than half of it.

- **Broadcast convergence and own-echo dedup.** Two Flux stores share one Synnax client. The first asserts a dispatch from store A converges in store B via `sy_schematic_set`. The second asserts that the originating store's undo stack survives its own echo by undoing right after a round-trip and verifying full revert.

- **Node and edge change translators.** Pure-function tests for `nodeChangesToActions` and `edgeChangesToActions`, including the load-bearing `addEdge`-before-`setConfig` ordering on `"add"` and the pipe-default config contract.

- **Haul helpers.** Coverage for `HAUL_TYPE`, `createHaulItem`, `isHaulItem`, `filterHaulItems`, and `canDropHaulItem`.

Renderer tests (`NodeRenderer`, `EdgeRenderer`) are intentionally not in this PR. They need either Aether test infrastructure that doesn't exist yet or a small refactor to lift the renderers as named exports. That is a separate concern with its own scope.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds 47 unit tests across three files to improve schematic regression coverage: a new `Diagram.spec.ts` for pure-function change translators, a new `haul.spec.ts` for drag-and-drop helpers, and additions to `queries.spec.tsx` covering edge-segment preprocessing, undo coalescing, broadcast convergence, and own-echo dedup.

- **`Diagram.spec.ts`** tests `nodeChangesToActions` and `edgeChangesToActions` as pure functions, including the `addEdge`-before-`setConfig` ordering and pipe-default config seeding.
- **`haul.spec.ts`** provides full coverage of `HAUL_TYPE`, `createHaulItem`, `isHaulItem`, `filterHaulItems`, and `canDropHaulItem`.
- **`queries.spec.tsx`** adds a `beforeEach`/`afterEach` lifecycle for the new edge-segment and undo tests (a structural improvement over the existing hook-accumulation pattern), and two broadcast/echo tests that each spin up a second `Flux.Client` backed by the same Synnax test client.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a pure test addition with no changes to production code paths.

All three files add or extend test coverage only. The pure-function tests in Diagram.spec.ts and haul.spec.ts are self-contained and correct. The queries.spec.tsx additions introduce a proper beforeEach/afterEach lifecycle that addresses the hook-accumulation pattern from the existing tests. The only notable gap is that two broadcast tests create a second Flux.Client and related React hooks inline without tracking them for cleanup, leaving orphaned resources after those tests finish — this is a test hygiene issue that does not affect correctness of test assertions or production behavior.

No files require special attention for merge safety.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pluto/src/schematic/Diagram.spec.ts | New pure-function tests for nodeChangesToActions and edgeChangesToActions; one assertion uses a TypeScript narrowing AND-expression idiom that is functionally correct but slightly opaque. |
| pluto/src/schematic/haul.spec.ts | New tests for all haul helpers; straightforward and complete, no issues found. |
| pluto/src/schematic/queries.spec.tsx | Adds edge-segment, undo-coalescing, broadcast, and echo-dedup tests; the two broadcast tests create a second WrapperB Flux.Client and hooks inside the test body without persisting or cleaning up those resources in afterEach. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[queries.spec.tsx] --> B["beforeEach: createTestSchematic\nloadSchematic(Wrapper)\nrenderHook x4"]
    B --> C["afterEach: cleanup()\nunmounts all 5 handles"]
    A --> D["broadcast tests (inline setup)"]
    D --> E["createAsyncSynnaxWrapper → WrapperB\nloadSchematic(WrapperB) — utils discarded\nrenderHook nodesB — not unmounted"]
    E --> F["⚠ WrapperB resources orphaned\nafter test body completes"]
    G[Diagram.spec.ts] --> H["nodeChangesToActions\npure-function tests"]
    G --> I["edgeChangesToActions\naddEdge → setConfig ordering\npipe-default config"]
    J[haul.spec.ts] --> K["HAUL_TYPE / createHaulItem\nisHaulItem / filterHaulItems\ncanDropHaulItem"]
```

<sub>Reviews (3): Last reviewed commit: ["Tighten queries.spec.tsx coalesce test +..."](https://github.com/synnaxlabs/synnax/commit/ce6d5da22da1818db54e3eefaf2bd3dd7b4da922) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33983916)</sub>

<!-- /greptile_comment -->