### PR TITLE
SY-4246: Fix Python deployment scripts

### DIFF
--- a/.github/workflows/deploy.py.yaml
+++ b/.github/workflows/deploy.py.yaml
@@ -60,6 +60,9 @@ jobs:
               - *freighter
               - client/py/**
 
+      - name: Pin internal dependency constraints
+        run: ./scripts/pin_internal_deps.sh
+
       - name: Publish Alamos
         if: steps.filter.outputs.alamos == 'true'
         working-directory: alamos/py

--- a/scripts/pin_internal_deps.sh
+++ b/scripts/pin_internal_deps.sh
@@ -95,7 +95,9 @@ verify_pinned() {
 
 SED_ARGS=()
 for name in "${INTERNAL_PACKAGES[@]}"; do
-    dep_constraint="$(constraint_for "$(version_of "$(pyproject_for "$name")")")"
+    dep_pyproject="$(pyproject_for "$name")"
+    dep_version="$(version_of "$dep_pyproject")"
+    dep_constraint="$(constraint_for "$dep_version")"
     SED_ARGS+=(-e "s|^([[:space:]]*)\"${name}([<>=!~][^\"]*)?\"(,?)[[:space:]]*\$|\1\"${name}${dep_constraint}\"\3|")
     echo "→ ${name}${dep_constraint}"
 done

--- a/scripts/pin_internal_deps.sh
+++ b/scripts/pin_internal_deps.sh
@@ -61,7 +61,7 @@ version_of() {
         echo "❌ File not found: $pyproject" >&2
         return 1
     fi
-    version="$(grep -m1 '^version[[:space:]]*=' "$pyproject" | cut -d '"' -f2)"
+    version="$(grep -m1 '^version[[:space:]]*=' "$pyproject" | sed "s/.*=[[:space:]]*['\"]//;s/['\"].*//")"
     if [[ -z "$version" ]]; then
         echo "❌ Could not read version from $pyproject" >&2
         return 1
@@ -79,10 +79,24 @@ constraint_for() {
     echo ">=${version},<${major}.$((minor + 1)).0"
 }
 
+# Fails if any internal package is still listed as an unconstrained dependency. This
+# guards against a silent sed no-op (e.g. an unexpected pyproject.toml format) leaving a
+# release with the very unconstrained metadata this script exists to prevent.
+verify_pinned() {
+    local pyproject="$1" name
+    for name in "${INTERNAL_PACKAGES[@]}"; do
+        if grep -Eq "^[[:space:]]*\"${name}\"" "$pyproject"; then
+            echo "❌ ${pyproject}: '${name}' is still unconstrained after pinning" >&2
+            return 1
+        fi
+    done
+    return 0
+}
+
 SED_ARGS=()
 for name in "${INTERNAL_PACKAGES[@]}"; do
     dep_constraint="$(constraint_for "$(version_of "$(pyproject_for "$name")")")"
-    SED_ARGS+=(-e "s|^([[:space:]]*)\"${name}([<>=!~][^\"]*)?\",|\1\"${name}${dep_constraint}\",|")
+    SED_ARGS+=(-e "s|^([[:space:]]*)\"${name}([<>=!~][^\"]*)?\"(,?)[[:space:]]*\$|\1\"${name}${dep_constraint}\"\3|")
     echo "→ ${name}${dep_constraint}"
 done
 
@@ -95,5 +109,8 @@ for d in "${PACKAGE_DIRS[@]}"; do
     tmp="$(mktemp)"
     sed -E "${SED_ARGS[@]}" "$pyproject" > "$tmp"
     mv "$tmp" "$pyproject"
+    if ! verify_pinned "$pyproject"; then
+        exit 1
+    fi
     echo "✅ Pinned internal deps in $pyproject"
 done

--- a/scripts/pin_internal_deps.sh
+++ b/scripts/pin_internal_deps.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+
+# Copyright 2026 Synnax Labs, Inc.
+#
+# Use of this software is governed by the Business Source License included in the file
+# licenses/BSL.txt.
+#
+# As of the Change Date specified in that file, in accordance with the Business Source
+# License, use of this software will be governed by the Apache License, Version 2.0,
+# included in the file licenses/APL.txt.
+
+# Pins the version constraints of internal workspace dependencies (alamos,
+# synnax-freighter, synnax-x) in each Python package's pyproject.toml to
+# ">=<dep-version>,<<dep-next-minor>>".
+#
+# Each constraint is derived from the depended-on package's own version, not the
+# depending package's. This keeps the published metadata satisfiable even when versions
+# diverge: if synnax is 0.55.2 but synnax-x is still 0.55.1, synnax pins
+# "synnax-x>=0.55.1,<0.56.0" (the release that actually exists) rather than demanding a
+# nonexistent 0.55.2.
+#
+# uv does not rewrite workspace dependency constraints at publish time, and the
+# pyproject.toml entries are intentionally left unconstrained for local development.
+# This script is run by the deploy pipeline immediately before `uv build` so the
+# published wheel metadata pins matching releases (see SY-4246). It is not meant to be
+# committed: it mutates the working tree of an ephemeral release checkout.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(
+    cd "$(dirname "${BASH_SOURCE[0]}")" > /dev/null 2>&1
+    pwd
+)"
+ROOT_DIR="$(cd "$SCRIPT_DIR/.." > /dev/null 2>&1 && pwd)"
+
+INTERNAL_PACKAGES=("alamos" "synnax-freighter" "synnax-x")
+
+PACKAGE_DIRS=(
+    "$ROOT_DIR/alamos/py"
+    "$ROOT_DIR/freighter/py"
+    "$ROOT_DIR/client/py"
+    "$ROOT_DIR/x/py"
+)
+
+# pyproject.toml that defines each internal package.
+pyproject_for() {
+    case "$1" in
+        alamos) echo "$ROOT_DIR/alamos/py/pyproject.toml" ;;
+        synnax-freighter) echo "$ROOT_DIR/freighter/py/pyproject.toml" ;;
+        synnax-x) echo "$ROOT_DIR/x/py/pyproject.toml" ;;
+        *)
+            echo "❌ Unknown internal package: $1" >&2
+            return 1
+            ;;
+    esac
+}
+
+version_of() {
+    local pyproject="$1" version
+    if [[ ! -f "$pyproject" ]]; then
+        echo "❌ File not found: $pyproject" >&2
+        return 1
+    fi
+    version="$(grep -m1 '^version[[:space:]]*=' "$pyproject" | cut -d '"' -f2)"
+    if [[ -z "$version" ]]; then
+        echo "❌ Could not read version from $pyproject" >&2
+        return 1
+    fi
+    echo "$version"
+}
+
+# Maps a version to a ">=<version>,<<next-minor>>" constraint, e.g. 0.55.1 ->
+# >=0.55.1,<0.56.0.
+constraint_for() {
+    local version="$1" major minor
+    major="${version%%.*}"
+    minor="${version#*.}"
+    minor="${minor%%.*}"
+    echo ">=${version},<${major}.$((minor + 1)).0"
+}
+
+SED_ARGS=()
+for name in "${INTERNAL_PACKAGES[@]}"; do
+    dep_constraint="$(constraint_for "$(version_of "$(pyproject_for "$name")")")"
+    SED_ARGS+=(-e "s|^([[:space:]]*)\"${name}([<>=!~][^\"]*)?\",|\1\"${name}${dep_constraint}\",|")
+    echo "→ ${name}${dep_constraint}"
+done
+
+for d in "${PACKAGE_DIRS[@]}"; do
+    pyproject="$d/pyproject.toml"
+    if [[ ! -f "$pyproject" ]]; then
+        echo "❌ File not found: $pyproject" >&2
+        exit 1
+    fi
+    tmp="$(mktemp)"
+    sed -E "${SED_ARGS[@]}" "$pyproject" > "$tmp"
+    mv "$tmp" "$pyproject"
+    echo "✅ Pinned internal deps in $pyproject"
+done


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue number and link -->

[SY-4246](https://linear.app/synnax/issue/SY-4246/fix-dependency-constraints-in-python-deployment)

## Description

<!-- Write a description describing the changes. -->

Fix Python deployment scripts. Previously, published packages to PyPI did NOT specify the relevant versions for workspace dependencies, so `synnax` did not specify a version constraint for `synnax-x`. This PR dynamically specifies those dependencies via a Bash script before publishing.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a Bash script (`scripts/pin_internal_deps.sh`) and a single workflow step that rewrites internal workspace dependency entries in each `pyproject.toml` from bare names (e.g. `\"alamos\"`) to tight version constraints (e.g. `\"alamos>=0.55.0,<0.56.0\"`) immediately before the `uv build` steps run, so published PyPI wheels carry correct dependency metadata.

- **`pin_internal_deps.sh`**: reads each internal package's `version` field, computes a `>=X.Y.Z,<X.(Y+1).0` upper-bounded range, applies it via `sed -E` with ERE capture groups, and validates with `verify_pinned` that no bare unconstrained entry survived.
- **`deploy.py.yaml`**: inserts one unconditional `run: ./scripts/pin_internal_deps.sh` step ahead of all conditional `uv build` steps, so every package built in a single workflow run sees consistent pinned metadata.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the pinning script mutates only ephemeral CI working-tree files, includes a hard-fail verification pass after each sed rewrite, and the workflow change is a single unconditional step that runs before any build.

The sed pattern, constraint arithmetic, and verify_pinned guard all check out against the actual pyproject.toml layouts. Both issues flagged in earlier review rounds have been addressed.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/pin_internal_deps.sh | New script that reads each internal package's version, builds a >=X.Y.Z,<X.(Y+1).0 constraint, rewrites all four pyproject.toml files with sed, and verifies no bare unconstrained entry remains. |
| .github/workflows/deploy.py.yaml | Adds a single unconditional step (pin_internal_deps.sh) immediately before the conditional uv build steps; no other workflow logic changed. |

</details>

<sub>Reviews (3): Last reviewed commit: ["Address Greptile comment"](https://github.com/synnaxlabs/synnax/commit/f586fad7fff061db1670adf14970cbdd9e6c7b2e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34284595)</sub>

<!-- /greptile_comment -->