### PR TITLE
SY-4257: Fix Flaky Aspen Pledge Tests

### DIFF
--- a/aspen/internal/cluster/pledge/pledge_test.go
+++ b/aspen/internal/cluster/pledge/pledge_test.go
@@ -81,10 +81,21 @@ var _ = Describe("PledgeServer", func() {
 
 		Context("No nodes Responding", func() {
 			It("Should submit round robin proposals at scaled intervals", func(ctx SpecContext) {
+				const numTransports = 4
+				tCtx, cancel := context.WithCancel(ctx)
+				defer cancel()
 				var (
-					peers         []address.Address
-					numTransports = 4
-					handler       = func(ctx context.Context, req pledge.Request) (pledge.Response, error) {
+					peers []address.Address
+					count int
+					// Terminate once we've observed two full round-robin cycles rather
+					// than on a wall-clock deadline. A short deadline races with coarse
+					// timer resolution (notably on Windows), where the retry ticker's
+					// first tick can fire after the deadline, yielding zero attempts.
+					handler = func(_ context.Context, req pledge.Request) (pledge.Response, error) {
+						count++
+						if count >= 2*numTransports {
+							cancel()
+						}
 						return req, errors.New("pledge failed")
 					}
 				)
@@ -93,20 +104,16 @@ var _ = Describe("PledgeServer", func() {
 					t.BindHandler(handler)
 					peers = append(peers, t.Address)
 				}
-				tCtx, cancel := context.WithTimeout(ctx, 10*time.Millisecond)
-				defer cancel()
-				res, err := pledge.Pledge(tCtx, baseConfig(net), pledge.Config{
+				Expect(pledge.Pledge(tCtx, baseConfig(net), pledge.Config{
 					Instrumentation: ins.Child("no-nodes-responding"),
 					Peers:           peers,
 					Candidates:      func() node.Group { return node.Group{} },
-				}, pledge.BlazingFastConfig)
-				Expect(err).To(MatchError(context.DeadlineExceeded))
-				Expect(res.Key).To(Equal(node.Key(0)))
+				}, pledge.BlazingFastConfig)).Error().To(MatchError(context.Canceled))
 				entries := net.Entries()
+				Expect(len(entries)).To(BeNumerically(">=", 2*numTransports))
 				for i, entry := range entries {
-					Expect(entry.Target).To(Equal(peers[i%4]))
+					Expect(entry.Target).To(Equal(peers[i%numTransports]))
 				}
-				Expect(entries).ToNot(HaveLen(0))
 			})
 		})
 	})
@@ -122,13 +129,15 @@ var _ = Describe("PledgeServer", func() {
 				candidates := allCandidates(nodes)
 				tCtx, cancel := context.WithTimeout(ctx, 150*time.Millisecond)
 				defer cancel()
-				res, err := pledge.Pledge(tCtx, baseConfig(net), pledge.Config{
+				res := MustSucceed(pledge.Pledge(tCtx, baseConfig(net), pledge.Config{
 					Instrumentation: ins.Child("cluster-state-synchronized"),
 					Peers:           nodes.Addresses(),
 					Candidates:      candidates,
-				}, pledge.BlazingFastConfig)
-				Expect(err).To(BeNil())
-				Expect(res.Key).To(Equal(node.Key(10)))
+				}, pledge.BlazingFastConfig))
+				// The pledge algorithm may assign a marginally higher key than the
+				// minimum when a quorum consultation hits a transient timeout and the
+				// responsible retries with an incremented proposal (see pledge.go).
+				Expect(res.Key).To(BeNumerically(">=", node.Key(10)))
 			})
 		})
 		Context("Responsible is Missing UniqueLeaseholders", func() {
@@ -149,7 +158,7 @@ var _ = Describe("PledgeServer", func() {
 				nodes = provisionCandidates(10, net, nodes, candidates, nil)
 				tCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
 				defer cancel()
-				res, err := pledge.Pledge(
+				res := MustSucceed(pledge.Pledge(
 					tCtx,
 					baseConfig(net),
 					pledge.Config{
@@ -157,9 +166,8 @@ var _ = Describe("PledgeServer", func() {
 						Peers:      []address.Address{nodes[0].Address},
 					},
 					pledge.BlazingFastConfig,
-				)
-				Expect(err).To(BeNil())
-				Expect(res.Key).To(Equal(node.Key(10)))
+				))
+				Expect(res.Key).To(BeNumerically(">=", node.Key(10)))
 			})
 		})
 		Context("One juror are aware of a new node", func() {
@@ -179,7 +187,7 @@ var _ = Describe("PledgeServer", func() {
 				}, nil)
 				tCtx, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
 				defer cancel()
-				res, err := pledge.Pledge(
+				res := MustSucceed(pledge.Pledge(
 					tCtx,
 					baseConfig(net),
 					pledge.Config{
@@ -188,8 +196,7 @@ var _ = Describe("PledgeServer", func() {
 						Candidates:      extraCandidates,
 					},
 					pledge.BlazingFastConfig,
-				)
-				Expect(err).To(BeNil())
+				))
 				Expect(res.Key).To(BeNumerically(">=", node.Key(11)))
 			})
 		})


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4257](https://linear.app/synnax/issue/SY-4257)

## Description

Two pledge specs in `aspen/internal/cluster/pledge` flaked on the 0.56.0 release CI (Ubuntu and Windows). Both asserted exact, timing-sensitive outcomes against an algorithm that is intentionally non-deterministic under load.

**`Responsible is Missing UniqueLeaseholders` (Ubuntu — expected key 10, got 11).** The pledge algorithm deliberately assigns marginally higher keys on retry: when a quorum consultation hits a transient timeout (`BlazingFastConfig.RequestTimeout` is only 5ms), the responsible increments its proposed key and retries. Under CI load the assigned key drifts upward, so an exact `Equal(node.Key(10))` assertion is wrong. Changed this and the sibling `Cluster State is Synchronized` test to `BeNumerically(">=", ...)`, matching the behavior documented in `pledge.go` and the existing `One juror are aware of a new node` test.

**`No nodes Responding` (Windows — zero requests recorded).** The test bounded the pledge loop with a 10ms deadline and a 1µs `ScaledTicker`. On Windows, coarse timer resolution can delay the ticker's first tick past the deadline, so the loop returns before sending any request. Reworked the test to terminate on observed work — it cancels after two full round-robin cycles — rather than on a wall-clock deadline, removing the timer-resolution race entirely while still validating round-robin ordering.

Also converted the success-path assertions to `MustSucceed(...)` per the repo's Ginkgo conventions.

Verified with 60 sequential repeats plus parallel `--until-it-fails` rounds under `-p --race`, all green.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two flaky test specs in `aspen/internal/cluster/pledge` by removing timing-sensitive assertions that assumed deterministic outcomes from a deliberately non-deterministic algorithm. The changes are confined to the test file.

- **\"No nodes Responding\"**: Replaces a 10 ms `WithTimeout` deadline (which races with Windows coarse timer resolution) with a `WithCancel` context that terminates after exactly `2*numTransports` handler invocations, validating round-robin behavior via observed work rather than wall-clock time. The error expectation updates from `DeadlineExceeded` to `Canceled` accordingly.
- **\"Cluster State is Synchronized\" and \"Responsible is Missing UniqueLeaseholders\"**: Relaxes `Equal(node.Key(10))` to `BeNumerically(\">=\", node.Key(10))`, reflecting the algorithm's documented retry-with-increment behavior that can assign marginally higher keys under load. Both success-path results are also wrapped with `MustSucceed` per the repo's Ginkgo conventions.

<h3>Confidence Score: 5/5</h3>

Safe to merge — only modifies test assertions to remove spurious timer-dependent failures with no production code touched.

The work-based cancellation in 'No nodes Responding' is a clean, deterministic replacement for the wall-clock deadline: cancel() fires synchronously inside the handler on the 8th call, Pledge sees ctx.Err() non-nil immediately after that Send returns, so the exit path is guaranteed regardless of OS timer resolution. The relaxed >= assertions match the algorithm's documented retry-with-increment behavior and are consistent with the existing test. The count variable is accessed serially, consistent with 60-run and --race verification.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| aspen/internal/cluster/pledge/pledge_test.go | Test-only change: removes timing-sensitive assertions that caused flakes on CI, replaces wall-clock deadline with work-based cancellation for the Windows-unsafe test, and adopts MustSucceed for success paths. |

</details>

<sub>Reviews (1): Last reviewed commit: ["SY-4257: Fix Flaky Aspen Pledge Tests"](https://github.com/synnaxlabs/synnax/commit/4205b53f6fd9c9c2c0205ea3fdaddba8e81a61ba) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34594436)</sub>

<!-- /greptile_comment -->