### PR TITLE
SY-4271: Improve Core Panic Recovery

### DIFF
--- a/aspen/transport/grpc/transport.go
+++ b/aspen/transport/grpc/transport.go
@@ -341,7 +341,10 @@ func (t *Transport) Configure(addr address.Address, ins alamos.Instrumentation, 
 	if external {
 		return nil
 	}
-	t.server = grpc.NewServer()
+	t.server = grpc.NewServer(
+		grpc.ChainUnaryInterceptor(fgrpc.RecoveryUnaryServerInterceptor(ins)),
+		grpc.ChainStreamInterceptor(fgrpc.RecoveryStreamServerInterceptor(ins)),
+	)
 	t.BindTo(t.server)
 	t.addr = addr
 	mw, err := falamos.Middleware(falamos.Config{Instrumentation: ins})

--- a/core/pkg/api/layer.go
+++ b/core/pkg/api/layer.go
@@ -19,6 +19,7 @@ import (
 	"github.com/samber/lo"
 	"github.com/synnaxlabs/freighter"
 	"github.com/synnaxlabs/freighter/alamos"
+	"github.com/synnaxlabs/freighter/recovery"
 	"github.com/synnaxlabs/synnax/pkg/api/access"
 	"github.com/synnaxlabs/synnax/pkg/api/arc"
 	"github.com/synnaxlabs/synnax/pkg/api/auth"
@@ -219,7 +220,8 @@ func (l *Layer) BindTo(t Transport) {
 	var (
 		tk                 = auth.TokenMiddleware(l.config.Service.Token)
 		instrumentation    = lo.Must(alamos.Middleware(alamos.Config{Instrumentation: l.config.Instrumentation}))
-		insecureMiddleware = []freighter.Middleware{instrumentation}
+		rec                = recovery.Middleware(l.config.Instrumentation)
+		insecureMiddleware = []freighter.Middleware{rec, instrumentation}
 		secureMiddleware   = make([]freighter.Middleware, len(insecureMiddleware))
 	)
 	copy(secureMiddleware, insecureMiddleware)

--- a/core/pkg/server/grpc.go
+++ b/core/pkg/server/grpc.go
@@ -38,7 +38,11 @@ func (g *GRPCBranch) Key() string { return "grpc" }
 
 // Init implements Branch.
 func (g *GRPCBranch) Init(ctx BranchContext) {
-	g.server = grpc.NewServer(g.credentials(ctx))
+	g.server = grpc.NewServer(
+		g.credentials(ctx),
+		grpc.ChainUnaryInterceptor(fgrpc.RecoveryUnaryServerInterceptor(ctx.Instrumentation)),
+		grpc.ChainStreamInterceptor(fgrpc.RecoveryStreamServerInterceptor(ctx.Instrumentation)),
+	)
 	for _, t := range g.Transports {
 		t.BindTo(g.server)
 	}

--- a/core/pkg/service/driver/driver.go
+++ b/core/pkg/service/driver/driver.go
@@ -148,7 +148,11 @@ func (d *Driver) startCommandStreaming(ctx context.Context) error {
 	streamerRequests := confluence.NewStream[framer.StreamerRequest]()
 	streamer.InFrom(streamerRequests)
 	d.streamerRequests = streamerRequests
-	p.Flow(sCtx, confluence.CloseOutputInletsOnExit())
+	p.Flow(
+		sCtx,
+		confluence.CloseOutputInletsOnExit(),
+		confluence.RecoverWithErrOnPanic(),
+	)
 	return nil
 }
 
@@ -183,7 +187,10 @@ func (d *Driver) processCommand(ctx context.Context, frame framer.Frame) {
 				d.cfg.TaskTimeout,
 				signal.WithInstrumentation(d.cfg.Instrumentation),
 			)
-			sCtx.Go(func(ctx context.Context) error { return t.Exec(ctx, cmd) })
+			sCtx.Go(
+				func(ctx context.Context) error { return t.Exec(ctx, cmd) },
+				signal.RecoverWithErrOnPanic(),
+			)
 			err := sCtx.Wait()
 			cancel()
 			if err != nil {
@@ -236,7 +243,10 @@ func (d *Driver) configureExistingTasks(ctx context.Context) {
 	)
 	defer cancel()
 	for _, t := range tasks {
-		sCtx.Go(func(ctx context.Context) error { d.configure(ctx, t); return nil })
+		sCtx.Go(
+			func(ctx context.Context) error { d.configure(ctx, t); return nil },
+			signal.RecoverWithErrOnPanic(),
+		)
 	}
 	if err := sCtx.Wait(); err != nil {
 		d.cfg.L.Error("timed out configuring existing tasks", zap.Error(err))
@@ -280,7 +290,7 @@ func (d *Driver) configure(ctx context.Context, t task.Task) {
 		}
 		d.cfg.L.Warn("no factory handled task", zap.Stringer("task", t))
 		return nil
-	})
+	}, signal.RecoverWithErrOnPanic())
 	if err := sCtx.Wait(); err != nil {
 		d.cfg.L.Error(
 			"failed to configure task", zap.Stringer("task", t), zap.Error(err),

--- a/core/pkg/service/driver/driver_test.go
+++ b/core/pkg/service/driver/driver_test.go
@@ -408,6 +408,41 @@ var _ = Describe("Driver", func() {
 			Eventually(func() bool { return execCalled.Load() }).Should(BeTrue())
 		})
 
+		It("should continue configuring new tasks after a configuration panic", func(ctx SpecContext) {
+			var (
+				knownKeys         sync.Map
+				configAttempts    atomic.Int32
+				healthyConfigured atomic.Bool
+			)
+			factory := &mockFactory{
+				name: "test",
+				configureFunc: func(
+					_ context.Context,
+					t task.Task,
+				) (driver.Task, error) {
+					if _, ok := knownKeys.Load(t.Key); !ok {
+						return nil, driver.ErrTaskNotHandled
+					}
+					if configAttempts.Add(1) == 1 {
+						panic("boom during configure")
+					}
+					healthyConfigured.Store(true)
+					return &mockTask{key: t.Key}, nil
+				},
+			}
+			openDriver(ctx, factory)
+
+			t1 := newTask(embeddedRackKey(ctx))
+			knownKeys.Store(t1.Key, true)
+			Expect(taskService.NewWriter(nil).Create(ctx, &t1)).To(Succeed())
+			Eventually(func() int32 { return configAttempts.Load() }).Should(Equal(int32(1)))
+
+			t2 := newTask(embeddedRackKey(ctx))
+			knownKeys.Store(t2.Key, true)
+			Expect(taskService.NewWriter(nil).Create(ctx, &t2)).To(Succeed())
+			Eventually(func() bool { return healthyConfigured.Load() }).Should(BeTrue())
+		})
+
 		It("should handle task stop error gracefully during reconfiguration", func(ctx SpecContext) {
 			var (
 				stopCalled  atomic.Bool
@@ -913,6 +948,47 @@ var _ = Describe("Driver", func() {
 			writeCommand(ctx, cmd)
 
 			Eventually(func() bool { return execCalled.Load() }, "2s").Should(BeTrue())
+		})
+
+		It("should not crash the process when a task's Exec panics", func(ctx SpecContext) {
+			var (
+				panicExecCalled   atomic.Bool
+				healthyExecCalled atomic.Bool
+				configReady       = make(chan struct{})
+				readyOnce         sync.Once
+			)
+			factory := &mockFactory{
+				name: "test",
+				configureFunc: func(
+					_ context.Context,
+					t task.Task,
+				) (driver.Task, error) {
+					readyOnce.Do(func() { close(configReady) })
+					return &mockTask{
+						key: t.Key,
+						execFunc: func(_ context.Context, cmd task.Command) error {
+							if cmd.Type == "panic" {
+								panicExecCalled.Store(true)
+								panic("boom during exec")
+							}
+							healthyExecCalled.Store(true)
+							return nil
+						},
+					}, nil
+				},
+			}
+			openDriver(ctx, factory)
+			time.Sleep(50 * time.Millisecond)
+
+			t := newTask(embeddedRackKey(ctx))
+			Expect(taskService.NewWriter(nil).Create(ctx, &t)).To(Succeed())
+			Eventually(configReady).Should(BeClosed())
+
+			writeCommand(ctx, task.Command{Task: t.Key, Type: "panic", Key: "cmd-panic"})
+			Eventually(func() bool { return panicExecCalled.Load() }, "2s").Should(BeTrue())
+
+			writeCommand(ctx, task.Command{Task: t.Key, Type: "start", Key: "cmd-healthy"})
+			Eventually(func() bool { return healthyExecCalled.Load() }, "2s").Should(BeTrue())
 		})
 
 		It("should log warning for unsupported command without crashing", func(ctx SpecContext) {

--- a/freighter/go/grpc/recovery.go
+++ b/freighter/go/grpc/recovery.go
@@ -1,0 +1,61 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+package grpc
+
+import (
+	"context"
+	"runtime/debug"
+
+	"github.com/synnaxlabs/alamos"
+	"github.com/synnaxlabs/freighter/recovery"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+// RecoveryUnaryServerInterceptor returns a grpc.UnaryServerInterceptor that recovers
+// from panics in unary handlers, records the stack via ins, and returns a
+// codes.Internal status. It is a transport-level backstop for gRPC handlers that do not
+// pass through the freighter recovery Middleware, such as cluster-internal services.
+func RecoveryUnaryServerInterceptor(ins alamos.Instrumentation) grpc.UnaryServerInterceptor {
+	return func(
+		ctx context.Context,
+		req any,
+		info *grpc.UnaryServerInfo,
+		handler grpc.UnaryHandler,
+	) (resp any, err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				recovery.LogPanic(ins, info.FullMethod, r, debug.Stack())
+				err = status.Error(codes.Internal, recovery.ErrPanic.Error())
+			}
+		}()
+		return handler(ctx, req)
+	}
+}
+
+// RecoveryStreamServerInterceptor returns a grpc.StreamServerInterceptor that recovers
+// from panics in streaming handlers, mirroring RecoveryUnaryServerInterceptor.
+func RecoveryStreamServerInterceptor(ins alamos.Instrumentation) grpc.StreamServerInterceptor {
+	return func(
+		srv any,
+		ss grpc.ServerStream,
+		info *grpc.StreamServerInfo,
+		handler grpc.StreamHandler,
+	) (err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				recovery.LogPanic(ins, info.FullMethod, r, debug.Stack())
+				err = status.Error(codes.Internal, recovery.ErrPanic.Error())
+			}
+		}()
+		return handler(srv, ss)
+	}
+}

--- a/freighter/go/grpc/recovery_test.go
+++ b/freighter/go/grpc/recovery_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Recovery Interceptors", func() {
 				func(context.Context, any) (any, error) { panic("boom") },
 			)
 			Expect(status.Code(err)).To(Equal(codes.Internal))
-			Expect(err.Error()).To(ContainSubstring(recovery.ErrPanic.Error()))
+			Expect(err).To(MatchError(ContainSubstring(recovery.ErrPanic.Error())))
 		})
 
 		It("should pass through a non-panicking handler", func() {
@@ -53,6 +53,7 @@ var _ = Describe("Recovery Interceptors", func() {
 				func(any, grpc.ServerStream) error { panic("boom") },
 			)
 			Expect(status.Code(err)).To(Equal(codes.Internal))
+			Expect(err).To(MatchError(ContainSubstring(recovery.ErrPanic.Error())))
 		})
 	})
 })

--- a/freighter/go/grpc/recovery_test.go
+++ b/freighter/go/grpc/recovery_test.go
@@ -1,0 +1,58 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+package grpc_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/synnaxlabs/alamos"
+	fgrpc "github.com/synnaxlabs/freighter/grpc"
+	"github.com/synnaxlabs/freighter/recovery"
+	. "github.com/synnaxlabs/x/testutil"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+)
+
+var _ = Describe("Recovery Interceptors", func() {
+	Describe("Unary", func() {
+		It("should recover a panic and return a codes.Internal status", func() {
+			interceptor := fgrpc.RecoveryUnaryServerInterceptor(alamos.Instrumentation{})
+			info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+			_, err := interceptor(context.Background(), nil, info,
+				func(context.Context, any) (any, error) { panic("boom") },
+			)
+			Expect(status.Code(err)).To(Equal(codes.Internal))
+			Expect(err.Error()).To(ContainSubstring(recovery.ErrPanic.Error()))
+		})
+
+		It("should pass through a non-panicking handler", func() {
+			interceptor := fgrpc.RecoveryUnaryServerInterceptor(alamos.Instrumentation{})
+			info := &grpc.UnaryServerInfo{FullMethod: "/test.Service/Method"}
+			resp := MustSucceed(interceptor(context.Background(), "req", info,
+				func(_ context.Context, req any) (any, error) { return req, nil },
+			))
+			Expect(resp).To(Equal("req"))
+		})
+	})
+
+	Describe("Stream", func() {
+		It("should recover a panic and return a codes.Internal status", func() {
+			interceptor := fgrpc.RecoveryStreamServerInterceptor(alamos.Instrumentation{})
+			info := &grpc.StreamServerInfo{FullMethod: "/test.Service/Stream"}
+			err := interceptor(nil, nil, info,
+				func(any, grpc.ServerStream) error { panic("boom") },
+			)
+			Expect(status.Code(err)).To(Equal(codes.Internal))
+		})
+	})
+})

--- a/freighter/go/grpc/recovery_wire_test.go
+++ b/freighter/go/grpc/recovery_wire_test.go
@@ -1,0 +1,159 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+package grpc_test
+
+import (
+	"context"
+	"net"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/synnaxlabs/alamos"
+	"github.com/synnaxlabs/freighter"
+	fgrpc "github.com/synnaxlabs/freighter/grpc"
+	v1 "github.com/synnaxlabs/freighter/grpc/v1"
+	"github.com/synnaxlabs/freighter/recovery"
+	"github.com/synnaxlabs/freighter/test"
+	"github.com/synnaxlabs/x/address"
+	. "github.com/synnaxlabs/x/testutil"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+// A negative request ID instructs the wire-test handlers to panic, exercising the
+// recovery interceptors without a dedicated control channel.
+const panicID = -1
+
+var _ = Describe("Recovery (wire)", Ordered, Serial, func() {
+	var (
+		unaryClient  freighter.UnaryClient[test.Request, test.Response]
+		streamClient freighter.StreamClient[test.Request, test.Response]
+		addr         address.Address
+		grpcServer   *grpc.Server
+	)
+
+	BeforeAll(func() {
+		lis := MustSucceed(net.Listen("tcp", "localhost:0"))
+		addr = address.Address(lis.Addr().String())
+
+		ins := alamos.Instrumentation{}
+		grpcServer = grpc.NewServer(
+			grpc.ChainUnaryInterceptor(fgrpc.RecoveryUnaryServerInterceptor(ins)),
+			grpc.ChainStreamInterceptor(fgrpc.RecoveryStreamServerInterceptor(ins)),
+		)
+
+		uServer := &fgrpc.UnaryServer[
+			test.Request, *v1.Request,
+			test.Response, *v1.Response,
+		]{
+			RequestTranslator:  requestTranslator{},
+			ResponseTranslator: responseTranslator{},
+			ServiceDesc:        &v1.TestUnaryService_ServiceDesc,
+			Internal:           true,
+		}
+		uServer.BindHandler(func(_ context.Context, req test.Request) (test.Response, error) {
+			if req.ID == panicID {
+				panic("boom in unary handler")
+			}
+			return test.Response(req), nil
+		})
+		uServer.BindTo(grpcServer)
+
+		sServer := &streamServer{
+			StreamServerCore: fgrpc.StreamServerCore[
+				test.Request, *v1.Request,
+				test.Response, *v1.Response,
+			]{
+				RequestTranslator:  requestTranslator{},
+				ResponseTranslator: responseTranslator{},
+				ServiceDesc:        &v1.TestStreamService_ServiceDesc,
+				Internal:           true,
+			},
+		}
+		sServer.BindHandler(func(
+			_ context.Context,
+			server freighter.ServerStream[test.Request, test.Response],
+		) error {
+			req, err := server.Receive()
+			if err != nil {
+				return err
+			}
+			if req.ID == panicID {
+				panic("boom in stream handler")
+			}
+			return server.Send(test.Response{ID: req.ID + 1, Message: req.Message})
+		})
+		sServer.BindTo(grpcServer)
+
+		pool := fgrpc.NewPool("", grpc.WithTransportCredentials(insecure.NewCredentials()))
+		unaryClient = &fgrpc.UnaryClient[
+			test.Request, *v1.Request,
+			test.Response, *v1.Response,
+		]{
+			RequestTranslator:  requestTranslator{},
+			ResponseTranslator: responseTranslator{},
+			Pool:               pool,
+			ServiceDesc:        &v1.TestUnaryService_ServiceDesc,
+			Exec: func(
+				ctx context.Context,
+				conn grpc.ClientConnInterface,
+				req *v1.Request,
+			) (*v1.Response, error) {
+				return v1.NewTestUnaryServiceClient(conn).Exec(ctx, req)
+			},
+		}
+		streamClient = &fgrpc.StreamClient[
+			test.Request, *v1.Request,
+			test.Response, *v1.Response,
+		]{
+			RequestTranslator:  requestTranslator{},
+			ResponseTranslator: responseTranslator{},
+			Pool:               pool,
+			ServiceDesc:        &v1.TestStreamService_ServiceDesc,
+			ClientFunc: func(
+				ctx context.Context,
+				conn grpc.ClientConnInterface,
+			) (fgrpc.GRPCClientStream[*v1.Request, *v1.Response], error) {
+				return v1.NewTestStreamServiceClient(conn).Exec(ctx)
+			},
+		}
+
+		go func() {
+			defer GinkgoRecover()
+			Expect(grpcServer.Serve(lis)).To(Succeed())
+		}()
+	})
+
+	AfterAll(func() { grpcServer.GracefulStop() })
+
+	It("should contain a unary handler panic and keep serving", func(ctx SpecContext) {
+		By("surfacing the panic to the client as a generic error")
+		Expect(unaryClient.Send(ctx, addr, test.Request{ID: panicID})).
+			Error().To(MatchError(ContainSubstring(recovery.ErrPanic.Error())))
+
+		By("continuing to serve subsequent requests")
+		Expect(MustSucceed(unaryClient.Send(ctx, addr, test.Request{ID: 7, Message: "ok"}))).
+			To(Equal(test.Response{ID: 7, Message: "ok"}))
+	})
+
+	It("should contain a stream handler panic and keep serving", func(ctx SpecContext) {
+		By("surfacing the panic on the panicking stream")
+		panicStream := MustSucceed(streamClient.Stream(ctx, addr))
+		Expect(panicStream.Send(test.Request{ID: panicID})).To(Succeed())
+		Expect(panicStream.Receive()).
+			Error().To(MatchError(ContainSubstring(recovery.ErrPanic.Error())))
+
+		By("continuing to serve new streams")
+		okStream := MustSucceed(streamClient.Stream(ctx, addr))
+		Expect(okStream.Send(test.Request{ID: 5, Message: "ok"})).To(Succeed())
+		Expect(MustSucceed(okStream.Receive())).
+			To(Equal(test.Response{ID: 6, Message: "ok"}))
+	})
+})

--- a/freighter/go/http/recovery_wire_test.go
+++ b/freighter/go/http/recovery_wire_test.go
@@ -1,0 +1,69 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+package http_test
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/gofiber/fiber/v3"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/synnaxlabs/alamos"
+	fhttp "github.com/synnaxlabs/freighter/http"
+	"github.com/synnaxlabs/freighter/recovery"
+	"github.com/synnaxlabs/freighter/test"
+	"github.com/synnaxlabs/x/address"
+	"github.com/synnaxlabs/x/net"
+	. "github.com/synnaxlabs/x/testutil"
+)
+
+var _ = Describe("Recovery (wire)", func() {
+	It("should contain a handler panic and keep serving", func(ctx context.Context) {
+		addr := address.Newf("localhost:%d", MustSucceed(net.FindOpenPort()))
+		app := fiber.New(fiber.Config{})
+		app.Get("/health", func(c fiber.Ctx) error { return c.SendStatus(fiber.StatusOK) })
+		router := MustSucceed(fhttp.NewRouter())
+		server := fhttp.NewUnaryServer[test.Request, test.Response](router, "/")
+		server.Use(recovery.Middleware(alamos.Instrumentation{}))
+
+		panicNext := true
+		server.BindHandler(func(_ context.Context, req test.Request) (test.Response, error) {
+			if panicNext {
+				panic("boom in handler")
+			}
+			return test.Response(req), nil
+		})
+		router.BindTo(app)
+		go func() {
+			defer GinkgoRecover()
+			Expect(app.Listen(addr.PortString(), fiber.ListenConfig{
+				DisableStartupMessage: true,
+			})).To(Succeed())
+		}()
+		DeferCleanup(func() { Expect(app.Shutdown()).To(Succeed()) })
+		Eventually(func(g Gomega) {
+			_, err := http.Get("http://" + addr.String() + "/health")
+			g.Expect(err).To(Succeed())
+		}).WithPolling(time.Millisecond).Should(Succeed())
+
+		client := MustSucceed(fhttp.NewUnaryClient[test.Request, test.Response]())
+
+		By("surfacing the panic to the client as a generic error, not a dropped connection")
+		Expect(client.Send(ctx, addr, test.Request{ID: 1})).
+			Error().To(MatchError(ContainSubstring(recovery.ErrPanic.Error())))
+
+		By("continuing to serve subsequent requests")
+		panicNext = false
+		Expect(MustSucceed(client.Send(ctx, addr, test.Request{ID: 2, Message: "ok"}))).
+			To(Equal(test.Response{ID: 2, Message: "ok"}))
+	})
+})

--- a/freighter/go/recovery/recovery.go
+++ b/freighter/go/recovery/recovery.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+// Package recovery provides panic-recovery boundaries for freighter request handlers.
+// A panic in a handler would otherwise unwind through the transport, where nothing
+// recovers it, and take down the entire process. Middleware converts such a panic into
+// a generic error returned to the caller, records the panic and stack trace
+// server-side, and keeps the node running. LogPanic and ErrPanic are exported for
+// transport-specific recovery boundaries (e.g. the gRPC interceptors in the freighter
+// grpc package) so panic handling stays consistent across transports.
+package recovery
+
+import (
+	"runtime/debug"
+
+	"github.com/synnaxlabs/alamos"
+	"github.com/synnaxlabs/freighter"
+	"github.com/synnaxlabs/x/errors"
+	"go.uber.org/zap"
+)
+
+// ErrPanic is returned to the caller when a handler panics. Its message is
+// intentionally generic: the panic value and stack trace are recorded in the server
+// logs and never sent over the wire, to avoid leaking internal detail to clients.
+var ErrPanic = errors.New("the server encountered an unexpected internal error")
+
+// Middleware returns a freighter.Middleware that recovers from panics in any
+// downstream middleware or in the handler itself, converting them into ErrPanic so the
+// transport can encode and return the error to the caller. Install it as the first
+// (outermost) middleware so it also covers panics raised by other middleware.
+func Middleware(ins alamos.Instrumentation) freighter.Middleware {
+	return freighter.MiddlewareFunc(func(
+		ctx freighter.Context,
+		next freighter.Next,
+	) (oCtx freighter.Context, err error) {
+		defer func() {
+			if r := recover(); r != nil {
+				LogPanic(ins, ctx.Target.String(), r, debug.Stack())
+				oCtx = freighter.Context{
+					Context:  ctx.Context,
+					Protocol: ctx.Protocol,
+					Params:   make(freighter.Params),
+				}
+				err = ErrPanic
+			}
+		}()
+		return next(ctx)
+	})
+}
+
+// LogPanic records a recovered panic and its stack at ERROR via ins. target identifies
+// the handler that panicked (a request target or a gRPC method). It is used by both
+// Middleware and transport-specific recovery boundaries so the log format stays
+// consistent. It is a no-op if ins has no logger.
+func LogPanic(ins alamos.Instrumentation, target string, recovered any, stack []byte) {
+	if ins.L == nil {
+		return
+	}
+	ins.L.Error(
+		"recovered from panic in handler",
+		zap.String("target", target),
+		zap.Any("panic", recovered),
+		zap.ByteString("stack", stack),
+	)
+}

--- a/freighter/go/recovery/recovery_suite_test.go
+++ b/freighter/go/recovery/recovery_suite_test.go
@@ -1,0 +1,22 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+package recovery_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestRecovery(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Recovery Suite")
+}

--- a/freighter/go/recovery/recovery_test.go
+++ b/freighter/go/recovery/recovery_test.go
@@ -67,7 +67,7 @@ var _ = Describe("Recovery", func() {
 					panic("super-secret internal detail")
 				},
 			))
-			Expect(err.Error()).ToNot(ContainSubstring("super-secret"))
+			Expect(err).ToNot(MatchError(ContainSubstring("super-secret")))
 		})
 
 		It("should pass through unmodified when no panic occurs", func() {

--- a/freighter/go/recovery/recovery_test.go
+++ b/freighter/go/recovery/recovery_test.go
@@ -74,11 +74,11 @@ var _ = Describe("Recovery", func() {
 			mc := newCollector()
 			oCtx := MustSucceed(mc.Exec(newContext(), freighter.FinalizerFunc(
 				func(c freighter.Context) (freighter.Context, error) {
-					c.Params.Set("handled", true)
+					c.Set("handled", true)
 					return c, nil
 				},
 			)))
-			Expect(oCtx.Params.GetDefault("handled", false)).To(BeTrue())
+			Expect(oCtx.GetDefault("handled", false)).To(BeTrue())
 		})
 	})
 

--- a/freighter/go/recovery/recovery_test.go
+++ b/freighter/go/recovery/recovery_test.go
@@ -1,0 +1,92 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+package recovery_test
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/synnaxlabs/alamos"
+	"github.com/synnaxlabs/freighter"
+	"github.com/synnaxlabs/freighter/recovery"
+	. "github.com/synnaxlabs/x/testutil"
+)
+
+func newCollector() freighter.MiddlewareCollector {
+	var mc freighter.MiddlewareCollector
+	mc.Use(recovery.Middleware(alamos.Instrumentation{}))
+	return mc
+}
+
+func newContext() freighter.Context {
+	return freighter.Context{
+		Context:  context.Background(),
+		Protocol: "test",
+		Target:   "test-target",
+		Params:   make(freighter.Params),
+	}
+}
+
+var _ = Describe("Recovery", func() {
+	Describe("Middleware", func() {
+		It("should recover a panic in the finalizer and return ErrPanic", func() {
+			mc := newCollector()
+			oCtx, err := mc.Exec(newContext(), freighter.FinalizerFunc(
+				func(freighter.Context) (freighter.Context, error) {
+					panic("boom in handler")
+				},
+			))
+			Expect(err).To(MatchError(recovery.ErrPanic))
+			Expect(oCtx.Protocol).To(Equal("test"))
+		})
+
+		It("should recover a panic raised by a downstream middleware", func() {
+			mc := newCollector()
+			mc.Use(freighter.MiddlewareFunc(func(
+				freighter.Context,
+				freighter.Next,
+			) (freighter.Context, error) {
+				panic("boom in middleware")
+			}))
+			_, err := mc.Exec(newContext(), freighter.NopFinalizer)
+			Expect(err).To(MatchError(recovery.ErrPanic))
+		})
+
+		It("should not leak the panic value into the returned error", func() {
+			mc := newCollector()
+			_, err := mc.Exec(newContext(), freighter.FinalizerFunc(
+				func(freighter.Context) (freighter.Context, error) {
+					panic("super-secret internal detail")
+				},
+			))
+			Expect(err.Error()).ToNot(ContainSubstring("super-secret"))
+		})
+
+		It("should pass through unmodified when no panic occurs", func() {
+			mc := newCollector()
+			oCtx := MustSucceed(mc.Exec(newContext(), freighter.FinalizerFunc(
+				func(c freighter.Context) (freighter.Context, error) {
+					c.Params.Set("handled", true)
+					return c, nil
+				},
+			)))
+			Expect(oCtx.Params.GetDefault("handled", false)).To(BeTrue())
+		})
+	})
+
+	Describe("LogPanic", func() {
+		It("should be a no-op when the instrumentation has no logger", func() {
+			Expect(func() {
+				recovery.LogPanic(alamos.Instrumentation{}, "target", "boom", []byte("stack"))
+			}).ToNot(Panic())
+		})
+	})
+})


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4271](https://linear.app/synnax/issue/SY-4271)

## Description

A panic in a request handler or task previously propagated with no recovery boundary above it and crashed the entire node. This was not hypothetical: an Arc program panicking during task start (a `nil` → `uint8` cast in `telem.NewSeriesFromAny`) took down `core`. An audit found the same exposure across the whole network surface — HTTP unary, WebSocket, and gRPC handlers have no panic recovery (Fiber/fasthttp does not recover by default, and `grpc.NewServer` was constructed with no interceptors), so any handler panic crashes the process.

This PR adds recovery boundaries so a single bad handler or task degrades gracefully instead of taking down the node:

- **`freighter/recovery`** — a transport-agnostic recovery `Middleware` that wraps the handler chain in `defer recover()`, covering unary and stream over **both** HTTP and gRPC. It is installed first (outermost) in the API middleware chain so it also covers panics raised by other middleware. On a panic it logs the stack server-side and returns a generic error that the existing error-encoding path returns to the caller. The panic value and stack are never sent over the wire (no information leak).
- **`freighter/grpc`** — `RecoveryUnaryServerInterceptor` / `RecoveryStreamServerInterceptor` as a transport-level backstop, wired at the core and aspen `grpc.NewServer` sites. These catch panics in gRPC handlers that do not pass through the API middleware (cluster-internal services), returning `codes.Internal`.
- **`driver`** — task `Exec` and factory configuration routines now recover, so a task panic becomes an error status rather than a process crash.

Design notes:
- **Retry**: handlers are not retried on panic. A panic is a deterministic bug and requests are often non-idempotent; we recover, log, return the error, and let the client decide.
- **Logging**: the stack is captured with `runtime/debug.Stack()` at the boundary and logged once at ERROR via the existing instrumentation; a shared `recovery.LogPanic` keeps the format consistent across the middleware and the gRPC interceptors.

The model-level default in `x/signal` (routines default to `propagatePanic`) is intentionally left unchanged here and tracked separately.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds layered panic recovery across the entire Synnax network surface so a single bad handler or task degrades gracefully instead of crashing the node. The implementation is thorough and well-tested, addressing HTTP, WebSocket, and gRPC transports as well as driver task lifecycle.

- **`freighter/recovery`** — a new transport-agnostic `Middleware` installed as the outermost entry in the API middleware chain; it wraps `next(ctx)` in `defer recover()`, logs the stack server-side via the shared `LogPanic` helper, and returns the generic `ErrPanic` without leaking internal details over the wire.
- **`freighter/grpc`** — `RecoveryUnaryServerInterceptor` / `RecoveryStreamServerInterceptor` wired at both the core and aspen `grpc.NewServer` sites; these act as a transport-level backstop for cluster-internal gRPC services that bypass the API middleware chain.
- **`driver`** — task `Exec` and factory configuration goroutines now carry `signal.RecoverWithErrOnPanic()`, so a task panic becomes a logged error rather than a process crash; the command-streaming pipeline receives `confluence.RecoverWithErrOnPanic()` for the same reason.

<h3>Confidence Score: 5/5</h3>

Safe to merge; recovery boundaries are additive and the only changes to existing behaviour are catching panics that previously crashed the process.

The middleware and interceptors are narrow, well-tested (unit + wire tests for HTTP, gRPC unary/stream, and driver task paths), and add no new failure modes. Existing production paths are unchanged when no panic occurs. The one finding is a test-only unsynchronized bool that may be flagged by the race detector but cannot affect production behaviour.

freighter/go/http/recovery_wire_test.go — the unsynchronized bool should be replaced with atomic.Bool before running with -race.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| freighter/go/recovery/recovery.go | New package providing the core panic recovery middleware; correctly uses named return values with defer/recover, returns a generic ErrPanic without leaking internal detail, and exports LogPanic for cross-transport consistency. |
| freighter/go/grpc/recovery.go | Transport-level gRPC backstop interceptors for unary and stream; correctly captures stack via debug.Stack() in the defer, assigns to named return err, and delegates logging to the shared LogPanic helper. |
| core/pkg/api/layer.go | Recovery middleware added as the first (outermost) entry in insecureMiddleware, correctly covering both insecure and secure handler chains including all downstream middleware. |
| core/pkg/server/grpc.go | Recovery unary and stream interceptors wired at the core gRPC server construction site; correctly installed alongside credentials option. |
| aspen/transport/grpc/transport.go | Recovery interceptors added to the aspen internal gRPC server; the external=true early-return path is unchanged and correct since external transports are configured elsewhere. |
| core/pkg/service/driver/driver.go | RecoverWithErrOnPanic added to task Exec, factory configure goroutines, and the pipeline; panic-prone factory call occurs before the mutex is re-acquired, so no deadlock risk on recovery. |
| freighter/go/http/recovery_wire_test.go | Wire test for HTTP panic containment; panicNext is a plain bool shared between the test goroutine and the Fiber handler goroutine without synchronization, which may be flagged by the race detector. |
| freighter/go/grpc/recovery_wire_test.go | End-to-end wire tests for gRPC unary and stream recovery; correctly verifies both that the panic is contained and that subsequent requests keep working. |
| core/pkg/service/driver/driver_test.go | Two new test cases added: configure panic and Exec panic; both exercise the recovery paths correctly, using atomic bools and channels for synchronization. |
| freighter/go/recovery/recovery_test.go | Comprehensive unit tests for the recovery middleware covering panic in handler, panic in downstream middleware, no-leak assertion, and no-op logger path. |
| freighter/go/grpc/recovery_test.go | Unit tests for the gRPC interceptors; both unary and stream tests verify codes.Internal status code and that the ErrPanic message is present without leaking the panic value. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Client
    participant FM as Freighter Recovery Middleware
    participant GI as gRPC Interceptor
    participant H as Handler

    C->>FM: Request
    FM->>GI: next(ctx)
    GI->>H: handler(req)
    H-->>GI: panic
    GI->>GI: recover() converts to codes.Internal
    GI-->>FM: error
    FM-->>C: ErrPanic (no stack leak)

    Note over FM,GI: Middleware is outermost for API handlers. Interceptor is backstop for cluster-internal gRPC only.

    C->>FM: Subsequent request
    FM->>GI: next(ctx)
    GI->>H: handler(req)
    H-->>GI: OK
    GI-->>FM: OK
    FM-->>C: OK
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `core/pkg/service/driver/driver_test.go`, line 996-999 ([link](https://github.com/synnaxlabs/synnax/blob/5d1230959631ebc4b5124dd2b7cb7094517d5c3f/core/pkg/service/driver/driver_test.go#L996-L999)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **`time.Sleep` makes the test fragile in slow environments**

   `time.Sleep(50 * time.Millisecond)` is placed after `openDriver` but before creating the task. `Open()` already establishes the task-change observer synchronously before returning, so the sleep appears unnecessary. In a slow CI runner the delay may be insufficient and occasionally let a task-change event race ahead of the driver setup, making the test flaky. Using `Eventually` or removing the sleep would be more robust.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (3): Last reviewed commit: ["SY-4271: Add gRPC wire-level recovery te..."](https://github.com/synnaxlabs/synnax/commit/06d1b18d703762140210f3da20bc1b19b5707797) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34659680)</sub>

<!-- /greptile_comment -->