### PR TITLE
SY-4256: Fix Schematic Connection Line Rendering

### DIFF
--- a/pluto/src/schematic/edge/common/ConnectionLine.tsx
+++ b/pluto/src/schematic/edge/common/ConnectionLine.tsx
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { box, location } from "@synnaxlabs/x";
+import { location } from "@synnaxlabs/x";
 import { useReactFlow } from "@xyflow/react";
 import { type CSSProperties, type ReactElement } from "react";
 
@@ -21,6 +21,8 @@ const STYLE: CSSProperties = { strokeWidth: 2 };
 export const ConnectionLine = ({
   source,
   target,
+  sourceBox,
+  targetBox,
   status,
 }: Diagram.ConnectionLineProps): ReactElement => {
   const connectedHandle = document.querySelector(".react-flow__handle-connecting");
@@ -35,8 +37,8 @@ export const ConnectionLine = ({
     targetPos: target.position,
     sourceOrientation: source.orientation,
     targetOrientation: target.orientation,
-    sourceBox: box.ZERO,
-    targetBox: box.ZERO,
+    sourceBox,
+    targetBox,
   });
   const points = Segmented.segmentsToPoints(
     source.position,

--- a/pluto/src/schematic/edge/common/segmented/connector.spec.ts
+++ b/pluto/src/schematic/edge/common/segmented/connector.spec.ts
@@ -12,6 +12,32 @@ import { describe, expect, it } from "vitest";
 
 import { Segmented } from "@/schematic/edge/common/segmented";
 
+const within = (v: number, a: number, b: number): boolean =>
+  v >= Math.min(a, b) - 0.001 && v <= Math.max(a, b) + 0.001;
+
+// selfCrosses reports whether the orthogonal polyline through pts has any
+// non-adjacent pair of segments that intersect or overlap, i.e. the path loops
+// back over itself ("pigtail").
+const selfCrosses = (pts: xy.XY[]): boolean => {
+  const segs = pts.slice(1).map((p, i) => ({ a: pts[i], b: p }));
+  for (let i = 0; i < segs.length; i++)
+    for (let j = i + 2; j < segs.length; j++) {
+      const { a: a1, b: b1 } = segs[i];
+      const { a: a2, b: b2 } = segs[j];
+      const h1 = a1.y === b1.y;
+      const h2 = a2.y === b2.y;
+      if (h1 && !h2) {
+        if (within(a2.x, a1.x, b1.x) && within(a1.y, a2.y, b2.y)) return true;
+      } else if (!h1 && h2) {
+        if (within(a1.x, a2.x, b2.x) && within(a2.y, a1.y, b1.y)) return true;
+      } else if (h1 && h2 && Math.abs(a1.y - a2.y) < 0.001) {
+        if (within(a2.x, a1.x, b1.x) || within(b2.x, a1.x, b1.x)) return true;
+      } else if (!h1 && !h2 && Math.abs(a1.x - a2.x) < 0.001)
+        if (within(a2.y, a1.y, b1.y) || within(b2.y, a1.y, b1.y)) return true;
+    }
+  return false;
+};
+
 describe("connector", () => {
   describe("needToGoAroundSource", () => {
     interface spec {
@@ -455,9 +481,11 @@ describe("connector", () => {
     // so the segment's length scales with the node's absolute position and the preview
     // shoots off-screen. With a real box the routing is translation-invariant.
     const NODE_DIMS = { width: 40, height: 40 };
+    // Same-side handles with the target behind the source force a go-around through
+    // prepareNode (the box-dependent path), without the facing-stub short-circuit.
     const buildProps = (offset: xy.XY): Segmented.BuildNew => ({
       sourceOrientation: "right",
-      targetOrientation: "left",
+      targetOrientation: "right",
       sourcePos: xy.translate({ x: 540, y: 100 }, offset),
       targetPos: xy.translate({ x: 400, y: 300 }, offset),
       sourceBox: box.construct(xy.translate({ x: 500, y: 80 }, offset), NODE_DIMS),
@@ -480,6 +508,61 @@ describe("connector", () => {
       const near = withZeroBox(xy.ZERO);
       const far = withZeroBox({ x: 5000, y: 5000 });
       expect(far).not.toEqual(near);
+    });
+  });
+
+  describe("facing handles do not produce a self-crossing pigtail", () => {
+    // When two handles point at each other and the nodes are dragged close enough
+    // that their stubs cross, the connector must not fold back over itself. It must
+    // still terminate exactly on the target.
+    const SOURCE = { x: 0, y: 0 };
+    const buildProps = (target: xy.XY): Segmented.BuildNew => ({
+      sourcePos: SOURCE,
+      targetPos: target,
+      sourceOrientation: "right",
+      targetOrientation: "left",
+      sourceBox: box.construct({ x: -40, y: -15 }, { width: 40, height: 30 }),
+      targetBox: box.construct(
+        { x: target.x, y: target.y - 15 },
+        { width: 40, height: 30 },
+      ),
+    });
+
+    interface Spec {
+      name: string;
+      target: xy.XY;
+    }
+
+    const SPECS: Spec[] = [
+      { name: "directly above, stubs overlap", target: { x: 0, y: -20 } },
+      { name: "directly below, stubs overlap", target: { x: 0, y: 20 } },
+      { name: "slightly right and above", target: { x: 10, y: -20 } },
+      { name: "slightly right and below", target: { x: 10, y: 20 } },
+      { name: "nearly aligned right and above", target: { x: 15, y: -15 } },
+      { name: "closer than a single stub", target: { x: 5, y: -25 } },
+    ];
+
+    for (const { name, target } of SPECS)
+      it(name, () => {
+        const conn = Segmented.createConnector(buildProps(target));
+        const points = Segmented.segmentsToPoints(SOURCE, conn, 1, false);
+        expect(selfCrosses(points)).toBe(false);
+        expect(Segmented.travelSegments(SOURCE, ...conn)).toEqual(target);
+      });
+
+    it("sweeps the close range without ever self-crossing", () => {
+      for (let dx = 0; dx <= 15; dx += 5)
+        for (let dy = -40; dy <= 40; dy += 5) {
+          if (dx === 0 && dy === 0) continue;
+          const target = { x: dx, y: dy };
+          const conn = Segmented.createConnector(buildProps(target));
+          const points = Segmented.segmentsToPoints(SOURCE, conn, 1, false);
+          expect(selfCrosses(points), `dx=${dx} dy=${dy}`).toBe(false);
+          expect(
+            Segmented.travelSegments(SOURCE, ...conn),
+            `dx=${dx} dy=${dy}`,
+          ).toEqual(target);
+        }
     });
   });
 

--- a/pluto/src/schematic/edge/common/segmented/connector.spec.ts
+++ b/pluto/src/schematic/edge/common/segmented/connector.spec.ts
@@ -448,6 +448,41 @@ describe("connector", () => {
       });
   });
 
+  describe("go-around routing is anchored to the node box", () => {
+    // The connection-line preview routes a "go around the node" segment via
+    // prepareNode, which reads the node's edge from the source/target boxes. When
+    // box.ZERO is supplied that edge resolves to the world origin instead of the node,
+    // so the segment's length scales with the node's absolute position and the preview
+    // shoots off-screen. With a real box the routing is translation-invariant.
+    const NODE_DIMS = { width: 40, height: 40 };
+    const buildProps = (offset: xy.XY): Segmented.BuildNew => ({
+      sourceOrientation: "right",
+      targetOrientation: "left",
+      sourcePos: xy.translate({ x: 540, y: 100 }, offset),
+      targetPos: xy.translate({ x: 400, y: 300 }, offset),
+      sourceBox: box.construct(xy.translate({ x: 500, y: 80 }, offset), NODE_DIMS),
+      targetBox: box.construct(xy.translate({ x: 360, y: 280 }, offset), NODE_DIMS),
+    });
+
+    it("produces the same shape regardless of the node's absolute position", () => {
+      const atOrigin = Segmented.createConnector(buildProps(xy.ZERO));
+      const farAway = Segmented.createConnector(buildProps({ x: 5000, y: 5000 }));
+      expect(farAway).toEqual(atOrigin);
+    });
+
+    it("anchors the go-around segment to the node and not the world origin", () => {
+      const withZeroBox = (offset: xy.XY): Segmented.Segment[] =>
+        Segmented.createConnector({
+          ...buildProps(offset),
+          sourceBox: box.ZERO,
+          targetBox: box.ZERO,
+        });
+      const near = withZeroBox(xy.ZERO);
+      const far = withZeroBox({ x: 5000, y: 5000 });
+      expect(far).not.toEqual(near);
+    });
+  });
+
   describe("dragging segments", () => {
     interface Spec {
       name: string;

--- a/pluto/src/schematic/edge/common/segmented/connector.ts
+++ b/pluto/src/schematic/edge/common/segmented/connector.ts
@@ -361,6 +361,30 @@ const internalNewConnector = ({
     targetStumpTip = travelSegments(targetPos, targetStump);
   }
 
+  // When the handles face each other and the nodes are close enough that their stubs
+  // have crossed, there is no room to route between them: splitting the gap folds the
+  // path back over itself, and the per-node go-around logic below compounds it into a
+  // self-crossing loop. Approach the target perpendicular-first and drop the opposing
+  // stub instead, which honors the source stub without doubling back.
+  if (location.swap(sourceOrientation) === targetOrientation) {
+    const dir = direction.construct(sourceOrientation);
+    const stubsCrossed =
+      (targetStumpTip[dir] - sourceStumpTip[dir]) *
+        orientationMagnitude(sourceOrientation) <=
+      0;
+    if (stubsCrossed) {
+      const swappedDir = direction.swap(dir);
+      return [
+        sourceStump,
+        {
+          direction: swappedDir,
+          length: targetPos[swappedDir] - sourceStumpTip[swappedDir],
+        },
+        { direction: dir, length: targetPos[dir] - sourceStumpTip[dir] },
+      ];
+    }
+  }
+
   const segments = [sourceStump];
   const extraSourceSeg = prepareNode({
     sourceStumpTip,

--- a/pluto/src/vis/diagram/Diagram.tsx
+++ b/pluto/src/vis/diagram/Diagram.tsx
@@ -67,7 +67,7 @@ import {
   type Viewport,
 } from "@/vis/diagram/aether/types";
 import { Context } from "@/vis/diagram/Context";
-import { calculateCursorPosition } from "@/vis/diagram/util";
+import { calculateCursorPosition, internalNodeBox } from "@/vis/diagram/util";
 
 export interface NodeProps {
   nodeKey: string;
@@ -229,6 +229,8 @@ export const create = ({
           connectionLineRenderer({
             source: diagram.createEndpoint(rf.fromX, rf.fromY, rf.fromPosition),
             target: diagram.createEndpoint(rf.toX, rf.toY, rf.toPosition),
+            sourceBox: internalNodeBox(rf.fromNode),
+            targetBox: internalNodeBox(rf.toNode),
             status: rf.connectionStatus,
             style: rf.connectionLineStyle ?? {},
           })

--- a/pluto/src/vis/diagram/aether/types.ts
+++ b/pluto/src/vis/diagram/aether/types.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { box, dimensions, id, type location, xy } from "@synnaxlabs/x";
+import { type box, dimensions, id, type location, xy } from "@synnaxlabs/x";
 import type * as rf from "@xyflow/react";
 import { MarkerType } from "@xyflow/react";
 import type React from "react";

--- a/pluto/src/vis/diagram/aether/types.ts
+++ b/pluto/src/vis/diagram/aether/types.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { dimensions, id, type location, xy } from "@synnaxlabs/x";
+import { box, dimensions, id, type location, xy } from "@synnaxlabs/x";
 import type * as rf from "@xyflow/react";
 import { MarkerType } from "@xyflow/react";
 import type React from "react";
@@ -196,6 +196,8 @@ export interface EdgeProps {
 export interface ConnectionLineProps {
   source: EdgeEndpoint;
   target: EdgeEndpoint;
+  sourceBox: box.Box;
+  targetBox: box.Box;
   status: "valid" | "invalid" | null;
   style: React.CSSProperties;
 }

--- a/pluto/src/vis/diagram/util.spec.ts
+++ b/pluto/src/vis/diagram/util.spec.ts
@@ -1,0 +1,37 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { box, xy } from "@synnaxlabs/x";
+import { type InternalNode } from "@xyflow/react";
+import { describe, expect, it } from "vitest";
+
+import { internalNodeBox } from "@/vis/diagram/util";
+
+const node = (
+  positionAbsolute: xy.XY,
+  measured: { width?: number; height?: number },
+): InternalNode =>
+  ({ measured, internals: { positionAbsolute } }) as unknown as InternalNode;
+
+describe("internalNodeBox", () => {
+  it("builds a flow-coordinate box from the node's absolute position and dimensions", () => {
+    const b = internalNodeBox(node({ x: 500, y: 80 }, { width: 40, height: 30 }));
+    expect(box.topLeft(b)).toEqual(xy.construct(500, 80));
+    expect(box.width(b)).toEqual(40);
+    expect(box.height(b)).toEqual(30);
+  });
+
+  it("returns box.ZERO when the node is null", () => {
+    expect(internalNodeBox(null)).toEqual(box.ZERO);
+  });
+
+  it("returns box.ZERO when the node has not been measured yet", () => {
+    expect(internalNodeBox(node({ x: 500, y: 80 }, {}))).toEqual(box.ZERO);
+  });
+});

--- a/pluto/src/vis/diagram/util.ts
+++ b/pluto/src/vis/diagram/util.ts
@@ -8,7 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { box, dimensions, location, scale, xy } from "@synnaxlabs/x";
-import { type ReactFlowInstance } from "@xyflow/react";
+import { type InternalNode, type ReactFlowInstance } from "@xyflow/react";
 
 import { type Diagram } from ".";
 
@@ -16,6 +16,16 @@ export const selectNode = (key: string): HTMLDivElement => {
   const el = document.querySelector(`[data-id="${key}"]`);
   if (el == null) throw new Error(`[diagram] - cannot find node with key: ${key}`);
   return el as HTMLDivElement;
+};
+
+/// @returns the box, in flow coordinates, occupied by the given react-flow internal
+/// node. Returns box.ZERO when the node is null or has not been measured yet, which is
+/// the case for the connection target while the user is dragging over empty space.
+export const internalNodeBox = (node: InternalNode | null): box.Box => {
+  if (node == null) return box.ZERO;
+  const { width, height } = node.measured;
+  if (width == null || height == null) return box.ZERO;
+  return box.construct(node.internals.positionAbsolute, { width, height });
 };
 
 export const selectNodeBox = (flow: ReactFlowInstance, key: string): box.Box => {


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4256](https://linear.app/synnax/issue/SY-4256)

## Description

Two related schematic edge-routing fixes.

### 1. Connection-line preview used the wrong node boxes

While dragging to create an edge, the connection-line preview would sometimes shoot far off-screen, even though the edge looked correct the moment it was released.

The preview and the finalized edge share the same `createConnector` router, but the preview passed `box.ZERO` for both node boxes. Those boxes feed `prepareNode`'s "route around the node" logic, which reads the node's edge via `box.loc(sourceBox, ...)`. With a zero-sized box at the world origin, the wrap segment's length resolves relative to `(0, 0)` instead of the node, so its magnitude scaled with the node's absolute position. On release the real box is supplied, so the same math produced a small, correct segment.

Fix:
- `internalNodeBox` (new helper in `vis/diagram/util.ts`) builds a flow-coordinate box from a react-flow `InternalNode`, falling back to `box.ZERO` for a null/unmeasured node (cursor over empty space).
- `ConnectionLineProps` now carries `sourceBox`/`targetBox`; the diagram adapter derives them from `rf.fromNode`/`rf.toNode`.
- `ConnectionLine` passes the real boxes into `createConnector`.

### 2. Self-crossing "pigtail" when facing handles are dragged close

When two handles point at each other (e.g. `right`↔`left`) and the nodes are dragged close enough that their 10px stubs cross, `createConnector` produced a self-intersecting loop. Splitting the gap between the facing stubs yields negative half-segments, and `prepareNode` firing on both nodes (each "going around" the other) compounds it into a loop. A freshly drawn edge has no stored middle, so it re-routes via `createConnector` every frame while you position the node.

Fix: detect the facing-and-crossed condition from the original stub tips, before `prepareNode` runs, and short-circuit to a perpendicular-first approach that drops the opposing stub. Honoring both stubs once they overlap is geometrically impossible without doubling back; this keeps the path free of self-crossings and always lands exactly on the target. Cases with room between the stubs are unchanged.

## Test Plan

- `connector.spec.ts` "facing handles do not produce a self-crossing pigtail": named cases plus a close-range sweep, each asserting no self-intersection (non-adjacent segment overlap) and exact termination on the target. These fail against the unfixed router and pass after the fix.
- `connector.spec.ts` "go-around routing is anchored to the node box": connector is translation-invariant with real boxes and position-dependent with `box.ZERO` (covers fix #1).
- `util.spec.ts`: `internalNodeBox` builds the correct box and falls back to `box.ZERO` for null/unmeasured nodes.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two related schematic edge-routing bugs: a connection-line preview that shot off-screen because it always passed `box.ZERO` as node bounds into `createConnector`, and a self-crossing \"pigtail\" loop produced when facing handles (e.g. `right`↔`left`) were dragged so close that their 10 px stubs overlapped.

- **Fix 1 – preview boxes**: introduces `internalNodeBox` in `util.ts` to extract flow-coordinate bounds from a react-flow `InternalNode`, wires `sourceBox`/`targetBox` through `ConnectionLineProps`, and passes them into the live `createConnector` call instead of `box.ZERO`.
- **Fix 2 – pigtail short-circuit**: in `internalNewConnector`, detects the facing-and-crossed condition from stub tips before `prepareNode` runs, and returns a clean three-segment perpendicular-first path that drops the conflicting opposing stub, eliminating the self-intersection.
- Both fixes ship with targeted unit tests (`util.spec.ts` for the helper, new `connector.spec.ts` groups for the crossing detector and translation-invariance check).

<h3>Confidence Score: 5/5</h3>

Safe to merge — both fixes are narrow and well-contained, and the existing connector routing for non-degenerate cases is untouched.

The facing-stub early return is geometrically correct for all four orientation pairs, accounts for the stub-adjustment block that runs before it, and always terminates exactly on the target. `internalNodeBox` correctly handles null and unmeasured nodes. Both fixes are covered by targeted unit tests that would have caught the original bugs, and the sweep test exercises the close-range space that originally produced pigtails.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pluto/src/schematic/edge/common/segmented/connector.ts | Adds a facing-and-crossed early-return path in `internalNewConnector` that produces a self-intersection-free three-segment route; logic is geometrically sound and accounts for the stub-adjustment block that runs before it. |
| pluto/src/vis/diagram/util.ts | New `internalNodeBox` helper correctly reads `internals.positionAbsolute` and `measured` dimensions, falls back to `box.ZERO` for null or unmeasured nodes. |
| pluto/src/vis/diagram/Diagram.tsx | Wires `internalNodeBox(rf.fromNode)` and `internalNodeBox(rf.toNode)` into the connection-line renderer call; straightforward plumbing change. |
| pluto/src/schematic/edge/common/ConnectionLine.tsx | Accepts `sourceBox`/`targetBox` from props and forwards them to `createConnector`, replacing the previous `box.ZERO` hardcoded values; `box` import correctly removed. |
| pluto/src/vis/diagram/aether/types.ts | Adds `sourceBox: box.Box` and `targetBox: box.Box` to `ConnectionLineProps`; type-only change, correctly imports `box` from `@synnaxlabs/x`. |
| pluto/src/schematic/edge/common/segmented/connector.spec.ts | Adds two new describe blocks: translation-invariance test for go-around routing, and a named + sweep suite for the facing-handle pigtail fix; `selfCrosses` utility is correct for the tested scenarios. |
| pluto/src/vis/diagram/util.spec.ts | New test file covering `internalNodeBox` for the happy path, null input, and unmeasured node; complete coverage of all branches. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Diagram.tsx\nConnectionLine renderer"] -->|"internalNodeBox(rf.fromNode)\ninternalNodeBox(rf.toNode)"| B["util.ts\ninternalNodeBox()"]
    B -->|"node == null\nor unmeasured"| C["box.ZERO fallback"]
    B -->|"valid node"| D["box.construct(\n  positionAbsolute,\n  measured dims)"]
    A -->|"sourceBox, targetBox\npassed in props"| E["ConnectionLineProps\n(types.ts)"]
    E --> F["ConnectionLine.tsx\ncreateConnector(props)"]
    F --> G["connector.ts\ninternalNewConnector()"]
    G --> H{"Facing handles\nlocation.swap(src) === tgt?"}
    H -->|"No"| I["Normal routing\nprepareNode + go-around"]
    H -->|"Yes"| J{"Stubs crossed?\ntipDelta × magnitude ≤ 0"}
    J -->|"No - room to route"| I
    J -->|"Yes - stubs overlap"| K["3-segment perpendicular-first\npath, drops opposing stub"]
    I --> L["compressSegments()"]
    K --> L
    L --> M["Final Segment[]"]
```

<sub>Reviews (3): Last reviewed commit: ["SY-4256: Use type-only import for box in..."](https://github.com/synnaxlabs/synnax/commit/df30982857f5c56d9292473663a87189ebefd740) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34504107)</sub>

<!-- /greptile_comment -->