### PR TITLE
SY-4264: Fix Table Value Rendering Vertical Drift

### DIFF
--- a/pluto/src/table/Table.css
+++ b/pluto/src/table/Table.css
@@ -163,6 +163,7 @@
 
     .pluto-table__cell {
         border: var(--pluto-border);
+        box-sizing: border-box;
         z-index: 5;
         position: relative;
         border-top: none;
@@ -171,15 +172,16 @@
         overflow: hidden;
 
         /*
-         * The inner content div is locked to the row's stored size so a cell
-         * whose content wants more vertical room (e.g. wrapped text) clips
-         * at the row's bottom instead of growing the row. Without this, the
-         * row's drag handle (positioned from rowYCursor + row.size) and the
-         * row's visible bottom border drift apart.
+         * Stored size goes on the <td> with box-sizing: border-box so the
+         * content div fills the rest and overflow clips at the row's bottom.
+         * border-box also absorbs the bottom border into the size, keeping the
+         * DOM row height in lockstep with the canvas's rowYCursor (which
+         * advances by row.size).
          */
         & > .pluto-table__cell__content {
             overflow: hidden;
             width: 100%;
+            height: 100%;
         }
         &::after {
             content: "";

--- a/pluto/src/table/cells/Cell.tsx
+++ b/pluto/src/table/cells/Cell.tsx
@@ -13,9 +13,10 @@ import { CSS } from "@/css";
 
 export interface CellProps extends React.ComponentPropsWithRef<"td"> {
   selected?: boolean;
-  // height is the row's stored size in px. The inner content div is locked
-  // to this so a cell whose content wants more vertical room (e.g. wrapped
-  // text) clips at the row's bottom instead of growing the row.
+  // height is the row's stored size in px, applied to the <td> with
+  // box-sizing: border-box so the bottom border is absorbed rather than
+  // added. Otherwise rows render 1px taller than rowYCursor advances and the
+  // canvas value drifts upward down the table.
   height: number;
 }
 
@@ -27,15 +28,15 @@ export const Cell = ({
   className,
   selected = false,
   height,
+  style,
   ...rest
 }: CellProps): ReactElement => (
   <td
     ref={ref}
     {...rest}
+    style={{ ...style, height }}
     className={CSS(CSS.BE("table", "cell"), CSS.selected(selected), className)}
   >
-    <div className={CSS.BEM("table", "cell", "content")} style={{ height }}>
-      {children}
-    </div>
+    <div className={CSS.BEM("table", "cell", "content")}>{children}</div>
   </td>
 );


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4264](https://linear.app/synnax/issue/SY-4264)

## Description

Table cell values are painted on a canvas, with each cell's canvas box positioned by a running JS cursor that advances by exactly `row.size` per row (`Table.tsx` `rowYCursor`). The visible grid, however, is a real DOM `<table>` whose cells carried a 1px bottom border *on top of* their stored height (the height was applied to the inner content div, leaving the border to add to the `<td>`'s outer height). The DOM therefore stacked each row 1px taller than the canvas predicted, so the canvas-rendered value drifted progressively upward relative to its cell as you moved down the table — by row 14 the value was jammed against the top edge.

The fix applies the stored row height to the `<td>` itself with `box-sizing: border-box`, so the bottom border is absorbed into `row.size` rather than added to it. The content div now fills the cell with `height: 100%`. This keeps the DOM row height in lockstep with the canvas cursor, eliminating the drift.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a progressive vertical drift between canvas-rendered cell values and their DOM table cells by applying the stored row height to the `<td>` element (with `box-sizing: border-box`) instead of the inner content div, so the 1px bottom border is absorbed into `row.size` rather than added on top. It also corrects a pre-existing bug where caller-supplied `style` props (`backgroundColor`, `width`) were silently dropped because `style` was not extracted before the `...rest` spread.

- **CSS**: Adds `box-sizing: border-box` to `.pluto-table__cell` and sets `height: 100%` on the content div so it fills the corrected `<td>` content area.
- **Cell.tsx**: Moves the `height` inline style from the inner `<div>` to the `<td>`, and explicitly destructures and spreads `style` so `Text` and `Value` cell background colors and explicit widths are preserved on every render.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the fix is minimal and targeted, and the style-prop merge regression is also correctly resolved in this same PR.

Both changed files contain only the intended CSS model correction and a style-prop extraction fix. Moving the height constraint from the child div to the parent td with border-box makes DOM row heights match the canvas cursor exactly, and explicitly spreading style before height prevents caller styles from being shadowed. No unrelated code paths are touched.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| pluto/src/table/cells/Cell.tsx | Moves height from the inner content div to the <td> itself, extracts and properly merges the style prop so caller-supplied styles (backgroundColor, width) are no longer silently discarded, and removes the now-redundant explicit height from the child div. |
| pluto/src/table/Table.css | Adds box-sizing: border-box to .pluto-table__cell so the bottom border is absorbed into the row.size value; sets height: 100% on the inner content div so it fills the now-correct <td> content area; updates the explanatory comment. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Canvas as Canvas rowYCursor
    participant TD as td element
    participant Div as cell content div

    Note over Canvas,Div: Before fix
    Canvas->>TD: no explicit height style
    TD->>Div: style height 30px
    Note over TD: TD actual height = 30px content + 1px border = 31px
    Note over Canvas,TD: DOM rows grow 1px per row, canvas value drifts upward

    Note over Canvas,Div: After fix
    Canvas->>TD: style height 30px with box-sizing border-box
    Note over TD: TD actual height = 30px border absorbed
    TD->>Div: height 100% fills 29px content area
    Note over Canvas,TD: DOM row height matches canvas rowYCursor advance, no drift
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `pluto/src/table/cells/Cell.tsx`, line 25-38 ([link](https://github.com/synnaxlabs/synnax/blob/b704d1debbaa8ac4c82a1edca8b30f55e9327cb5/pluto/src/table/cells/Cell.tsx#L25-L38)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> The `style={{ height }}` spread after `{...rest}` silently discards any `style` prop passed by callers. Both `Text` (passes `backgroundColor` + `width`) and `Value` (passes `width`) in `Cells.tsx` rely on `style` surviving into the `<td>`. With this ordering, those values are dropped on every render — `Text` cells lose their background colour and the explicit width that keeps canvas/DOM column alignment is gone for `Value` cells when indicators are hidden.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["SY-4264: Fix Table Value Rendering Verti..."](https://github.com/synnaxlabs/synnax/commit/f5e8242d6ff5cf4ee1bfe64ebe316de2caedc3f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34625190)</sub>

<!-- /greptile_comment -->