### PR TITLE
SY-3111: Fix Flaky Cesium Garbage Collection Test

### DIFF
--- a/cesium/gc_test.go
+++ b/cesium/gc_test.go
@@ -12,6 +12,7 @@ package cesium_test
 import (
 	"math"
 	"path"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -21,6 +22,13 @@ import (
 	"github.com/synnaxlabs/x/telem"
 	. "github.com/synnaxlabs/x/testutil"
 )
+
+// gcConvergeTimeout bounds how long a spec waits for background garbage
+// collection to converge on a final file size. The default Gomega timeout (1s)
+// is not enough on slow filesystems (Windows and macOS osFS in CI), where a
+// full-file GC rewrite can take much longer and may require more than one
+// compaction pass.
+const gcConvergeTimeout = 30 * time.Second
 
 var _ = Describe("Garbage collection", Ordered, func() {
 	for fsName, openFS := range FileSystems {
@@ -97,7 +105,7 @@ var _ = Describe("Garbage collection", Ordered, func() {
 						i, err := fs.Stat(path.Join(channelKeyToPath(basic) + "/1.domain"))
 						g.Expect(err).ToNot(HaveOccurred())
 						return uint32(i.Size())
-					}).Should(Equal(42 * uint32(telem.Int64T.Density())))
+					}).WithTimeout(gcConvergeTimeout).Should(Equal(42 * uint32(telem.Int64T.Density())))
 				})
 			})
 
@@ -160,7 +168,7 @@ var _ = Describe("Garbage collection", Ordered, func() {
 						i, err := fs.Stat(path.Join(channelKeyToPath(basic) + "/1.domain"))
 						g.Expect(err).ToNot(HaveOccurred())
 						return uint32(i.Size())
-					}).Should(Equal(54 * uint32(telem.Int64T.Density())))
+					}).WithTimeout(gcConvergeTimeout).Should(Equal(54 * uint32(telem.Int64T.Density())))
 
 					By("Asserting that the data is still correct", func() {
 						f := MustSucceed(db.Read(ctx, telem.TimeRangeMax, basic))
@@ -241,7 +249,7 @@ var _ = Describe("Garbage collection", Ordered, func() {
 						i, err = fs.Stat(path.Join(channelKeyToPath(basic) + "/5.domain"))
 						g.Expect(err).ToNot(HaveOccurred())
 						g.Expect(i.Size()).To(Equal(int64(40)))
-					}).Should(Succeed())
+					}).WithTimeout(gcConvergeTimeout).Should(Succeed())
 
 					By("Writing more data – they should go to the newly freed files, i.e. file 3 or file 4")
 					// This should go to file 10.


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-3111](https://linear.app/synnax/issue/SY-3111)

## Description

The garbage collection specs in `cesium/gc_test.go` poll for background GC (10ms `TryInterval`) to converge on a final on-disk file size, but relied on Gomega's default 1s `Eventually` timeout. The indexed-channel spec requires the domain file to be recompacted a second time after a third overlapping delete (432 -> 336 bytes), i.e. a second full-file GC rewrite pass. On slow CI filesystems (Windows and macOS `osFS`) a full-file copy + rename can't reliably complete that second pass within 1s, so the spec flakes; Ubuntu's faster filesystem makes it rare but not impossible.

This bumps the timeout on the three GC-convergence `Eventually` assertions to 30s via a shared `gcConvergeTimeout` constant. The assertions still check exact file sizes, so correctness is unchanged: a real regression that never converges still fails, just after a longer wait.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes flaky Cesium GC tests on slow CI filesystems by introducing a `gcConvergeTimeout` constant (30 s) applied to three `Eventually` assertions, and bundles several Windows-compatibility fixes for the `oracle` tool alongside a significant parallelization refactor of `scripts/update_copyrights.sh`.

- **`cesium/gc_test.go`**: Replaces the implicit 1 s Gomega timeout with an explicit 30 s `gcConvergeTimeout` on all three GC-convergence `Eventually` calls; correctness checks (exact file sizes) are unchanged.
- **`oracle/cmd/check_test.go` + `oracle/paths/paths.go`**: Appends `.exe` to the oracle binary path on Windows and normalizes `Normalize()` output to forward slashes via `filepath.ToSlash`, fixing cross-platform path handling.
- **`scripts/update_copyrights.sh`**: Replaces sequential `sed`-per-file processing with an in-memory `LINES` array and a parallel `xargs -P` dispatch pattern; `emit_lines` was left behind as dead code after the refactor.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the test and oracle changes are straightforward and correct, and the copyright-script refactor is well-structured with one minor issue in the xargs invocation.

The GC test timeout bump and the two oracle Windows-compat fixes are mechanical and low-risk. The copyright script refactor is substantial but well-reasoned; the main concern is that printf '%s
' | xargs splits on all whitespace, which would corrupt any filename containing a space. In practice this repository's source files don't use spaces in names, so the bug is latent rather than immediately harmful.

scripts/update_copyrights.sh — the xargs invocation and the leftover emit_lines function.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cesium/gc_test.go | Adds gcConvergeTimeout = 30s constant and applies it to three Eventually assertions to fix flaky GC tests on slow CI filesystems. |
| oracle/cmd/check_test.go | Adds .exe suffix to the oracle binary path on Windows so the build test finds the correct output binary. |
| oracle/paths/paths.go | Applies filepath.ToSlash() to the result of Normalize so callers always receive forward-slash paths regardless of OS. |
| scripts/update_copyrights.sh | Major refactor: switches from sequential sed-based file processing to parallel xargs batches with an in-memory LINES array. Includes an unused emit_lines function and a minor xargs whitespace splitting concern for filenames with spaces. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[update_copyrights.sh invoked] --> B{BATCH_MODE?}
    B -- yes --> C[process_file for each arg]
    C --> D[read_whole_file into LINES array]
    D --> E[locate_existing_header]
    E --> F{Already canonical?}
    F -- yes --> G[print SKIPPED tab path]
    F -- no --> H[Build new file content in-memory]
    H --> I[Write atomically via mktemp and cat]
    I --> J[print UPDATED tab path]
    B -- no --> K[Parse args and enumerate files]
    K --> L[Collect FILES_TO_UPDATE]
    L --> M[xargs -P workers dispatch batch subprocesses]
    M --> N[Read TAB-separated STATUS lines]
    N --> O[Aggregate UPDATED and SKIPPED counts]
    O --> P[Print summary]
```

<sub>Reviews (1): Last reviewed commit: ["SY-3111: Fix Flaky Cesium Garbage Collec..."](https://github.com/synnaxlabs/synnax/commit/23f7135da7ea35f4ee41128c54021eed749614d2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34413675)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->