### PR TITLE
SY-4065: Emit String Literal Default for String-Valued Enum Variants

### DIFF
--- a/oracle/plugin/ts/types/types.go
+++ b/oracle/plugin/ts/types/types.go
@@ -1743,6 +1743,13 @@ func (p *Plugin) applyValidation(zodType string, domain resolution.Domain, typeR
 }
 
 func (p *Plugin) enumVariantToTS(ev validation.EnumVariant, data *templateData) string {
+	// String-valued enums are emitted as `z.enum([...])` plus a type alias and
+	// have no runtime object to dot into. Emit the raw string literal instead;
+	// only numeric enums get the `Type.variant` form, since those emit as TS
+	// runtime enums.
+	if form, ok := ev.Type.Form.(resolution.EnumForm); ok && !form.IsIntEnum {
+		return fmt.Sprintf("%q", ev.Variant.StringValue())
+	}
 	enumName := domain.GetName(ev.Type, "ts")
 	variantRef := fmt.Sprintf("%s.%s", enumName, ev.Variant.Name)
 	if ev.Type.Namespace != data.Namespace {

--- a/oracle/plugin/ts/types/types_test.go
+++ b/oracle/plugin/ts/types/types_test.go
@@ -2332,6 +2332,47 @@ var _ = Describe("TS Types Plugin", func() {
 				ExpectContent(resp, "types.gen.ts").
 					ToContain(`concurrency: control.concurrencyZ.default(control.Concurrency.exclusive)`)
 			})
+
+			It("Should emit a string literal default for a string-valued enum variant", func(ctx SpecContext) {
+				source := `
+					@ts output "out"
+
+					Level enum {
+						info    = "info"
+						warning = "warning"
+					}
+
+					Config struct {
+						level Level @validate default LevelInfo
+					}
+				`
+				resp := MustGenerate(ctx, source, "config", loader, typesPlugin)
+				ExpectContent(resp, "types.gen.ts").
+					ToContain(`level: levelZ.default("info")`)
+			})
+
+			It("Should emit a string literal default for a cross-namespace string-valued enum variant", func(ctx SpecContext) {
+				loader.Add("schemas/text", `
+					@ts output "x/ts/src/text"
+
+					Level enum {
+						p     = "p"
+						small = "small"
+					}
+				`)
+				source := `
+					import "schemas/text"
+
+					@ts output "client/ts/src/lineplot"
+
+					Title struct {
+						level text.Level @validate default text.LevelP
+					}
+				`
+				resp := MustGenerate(ctx, source, "lineplot", loader, typesPlugin)
+				ExpectContent(resp, "types.gen.ts").
+					ToContain(`level: text.levelZ.default("p")`)
+			})
 		})
 	})
 })


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4065](https://linear.app/synnax/issue/SY-4065)

## Description

Prerequisite for the SY-4065 (1/3) line plot work that adds `@validate default` to enum fields on `text.Level` and `spatial.Direction`. Without this generator fix, the resulting zod schemas reference `text.Level.p` and `spatial.Direction.x` at runtime, which are undefined.

The TS oracle generator's `enumVariantToTS` emitted `Type.variant` uniformly for every `@validate default` identifier referencing an enum value. That works for numeric-valued enums (which the generator outputs as TS runtime enums) but breaks at runtime for string-valued enums (which emit as `z.enum([...])` plus a type-only alias) because the type alias has no runtime object to dot into.

Fix: when the resolved enum form has `IsIntEnum: false`, emit the raw string literal (`.default("p")`) instead of `Type.variant`. Numeric-valued enums (e.g. `control.Concurrency`) keep the existing `Type.variant` form.

Two new tests cover same-namespace and cross-namespace string-valued enum defaults. The two existing numeric-enum tests still pass unchanged. All 141 TS types plugin specs pass.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the TS oracle code-generator so that `@validate default` annotations on string-valued enum fields emit a raw string literal (e.g. `.default("p")`) rather than a `Type.variant` reference that resolves to `undefined` at runtime, since string-valued enums are emitted as `z.enum([...])`  with no backing TS runtime object.

- `enumVariantToTS` in `types.go` gains an early-return that checks `EnumForm.IsIntEnum`; when false it calls `fmt.Sprintf("%q", ev.Variant.StringValue())` instead of constructing the dot-access reference.
- Two new Ginkgo specs are added in `types_test.go` covering same-namespace and cross-namespace string-valued enum defaults; the four existing numeric-enum specs are untouched.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a small, targeted fix with no regressions on existing numeric-enum paths and new tests that confirm the corrected output.

The fix is minimal and well-scoped: one early-return branch in `enumVariantToTS` guarded by the existing `EnumForm.IsIntEnum` flag. All prior numeric-enum specs continue to pass unchanged, two new string-enum specs exercise both the same-namespace and cross-namespace code paths, and `StringValue()` on a non-string value safely returns an empty string rather than panicking. No existing callers are affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| oracle/plugin/ts/types/types.go | Adds early-return branch in `enumVariantToTS` to emit a raw string literal for string-valued enums instead of the `Type.variant` runtime-object reference that would be undefined at runtime. |
| oracle/plugin/ts/types/types_test.go | Adds two new Ginkgo specs for same-namespace and cross-namespace string-valued enum defaults; existing numeric-enum tests are unchanged. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[enumVariantToTS called] --> B{IsEnumForm AND not IsIntEnum?}
    B -- Yes: string enum --> C[Return raw string literal\ne.g. p or info]
    B -- No: int enum or non-enum --> D[Build dot-access reference]
    D --> E{Same namespace?}
    E -- Yes --> F[Return enumName.variant\ne.g. Mode.automatic]
    E -- No --> G[Return ns.enumName.variant\ne.g. control.Concurrency.exclusive]
    C --> H[Zod schema: .default and string literal]
    F --> I[Zod schema: .default and Type.variant]
    G --> I
```

<sub>Reviews (1): Last reviewed commit: ["SY-4065: Emit string literal default for..."](https://github.com/synnaxlabs/synnax/commit/0774f447f331a17b44c81254bc67f8f689fc0de2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34039919)</sub>

<!-- /greptile_comment -->