### PR TITLE
SY-4199: Treat Select Branch Into ExecBoth Node As Trigger

### DIFF
--- a/arc/go/analyzer/flow/flow.go
+++ b/arc/go/analyzer/flow/flow.go
@@ -641,7 +641,9 @@ func analyzeRoutingTargetWithParam(
 				}
 			}
 		} else {
-			if len(fnType.Type.Inputs) > 0 {
+			//  A select branch into such an ExecBoth node is a trigger, not a typed input.
+			upstreamIsTrigger := fnType.Exec == symbol.ExecBoth && len(fnType.Type.Config) > 0
+			if !upstreamIsTrigger && len(fnType.Type.Inputs) > 0 {
 				param := fnType.Type.Inputs[0]
 				if err := atypes.Check(ctx.Constraints, sourceType, param.Type, ctx.AST,
 					"routing table output to func parameter"); err != nil {

--- a/arc/go/analyzer/flow/flow_test.go
+++ b/arc/go/analyzer/flow/flow_test.go
@@ -1644,5 +1644,60 @@ var _ = Describe("upstreamIsTrigger Suppression", func() {
 			Expect(ctx.Diagnostics.Ok()).To(BeFalse())
 			Expect((*ctx.Diagnostics)[0].Message).To(ContainSubstring("does not match"))
 		})
+
+		It("Should reject a select branch routing into an ExecBoth fn with empty Config and a mismatched input type", func(bCtx SpecContext) {
+			resolver := []symbol.Symbol{
+				{Name: "flag", Kind: symbol.KindChannel, Type: types.Chan(types.U8()), ID: 1},
+				{
+					Name: "target",
+					Kind: symbol.KindFunction,
+					Exec: symbol.ExecBoth,
+					Type: types.Function(types.FunctionProperties{
+						Inputs:  types.Params{{Name: "v", Type: types.String()}},
+						Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.TimeStamp()}},
+					}),
+				},
+			}
+			ast := MustSucceed(parser.Parse(`
+			flag -> select{} -> {
+				true: target{},
+				false: target{}
+			}`))
+			ctx := context.NewRoot(bCtx, ast, NewRoot(nil, resolver...))
+			analyzer.AnalyzeProgram(ctx)
+			Expect(ctx.Diagnostics.Ok()).To(BeFalse())
+			Expect((*ctx.Diagnostics)[0].Message).To(ContainSubstring("does not match"))
+		})
+
+		It("Should accept select branches routing into a user-defined func with no inputs", func(bCtx SpecContext) {
+			resolver := []symbol.Symbol{
+				{Name: "flag", Kind: symbol.KindChannel, Type: types.Chan(types.U8()), ID: 1},
+				execFlowFn("example_func", nil, types.Type{}),
+			}
+			ast := MustSucceed(parser.Parse(`
+			flag -> select{} -> {
+				true: example_func{},
+				false: example_func{}
+			}`))
+			ctx := context.NewRoot(bCtx, ast, NewRoot(nil, resolver...))
+			analyzer.AnalyzeProgram(ctx)
+			Expect(ctx.Diagnostics.Ok()).To(BeTrue(), ctx.Diagnostics.String())
+		})
+
+		It("Should accept a select chain through time.now into an i64 channel", func(bCtx SpecContext) {
+			resolver := []symbol.Symbol{
+				{Name: "flag", Kind: symbol.KindChannel, Type: types.Chan(types.U8()), ID: 1},
+				{Name: "i64_ch", Kind: symbol.KindChannel, Type: types.Chan(types.I64()), ID: 2},
+			}
+			ast := MustSucceed(parser.Parse(`
+			import time
+			flag -> select{} -> {
+				true: time.now{} -> i64_ch,
+				false: time.now{} -> i64_ch
+			}`))
+			ctx := context.NewRoot(bCtx, ast, NewRoot(nil, resolver...))
+			analyzer.AnalyzeProgram(ctx)
+			Expect(ctx.Diagnostics.Ok()).To(BeTrue(), ctx.Diagnostics.String())
+		})
 	})
 })

--- a/arc/go/analyzer/flow/flow_test.go
+++ b/arc/go/analyzer/flow/flow_test.go
@@ -1604,4 +1604,45 @@ var _ = Describe("upstreamIsTrigger Suppression", func() {
 			Expect(ctx.Diagnostics.Ok()).To(BeTrue(), ctx.Diagnostics.String())
 		})
 	})
+
+	Describe("In select routing branches", func() {
+		It("Should accept a select branch routing into an ExecBoth fn with a mismatched input type", func(bCtx SpecContext) {
+			resolver := []symbol.Symbol{
+				{Name: "flag", Kind: symbol.KindChannel, Type: types.Chan(types.U8()), ID: 1},
+				execBothFn(
+					"setter",
+					types.Params{
+						{Name: "key_or_name", Type: types.String()},
+						{Name: "message", Type: types.String()},
+						{Name: "variant", Type: types.String()},
+					},
+					types.String(),
+				),
+			}
+			ast := MustSucceed(parser.Parse(`
+			flag -> select{} -> {
+				true: setter{key_or_name="a", message="up", variant="info"},
+				false: setter{key_or_name="b", message="down", variant="info"}
+			}`))
+			ctx := context.NewRoot(bCtx, ast, NewRoot(nil, resolver...))
+			analyzer.AnalyzeProgram(ctx)
+			Expect(ctx.Diagnostics.Ok()).To(BeTrue(), ctx.Diagnostics.String())
+		})
+
+		It("Should reject a select branch routing into an ExecFlow fn with a mismatched input type", func(bCtx SpecContext) {
+			resolver := []symbol.Symbol{
+				{Name: "flag", Kind: symbol.KindChannel, Type: types.Chan(types.U8()), ID: 1},
+				execFlowFn("sink", types.Params{{Name: "v", Type: types.String()}}, types.Type{}),
+			}
+			ast := MustSucceed(parser.Parse(`
+			flag -> select{} -> {
+				true: sink{},
+				false: sink{}
+			}`))
+			ctx := context.NewRoot(bCtx, ast, NewRoot(nil, resolver...))
+			analyzer.AnalyzeProgram(ctx)
+			Expect(ctx.Diagnostics.Ok()).To(BeFalse())
+			Expect((*ctx.Diagnostics)[0].Message).To(ContainSubstring("does not match"))
+		})
+	})
 })


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue
[SY-4199](https://linear.app/synnax/issue/SY-4199/arc-select-updates)

## Description

The normal flow path suppresses positional input binding when an edge feeds an ExecBoth node with config (the edge is a trigger, not a typed input), but the select routing path did not. A select branch into status.set{...} bound the select's output type to the node's first input parameter, producing a spurious "output type ... does not match func ... parameter type ..." error.

Mirror the upstreamIsTrigger exemption from parseFunction into analyzeRoutingTargetWithParam so select-routed ExecBoth nodes are handled consistently.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a missing `upstreamIsTrigger` exemption in `analyzeRoutingTargetWithParam` so that a select-branch edge feeding an `ExecBoth` node with non-empty `Config` is treated as a trigger (not a typed positional input), mirroring the existing logic already present in `parseFunction`.

- **`flow.go`**: Adds a two-line `upstreamIsTrigger` guard (identical condition to the one in `parseFunction`) before the positional type-check in `analyzeRoutingTargetWithParam`'s `else` branch, eliminating spurious "output type ... does not match func ... parameter type" errors for select-routed ExecBoth nodes.
- **`flow_test.go`**: Adds five new tests covering the happy path (ExecBoth+Config → accepted), the negative path (ExecFlow → still rejected), the regression case (ExecBoth + empty Config → still rejected), a no-input baseline, and a realistic `time.now` chain through select.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a two-line guard that exactly replicates an already-proven pattern from parseFunction, with five new tests confirming both the fix and the boundaries where suppression must not activate.

The fix is minimal and surgical: it adds the same upstreamIsTrigger condition that already exists in parseFunction at line 95 into the parallel analyzeRoutingTargetWithParam path. The new condition is identical in both sites (ExecBoth && len(Config) > 0), eliminating the divergence that caused the bug. All edge cases (ExecFlow still rejected, ExecBoth+empty Config still rejected, no-input baseline, realistic time.now chain) are covered by new tests, and no existing tests are changed.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| arc/go/analyzer/flow/flow.go | Adds a two-line upstreamIsTrigger guard in analyzeRoutingTargetWithParam that exactly mirrors the existing guard in parseFunction — correct and minimal. |
| arc/go/analyzer/flow/flow_test.go | Five new tests cover the fixed path, the ExecFlow rejection, the ExecBoth+empty-Config regression, a no-input baseline, and a realistic time.now select chain — thorough coverage. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["flag channel (U8)"] --> B["select{}"]
    B -->|"true branch"| C["analyzeRoutingTargetWithParam"]
    B -->|"false branch"| D["analyzeRoutingTargetWithParam"]

    C --> E{{"ExecBoth AND len(Config) > 0?"}}
    D --> E

    E -->|"YES (upstreamIsTrigger)"| F["Skip positional type-check\n✅ No spurious error"]
    E -->|"NO"| G{{"len(Inputs) > 0?"}}

    G -->|"YES"| H["atypes.Check(sourceType, param.Type)\nType mismatch → diagnostic"]
    G -->|"NO"| I["Pass through\n✅ No error"]
```

<sub>Reviews (2): Last reviewed commit: ["SY-4199: add tests"](https://github.com/synnaxlabs/synnax/commit/447b965c7ad8d1d69f1ca5b551e2edbeaf4822c3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34210449)</sub>

<!-- /greptile_comment -->