### PR TITLE
SY-4258: Fix Flaky Windows Storage Layer Test

### DIFF
--- a/core/pkg/storage/layer_test.go
+++ b/core/pkg/storage/layer_test.go
@@ -31,9 +31,11 @@ var _ = Describe("storage", func() {
 		)
 		BeforeEach(func() {
 			tempDir = MustSucceed(os.MkdirTemp("", "synnax-test"))
+			// DeferCleanup runs after the layer's Close, whereas an AfterEach would
+			// fire while files are still open and fail RemoveAll on Windows.
+			DeferCleanup(func() { Expect(os.RemoveAll(tempDir)).To(Succeed()) })
 			cfg = storage.LayerConfig{Dirname: filepath.Join(tempDir, "storage")}
 		})
-		AfterEach(func() { Expect(os.RemoveAll(tempDir)).ToNot(HaveOccurred()) })
 		Describe("Acquiring a lock", func() {
 			It("Should return an error if the lock is already acquired", func(ctx SpecContext) {
 				MustOpen(storage.OpenLayer(ctx, cfg))


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4258](https://linear.app/synnax/issue/SY-4258)

## Description

The `storage` suite's "Acquiring a lock" spec was failing on Windows CI (passing on Ubuntu/macOS) during its `AfterEach`:

```
unlinkat C:\...\synnax-test...\storage\kv\000002.log: The process cannot access the file because it is being used by another process.
```

The spec opens a storage layer (via `MustOpen`, which schedules `Close` through `DeferCleanup`), asserts a second open fails on the directory lock, and relied on a container-level `AfterEach(os.RemoveAll(tempDir))` to clean up.

Ginkgo runs **all static `AfterEach` nodes before any `DeferCleanup`** (confirmed in `ginkgo/internal/group.go`: `DeferCleanup` nodes are only included after the static after-nodes are exhausted). So `os.RemoveAll(tempDir)` ran while the layer was still open, holding the pebble WAL and `LOCK` file. On Linux/macOS this succeeds because POSIX allows unlinking open files; on Windows deleting an open file fails, so the failure was deterministic there rather than truly flaky.

The fix moves the temp-directory removal from `AfterEach` to a `DeferCleanup` registered in `BeforeEach`. `DeferCleanup` callbacks run in reverse registration order, so the layer's `Close` (registered later, in the `It`) now runs before the directory removal (registered earlier, in `BeforeEach`). This also matches the codebase convention of handling teardown via `DeferCleanup` rather than closing resources in `AfterEach`.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a Windows-only CI failure in the storage layer tests by correcting the teardown ordering. Ginkgo executes all static `AfterEach` nodes before any `DeferCleanup` callbacks, so the old `AfterEach(os.RemoveAll(tempDir))` ran while the pebble WAL and `LOCK` file were still held by an open storage layer — succeeding silently on POSIX but failing on Windows.

- Moves `os.RemoveAll(tempDir)` from `AfterEach` into a `DeferCleanup` registered in `BeforeEach`. Because `DeferCleanup` nodes execute in reverse registration order, the layer's `Close` (registered later, inside the `It` body via `MustOpen`) fires before the directory removal, fixing the Windows race.
- Updates the Gomega matcher from `ToNot(HaveOccurred())` to `To(Succeed())`, which is the idiomatic form for asserting on error return values.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a minimal, well-scoped test teardown fix that does not touch production code.

The fix correctly exploits Ginkgo's LIFO DeferCleanup ordering to ensure the storage layer is closed before the temp directory is removed. No production paths are affected, and the existing AfterEach(os.RemoveAll(p)) in the Existing Directory block is safe because the test there expects an open failure, so no layer handle is ever held open when that cleanup fires.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| core/pkg/storage/layer_test.go | Moves os.RemoveAll(tempDir) from a static AfterEach into a DeferCleanup registered in BeforeEach, ensuring the storage layer closes before the directory is deleted on Windows. Also tightens the Gomega assertion from ToNot(HaveOccurred()) to To(Succeed()). |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant G as Ginkgo Runner
    participant BE as BeforeEach
    participant IT as It (test body)
    participant AE as AfterEach / DeferCleanup

    Note over G: Before fix
    G->>BE: register tempDir
    G->>IT: MustOpen(layer) → DeferCleanup(layer.Close)
    G->>AE: static AfterEach → os.RemoveAll(tempDir)  ❌ layer still open on Windows
    AE->>AE: DeferCleanup(layer.Close)  runs after RemoveAll

    Note over G: After fix
    G->>BE: register tempDir + DeferCleanup(os.RemoveAll(tempDir))
    G->>IT: MustOpen(layer) → DeferCleanup(layer.Close)  [registered later]
    G->>AE: DeferCleanup(layer.Close)  runs first (LIFO)
    AE->>AE: DeferCleanup(os.RemoveAll(tempDir))  runs second ✅
```

<sub>Reviews (1): Last reviewed commit: ["SY-4258: Fix Flaky Windows Storage Layer..."](https://github.com/synnaxlabs/synnax/commit/b4b5659d1e718ff629de55af332237f29c1f2c0a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34594403)</sub>

<!-- /greptile_comment -->