### PR TITLE
[perf]: Stabilize Map and Array Selector Returns

### DIFF
--- a/pluto/src/schematic/queries.spec.tsx
+++ b/pluto/src/schematic/queries.spec.tsx
@@ -227,6 +227,80 @@ describe("schematic queries", () => {
       );
       expect(result.current.size).toBe(0);
     });
+
+    it("useSelectNodes keeps its reference when an unrelated node changes", async () => {
+      const isolated = await createTestSchematic(ws.key);
+      await loadSchematic(Wrapper, isolated.key);
+      const { result } = renderHook(
+        () => ({
+          nodes: Schematic.useSelectNodes({ key: isolated.key, keys: ["n1"] }),
+          dispatch: Schematic.useDispatch(),
+        }),
+        { wrapper: Wrapper },
+      );
+      const initial = result.current.nodes;
+      expect(initial.map((n) => n.key)).toEqual(["n1"]);
+      await act(async () => {
+        await result.current.dispatch.dispatchAsync({
+          key: isolated.key,
+          actions: [
+            schematic.setNodePosition({ key: "n2", position: { x: 50, y: 50 } }),
+          ],
+        });
+      });
+      expect(result.current.nodes).toBe(initial);
+    });
+
+    it("useSelectNodes returns a new array when a requested node changes", async () => {
+      const isolated = await createTestSchematic(ws.key);
+      await loadSchematic(Wrapper, isolated.key);
+      const { result } = renderHook(
+        () => ({
+          nodes: Schematic.useSelectNodes({ key: isolated.key, keys: ["n1"] }),
+          dispatch: Schematic.useDispatch(),
+        }),
+        { wrapper: Wrapper },
+      );
+      const initial = result.current.nodes;
+      await act(async () => {
+        await result.current.dispatch.dispatchAsync({
+          key: isolated.key,
+          actions: [
+            schematic.setNodePosition({ key: "n1", position: { x: 99, y: 99 } }),
+          ],
+        });
+      });
+      await waitFor(() => {
+        expect(result.current.nodes).not.toBe(initial);
+        expect(result.current.nodes[0].position).toEqual({ x: 99, y: 99 });
+      });
+    });
+
+    it("useSelectConfigs keeps its reference when an unrelated change occurs", async () => {
+      const isolated = await createTestSchematic(ws.key);
+      await loadSchematic(Wrapper, isolated.key);
+      const { result } = renderHook(
+        () => ({
+          configs: Schematic.useSelectConfigs({
+            key: isolated.key,
+            keys: ["n1", "n2"],
+          }),
+          dispatch: Schematic.useDispatch(),
+        }),
+        { wrapper: Wrapper },
+      );
+      const initial = result.current.configs;
+      expect(initial.size).toBe(2);
+      await act(async () => {
+        await result.current.dispatch.dispatchAsync({
+          key: isolated.key,
+          actions: [
+            schematic.setNodePosition({ key: "n1", position: { x: 5, y: 5 } }),
+          ],
+        });
+      });
+      expect(result.current.configs).toBe(initial);
+    });
   });
 
   describe("useCreate", () => {

--- a/pluto/src/schematic/queries.spec.tsx
+++ b/pluto/src/schematic/queries.spec.tsx
@@ -294,9 +294,7 @@ describe("schematic queries", () => {
       await act(async () => {
         await result.current.dispatch.dispatchAsync({
           key: isolated.key,
-          actions: [
-            schematic.setNodePosition({ key: "n1", position: { x: 5, y: 5 } }),
-          ],
+          actions: [schematic.setNodePosition({ key: "n1", position: { x: 5, y: 5 } })],
         });
       });
       expect(result.current.configs).toBe(initial);

--- a/pluto/src/schematic/queries.ts
+++ b/pluto/src/schematic/queries.ts
@@ -13,7 +13,7 @@ import {
   schematic,
   type workspace,
 } from "@synnaxlabs/client";
-import { array, type record, uuid, xy } from "@synnaxlabs/x";
+import { array, compare, type record, uuid, xy } from "@synnaxlabs/x";
 import { useCallback } from "react";
 
 import { Flux } from "@/flux";
@@ -167,6 +167,7 @@ export const useSelectConfigs = Flux.createSelector<
     }
     return result;
   },
+  equal: compare.mapsEqual,
 });
 
 export interface SelectNodesArgs {
@@ -186,6 +187,7 @@ export const useSelectNodes = Flux.createSelector<
     const keySet = new Set(keys);
     return s.nodes.filter((n) => keySet.has(n.key));
   },
+  equal: compare.arraysEqual,
 });
 
 export interface SelectFieldArgs {

--- a/x/ts/src/compare/compare.spec.ts
+++ b/x/ts/src/compare/compare.spec.ts
@@ -46,4 +46,119 @@ describe("compare", () => {
       });
     });
   });
+
+  describe("mapsEqual", () => {
+    it("returns true for the same reference", () => {
+      const m = new Map<string, number>([["a", 1]]);
+      expect(compare.mapsEqual(m, m)).toBe(true);
+    });
+
+    it("returns true for content-equal maps with identity-equal values", () => {
+      const a = new Map<string, number>([
+        ["a", 1],
+        ["b", 2],
+      ]);
+      const b = new Map<string, number>([
+        ["a", 1],
+        ["b", 2],
+      ]);
+      expect(compare.mapsEqual(a, b)).toBe(true);
+    });
+
+    it("returns true regardless of insertion order", () => {
+      const a = new Map<string, number>([
+        ["a", 1],
+        ["b", 2],
+      ]);
+      const b = new Map<string, number>([
+        ["b", 2],
+        ["a", 1],
+      ]);
+      expect(compare.mapsEqual(a, b)).toBe(true);
+    });
+
+    it("returns false when sizes differ", () => {
+      const a = new Map<string, number>([["a", 1]]);
+      const b = new Map<string, number>([
+        ["a", 1],
+        ["b", 2],
+      ]);
+      expect(compare.mapsEqual(a, b)).toBe(false);
+    });
+
+    it("returns false when a key is present in one but missing in the other", () => {
+      const a = new Map<string, number>([
+        ["a", 1],
+        ["b", 2],
+      ]);
+      const b = new Map<string, number>([
+        ["a", 1],
+        ["c", 2],
+      ]);
+      expect(compare.mapsEqual(a, b)).toBe(false);
+    });
+
+    it("returns false when a value differs by identity", () => {
+      const a = new Map<string, { v: number }>([["a", { v: 1 }]]);
+      const b = new Map<string, { v: number }>([["a", { v: 1 }]]);
+      expect(compare.mapsEqual(a, b)).toBe(false);
+    });
+
+    it("returns true when a value is the same object reference", () => {
+      const shared = { v: 1 };
+      const a = new Map<string, { v: number }>([["a", shared]]);
+      const b = new Map<string, { v: number }>([["a", shared]]);
+      expect(compare.mapsEqual(a, b)).toBe(true);
+    });
+
+    it("treats undefined values as present", () => {
+      const a = new Map<string, number | undefined>([["a", undefined]]);
+      const b = new Map<string, number | undefined>([["b", undefined]]);
+      expect(compare.mapsEqual(a, b)).toBe(false);
+    });
+
+    it("returns true for two empty maps", () => {
+      expect(compare.mapsEqual(new Map(), new Map())).toBe(true);
+    });
+  });
+
+  describe("arraysEqual", () => {
+    it("returns true for the same reference", () => {
+      const a = [1, 2, 3];
+      expect(compare.arraysEqual(a, a)).toBe(true);
+    });
+
+    it("returns true for content-equal primitive arrays", () => {
+      expect(compare.arraysEqual([1, 2, 3], [1, 2, 3])).toBe(true);
+    });
+
+    it("returns false when lengths differ", () => {
+      expect(compare.arraysEqual([1, 2], [1, 2, 3])).toBe(false);
+    });
+
+    it("returns false when an element differs by value", () => {
+      expect(compare.arraysEqual([1, 2, 3], [1, 9, 3])).toBe(false);
+    });
+
+    it("is order-sensitive", () => {
+      expect(compare.arraysEqual([1, 2, 3], [3, 2, 1])).toBe(false);
+    });
+
+    it("uses identity equality for object elements", () => {
+      const a = { v: 1 };
+      const b = { v: 1 };
+      expect(compare.arraysEqual([a], [a])).toBe(true);
+      expect(compare.arraysEqual([a], [b])).toBe(false);
+    });
+
+    it("returns true for two empty arrays", () => {
+      expect(compare.arraysEqual([], [])).toBe(true);
+    });
+
+    it("works with readonly arrays", () => {
+      const a: readonly number[] = [1, 2, 3];
+      const b: readonly number[] = [1, 2, 3];
+      expect(compare.arraysEqual(a, b)).toBe(true);
+    });
+  });
 });

--- a/x/ts/src/compare/compare.ts
+++ b/x/ts/src/compare/compare.ts
@@ -104,6 +104,35 @@ export const uniqueUnorderedPrimitiveArrays = <T extends primitive.Value>(
   return unorderedPrimitiveArrays(uniqueA, uniqueB);
 };
 
+/**
+ * Returns true if the two maps have the same set of keys and each value is
+ * identity-equal (===). Intended for use as a reference-stability comparator
+ * (e.g. React's `useSyncExternalStoreWithSelector`) where the values are
+ * already reference-stable in storage (e.g. Immer state). For deeper value
+ * comparison, compose with `deep.equal` at the call site.
+ */
+export const mapsEqual = <K, V>(a: Map<K, V>, b: Map<K, V>): boolean => {
+  if (a === b) return true;
+  if (a.size !== b.size) return false;
+  for (const [k, v] of a) if (!b.has(k) || b.get(k) !== v) return false;
+  return true;
+};
+
+/**
+ * Returns true if the two arrays have the same length and each element is
+ * identity-equal (===). Same use case as `mapsEqual` for selectors that
+ * derive arrays from reference-stable storage.
+ */
+export const arraysEqual = <T>(
+  a: readonly T[] | T[],
+  b: readonly T[] | T[],
+): boolean => {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  for (let i = 0; i < a.length; i++) if (a[i] !== b[i]) return false;
+  return true;
+};
+
 export const order = (a: spatial.Order, b: spatial.Order): number => {
   if (a === b) return 0;
   if (a === "first" && b === "last") return 1;


### PR DESCRIPTION
## Description

`useSelectConfigs` (returns `Map<string, ElementConfig>`) and `useSelectNodes` (returns `schematic.Node[]`) both allocate a fresh container in their `select` callback, so without a custom `equal` comparator the consumer re-renders on every unrelated schematic dispatch — even when none of the requested elements changed.

This PR adds two boolean-returning shallow comparators to `@synnaxlabs/x/compare`:

- `mapsEqual<K, V>(a, b)` — true when both Maps have the same keys and each value is identity-equal.
- `arraysEqual<T>(a, b)` — true when both arrays have the same length and each element is identity-equal.

Both are intended for selector `equal` callbacks where the container values are already reference-stable in storage (Immer). For deeper comparison, callers compose with `deep.equal`.

Applies both to the two schematic selectors and adds regression tests that fail without the comparator and pass with it.

> Note: `useSelectCells` on the table side has the exact same shape, but it lives on the `sy-4066-2-pluto-owned-table-state` branch (not yet on rc). It will adopt the utility once that branch picks up rc.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes unnecessary re-renders in two schematic selectors by adding shallow reference-equality comparators (`mapsEqual` and `arraysEqual`) to `@synnaxlabs/x/compare` and wiring them into `useSelectConfigs` and `useSelectNodes` via their `equal` callbacks.

- `mapsEqual<K,V>` and `arraysEqual<T>` are added to `x/ts/src/compare/compare.ts` with identity (`===`) element comparison, intended for Immer-backed stores where individual values are already reference-stable.
- `useSelectConfigs` and `useSelectNodes` in `pluto/src/schematic/queries.ts` each receive their respective comparator, preventing re-renders when unrelated schematic dispatches produce a new container but identical contents.
- Regression tests verify both reference stability on unrelated changes and a fresh reference when a tracked node's position mutates.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive, narrowly scoped to two selectors, and backed by regression tests that exercise both the stability and the mutation paths.

Both comparators are simple, correctly short-circuit on the fast path (same reference → true, different size → false), and are consistent with the existing primitiveArrays pattern already in the file. The Immer assumption (reference-stable leaf values) is accurately documented and matches the actual storage layer.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| x/ts/src/compare/compare.ts | Adds mapsEqual and arraysEqual shallow-identity comparators; implementations are correct and consistent with existing primitiveArrays pattern in the same file. |
| x/ts/src/compare/compare.spec.ts | Adds thorough unit tests for both new functions covering same-reference, same-value, different-key, different-value, insertion-order, and empty-container cases. |
| pluto/src/schematic/queries.ts | Wires compare.mapsEqual and compare.arraysEqual into useSelectConfigs and useSelectNodes respectively; straightforward one-liner changes. |
| pluto/src/schematic/queries.spec.tsx | Adds three integration tests: stability + mutation test for useSelectNodes, and stability test for useSelectConfigs (mutation test for useSelectConfigs still absent, noted in a prior review). |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Schematic store dispatch] --> B{Selector fires}
    B --> C[select callback\nallocates new container]
    C --> D{equal callback invoked\na = previous, b = new}
    D -->|useSelectConfigs| E[mapsEqual]
    D -->|useSelectNodes| F[arraysEqual]
    E --> G{same size?}
    G -->|No| H[return false\n→ re-render]
    G -->|Yes| I{all keys present\nand values ===?}
    I -->|No| H
    I -->|Yes| J[return true\n→ skip re-render]
    F --> K{same length?}
    K -->|No| H
    K -->|Yes| L{all elements ===?}
    L -->|No| H
    L -->|Yes| J
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `pluto/src/schematic/queries.spec.tsx`, line 291-310 ([link](https://github.com/synnaxlabs/synnax/blob/054ff104680c4254376c59d7fbf96d63f850839a/pluto/src/schematic/queries.spec.tsx#L291-L310)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Missing complementary "returns new Map" test for `useSelectConfigs`**

   `useSelectNodes` has two tests: one verifying reference stability when nothing relevant changes, and one verifying that a new array reference is returned when a requested node mutates. `useSelectConfigs` only has the stability half. Without the positive test, a broken `mapsEqual` that always returned `true` would go undetected — the suite would still pass even though `useSelectConfigs` would silently swallow config updates and fail to trigger the re-render callers depend on. A test that dispatches a `setConfig` for n1 and then asserts `result.current.configs !== initial` (and that the new value is present) would close this gap.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Format schematic queries spec"](https://github.com/synnaxlabs/synnax/commit/3958c5ad28b0c48b49d0c04c2819ec9853e456fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34291972)</sub>

<!-- /greptile_comment -->