### PR TITLE
SY-4066: Fix Unused zod Import in Oracle TS Generator

### DIFF
--- a/oracle/plugin/ts/types/types.go
+++ b/oracle/plugin/ts/types/types.go
@@ -703,7 +703,7 @@ func (p *Plugin) processStruct(entry resolution.Type, table *resolution.Table, d
 					if isFieldUnchanged(parentField, field) {
 						continue
 					} else if isOnlyOptionalityChange(parentField, field) {
-						sd.PartialFields = append(sd.PartialFields, p.processField(field, entry, table, data, sd.UseInput, sd.ConcreteTypes))
+						sd.PartialFields = append(sd.PartialFields, fieldData{TSName: camelCase(field.Name)})
 					} else {
 						sd.OmittedFields = append(sd.OmittedFields, camelCase(field.Name))
 						sd.ExtendFields = append(sd.ExtendFields, p.processField(field, entry, table, data, sd.UseInput, sd.ConcreteTypes))

--- a/oracle/plugin/ts/types/types_test.go
+++ b/oracle/plugin/ts/types/types_test.go
@@ -1381,6 +1381,43 @@ var _ = Describe("TS Types Plugin", func() {
 			Expect(content).NotTo(ContainSubstring(`name: z.string().optional()`))
 		})
 
+		It("Should not emit unused zod import when array/map/record fields only flip optionality", func(ctx SpecContext) {
+			source := `
+				@ts output "out"
+
+				Item struct {
+					id string
+				}
+
+				Parent struct {
+					items Item[]
+					tags map<string, Item>
+					data record
+				}
+
+				Child struct extends Parent {
+					items Item[]?
+					tags map<string, Item>?
+					data record?
+				}
+			`
+			table, diag := analyzer.AnalyzeSource(ctx, source, "test", loader)
+			Expect(diag.Ok()).To(BeTrue())
+
+			resp, err := typesPlugin.Generate(&plugin.Request{Resolutions: table})
+			Expect(err).To(BeNil())
+
+			content := string(resp.Files[0].Content)
+			Expect(content).To(ContainSubstring(
+				`.partial({ items: true, tags: true, data: true })`,
+			))
+			// The partial form does not reference zod.* — the import would be
+			// unused and trip the no-unused-vars lint in downstream packages.
+			Expect(content).NotTo(ContainSubstring(`zod }`))
+			Expect(content).NotTo(ContainSubstring(`zod,`))
+			Expect(content).NotTo(ContainSubstring(`, zod `))
+		})
+
 		It("Should handle extension without new fields (only omissions)", func(ctx SpecContext) {
 			source := `
 				@ts output "out"


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4066](https://linear.app/synnax/issue/SY-4066)

## Description

When a `struct extends` form in an `.oracle` schema overrides an
array/map/record field with only an optionality flip (e.g.
`rows Row[]?` over a parent's `rows Row[]`), the TS plugin emits a
`.partial({ rows: true })` call. The template only consumes the field's
`TSName` for that path.

However, `processField` runs anyway and has import side effects: for
optional array/map/record types it adds a `zod` import from
`@synnaxlabs/x` (`oracle/plugin/ts/types/types.go:1144, 1158, 1168`). The
import never lands in the emitted code, so any downstream TS workspace
that depends on the generated file fails eslint's
`@typescript-eslint/no-unused-vars` rule on its `types.gen.ts`.

The fix constructs `fieldData{TSName: camelCase(field.Name)}` directly
for partial entries, bypassing `processField` and its import side
effects. The template never references the other `fieldData` attributes
for partial fields, so this is exactly the data shape needed.

This surfaced while applying review feedback on
[#2354](https://github.com/synnaxlabs/synnax/pull/2354) (SY-4066) where
the `New` form of `Table` was extended to mark `rows`, `columns`, and
`cells` optional. The same generator path will also benefit the line
plot 1/3 PR ([#2356](https://github.com/synnaxlabs/synnax/pull/2356)).

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a spurious `zod` import emitted by the TypeScript code generator when a `struct extends` form only flips optionality on an array, map, or `record` field. The root cause was that `processField` was called for partial fields despite the template only ever reading `TSName` from the result; the fix constructs a minimal `fieldData{TSName: camelCase(field.Name)}` directly, skipping `processField` and its import side-effects.

- **`types.go`**: One-line change replaces `p.processField(...)` with `fieldData{TSName: ...}` in the `isOnlyOptionalityChange` branch, correctly reflecting that the template only accesses `TSName` for partial entries.
- **`types_test.go`**: New test asserts that array, map, and record fields flipping optionality produce the correct `.partial({...})` call without any `zod` import in the output.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single-line substitution in a well-understood code path, fully covered by a new focused test.

The fix is minimal and provably correct: the template only accesses TSName from fieldData for partial entries, so constructing fieldData{TSName: camelCase(field.Name)} supplies exactly what is needed. The new test directly asserts the absence of the spurious zod import for all three affected type categories (array, map, record). No existing behavior is altered for other code paths.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| oracle/plugin/ts/types/types.go | Single-line fix: replaces processField(...) with fieldData{TSName: camelCase(field.Name)} for partial-only fields, eliminating spurious zod import side-effects. |
| oracle/plugin/ts/types/types_test.go | New test covers array, map, and record fields that only flip optionality, asserting the .partial() call is emitted and no zod import is present. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[processStruct: field exists in parent] --> B{isFieldUnchanged?}
    B -- yes --> C[skip field]
    B -- no --> D{isOnlyOptionalityChange?}
    D -- yes BEFORE --> E_OLD[processField adds zod import side-effect]
    D -- yes AFTER --> E_NEW[fieldData with TSName only, no imports]
    D -- no --> F[processField + OmittedFields + ExtendFields]
    E_NEW --> G[PartialFields append]
    E_OLD --> G
    G --> H[Template emits .partial TSName true, only reads TSName]
```

<sub>Reviews (1): Last reviewed commit: ["SY-4066: Fix Unused zod Import in Oracle..."](https://github.com/synnaxlabs/synnax/commit/aaea9e92d885bd2870f654586cf0507ad3ea5014) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=33986642)</sub>

<!-- /greptile_comment -->