### PR TITLE
SY-4269: Reject Arc Flow Nodes With Unconnected Required Inputs

### DIFF
--- a/arc/cpp/runtime/wasm/node_test.cpp
+++ b/arc/cpp/runtime/wasm/node_test.cpp
@@ -91,28 +91,16 @@ std::vector<std::shared_ptr<stl::Module>> build_stl_modules(
     };
 }
 
-/// @brief compiles a single Arc function definition, calls it, and returns the first
-/// output value. Parses the function name and return type from the definition to create
-/// the necessary flow and channel automatically.
+/// @brief compiles a single Arc function definition, calls its exported WASM
+/// function directly with the given params, and returns the first output value.
+/// A function declaration compiles and exports to WASM on its own, so the
+/// definition is compiled as-is with no flow or channel scaffolding.
 template<typename T>
 T call_func(
     const synnax::Synnax &client,
     const std::string &func_def,
     const std::vector<x::telem::SampleValue> &params = {}
 ) {
-    static const std::unordered_map<std::string, x::telem::DataType> arc_types = {
-        {"i8", x::telem::INT8_T},
-        {"i16", x::telem::INT16_T},
-        {"i32", x::telem::INT32_T},
-        {"i64", x::telem::INT64_T},
-        {"u8", x::telem::UINT8_T},
-        {"u16", x::telem::UINT16_T},
-        {"u32", x::telem::UINT32_T},
-        {"u64", x::telem::UINT64_T},
-        {"f32", x::telem::FLOAT32_T},
-        {"f64", x::telem::FLOAT64_T},
-    };
-
     // Parse function name: first word after "func "
     auto func_pos = func_def.find("func ");
     if (func_pos == std::string::npos)
@@ -121,34 +109,13 @@ T call_func(
     auto name_end = func_def.find_first_of("( ", name_start);
     auto func_name = func_def.substr(name_start, name_end - name_start);
 
-    // Parse return type: last type token before '{'
-    auto brace = func_def.find('{');
-    if (brace == std::string::npos)
-        throw std::runtime_error("call_func: no '{' in definition");
-    auto pre = func_def.substr(0, brace);
-    auto pos = pre.find_last_not_of(" \t\n");
-    auto start = pre.find_last_of(" \t\n()", pos);
-    auto ret_type = pre.substr(start + 1, pos - start);
-    auto it = arc_types.find(ret_type);
-    auto dt = it != arc_types.end() ? it->second : x::telem::INT64_T;
-
-    // Create virtual output channel and build source
-    auto ch = synnax::channel::Channel{
-        .name = random_name("out"),
-        .data_type = dt,
-        .is_virtual = true,
-    };
-    if (const auto err = client.channels.create(ch))
-        throw std::runtime_error("Failed to create channel: " + err.message());
-    auto source = func_def + "\n" + func_name + "{} -> " + ch.name;
-
     auto str_st = std::make_shared<stl::strings::State>();
     auto series_st = std::make_shared<stl::series::State>();
     auto var_st = std::make_shared<stl::stateful::Variables>();
     auto channel_st = std::make_shared<stl::channels::State>();
     auto stl_modules = build_stl_modules(channel_st, str_st, series_st, var_st);
 
-    auto mod = compile_arc(client, source);
+    auto mod = compile_arc(client, func_def);
     auto wasm_mod = ASSERT_NIL_P(
         wasm::Module::open({
             .program = mod,

--- a/arc/go/analyzer/resolve.go
+++ b/arc/go/analyzer/resolve.go
@@ -14,11 +14,15 @@ import (
 	atypes "github.com/synnaxlabs/arc/analyzer/types"
 	"github.com/synnaxlabs/arc/ir"
 	"github.com/synnaxlabs/x/diagnostics"
+	"github.com/synnaxlabs/x/set"
 )
 
 // ResolveNodeTypes checks type compatibility across edges, unifies the constraint
-// system, and applies substitutions to resolve concrete types in node inputs,
-// outputs, and config parameters.
+// system, applies substitutions to resolve concrete types in node inputs,
+// outputs, and config parameters, and verifies that every required input is
+// satisfied by an incoming edge. A required input is one whose parameter has no
+// default Value; leaving it unconnected would force the runtime to materialize a
+// series from a nil value, so it is rejected here as a diagnostic instead.
 func ResolveNodeTypes(
 	nodes ir.Nodes,
 	edges ir.Edges,
@@ -69,5 +73,28 @@ func ResolveNodeTypes(
 			nodes[idx].Config[j].Type = cs.ApplySubstitutions(p.Type)
 		}
 	}
-	return true
+	connected := set.New[ir.Handle]()
+	for _, edge := range edges {
+		connected.Add(edge.Target)
+	}
+	missingRequiredInput := false
+	for _, n := range nodes {
+		for _, p := range n.Inputs {
+			if p.Value != nil {
+				continue
+			}
+			if connected.Contains(ir.Handle{Node: n.Key, Param: p.Name}) {
+				continue
+			}
+			diag.Add(diagnostics.Errorf(
+				nil,
+				"node '%s' (%s) missing required input '%s'",
+				n.Key,
+				n.Type,
+				p.Name,
+			))
+			missingRequiredInput = true
+		}
+	}
+	return !missingRequiredInput
 }

--- a/arc/go/analyzer/resolve_test.go
+++ b/arc/go/analyzer/resolve_test.go
@@ -104,6 +104,36 @@ var _ = Describe("ResolveNodeTypes", func() {
 		Expect(diag.Ok()).To(BeTrue())
 	})
 
+	It("Should error when a required input has no incoming edge", func() {
+		nodes := ir.Nodes{
+			{Key: "sel", Type: "select", Inputs: types.Params{{Name: "output", Type: types.U8()}}},
+		}
+		Expect(analyzer.ResolveNodeTypes(nodes, ir.Edges{}, cs, diag)).To(BeFalse())
+		Expect(diag.String()).To(ContainSubstring(
+			"node 'sel' (select) missing required input 'output'"))
+	})
+
+	It("Should not error when an unconnected input has a default value", func() {
+		nodes := ir.Nodes{
+			{Key: "gen", Type: "gen", Inputs: types.Params{{Name: "seed", Type: types.I64(), Value: int64(1)}}},
+		}
+		Expect(analyzer.ResolveNodeTypes(nodes, ir.Edges{}, cs, diag)).To(BeTrue())
+		Expect(diag.Ok()).To(BeTrue())
+	})
+
+	It("Should not error when a required input is satisfied by an edge", func() {
+		nodes := ir.Nodes{
+			{Key: "source", Type: "on", Outputs: types.Params{{Name: "output", Type: types.U8()}}},
+			{Key: "sel", Type: "select", Inputs: types.Params{{Name: "input", Type: types.U8()}}},
+		}
+		edges := ir.Edges{{
+			Source: ir.Handle{Node: "source", Param: "output"},
+			Target: ir.Handle{Node: "sel", Param: "input"},
+		}}
+		Expect(analyzer.ResolveNodeTypes(nodes, edges, cs, diag)).To(BeTrue())
+		Expect(diag.Ok()).To(BeTrue())
+	})
+
 	It("Should error on type mismatch between concrete types", func() {
 		nodes := ir.Nodes{
 			{Key: "source", Type: "on", Outputs: types.Params{{Name: "output", Type: types.F64()}}},

--- a/arc/go/analyzer/resolve_test.go
+++ b/arc/go/analyzer/resolve_test.go
@@ -94,7 +94,7 @@ var _ = Describe("ResolveNodeTypes", func() {
 	It("Should skip edges with missing target input param", func() {
 		nodes := ir.Nodes{
 			{Key: "source", Type: "on", Outputs: types.Params{{Name: "output", Type: types.F64()}}},
-			{Key: "target", Type: "func", Inputs: types.Params{{Name: "value", Type: types.F64()}}},
+			{Key: "target", Type: "func", Inputs: types.Params{{Name: "value", Type: types.F64(), Value: float64(0)}}},
 		}
 		edges := ir.Edges{{
 			Source: ir.Handle{Node: "source", Param: "output"},

--- a/arc/go/graph/analyze.go
+++ b/arc/go/graph/analyze.go
@@ -193,20 +193,17 @@ func Analyze(
 		return ir.IR{}, aCtx.Diagnostics
 	}
 
-	// Step 5A: Check for Duplicate Edge Targets and Build Connected Inputs Map
-	connectedInputs := make(map[string]set.Set[string])
+	// Step 5A: Check for Duplicate Edge Targets
+	targets := set.New[ir.Handle]()
 	for _, edge := range g.Edges {
-		if connectedInputs[edge.Target.Node] == nil {
-			connectedInputs[edge.Target.Node] = make(set.Set[string])
-		}
-		if connectedInputs[edge.Target.Node].Contains(edge.Target.Param) {
+		if targets.Contains(edge.Target) {
 			aCtx.Diagnostics.Add(diagnostics.Errorf(nil,
 				"multiple edges target node '%s' parameter '%s'",
 				edge.Target.Node,
 				edge.Target.Param,
 			))
 		}
-		connectedInputs[edge.Target.Node].Add(edge.Target.Param)
+		targets.Add(edge.Target)
 	}
 	if !aCtx.Diagnostics.Ok() {
 		return ir.IR{}, aCtx.Diagnostics

--- a/arc/go/graph/analyze.go
+++ b/arc/go/graph/analyze.go
@@ -212,33 +212,6 @@ func Analyze(
 		return ir.IR{}, aCtx.Diagnostics
 	}
 
-	// Step 5B: Check Missing Required Inputs
-	for _, n := range g.Nodes {
-		freshType := freshFuncTypes[n.Key]
-		if freshType.Inputs == nil {
-			continue
-		}
-		connected := connectedInputs[n.Key]
-		for _, inputParam := range freshType.Inputs {
-			if !connected.Contains(inputParam.Name) {
-				// Check if this parameter has a default value (is optional)
-				if inputParam.Value == nil {
-					// Required parameter is missing
-					aCtx.Diagnostics.Add(diagnostics.Errorf(
-						nil,
-						"node '%s' (%s) missing required input '%s'",
-						n.Key,
-						n.Type,
-						inputParam.Name,
-					))
-				}
-			}
-		}
-	}
-	if !aCtx.Diagnostics.Ok() {
-		return ir.IR{}, aCtx.Diagnostics
-	}
-
 	// Step 6: Substitute TypeMap after unification
 	for node, typ := range aCtx.TypeMap {
 		aCtx.TypeMap[node] = aCtx.Constraints.ApplySubstitutions(typ)

--- a/arc/go/text/text_test.go
+++ b/arc/go/text/text_test.go
@@ -144,25 +144,28 @@ var _ = Describe("Text", func() {
 
 	Describe("Analyze", func() {
 		It("Should correctly analyze a text-based arc program", func(ctx SpecContext) {
+			resolver := []symbol.Symbol{
+				{Name: "in", Kind: symbol.KindChannel, Type: types.Chan(types.I64()), ID: 100},
+			}
 			source := `
 			func add(a i64, b i64) i64 {
 			    return a + b
 			}
 
-			func adder{} (a i64, b i64) i64 {
-			    return a + b
+			func adder{} (a i64) i64 {
+			    return a
 			}
 
 			func print{} () {}
 
-			adder{} -> print{}`
+			in -> adder{} -> print{}`
 			parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
 			Expect(parsedText.AST).ToNot(BeNil())
-			inter, diagnostics := text.Analyze(ctx, parsedText, NewRoot(nil))
+			inter, diagnostics := text.Analyze(ctx, parsedText, NewRoot(nil, resolver...))
 			Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
 			Expect(inter.Functions).To(HaveLen(3))
-			Expect(inter.Nodes).To(HaveLen(2))
-			Expect(inter.Edges).To(HaveLen(1))
+			Expect(inter.Nodes).To(HaveLen(3))
+			Expect(inter.Edges).To(HaveLen(2))
 
 			f := inter.Functions[0]
 			Expect(f.Key).To(Equal("add"))
@@ -172,9 +175,8 @@ var _ = Describe("Text", func() {
 
 			s := inter.Functions[1]
 			Expect(s.Key).To(Equal("adder"))
-			Expect(s.Inputs).To(HaveLen(2))
+			Expect(s.Inputs).To(HaveLen(1))
 			Expect(s.Inputs[0].Type).To(Equal(types.I64()))
-			Expect(s.Inputs[1].Type).To(Equal(types.I64()))
 
 			n1 := findNodeByKey(inter.Nodes, "adder_0")
 			Expect(n1.Type).To(Equal("adder"))
@@ -651,6 +653,22 @@ sensor -> math.avg{} -> output`
 				Expect(diags.Ok()).To(BeFalse())
 			})
 
+			It("Should reject a flow node whose required input is never connected", func(ctx SpecContext) {
+				resolver := []symbol.Symbol{
+					{Name: "trigger", Kind: symbol.KindChannel, Type: types.Chan(types.U8()), ID: 100},
+					{Name: "log", Kind: symbol.KindChannel, Type: types.WriteChan(types.String()), ID: 200},
+				}
+				// The juxtaposition `(1 > 0) select{}` never wires the comparison
+				// into select's selector, leaving select's required u8 input with
+				// no source. Previously this compiled and panicked at runtime when
+				// the node state tried to materialize a series from a nil value.
+				source := `trigger -> (1 > 0) select{} -> { true: "hello" + "!" -> log,}`
+				parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
+				_, diags := text.Analyze(ctx, parsedText, NewRoot(nil, resolver...))
+				Expect(diags.Ok()).To(BeFalse())
+				Expect(diags.String()).To(ContainSubstring("missing required input"))
+			})
+
 			It("Should emit deprecation warning for bare stable_for", func(ctx SpecContext) {
 				resolver := []symbol.Symbol{
 					{Name: "sensor", Kind: symbol.KindChannel, Type: types.Chan(types.U8()), ID: 100},
@@ -978,7 +996,7 @@ time.wait{duration=500ms} -> output`
 
 				func sink{} () {}
 
-				transform{scale=SCALE, offset=OFFSET} -> sink{}`
+				0.0 -> transform{scale=SCALE, offset=OFFSET} -> sink{}`
 				parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
 				inter, diagnostics := text.Analyze(ctx, parsedText, NewRoot(nil))
 				Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
@@ -1005,7 +1023,7 @@ time.wait{duration=500ms} -> output`
 
 				func sink{} () {}
 
-				filter{threshold=THRESHOLD, enabled=1} -> sink{}`
+				0 -> filter{threshold=THRESHOLD, enabled=1} -> sink{}`
 				parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
 				inter, diagnostics := text.Analyze(ctx, parsedText, NewRoot(nil))
 				Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
@@ -1033,7 +1051,7 @@ time.wait{duration=500ms} -> output`
 
 				func sink{} () {}
 
-				clamp{max=MAX_VALUE} -> sink{}`
+				i32(0) -> clamp{max=MAX_VALUE} -> sink{}`
 				parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
 				inter, diagnostics := text.Analyze(ctx, parsedText, NewRoot(nil))
 				Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
@@ -1053,7 +1071,7 @@ time.wait{duration=500ms} -> output`
 
 				func sink{} () {}
 
-				transform{2.5, 0.1} -> sink{}`
+				0.0 -> transform{2.5, 0.1} -> sink{}`
 				parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
 				inter, diagnostics := text.Analyze(ctx, parsedText, NewRoot(nil))
 				Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
@@ -1074,7 +1092,7 @@ time.wait{duration=500ms} -> output`
 
 				func sink{} () {}
 
-				controller{100.0} -> sink{}`
+				0.0 -> controller{100.0} -> sink{}`
 				parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
 				inter, diagnostics := text.Analyze(ctx, parsedText, NewRoot(nil))
 				Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
@@ -1258,7 +1276,12 @@ time.wait{duration=500ms} -> output`
 				Expect(channelNode.Outputs.Has(edge.Source.Param)).To(BeTrue())
 			})
 
-			It("Should handle binary operator parameter names", func(ctx SpecContext) {
+			It("Should reject a multi-input function used as a bare flow node", func(ctx SpecContext) {
+				// A flow node receives a single value from its upstream, so a
+				// function with more than one required input cannot have all of
+				// its inputs sourced in flow form. The unconnected inputs are
+				// reported as diagnostics rather than producing IR that panics
+				// at runtime when materializing a series from a nil value.
 				source := `
 				func add{} (a i64, b i64) i64 {
 				    return a + b
@@ -1268,27 +1291,20 @@ time.wait{duration=500ms} -> output`
 
 				add{} -> print{}`
 				parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
-				inter, diagnostics := text.Analyze(ctx, parsedText, NewRoot(nil))
-				Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
-
-				edge := inter.Edges[0]
-				srcNode := findNodeByKey(inter.Nodes, edge.Source.Node)
-				tgtNode := findNodeByKey(inter.Nodes, edge.Target.Node)
-
-				Expect(edge.Source.Param).To(Equal("output"))
-				Expect(srcNode.Outputs.Has(edge.Source.Param)).To(BeTrue())
-
-				Expect(edge.Target.Param).To(Equal("value"))
-				Expect(tgtNode.Inputs.Has(edge.Target.Param)).To(BeTrue())
-
-				Expect(srcNode.Inputs).To(HaveLen(2))
-				Expect(srcNode.Inputs.Has("a")).To(BeTrue())
-				Expect(srcNode.Inputs.Has("b")).To(BeTrue())
+				_, diagnostics := text.Analyze(ctx, parsedText, NewRoot(nil))
+				Expect(diagnostics.Ok()).To(BeFalse())
+				Expect(diagnostics.String()).To(SatisfyAll(
+					ContainSubstring("missing required input 'a'"),
+					ContainSubstring("missing required input 'b'"),
+				))
 			})
 		})
 
 		Context("Output Routing Tables", func() {
 			It("Should analyze simple output routing with multiple targets", func(ctx SpecContext) {
+				resolver := []symbol.Symbol{
+					{Name: "signal", Kind: symbol.KindChannel, Type: types.Chan(types.F64()), ID: 10101},
+				}
 				source := `
 				func demux{threshold f64} (value f64) (high f64, low f64) {
 				    if (value > threshold) {
@@ -1302,16 +1318,16 @@ time.wait{duration=500ms} -> output`
 
 				func logger{} (value f64) {}
 
-				demux{threshold=100.0} -> {
+				signal -> demux{threshold=100.0} -> {
 				    high: alarm{},
 				    low: logger{}
 				}`
 				parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
-				inter, diagnostics := text.Analyze(ctx, parsedText, NewRoot(nil))
+				inter, diagnostics := text.Analyze(ctx, parsedText, NewRoot(nil, resolver...))
 				Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
 
-				Expect(inter.Nodes).To(HaveLen(3))
-				Expect(inter.Edges).To(HaveLen(2))
+				Expect(inter.Nodes).To(HaveLen(4))
+				Expect(inter.Edges).To(HaveLen(3))
 
 				demuxNode := findNodeByKey(inter.Nodes, "demux_0")
 				alarmNode := findNodeByKey(inter.Nodes, "alarm_0")
@@ -1333,6 +1349,9 @@ time.wait{duration=500ms} -> output`
 			})
 
 			It("Should handle routing with chained processing", func(ctx SpecContext) {
+				resolver := []symbol.Symbol{
+					{Name: "signal", Kind: symbol.KindChannel, Type: types.Chan(types.F64()), ID: 10102},
+				}
 				source := `
 				func demux{threshold f64} (value f64) (high f64, low f64) {
 				    if (value > threshold) {
@@ -1348,29 +1367,33 @@ time.wait{duration=500ms} -> output`
 
 				func display{} (value f64) {}
 
-				demux{threshold=100.0} -> {
+				signal -> demux{threshold=100.0} -> {
 				    high: amplify{} -> display{}
 				}`
 				parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
-				inter, diagnostics := text.Analyze(ctx, parsedText, NewRoot(nil))
+				inter, diagnostics := text.Analyze(ctx, parsedText, NewRoot(nil, resolver...))
 				Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
 
-				Expect(inter.Nodes).To(HaveLen(3))
-				Expect(inter.Edges).To(HaveLen(2))
+				Expect(inter.Nodes).To(HaveLen(4))
+				Expect(inter.Edges).To(HaveLen(3))
 
-				edge0 := inter.Edges[0]
-				Expect(edge0.Source.Node).To(Equal("demux_0"))
-				Expect(edge0.Source.Param).To(Equal("high"))
-				Expect(edge0.Target.Node).To(Equal("amplify_0"))
+				demuxToAmplify := findEdgeBySourceParam(inter.Edges, "high")
+				Expect(demuxToAmplify.Source.Node).To(Equal("demux_0"))
+				Expect(demuxToAmplify.Target.Node).To(Equal("amplify_0"))
 
-				edge1 := inter.Edges[1]
-				Expect(edge1.Source.Node).To(Equal("amplify_0"))
-				Expect(edge1.Target.Node).To(Equal("display_0"))
+				var amplifyToDisplay ir.Edge
+				for _, e := range inter.Edges {
+					if e.Source.Node == "amplify_0" {
+						amplifyToDisplay = e
+					}
+				}
+				Expect(amplifyToDisplay.Target.Node).To(Equal("display_0"))
 			})
 
 			It("Should not create phantom output edges for void functions in routing branches", func(ctx SpecContext) {
 				resolver := []symbol.Symbol{
 					{Name: "counter", Kind: symbol.KindChannel, Type: types.Chan(types.U32()), ID: 10301},
+					{Name: "signal", Kind: symbol.KindChannel, Type: types.Chan(types.F64()), ID: 10302},
 				}
 				source := `
 				func demux{threshold f64} (value f64) (high f64, low f64) {
@@ -1385,7 +1408,7 @@ time.wait{duration=500ms} -> output`
 				    ch = ch + 1
 				}
 
-				demux{threshold=100.0} -> {
+				signal -> demux{threshold=100.0} -> {
 				    high: increment{ch=counter}
 				}`
 				parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
@@ -1448,6 +1471,9 @@ time.wait{duration=500ms} -> output`
 			})
 
 			It("Should calculate strata for output routing tables", func(ctx SpecContext) {
+				resolver := []symbol.Symbol{
+					{Name: "signal", Kind: symbol.KindChannel, Type: types.Chan(types.F64()), ID: 10103},
+				}
 				source := `
 				func demux{threshold f64} (value f64) (high f64, low f64) {
 				    if (value > threshold) {
@@ -1461,17 +1487,18 @@ time.wait{duration=500ms} -> output`
 
 				func logger{} (value f64) {}
 
-				demux{threshold=100.0} -> {
+				signal -> demux{threshold=100.0} -> {
 				    high: alarm{},
 				    low: logger{}
 				}`
 				parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
-				inter, diagnostics := text.Analyze(ctx, parsedText, NewRoot(nil))
+				inter, diagnostics := text.Analyze(ctx, parsedText, NewRoot(nil, resolver...))
 				Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
 
-				Expect(inter.Root.Strata).To(HaveLen(2))
-				Expect(inter.Root.Strata[0][0].Key()).To(Equal("demux_0"))
-				keys := lo.Map(inter.Root.Strata[1], func(m ir.Member, _ int) string {
+				Expect(inter.Root.Strata).To(HaveLen(3))
+				Expect(inter.Root.Strata[0][0].Key()).To(Equal("on_signal_0"))
+				Expect(inter.Root.Strata[1][0].Key()).To(Equal("demux_0"))
+				keys := lo.Map(inter.Root.Strata[2], func(m ir.Member, _ int) string {
 					return m.Key()
 				})
 				Expect(keys).To(ContainElements("alarm_0", "logger_0"))
@@ -1531,6 +1558,7 @@ time.wait{duration=500ms} -> output`
 				resolver := []symbol.Symbol{
 					{Name: "high_chan", Kind: symbol.KindChannel, Type: types.Chan(types.F64()), ID: 10041},
 					{Name: "low_chan", Kind: symbol.KindChannel, Type: types.Chan(types.F64()), ID: 10045},
+					{Name: "signal", Kind: symbol.KindChannel, Type: types.Chan(types.F64()), ID: 10046},
 				}
 				source := `
 				func demux{threshold f64} (value f64) (high f64, low f64) {
@@ -1541,7 +1569,7 @@ time.wait{duration=500ms} -> output`
 				    }
 				}
 
-				demux{threshold=100.0} -> {
+				signal -> demux{threshold=100.0} -> {
 				    high: high_chan,
 				    low: low_chan
 				}`
@@ -1549,7 +1577,7 @@ time.wait{duration=500ms} -> output`
 				inter, diagnostics := text.Analyze(ctx, parsedText, NewRoot(nil, resolver...))
 				Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
 
-				Expect(inter.Nodes).To(HaveLen(3))
+				Expect(inter.Nodes).To(HaveLen(4))
 
 				writeCount := countNodesByType(inter.Nodes, "write")
 				Expect(writeCount).To(Equal(2))
@@ -2276,6 +2304,7 @@ time.wait{duration=500ms} -> output`
 			It("Should handle sequence in routing table as sink", func(ctx SpecContext) {
 				resolver := []symbol.Symbol{
 					{Name: "high_chan", Kind: symbol.KindChannel, Type: types.Chan(types.F64()), ID: 10071},
+					{Name: "signal", Kind: symbol.KindChannel, Type: types.Chan(types.F64()), ID: 10072},
 				}
 				source := `
 				sequence alarm {
@@ -2290,7 +2319,7 @@ time.wait{duration=500ms} -> output`
 				    }
 				}
 
-				demux{threshold=100.0} -> {
+				signal -> demux{threshold=100.0} -> {
 				    high: alarm,
 				    low: high_chan
 				}`
@@ -2298,17 +2327,18 @@ time.wait{duration=500ms} -> output`
 				inter, diagnostics := text.Analyze(ctx, parsedText, NewRoot(nil, resolver...))
 				Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
 
-				// demux node + write node for the `low` branch. The `high`
-				// branch is a scope reference that becomes an activation.
-				Expect(inter.Nodes).To(HaveLen(2))
+				// on node for signal + demux node + write node for the `low`
+				// branch. The `high` branch is a scope reference that becomes
+				// an activation.
+				Expect(inter.Nodes).To(HaveLen(3))
 
 				demuxNode := findNodeByType(inter.Nodes, "demux")
 				writeNode := findNodeByType(inter.Nodes, "write")
 				Expect(writeNode.Channels.Write).To(HaveKey(uint32(10071)))
 
-				// Only the write edge exists; the `high` branch lands on
-				// alarm's scope activation.
-				Expect(inter.Edges).To(HaveLen(1))
+				// The signal->demux edge and the write edge exist; the `high`
+				// branch lands on alarm's scope activation.
+				Expect(inter.Edges).To(HaveLen(2))
 				alarm := findTopLevelScope(inter, "alarm")
 				Expect(alarm.Activation).ToNot(BeNil())
 				Expect(alarm.Activation.Node).To(Equal(demuxNode.Key))
@@ -3465,16 +3495,19 @@ time.wait{duration=500ms} -> output`
 
 	Describe("Compile", func() {
 		It("Should compile a simple arc program to WebAssembly", func(ctx SpecContext) {
+			resolver := []symbol.Symbol{
+				{Name: "in", Kind: symbol.KindChannel, Type: types.Chan(types.I64()), ID: 100},
+			}
 			source := `
-			func adder{} (a i64, b i64) i64 {
-			    return a + b
+			func adder{} (a i64) i64 {
+			    return a
 			}
 
 			func print{} () {}
 
-			adder{} -> print{}`
+			in -> adder{} -> print{}`
 			parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
-			ir, diagnostics := text.Analyze(ctx, parsedText, NewRoot(nil))
+			ir, diagnostics := text.Analyze(ctx, parsedText, NewRoot(nil, resolver...))
 			Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
 
 			module := MustSucceed(text.Compile(ctx, ir))

--- a/arc/go/text/text_test.go
+++ b/arc/go/text/text_test.go
@@ -3514,6 +3514,22 @@ time.wait{duration=500ms} -> output`
 			Expect(module.Output.WASM).ToNot(BeEmpty())
 		})
 
+		It("Should compile a function-only program with no flow statement", func(ctx SpecContext) {
+			// A function declaration compiles and exports to WASM on its own,
+			// without being referenced by a flow node. This includes multi-input
+			// functions, which cannot be expressed as a runnable flow node at all
+			// (a flow node receives a single upstream value). Callers that invoke
+			// the exported function directly (e.g. the C++ runtime test harness)
+			// rely on this instead of scaffolding an unconnected flow node.
+			source := `func pow_ff(base f64, exp f64) f64 { return base ^ exp }`
+			parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
+			ir, diagnostics := text.Analyze(ctx, parsedText, NewRoot(nil))
+			Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
+
+			module := MustSucceed(text.Compile(ctx, ir))
+			Expect(module.Output.WASM).ToNot(BeEmpty())
+		})
+
 		It("Should compile function with channel config param assigned to intermediate variable", func(ctx SpecContext) {
 			// This is the exact user pattern that was failing:
 			// sp := set_point (where set_point is a chan f32 config param)


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4269](https://linear.app/synnax/issue/SY-4269)

## Description

A text-mode Arc program such as `trigger -> (1 > 0) select{} -> { true: ... }` compiled successfully but crashed the entire server node at run time. `select`'s required `u8` selector input was never wired (the `(1 > 0) select{}` juxtaposition produced no edge into it), so at runtime `node.New(...).Node()` tried to materialize a series from the input's `nil` default and panicked with `cannot cast <nil> to uint8`, taking down the process.

This is a semantic error, not a syntax error: a node with a required input (one with no default value) and no incoming edge can never run. The graphical frontend (`graph.Analyze`) already rejected this, but the text frontend (`text.Analyze`) did not. Rather than duplicate the check, the validation is hoisted into the shared `analyzer.ResolveNodeTypes` that **both** frontends call, and the now-redundant copy is removed from `graph.Analyze`. Such programs now fail compilation with `node '<key>' (<type>) missing required input '<param>'` instead of producing IR that panics.

This also formalizes that a flow node receives a single value from its upstream: a multi-input function used as a bare flow node (e.g. `add{}(a, b)`) can never have all of its inputs sourced and is now reported as an error.

Test fixtures that relied on the old leniency (flow functions whose required data input was never sourced) were updated to be complete programs — feeding a source where the construct is valid (single-input pipes) and asserting rejection where it is not (multi-input flow nodes).

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR hoists the missing-required-input check from `graph.Analyze` into the shared `analyzer.ResolveNodeTypes` so both the graph and text frontends reject programs where a required (default-less) node input has no incoming edge, preventing the runtime nil-cast panic described in SY-4269.

- **`analyzer.ResolveNodeTypes`** now builds a `connected` set from edge targets after type-checking and emits a diagnostic for every unconnected required input, collecting all errors before returning; the now-redundant Step 5B in `graph/analyze.go` is removed and Step 5A is simplified to a flat `set.New[ir.Handle]()`.
- **Test suite** is brought in line with the new stricter validation: single-input flow-node tests gain a source channel, the old "binary operator parameter names" integration test is replaced by a multi-input-bare-flow-node rejection test, and a direct regression test for the `trigger -> (1 > 0) select{}` panic is added.
- **C++ `call_func` helper** is simplified to compile and invoke function declarations directly via their WASM export, removing the now-invalid practice of scaffolding a virtual channel and an unconnected flow node.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change moves an existing validation check into shared infrastructure and adds validation that was previously absent from the text frontend, with good test coverage for all new and updated paths.

The core logic in ResolveNodeTypes is straightforward: build a set of connected edge targets, then flag any node input that has no default value and no incoming edge. All new error paths are exercised by unit tests and integration tests. The graph frontend removes its now-redundant duplicate check cleanly. No existing runtime behavior is silently altered — programs that previously compiled and panicked now fail at compile time with an actionable message.

No files require special attention.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| arc/go/analyzer/resolve.go | Adds missing-required-input validation to the shared ResolveNodeTypes pass; iterates edges a second time to build the connected set after type-checking, then reports every unconnected required (default-less) input as a diagnostic instead of returning early. |
| arc/go/graph/analyze.go | Removes the now-redundant Step 5B (missing-required-input check) and simplifies Step 5A to use a flat set.New[ir.Handle]() for duplicate-target detection, replacing the old nested map[string]set.Set[string]. |
| arc/go/analyzer/resolve_test.go | Adds three new unit tests covering the new validation (required-input error, optional-input pass-through, edge-satisfied pass-through); fixes the skip-missing-target-param test by giving the unconnected value param a default so the new check doesn't flag it. |
| arc/go/text/text_test.go | Updates integration tests to supply source channels for single-input flow nodes, converts the old binary-operator-parameter-names test into a rejection test for multi-input bare flow nodes, and adds the regression test for the original runtime-panic bug. |
| arc/cpp/runtime/wasm/node_test.cpp | Simplifies call_func to compile and call function declarations directly via WASM export rather than scaffolding a virtual channel and flow node — aligns with the new rule that multi-input functions cannot be expressed as bare flow nodes. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Parse source text / graph] --> B[Analyze: build IR nodes & edges]
    B --> C[Step 5: ResolveNodeTypes]
    C --> D{Type-check each edge}
    D -- mismatch --> E[Return false / emit error]
    D -- ok --> F[Unify constraints]
    F -- error --> E
    F -- ok --> G[Apply substitutions to all params]
    G --> H[Build connected set from edge targets]
    H --> I{For each node input: Value == nil AND not in connected?}
    I -- yes --> J[Emit missing required input diagnostic]
    I -- no --> K[Continue]
    J --> K
    K --> L{All nodes checked?}
    L -- no --> I
    L -- yes --> M{missingRequiredInput?}
    M -- yes --> E
    M -- no --> N[Step 5A: Duplicate edge target check]
    N --> O[Stratify & return IR]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `arc/go/graph/analyze.go`, line 196-213 ([link](https://github.com/synnaxlabs/synnax/blob/ad731ab6bfe7769057c3684f3222075e97a4f456/arc/go/graph/analyze.go#L196-L213)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Stale comment and dead allocation**

   After Step 5B was removed, `connectedInputs` is only read inside the duplicate-detection loop (via `.Contains`/`.Add`) and is never consumed after Step 5A completes. The label "and Build Connected Inputs Map" in the comment is now misleading, because the map's purpose was to feed the missing-required-input check that no longer lives here. The data is allocated and populated but goes unused by any subsequent step.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (4): Last reviewed commit: ["fixed C++ tests"](https://github.com/synnaxlabs/synnax/commit/04c6a72c4c624a0a28efdbd411b955724e498dcd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34659692)</sub>

<!-- /greptile_comment -->