### PR TITLE
SY-4217: Fix Custom Schematic Symbol Editor

### DIFF
--- a/.copyrightignore
+++ b/.copyrightignore
@@ -14,4 +14,5 @@ driver/ethercat/igh/ecrt.h
 
 # Test fixtures and third-party assets
 integration/tests/fixtures/test_symbol.svg
+integration/tests/fixtures/styled_symbol.svg
 docs/site/public/images/us-flag.svg

--- a/console/src/schematic/symbols/edit/FileDrop.tsx
+++ b/console/src/schematic/symbols/edit/FileDrop.tsx
@@ -8,7 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { Flex, Haul, Icon, Status, Text } from "@synnaxlabs/pluto";
-import { caseconv } from "@synnaxlabs/x";
+import { caseconv, type status } from "@synnaxlabs/x";
 import { type ReactElement, useState } from "react";
 
 import { CSS } from "@/css";
@@ -16,6 +16,14 @@ import { Runtime } from "@/runtime";
 
 const canDrop: Haul.CanDrop = ({ items }) =>
   items.some((item) => item.type === Haul.FILE_TYPE) && items.length === 1;
+
+const isSVGFile = (name: string): boolean => name.toLowerCase().endsWith(".svg");
+
+const INVALID_FILE_TYPE_STATUS: status.Crude = {
+  variant: "error",
+  message: "Invalid file type. Expected an SVG file.",
+};
+
 export interface FileDropProps extends Flex.BoxProps {
   onContentsChange: (contents: string, filename?: string) => void;
   enabled?: boolean;
@@ -37,8 +45,8 @@ export const FileDrop = ({
     if (event.dataTransfer.files.length === 0) return items;
 
     const file = event.dataTransfer.files[0];
-    if (!file.name.toLowerCase().endsWith(".svg")) {
-      addStatus({ message: "Invalid file type", variant: "error" });
+    if (!isSVGFile(file.name)) {
+      addStatus(INVALID_FILE_TYPE_STATUS);
       return items;
     }
 
@@ -58,6 +66,10 @@ export const FileDrop = ({
       });
       if (files == null) return;
       const [file] = files;
+      if (!isSVGFile(file.name)) {
+        addStatus(INVALID_FILE_TYPE_STATUS);
+        return;
+      }
       const contents = await file.read();
       const nameWithoutExt = file.name.replace(/\.svg$/i, "");
       const properName =

--- a/console/src/schematic/symbols/edit/Preview.tsx
+++ b/console/src/schematic/symbols/edit/Preview.tsx
@@ -25,22 +25,6 @@ interface PreviewProps {
   onHandlePlace: (handleKey: string, position: { x: number; y: number }) => void;
 }
 
-const preprocessSVG = (svgString: string): string => {
-  const parser = new DOMParser();
-  const svgDoc = parser.parseFromString(svgString, "image/svg+xml");
-  const svgElement = svgDoc.documentElement;
-
-  const addRegionIds = (el: Element) => {
-    if (!(el instanceof SVGElement) || el.tagName === "svg") return;
-    if (!el.id && !el.getAttribute("data-region-id"))
-      el.setAttribute("data-region-id", `region-${id.create()}`);
-    Array.from(el.children).forEach(addRegionIds);
-  };
-  Array.from(svgElement.children).forEach(addRegionIds);
-  const serializer = new XMLSerializer();
-  return serializer.serializeToString(svgElement);
-};
-
 export const Preview = ({
   selectedState,
   selectedHandle,
@@ -195,7 +179,7 @@ export const Preview = ({
 
   const form = Form.useContext();
   const handleContentsChange = (contents: string, filename?: string) => {
-    const processedSVG = preprocessSVG(contents);
+    const processedSVG = Schematic.Node.Region.normalizeSVG(contents);
     if (containerRef.current == null) return;
     onContentsChange(processedSVG);
 

--- a/integration/console/schematic/symbol_editor.py
+++ b/integration/console/schematic/symbol_editor.py
@@ -105,20 +105,26 @@ class SymbolEditor:
         )
         self.wait_for_form_visible()
 
-    def set_region_stroke_color(self, hex_color: str, region_index: int = 0) -> None:
-        """Set the stroke color for a region.
-
-        Args:
-            hex_color: Hex color string (e.g., "#FF0000" or "FF0000").
-            region_index: Index of the region (0-based).
-        """
-        region_items = self.page.locator(".pluto-list__item").filter(
+    def _region_rows(self) -> Locator:
+        """Locate the region rows (the only list items carrying color swatches)."""
+        return self.page.locator(".pluto-list__item").filter(
             has=self.page.locator(".pluto-color-swatch")
         )
-        region_item = region_items.nth(region_index)
-        stroke_swatch = region_item.locator(".pluto-color-swatch").first
-        stroke_swatch.click()
 
+    def region_count(self) -> int:
+        """Return the number of detected regions."""
+        return self._region_rows().count()
+
+    def _set_region_color(
+        self, swatch_index: int, hex_color: str, region_index: int
+    ) -> None:
+        swatch = (
+            self._region_rows()
+            .nth(region_index)
+            .locator(".pluto-color-swatch")
+            .nth(swatch_index)
+        )
+        swatch.click()
         color_picker = self.page.locator(".pluto-color-picker-container")
         color_picker.wait_for(state="visible", timeout=2000)
         hex_input = color_picker.locator(".sketch-picker input").first
@@ -127,6 +133,64 @@ class SymbolEditor:
         self.page.keyboard.press("Enter")
         self.page.keyboard.press("Escape")
         color_picker.wait_for(state="hidden", timeout=2000)
+
+    def set_region_stroke_color(self, hex_color: str, region_index: int = 0) -> None:
+        """Set the stroke color for a region (the first swatch in the row).
+
+        Args:
+            hex_color: Hex color string (e.g., "#FF0000" or "FF0000").
+            region_index: Index of the region (0-based).
+        """
+        self._set_region_color(0, hex_color, region_index)
+
+    def set_region_fill_color(self, hex_color: str, region_index: int = 0) -> None:
+        """Set the fill color for a region (the second swatch in the row).
+
+        Args:
+            hex_color: Hex color string (e.g., "#FF0000" or "FF0000").
+            region_index: Index of the region (0-based).
+        """
+        self._set_region_color(1, hex_color, region_index)
+
+    def get_preview_fill(self, selector: str) -> str:
+        """Return the computed fill (e.g. "rgb(255, 0, 0)") of a rendered preview shape.
+
+        Args:
+            selector: A CSS selector resolved within the rendered preview SVG.
+        """
+        el = self.page.locator(f".console-preview svg {selector}").first
+        el.wait_for(state="attached", timeout=5000)
+        return str(el.evaluate("(el) => getComputedStyle(el).fill"))
+
+    def assert_preview_fill(
+        self, selector: str, expected_rgb: str, timeout: int = 5000
+    ) -> None:
+        """Wait until a rendered preview shape resolves to the expected computed fill.
+
+        Args:
+            selector: A CSS selector resolved within the rendered preview SVG.
+            expected_rgb: The expected computed fill, e.g. "rgb(255, 0, 0)".
+        """
+        self.page.wait_for_function(
+            """([sel, exp]) => {
+                const el = document.querySelector('.console-preview svg ' + sel);
+                return el != null && getComputedStyle(el).fill === exp;
+            }""",
+            arg=[selector, expected_rgb],
+            timeout=timeout,
+        )
+
+    def assert_preview_width(self, expected: float, timeout: int = 5000) -> None:
+        """Wait until the rendered preview SVG reaches the expected width attribute."""
+        self.page.wait_for_function(
+            """(exp) => {
+                const svg = document.querySelector('.console-preview svg');
+                if (svg == null) return false;
+                return Math.abs(parseFloat(svg.getAttribute('width')) - exp) < 0.5;
+            }""",
+            arg=expected,
+            timeout=timeout,
+        )
 
     def add_handle(self) -> None:
         """Add a new connection handle."""

--- a/integration/tests/console/schematic/custom_symbols.py
+++ b/integration/tests/console/schematic/custom_symbols.py
@@ -19,6 +19,7 @@ from framework.utils import get_fixture_path
 from x import random_name
 
 TEST_SYMBOL_SVG = get_fixture_path("test_symbol.svg")
+STYLED_SYMBOL_SVG = get_fixture_path("styled_symbol.svg")
 
 
 class CustomSymbols(ConsoleCase):
@@ -80,6 +81,8 @@ class CustomSymbols(ConsoleCase):
         self.test_create_symbol_group(toolbar)
         self.test_rename_symbol_group(toolbar)
 
+        self.test_styled_symbol_applies_to_preview(toolbar)
+
         self.test_create_symbol(schematic, toolbar)
         self.test_rename_symbol(toolbar)
         self.test_rename_symbol_via_editor(toolbar)
@@ -110,6 +113,50 @@ class CustomSymbols(ConsoleCase):
             f"Group '{new_name}' should exist after rename"
         )
         self.test_group_name = new_name
+
+    def test_styled_symbol_applies_to_preview(self, toolbar: SymbolToolbar) -> None:
+        """Editing a styled symbol's colors and scale must update the live preview.
+
+        Regression for SY-4217. Real-world logo SVGs define colors via inline
+        style="fill:..." and <style> class rules, both of which outrank the
+        presentation attribute the renderer writes - so color edits used to compute
+        but never paint. Import now normalizes colors onto attributes (so overrides
+        win), strips <style> blocks (so they cannot leak), and excludes clip-path /
+        defs shapes from regions. This drives the editor exactly as a user would and
+        asserts on the rendered preview's computed colors.
+        """
+        self.log("Testing styled symbol normalization, recolor, and scale")
+        toolbar.select_group(self.test_group_name)
+        styled_name = f"Styled Symbol {self.suffix}"
+
+        editor = toolbar.create_symbol()
+        editor.upload_svg(STYLED_SYMBOL_SVG)
+
+        # Reading a preview shape waits for the preview to render before we inspect it.
+        # The rect's blue fill comes from an inline style; overriding it must paint.
+        assert editor.get_preview_fill("#body") != "rgb(255, 0, 0)"
+
+        # The clip-path shape must not surface as a phantom region: only the rect and
+        # the circle are painted.
+        assert editor.region_count() == 2, (
+            f"expected 2 regions (clip-path excluded), got {editor.region_count()}"
+        )
+
+        editor.set_region_fill_color("#FF0000", region_index=0)
+        editor.assert_preview_fill("#body", "rgb(255, 0, 0)")
+
+        # The circle's green fill comes from a <style> class rule; overriding it must
+        # paint once the block is stripped and the color flattened.
+        editor.set_region_fill_color("#FF00FF", region_index=1)
+        editor.assert_preview_fill("#badge", "rgb(255, 0, 255)")
+
+        # The default scale must resize the rendered preview (100 -> 50 at 50%).
+        editor.set_default_scale(50)
+        editor.assert_preview_width(50)
+
+        editor.set_name(styled_name)
+        editor.save()
+        toolbar.delete_symbol(styled_name)
 
     def test_create_symbol(self, schematic: Schematic, toolbar: SymbolToolbar) -> None:
         """Test creating a custom symbol with all properties set in the editor."""

--- a/integration/tests/fixtures/styled_symbol.svg
+++ b/integration/tests/fixtures/styled_symbol.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100" width="100" height="100">
+  <style>.brand { fill: #06ac38; }</style>
+  <defs>
+    <clipPath id="clip"><rect x="0" y="0" width="40" height="40" /></clipPath>
+  </defs>
+  <rect id="body" x="10" y="10" width="50" height="50" style="fill:#5a87c5" />
+  <circle id="badge" class="brand" cx="72" cy="72" r="18" />
+</svg>

--- a/pluto/src/schematic/node/common/custom/render.spec.tsx
+++ b/pluto/src/schematic/node/common/custom/render.spec.tsx
@@ -9,9 +9,11 @@
 
 import { type schematic } from "@synnaxlabs/client";
 import { type location } from "@synnaxlabs/x";
-import { renderHook } from "@testing-library/react";
+import { act, render, renderHook } from "@testing-library/react";
+import { type ReactElement } from "react";
 import { describe, expect, it, vi } from "vitest";
 
+import { Form } from "@/form";
 import { Custom } from "@/schematic/node/common/custom";
 
 const renderAttached = (args: Custom.UseRenderArgs, container: HTMLElement | null) => {
@@ -1086,5 +1088,219 @@ describe("Custom.useRender", () => {
       rerender({ activeState: "inactive" });
       expect(rect.getAttribute("fill")).toBe("#ff0000");
     });
+  });
+
+  // The symbol editor's form mutates its value object in place rather than
+  // producing a new reference on every change, so the same spec object is
+  // passed across rerenders. The diff must detect changes by value, not by
+  // object identity.
+  describe("in-place spec mutation", () => {
+    it("should update dimensions when the internal scale is mutated in place", () => {
+      const container = document.createElement("div");
+      const spec = createMockSpec();
+      const { result, rerender } = renderHook(() =>
+        Custom.useRender({
+          orientation: "top",
+          activeState: "inactive",
+          externalScale: 1,
+          spec,
+        }),
+      );
+      result.current(container);
+
+      const svg = container.querySelector("svg") as SVGSVGElement;
+      expect(svg.getAttribute("width")).toBe("100");
+
+      spec.scale = 2;
+      rerender();
+      expect(svg.getAttribute("width")).toBe("200");
+      expect(svg.getAttribute("height")).toBe("200");
+    });
+
+    it("should apply region color changes when a state is mutated in place", () => {
+      const container = document.createElement("div");
+      const spec = createMockSpec();
+      const { result, rerender } = renderHook(() =>
+        Custom.useRender({
+          orientation: "top",
+          activeState: "inactive",
+          externalScale: 1,
+          spec,
+        }),
+      );
+      result.current(container);
+
+      const rect = container.querySelector(".main") as SVGRectElement;
+      expect(rect.getAttribute("stroke")).toBe("#333");
+
+      spec.states[0].regions[0].strokeColor = "#abc";
+      rerender();
+      expect(rect.getAttribute("stroke")).toBe("#abc");
+    });
+
+    it("should toggle stroke scaling when scaleStroke is mutated in place", () => {
+      const container = document.createElement("div");
+      const spec = createMockSpec({ scaleStroke: false });
+      const { result, rerender } = renderHook(() =>
+        Custom.useRender({
+          orientation: "top",
+          activeState: "inactive",
+          externalScale: 1,
+          spec,
+        }),
+      );
+      result.current(container);
+
+      const rect = container.querySelector(".main") as SVGRectElement;
+      expect(rect.getAttribute("vector-effect")).toBe("non-scaling-stroke");
+
+      spec.scaleStroke = true;
+      rerender();
+      expect(rect.getAttribute("vector-effect")).toBeNull();
+    });
+  });
+
+  // When the SVG markup changes the element is re-parsed from scratch, discarding
+  // every derived attribute. All of them must be re-applied against the new DOM even
+  // when their own inputs (state, scaleStroke) are unchanged.
+  describe("re-application after SVG rebuild", () => {
+    it("should re-apply region colors to a rebuilt SVG with unchanged state", () => {
+      const container = document.createElement("div");
+      const { result, rerender } = renderHook(
+        ({ spec }) =>
+          Custom.useRender({
+            orientation: "top",
+            activeState: "inactive",
+            externalScale: 1,
+            spec,
+          }),
+        { initialProps: { spec: createMockSpec() } },
+      );
+      result.current(container);
+
+      expect(
+        (container.querySelector(".main") as SVGRectElement).getAttribute("stroke"),
+      ).toBe("#333");
+
+      rerender({
+        spec: createMockSpec({
+          svg: '<svg viewBox="0 0 100 100"><rect class="main" width="50" height="50" stroke="purple" fill="orange"/></svg>',
+        }),
+      });
+
+      const rebuilt = container.querySelector(".main") as SVGRectElement;
+      expect(rebuilt.getAttribute("stroke")).toBe("#333");
+      expect(rebuilt.getAttribute("fill")).toBe("#ccc");
+    });
+
+    it("should re-apply stroke scaling to a rebuilt SVG with unchanged scaleStroke", () => {
+      const container = document.createElement("div");
+      const { result, rerender } = renderHook(
+        ({ spec }) =>
+          Custom.useRender({
+            orientation: "top",
+            activeState: "inactive",
+            externalScale: 1,
+            spec,
+          }),
+        { initialProps: { spec: createMockSpec({ scaleStroke: false }) } },
+      );
+      result.current(container);
+      expect(
+        (container.querySelector(".main") as SVGRectElement).getAttribute(
+          "vector-effect",
+        ),
+      ).toBe("non-scaling-stroke");
+
+      rerender({
+        spec: createMockSpec({
+          scaleStroke: false,
+          svg: '<svg viewBox="0 0 100 100"><rect class="main" width="50" height="50" stroke="black" fill="white"/></svg>',
+        }),
+      });
+
+      expect(
+        (container.querySelector(".main") as SVGRectElement).getAttribute(
+          "vector-effect",
+        ),
+      ).toBe("non-scaling-stroke");
+    });
+  });
+});
+
+interface SymbolValues {
+  data: schematic.symbol.Spec;
+}
+
+const EDITOR_SVG =
+  '<svg viewBox="0 0 100 100"><rect data-region-id="rect-1" width="50" height="50" stroke="black" fill="white"/></svg>';
+
+const editorInitialValues = (): SymbolValues => ({
+  data: {
+    svg: "",
+    states: [{ key: "base", name: "Base", regions: [] }],
+    variant: "static",
+    handles: [],
+    scale: 1,
+    scaleStroke: false,
+    previewViewport: { zoom: 1, position: { x: 0, y: 0 } },
+  },
+});
+
+// Mirrors the editor's Preview: reads the live form spec and drives useRender with the
+// currently-selected state key as activeState. The editor's form mutates its value
+// object in place, so this exercises useRender through the real Form rather than a
+// hand-mutated spec.
+const PreviewLike = ({ activeState }: { activeState: string }): ReactElement => {
+  const spec = Form.useFieldValue<schematic.symbol.Spec>("data");
+  const setContainer = Custom.useRender({
+    orientation: "left",
+    activeState,
+    externalScale: 1,
+    spec,
+  });
+  return <div data-testid="container" ref={setContainer} />;
+};
+
+describe("custom symbol editor preview", () => {
+  it("should recolor a region when its color is edited through the form", () => {
+    let form!: Form.ContextValue<any>;
+    const Harness = (): ReactElement => {
+      form = Form.use<any>({ values: editorInitialValues() });
+      return (
+        <Form.Form {...form}>
+          <PreviewLike activeState="base" />
+        </Form.Form>
+      );
+    };
+
+    const { container } = render(<Harness />);
+
+    // Mimic the import flow: set the SVG first, then assign regions to the state by
+    // key in a separate commit, exactly as Preview.handleContentsChange does.
+    act(() => {
+      form.set("data.svg", EDITOR_SVG);
+    });
+    const region: schematic.symbol.Region = {
+      key: "region-1",
+      name: "Region 1",
+      selectors: ['[data-region-id="rect-1"]'],
+      strokeColor: "#000000",
+      fillColor: "#ffffff",
+    };
+    act(() => {
+      form.set("data.states.base.regions", [region]);
+    });
+
+    const rect = container.querySelector("rect") as SVGRectElement;
+    expect(rect).toBeTruthy();
+    expect(rect.getAttribute("stroke")).toBe("#000000");
+
+    // Editing the color the way RegionList does: set the keyed region path.
+    act(() => {
+      form.set("data.states.base.regions.region-1.strokeColor", "#ff0000");
+    });
+
+    expect(rect.getAttribute("stroke")).toBe("#ff0000");
   });
 });

--- a/pluto/src/schematic/node/common/custom/render.ts
+++ b/pluto/src/schematic/node/common/custom/render.ts
@@ -87,7 +87,9 @@ interface RenderState {
   baseDims: dimensions.Dimensions;
   prevExternalScale: number | undefined;
   prevOrientation: location.Outer | undefined;
-  prevSpecData: schematic.symbol.Spec | undefined;
+  prevSvg: string | undefined;
+  prevScale: number | undefined;
+  prevScaleStroke: boolean | undefined;
   prevState: schematic.symbol.State | undefined;
   prevStateOverrides: schematic.symbol.State[] | undefined;
 }
@@ -97,108 +99,145 @@ const createRenderState = (): RenderState => ({
   baseDims: { width: 0, height: 0 },
   prevExternalScale: undefined,
   prevOrientation: undefined,
-  prevSpecData: undefined,
+  prevSvg: undefined,
+  prevScale: undefined,
+  prevScaleStroke: undefined,
   prevState: undefined,
   prevStateOverrides: undefined,
 });
+
+// buildSVG parses the spec's markup into a fresh SVG element, records its base
+// dimensions, ensures its contents are wrapped in a single <g>, mounts it into the
+// container, and notifies onMount. The returned element starts from raw markup, so
+// every derived attribute (state colors, dimensions, stroke scaling) must be
+// re-applied by the caller afterwards.
+const buildSVG = (
+  container: HTMLElement,
+  state: RenderState,
+  spec: schematic.symbol.Spec,
+  onMount?: (svgElement: SVGSVGElement) => void,
+) => {
+  if (state.svgElement != null) {
+    state.svgElement.remove();
+    state.svgElement = null;
+  }
+  const parser = new DOMParser();
+  const doc = parser.parseFromString(spec.svg, "image/svg+xml");
+  const svgElement = doc.documentElement as unknown as SVGSVGElement;
+  state.svgElement = svgElement;
+
+  const viewBoxAttr = svgElement.getAttribute("viewBox");
+  if (viewBoxAttr) {
+    const [, , width, height] = viewBoxAttr.split(" ").map(Number);
+    state.baseDims = { width, height };
+  } else if (svgElement.viewBox?.baseVal)
+    state.baseDims = {
+      width: svgElement.viewBox.baseVal.width,
+      height: svgElement.viewBox.baseVal.height,
+    };
+  else state.baseDims = { width: 100, height: 100 };
+
+  const existingG = svgElement.querySelector("g");
+  if (!existingG) {
+    const gElement = doc.createElementNS("http://www.w3.org/2000/svg", "g");
+    const children = Array.from(svgElement.children);
+    children.forEach((child) => svgElement.removeChild(child));
+    children.forEach((child) => {
+      if (child !== gElement) gElement.appendChild(child);
+    });
+    svgElement.appendChild(gElement);
+  }
+  container.appendChild(svgElement);
+  onMount?.(svgElement);
+};
+
+const applyScale = (
+  state: RenderState,
+  orientation: location.Outer,
+  scale: number,
+  externalScale: number,
+) => {
+  if (state.svgElement == null) return;
+  let preScaledDims = state.baseDims;
+  if (direction.construct(orientation) === "y")
+    preScaledDims = dimensions.swap(preScaledDims);
+  const scaledDims = dimensions.scale(preScaledDims, scale * externalScale);
+  state.svgElement.setAttribute("width", scaledDims.width.toString());
+  state.svgElement.setAttribute("height", scaledDims.height.toString());
+  state.svgElement.setAttribute(
+    "viewBox",
+    `0 0 ${preScaledDims.width} ${preScaledDims.height}`,
+  );
+};
+
+const applyScaleStroke = (state: RenderState, scaleStroke: boolean) => {
+  if (state.svgElement == null) return;
+  const pathElements = state.svgElement.querySelectorAll(
+    "path, circle, rect, line, ellipse, polygon, polyline",
+  );
+  if (!scaleStroke)
+    pathElements.forEach((el) =>
+      el.setAttribute("vector-effect", "non-scaling-stroke"),
+    );
+  else pathElements.forEach((el) => el.removeAttribute("vector-effect"));
+};
 
 const runRender = (container: HTMLElement, args: UseRenderArgs, state: RenderState) => {
   const { orientation, activeState, externalScale, spec, onMount, stateOverrides } =
     args;
   if (spec == null || spec.svg.length === 0) return;
 
+  // useRender has two callers with opposite mutation models: the schematic node
+  // renderers receive a fresh spec reference from the flux cache on every update,
+  // while the symbol editor's form mutates a single spec object in place. Diffing by
+  // object identity is therefore wrong - it never detects the editor's in-place
+  // edits. Compare against value snapshots instead: primitives by value, states by
+  // deep equality.
   const externalScaleDiffers = state.prevExternalScale !== externalScale;
-  const svgDiffers = state.prevSpecData?.svg !== spec?.svg;
   const orientationDiffers = state.prevOrientation !== orientation;
-  const internalScaleDiffers = state.prevSpecData?.scale !== spec?.scale;
-  const scaleStrokeDiffers = state.prevSpecData?.scaleStroke !== spec?.scaleStroke;
-  const specDiffers = state.prevSpecData !== spec;
+  const svgDiffers = state.prevSvg !== spec.svg;
+  const scaleDiffers = state.prevScale !== spec.scale;
+  const scaleStrokeDiffers = state.prevScaleStroke !== spec.scaleStroke;
 
   const stateIndex = activeState === "active" ? 1 : 0;
   const currState = stateOverrides?.[stateIndex] ?? spec.states[stateIndex];
 
-  const stateDiffers = state.prevState !== currState;
+  const stateDiffers = !deep.equal(state.prevState, currState);
   const stateOverridesDiffers = !deep.equal(state.prevStateOverrides, stateOverrides);
-  const different =
-    externalScaleDiffers ||
-    svgDiffers ||
-    scaleStrokeDiffers ||
-    stateDiffers ||
-    stateOverridesDiffers;
-  if (!different) return;
-  if (externalScaleDiffers) state.prevExternalScale = externalScale;
-  if (orientationDiffers) state.prevOrientation = orientation;
-  if (specDiffers) state.prevSpecData = spec;
-  if (stateOverridesDiffers) state.prevStateOverrides = stateOverrides;
-  const { svg, scaleStroke, scale } = spec;
-  if (state.svgElement == null || svgDiffers) {
-    if (state.svgElement != null) {
-      state.svgElement.remove();
-      state.svgElement = null;
-    }
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(svg, "image/svg+xml");
-    const svgElement = doc.documentElement;
-    state.svgElement = svgElement as unknown as SVGSVGElement;
-
-    const viewBoxAttr = state.svgElement.getAttribute("viewBox");
-    if (viewBoxAttr) {
-      const [, , width, height] = viewBoxAttr.split(" ").map(Number);
-      state.baseDims = { width, height };
-    } else if (state.svgElement.viewBox?.baseVal)
-      state.baseDims = {
-        width: state.svgElement.viewBox.baseVal.width,
-        height: state.svgElement.viewBox.baseVal.height,
-      };
-    else state.baseDims = { width: 100, height: 100 };
-
-    const existingG = svgElement.querySelector("g");
-    if (!existingG) {
-      const gElement = doc.createElementNS("http://www.w3.org/2000/svg", "g");
-      const children = Array.from(svgElement.children);
-      children.forEach((child) => svgElement.removeChild(child));
-      children.forEach((child) => {
-        if (child !== gElement) gElement.appendChild(child);
-      });
-      svgElement.appendChild(gElement);
-    }
-    container.appendChild(svgElement);
-    onMount?.(state.svgElement);
-  }
-
-  if (stateDiffers || stateOverridesDiffers) {
-    applyState(state.svgElement, currState, state.prevState);
-    state.prevState = currState;
-  }
 
   if (
-    internalScaleDiffers ||
-    externalScaleDiffers ||
-    orientationDiffers ||
-    svgDiffers
-  ) {
-    let preScaledDims = state.baseDims;
-    if (direction.construct(orientation) === "y")
-      preScaledDims = dimensions.swap(preScaledDims);
-    const scaledDims = dimensions.scale(preScaledDims, scale * externalScale);
-    state.svgElement.setAttribute("width", scaledDims.width.toString());
-    state.svgElement.setAttribute("height", scaledDims.height.toString());
-    state.svgElement.setAttribute(
-      "viewBox",
-      `0 0 ${preScaledDims.width} ${preScaledDims.height}`,
-    );
+    !externalScaleDiffers &&
+    !orientationDiffers &&
+    !svgDiffers &&
+    !scaleDiffers &&
+    !scaleStrokeDiffers &&
+    !stateDiffers &&
+    !stateOverridesDiffers
+  )
+    return;
+
+  // A rebuilt SVG starts from raw markup with none of its derived attributes set, so
+  // colors, dimensions, and stroke scaling must all be re-applied even when their own
+  // inputs are unchanged.
+  const rebuilt = state.svgElement == null || svgDiffers;
+  if (rebuilt) buildSVG(container, state, spec, onMount);
+
+  if (currState != null && (rebuilt || stateDiffers || stateOverridesDiffers)) {
+    applyState(state.svgElement!, currState, rebuilt ? undefined : state.prevState);
+    state.prevState = deep.copy(currState);
   }
 
-  if (scaleStrokeDiffers) {
-    const pathElements = state.svgElement.querySelectorAll(
-      "path, circle, rect, line, ellipse, polygon, polyline",
-    );
-    if (!scaleStroke)
-      pathElements.forEach((el) =>
-        el.setAttribute("vector-effect", "non-scaling-stroke"),
-      );
-    else pathElements.forEach((el) => el.removeAttribute("vector-effect"));
-  }
+  if (rebuilt || scaleDiffers || externalScaleDiffers || orientationDiffers)
+    applyScale(state, orientation, spec.scale, externalScale);
+
+  if (rebuilt || scaleStrokeDiffers) applyScaleStroke(state, spec.scaleStroke);
+
+  state.prevExternalScale = externalScale;
+  state.prevOrientation = orientation;
+  state.prevSvg = spec.svg;
+  state.prevScale = spec.scale;
+  state.prevScaleStroke = spec.scaleStroke;
+  state.prevStateOverrides = deep.copy(stateOverrides);
 };
 
 /// useRender returns a ref callback that drives the SVG mount/state/scale lifecycle

--- a/pluto/src/schematic/node/common/region/region.spec.ts
+++ b/pluto/src/schematic/node/common/region/region.spec.ts
@@ -7,6 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+import { ValidationError } from "@synnaxlabs/client";
 import { color } from "@synnaxlabs/x";
 import { describe, expect, it } from "vitest";
 
@@ -252,5 +253,200 @@ describe("Region.extract", () => {
 
     const blueYellowRegion = regions.find((r) => r.strokeColor === "#0000ff");
     expect(blueYellowRegion?.selectors).toHaveLength(1);
+  });
+
+  it("should ignore shapes inside non-rendered containers", () => {
+    const svg = createSVG(`
+      <defs>
+        <clipPath id="clip"><rect style="fill: #ff0000" /></clipPath>
+        <mask id="m"><circle style="fill: #ff0000" /></mask>
+      </defs>
+      <rect style="fill: #00ff00" />
+    `);
+
+    const regions = Region.extract(svg);
+
+    expect(regions).toHaveLength(1);
+    expect(regions[0].fillColor).toBe("#00ff00");
+  });
+});
+
+const parse = (markup: string): SVGSVGElement => {
+  const doc = new DOMParser().parseFromString(
+    `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 100">${markup}</svg>`,
+    "image/svg+xml",
+  );
+  return doc.documentElement as unknown as SVGSVGElement;
+};
+
+// readResolver mimics the browser cascade engine closely enough for the rewrite logic:
+// it reports the element's effective fill/stroke from its inline style, falling back to
+// its presentation attribute. This lets the pure transform be exercised without a
+// browser; the real getComputedStyle resolver (which also resolves <style> rules and
+// inheritance) is covered by the integration suite.
+const readResolver: Region.ColorResolver = (el) => {
+  const read = (prop: "fill" | "stroke"): string | null =>
+    el.style.getPropertyValue(prop) || el.getAttribute(prop) || null;
+  return { fill: read("fill"), stroke: read("stroke") };
+};
+
+describe("Region.normalizeElement", () => {
+  describe("color flattening", () => {
+    it("should move an inline-style fill onto the presentation attribute", () => {
+      const svg = parse('<rect style="fill:#5a87c5" id="r"/>');
+      Region.normalizeElement(svg, () => ({ fill: "#5a87c5", stroke: null }));
+      const rect = svg.querySelector("rect")!;
+      expect(rect.getAttribute("fill")).toBe("#5a87c5");
+      expect(rect.style.getPropertyValue("fill")).toBe("");
+    });
+
+    it("should move both fill and stroke and remove the now-empty style attribute", () => {
+      const svg = parse('<rect style="fill:#111;stroke:#222" id="r"/>');
+      Region.normalizeElement(svg, () => ({ fill: "#111111", stroke: "#222222" }));
+      const rect = svg.querySelector("rect")!;
+      expect(rect.getAttribute("fill")).toBe("#111111");
+      expect(rect.getAttribute("stroke")).toBe("#222222");
+      expect(rect.hasAttribute("style")).toBe(false);
+    });
+
+    it("should preserve non-color inline style declarations", () => {
+      const svg = parse('<rect style="fill:#111;stroke-width:3" id="r"/>');
+      Region.normalizeElement(svg, () => ({ fill: "#111111", stroke: null }));
+      const rect = svg.querySelector("rect")!;
+      expect(rect.getAttribute("fill")).toBe("#111111");
+      expect(rect.style.getPropertyValue("stroke-width")).toBe("3");
+    });
+
+    it("should write a resolved class-based color (simulating getComputedStyle)", () => {
+      const svg = parse('<path class="st0" d="M0 0h10v10h-10z"/>');
+      Region.normalizeElement(svg, () => ({ fill: "#06ac38", stroke: null }));
+      const path = svg.querySelector("path")!;
+      expect(path.getAttribute("fill")).toBe("#06ac38");
+    });
+
+    it("should leave an attribute untouched when the resolver returns null", () => {
+      const svg = parse('<rect fill="#abcdef" id="r"/>');
+      Region.normalizeElement(svg, () => ({ fill: null, stroke: null }));
+      expect(svg.querySelector("rect")!.getAttribute("fill")).toBe("#abcdef");
+    });
+
+    it("should resolve each shape independently", () => {
+      const svg = parse(
+        '<rect style="fill:#aaa" id="a"/><circle style="fill:#bbb" id="b"/>',
+      );
+      Region.normalizeElement(svg, (el) => ({
+        fill: el.id === "a" ? "#aaaaaa" : "#bbbbbb",
+        stroke: null,
+      }));
+      expect(svg.querySelector("rect")!.getAttribute("fill")).toBe("#aaaaaa");
+      expect(svg.querySelector("circle")!.getAttribute("fill")).toBe("#bbbbbb");
+    });
+  });
+
+  describe("paint server / keyword preservation", () => {
+    it("should preserve a gradient url() reference rather than destroy it", () => {
+      const svg = parse('<rect fill="url(#grad)" id="r"/>');
+      Region.normalizeElement(svg, () => ({ fill: "url(#grad)", stroke: null }));
+      expect(svg.querySelector("rect")!.getAttribute("fill")).toBe("url(#grad)");
+    });
+
+    it("should preserve the none keyword", () => {
+      const svg = parse('<rect stroke="#111" id="r"/>');
+      Region.normalizeElement(svg, () => ({ fill: "none", stroke: "#111111" }));
+      const rect = svg.querySelector("rect")!;
+      expect(rect.getAttribute("fill")).toBe("none");
+      expect(rect.getAttribute("stroke")).toBe("#111111");
+    });
+  });
+
+  describe("<style> stripping", () => {
+    it("should remove <style> blocks so their rules cannot leak globally", () => {
+      const svg = parse('<style>.st0{fill:#06ac38}</style><path class="st0"/>');
+      Region.normalizeElement(svg, () => ({ fill: "#06ac38", stroke: null }));
+      expect(svg.querySelector("style")).toBeNull();
+      // the class color survives because it was flattened onto the element
+      expect(svg.querySelector("path")!.getAttribute("fill")).toBe("#06ac38");
+    });
+
+    it("should retain the class attribute (existing selectors keep matching)", () => {
+      const svg = parse('<style>.st0{fill:#06ac38}</style><path class="st0"/>');
+      Region.normalizeElement(svg, () => ({ fill: "#06ac38", stroke: null }));
+      expect(svg.querySelector("path")!.getAttribute("class")).toBe("st0");
+    });
+  });
+
+  describe("region id tagging", () => {
+    it("should tag shapes lacking an id with a data-region-id", () => {
+      const svg = parse('<rect width="1" height="1"/>');
+      Region.normalizeElement(svg, readResolver);
+      expect(svg.querySelector("rect")!.getAttribute("data-region-id")).toMatch(
+        /^region-/,
+      );
+    });
+
+    it("should not tag shapes that already carry an id", () => {
+      const svg = parse('<rect id="keep" width="1" height="1"/>');
+      Region.normalizeElement(svg, readResolver);
+      expect(svg.querySelector("rect")!.hasAttribute("data-region-id")).toBe(false);
+    });
+
+    it("should not overwrite an existing data-region-id", () => {
+      const svg = parse('<rect data-region-id="region-fixed" width="1" height="1"/>');
+      Region.normalizeElement(svg, readResolver);
+      expect(svg.querySelector("rect")!.getAttribute("data-region-id")).toBe(
+        "region-fixed",
+      );
+    });
+  });
+
+  describe("non-rendered containers", () => {
+    it("should not flatten colors onto shapes inside a clipPath or defs", () => {
+      const svg = parse(
+        '<defs><clipPath id="clip"><path id="cp" d="M0 0h1v1z"/></clipPath></defs>' +
+          '<rect id="vis" width="5" height="5"/>',
+      );
+      Region.normalizeElement(svg, () => ({ fill: "#123123", stroke: null }));
+      expect(svg.querySelector("#cp")!.getAttribute("fill")).toBeNull();
+      expect(svg.querySelector("#vis")!.getAttribute("fill")).toBe("#123123");
+    });
+  });
+
+  describe("idempotency & backwards compatibility", () => {
+    it("should be idempotent: re-normalizing a normalized SVG is a no-op", () => {
+      const svg = parse('<style>.st0{fill:#06ac38}</style><path class="st0"/>');
+      Region.normalizeElement(svg, () => ({ fill: "#06ac38", stroke: null }));
+      const first = new XMLSerializer().serializeToString(svg);
+      // second pass reads the now-attribute color back, matching the browser resolver's
+      // behavior on an already-flattened element.
+      Region.normalizeElement(svg, readResolver);
+      expect(new XMLSerializer().serializeToString(svg)).toBe(first);
+    });
+
+    it("should leave an already-attribute-based SVG visually identical", () => {
+      const svg = parse('<rect id="r" fill="#123456" stroke="#654321"/>');
+      Region.normalizeElement(svg, readResolver);
+      const rect = svg.querySelector("rect")!;
+      expect(rect.getAttribute("fill")).toBe("#123456");
+      expect(rect.getAttribute("stroke")).toBe("#654321");
+      expect(rect.hasAttribute("style")).toBe(false);
+    });
+  });
+});
+
+describe("Region.normalizeSVG", () => {
+  it("should throw a ValidationError when the input does not parse as an SVG", () => {
+    expect(() => Region.normalizeSVG("<not-svg>nope")).toThrow(ValidationError);
+  });
+
+  it("should throw a ValidationError when the input is empty", () => {
+    expect(() => Region.normalizeSVG("   ")).toThrow(ValidationError);
+  });
+
+  it("should strip <style> and tag shapes when run end-to-end", () => {
+    const out = Region.normalizeSVG(
+      '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 10 10"><style>.a{fill:red}</style><rect class="a" width="5" height="5"/></svg>',
+    );
+    expect(out).not.toContain("<style");
+    expect(out).toContain("data-region-id");
   });
 });

--- a/pluto/src/schematic/node/common/region/region.ts
+++ b/pluto/src/schematic/node/common/region/region.ts
@@ -7,10 +7,12 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { type schematic } from "@synnaxlabs/client";
-import { color } from "@synnaxlabs/x";
+import { type schematic, ValidationError } from "@synnaxlabs/client";
+import { color, id } from "@synnaxlabs/x";
 
-const VISUAL_ELEMENTS = [
+/// VISUAL_ELEMENTS are the SVG tags that carry paint (fill/stroke) and therefore
+/// participate in region extraction and color normalization.
+export const VISUAL_ELEMENTS = [
   "path",
   "rect",
   "circle",
@@ -20,6 +22,32 @@ const VISUAL_ELEMENTS = [
   "line",
   "text",
 ];
+
+// Tags whose descendants define geometry/paint for reuse but are never themselves
+// painted. Shapes inside them must be ignored, otherwise clip paths, gradient stops,
+// and symbol templates surface as phantom regions. Compared by exact case because SVG
+// element names are case-sensitive.
+const NON_RENDERED_CONTAINERS = new Set([
+  "defs",
+  "clipPath",
+  "mask",
+  "symbol",
+  "marker",
+  "pattern",
+]);
+
+const isRendered = (el: Element): boolean => {
+  for (let p = el.parentElement; p != null; p = p.parentElement)
+    if (NON_RENDERED_CONTAINERS.has(p.tagName)) return false;
+  return true;
+};
+
+/// collectVisualElements returns every painted shape in the tree, skipping shapes that
+/// live inside non-rendering containers (defs, clipPath, mask, ...).
+const collectVisualElements = (svg: Element): SVGElement[] =>
+  VISUAL_ELEMENTS.flatMap((tag) =>
+    Array.from(svg.querySelectorAll<SVGElement>(tag)),
+  ).filter(isRendered);
 
 interface ColorPair {
   stroke: string;
@@ -74,9 +102,7 @@ const generateSelector = (element: SVGElement): string => {
 };
 
 export const extract = (svgElement: SVGElement): schematic.symbol.Region[] => {
-  const visualElements = VISUAL_ELEMENTS.flatMap((selector) =>
-    Array.from(svgElement.querySelectorAll<SVGElement>(selector)),
-  );
+  const visualElements = collectVisualElements(svgElement);
   const groups = new Map<string, ElementGroup>();
   visualElements.forEach((element) => {
     const colorPair = getElementColors(element);
@@ -101,4 +127,110 @@ export const extract = (svgElement: SVGElement): schematic.symbol.Region[] => {
     region.fillColor = group.colorPair.fill;
     return region;
   });
+};
+
+const REGION_ID_ATTRIBUTE = "data-region-id";
+
+/// SymbolColors holds an element's resolved fill and stroke, each expressed as the
+/// value to write to the corresponding presentation attribute. A null value leaves
+/// that attribute untouched.
+export interface SymbolColors {
+  fill: string | null;
+  stroke: string | null;
+}
+
+/// ColorResolver computes the effective fill and stroke of an element. The default
+/// resolver used by normalizeSVG reads the browser's cascade via getComputedStyle;
+/// tests inject a deterministic resolver to exercise the rewrite without a browser.
+export type ColorResolver = (el: SVGElement) => SymbolColors;
+
+const setPaint = (el: SVGElement, attr: "fill" | "stroke", value: string | null) => {
+  if (value == null) return;
+  el.setAttribute(attr, value);
+  // Drop the now-redundant inline declaration so the presentation attribute is the
+  // single source of truth and nothing outranks a later attribute override.
+  el.style.removeProperty(attr);
+  if (el.getAttribute("style") === "") el.removeAttribute("style");
+};
+
+const addRegionIDs = (el: Element) => {
+  if (!(el instanceof SVGElement) || el.tagName === "svg") return;
+  if (el.id.length === 0 && el.getAttribute(REGION_ID_ATTRIBUTE) == null)
+    el.setAttribute(REGION_ID_ATTRIBUTE, `region-${id.create()}`);
+  Array.from(el.children).forEach(addRegionIDs);
+};
+
+/// normalizeElement rewrites an SVG in place into the canonical symbol form: every
+/// painted element's effective fill and stroke (resolved via resolveColors) are
+/// flattened onto presentation attributes, <style> blocks are removed, and each shape
+/// without an id is tagged with a stable data-region-id. The result is
+/// self-contained: its colors no longer depend on inline styles, <style> rules, or
+/// ancestor inheritance, so extract and the renderer's color override operate on a
+/// single predictable source. The transform is idempotent.
+export const normalizeElement = (
+  svg: SVGSVGElement,
+  resolveColors: ColorResolver,
+): void => {
+  // Resolve every element's colors before mutating anything: a live getComputedStyle
+  // resolver depends on the <style> block and ancestor paint that the rewrite removes.
+  const resolved = collectVisualElements(svg).map((el): [SVGElement, SymbolColors] => [
+    el,
+    resolveColors(el),
+  ]);
+  resolved.forEach(([el, { fill, stroke }]) => {
+    setPaint(el, "fill", fill);
+    setPaint(el, "stroke", stroke);
+  });
+  svg.querySelectorAll("style").forEach((styleEl) => styleEl.remove());
+  Array.from(svg.children).forEach(addRegionIDs);
+};
+
+const paintToAttribute = (computed: string): string | null => {
+  const trimmed = computed.trim();
+  if (trimmed.length === 0) return null;
+  // Paint servers (gradients, patterns) are not reducible to a single color; preserve
+  // the reference verbatim.
+  if (trimmed.startsWith("url(")) return trimmed;
+  if (trimmed === "none") return "none";
+  const parsed = color.fromCSS(trimmed);
+  // Fall back to the raw computed value for anything unparseable (e.g. context-fill);
+  // it remains a valid presentation-attribute value.
+  return parsed == null ? trimmed : color.hex(parsed);
+};
+
+const computedColorResolver: ColorResolver = (el) => {
+  const computed = getComputedStyle(el);
+  return {
+    fill: paintToAttribute(computed.fill),
+    stroke: paintToAttribute(computed.stroke),
+  };
+};
+
+/// normalizeSVG parses an SVG string, rewrites it into the canonical symbol form (see
+/// normalizeElement), and serializes it back. Colors are resolved with the browser's
+/// cascade engine, so it must run in a DOM environment; the SVG is briefly attached
+/// off-screen so getComputedStyle can resolve <style> rules and inherited paint. Throws
+/// a ValidationError if the input is empty or does not parse as an SVG, so callers can
+/// surface the failure to the user rather than storing an unusable symbol.
+export const normalizeSVG = (svgString: string): string => {
+  if (svgString.trim().length === 0) throw new ValidationError("The file is empty.");
+  const doc = new DOMParser().parseFromString(svgString, "image/svg+xml");
+  const root = doc.documentElement;
+  // A malformed document surfaces either as a non-<svg> root (the whole document is
+  // replaced) or as an embedded <parsererror> node, depending on the browser.
+  if (root.tagName !== "svg" || doc.querySelector("parsererror") != null)
+    throw new ValidationError("The file does not contain a valid SVG image.");
+  const svg = root as unknown as SVGSVGElement;
+  const host = document.createElement("div");
+  host.setAttribute("aria-hidden", "true");
+  host.style.cssText =
+    "position:absolute;width:0;height:0;overflow:hidden;opacity:0;pointer-events:none";
+  host.appendChild(svg);
+  document.body.appendChild(host);
+  try {
+    normalizeElement(svg, computedColorResolver);
+  } finally {
+    host.remove();
+  }
+  return new XMLSerializer().serializeToString(svg);
 };


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4217](https://linear.app/synnax/issue/SY-4217)

## Description

Editing an imported custom schematic symbol's scale, regions, or properties did not update the live preview, and real-world logo SVGs (Modbus, IBM, PagerDuty) could not be recolored at all. Two independent root causes:

**1. Render engine (`pluto/.../custom/render.ts`).** `useRender` diffed against live `spec`/`state` references to decide what to repaint. The schematic node renderers get a fresh reference from the flux cache, but the symbol editor's form mutates its value object **in place** — so "previous" was always the same object as "current", every diff resolved false, and nothing repainted after the initial mount. The engine now diffs against **value snapshots** (primitives by value, active state by deep equality) and re-applies every derived attribute (colors, dimensions, stroke scaling) whenever the SVG is rebuilt.

**2. Color cascade (`pluto/.../region/region.ts`, `console/.../edit/Preview.tsx`).** Logo SVGs define colors via inline `style="fill:…"` or a `<style>` class rule, both of which outrank the presentation attribute the renderer wrote — so color overrides were computed but never painted, and class-based colors were read as transparent. Imported SVGs are now **normalized**: effective colors are flattened onto presentation attributes via the browser cascade (`getComputedStyle`), `<style>` blocks are stripped (they would otherwise leak globally across symbol instances on a canvas), shapes are tagged with a stable `data-region-id`, and shapes inside non-rendered containers (`defs`/`clipPath`/`mask`/…) are excluded from regions. This makes the existing `extract`/`applyState` code correct with no changes to them.

Normalization runs only on import and is idempotent/selector-preserving, so existing stored symbols are untouched.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two independent bugs in the custom schematic symbol editor: the render engine now diffs against value snapshots (primitives by value, state by deep equality) rather than object identity, so in-place form mutations are detected correctly; and imported SVGs are now normalized at import time by flattening `style`-based colors onto presentation attributes, stripping `<style>` blocks, and tagging shapes with stable `data-region-id`s so the existing color-override path works for real-world logo SVGs.

- **`render.ts`**: `RenderState` tracks `prevSvg`/`prevScale`/`prevScaleStroke` as primitive snapshots; `stateDiffers` uses `deep.equal`; all derived attributes (colors, dimensions, stroke scaling) are unconditionally re-applied after an SVG rebuild.
- **`region.ts`**: New `normalizeSVG`/`normalizeElement` functions use the browser cascade (`getComputedStyle`) to resolve effective colors before stripping `<style>` blocks; `collectVisualElements` now filters out shapes inside `defs`, `clipPath`, `mask`, and similar non-rendered containers so they don't surface as phantom regions.
- **`FileDrop.tsx`**: Adds the missing `.svg` extension check to the file-picker path (already present for drag-and-drop).

<h3>Confidence Score: 5/5</h3>

The two core fixes are well-scoped and correct; the normalization is idempotent and only runs at import time, leaving existing stored symbols untouched.

Both root causes are addressed cleanly. The value-snapshot diffing in render.ts is a correct and minimal fix. The SVG normalization in region.ts resolves colors before stripping style blocks (the critical ordering constraint), uses a finally block for DOM cleanup, and is exercised by thorough unit and integration tests. No logic holes were found in the changed paths.

The addRegionIDs walk in region.ts still tags shapes inside defs/clipPath with data-region-id (a pre-existing inconsistency noted in a prior review comment); no other files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| pluto/src/schematic/node/common/region/region.ts | New normalizeSVG/normalizeElement functions flatten SVG colors onto presentation attributes, strip style blocks, and tag shapes with stable IDs; collectVisualElements now skips non-rendered containers; addRegionIDs still traverses into defs/clipPath descendants (pre-existing P2) |
| pluto/src/schematic/node/common/custom/render.ts | Fixes in-place spec mutation detection by diffing primitive snapshots (prevSvg/prevScale/prevScaleStroke) and deep equality for state, and unconditionally re-applies all derived attributes after an SVG rebuild; buildSVG/applyScale/applyScaleStroke extracted as standalone helpers |
| console/src/schematic/symbols/edit/Preview.tsx | Replaces the old local preprocessSVG with Schematic.Node.Region.normalizeSVG; ValidationError thrown by normalizeSVG is caught by handleError wrappers in FileDrop |
| console/src/schematic/symbols/edit/FileDrop.tsx | Adds SVG extension validation to the file-picker path (was already present for drag-and-drop), extracts isSVGFile helper and INVALID_FILE_TYPE_STATUS constant |
| pluto/src/schematic/node/common/region/region.spec.ts | Comprehensive new test suites for normalizeElement (color flattening, style stripping, region ID tagging, non-rendered containers, idempotency) and normalizeSVG (error cases, end-to-end) |
| pluto/src/schematic/node/common/custom/render.spec.tsx | New test groups for in-place spec mutation (scale, region color, scaleStroke) and SVG rebuild re-application; also adds an editor-like Form harness to exercise the real mutation path end-to-end |
| integration/tests/console/schematic/custom_symbols.py | New test_styled_symbol_applies_to_preview integration test exercises import, recolor, and scale on a styled SVG fixture, verifying computed preview fills and width attribute |
| integration/console/schematic/symbol_editor.py | Adds region_count, set_region_fill_color, get_preview_fill, assert_preview_fill, and assert_preview_width helpers; refactors set_region_stroke_color to use shared _set_region_color |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant FileDrop
    participant Preview
    participant normalizeSVG
    participant useRender
    participant Form

    User->>FileDrop: Drop/select .svg file
    FileDrop->>FileDrop: isSVGFile() check
    FileDrop->>Preview: onContentsChange(rawSVG, name)
    Preview->>normalizeSVG: normalizeSVG(rawSVG)
    normalizeSVG->>normalizeSVG: Parse SVG with DOMParser
    normalizeSVG->>normalizeSVG: Attach off-screen to document.body
    normalizeSVG->>normalizeSVG: collectVisualElements (skip defs/clipPath/mask)
    normalizeSVG->>normalizeSVG: getComputedStyle - flatten fill/stroke to attrs
    normalizeSVG->>normalizeSVG: Remove style blocks
    normalizeSVG->>normalizeSVG: addRegionIDs (tag unlabeled shapes)
    normalizeSVG->>normalizeSVG: host.remove()
    normalizeSVG-->>Preview: normalized SVG string
    Preview->>Form: set(data.svg, normalizedSVG)
    Preview->>Form: "set(data.states.*.regions, extractedRegions)"
    Note over useRender: Render-phase pass detects changes by value snapshot
    Form-->>useRender: spec (same object, mutated in place)
    useRender->>useRender: "prevSvg !== spec.svg? - buildSVG"
    useRender->>useRender: deep.equal(prevState, currState)? - applyState
    useRender->>useRender: "prevScale !== spec.scale? - applyScale"
    useRender->>useRender: "prevScaleStroke !== spec.scaleStroke? - applyScaleStroke"
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `pluto/src/schematic/node/common/region/region.ts`, line 1068 ([link](https://github.com/synnaxlabs/synnax/blob/abd664eda738674b49f8acad5b9a1deb31aa6217/pluto/src/schematic/node/common/region/region.ts#L1068)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`addRegionIDs` tags shapes inside non-rendered containers**

   `normalizeElement` carefully routes color processing through `collectVisualElements` (which respects `isRendered` and skips `defs`, `clipPath`, `mask`, etc.), but the final ID-tagging walk passes unconditionally through every descendant. A `<rect>` inside a `<clipPath>` — deliberately excluded from region extraction — will still receive a `data-region-id` in the stored SVG. The stored attribute is dead weight: `extract` will never return a region for it, and `generateSelector` is never called on it. Applying the same `isRendered` guard used by `collectVisualElements` would keep the stored markup consistent with the stated design (PR description: "shapes inside non-rendered containers are excluded from regions").
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["SY-4217: Fix Custom Schematic Symbol Edi..."](https://github.com/synnaxlabs/synnax/commit/f58f4af8983419a74738e330835b83914405a4d9) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34607240)</sub>

<!-- /greptile_comment -->