### PR TITLE
SY-4275: Fix Workspace Loading

### DIFF
--- a/console/src-tauri/tauri.conf.json
+++ b/console/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Synnax",
-  "version": "0.56.0",
+  "version": "0.56.1",
   "build": {
     "beforeBuildCommand": "pnpm build-vite",
     "beforeDevCommand": "pnpm dev-vite",

--- a/console/src/hooks/useEnsureState.ts
+++ b/console/src/hooks/useEnsureState.ts
@@ -1,0 +1,36 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { type PayloadAction } from "@reduxjs/toolkit";
+import { useEffect } from "react";
+import { useDispatch } from "react-redux";
+
+export interface CreateEnsureStateParams {
+  useExists: (key: string) => boolean;
+  create: (key: string) => PayloadAction<any>;
+}
+
+/**
+ * Creates a hook that guarantees a per-layout entry exists in a visualization's
+ * Redux slice before its renderer reads from it. The layout creator seeds this
+ * entry when a visualization is placed directly, but layouts restored from a
+ * workspace bypass the creator, so the renderer must seed it on mount. The hook
+ * returns whether the entry currently exists; callers should withhold rendering
+ * the visualization until it does.
+ */
+export const createEnsureState =
+  ({ useExists, create }: CreateEnsureStateParams) =>
+  (key: string): boolean => {
+    const dispatch = useDispatch();
+    const exists = useExists(key);
+    useEffect(() => {
+      if (!exists) dispatch(create(key));
+    }, [dispatch, exists, key]);
+    return exists;
+  };

--- a/console/src/hooks/useEnsureState.ts
+++ b/console/src/hooks/useEnsureState.ts
@@ -13,16 +13,15 @@ import { useDispatch } from "react-redux";
 
 export interface CreateEnsureStateParams {
   useExists: (key: string) => boolean;
-  create: (key: string) => PayloadAction<any>;
+  create: (key: string) => PayloadAction<{ key: string }>;
 }
 
 /**
- * Creates a hook that guarantees a per-layout entry exists in a visualization's
- * Redux slice before its renderer reads from it. The layout creator seeds this
- * entry when a visualization is placed directly, but layouts restored from a
- * workspace bypass the creator, so the renderer must seed it on mount. The hook
- * returns whether the entry currently exists; callers should withhold rendering
- * the visualization until it does.
+ * Creates a hook that guarantees a per-layout entry exists in a visualization's Redux
+ * slice before its renderer reads from it. The layout creator seeds this entry when a
+ * visualization is placed directly, but layouts restored from a workspace bypass the
+ * creator, so the renderer must seed it on mount. The hook returns whether the entry
+ * currently exists; callers should withhold rendering the visualization until it does.
  */
 export const createEnsureState =
   ({ useExists, create }: CreateEnsureStateParams) =>
@@ -31,6 +30,6 @@ export const createEnsureState =
     const exists = useExists(key);
     useEffect(() => {
       if (!exists) dispatch(create(key));
-    }, [dispatch, exists, key]);
+    }, [dispatch, exists, key, create]);
     return exists;
   };

--- a/console/src/schematic/Schematic.tsx
+++ b/console/src/schematic/Schematic.tsx
@@ -21,12 +21,14 @@ import { type ReactElement, useCallback, useMemo } from "react";
 import { useDispatch, useStore } from "react-redux";
 
 import { ContextMenu } from "@/components/context-menu";
+import { createEnsureState } from "@/hooks/useEnsureState";
 import { Layout } from "@/layout";
 import { Controller } from "@/schematic/Controller";
 import { Controls } from "@/schematic/Controls";
 import { useHandleNodeClickAction } from "@/schematic/navigate";
-import { selectEditable, useSelect } from "@/schematic/selectors";
+import { selectEditable, useSelect, useSelectOptional } from "@/schematic/selectors";
 import {
+  internalCreate,
   setEditable,
   setFitViewOnResize,
   setLegend,
@@ -177,10 +179,16 @@ const Internal: Layout.Renderer = ({ layoutKey: key, visible }) => {
   );
 };
 
+const useEnsureState = createEnsureState({
+  useExists: (key) => useSelectOptional(key) != null,
+  create: (key) => internalCreate({ key }),
+});
+
 export const Schematic: Layout.Renderer = (props) => {
   const { layoutKey } = props;
+  const exists = useEnsureState(layoutKey);
   const uploaded = useAutoUpload(layoutKey);
-  if (!uploaded) return null;
+  if (!exists || !uploaded) return null;
   return <Internal {...props} />;
 };
 Schematic.useName = Layout.createUseFluxName(

--- a/console/src/schematic/selectors.ts
+++ b/console/src/schematic/selectors.ts
@@ -31,8 +31,16 @@ export const selectSelected = (state: StoreState, key: string): string[] =>
 export const select = (state: StoreState, key: string): State =>
   selectSliceState(state).schematics[key];
 
+export const selectOptional = select as (
+  state: StoreState,
+  key: string,
+) => State | undefined;
+
 export const useSelect = (key: string): State =>
   useMemoSelect((state: StoreState) => select(state, key), [key]);
+
+export const useSelectOptional = (key: string): State | undefined =>
+  useMemoSelect((state: StoreState) => selectOptional(state, key), [key]);
 
 export const useSelectSelected = (key: string): string[] =>
   useMemoSelect((state: StoreState) => selectSelected(state, key), [key]);

--- a/console/src/table/Table.tsx
+++ b/console/src/table/Table.tsx
@@ -17,13 +17,20 @@ import { useDispatch } from "react-redux";
 
 import { ContextMenu, Controls } from "@/components";
 import { CSS } from "@/css";
+import { createEnsureState } from "@/hooks/useEnsureState";
 import { Layout } from "@/layout";
 import {
   useSelectEditable,
   useSelectHideIndicators,
+  useSelectOptional,
   useSelectSelectedCellKeys,
 } from "@/table/selectors";
-import { setEditable, setHideIndicators, setSelectedCells } from "@/table/slice";
+import {
+  internalCreate,
+  setEditable,
+  setHideIndicators,
+  setSelectedCells,
+} from "@/table/slice";
 import { useAutoUpload } from "@/table/useUpload";
 
 export { create, LAYOUT_TYPE, type LayoutType } from "@/table/layout";
@@ -133,9 +140,15 @@ const TableControls = ({ tableKey }: TableControlsProps): ReactElement | null =>
   );
 };
 
+const useEnsureState = createEnsureState({
+  useExists: (key) => useSelectOptional(key) != null,
+  create: (key) => internalCreate({ key }),
+});
+
 export const Table: Layout.Renderer = (props) => {
+  const exists = useEnsureState(props.layoutKey);
   const uploaded = useAutoUpload(props.layoutKey);
-  if (!uploaded) return null;
+  if (!exists || !uploaded) return null;
   return <Loaded {...props} />;
 };
 


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue number and link -->

[SY-####]()

## Description

<!-- Write a description describing the changes. -->

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a crash/broken-render scenario that occurs when schematics and tables are loaded from a saved workspace: the workspace restore path bypasses the normal layout creator, so the Redux slice entry for the visualization is absent when the renderer first mounts. A new shared hook factory `createEnsureState` dispatches the slice's `internalCreate` action on mount if the entry is missing, and returns `false` until the entry is live, letting both `Schematic` and `Table` gate their rendering on it.

- **`useEnsureState.ts`** — generic hook factory; renders nothing (returns `false`) for one React frame while dispatching the seed action, then unblocks rendering once the Redux entry exists.
- **`selectOptional` / `useSelectOptional`** — added to both the schematic and table selectors to surface the accurate `State | undefined` return type used by the `useExists` predicate.
- **`Schematic` / `Table` renderers** — now short-circuit on `!exists` in addition to `!uploaded`, preventing reads against a missing slice entry.
- **`tauri.conf.json`** — patch version bump to 0.56.1.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is narrowly scoped to adding a Redux state guard for workspace-restored visualizations and does not touch any data-mutation or upload logic.

The hook factory is correctly implemented: it only dispatches once (the create reducer is a no-op when the entry already exists), it includes create in the dependency array, and both callers pass stable module-level closures. The selectOptional additions are straightforward type-widening casts that match runtime behaviour. No pre-existing code paths are broken.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| console/src/hooks/useEnsureState.ts | New hook factory that seeds a Redux slice entry for a given layout key when one doesn't exist, returning false until the entry is live. |
| console/src/schematic/Schematic.tsx | Adds useEnsureState guard so the schematic renderer returns null until its Redux state entry is seeded, preventing crashes on workspace restore. |
| console/src/schematic/selectors.ts | Adds selectOptional / useSelectOptional variants that honestly type the lookup return as State | undefined, fixing the implicit undefined mismatch. |
| console/src/table/Table.tsx | Mirrors the schematic change — adds useEnsureState guard to the table renderer using the same pattern. |
| console/src-tauri/tauri.conf.json | Patch version bump from 0.56.0 to 0.56.1. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant WS as Workspace Restore
    participant R as React Renderer
    participant H as useEnsureState
    participant Redux as Redux Store

    WS->>Redux: Load workspace (may skip layout creator)
    R->>H: mount — call useEnsureState(key)
    H->>Redux: useSelectOptional(key) → undefined
    H-->>R: "exists = false → render null"
    H->>Redux: "dispatch internalCreate({ key })"
    Redux-->>H: state entry seeded
    H->>Redux: useSelectOptional(key) → State
    H-->>R: "exists = true"
    R->>R: useAutoUpload(key) → check pendingUpload
    R-->>R: render Internal / Loaded
```

<sub>Reviews (2): Last reviewed commit: ["Address PR comments"](https://github.com/synnaxlabs/synnax/commit/1a1f6257dd8822bcefdd0b335f2c2be0b30018ed) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34922761)</sub>

<!-- /greptile_comment -->