### PR TITLE
SY-4255: Fix Race in Driver Command Processing Test

### DIFF
--- a/core/pkg/service/driver/driver_test.go
+++ b/core/pkg/service/driver/driver_test.go
@@ -783,8 +783,8 @@ var _ = Describe("Driver", func() {
 					return &mockTask{
 						key: t.Key,
 						execFunc: func(_ context.Context, cmd task.Command) error {
-							execCalled.Store(true)
 							receivedCmd.Store(cmd)
+							execCalled.Store(true)
 							return nil
 						},
 					}, nil


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4255](https://linear.app/synnax/issue/SY-4255)

## Description

The `Driver Command Processing` test "should execute command on configured task" was flaky in CI, panicking with `interface conversion: interface {} is nil, not task.Command`.

The mock task's `execFunc` stored `execCalled` before `receivedCmd`, while the test polls `Eventually(execCalled.Load())` and then immediately reads `receivedCmd.Load().(task.Command)`. When the test goroutine observed `execCalled == true` in the window between the two stores, `receivedCmd.Load()` returned nil and the type assertion panicked.

This swaps the store order so `receivedCmd` is stored first. Because each atomic store establishes a happens-before edge, observing `execCalled == true` now guarantees `receivedCmd` is already populated. Pure test fix; no product code changes.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a one-line ordering bug in the driver command processing test that caused intermittent panics in CI. The mock task's `execFunc` previously stored `execCalled = true` before `receivedCmd`, so the `Eventually` poller could wake between the two stores and hit a nil type-assertion on `receivedCmd.Load().(task.Command)`.

- Swaps the two atomic stores so `receivedCmd` is always populated before `execCalled` is set to `true`, making the happens-before guarantee airtight under Go's memory model.
- No product code is changed; this is a pure test fix.

<h3>Confidence Score: 5/5</h3>

Safe to merge — one-line reorder in a test file with no product code changes.

The change is a two-line swap in a single test file. The fix correctly leverages Go's happens-before guarantees for atomic stores to eliminate the nil type-assertion race. No logic, API, or production code is touched.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| core/pkg/service/driver/driver_test.go | Swaps store order in mock task's execFunc — receivedCmd is now stored before execCalled — eliminating the nil-type-assertion race in the "should execute command on configured task" test. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test as Test goroutine
    participant Exec as execFunc goroutine

    Note over Exec: OLD (buggy) order
    Exec->>Exec: execCalled.Store(true)
    Note over Test: Eventually sees execCalled==true
    Test->>Test: receivedCmd.Load().(task.Command) 💥 nil panic!
    Exec->>Exec: receivedCmd.Store(cmd)

    Note over Exec: NEW (fixed) order
    Exec->>Exec: receivedCmd.Store(cmd)
    Exec->>Exec: execCalled.Store(true)
    Note over Test: Eventually sees execCalled==true
    Test->>Test: receivedCmd.Load().(task.Command) ✅ guaranteed non-nil
```

<sub>Reviews (1): Last reviewed commit: ["SY-4255: Fix race in driver command proc..."](https://github.com/synnaxlabs/synnax/commit/f2556379a31f192ec4bc209fc85eaf6750dfe8f8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34451219)</sub>

<!-- /greptile_comment -->