### PR TITLE
SY-4260: Fix Bad Schematic & Table Import

### DIFF
--- a/console/src/import/dataTransferItem.ts
+++ b/console/src/import/dataTransferItem.ts
@@ -10,6 +10,7 @@
 import { type Store } from "@reduxjs/toolkit";
 import { type Synnax } from "@synnaxlabs/client";
 import { type Pluto } from "@synnaxlabs/pluto";
+import { uuid } from "@synnaxlabs/x";
 
 import { ingestComponent } from "@/import/import";
 import { type DirectoryIngester, type FileIngesters } from "@/import/ingester";
@@ -101,7 +102,7 @@ export const dataTransferItem = async (
       placeLayout,
       store: fluxStore,
       client,
-      workspaceKey: workspaceKey ?? undefined,
+      workspaceKey: workspaceKey ?? uuid.ZERO,
     });
     return;
   }

--- a/console/src/import/import.ts
+++ b/console/src/import/import.ts
@@ -10,6 +10,7 @@
 import { type Store } from "@reduxjs/toolkit";
 import { DisconnectedError, type Synnax as Client } from "@synnaxlabs/client";
 import { Flux, type Pluto, Status, Synnax } from "@synnaxlabs/pluto";
+import { uuid } from "@synnaxlabs/x";
 import { useCallback } from "react";
 import { useStore } from "react-redux";
 import { ZodError } from "zod";
@@ -103,7 +104,7 @@ const importComponent = ({
           placeLayout,
           store: fluxStore,
           client,
-          workspaceKey: activeWorkspaceKeyAfter ?? undefined,
+          workspaceKey: activeWorkspaceKeyAfter ?? uuid.ZERO,
         });
       }, `Failed to import ${file.name}`),
     );

--- a/console/src/import/ingester.ts
+++ b/console/src/import/ingester.ts
@@ -23,7 +23,7 @@ export interface FileIngesterContext {
   placeLayout: Layout.Placer;
   store: Pluto.FluxStore;
   client: Synnax | null;
-  workspaceKey?: workspace.Key;
+  workspaceKey: workspace.Key;
 }
 
 export interface FileIngester {

--- a/console/src/schematic/Schematic.tsx
+++ b/console/src/schematic/Schematic.tsx
@@ -25,16 +25,7 @@ import { Layout } from "@/layout";
 import { Controller } from "@/schematic/Controller";
 import { Controls } from "@/schematic/Controls";
 import { useHandleNodeClickAction } from "@/schematic/navigate";
-import {
-  selectEditable,
-  useSelectAuthority,
-  useSelectControlStatus,
-  useSelectEditable,
-  useSelectFitViewOnResize,
-  useSelectLegend,
-  useSelectSelected,
-  useSelectViewport,
-} from "@/schematic/selectors";
+import { selectEditable, useSelect } from "@/schematic/selectors";
 import {
   setEditable,
   setFitViewOnResize,
@@ -50,13 +41,15 @@ const Internal: Layout.Renderer = ({ layoutKey: key, visible }) => {
   Base.useEnsureRetrieved({ key });
   const isSnapshot = Base.useSelectSnapshot({ key });
   const dispatch = useDispatch();
-  const editable = useSelectEditable(key);
-  const viewport = useSelectViewport(key);
-  const controlStatus = useSelectControlStatus(key);
-  const selected = useSelectSelected(key);
-  const legend = useSelectLegend(key);
-  const authority = useSelectAuthority(key);
-  const fitViewOnResize = useSelectFitViewOnResize(key);
+  const {
+    editable,
+    viewport,
+    controlStatus,
+    selected,
+    legend,
+    authority,
+    fitViewOnResize,
+  } = useSelect(key);
 
   const hasUpdatePermission =
     Access.useUpdateGranted(schematic.ontologyID(key)) && !isSnapshot;

--- a/console/src/schematic/Schematic.tsx
+++ b/console/src/schematic/Schematic.tsx
@@ -25,7 +25,16 @@ import { Layout } from "@/layout";
 import { Controller } from "@/schematic/Controller";
 import { Controls } from "@/schematic/Controls";
 import { useHandleNodeClickAction } from "@/schematic/navigate";
-import { selectEditable, useSelect } from "@/schematic/selectors";
+import {
+  selectEditable,
+  useSelectAuthority,
+  useSelectControlStatus,
+  useSelectEditable,
+  useSelectFitViewOnResize,
+  useSelectLegend,
+  useSelectSelected,
+  useSelectViewport,
+} from "@/schematic/selectors";
 import {
   setEditable,
   setFitViewOnResize,
@@ -41,15 +50,13 @@ const Internal: Layout.Renderer = ({ layoutKey: key, visible }) => {
   Base.useEnsureRetrieved({ key });
   const isSnapshot = Base.useSelectSnapshot({ key });
   const dispatch = useDispatch();
-  const {
-    editable,
-    viewport,
-    controlStatus,
-    selected,
-    legend,
-    authority,
-    fitViewOnResize,
-  } = useSelect(key);
+  const editable = useSelectEditable(key);
+  const viewport = useSelectViewport(key);
+  const controlStatus = useSelectControlStatus(key);
+  const selected = useSelectSelected(key);
+  const legend = useSelectLegend(key);
+  const authority = useSelectAuthority(key);
+  const fitViewOnResize = useSelectFitViewOnResize(key);
 
   const hasUpdatePermission =
     Access.useUpdateGranted(schematic.ontologyID(key)) && !isSnapshot;

--- a/console/src/schematic/selectors.ts
+++ b/console/src/schematic/selectors.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { type Control, type Diagram } from "@synnaxlabs/pluto";
+import { type Control } from "@synnaxlabs/pluto";
 import { type control } from "@synnaxlabs/x";
 
 import { useMemoSelect } from "@/hooks";
@@ -19,6 +19,7 @@ import {
   type State,
   type StoreState,
   type ToolbarTab,
+  type Viewport,
 } from "@/schematic/slice";
 import { type ToolbarState, ZERO_STATE } from "@/schematic/types";
 
@@ -90,10 +91,10 @@ export const selectFitViewOnResize = (state: StoreState, key: string): boolean =
 export const useSelectFitViewOnResize = (key: string): boolean =>
   useMemoSelect((state: StoreState) => selectFitViewOnResize(state, key), [key]);
 
-export const selectViewport = (state: StoreState, key: string): Diagram.Viewport =>
+export const selectViewport = (state: StoreState, key: string): Viewport =>
   select(state, key).viewport;
 
-export const useSelectViewport = (key: string): Diagram.Viewport =>
+export const useSelectViewport = (key: string): Viewport =>
   useMemoSelect((state: StoreState) => selectViewport(state, key), [key]);
 
 export const selectPendingUpload = (

--- a/console/src/schematic/services/import.spec.ts
+++ b/console/src/schematic/services/import.spec.ts
@@ -1,0 +1,75 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { type record } from "@synnaxlabs/x";
+import { describe, expect, it } from "vitest";
+
+import { parseImport } from "@/schematic/services/import";
+
+const configsOf = (s: { configs?: unknown }): record.Unknown =>
+  (s.configs ?? {}) as record.Unknown;
+
+const LEGACY_V2 = {
+  version: "2.0.0",
+  key: "88aee41e-53b7-4a76-9df9-aceccc220089",
+  type: "schematic",
+  name: "Schematic",
+  editable: true,
+  fitViewOnResize: false,
+  snapshot: false,
+  remoteCreated: false,
+  control: "released",
+  viewport: { position: { x: 0, y: 0 }, zoom: 1 },
+  viewportMode: "select",
+  legend: { visible: false, position: { x: 50, y: 50, units: { x: "px", y: "px" } } },
+  nodes: [
+    {
+      key: "n1",
+      position: { x: -300, y: -3.5 },
+      type: "custom",
+      width: 230,
+      height: 112,
+      zIndex: 4,
+    },
+  ],
+  edges: [],
+  props: { n1: { key: "valve", color: [28, 28, 28, 1] } },
+};
+
+const TYPED_EXPORT = {
+  key: "88aee41e-53b7-4a76-9df9-aceccc220089",
+  name: "Schematic",
+  type: "schematic",
+  version: "6.0.0",
+  snapshot: false,
+  nodes: [{ key: "n1", position: { x: 0, y: 0 } }],
+  edges: [],
+  configs: { n1: { variant: "valve", color: [28, 28, 28, 1] } },
+};
+
+describe("schematic import", () => {
+  describe("parseImport", () => {
+    it("should migrate a legacy console export, preserving every symbol config", () => {
+      const out = parseImport(LEGACY_V2, undefined);
+      expect(out.nodes).toHaveLength(1);
+      expect(configsOf(out).n1).toMatchObject({ variant: "valve" });
+    });
+
+    it("should import a typed schematic export directly, preserving configs", () => {
+      const out = parseImport(TYPED_EXPORT, undefined);
+      expect(out.nodes).toHaveLength(1);
+      expect(configsOf(out).n1).toMatchObject({ variant: "valve" });
+    });
+
+    it("should not silently drop configs by parsing a legacy file as a typed one", () => {
+      const out = parseImport(LEGACY_V2, undefined);
+      expect(configsOf(out)).not.toEqual({});
+    });
+  });
+});

--- a/console/src/schematic/services/import.spec.ts
+++ b/console/src/schematic/services/import.spec.ts
@@ -13,7 +13,7 @@ import { describe, expect, it } from "vitest";
 import { parseImport } from "@/schematic/services/import";
 
 const configsOf = (s: { configs?: unknown }): record.Unknown =>
-  (s.configs ?? {}) as record.Unknown;
+  typeof s.configs === "object" && s.configs != null ? { ...s.configs } : {};
 
 const LEGACY_V2 = {
   version: "2.0.0",

--- a/console/src/schematic/services/import.ts
+++ b/console/src/schematic/services/import.ts
@@ -9,26 +9,33 @@
 
 import { DisconnectedError, schematic } from "@synnaxlabs/client";
 import { Access } from "@synnaxlabs/pluto";
-import { type record, uuid } from "@synnaxlabs/x";
+import { uuid } from "@synnaxlabs/x";
 
 import { type Import } from "@/import";
 import { create, LAYOUT_TYPE } from "@/schematic/layout";
 import { anyStateZ } from "@/schematic/slice";
 
-const parseImport = (
+export const parseImport = (
   data: unknown,
   fallbackName: string | undefined,
 ): schematic.New => {
-  const direct = schematic.schematicZ.safeParse(data);
-  if (direct.success) {
-    const { key: _key, ...rest } = direct.data;
-    return { ...rest, name: fallbackName ?? rest.name };
+  // Legacy console-state exports are tried first because their schemas are strict: they
+  // require a version literal plus the console-only editable / control / viewport /
+  // props fields, so a current typed export never matches and falls through to the
+  // direct branch. The typed schematicZ is the opposite — it strips unknown keys and
+  // defaults configs to {}, so trying it first silently accepts a legacy file, drops
+  // its props, and yields a schematic with no symbol configs (a blank import).
+  if (typeof data === "object" && data != null) {
+    const legacy = anyStateZ.safeParse({ ...data, remoteCreated: false });
+    if (legacy.success) {
+      if (legacy.data.pendingUpload == null)
+        throw new Error("Imported schematic has no graph data");
+      const { snapshot, nodes, edges, configs } = legacy.data.pendingUpload;
+      return { name: fallbackName ?? "Schematic", snapshot, nodes, edges, configs };
+    }
   }
-  const legacy = anyStateZ.parse({ ...(data as record.Unknown), remoteCreated: false });
-  if (legacy.pendingUpload == null)
-    throw new Error("Imported schematic has no graph data");
-  const { snapshot, nodes, edges, configs } = legacy.pendingUpload;
-  return { name: fallbackName ?? "Schematic", snapshot, nodes, edges, configs };
+  const { key: _key, ...rest } = schematic.schematicZ.parse(data);
+  return { ...rest, name: fallbackName ?? rest.name };
 };
 
 export const ingest: Import.FileIngester = async (

--- a/console/src/schematic/services/import.ts
+++ b/console/src/schematic/services/import.ts
@@ -9,7 +9,6 @@
 
 import { DisconnectedError, schematic } from "@synnaxlabs/client";
 import { Access } from "@synnaxlabs/pluto";
-import { uuid } from "@synnaxlabs/x";
 
 import { type Import } from "@/import";
 import { create, LAYOUT_TYPE } from "@/schematic/layout";
@@ -46,7 +45,7 @@ export const ingest: Import.FileIngester = async (
     throw new Error("You do not have permission to import schematics");
   if (client == null) throw new DisconnectedError();
   const newPayload = parseImport(data, layout?.name);
-  const created = await client.schematics.create(workspaceKey ?? uuid.ZERO, newPayload);
+  const created = await client.schematics.create(workspaceKey, newPayload);
   const { key, name } = created;
   store.schematics.set(key, created);
   placeLayout(create({ ...layout, key, name, type: LAYOUT_TYPE }));

--- a/console/src/schematic/slice.ts
+++ b/console/src/schematic/slice.ts
@@ -16,6 +16,7 @@ import { type RootState } from "@/store";
 
 export type SliceState = latest.SliceState;
 export type State = latest.State;
+export interface Viewport extends latest.Viewport {}
 export type LegendState = latest.LegendState;
 export type ToolbarTab = latest.ToolbarTab;
 export type ToolbarState = latest.ToolbarState;

--- a/console/src/schematic/types/index.ts
+++ b/console/src/schematic/types/index.ts
@@ -45,6 +45,7 @@ export type EdgeProps = PSchematic.Edge.Config;
 export type Props = NodeProps | EdgeProps;
 export type State = v6.State;
 export type SliceState = v6.SliceState;
+export interface Viewport extends v6.Viewport {}
 export type ToolbarTab = v0.ToolbarTab;
 export type ToolbarState = v0.ToolbarState;
 export type LegendState = v6.LegendState;

--- a/console/src/schematic/types/v6.ts
+++ b/console/src/schematic/types/v6.ts
@@ -9,7 +9,7 @@
 
 import { schematic } from "@synnaxlabs/client";
 import { control, Schematic, Viewport } from "@synnaxlabs/pluto";
-import { color, control as xControl, migrate, record, sticky, xy } from "@synnaxlabs/x";
+import { color, control as xcontrol, migrate, record, sticky, xy } from "@synnaxlabs/x";
 import { z } from "zod";
 
 import * as v0 from "@/schematic/types/v0";
@@ -26,7 +26,7 @@ export const viewportZ = z.object({
   zoom: z.number(),
   mode: Viewport.modeZ.default("select"),
 });
-export interface ViewportState extends z.infer<typeof viewportZ> {}
+export interface Viewport extends z.infer<typeof viewportZ> {}
 
 export const nodeZ = schematic.nodeZ;
 export type Node = schematic.Node;
@@ -49,16 +49,14 @@ export interface LegendState extends z.infer<typeof legendStateZ> {}
 
 export const pendingUploadZ = schematic.schematicZ
   .omit({ configs: true, name: true })
-  .extend({
-    configs: z.record(z.string(), elementConfigZ),
-  });
+  .extend({ configs: z.record(z.string(), elementConfigZ) });
 export interface PendingUpload extends z.infer<typeof pendingUploadZ> {}
 
 export const stateZ = z.object({
   version: z.literal(VERSION),
   selected: z.array(z.string()).default([]),
   controlStatus: control.statusZ,
-  authority: xControl.authorityZ,
+  authority: xcontrol.authorityZ,
   legend: legendStateZ,
   toolbar: v0.toolbarStateZ,
   editable: z.boolean(),
@@ -78,10 +76,7 @@ export const ZERO_STATE: State = {
     position: { x: 50, y: 50, units: { x: "px", y: "px" } },
     colors: {},
   },
-  toolbar: {
-    activeTab: "symbols",
-    selectedSymbolGroup: "general",
-  },
+  toolbar: { activeTab: "symbols", selectedSymbolGroup: "general" },
   editable: false,
   fitViewOnResize: false,
   viewport: { position: xy.ZERO, zoom: 1, mode: "select" },
@@ -94,10 +89,7 @@ export const sliceStateZ = z.object({
 });
 export interface SliceState extends z.infer<typeof sliceStateZ> {}
 
-export const ZERO_SLICE_STATE: SliceState = {
-  version: VERSION,
-  schematics: {},
-};
+export const ZERO_SLICE_STATE: SliceState = { version: VERSION, schematics: {} };
 
 const migrateNode = (node: v0.Node): Node => {
   const next: Node = { key: node.key, position: node.position };

--- a/console/src/table/services/import.spec.ts
+++ b/console/src/table/services/import.spec.ts
@@ -1,0 +1,75 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { type record } from "@synnaxlabs/x";
+import { describe, expect, it } from "vitest";
+
+import { parseImport } from "@/table/services/import";
+
+// A legacy v0 console export parks its structural model under layout.rows /
+// layout.columns and stores a per-cell `selected` flag. It carries a valid uuid key and
+// (in the swallow-prone case) a name, so the lenient typed tableZ would accept it
+// directly — dropping the layout and yielding empty rows/columns.
+const LEGACY_V0 = {
+  version: "0.0.0",
+  type: "table",
+  key: "88aee41e-53b7-4a76-9df9-aceccc220089",
+  name: "My Table",
+  lastSelected: null,
+  editable: true,
+  remoteCreated: false,
+  layout: {
+    rows: [{ size: 36, cells: [{ key: "c1" }, { key: "c2" }] }],
+    columns: [{ size: 72 }, { size: 72 }],
+  },
+  cells: {
+    c1: { key: "c1", variant: "text", selected: false, props: { value: "hello" } },
+    c2: { key: "c2", variant: "value", selected: false, props: {} },
+  },
+};
+
+const TYPED_EXPORT = {
+  key: "88aee41e-53b7-4a76-9df9-aceccc220089",
+  name: "My Table",
+  type: "table",
+  version: "1.0.0",
+  rows: [{ size: 36, cells: ["c1", "c2"] }],
+  columns: [{ size: 72 }, { size: 72 }],
+  cells: {
+    c1: { key: "c1", variant: "text", props: { value: "hello" } },
+    c2: { key: "c2", variant: "value", props: {} },
+  },
+};
+
+const cellsOf = (t: { cells?: unknown }): record.Unknown =>
+  typeof t.cells === "object" && t.cells != null ? { ...t.cells } : {};
+
+describe("table import", () => {
+  describe("parseImport", () => {
+    it("should migrate a legacy console export, preserving rows, columns, and cells", () => {
+      const out = parseImport(LEGACY_V0, undefined);
+      expect(out.rows).toHaveLength(1);
+      expect(out.columns).toHaveLength(2);
+      expect(Object.keys(cellsOf(out))).toEqual(["c1", "c2"]);
+    });
+
+    it("should not silently drop the layout by parsing a legacy file as a typed one", () => {
+      const out = parseImport(LEGACY_V0, undefined);
+      expect(out.rows).not.toHaveLength(0);
+      expect(out.columns).not.toHaveLength(0);
+    });
+
+    it("should import a typed table export directly, preserving structure", () => {
+      const out = parseImport(TYPED_EXPORT, undefined);
+      expect(out.rows).toHaveLength(1);
+      expect(out.columns).toHaveLength(2);
+      expect(Object.keys(cellsOf(out))).toEqual(["c1", "c2"]);
+    });
+  });
+});

--- a/console/src/table/services/import.ts
+++ b/console/src/table/services/import.ts
@@ -9,23 +9,34 @@
 
 import { DisconnectedError, table } from "@synnaxlabs/client";
 import { Access } from "@synnaxlabs/pluto";
-import { type record, uuid } from "@synnaxlabs/x";
+import { uuid } from "@synnaxlabs/x";
 
 import { type Import } from "@/import";
 import { create, LAYOUT_TYPE } from "@/table/layout";
 import { anyStateZ } from "@/table/slice";
 
-const parseImport = (data: unknown, fallbackName: string | undefined): table.New => {
-  const direct = table.tableZ.safeParse(data);
-  if (direct.success) {
-    const { key: _key, ...rest } = direct.data;
-    return { ...rest, name: fallbackName ?? rest.name };
+export const parseImport = (
+  data: unknown,
+  fallbackName: string | undefined,
+): table.New => {
+  // Legacy console-state exports are tried first because their schemas are strict: they
+  // require a version literal plus the console-only lastSelected / editable / layout
+  // fields, so a current typed export never matches and falls through to the direct
+  // branch. The typed tableZ is the opposite — it strips unknown keys and defaults rows
+  // / columns / cells to empty, so trying it first silently accepts a legacy file,
+  // drops its structural model, and yields a table with no rows or columns (a blank
+  // import).
+  if (typeof data === "object" && data != null) {
+    const legacy = anyStateZ.safeParse({ ...data, remoteCreated: false });
+    if (legacy.success) {
+      if (legacy.data.pendingUpload == null)
+        throw new Error("Imported table has no structural data");
+      const { key: _key, rows, columns, cells } = legacy.data.pendingUpload;
+      return { name: fallbackName ?? "Table", rows, columns, cells };
+    }
   }
-  const legacy = anyStateZ.parse({ ...(data as record.Unknown), remoteCreated: false });
-  if (legacy.pendingUpload == null)
-    throw new Error("Imported table has no structural data");
-  const { key: _key, rows, columns, cells } = legacy.pendingUpload;
-  return { name: fallbackName ?? "Table", rows, columns, cells };
+  const { key: _key, ...rest } = table.tableZ.parse(data);
+  return { ...rest, name: fallbackName ?? rest.name };
 };
 
 export const ingest: Import.FileIngester = async (

--- a/console/src/table/services/import.ts
+++ b/console/src/table/services/import.ts
@@ -9,7 +9,6 @@
 
 import { DisconnectedError, table } from "@synnaxlabs/client";
 import { Access } from "@synnaxlabs/pluto";
-import { uuid } from "@synnaxlabs/x";
 
 import { type Import } from "@/import";
 import { create, LAYOUT_TYPE } from "@/table/layout";
@@ -47,7 +46,7 @@ export const ingest: Import.FileIngester = async (
     throw new Error("You do not have permission to import tables");
   if (client == null) throw new DisconnectedError();
   const newPayload = parseImport(data, layout?.name);
-  const created = await client.tables.create(workspaceKey ?? uuid.ZERO, newPayload);
+  const created = await client.tables.create(workspaceKey, newPayload);
   store.tables.set(created.key, created);
   placeLayout(
     create({ ...layout, key: created.key, name: created.name, type: LAYOUT_TYPE }),


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4260](https://linear.app/synnax/issue/SY-4260)

## Description

Fixes several issues with importing and opening schematics (and the analogous table paths) after the move to server-typed schematic/table state.

- **Blank import of legacy files.** `parseImport` tried the typed `schematicZ` / `tableZ` first. Those schemas are lenient — they strip unknown keys and default `configs` / `rows`/`columns`/`cells` to empty — so a legacy console export (which stores symbol state under `props`, or table structure under `layout`) parsed "successfully" with everything dropped, producing a blank schematic/table. The strict legacy state schemas are now tried first, falling back to the typed direct parse only when the data isn't a legacy export.

- **Required `workspaceKey` on the file ingester.** `Import.FileIngesterContext.workspaceKey` is now a required `workspace.Key` (no longer `| undefined`); the value is defaulted to `uuid.ZERO` at each context-construction site, so ingesters can rely on it.

Adds regression tests for both the schematic and table import paths.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two bugs in the schematic and table import paths introduced when the system moved to server-typed state: blank imports of legacy files (caused by the lenient typed schema silently accepting and stripping legacy data), and a required `workspaceKey` field on `FileIngesterContext`.

- **Blank legacy import fix**: `parseImport` now tries the strict legacy `anyStateZ` schema first (requiring specific version literals and console-only fields). When that succeeds it extracts data from `pendingUpload`; when it fails it falls through to the typed parse path.
- **`workspaceKey` fix**: The field is now typed as required `workspace.Key` on `FileIngesterContext`; callers default to `uuid.ZERO` instead of forwarding `undefined`.
- **Regression tests**: Both schematic and table import paths get spec files covering legacy, typed, and silent-drop scenarios.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the parse-order inversion is logically sound and the key invariant (strict legacy schemas require console-only fields that typed server exports never carry) is verified by the new regression tests.

The legacy-first approach is correct: every legacy state schema requires a specific version literal plus console-only fields that typed server exports never carry, so the two branches are mutually exclusive in practice. The workspaceKey change is mechanical and all three construction sites are updated consistently.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| console/src/schematic/services/import.ts | Core fix: legacy-first parse order correctly prevents lenient typed schema from silently consuming legacy files; workspaceKey nullish guard removed after upstream default. |
| console/src/table/services/import.ts | Mirrors schematic fix for table import; same legacy-first parse order. |
| console/src/schematic/services/import.spec.ts | New regression tests covering legacy v2, typed v6, and silent-drop prevention for schematic import. |
| console/src/table/services/import.spec.ts | New regression tests covering legacy v0, typed v1, and silent-drop prevention for table import. |
| console/src/import/ingester.ts | Makes workspaceKey required on FileIngesterContext, removing the optionality that forced downstream guards. |
| console/src/import/import.ts | Defaults workspaceKey to uuid.ZERO before constructing context. |
| console/src/import/dataTransferItem.ts | Second context-construction site updated with the same uuid.ZERO default. |
| console/src/schematic/selectors.ts | Replaces Diagram.Viewport import with locally-defined Viewport type that includes the mode field; no logic change. |
| console/src/schematic/types/v6.ts | Renames ViewportState to Viewport and minor formatting cleanup; no logic changes. |
| console/src/schematic/types/index.ts | Re-exports the new Viewport interface from v6 through the types barrel. |
| console/src/schematic/slice.ts | Re-exports Viewport from latest types so selectors can import it from the slice module. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Import file data] --> B{data is object?}
    B -- No --> E
    B -- Yes --> C[anyStateZ.safeParse with remoteCreated: false]
    C -- success --> D{pendingUpload == null?}
    D -- Yes --> ERR[throw: no graph data]
    D -- No --> OK1[Extract nodes/edges/configs - Return schematic.New]
    C -- fail --> E[schematicZ.parse / tableZ.parse]
    E -- success --> OK2[Return typed schematic.New / table.New]
    E -- fail --> ZERR[throw ZodError]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `console/src/schematic/selectors.ts`, line 82-95 ([link](https://github.com/synnaxlabs/synnax/blob/d45cc01a5992fd26f1feccde9b02e3b4c0620c74/console/src/schematic/selectors.ts#L82-L95)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Selectors used in `Internal` still lack null guards**

   The PR description says the crash is fixed by "reading through individual selectors with graceful fallbacks." Four of the seven selectors now used in `Internal` do have `?.` guards (`selectControlStatus`, `selectAuthority`, `selectLegend`, `selectSelected`), but `selectEditable`, `selectViewport`, and `selectFitViewOnResize` access `select(state, key)` directly without `?.`.

   `useAutoUpload` returns `true` when the Redux state entry doesn't exist, because `selectPendingUpload` uses `?.pendingUpload` — so `undefined == null` evaluates to `true` and `Internal` renders. On that first render `select(state, key)` returns `undefined`, and `undefined.editable` / `undefined.viewport` / `undefined.fitViewOnResize` all throw — producing the same crash the PR is trying to eliminate, just with a different error message.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["go back to nondesctructure"](https://github.com/synnaxlabs/synnax/commit/6d41ad50365c90a31f0aa7f1bf4e55afedc2f649) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34615586)</sub>

<!-- /greptile_comment -->