### PR TITLE
SY-4265: Gate Arc LSP Hover & Highlighting on Module Imports

### DIFF
--- a/arc/go/lsp/hover.go
+++ b/arc/go/lsp/hover.go
@@ -428,15 +428,18 @@ func cleanDocComment(comments []string) string {
 // resolveDotted resolves a possibly-qualified name like "time.now" by
 // splitting on dots and walking: the head is resolved in scope, each
 // subsequent segment is resolved against the previous result's children.
-// IncludeInternal is passed so bare module names (filtered out of normal
-// user-code resolution) are reachable for hover and similar tooling.
+// Resolution mirrors user-code resolution (no IncludeInternal), so a
+// module that is reachable only through the ambient prelude — i.e. one the
+// document has not imported — does not resolve. Hovering a member of an
+// unimported module therefore returns nothing, matching the analyzer's
+// "undefined" diagnostic instead of rendering docs as if it were valid.
 func resolveDotted(
 	ctx context.Context,
 	scope *symbol.Symbol,
 	name string,
 ) (*symbol.Symbol, error) {
 	head, tail, hasDot := strings.Cut(name, ".")
-	sym, err := scope.Resolve(ctx, head, symbol.IncludeInternal)
+	sym, err := scope.Resolve(ctx, head)
 	if err != nil {
 		return nil, err
 	}

--- a/arc/go/lsp/hover_test.go
+++ b/arc/go/lsp/hover_test.go
@@ -116,13 +116,13 @@ var _ = Describe("Hover", func() {
 		})
 
 		It("should provide hover for 'control.set_authority' function", func(ctx SpecContext) {
-			content := "control.set_authority{value=255}"
+			content := "import control\n\ntrig -> control.set_authority{value=255}"
 			OpenArcDocument(server, ctx, uri, content)
 
 			hover := MustSucceed(server.Hover(ctx, &protocol.HoverParams{
 				TextDocumentPositionParams: protocol.TextDocumentPositionParams{
 					TextDocument: protocol.TextDocumentIdentifier{URI: uri},
-					Position:     protocol.Position{Line: 0, Character: 12},
+					Position:     protocol.Position{Line: 2, Character: 20}, // control.set_a|uthority
 				},
 			}))
 
@@ -132,13 +132,13 @@ var _ = Describe("Hover", func() {
 		})
 
 		It("should provide hover for 'math.avg' function", func(ctx SpecContext) {
-			content := "sensor -> math.avg{} -> output"
+			content := "import math\n\nsensor -> math.avg{} -> output"
 			OpenArcDocument(server, ctx, uri, content)
 
 			hover := MustSucceed(server.Hover(ctx, &protocol.HoverParams{
 				TextDocumentPositionParams: protocol.TextDocumentPositionParams{
 					TextDocument: protocol.TextDocumentIdentifier{URI: uri},
-					Position:     protocol.Position{Line: 0, Character: 16},
+					Position:     protocol.Position{Line: 2, Character: 16},
 				},
 			}))
 
@@ -164,13 +164,13 @@ var _ = Describe("Hover", func() {
 		})
 
 		It("should provide hover for 'stable.for' function", func(ctx SpecContext) {
-			content := "sensor -> stable.for{duration=5s} -> output"
+			content := "import stable\n\nsensor -> stable.for{duration=5s} -> output"
 			OpenArcDocument(server, ctx, uri, content)
 
 			hover := MustSucceed(server.Hover(ctx, &protocol.HoverParams{
 				TextDocumentPositionParams: protocol.TextDocumentPositionParams{
 					TextDocument: protocol.TextDocumentIdentifier{URI: uri},
-					Position:     protocol.Position{Line: 0, Character: 18},
+					Position:     protocol.Position{Line: 2, Character: 18},
 				},
 			}))
 
@@ -180,13 +180,13 @@ var _ = Describe("Hover", func() {
 		})
 
 		It("should provide hover for 'time.now' function", func(ctx SpecContext) {
-			content := "t := time.now()"
+			content := "import time\n\nfunc test() i64 {\n    return time.now()\n}"
 			OpenArcDocument(server, ctx, uri, content)
 
 			hover := MustSucceed(server.Hover(ctx, &protocol.HoverParams{
 				TextDocumentPositionParams: protocol.TextDocumentPositionParams{
 					TextDocument: protocol.TextDocumentIdentifier{URI: uri},
-					Position:     protocol.Position{Line: 0, Character: 11}, // n|ow
+					Position:     protocol.Position{Line: 3, Character: 17}, // n|ow
 				},
 			}))
 
@@ -212,13 +212,13 @@ var _ = Describe("Hover", func() {
 		})
 
 		It("should provide hover for 'time.interval' function", func(ctx SpecContext) {
-			content := "time.interval{period=100ms}"
+			content := "import time\n\ntime.interval{period=100ms} -> output"
 			OpenArcDocument(server, ctx, uri, content)
 
 			hover := MustSucceed(server.Hover(ctx, &protocol.HoverParams{
 				TextDocumentPositionParams: protocol.TextDocumentPositionParams{
 					TextDocument: protocol.TextDocumentIdentifier{URI: uri},
-					Position:     protocol.Position{Line: 0, Character: 7}, // time.i|nterval
+					Position:     protocol.Position{Line: 2, Character: 7}, // time.i|nterval
 				},
 			}))
 
@@ -244,13 +244,13 @@ var _ = Describe("Hover", func() {
 		})
 
 		It("should provide hover for 'time.wait' function", func(ctx SpecContext) {
-			content := "time.wait{duration=500ms}"
+			content := "import time\n\ntime.wait{duration=500ms} -> output"
 			OpenArcDocument(server, ctx, uri, content)
 
 			hover := MustSucceed(server.Hover(ctx, &protocol.HoverParams{
 				TextDocumentPositionParams: protocol.TextDocumentPositionParams{
 					TextDocument: protocol.TextDocumentIdentifier{URI: uri},
-					Position:     protocol.Position{Line: 0, Character: 7}, // time.w|ait
+					Position:     protocol.Position{Line: 2, Character: 7}, // time.w|ait
 				},
 			}))
 
@@ -680,9 +680,9 @@ func add(a i32, b i32) i32 {
 			}))
 			server.SetClient(&MockClient{})
 
-			content := "func test() i64 {\n    return time.now()\n}"
+			content := "import time\n\nfunc test() i64 {\n    return time.now()\n}"
 			OpenArcDocument(server, ctx, uri, content)
-			hover := Hover(server, ctx, uri, 1, 14)
+			hover := Hover(server, ctx, uri, 3, 14)
 			Expect(hover).ToNot(BeNil())
 			Expect(hover.Contents.Value).To(ContainSubstring("now"))
 		})
@@ -699,6 +699,23 @@ func add(a i32, b i32) i32 {
 			OpenArcDocument(server, ctx, uri, content)
 			hover := Hover(server, ctx, uri, 1, 10)
 			Expect(hover).To(BeNil())
+		})
+
+		It("Should not provide hover for a member of an unimported module", func(ctx SpecContext) {
+			// `time` is not imported, so `time.now` is an undefined reference
+			// to the analyzer. Hover must not render docs as if it were valid.
+			content := "func test() i64 {\n    return time.now()\n}"
+			OpenArcDocument(server, ctx, uri, content)
+			hover := Hover(server, ctx, uri, 1, 17) // n|ow
+			Expect(hover).To(BeNil())
+		})
+
+		It("Should provide hover for a member of an imported module", func(ctx SpecContext) {
+			content := "import time\n\nfunc test() i64 {\n    return time.now()\n}"
+			OpenArcDocument(server, ctx, uri, content)
+			hover := Hover(server, ctx, uri, 3, 17) // n|ow
+			Expect(hover).ToNot(BeNil())
+			Expect(hover.Contents.Value).To(ContainSubstring("#### time.now"))
 		})
 	})
 
@@ -893,7 +910,7 @@ func add(a i32, b i32) i32 {
 		})
 
 		It("should tokenize member name as function in qualified calls", func(ctx SpecContext) {
-			OpenArcDocument(server, ctx, uri, "time.interval{period=100ms}")
+			OpenArcDocument(server, ctx, uri, "import time\n\ntime.interval{period=100ms} -> output")
 			tokens := SemanticTokens(server, ctx, uri)
 			Expect(tokens).ToNot(BeNil())
 			foundFunction := false

--- a/arc/go/lsp/semantic.go
+++ b/arc/go/lsp/semantic.go
@@ -105,7 +105,11 @@ func extractSemanticTokens(ctx context.Context, content string, docIR ir.IR) []u
 		if i+1 < len(allTokens) {
 			nextType = allTokens[i+1].GetTokenType()
 		}
-		tokenType := classifyToken(ctx, t, prevType, nextType, importIdents.Contains(i), docIR)
+		qualifier := ""
+		if prevType == parser.ArcLexerDOT && i >= 2 {
+			qualifier = allTokens[i-2].GetText()
+		}
+		tokenType := classifyToken(ctx, t, prevType, nextType, importIdents.Contains(i), docIR, qualifier)
 		if tokenType == nil {
 			continue
 		}
@@ -278,11 +282,14 @@ func classifyToken(
 	prevTokenType, nextTokenType int,
 	inImport bool,
 	docIR ir.IR,
+	qualifier string,
 ) *uint32 {
-	return classifyTokenAt(ctx, t, prevTokenType, nextTokenType, inImport, docIR, t.GetLine(), t.GetColumn())
+	return classifyTokenAt(ctx, t, prevTokenType, nextTokenType, inImport, docIR, t.GetLine(), t.GetColumn(), qualifier)
 }
 
 // Variant with explicit (line1, col0) for tokens lexed out of a sub-string.
+// qualifier is the identifier preceding the DOT when t is a member access
+// (e.g. "time" in "time.now"); it is empty otherwise.
 func classifyTokenAt(
 	ctx context.Context,
 	t antlr.Token,
@@ -290,6 +297,7 @@ func classifyTokenAt(
 	inImport bool,
 	docIR ir.IR,
 	line1, col0 int,
+	qualifier string,
 ) *uint32 {
 	antlrType := t.GetTokenType()
 	// Identifiers (and AUTHORITY used as an importable name) inside an import
@@ -309,11 +317,26 @@ func classifyTokenAt(
 			prevTokenType == parser.ArcLexerFLOAT_LITERAL) {
 		return nil
 	}
-	// IDENTIFIER after DOT is the member part of a qualified name
-	// (e.g., "set_authority" in "control.set_authority"). Color it as a function.
+	// IDENTIFIER after DOT is the member part of a qualified name (e.g.,
+	// "set_authority" in "control.set_authority"). Color it by its symbol
+	// kind only when the qualifier resolves to an imported module that
+	// actually has this member. An unimported or unknown qualifier yields no
+	// token, so the highlight matches the analyzer's "undefined" view rather
+	// than implying a valid reference.
 	if antlrType == parser.ArcLexerIDENTIFIER && prevTokenType == parser.ArcLexerDOT {
-		tokenType := uint32(SemanticTokenTypeFunction)
-		return &tokenType
+		if docIR.Symbols == nil || qualifier == "" {
+			return nil
+		}
+		scope := findScopeAtInternalPosition(docIR.Symbols, position{Line: line1, Col: col0})
+		mod, err := scope.Resolve(ctx, qualifier)
+		if err != nil {
+			return nil
+		}
+		member, err := mod.Resolve(ctx, t.GetText())
+		if err != nil {
+			return nil
+		}
+		return mapSymbolKind(member.Kind)
 	}
 	// IDENTIFIER followed by DOT is a qualifier; if it names an imported
 	// module (directly or via alias), color it as a namespace so callers can
@@ -475,12 +498,16 @@ func expandStringToken(ctx context.Context, t antlr.Token, docIR ir.IR) []lsp.To
 			if i+1 < len(inner) {
 				next = inner[i+1].GetTokenType()
 			}
+			qualifier := ""
+			if prev == parser.ArcLexerDOT && i >= 2 {
+				qualifier = inner[i-2].GetText()
+			}
 			relLine, relCol := uint32(it.GetLine()-1), uint32(it.GetColumn())
 			absLine, absCol := baseLine+relLine, relCol
 			if relLine == 0 {
 				absCol = baseCol + relCol
 			}
-			tt := classifyTokenAt(ctx, it, prev, next, false, docIR, int(absLine)+1, int(absCol))
+			tt := classifyTokenAt(ctx, it, prev, next, false, docIR, int(absLine)+1, int(absCol), qualifier)
 			if tt == nil {
 				continue
 			}

--- a/arc/go/lsp/semantic_test.go
+++ b/arc/go/lsp/semantic_test.go
@@ -420,6 +420,28 @@ var _ = Describe("Semantic Tokens", func() {
 			Expect(filterByType(tokens, tokenTypeNamespace)).To(BeEmpty())
 		})
 
+		It("does not route an unimported qualifier's member to function", func(ctx SpecContext) {
+			// `now` at col 29 must not be function-colored: `time` is not
+			// imported, so the analyzer treats `time.now` as undefined and the
+			// highlight must match rather than imply a valid call.
+			OpenArcDocument(server, ctx, uri,
+				"func cat() i64 { return time.now() }\n")
+			fns := filterByType(decodeSemanticTokens(SemanticTokens(server, ctx, uri).Data), tokenTypeFunction)
+			for _, t := range fns {
+				Expect(t.StartChar).ToNot(Equal(uint32(29)),
+					"unimported member `now` must not be colored as a function")
+			}
+		})
+
+		It("routes an imported qualifier's member to function", func(ctx SpecContext) {
+			OpenArcDocument(server, ctx, uri,
+				"import time\n\nfunc cat() i64 { return time.now() }\n")
+			fns := filterByType(decodeSemanticTokens(SemanticTokens(server, ctx, uri).Data), tokenTypeFunction)
+			Expect(fns).To(ContainElement(
+				decodedToken{Line: 2, StartChar: 29, Length: 3, TokenType: tokenTypeFunction},
+			))
+		})
+
 		It("routes sequence and stage names to the function token type", func(ctx SpecContext) {
 			// Sequence and stage names should share the same highlight
 			// color as function names — they are declarations of named,


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4265](https://linear.app/synnax/issue/SY-4265)

## Description

The Arc LSP treated standard-library and host-injected modules (`time`, `math`, `control`, …) as ambient: they live above the program root and are always present, so hover and semantic highlighting surfaced them even when the document had not imported them. The analyzer correctly reports an unimported `time.now` as an undefined reference, so users saw an error squiggle while simultaneously getting full hover docs and function highlighting — the "weird with modules" behavior.

This change makes hover and semantic highlighting respect the same import gate the analyzer enforces:

- **Hover** (`resolveDotted`) now resolves a qualified head with normal user-code resolution (no `IncludeInternal`). A module reachable only through the ambient prelude — i.e. not imported — no longer resolves, so hovering `time.now` without `import time` returns nothing, matching the diagnostic. Imported modules still hover via their alias.
- **Semantic tokens** no longer color a post-`.` member as a function unconditionally. The member is colored by its symbol kind only when the qualifier resolves to an imported module that actually has that member; an unimported or unknown qualifier yields no token.

Completion is intentionally unchanged: offering `module.member` with an auto-import edit (which inserts the missing `import`) is an existing feature, not the bug.

A few pre-existing hover/semantic tests relied on the old behavior (hovering `time.now`, `math.avg`, etc. with no import). They are preserved, updated to import the module and use parseable program forms.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR gates the Arc LSP's hover and semantic-token highlighting behind the same module-import check the analyzer uses. Previously, modules in the ambient prelude (e.g. `time`, `math`, `control`) were always resolvable for hover and coloring, producing a confusing UX where `time.now` showed docs and was colored as a function even though the analyzer simultaneously raised an "undefined" diagnostic.

- **Hover** (`resolveDotted`): drops `IncludeInternal` so un-imported module heads no longer resolve, making hover return `nil` to match the diagnostic.
- **Semantic tokens** (`classifyTokenAt`): instead of unconditionally coloring a post-`.` identifier as a function, the qualifier is now looked up in the symbol table; coloring is applied only when the qualifier resolves to an imported module that actually has the member. All previously passing tests are updated to include the required `import` statement, and new regression tests cover both the negative (unimported → no hover/color) and positive (imported → hover/color) cases.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the changes are narrowly scoped to hover and semantic token paths, with no impact on the analyzer, completion, or any data-flow logic.

Both hover and semantic token paths now correctly mirror the analyzer's import gate. The qualifier extraction via `allTokens[i-2]` is reliable for normal `module.member` patterns and fails safely for unusual token arrangements. The existing test suite was fully updated to require import statements, and new regression tests verify both the negative and positive behaviors for each path.

No files require special attention; all four files are straightforward and the changes are self-contained within the LSP layer.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| arc/go/lsp/hover.go | Removes `IncludeInternal` from `resolveDotted`'s head resolution, correctly blocking hover for un-imported ambient modules. Logic is clean and minimal. |
| arc/go/lsp/semantic.go | Adds qualifier-extraction and scope-resolution before coloring a post-DOT identifier. The `allTokens[i-2]` index assumption is correct for normal `module.member` patterns and fails safely for unusual token arrangements; no false positives possible. |
| arc/go/lsp/hover_test.go | Existing tests updated to include required `import` statements with adjusted positions; two new tests (imported/unimported) clearly cover the gated behavior. |
| arc/go/lsp/semantic_test.go | Two new tests pin the negative (unimported qualifier → no function token at col 29) and positive (imported qualifier → function token at col 29) cases; column arithmetic verified as correct. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[LSP Request\nhover or semantic tokens] --> B{Request type?}

    B -->|Hover| C[resolveDotted\nhead = 'time', tail = 'now']
    C --> D[scope.Resolve ctx, head\nno IncludeInternal]
    D -->|Not imported| E[err != nil → return nil\nNo hover rendered]
    D -->|Imported| F[recurse: resolveDotted ctx, sym, tail]
    F --> G[Return symbol → render hover docs]

    B -->|Semantic tokens| H[extractSemanticTokens\nfor each token i]
    H --> I{prevType == DOT\n&& i >= 2?}
    I -->|No| J[classifyToken normal path]
    I -->|Yes| K[qualifier = allTokens i-2 .GetText]
    K --> L[findScopeAtInternalPosition\nposition of member token]
    L --> M[scope.Resolve ctx, qualifier\nno IncludeInternal]
    M -->|Not imported / err| N[return nil\nNo semantic token emitted]
    M -->|Imported| O[mod.Resolve ctx, memberText]
    O -->|member not found| N
    O -->|member found| P[mapSymbolKind member.Kind\nEmit colored token]
```

<sub>Reviews (1): Last reviewed commit: ["SY-4265: Gate Arc LSP hover and highligh..."](https://github.com/synnaxlabs/synnax/commit/991ea5c579877a37c0e430f82ba9372173fef3ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34628506)</sub>

<!-- /greptile_comment -->