### PR TITLE
SY-4263: Fix Arc graphical `set_status` to `status.set` migration

### DIFF
--- a/arc/go/ir/format.go
+++ b/arc/go/ir/format.go
@@ -26,8 +26,6 @@ func TreePrefix(last bool) string {
 	return "├── "
 }
 
-// treeIndent returns the indent for children of a tree item. If last is true, returns "
-// ", otherwise "│   ".
 func treeIndent(last bool) string {
 	if last {
 		return "    "

--- a/arc/go/ir/format.go
+++ b/arc/go/ir/format.go
@@ -17,8 +17,8 @@ import (
 	"github.com/synnaxlabs/arc/types"
 )
 
-// TreePrefix returns the prefix for a tree item.
-// If last is true, returns "└── ", otherwise "├── ".
+// TreePrefix returns the prefix for a tree item. If last is true, returns "└── ",
+// otherwise "├── ".
 func TreePrefix(last bool) string {
 	if last {
 		return "└── "
@@ -26,23 +26,13 @@ func TreePrefix(last bool) string {
 	return "├── "
 }
 
-// treePrefix is an alias for TreePrefix for internal use.
-func treePrefix(last bool) string {
-	return TreePrefix(last)
-}
-
-// TreeIndent returns the indent for children of a tree item.
-// If last is true, returns "    ", otherwise "│   ".
-func TreeIndent(last bool) string {
+// treeIndent returns the indent for children of a tree item. If last is true, returns "
+// ", otherwise "│   ".
+func treeIndent(last bool) string {
 	if last {
 		return "    "
 	}
 	return "│   "
-}
-
-// treeIndent is an alias for TreeIndent for internal use.
-func treeIndent(last bool) string {
-	return TreeIndent(last)
 }
 
 // formatParams formats a slice of Params as "name (type), name (type), ..."

--- a/arc/go/ir/function.go
+++ b/arc/go/ir/function.go
@@ -54,7 +54,7 @@ func (f Function) stringWithPrefix(prefix string) string {
 	// Channels
 	isLast := !hasConfig && !hasInputs && !hasOutputs
 	b.WriteString(prefix)
-	b.WriteString(treePrefix(isLast))
+	b.WriteString(TreePrefix(isLast))
 	b.WriteString("channels: ")
 	b.WriteString(formatChannels(f.Channels))
 	b.WriteString("\n")
@@ -62,7 +62,7 @@ func (f Function) stringWithPrefix(prefix string) string {
 	if hasConfig {
 		isLast = !hasInputs && !hasOutputs
 		b.WriteString(prefix)
-		b.WriteString(treePrefix(isLast))
+		b.WriteString(TreePrefix(isLast))
 		b.WriteString("config: ")
 		b.WriteString(formatParams(f.Config))
 		b.WriteString("\n")
@@ -71,7 +71,7 @@ func (f Function) stringWithPrefix(prefix string) string {
 	if hasInputs {
 		isLast = !hasOutputs
 		b.WriteString(prefix)
-		b.WriteString(treePrefix(isLast))
+		b.WriteString(TreePrefix(isLast))
 		b.WriteString("inputs: ")
 		b.WriteString(formatParams(f.Inputs))
 		b.WriteString("\n")
@@ -79,7 +79,7 @@ func (f Function) stringWithPrefix(prefix string) string {
 
 	if hasOutputs {
 		b.WriteString(prefix)
-		b.WriteString(treePrefix(true))
+		b.WriteString(TreePrefix(true))
 		b.WriteString("outputs: ")
 		b.WriteString(formatParams(f.Outputs))
 		b.WriteString("\n")

--- a/arc/go/ir/ir.go
+++ b/arc/go/ir/ir.go
@@ -114,39 +114,39 @@ func (i *IR) stringWithPrefix(prefix string) string {
 
 func (i *IR) writeFunctions(b *strings.Builder, prefix string, last bool) {
 	b.WriteString(prefix)
-	b.WriteString(treePrefix(last))
+	b.WriteString(TreePrefix(last))
 	lo.Must(fmt.Fprintf(b, "Functions (%d)\n", len(i.Functions)))
 	childPrefix := prefix + treeIndent(last)
 	for j, f := range i.Functions {
 		isLast := j == len(i.Functions)-1
 		b.WriteString(childPrefix)
-		b.WriteString(treePrefix(isLast))
+		b.WriteString(TreePrefix(isLast))
 		b.WriteString(f.stringWithPrefix(childPrefix + treeIndent(isLast)))
 	}
 }
 
 func (i *IR) writeNodes(b *strings.Builder, prefix string, last bool) {
 	b.WriteString(prefix)
-	b.WriteString(treePrefix(last))
+	b.WriteString(TreePrefix(last))
 	lo.Must(fmt.Fprintf(b, "Nodes (%d)\n", len(i.Nodes)))
 	childPrefix := prefix + treeIndent(last)
 	for j, n := range i.Nodes {
 		isLast := j == len(i.Nodes)-1
 		b.WriteString(childPrefix)
-		b.WriteString(treePrefix(isLast))
+		b.WriteString(TreePrefix(isLast))
 		b.WriteString(n.stringWithPrefix(childPrefix + treeIndent(isLast)))
 	}
 }
 
 func (i *IR) writeEdges(b *strings.Builder, prefix string, last bool) {
 	b.WriteString(prefix)
-	b.WriteString(treePrefix(last))
+	b.WriteString(TreePrefix(last))
 	lo.Must(fmt.Fprintf(b, "Edges (%d)\n", len(i.Edges)))
 	childPrefix := prefix + treeIndent(last)
 	for j, e := range i.Edges {
 		isLast := j == len(i.Edges)-1
 		b.WriteString(childPrefix)
-		b.WriteString(treePrefix(isLast))
+		b.WriteString(TreePrefix(isLast))
 		b.WriteString(e.String())
 		b.WriteString("\n")
 	}
@@ -154,7 +154,7 @@ func (i *IR) writeEdges(b *strings.Builder, prefix string, last bool) {
 
 func (i *IR) writeRoot(b *strings.Builder, prefix string, last bool) {
 	b.WriteString(prefix)
-	b.WriteString(treePrefix(last))
+	b.WriteString(TreePrefix(last))
 	b.WriteString("Root\n")
 	childPrefix := prefix + treeIndent(last)
 	b.WriteString(i.Root.stringWithPrefix(childPrefix))
@@ -170,13 +170,13 @@ func (s Scope) stringWithPrefix(prefix string) string {
 		for i, stratum := range s.Strata {
 			isLast := i == len(s.Strata)-1 && len(s.Transitions) == 0
 			b.WriteString(prefix)
-			b.WriteString(treePrefix(isLast))
+			b.WriteString(TreePrefix(isLast))
 			lo.Must(fmt.Fprintf(&b, "stratum %d\n", i))
 			childPrefix := prefix + treeIndent(isLast)
 			for j, m := range stratum {
 				isLastMember := j == len(stratum)-1
 				b.WriteString(childPrefix)
-				b.WriteString(treePrefix(isLastMember))
+				b.WriteString(TreePrefix(isLastMember))
 				b.WriteString(m.stringWithPrefix(childPrefix + treeIndent(isLastMember)))
 			}
 		}
@@ -184,14 +184,14 @@ func (s Scope) stringWithPrefix(prefix string) string {
 		for i, m := range s.Steps {
 			isLast := i == len(s.Steps)-1 && len(s.Transitions) == 0
 			b.WriteString(prefix)
-			b.WriteString(treePrefix(isLast))
+			b.WriteString(TreePrefix(isLast))
 			b.WriteString(m.stringWithPrefix(prefix + treeIndent(isLast)))
 		}
 	}
 	for i, t := range s.Transitions {
 		isLast := i == len(s.Transitions)-1
 		b.WriteString(prefix)
-		b.WriteString(treePrefix(isLast))
+		b.WriteString(TreePrefix(isLast))
 		b.WriteString(t.String())
 		b.WriteByte('\n')
 	}

--- a/arc/go/ir/node.go
+++ b/arc/go/ir/node.go
@@ -41,7 +41,7 @@ func (n Node) stringWithPrefix(prefix string) string {
 
 	isLast := !hasConfig && !hasInputs && !hasOutputs
 	b.WriteString(prefix)
-	b.WriteString(treePrefix(isLast))
+	b.WriteString(TreePrefix(isLast))
 	b.WriteString("channels: ")
 	b.WriteString(formatChannels(n.Channels))
 	b.WriteString("\n")
@@ -49,7 +49,7 @@ func (n Node) stringWithPrefix(prefix string) string {
 	if hasConfig {
 		isLast = !hasInputs && !hasOutputs
 		b.WriteString(prefix)
-		b.WriteString(treePrefix(isLast))
+		b.WriteString(TreePrefix(isLast))
 		b.WriteString("config: ")
 		b.WriteString(formatParams(n.Config))
 		b.WriteString("\n")
@@ -58,7 +58,7 @@ func (n Node) stringWithPrefix(prefix string) string {
 	if hasInputs {
 		isLast = !hasOutputs
 		b.WriteString(prefix)
-		b.WriteString(treePrefix(isLast))
+		b.WriteString(TreePrefix(isLast))
 		b.WriteString("inputs: ")
 		b.WriteString(formatParams(n.Inputs))
 		b.WriteString("\n")
@@ -66,7 +66,7 @@ func (n Node) stringWithPrefix(prefix string) string {
 
 	if hasOutputs {
 		b.WriteString(prefix)
-		b.WriteString(treePrefix(true))
+		b.WriteString(TreePrefix(true))
 		b.WriteString("outputs: ")
 		b.WriteString(formatParams(n.Outputs))
 		b.WriteString("\n")

--- a/core/pkg/service/arc/migrate.go
+++ b/core/pkg/service/arc/migrate.go
@@ -16,9 +16,45 @@ package arc
 import (
 	"context"
 
+	"github.com/synnaxlabs/arc/graph"
 	v54 "github.com/synnaxlabs/synnax/pkg/service/arc/migrations/v54"
+	"github.com/synnaxlabs/x/encoding/msgpack"
 )
 
 func MigrateArc(ctx context.Context, old v54.Arc) (Arc, error) {
 	return AutoMigrateArc(ctx, old)
+}
+
+// RenameSetStatus rewrites every deprecated set_status flow node in a to status.set.
+func RenameSetStatus(_ context.Context, a Arc) (Arc, error) {
+	for i := range a.Graph.Nodes {
+		a.Graph.Nodes[i] = migrateLegacySetStatusNode(a.Graph.Nodes[i])
+	}
+	return a, nil
+}
+
+// migrateLegacySetStatusNode rewrites a deprecated set_status flow node to status.set,
+// remapping the legacy statusKey config parameter to key_or_name and dropping any
+// parameters the new function no longer accepts. Nodes of any other type are returned
+// unchanged. This mirrors the Console-side migration in console/src/arc/types/v2.ts.
+func migrateLegacySetStatusNode(n graph.Node) graph.Node {
+	if n.Type != "set_status" {
+		return n
+	}
+	n.Type = "status.set"
+	n.Config = msgpack.EncodedJSON{
+		"key_or_name": legacyStatusConfigString(n.Config, "statusKey", ""),
+		"variant":     legacyStatusConfigString(n.Config, "variant", "success"),
+		"message":     legacyStatusConfigString(n.Config, "message", ""),
+	}
+	return n
+}
+
+// legacyStatusConfigString returns the string value stored at key in config, falling
+// back to def when the key is absent or does not hold a string.
+func legacyStatusConfigString(config msgpack.EncodedJSON, key, def string) string {
+	if v, ok := config[key].(string); ok {
+		return v
+	}
+	return def
 }

--- a/core/pkg/service/arc/migrations/v54/migrate_test.go
+++ b/core/pkg/service/arc/migrations/v54/migrate_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/synnaxlabs/synnax/pkg/service/arc"
 	v54 "github.com/synnaxlabs/synnax/pkg/service/arc/migrations/v54"
 	colorv54 "github.com/synnaxlabs/x/color/migrations/v54"
+	"github.com/synnaxlabs/x/encoding/msgpack"
 	"github.com/synnaxlabs/x/gorp"
 	"github.com/synnaxlabs/x/kv/memkv"
 	labelv54 "github.com/synnaxlabs/x/label/migrations/v54"
@@ -34,7 +35,7 @@ var _ = Describe("v54 -> current Arc migration", func() {
 	It("rewrites v54-encoded entries through the new codec", func(ctx SpecContext) {
 		db := DeferClose(gorp.Wrap(memkv.New()))
 
-		v54Table := MustOpen(gorp.OpenTable[uuid.UUID, v54.Arc](
+		v54Table := MustOpen(gorp.OpenTable(
 			ctx, gorp.TableConfig[v54.Key, v54.Arc]{DB: db},
 		))
 		seed := v54.Arc{
@@ -65,14 +66,11 @@ var _ = Describe("v54 -> current Arc migration", func() {
 		}
 		Expect(v54Table.NewCreate().Entry(&seed).Exec(ctx, db)).To(Succeed())
 
-		currentTable := MustOpen(gorp.OpenTable[uuid.UUID, arc.Arc](
+		currentTable := MustOpen(gorp.OpenTable(
 			ctx, gorp.TableConfig[arc.Key, arc.Arc]{
 				DB: db,
 				Migrations: []migrate.Migration{
-					gorp.NewEntryMigration[uuid.UUID, uuid.UUID, v54.Arc, arc.Arc](
-						"v54_drop_program_status",
-						arc.MigrateArc,
-					),
+					gorp.NewEntryMigration("v54_drop_program_status", arc.MigrateArc),
 				},
 			},
 		))
@@ -99,10 +97,122 @@ var _ = Describe("v54 -> current Arc migration", func() {
 		Expect(got.Status).To(BeNil())
 	})
 
+	It("rewrites deprecated set_status graph nodes to status.set", func(ctx SpecContext) {
+		db := DeferClose(gorp.Wrap(memkv.New()))
+
+		v54Table := MustOpen(gorp.OpenTable(
+			ctx, gorp.TableConfig[v54.Key, v54.Arc]{DB: db},
+		))
+		seed := v54.Arc{
+			Key:  uuid.New(),
+			Name: "Legacy Status Graph",
+			Mode: v54.ModeGraph,
+			Graph: graphv54.Graph{
+				Nodes: graphv54.Nodes{
+					{
+						Key:  "alarm",
+						Type: "set_status",
+						Config: msgpack.EncodedJSON{
+							"statusKey":   "ox_alarm",
+							"variant":     "error",
+							"message":     "Overpressure",
+							"description": "dropped on migrate",
+						},
+						Position: spatialv54.XY{X: 0, Y: 0},
+					},
+					{
+						Key:      "scale",
+						Type:     "scale",
+						Config:   msgpack.EncodedJSON{"factor": "2"},
+						Position: spatialv54.XY{X: 100, Y: 0},
+					},
+				},
+			},
+		}
+		Expect(v54Table.NewCreate().Entry(&seed).Exec(ctx, db)).To(Succeed())
+
+		currentTable := MustOpen(gorp.OpenTable(
+			ctx, gorp.TableConfig[arc.Key, arc.Arc]{
+				DB: db,
+				Migrations: []migrate.Migration{
+					gorp.NewEntryMigration("v54_drop_program_status", arc.MigrateArc),
+					migrate.WithAddedDeps(
+						gorp.NewEntryMigration(
+							"v55_rename_set_status",
+							arc.RenameSetStatus,
+						),
+						"v54_drop_program_status",
+					),
+				},
+			},
+		))
+
+		var got arc.Arc
+		Expect(currentTable.NewRetrieve().
+			Where(gorp.MatchKeys[arc.Key, arc.Arc](seed.Key)).
+			Entry(&got).Exec(ctx, db)).To(Succeed())
+		Expect(got.Graph.Nodes).To(HaveLen(2))
+
+		alarm := MustBeOk(got.Graph.Nodes.Find("alarm"))
+		Expect(alarm.Type).To(Equal("status.set"))
+		Expect(alarm.Config["key_or_name"]).To(Equal("ox_alarm"))
+		Expect(alarm.Config["variant"]).To(Equal("error"))
+		Expect(alarm.Config["message"]).To(Equal("Overpressure"))
+		Expect(alarm.Config).ToNot(HaveKey("statusKey"))
+		Expect(alarm.Config).ToNot(HaveKey("description"))
+
+		scale := MustBeOk(got.Graph.Nodes.Find("scale"))
+		Expect(scale.Type).To(Equal("scale"))
+		Expect(scale.Config["factor"]).To(Equal("2"))
+	})
+
+	It("defaults missing set_status config parameters", func(ctx SpecContext) {
+		db := DeferClose(gorp.Wrap(memkv.New()))
+
+		v54Table := MustOpen(gorp.OpenTable(
+			ctx, gorp.TableConfig[v54.Key, v54.Arc]{DB: db},
+		))
+		seed := v54.Arc{
+			Key:  uuid.New(),
+			Name: "Bare Status Node",
+			Mode: v54.ModeGraph,
+			Graph: graphv54.Graph{
+				Nodes: graphv54.Nodes{{Key: "alarm", Type: "set_status"}},
+			},
+		}
+		Expect(v54Table.NewCreate().Entry(&seed).Exec(ctx, db)).To(Succeed())
+
+		currentTable := MustOpen(gorp.OpenTable(
+			ctx, gorp.TableConfig[arc.Key, arc.Arc]{
+				DB: db,
+				Migrations: []migrate.Migration{
+					gorp.NewEntryMigration("v54_drop_program_status", arc.MigrateArc),
+					migrate.WithAddedDeps(
+						gorp.NewEntryMigration(
+							"v55_rename_set_status",
+							arc.RenameSetStatus,
+						),
+						"v54_drop_program_status",
+					),
+				},
+			},
+		))
+
+		var got arc.Arc
+		Expect(currentTable.NewRetrieve().
+			Where(gorp.MatchKeys[arc.Key, arc.Arc](seed.Key)).
+			Entry(&got).Exec(ctx, db)).To(Succeed())
+		alarm := MustBeOk(got.Graph.Nodes.Find("alarm"))
+		Expect(alarm.Type).To(Equal("status.set"))
+		Expect(alarm.Config["key_or_name"]).To(Equal(""))
+		Expect(alarm.Config["variant"]).To(Equal("success"))
+		Expect(alarm.Config["message"]).To(Equal(""))
+	})
+
 	It("drops Status and Program and preserves core wire fields when v54 entries carry a populated Status", func(ctx SpecContext) {
 		db := DeferClose(gorp.Wrap(memkv.New()))
 
-		v54Table := MustOpen(gorp.OpenTable[uuid.UUID, v54.Arc](
+		v54Table := MustOpen(gorp.OpenTable(
 			ctx, gorp.TableConfig[v54.Key, v54.Arc]{DB: db},
 		))
 		statusKey := uuid.New().String()
@@ -127,14 +237,11 @@ var _ = Describe("v54 -> current Arc migration", func() {
 		}
 		Expect(v54Table.NewCreate().Entry(&seed).Exec(ctx, db)).To(Succeed())
 
-		currentTable := MustOpen(gorp.OpenTable[uuid.UUID, arc.Arc](
+		currentTable := MustOpen(gorp.OpenTable(
 			ctx, gorp.TableConfig[arc.Key, arc.Arc]{
 				DB: db,
 				Migrations: []migrate.Migration{
-					gorp.NewEntryMigration[uuid.UUID, uuid.UUID, v54.Arc, arc.Arc](
-						"v54_drop_program_status",
-						arc.MigrateArc,
-					),
+					gorp.NewEntryMigration("v54_drop_program_status", arc.MigrateArc),
 				},
 			},
 		))

--- a/core/pkg/service/arc/service.go
+++ b/core/pkg/service/arc/service.go
@@ -38,11 +38,12 @@ import (
 
 // ServiceConfig is the configuration for opening a Arc service.
 type ServiceConfig struct {
-	// DB is the database that the Arc service will store arcs in.
+	// DB is the database that the Arc service will store Arcs in.
+	//
 	// [REQUIRED]
 	DB *gorp.DB
-	// Ontology is used to define relationships between arcs and other entities in
-	// the Synnax resource graph.
+	// Ontology is used to define relationships between Arcs and other entities in the
+	// Synnax resource graph.
 	//
 	// [REQUIRED]
 	Ontology *ontology.Ontology
@@ -50,27 +51,24 @@ type ServiceConfig struct {
 	//
 	// [REQUIRED]
 	Channel *channel.Service
-	// Task is used for deleting tasks associated with arcs when arcs are deleted.
+	// Task is used for deleting tasks associated with Arcs when Arcs are deleted.
 	//
 	// [REQUIRED]
 	Task *task.Service
-	// Signals is used for propagating changes to arcs through the cluster.
+	// Signals is used for propagating changes to Arcs through the cluster.
 	//
-	// [OPTIONAL] - Defaults to nil. Signals will not be propagated if this service
-	// is nil.
+	// [OPTIONAL] - Defaults to nil. Signals will not be propagated if this service is
+	// nil.
 	Signals *signals.Provider
-	// Search is the search index for fuzzy searching arcs.
+	// Search is the search index for fuzzy searching Arcs.
+	//
 	// [REQUIRED]
 	Search *search.Index
 	// Instrumentation is used for logging, tracing, and metrics.
 	alamos.Instrumentation
 }
 
-var (
-	_ config.Config[ServiceConfig] = ServiceConfig{}
-	// DefaultServiceConfig is the default configuration for opening a Arc service.
-	DefaultServiceConfig = ServiceConfig{}
-)
+var _ config.Config[ServiceConfig] = ServiceConfig{}
 
 // Override implements config.Config.
 func (c ServiceConfig) Override(other ServiceConfig) ServiceConfig {
@@ -102,24 +100,23 @@ type Service struct {
 	cfg    ServiceConfig
 }
 
-// NewChannelResolver returns the dynamic resolver that the analyzer
-// consults for cluster channels not statically known to the program.
+// NewChannelResolver returns the dynamic resolver that the analyzer consults for
+// cluster channels not statically known to the program.
 func (s *Service) NewChannelResolver(tx gorp.Tx) *symbol.ChannelResolver {
 	return symbol.NewChannelResolver(s.cfg.Channel, tx)
 }
 
 // NewSymbolResolver is the dynamic resolver attached to a program root's
-// GlobalResolver. It resolves cluster channels by name or numeric key.
-// Static prelude symbols (STL, status module) are attached to the
-// ambient by NewRoot rather than chained behind this resolver.
+// GlobalResolver. It resolves cluster channels by name or numeric key. Static prelude
+// symbols (STL, status module) are attached to the ambient by NewRoot rather than
+// chained behind this resolver.
 func (s *Service) NewSymbolResolver(tx gorp.Tx) arc.SymbolResolver {
 	return s.NewChannelResolver(tx)
 }
 
-// NewRoot builds a program root populated with STL + status module +
-// the cluster channel resolver attached as the dynamic resolver. This
-// is the production analysis root: tx is consulted for channel lookups,
-// nil means "use the service DB directly."
+// NewRoot builds a program root populated with STL + status module + the cluster
+// channel resolver attached as the dynamic resolver. This is the production analysis
+// root: tx is consulted for channel lookups, nil means "use the service DB directly."
 func (s *Service) NewRoot(tx gorp.Tx) *arcsymbol.Symbol {
 	stlSyms := stl.NewSymbols()
 	statusSyms := arcstatus.NewSymbols()
@@ -137,8 +134,8 @@ func (s *Service) NewLSP() (*lsp.Server, error) {
 		OnExternalChange: observe.Translator[gorp.TxReader[channel.Key, channel.Channel], struct{}]{
 			Observable: s.cfg.Channel.Observe(),
 			Translate: func(
-				ctx context.Context,
-				r gorp.TxReader[channel.Key, channel.Channel],
+				context.Context,
+				gorp.TxReader[channel.Key, channel.Channel],
 			) (struct{}, bool) {
 				return struct{}{}, true
 			},
@@ -148,8 +145,8 @@ func (s *Service) NewLSP() (*lsp.Server, error) {
 
 func (s *Service) Close() error { return s.closer.Close() }
 
-// CompileProgram retrieves an Arc program by key and compiles its Module.
-// The returned Arc has its Module field populated with the compiled module.
+// CompileProgram retrieves an Arc program by key and compiles its Module. The returned
+// Arc has its Module field populated with the compiled module.
 func (s *Service) CompileProgram(ctx context.Context, key Key) (Arc, error) {
 	var entry Arc
 	err := s.NewRetrieve().Where(MatchKeys(key)).Entry(&entry).Exec(ctx, nil)
@@ -157,7 +154,7 @@ func (s *Service) CompileProgram(ctx context.Context, key Key) (Arc, error) {
 		return Arc{}, err
 	}
 	var prog arc.Program
-	if entry.Mode == "text" {
+	if entry.Mode == ModeText {
 		prog, err = arc.CompileText(ctx, entry.Text, s.NewRoot(nil))
 	} else {
 		prog, err = arc.CompileGraph(ctx, entry.Graph, s.NewRoot(nil))
@@ -173,23 +170,24 @@ func (s *Service) CompileProgram(ctx context.Context, key Key) (Arc, error) {
 // configuration will be used as an override for the previous configuration in the list.
 // See the ConfigValues struct for information on which fields should be set.
 func OpenService(ctx context.Context, configs ...ServiceConfig) (s *Service, err error) {
-	cfg, err := config.New(DefaultServiceConfig, configs...)
+	cfg, err := config.New(ServiceConfig{}, configs...)
 	if err != nil {
 		return nil, err
 	}
 	s = &Service{cfg: cfg}
 	cleanup, ok := service.NewOpener(ctx, &s.closer)
 	defer func() { err = cleanup(err) }()
-	if s.table, err = gorp.OpenTable[Key, Arc](ctx, gorp.TableConfig[Key, Arc]{
+	if s.table, err = gorp.OpenTable(ctx, gorp.TableConfig[Key, Arc]{
 		DB: cfg.DB,
 		Migrations: []migrate.Migration{
 			gorp.CodecMigration[Key, arcv54.Arc]("msgpack_to_orc"),
 			migrate.WithAddedDeps(
-				gorp.NewEntryMigration[Key, Key, arcv54.Arc, Arc](
-					"v54_drop_program_status",
-					MigrateArc,
-				),
+				gorp.NewEntryMigration("v54_drop_program_status", MigrateArc),
 				"msgpack_to_orc",
+			),
+			migrate.WithAddedDeps(
+				gorp.NewEntryMigration("v55_rename_set_status", RenameSetStatus),
+				"v54_drop_program_status",
 			),
 		},
 		Instrumentation: cfg.Instrumentation,
@@ -203,7 +201,7 @@ func OpenService(ctx context.Context, configs ...ServiceConfig) (s *Service, err
 		if sig, err = signals.PublishFromGorp(
 			ctx,
 			s.cfg.Signals,
-			signals.GorpPublisherConfigUUID[Arc](s.table.Observe()),
+			signals.GorpPublisherConfigUUID(s.table.Observe()),
 		); !ok(err, sig) {
 			return nil, err
 		}
@@ -211,9 +209,9 @@ func OpenService(ctx context.Context, configs ...ServiceConfig) (s *Service, err
 	return s, nil
 }
 
-// NewWriter opens a new writer for creating, updating, and deleting arcs in Synnax. If
+// NewWriter opens a new writer for creating, updating, and deleting Arcs in Synnax. If
 // tx is provided, the writer will use that transaction. If tx is nil, the Writer will
-// execute the operations directly on the underlying gorp.DB.
+// execute the operations directly against the underlying gorp.DB.
 func (s *Service) NewWriter(tx gorp.Tx) Writer {
 	return Writer{
 		tx:    gorp.OverrideTx(s.cfg.DB, tx),
@@ -223,7 +221,7 @@ func (s *Service) NewWriter(tx gorp.Tx) Writer {
 	}
 }
 
-// NewRetrieve opens a new query builder for retrieving arcs from Synnax.
+// NewRetrieve opens a new query builder for retrieving Arcs from Synnax.
 func (s *Service) NewRetrieve() Retrieve {
 	return Retrieve{
 		gorp:   s.table.NewRetrieve(),


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue number and link -->

[SY-4263](https://linear.app/synnax/issue/SY-4263/fix-arc-graphical-setstatus-migrations)

## Description

<!-- Write a description describing the changes. -->

Add a Core-side migration for graphical Arcs.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a Core-side database migration (`v55_rename_set_status`) that rewrites every deprecated `set_status` graph node to `status.set`, remapping `statusKey` → `key_or_name` and applying safe defaults for missing fields. It also removes redundant private alias functions in the Arc IR formatting layer and cleans up several documentation comments and coding style in `service.go`.

- **New migration** (`RenameSetStatus`): registered in the `OpenService` table with a dependency on the v54 migration; remaps config keys and drops unrecognised fields. Two new tests cover the happy path and the defaults-for-missing-config edge case.
- **IR formatting cleanup** (`format.go`, `function.go`, `ir.go`, `node.go`): removes the now-superfluous `treePrefix`/`TreeIndent` alias functions; callers are updated to call `TreePrefix` directly and the implementation is collapsed into the unexported `treeIndent`.
- **`service.go` hygiene**: replaces the `"text"` string literal with the typed `ModeText` constant, drops the exported zero-value `DefaultServiceConfig` variable, and rewrites several doc comments for clarity.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the migration is additive, the dependency chain is correctly ordered, and existing data is handled safely including nil configs.

The change introduces a well-scoped database migration that iterates a flat node list, handles nil/missing config fields with safe type-assertion comma-ok checks, and is covered by two targeted tests. The IR alias-removal and service.go cleanups are mechanical and carry no behavioral risk.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| core/pkg/service/arc/migrate.go | Adds RenameSetStatus migration and helpers; nil-config safety is correct; flat-node iteration covers the full graph structure. |
| core/pkg/service/arc/service.go | Registers v55 migration in the correct dependency chain; replaces "text" literal with ModeText constant; removes DefaultServiceConfig; doc-comment rewrites only. |
| core/pkg/service/arc/migrations/v54/migrate_test.go | Adds two well-structured tests covering normal set_status migration and the bare/default-config edge case; existing tests simplified with inferred type parameters. |
| arc/go/ir/format.go | Removes the redundant treePrefix alias and collapses TreeIndent/treeIndent into a single unexported implementation; no external Go callers of TreeIndent exist. |
| arc/go/ir/function.go | Call sites updated from treePrefix to TreePrefix; functionally identical. |
| arc/go/ir/ir.go | Call sites updated from treePrefix to TreePrefix; treeIndent calls unchanged; functionally identical. |
| arc/go/ir/node.go | Call sites updated from treePrefix to TreePrefix; functionally identical. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Arc entry read from DB] --> B{Migration chain}
    B --> C["msgpack_to_orc\n(codec migration)"]
    C --> D["v54_drop_program_status\n(MigrateArc)\ndrops Status & Program fields"]
    D --> E["v55_rename_set_status\n(RenameSetStatus)\niterates Graph.Nodes"]
    E --> F{Node.Type == 'set_status'?}
    F -- Yes --> G["Remap config:\nstatusKey → key_or_name\nvariant (keep or default 'success')\nmessage (keep or default '')\ndrop unknown keys\nNode.Type = 'status.set'"]
    F -- No --> H[Node unchanged]
    G --> I[Migrated Arc returned]
    H --> I
```

<sub>Reviews (2): Last reviewed commit: ["remove bad doc comment"](https://github.com/synnaxlabs/synnax/commit/7b8d0932dbb8d2e65b2f8c767de44db6a3d0439a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34635300)</sub>

<!-- /greptile_comment -->