### PR TITLE
SY-4270: Fix Flaky Debounce Tests

### DIFF
--- a/arc/go/lsp/server.go
+++ b/arc/go/lsp/server.go
@@ -254,9 +254,15 @@ func (s *Server) DidOpen(ctx context.Context, params *protocol.DidOpenTextDocume
 		Content:  params.TextDocument.Text,
 		metadata: metadata,
 	}
-	doc.debouncer = debounce.New(s.cfg.DebounceDelay, s.cfg.MaxDebounceDelay, func(ctx context.Context) {
-		s.runAnalysis(ctx, doc, uri)
+	deb, err := debounce.New(debounce.Config{
+		Delay:    s.cfg.DebounceDelay,
+		MaxDelay: s.cfg.MaxDebounceDelay,
+		Callback: func(ctx context.Context) { s.runAnalysis(ctx, doc, uri) },
 	})
+	if err != nil {
+		return errors.Wrap(err, "create document debouncer")
+	}
+	doc.debouncer = deb
 	s.mu.Lock()
 	s.documents[uri] = doc
 	s.mu.Unlock()

--- a/x/go/debounce/debounce.go
+++ b/x/go/debounce/debounce.go
@@ -75,12 +75,13 @@ func (c Config) Validate() error {
 // MaxDelay caps the total delay from the first unprocessed trigger, ensuring sustained
 // rapid triggers still produce periodic invocations.
 type Debouncer struct {
-	cfg      Config
-	mu       sync.Mutex
-	timer    xtime.Timer
-	timerGen uint64
-	cancel   context.CancelFunc
-	firstAt  time.Time
+	cfg        Config
+	mu         sync.Mutex
+	timer      xtime.Timer
+	timerGen   uint64
+	cancel     context.CancelFunc
+	firstAt    time.Time
+	firstAtSet bool
 }
 
 // New creates a Debouncer from the merged set of configs. It returns an error if the
@@ -103,8 +104,9 @@ func (d *Debouncer) Trigger() {
 	d.timerGen++
 	gen := d.timerGen
 	now := d.cfg.Clock.Now()
-	if d.firstAt.IsZero() {
+	if !d.firstAtSet {
 		d.firstAt = now
+		d.firstAtSet = true
 	}
 	delay, maxDelay := d.cfg.Delay, d.cfg.MaxDelay
 	if maxDelay > 0 {
@@ -113,7 +115,7 @@ func (d *Debouncer) Trigger() {
 		}
 	}
 	if delay <= 0 {
-		d.firstAt = time.Time{}
+		d.firstAtSet = false
 		d.fireLocked()
 		return
 	}
@@ -127,7 +129,7 @@ func (d *Debouncer) Stop() {
 	d.stopTimerLocked()
 	d.timerGen++
 	d.cancelLocked()
-	d.firstAt = time.Time{}
+	d.firstAtSet = false
 }
 
 // onTimerFire is invoked by Clock.AfterFunc when the timer elapses. The gen check
@@ -139,7 +141,7 @@ func (d *Debouncer) onTimerFire(gen uint64) {
 	if d.timerGen != gen {
 		return
 	}
-	d.firstAt = time.Time{}
+	d.firstAtSet = false
 	d.fireLocked()
 }
 

--- a/x/go/debounce/debounce.go
+++ b/x/go/debounce/debounce.go
@@ -37,7 +37,7 @@ type Config struct {
 	// Clock is the time source used both for MaxDelay tracking and for scheduling the
 	// trailing-edge timer.
 	//
-	// [OPTIONAL] - defaults to xtime.Real{}.
+	// [OPTIONAL] - defaults to xtime.Real.
 	Clock xtime.Clock
 	// Callback is invoked in a new goroutine each time the debouncer fires. Its context
 	// is cancelled if Trigger or Stop is called while it is still running.

--- a/x/go/debounce/debounce.go
+++ b/x/go/debounce/debounce.go
@@ -15,51 +15,100 @@ import (
 	"context"
 	"sync"
 	"time"
+
+	"github.com/synnaxlabs/x/config"
+	"github.com/synnaxlabs/x/override"
+	xtime "github.com/synnaxlabs/x/time"
+	"github.com/synnaxlabs/x/validate"
 )
 
-// Debouncer coalesces rapid triggers into a single invocation of a callback.
-// Each Trigger resets a trailing-edge timer. When the timer fires, the callback
-// runs in a new goroutine with a cancellable context. If Trigger or Stop is
-// called while the callback is still running, its context is cancelled.
-//
-// MaxDelay caps the total delay from the first unprocessed trigger, ensuring
-// sustained rapid triggers still produce periodic invocations.
-type Debouncer struct {
-	// Delay is the trailing-edge delay after the last trigger before the
-	// callback fires.
+// Config configures a Debouncer.
+type Config struct {
+	// Delay is the trailing-edge delay after the last trigger before the callback
+	// fires.
+	//
+	// [REQUIRED]
 	Delay time.Duration
-	// MaxDelay caps the total time from the first unprocessed trigger to
-	// callback invocation. Zero means no cap.
+	// MaxDelay caps the total time from the first unprocessed trigger to callback
+	// invocation. Zero means no cap.
+	//
+	// [OPTIONAL] - defaults to 0.
 	MaxDelay time.Duration
-	fn       func(ctx context.Context)
+	// Clock is the time source used both for MaxDelay tracking and for scheduling the
+	// trailing-edge timer.
+	//
+	// [OPTIONAL] - defaults to xtime.Real{}.
+	Clock xtime.Clock
+	// Callback is invoked in a new goroutine each time the debouncer fires. Its context
+	// is cancelled if Trigger or Stop is called while it is still running.
+	//
+	// [REQUIRED]
+	Callback func(context.Context)
+}
+
+var _ config.Config[Config] = Config{}
+
+// Override returns c with any non-zero fields of other applied on top.
+func (c Config) Override(other Config) Config {
+	c.Delay = override.Numeric(c.Delay, other.Delay)
+	c.MaxDelay = override.Numeric(c.MaxDelay, other.MaxDelay)
+	c.Clock = override.Nil(c.Clock, other.Clock)
+	c.Callback = override.Nil(c.Callback, other.Callback)
+	return c
+}
+
+// Validate returns an error if c contains invalid values.
+func (c Config) Validate() error {
+	v := validate.New("debounce")
+	validate.GreaterThan(v, "delay", c.Delay, 0)
+	validate.GreaterThanEq(v, "max_delay", c.MaxDelay, 0)
+	validate.NotNil(v, "clock", c.Clock)
+	validate.NotNil(v, "callback", c.Callback)
+	return v.Error()
+}
+
+// Debouncer coalesces rapid triggers into a single invocation of a callback. Each
+// Trigger resets a trailing-edge timer. When the timer fires, the callback runs in a
+// new goroutine with a cancellable context. If Trigger or Stop is called while the
+// callback is still running, its context is cancelled.
+//
+// MaxDelay caps the total delay from the first unprocessed trigger, ensuring sustained
+// rapid triggers still produce periodic invocations.
+type Debouncer struct {
+	cfg      Config
 	mu       sync.Mutex
-	timer    *time.Timer
+	timer    xtime.Timer
+	timerGen uint64
 	cancel   context.CancelFunc
 	firstAt  time.Time
 }
 
-// New creates a Debouncer that will call fn when the trailing-edge timer fires.
-func New(delay, maxDelay time.Duration, fn func(ctx context.Context)) *Debouncer {
-	return &Debouncer{Delay: delay, MaxDelay: maxDelay, fn: fn}
+// New creates a Debouncer from the merged set of configs. It returns an error if the
+// resulting Config fails validation.
+func New(configs ...Config) (*Debouncer, error) {
+	cfg, err := config.New(Config{Clock: xtime.Real}, configs...)
+	if err != nil {
+		return nil, err
+	}
+	return &Debouncer{cfg: cfg}, nil
 }
 
-// Trigger resets the debounce timer. If the timer is already running, it is
-// stopped and restarted. If a previous callback is in-flight, its context is
-// cancelled.
+// Trigger resets the debounce timer. If the timer is already running, the pending fire
+// is superseded. If a previous callback is in-flight, its context is cancelled.
 func (d *Debouncer) Trigger() {
 	d.mu.Lock()
 	defer d.mu.Unlock()
 	d.cancelLocked()
-	if d.timer != nil {
-		d.timer.Stop()
-	}
-	now := time.Now()
+	d.stopTimerLocked()
+	d.timerGen++
+	gen := d.timerGen
+	now := d.cfg.Clock.Now()
 	if d.firstAt.IsZero() {
 		d.firstAt = now
 	}
-	delay := d.Delay
-	if d.MaxDelay > 0 {
-		if maxRemaining := d.MaxDelay - now.Sub(d.firstAt); maxRemaining < delay {
+	delay, maxDelay := d.cfg.Delay, d.cfg.MaxDelay
+	if maxDelay > 0 {
+		if maxRemaining := maxDelay - now.Sub(d.firstAt); maxRemaining < delay {
 			delay = maxRemaining
 		}
 	}
@@ -68,24 +117,37 @@ func (d *Debouncer) Trigger() {
 		d.fireLocked()
 		return
 	}
-	d.timer = time.AfterFunc(delay, func() {
-		d.mu.Lock()
-		d.firstAt = time.Time{}
-		d.fireLocked()
-		d.mu.Unlock()
-	})
+	d.timer = d.cfg.Clock.AfterFunc(delay, func() { d.onTimerFire(gen) })
 }
 
-// Stop cancels any pending timer and any in-flight callback.
+// Stop supersedes any pending timer and cancels any in-flight callback.
 func (d *Debouncer) Stop() {
 	d.mu.Lock()
 	defer d.mu.Unlock()
+	d.stopTimerLocked()
+	d.timerGen++
+	d.cancelLocked()
+	d.firstAt = time.Time{}
+}
+
+// onTimerFire is invoked by Clock.AfterFunc when the timer elapses. The gen check
+// guards against a timer that fired between a concurrent Trigger/Stop calling
+// timer.Stop (which returned false) and the firing goroutine acquiring d.mu.
+func (d *Debouncer) onTimerFire(gen uint64) {
+	d.mu.Lock()
+	defer d.mu.Unlock()
+	if d.timerGen != gen {
+		return
+	}
+	d.firstAt = time.Time{}
+	d.fireLocked()
+}
+
+func (d *Debouncer) stopTimerLocked() {
 	if d.timer != nil {
 		d.timer.Stop()
 		d.timer = nil
 	}
-	d.cancelLocked()
-	d.firstAt = time.Time{}
 }
 
 func (d *Debouncer) cancelLocked() {
@@ -98,5 +160,5 @@ func (d *Debouncer) cancelLocked() {
 func (d *Debouncer) fireLocked() {
 	ctx, cancel := context.WithCancel(context.Background())
 	d.cancel = cancel
-	go d.fn(ctx)
+	go d.cfg.Callback(ctx)
 }

--- a/x/go/debounce/debounce.go
+++ b/x/go/debounce/debounce.go
@@ -30,7 +30,7 @@ type Config struct {
 	// [REQUIRED]
 	Delay time.Duration
 	// MaxDelay caps the total time from the first unprocessed trigger to callback
-	// invocation. Zero means no cap.
+	// invocation.
 	//
 	// [OPTIONAL] - defaults to 0.
 	MaxDelay time.Duration

--- a/x/go/debounce/debounce_test.go
+++ b/x/go/debounce/debounce_test.go
@@ -11,129 +11,294 @@ package debounce_test
 
 import (
 	"context"
+	"sync"
 	"sync/atomic"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/synnaxlabs/x/debounce"
+	. "github.com/synnaxlabs/x/testutil"
+	xtime "github.com/synnaxlabs/x/time"
 )
 
-var _ = Describe("Debouncer", func() {
-	Describe("Trigger", func() {
-		It("Should fire the callback after the delay", func() {
-			var called atomic.Int32
-			d := debounce.New(20*time.Millisecond, 0, func(ctx context.Context) {
-				called.Add(1)
+func noopCallback(context.Context) {}
+
+var _ = Describe("Debounce", func() {
+	Describe("Config", func() {
+		Describe("Override", func() {
+			It("Should override Delay when the override is non-zero", func() {
+				base := debounce.Config{Delay: 10 * time.Millisecond}
+				o := debounce.Config{Delay: 20 * time.Millisecond}
+				Expect(base.Override(o).Delay).To(Equal(20 * time.Millisecond))
 			})
+			It("Should preserve Delay when the override is zero", func() {
+				base := debounce.Config{Delay: 10 * time.Millisecond}
+				Expect(base.Override(debounce.Config{}).Delay).
+					To(Equal(10 * time.Millisecond))
+			})
+			It("Should override MaxDelay when the override is non-zero", func() {
+				base := debounce.Config{MaxDelay: 10 * time.Millisecond}
+				o := debounce.Config{MaxDelay: 20 * time.Millisecond}
+				Expect(base.Override(o).MaxDelay).To(Equal(20 * time.Millisecond))
+			})
+			It("Should preserve MaxDelay when the override is zero", func() {
+				base := debounce.Config{MaxDelay: 10 * time.Millisecond}
+				Expect(base.Override(debounce.Config{}).MaxDelay).
+					To(Equal(10 * time.Millisecond))
+			})
+			It("Should override Clock when the override is non-nil", func() {
+				base := debounce.Config{Clock: xtime.Real}
+				fake := &xtime.Fake{}
+				Expect(base.Override(debounce.Config{Clock: fake}).Clock).
+					To(Equal(xtime.Clock(fake)))
+			})
+			It("Should preserve Clock when the override is nil", func() {
+				base := debounce.Config{Clock: xtime.Real}
+				Expect(base.Override(debounce.Config{}).Clock).NotTo(BeNil())
+			})
+			It("Should override Callback when the override is non-nil", func() {
+				var called atomic.Bool
+				base := debounce.Config{Callback: noopCallback}
+				o := debounce.Config{
+					Callback: func(context.Context) { called.Store(true) },
+				}
+				base.Override(o).Callback(context.Background())
+				Expect(called.Load()).To(BeTrue())
+			})
+			It("Should preserve Callback when the override is nil", func() {
+				base := debounce.Config{Callback: noopCallback}
+				Expect(base.Override(debounce.Config{}).Callback).NotTo(BeNil())
+			})
+		})
+
+		Describe("Validate", func() {
+			It("Should fail when Delay is zero", func() {
+				cfg := debounce.Config{
+					Clock:    xtime.Real,
+					Callback: noopCallback,
+				}
+				Expect(cfg.Validate()).To(MatchError(ContainSubstring("delay")))
+			})
+			It("Should fail when Delay is negative", func() {
+				cfg := debounce.Config{
+					Delay:    -1,
+					Clock:    xtime.Real,
+					Callback: noopCallback,
+				}
+				Expect(cfg.Validate()).To(MatchError(ContainSubstring("delay")))
+			})
+			It("Should fail when MaxDelay is negative", func() {
+				cfg := debounce.Config{
+					Delay:    time.Millisecond,
+					MaxDelay: -1,
+					Clock:    xtime.Real,
+					Callback: noopCallback,
+				}
+				Expect(cfg.Validate()).To(MatchError(ContainSubstring("max_delay")))
+			})
+			It("Should fail when Clock is nil", func() {
+				cfg := debounce.Config{
+					Delay:    time.Millisecond,
+					Callback: noopCallback,
+				}
+				Expect(cfg.Validate()).To(MatchError(ContainSubstring("clock")))
+			})
+			It("Should fail when Callback is nil", func() {
+				cfg := debounce.Config{
+					Delay: time.Millisecond,
+					Clock: xtime.Real,
+				}
+				Expect(cfg.Validate()).To(MatchError(ContainSubstring("callback")))
+			})
+			It("Should succeed when Delay, Clock, and Callback are all set", func() {
+				cfg := debounce.Config{
+					Delay:    time.Millisecond,
+					Clock:    xtime.Real,
+					Callback: noopCallback,
+				}
+				Expect(cfg.Validate()).To(Succeed())
+			})
+		})
+	})
+
+	Describe("Trigger", func() {
+		It("Should fire the callback once the delay has elapsed", func() {
+			clk := &xtime.Fake{}
+			var called atomic.Int32
+			d := MustSucceed(debounce.New(debounce.Config{
+				Delay:    5 * time.Millisecond,
+				Clock:    clk,
+				Callback: func(context.Context) { called.Add(1) },
+			}))
+			DeferCleanup(d.Stop)
 			d.Trigger()
-			Eventually(func() int32 { return called.Load() }).Should(Equal(int32(1)))
+			Consistently(called.Load, "20ms").Should(Equal(int32(0)))
+			clk.Advance(5 * time.Millisecond)
+			Eventually(called.Load).Should(Equal(int32(1)))
 		})
 
 		It("Should coalesce rapid triggers into a single invocation", func() {
+			clk := &xtime.Fake{}
 			var called atomic.Int32
-			d := debounce.New(20*time.Millisecond, 0, func(ctx context.Context) {
-				called.Add(1)
-			})
+			d := MustSucceed(debounce.New(debounce.Config{
+				Delay:    20 * time.Millisecond,
+				Clock:    clk,
+				Callback: func(context.Context) { called.Add(1) },
+			}))
+			DeferCleanup(d.Stop)
 			for range 10 {
 				d.Trigger()
 			}
-			Eventually(func() int32 { return called.Load() }).Should(Equal(int32(1)))
-			Consistently(func() int32 { return called.Load() }, 50*time.Millisecond).Should(Equal(int32(1)))
-		})
-
-		It("Should reset the timer on each trigger", func() {
-			var called atomic.Int32
-			d := debounce.New(30*time.Millisecond, 0, func(ctx context.Context) {
-				called.Add(1)
-			})
-			d.Trigger()
-			time.Sleep(15 * time.Millisecond)
-			d.Trigger()
-			time.Sleep(15 * time.Millisecond)
-			Expect(called.Load()).To(Equal(int32(0)))
-			Eventually(func() int32 { return called.Load() }).Should(Equal(int32(1)))
+			clk.Advance(20 * time.Millisecond)
+			Eventually(called.Load).Should(Equal(int32(1)))
+			clk.Advance(time.Hour)
+			Consistently(called.Load, "20ms").Should(Equal(int32(1)))
 		})
 
 		It("Should cancel in-flight work when re-triggered", func() {
-			var cancelled atomic.Bool
-			d := debounce.New(5*time.Millisecond, 0, func(ctx context.Context) {
-				<-ctx.Done()
-				cancelled.Store(true)
-			})
+			clk := &xtime.Fake{}
+			var (
+				once      sync.Once
+				started   = make(chan struct{})
+				cancelled atomic.Bool
+			)
+			d := MustSucceed(debounce.New(debounce.Config{
+				Delay: 5 * time.Millisecond,
+				Clock: clk,
+				Callback: func(ctx context.Context) {
+					once.Do(func() { close(started) })
+					<-ctx.Done()
+					cancelled.Store(true)
+				},
+			}))
+			DeferCleanup(d.Stop)
 			d.Trigger()
-			time.Sleep(10 * time.Millisecond)
+			clk.Advance(5 * time.Millisecond)
+			Eventually(started).Should(BeClosed())
 			d.Trigger()
-			Eventually(func() bool { return cancelled.Load() }).Should(BeTrue())
+			Eventually(cancelled.Load).Should(BeTrue())
 		})
 	})
 
 	Describe("MaxDelay", func() {
-		It("Should fire before the trailing delay when max delay is exceeded", func() {
+		It("Should clamp the delay when the cap would otherwise be exceeded", func() {
+			clk := &xtime.Fake{}
 			var called atomic.Int32
-			d := debounce.New(50*time.Millisecond, 80*time.Millisecond, func(ctx context.Context) {
-				called.Add(1)
-			})
+			d := MustSucceed(debounce.New(debounce.Config{
+				Delay:    time.Hour,
+				MaxDelay: 30 * time.Millisecond,
+				Clock:    clk,
+				Callback: func(context.Context) { called.Add(1) },
+			}))
+			DeferCleanup(d.Stop)
 			d.Trigger()
-			time.Sleep(40 * time.Millisecond)
+			clk.Advance(15 * time.Millisecond)
 			d.Trigger()
-			time.Sleep(40 * time.Millisecond)
+			clk.Advance(30 * time.Millisecond)
 			d.Trigger()
-			Eventually(func() int32 { return called.Load() }).Should(BeNumerically(">=", int32(1)))
+			Eventually(called.Load).Should(Equal(int32(1)))
 		})
 
-		It("Should fire immediately when max delay is fully elapsed", func() {
+		It("Should fire immediately when the cap is fully elapsed", func() {
+			clk := &xtime.Fake{}
 			var called atomic.Int32
-			d := debounce.New(50*time.Millisecond, 30*time.Millisecond, func(ctx context.Context) {
-				called.Add(1)
-			})
+			d := MustSucceed(debounce.New(debounce.Config{
+				Delay:    time.Hour,
+				MaxDelay: 30 * time.Millisecond,
+				Clock:    clk,
+				Callback: func(context.Context) { called.Add(1) },
+			}))
+			DeferCleanup(d.Stop)
 			d.Trigger()
-			time.Sleep(35 * time.Millisecond)
+			clk.Advance(time.Hour)
 			d.Trigger()
-			time.Sleep(10 * time.Millisecond)
-			Expect(called.Load()).To(BeNumerically(">=", int32(1)))
+			Eventually(called.Load).Should(Equal(int32(1)))
+		})
+
+		It("Should not clamp the delay when only one trigger fits inside the cap", func() {
+			clk := &xtime.Fake{}
+			var called atomic.Int32
+			d := MustSucceed(debounce.New(debounce.Config{
+				Delay:    5 * time.Millisecond,
+				MaxDelay: time.Hour,
+				Clock:    clk,
+				Callback: func(context.Context) { called.Add(1) },
+			}))
+			DeferCleanup(d.Stop)
+			d.Trigger()
+			clk.Advance(5 * time.Millisecond)
+			Eventually(called.Load).Should(Equal(int32(1)))
 		})
 	})
 
 	Describe("Stop", func() {
 		It("Should prevent a pending trigger from firing", func() {
+			clk := &xtime.Fake{}
 			var called atomic.Int32
-			d := debounce.New(20*time.Millisecond, 0, func(ctx context.Context) {
-				called.Add(1)
-			})
+			d := MustSucceed(debounce.New(debounce.Config{
+				Delay:    20 * time.Millisecond,
+				Clock:    clk,
+				Callback: func(context.Context) { called.Add(1) },
+			}))
 			d.Trigger()
 			d.Stop()
-			Consistently(func() int32 { return called.Load() }, 50*time.Millisecond).Should(Equal(int32(0)))
+			clk.Advance(time.Hour)
+			Consistently(called.Load, "20ms").Should(Equal(int32(0)))
 		})
 
 		It("Should cancel in-flight work", func() {
-			var cancelled atomic.Bool
-			d := debounce.New(5*time.Millisecond, 0, func(ctx context.Context) {
-				<-ctx.Done()
-				cancelled.Store(true)
-			})
+			clk := &xtime.Fake{}
+			var (
+				once      sync.Once
+				started   = make(chan struct{})
+				cancelled atomic.Bool
+			)
+			d := MustSucceed(debounce.New(debounce.Config{
+				Delay: 5 * time.Millisecond,
+				Clock: clk,
+				Callback: func(ctx context.Context) {
+					once.Do(func() { close(started) })
+					<-ctx.Done()
+					cancelled.Store(true)
+				},
+			}))
 			d.Trigger()
-			time.Sleep(10 * time.Millisecond)
+			clk.Advance(5 * time.Millisecond)
+			Eventually(started).Should(BeClosed())
 			d.Stop()
-			Eventually(func() bool { return cancelled.Load() }).Should(BeTrue())
+			Eventually(cancelled.Load).Should(BeTrue())
 		})
 
 		It("Should be safe to call multiple times", func() {
-			d := debounce.New(20*time.Millisecond, 0, func(ctx context.Context) {})
+			d := MustSucceed(debounce.New(debounce.Config{
+				Delay:    20 * time.Millisecond,
+				Callback: noopCallback,
+			}))
 			d.Stop()
 			d.Stop()
 		})
 
-		It("Should reset max delay tracking", func() {
+		It("Should reset MaxDelay tracking so the next Trigger is not clamped", func() {
+			clk := &xtime.Fake{}
 			var called atomic.Int32
-			d := debounce.New(20*time.Millisecond, 100*time.Millisecond, func(ctx context.Context) {
-				called.Add(1)
-			})
+			d := MustSucceed(debounce.New(debounce.Config{
+				Delay:    5 * time.Millisecond,
+				MaxDelay: time.Hour,
+				Clock:    clk,
+				Callback: func(context.Context) { called.Add(1) },
+			}))
+			DeferCleanup(d.Stop)
 			d.Trigger()
+			clk.Advance(5 * time.Millisecond)
+			Eventually(called.Load).Should(Equal(int32(1)))
 			d.Stop()
-			time.Sleep(10 * time.Millisecond)
+			clk.Advance(2 * time.Hour)
 			d.Trigger()
-			Eventually(func() int32 { return called.Load() }).Should(Equal(int32(1)))
+			clk.Advance(4 * time.Millisecond)
+			Consistently(called.Load, "20ms").Should(Equal(int32(1)))
+			clk.Advance(time.Millisecond)
+			Eventually(called.Load).Should(Equal(int32(2)))
 		})
 	})
 })

--- a/x/go/time/clock.go
+++ b/x/go/time/clock.go
@@ -31,8 +31,8 @@ type Clock interface {
 	// elapses.
 	After(time.Duration) <-chan time.Time
 	// AfterFunc schedules fn to be called after the duration elapses and returns a
-	// Timer that can be used to cancel the call. If Stop is called before fn would
-	// have run, fn is not called.
+	// Timer that can be used to cancel the call. If Stop is called before fn would have
+	// run, fn is not called.
 	AfterFunc(time.Duration, func()) Timer
 }
 

--- a/x/go/time/clock.go
+++ b/x/go/time/clock.go
@@ -1,0 +1,134 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+package time
+
+import (
+	"sync"
+	"time"
+)
+
+// Timer is a single-shot timer scheduled via Clock.AfterFunc. Stop prevents the timer
+// from firing and returns true if the call stopped the timer, or false if the timer
+// has already fired or been stopped.
+type Timer interface {
+	// Stop prevents the timer from firing and returns true if the call stopped the timer,
+	// or false if the timer has already fired or been stopped.
+	Stop() bool
+}
+
+// Clock provides a time source and timer scheduler.
+type Clock interface {
+	// Now returns the current time.
+	Now() time.Time
+	// After returns a channel that will receive the current time after the duration
+	// elapses.
+	After(time.Duration) <-chan time.Time
+	// AfterFunc waits on a channel registered with After in a goroutine, calling fn
+	// unless the returned Timer's Stop method wins the race first. The goroutine always
+	// drains the channel, so Advance can still complete its send when a timer is
+	// stopped.
+	AfterFunc(time.Duration, func()) Timer
+}
+
+type real struct{}
+
+// Real is a Clock that uses the system's real-time clock.
+var Real Clock = real{}
+
+func (real) Now() time.Time { return time.Now() }
+
+func (real) After(d time.Duration) <-chan time.Time { return time.After(d) }
+
+func (real) AfterFunc(d time.Duration, f func()) Timer { return time.AfterFunc(d, f) }
+
+// Fake is a Clock that uses a fake time source and timer scheduler for testing.
+type Fake struct {
+	mu     sync.Mutex
+	now    time.Time
+	timers []*fakeTimer
+}
+
+var _ Clock = &Fake{}
+
+type fakeTimer struct {
+	at time.Time
+	ch chan time.Time
+}
+
+// Now returns the current time.
+func (f *Fake) Now() time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.now
+}
+
+// After returns a channel that will receive the current time after the duration elapses.
+func (f *Fake) After(d time.Duration) <-chan time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	ch := make(chan time.Time)
+	t := &fakeTimer{at: f.now.Add(d), ch: ch}
+	f.timers = append(f.timers, t)
+	return ch
+}
+
+// AfterFunc waits on a channel registered with After in a goroutine, calling fn unless
+// the returned Timer's Stop method wins the race first. The goroutine always drains the
+// channel, so Advance can still complete its send when a timer is stopped.
+func (f *Fake) AfterFunc(d time.Duration, fn func()) Timer {
+	t := &fakeFuncTimer{}
+	ch := f.After(d)
+	go func() {
+		<-ch
+		if t.claim() {
+			fn()
+		}
+	}()
+	return t
+}
+
+// fakeFuncTimer coordinates the race between Stop and the AfterFunc goroutine: whoever
+// calls claim first wins. Stop winning suppresses fn; the goroutine winning runs fn.
+type fakeFuncTimer struct {
+	mu      sync.Mutex
+	claimed bool
+}
+
+func (t *fakeFuncTimer) claim() bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.claimed {
+		return false
+	}
+	t.claimed = true
+	return true
+}
+
+func (t *fakeFuncTimer) Stop() bool { return t.claim() }
+
+// Advance advances the clock by the given duration. It fires any timers whose deadline
+// has been crossed and removes them from the list of pending timers.
+func (f *Fake) Advance(d time.Duration) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.now = f.now.Add(d)
+	now := f.now
+	timers := f.timers
+	remaining := timers[:0]
+	for _, t := range timers {
+		if !t.at.After(now) {
+			t.ch <- now
+			close(t.ch)
+		} else {
+			remaining = append(remaining, t)
+		}
+	}
+	f.timers = remaining
+}

--- a/x/go/time/clock.go
+++ b/x/go/time/clock.go
@@ -30,10 +30,9 @@ type Clock interface {
 	// After returns a channel that will receive the current time after the duration
 	// elapses.
 	After(time.Duration) <-chan time.Time
-	// AfterFunc waits on a channel registered with After in a goroutine, calling fn
-	// unless the returned Timer's Stop method wins the race first. The goroutine always
-	// drains the channel, so Advance can still complete its send when a timer is
-	// stopped.
+	// AfterFunc schedules fn to be called after the duration elapses and returns a
+	// Timer that can be used to cancel the call. If Stop is called before fn would
+	// have run, fn is not called.
 	AfterFunc(time.Duration, func()) Timer
 }
 
@@ -114,21 +113,26 @@ func (t *fakeFuncTimer) claim() bool {
 func (t *fakeFuncTimer) Stop() bool { return t.claim() }
 
 // Advance advances the clock by the given duration. It fires any timers whose deadline
-// has been crossed and removes them from the list of pending timers.
+// has been crossed and removes them from the list of pending timers. Channel sends
+// happen after f.mu is released so that timer receivers (including AfterFunc callbacks)
+// can safely call back into the clock without deadlocking.
 func (f *Fake) Advance(d time.Duration) {
 	f.mu.Lock()
-	defer f.mu.Unlock()
 	f.now = f.now.Add(d)
 	now := f.now
-	timers := f.timers
-	remaining := timers[:0]
-	for _, t := range timers {
+	var fire []*fakeTimer
+	remaining := f.timers[:0]
+	for _, t := range f.timers {
 		if !t.at.After(now) {
-			t.ch <- now
-			close(t.ch)
+			fire = append(fire, t)
 		} else {
 			remaining = append(remaining, t)
 		}
 	}
 	f.timers = remaining
+	f.mu.Unlock()
+	for _, t := range fire {
+		t.ch <- now
+		close(t.ch)
+	}
 }

--- a/x/go/time/clock_test.go
+++ b/x/go/time/clock_test.go
@@ -1,0 +1,146 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+package time_test
+
+import (
+	"sync/atomic"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	xtime "github.com/synnaxlabs/x/time"
+)
+
+var _ = Describe("Clock", func() {
+	Describe("Real", func() {
+		It("Should return a value bracketed by time.Now", func() {
+			before := time.Now()
+			got := xtime.Real.Now()
+			after := time.Now()
+			Expect(got).To(BeTemporally(">=", before))
+			Expect(got).To(BeTemporally("<=", after))
+		})
+		It("Should deliver a value on After after the duration elapses", func() {
+			Eventually(xtime.Real.After(5*time.Millisecond), "100ms").
+				Should(Receive())
+		})
+		It("Should call AfterFunc functions after the duration elapses", func() {
+			done := make(chan struct{})
+			xtime.Real.AfterFunc(5*time.Millisecond, func() { close(done) })
+			Eventually(done, "100ms").Should(BeClosed())
+		})
+		It("Should let Stop cancel a pending AfterFunc timer", func() {
+			var called atomic.Bool
+			t := xtime.Real.AfterFunc(time.Hour, func() { called.Store(true) })
+			Expect(t.Stop()).To(BeTrue())
+			Consistently(called.Load, "20ms").Should(BeFalse())
+		})
+	})
+
+	Describe("Fake", func() {
+		It("Should start at the zero time", func() {
+			Expect((&xtime.Fake{}).Now()).To(Equal(time.Time{}))
+		})
+		It("Should advance by the supplied duration", func() {
+			f := &xtime.Fake{}
+			f.Advance(5 * time.Second)
+			f.Advance(2 * time.Second)
+			Expect(f.Now()).To(Equal(time.Time{}.Add(7 * time.Second)))
+		})
+
+		Describe("After", func() {
+			It("Should fire timers whose deadline has been crossed", func() {
+				f := &xtime.Fake{}
+				ch := f.After(time.Second)
+				go f.Advance(2 * time.Second)
+				var got time.Time
+				Eventually(ch).Should(Receive(&got))
+				Expect(got).To(Equal(time.Time{}.Add(2 * time.Second)))
+			})
+			It("Should close timer channels after firing", func() {
+				f := &xtime.Fake{}
+				ch := f.After(time.Second)
+				go f.Advance(2 * time.Second)
+				Eventually(ch).Should(Receive())
+				Eventually(ch).Should(BeClosed())
+			})
+			It("Should not fire timers whose deadline has not been crossed", func() {
+				f := &xtime.Fake{}
+				ch := f.After(time.Second)
+				f.Advance(500 * time.Millisecond)
+				Consistently(ch, "50ms").ShouldNot(Receive())
+			})
+			It("Should fire only timers whose deadline has been crossed", func() {
+				f := &xtime.Fake{}
+				early := f.After(time.Second)
+				late := f.After(10 * time.Second)
+				go f.Advance(2 * time.Second)
+				Eventually(early).Should(Receive())
+				Consistently(late, "50ms").ShouldNot(Receive())
+			})
+			It("Should fire previously-registered timers on a later Advance", func() {
+				f := &xtime.Fake{}
+				ch := f.After(time.Second)
+				f.Advance(500 * time.Millisecond)
+				go f.Advance(700 * time.Millisecond)
+				Eventually(ch).Should(Receive())
+			})
+		})
+
+		Describe("AfterFunc", func() {
+			It("Should call scheduled functions when Advance crosses the deadline", func() {
+				f := &xtime.Fake{}
+				done := make(chan struct{})
+				f.AfterFunc(time.Second, func() { close(done) })
+				go f.Advance(2 * time.Second)
+				Eventually(done).Should(BeClosed())
+			})
+			It("Should not call functions whose deadline has not been crossed", func() {
+				f := &xtime.Fake{}
+				var called atomic.Int32
+				f.AfterFunc(time.Second, func() { called.Add(1) })
+				f.Advance(500 * time.Millisecond)
+				Consistently(called.Load, "20ms").Should(Equal(int32(0)))
+			})
+			It("Should call only functions whose deadline has been crossed", func() {
+				f := &xtime.Fake{}
+				earlyFired := make(chan struct{})
+				var late atomic.Int32
+				f.AfterFunc(time.Second, func() { close(earlyFired) })
+				f.AfterFunc(10*time.Second, func() { late.Add(1) })
+				go f.Advance(2 * time.Second)
+				Eventually(earlyFired).Should(BeClosed())
+				Consistently(late.Load, "20ms").Should(Equal(int32(0)))
+			})
+			It("Should let Stop cancel a pending timer", func() {
+				f := &xtime.Fake{}
+				var called atomic.Int32
+				t := f.AfterFunc(time.Second, func() { called.Add(1) })
+				Expect(t.Stop()).To(BeTrue())
+				go f.Advance(2 * time.Second)
+				Consistently(called.Load, "20ms").Should(Equal(int32(0)))
+			})
+			It("Should return false from Stop once the timer has fired", func() {
+				f := &xtime.Fake{}
+				fired := make(chan struct{})
+				t := f.AfterFunc(time.Second, func() { close(fired) })
+				go f.Advance(2 * time.Second)
+				Eventually(fired).Should(BeClosed())
+				Expect(t.Stop()).To(BeFalse())
+			})
+			It("Should return false from Stop after a prior Stop", func() {
+				f := &xtime.Fake{}
+				t := f.AfterFunc(time.Second, func() {})
+				Expect(t.Stop()).To(BeTrue())
+				Expect(t.Stop()).To(BeFalse())
+			})
+		})
+	})
+})


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4270](https://linear.app/synnax/issue/SY-4270)

## Description

The debounce tests relied on wall-clock timing (`time.Sleep`, `time.AfterFunc`), which made them flaky under variable scheduling. This PR introduces a `Clock` interface in `x/go/time` with `Now`, `After`, and `AfterFunc` methods, plus `Real` and `Fake` implementations, and refactors `x/go/debounce` to take a `Clock` via its `Config`.

The debouncer now schedules its trailing-edge timer through `Clock.AfterFunc`, so tests can drive every wait deterministically by advancing a `Fake` clock instead of sleeping. The package also gains a standard `Config` / `Override` / `Validate` shape matching the rest of the codebase, with the callback moved into `Config.Callback`.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR eliminates flaky debounce tests by introducing a `Clock` interface with `Real` and `Fake` implementations in `x/go/time`, then wiring `Fake` into the debounce test suite so every timer advance is driven deterministically instead of via `time.Sleep`.

- **`x/go/time/clock.go`**: New `Clock` interface (`Now`, `After`, `AfterFunc`) with a production `Real` wrapper and a `Fake` that tracks wall time internally; `Fake.Advance` partitions and fires pending timers after releasing its lock to avoid re-entrant deadlocks.
- **`x/go/debounce/debounce.go`**: Debouncer refactored to a `Config`/`Override`/`Validate` pattern; scheduling now goes through `Clock.AfterFunc` and a `timerGen` generation counter guards against stale timer callbacks racing with `Stop`/`Trigger`.
- **`arc/go/lsp/server.go`**: Updated to the new variadic-config API with proper error propagation from `debounce.New`.

<h3>Confidence Score: 5/5</h3>

Safe to merge; changes are well-scoped to the debounce and clock packages with no impact on production timing paths.

The production debounce logic and the new Clock abstraction are sound. The timerGen guard correctly handles all concurrency races. The only findings are in test code where a few AfterFunc goroutines are left blocked after certain clock_test.go tests end, but this does not affect correctness of the shipped library.

x/go/time/clock_test.go — three AfterFunc tests leave goroutines blocked indefinitely.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| x/go/time/clock.go | New Clock interface with Real and Fake implementations. Fake.Advance correctly drops its mutex before sending to timer channels, preventing the deadlock noted in a previous thread. AfterFunc relies on a goroutine-per-timer model that leaks goroutines if timers are never fired. |
| x/go/time/clock_test.go | Comprehensive tests for both Real and Fake clocks. Three AfterFunc tests leave goroutines blocked indefinitely because the timer channels are never drained after the test ends. |
| x/go/debounce/debounce.go | Refactored to use Config/Override/Validate pattern and Clock abstraction. The timerGen guard correctly handles the race between Stop/Trigger and an in-flight timer callback. override.Numeric on MaxDelay cannot represent a zero override (flagged in a prior thread). |
| x/go/debounce/debounce_test.go | Tests fully migrated to deterministic fake-clock control; all real-time sleeps removed. Coverage extended with Config validation and Override unit tests. |
| arc/go/lsp/server.go | Call site updated to the new debounce.New(Config{...}) API with proper error handling. The LSP server config always supplies a non-zero DebounceDelay (default 200ms), so validation will not fail in production. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test
    participant Fake as Fake Clock
    participant Debouncer
    participant Callback

    Test->>Debouncer: Trigger()
    Debouncer->>Fake: AfterFunc(delay, onTimerFire)
    Fake-->>Debouncer: fakeFuncTimer
    Note over Fake: goroutine blocks on <-ch

    Test->>Fake: Advance(delay)
    Note over Fake: release mu, send on ch
    Fake->>Debouncer: onTimerFire(gen)
    Debouncer->>Callback: go Callback(ctx)

    Test->>Debouncer: Trigger() (re-trigger)
    Debouncer->>Debouncer: cancelLocked() — cancel in-flight ctx
    Debouncer->>Debouncer: stopTimerLocked() — Stop() fakeFuncTimer
    Debouncer->>Debouncer: timerGen++ — invalidate stale fire
    Debouncer->>Fake: AfterFunc(delay, onTimerFire)

    Test->>Debouncer: Stop()
    Debouncer->>Debouncer: stopTimerLocked()
    Debouncer->>Debouncer: timerGen++
    Debouncer->>Debouncer: cancelLocked()
    Debouncer->>Debouncer: "firstAtSet = false"
```

<sub>Reviews (2): Last reviewed commit: ["fix formatting"](https://github.com/synnaxlabs/synnax/commit/3bc0b56ae2ed9f63234ca08b90234240b705b03f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34663723)</sub>

<!-- /greptile_comment -->