### PR TITLE
SY-4236: Add IsValid Method to Oracle-Generated Go Enums

### DIFF
--- a/core/pkg/distribution/channel/types.gen.go
+++ b/core/pkg/distribution/channel/types.gen.go
@@ -44,6 +44,16 @@ const (
 	OperationTypeDerivative OperationType = "derivative"
 )
 
+// IsValid reports whether o is one of the defined OperationType values.
+func (o OperationType) IsValid() bool {
+	switch o {
+	case OperationTypeMin, OperationTypeMax, OperationTypeAvg, OperationTypeNone, OperationTypeDerivative:
+		return true
+	default:
+		return false
+	}
+}
+
 // Operation defines an aggregation operation applied to channel data. Operations
 // calculate min, max, or average values over a time duration or triggered by a reset
 // channel.

--- a/core/pkg/distribution/ontology/types.gen.go
+++ b/core/pkg/distribution/ontology/types.gen.go
@@ -40,6 +40,16 @@ const (
 	ResourceTypeWorkspace       ResourceType = "workspace"
 )
 
+// IsValid reports whether r is one of the defined ResourceType values.
+func (r ResourceType) IsValid() bool {
+	switch r {
+	case ResourceTypeArc, ResourceTypeBuiltin, ResourceTypeChannel, ResourceTypeDevice, ResourceTypeFramer, ResourceTypeGroup, ResourceTypeLabel, ResourceTypeLineplot, ResourceTypeLog, ResourceTypeNode, ResourceTypePolicy, ResourceTypeRack, ResourceTypeRange, ResourceTypeRangeAlias, ResourceTypeRole, ResourceTypeSchematic, ResourceTypeSchematicSymbol, ResourceTypeStatus, ResourceTypeTable, ResourceTypeTask, ResourceTypeUser, ResourceTypeView, ResourceTypeWorkspace:
+		return true
+	default:
+		return false
+	}
+}
+
 // ID ID is a unique identifier for a Resource. An example:
 //
 // userID := ID{ Key: "748d31e2-5732-4cb5-8bc9-64d4ad51efe8", Type: "user", }

--- a/core/pkg/service/access/types.gen.go
+++ b/core/pkg/service/access/types.gen.go
@@ -21,3 +21,13 @@ const (
 	ActionRetrieve Action = "retrieve"
 	ActionUpdate   Action = "update"
 )
+
+// IsValid reports whether a is one of the defined Action values.
+func (a Action) IsValid() bool {
+	switch a {
+	case ActionCreate, ActionDelete, ActionRetrieve, ActionUpdate:
+		return true
+	default:
+		return false
+	}
+}

--- a/core/pkg/service/arc/types.gen.go
+++ b/core/pkg/service/arc/types.gen.go
@@ -33,6 +33,16 @@ const (
 	ModeGraph Mode = "graph"
 )
 
+// IsValid reports whether m is one of the defined Mode values.
+func (m Mode) IsValid() bool {
+	switch m {
+	case ModeText, ModeGraph:
+		return true
+	default:
+		return false
+	}
+}
+
 // StatusDetails contains Arc-specific status details for execution state.
 type StatusDetails struct {
 	// Running indicates whether the Arc module is currently executing.

--- a/oracle/install.sh
+++ b/oracle/install.sh
@@ -263,7 +263,12 @@ if $INSTALL_CLI; then
     mkdir -p "$INSTALL_DIR"
 
     BUILD_TIME=$(date -u '+%Y-%m-%d %H:%M:%S UTC')
+    # -buildvcs=false: VCS stamping fails when Oracle is built from a Git worktree
+    # (where .git is a file, not a directory) because Go's repo-root detection walks
+    # past it and errors. BuildTime is injected via ldflags above, so the embedded Git
+    # revision is not needed.
     run "Compiling..." go build \
+        -buildvcs=false \
         -ldflags "-X 'github.com/synnaxlabs/oracle/cmd.BuildTime=$BUILD_TIME'" \
         -o "$INSTALL_DIR/oracle" .
 

--- a/oracle/plugin/go/types/types.go
+++ b/oracle/plugin/go/types/types.go
@@ -495,6 +495,10 @@ type enumData struct {
 	StartsAtOne bool
 }
 
+// Receiver returns the single-letter, lowercased method receiver name for the enum type
+// (e.g. "n" for Notation), falling back to "e" for an empty name.
+func (e enumData) Receiver() string { return strings.ToLower(e.Name[:1]) }
+
 type enumValueData struct {
 	Name     string
 	Value    string
@@ -574,6 +578,18 @@ const (
 	{{$enum.Name}}{{.Name}} {{$enum.Name}} = "{{.Value}}"
 {{- end}}
 )
+{{- if $enum.Values}}
+
+// IsValid reports whether {{$enum.Receiver}} is one of the defined {{$enum.Name}} values.
+func ({{$enum.Receiver}} {{$enum.Name}}) IsValid() bool {
+	switch {{$enum.Receiver}} {
+	case {{range $i, $v := $enum.Values}}{{if $i}}, {{end}}{{$enum.Name}}{{$v.Name}}{{end}}:
+		return true
+	default:
+		return false
+	}
+}
+{{- end}}
 {{- end}}
 {{- end}}
 {{range .Structs}}

--- a/oracle/plugin/go/types/types.go
+++ b/oracle/plugin/go/types/types.go
@@ -496,7 +496,7 @@ type enumData struct {
 }
 
 // Receiver returns the single-letter, lowercased method receiver name for the enum type
-// (e.g. "n" for Notation), falling back to "e" for an empty name.
+// (e.g. "n" for Notation).
 func (e enumData) Receiver() string { return strings.ToLower(e.Name[:1]) }
 
 type enumValueData struct {

--- a/oracle/plugin/go/types/types_test.go
+++ b/oracle/plugin/go/types/types_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/synnaxlabs/oracle/plugin"
 	"github.com/synnaxlabs/oracle/plugin/go/types"
 	. "github.com/synnaxlabs/oracle/testutil"
+	. "github.com/synnaxlabs/x/testutil"
 )
 
 func TestGoTypes(t *testing.T) {
@@ -504,6 +505,53 @@ var _ = Describe("Go Types Plugin", func() {
 				content := string(resp.Files[0].Content)
 				Expect(content).To(ContainSubstring(`// Direction indicates a compass direction.`))
 				Expect(content).To(ContainSubstring(`type Direction string`))
+			})
+
+			It("Should generate an IsValid method for string enums", func(ctx SpecContext) {
+				source := `
+					@go output "core/status"
+
+					Variant enum {
+						success = "success"
+						warning = "warning"
+						error = "error"
+					}
+				`
+				table, diag := analyzer.AnalyzeSource(ctx, source, "status", loader)
+				Expect(diag.Ok()).To(BeTrue())
+
+				resp := MustSucceed(
+					goPlugin.Generate(&plugin.Request{Resolutions: table}),
+				)
+
+				content := string(resp.Files[0].Content)
+				Expect(content).To(ContainSubstring(`// IsValid reports whether v is one of the defined Variant values.`))
+				Expect(content).To(ContainSubstring(`func (v Variant) IsValid() bool {`))
+				Expect(content).To(ContainSubstring(`case VariantSuccess, VariantWarning, VariantError:`))
+				Expect(content).To(ContainSubstring(`return true`))
+				Expect(content).To(ContainSubstring(`return false`))
+			})
+
+			It("Should not generate an IsValid method for int enums", func(ctx SpecContext) {
+				source := `
+					@go output "core/priority"
+
+					Priority enum {
+						low = 0
+						medium = 1
+						high = 2
+					}
+				`
+				table, diag := analyzer.AnalyzeSource(ctx, source, "priority", loader)
+				Expect(diag.Ok()).To(BeTrue())
+
+				resp := MustSucceed(
+					goPlugin.Generate(&plugin.Request{Resolutions: table}),
+				)
+
+				content := string(resp.Files[0].Content)
+				Expect(content).To(ContainSubstring(`type Priority uint8`))
+				Expect(content).NotTo(ContainSubstring(`func (p Priority) IsValid()`))
 			})
 
 		})

--- a/x/go/notation/types.gen.go
+++ b/x/go/notation/types.gen.go
@@ -19,3 +19,13 @@ const (
 	NotationScientific  Notation = "scientific"
 	NotationEngineering Notation = "engineering"
 )
+
+// IsValid reports whether n is one of the defined Notation values.
+func (n Notation) IsValid() bool {
+	switch n {
+	case NotationStandard, NotationScientific, NotationEngineering:
+		return true
+	default:
+		return false
+	}
+}

--- a/x/go/spatial/types.gen.go
+++ b/x/go/spatial/types.gen.go
@@ -19,6 +19,16 @@ const (
 	XLocationRight XLocation = "right"
 )
 
+// IsValid reports whether x is one of the defined XLocation values.
+func (x XLocation) IsValid() bool {
+	switch x {
+	case XLocationLeft, XLocationRight:
+		return true
+	default:
+		return false
+	}
+}
+
 // YLocation is a vertical-axis location at the top or bottom edge.
 type YLocation string
 
@@ -26,6 +36,16 @@ const (
 	YLocationTop    YLocation = "top"
 	YLocationBottom YLocation = "bottom"
 )
+
+// IsValid reports whether y is one of the defined YLocation values.
+func (y YLocation) IsValid() bool {
+	switch y {
+	case YLocationTop, YLocationBottom:
+		return true
+	default:
+		return false
+	}
+}
 
 // StickyUnit is the measurement unit for a sticky coordinate, either pixels or a
 // decimal fraction of the container.
@@ -35,6 +55,16 @@ const (
 	StickyUnitPx      StickyUnit = "px"
 	StickyUnitDecimal StickyUnit = "decimal"
 )
+
+// IsValid reports whether s is one of the defined StickyUnit values.
+func (s StickyUnit) IsValid() bool {
+	switch s {
+	case StickyUnitPx, StickyUnitDecimal:
+		return true
+	default:
+		return false
+	}
+}
 
 // OuterLocation is a position indicator for elements anchored to the outer edge of a
 // container. Used for orientation and positioning of UI elements.
@@ -47,6 +77,16 @@ const (
 	OuterLocationLeft   OuterLocation = "left"
 )
 
+// IsValid reports whether o is one of the defined OuterLocation values.
+func (o OuterLocation) IsValid() bool {
+	switch o {
+	case OuterLocationTop, OuterLocationRight, OuterLocationBottom, OuterLocationLeft:
+		return true
+	default:
+		return false
+	}
+}
+
 // Direction is a 2D axis direction.
 type Direction string
 
@@ -54,6 +94,16 @@ const (
 	DirectionX Direction = "x"
 	DirectionY Direction = "y"
 )
+
+// IsValid reports whether d is one of the defined Direction values.
+func (d Direction) IsValid() bool {
+	switch d {
+	case DirectionX, DirectionY:
+		return true
+	default:
+		return false
+	}
+}
 
 // AngularDirection is a rotational direction in 2D space.
 type AngularDirection string
@@ -63,12 +113,32 @@ const (
 	AngularDirectionCounterclockwise AngularDirection = "counterclockwise"
 )
 
+// IsValid reports whether a is one of the defined AngularDirection values.
+func (a AngularDirection) IsValid() bool {
+	switch a {
+	case AngularDirectionClockwise, AngularDirectionCounterclockwise:
+		return true
+	default:
+		return false
+	}
+}
+
 // CenterLocation is a location at the center of a container.
 type CenterLocation string
 
 const (
 	CenterLocationCenter CenterLocation = "center"
 )
+
+// IsValid reports whether c is one of the defined CenterLocation values.
+func (c CenterLocation) IsValid() bool {
+	switch c {
+	case CenterLocationCenter:
+		return true
+	default:
+		return false
+	}
+}
 
 // Location is a position indicator covering the four outer edges of a container and its
 // center.
@@ -82,6 +152,16 @@ const (
 	LocationCenter Location = "center"
 )
 
+// IsValid reports whether l is one of the defined Location values.
+func (l Location) IsValid() bool {
+	switch l {
+	case LocationTop, LocationRight, LocationBottom, LocationLeft, LocationCenter:
+		return true
+	default:
+		return false
+	}
+}
+
 // Alignment is a positioning indicator for aligning content along an axis within a
 // container.
 type Alignment string
@@ -92,6 +172,16 @@ const (
 	AlignmentEnd    Alignment = "end"
 )
 
+// IsValid reports whether a is one of the defined Alignment values.
+func (a Alignment) IsValid() bool {
+	switch a {
+	case AlignmentStart, AlignmentCenter, AlignmentEnd:
+		return true
+	default:
+		return false
+	}
+}
+
 // Order is a positional ordering indicator for elements in a sequence.
 type Order string
 
@@ -99,6 +189,16 @@ const (
 	OrderFirst Order = "first"
 	OrderLast  Order = "last"
 )
+
+// IsValid reports whether o is one of the defined Order values.
+func (o Order) IsValid() bool {
+	switch o {
+	case OrderFirst, OrderLast:
+		return true
+	default:
+		return false
+	}
+}
 
 // Dimension is the name of a 2D size axis.
 type Dimension string
@@ -108,6 +208,16 @@ const (
 	DimensionHeight Dimension = "height"
 )
 
+// IsValid reports whether d is one of the defined Dimension values.
+func (d Dimension) IsValid() bool {
+	switch d {
+	case DimensionWidth, DimensionHeight:
+		return true
+	default:
+		return false
+	}
+}
+
 // SignedDimension is the name of a 2D signed size axis.
 type SignedDimension string
 
@@ -115,6 +225,16 @@ const (
 	SignedDimensionSignedWidth  SignedDimension = "signedWidth"
 	SignedDimensionSignedHeight SignedDimension = "signedHeight"
 )
+
+// IsValid reports whether s is one of the defined SignedDimension values.
+func (s SignedDimension) IsValid() bool {
+	switch s {
+	case SignedDimensionSignedWidth, SignedDimensionSignedHeight:
+		return true
+	default:
+		return false
+	}
+}
 
 // XY is a 2D coordinate point with x and y values. Used for positioning elements in
 // two-dimensional space.

--- a/x/go/status/types.gen.go
+++ b/x/go/status/types.gen.go
@@ -28,6 +28,16 @@ const (
 	VariantDisabled Variant = "disabled"
 )
 
+// IsValid reports whether v is one of the defined Variant values.
+func (v Variant) IsValid() bool {
+	switch v {
+	case VariantSuccess, VariantInfo, VariantWarning, VariantError, VariantLoading, VariantDisabled:
+		return true
+	default:
+		return false
+	}
+}
+
 // Status is a standardized message used to communicate state across the Synnax
 // platform. Statuses support different severity variants and can carry
 // component-specific details.

--- a/x/go/telem/types.gen.go
+++ b/x/go/telem/types.gen.go
@@ -52,6 +52,16 @@ const (
 	TimestampFormatDateTime    TimestampFormat = "dateTime"
 )
 
+// IsValid reports whether t is one of the defined TimestampFormat values.
+func (t TimestampFormat) IsValid() bool {
+	switch t {
+	case TimestampFormatISO, TimestampFormatISODate, TimestampFormatTime, TimestampFormatPreciseTime, TimestampFormatDate, TimestampFormatPreciseDate, TimestampFormatDateTime:
+		return true
+	default:
+		return false
+	}
+}
+
 // TimeZone is the time zone used when rendering timestamps.
 type TimeZone string
 
@@ -59,6 +69,16 @@ const (
 	TimeZoneLocal TimeZone = "local"
 	TimeZoneUTC   TimeZone = "UTC"
 )
+
+// IsValid reports whether t is one of the defined TimeZone values.
+func (t TimeZone) IsValid() bool {
+	switch t {
+	case TimeZoneLocal, TimeZoneUTC:
+		return true
+	default:
+		return false
+	}
+}
 
 // TimeRange is a time interval defined by a start and end timestamp. The range is
 // start-inclusive and end-exclusive, following standard interval conventions for

--- a/x/go/text/types.gen.go
+++ b/x/go/text/types.gen.go
@@ -25,3 +25,13 @@ const (
 	LevelP     Level = "p"
 	LevelSmall Level = "small"
 )
+
+// IsValid reports whether l is one of the defined Level values.
+func (l Level) IsValid() bool {
+	switch l {
+	case LevelH1, LevelH2, LevelH3, LevelH4, LevelH5, LevelP, LevelSmall:
+		return true
+	default:
+		return false
+	}
+}


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4236](https://linear.app/synnax/issue/SY-4236)

## Description

Oracle now generates an `IsValid()` method on each **string** enum it emits for Go. The method returns `true` when the receiver equals one of the defined enum constants and `false` otherwise, giving callers a first-class way to validate an enum value (e.g. one decoded off the wire or supplied by a client) instead of writing ad-hoc membership checks.

```go
// IsValid reports whether n is one of the defined Notation values.
func (n Notation) IsValid() bool {
	switch n {
	case NotationStandard, NotationScientific, NotationEngineering:
		return true
	default:
		return false
	}
}
```

After regenerating (`oracle sync`), the method lands on `notation.Notation`, `telem.TimeZone`, `telem.TimestampFormat`, `status.Variant`, `text.Level`, `access.Action`, `ontology.ResourceType`, `channel.OperationType`, `arc.Mode`, and the `spatial.*` enums.

### Why string enums only

`IsValid` is generated for string enums and **deliberately not** for int enums:

- **Bitflags**: `arc/go/types.ChanDirection` is a bitfield (`d & ChanDirectionRead`), so a combined `Read|Write` (= 3) is a legitimate value that is *not* one of the named constants. A switch over defined constants would wrongly report it invalid.
- **Zero/sentinel values**: several int enums use a zero `Invalid`/`None` sentinel, and some already carry custom methods (`IsSet`, `IsRead`) and `validate.NewInclusiveBoundsChecker`-based validation.

The generator can't distinguish these cases, so emitting `IsValid` for int enums would produce incorrect semantics. String enums are closed, unordered sets where membership *is* validity.

### Changes

- `oracle/plugin/go/types/types.go`: added a `Receiver()` helper on `enumData` and extended the string-enum template branch to emit `IsValid()`.
- `oracle/plugin/go/types/types_test.go`: specs asserting `IsValid` is generated for string enums and absent for int enums.
- Regenerated `.gen.go` files across `x/go/*` and `core/pkg/**` via `oracle sync`.
- `oracle/install.sh`: build Oracle with `-buildvcs=false` so it compiles from a Git worktree (where `.git` is a file, not a directory).

No consumers are wired up to `IsValid` yet — that's intentional. The two genuine Go-side gaps (`channel.OperationType` is decoded from the wire without validation; `arc.Mode` silently falls through to the graph branch on an unknown value) are behavior changes and are left as follow-ups.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR teaches the Oracle Go code generator to emit an `IsValid()` method on every string-typed enum it generates, then re-runs `oracle sync` to propagate the new method across all affected packages. String enums are chosen deliberately because they form closed, unordered sets where membership equals validity, unlike int enums (bitflags, sentinels).

- **Generator (`oracle/plugin/go/types/types.go`)**: A `Receiver()` helper is added to `enumData` and the string-enum template branch is extended with an `IsValid()` switch block, gated on `{{- if $enum.Values}}` to handle the degenerate empty-enum edge case.
- **Tests (`oracle/plugin/go/types/types_test.go`)**: Two new specs verify that `IsValid` is generated for string enums and absent for int enums, using the `MustSucceed` helper imported from `x/testutil`.
- **Regenerated files**: Ten `.gen.go` files across `x/go/*` and `core/pkg/**` receive the new method; `oracle/install.sh` gains `-buildvcs=false` so Oracle compiles correctly from a Git worktree.

<h3>Confidence Score: 5/5</h3>

This PR is additive only — new methods on existing types, no changed logic in consumers — and is safe to merge.

Every .gen.go change is mechanical output from the updated template; the generator logic is well-tested by the new specs; the install.sh worktree fix is isolated and well-commented. No consumer code is modified, so regressions in existing behaviour are not possible.

No files require special attention. The Receiver() empty-name edge case in oracle/plugin/go/types/types.go is already tracked in the review thread.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| oracle/plugin/go/types/types.go | Adds Receiver() helper on enumData and extends the string-enum template to emit IsValid(); the Receiver() call is guarded by {{- if $enum.Values}} so empty-values enums skip it, but an empty Name would still panic (already flagged in review thread). |
| oracle/plugin/go/types/types_test.go | Adds two specs: one asserting IsValid is generated for string enums (checking receiver letter, method signature, and case list), and one asserting it is absent for int enums. Coverage is complete for the new generator branch. |
| oracle/install.sh | Adds -buildvcs=false to the go build invocation to support builds from Git worktrees; well-commented trade-off (loses embedded git revision, retains BuildTime via ldflags). |
| x/go/spatial/types.gen.go | Regenerated file; IsValid added to all spatial string enums. CenterLocation with its single-value switch is valid Go. |
| core/pkg/distribution/ontology/types.gen.go | Regenerated; IsValid added to ResourceType correctly enumerating all 23 constants on one case line. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Oracle template engine] --> B{IsIntEnum?}
    B -->|Yes| C[Emit uint8 type + iota const block, No IsValid]
    B -->|No - string enum| D{Has Values?}
    D -->|No| E[Emit string type + empty const block, No IsValid]
    D -->|Yes| F[Emit string type + const block + IsValid switch]
    F --> G[enumData.Receiver: e.Name at 0 → first letter lowercased]
    F --> H[switch: case Enum1 Enum2 ... return true, default: return false]
```

<sub>Reviews (2): Last reviewed commit: ["Update docstring"](https://github.com/synnaxlabs/synnax/commit/4c0ead08063728609cab12324666a10d0f266a02) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34023665)</sub>

<!-- /greptile_comment -->