### PR TITLE
[tauri] Fix Workspace Export

### DIFF
--- a/console/src/runtime/files.ts
+++ b/console/src/runtime/files.ts
@@ -276,7 +276,12 @@ const pickWritableDirectoryTauri = async ({
   title,
   subdirectory,
 }: PickWritableDirectoryArgs): Promise<WritableDirectory | null> => {
-  const parent = await open({ title, directory: true, multiple: false });
+  const parent = await open({
+    title,
+    directory: true,
+    multiple: false,
+    recursive: true,
+  });
   if (parent == null || Array.isArray(parent)) return null;
   const dirPath = await join(parent, subdirectory);
   const preExisted = await exists(dirPath);


### PR DESCRIPTION
[[tauri] re-enable recursive: true

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR re-enables `recursive: true` on the Tauri `open()` dialog call in `pickWritableDirectoryTauri`, which is required for workspace export to work correctly on the desktop app.

- Without `recursive: true`, Tauri's security scope only grants access to the selected parent directory itself, not its subdirectories — this caused `mkdir` and `writeTextFile` calls targeting the `subdirectory` child path to fail silently or throw a permissions error.
- The fix is minimal and targeted, restoring the scope flag so subdirectory writes during workspace export are permitted.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change restores a missing scope flag that blocked subdirectory writes during workspace export.

The one-line addition of `recursive: true` directly matches what Tauri requires to grant filesystem scope over subdirectories of the picked parent. The rest of the function already uses `mkdir` and `writeTextFile` targeting a child path, so the flag is clearly necessary and its absence was the root cause of the broken export.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| console/src/runtime/files.ts | Adds `recursive: true` to the Tauri directory picker used for writable directory selection, allowing subdirectory access within the picked parent — required for workspace export to write into a subdirectory. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant Dialog as Tauri Dialog (open)
    participant FS as Tauri FS Plugin
    participant Disk

    User->>Dialog: "pickWritableDirectoryTauri({ title, subdirectory })"
    Dialog-->>User: OS directory picker (recursive: true scope)
    User->>Dialog: Selects parent directory
    Dialog-->>FS: Grants scope: parent + subdirectories
    FS->>Disk: join(parent, subdirectory) → dirPath
    FS->>Disk: exists(dirPath)
    Disk-->>FS: preExisted
    Note over FS,Disk: On writeText call:
    FS->>Disk: "mkdir(dirPath, { recursive: true })"
    FS->>Disk: writeTextFile(join(dirPath, name), contents)
    FS-->>User: WritableDirectory handle
```

<sub>Reviews (1): Last reviewed commit: ["\[tauri\] re-enable \`recursive: true\`"](https://github.com/synnaxlabs/synnax/commit/6bc558a1d9180a76103700b2142a4915e704f60c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34629169)</sub>

<!-- /greptile_comment -->