### PR TITLE
SY-4171: Re-fire Constants on Upstream Trigger (Matching Expressions)

### DIFF
--- a/arc/go/ir/node.go
+++ b/arc/go/ir/node.go
@@ -25,6 +25,12 @@ func (n Nodes) Find(key string) (Node, bool) {
 // Get returns the node with the given key. Panics if not found.
 func (n Nodes) Get(key string) Node { return lo.Must(n.Find(key)) }
 
+// IsEntryNode reports whether n is an entry node: it has no incoming edges and
+// reads no channels. Entry nodes fire once per activation.
+func (n Node) IsEntryNode(edges Edges) bool {
+	return len(edges.GetInputs(n.Key)) == 0 && len(n.Channels.Read) == 0
+}
+
 // String returns the string representation of the node.
 func (n Node) String() string {
 	return n.stringWithPrefix("")

--- a/arc/go/ir/node_test.go
+++ b/arc/go/ir/node_test.go
@@ -13,6 +13,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/synnaxlabs/arc/ir"
+	"github.com/synnaxlabs/arc/types"
 )
 
 var _ = Describe("Nodes", func() {
@@ -70,4 +71,29 @@ var _ = Describe("Nodes", func() {
 			}).To(Panic())
 		})
 	})
+})
+
+var _ = Describe("IsEntryNode", func() {
+	reads := func(key uint32) types.Channels {
+		return types.Channels{Read: map[uint32]string{key: "ch"}}
+	}
+	edgeInto := func(nodeKey string) ir.Edge {
+		return ir.Edge{Target: ir.Handle{Node: nodeKey, Param: ir.DefaultInputParam}}
+	}
+	DescribeTable(
+		"Classification",
+		func(node ir.Node, edges ir.Edges, expected bool) {
+			Expect(node.IsEntryNode(edges)).To(Equal(expected))
+		},
+		Entry("no incoming edges and no channel reads",
+			ir.Node{Key: "n"}, ir.Edges{}, true),
+		Entry("an incoming edge",
+			ir.Node{Key: "n"}, ir.Edges{edgeInto("n")}, false),
+		Entry("a channel read",
+			ir.Node{Key: "n", Channels: reads(1)}, ir.Edges{}, false),
+		Entry("both an incoming edge and a channel read",
+			ir.Node{Key: "n", Channels: reads(1)}, ir.Edges{edgeInto("n")}, false),
+		Entry("an edge that targets a different node",
+			ir.Node{Key: "n"}, ir.Edges{edgeInto("other")}, true),
+	)
 })

--- a/arc/go/routing_table_test.go
+++ b/arc/go/routing_table_test.go
@@ -295,6 +295,35 @@ var _ = Describe("Routing Table Runtime", func() {
 			Expect(changed).To(BeTrue())
 			Expect(telem.UnmarshalSeries[float64](out.Get(200).Series[0])).To(Equal([]float64{160.0, 180.0}))
 		})
+
+		It("Should re-fire a chained constant on every upstream trigger with monotonically increasing timestamps", func(ctx SpecContext) {
+			resolver := channelSymbols(map[string]channelDef{
+				"trig": {types.U8(), 100},
+				"log":  {types.U8(), 200},
+			})
+			h := newRuntimeHarness(ctx, `trig -> 1 -> log`, resolver,
+				channels.Digest{Key: 100, DataType: telem.Uint8T},
+				channels.Digest{Key: 200, DataType: telem.Uint8T},
+			)
+			defer h.Close(ctx)
+
+			const fires = 4
+			timestamps := make([]telem.TimeStamp, 0, fires)
+			for i := range fires {
+				h.Ingest(100, telem.NewSeriesV[uint8](1))
+				h.Tick(ctx, telem.TimeSpan(i+1)*telem.Millisecond)
+				h.channelState.ClearReads()
+				out, _ := h.Flush()
+				Expect(out.Get(200).Series).ToNot(BeEmpty(),
+					"log should be written on every upstream trigger (fire %d)", i)
+				timestamps = append(timestamps,
+					telem.ValueAt[telem.TimeStamp](h.OutputTime("const_0", 0), 0))
+			}
+			for i := 1; i < len(timestamps); i++ {
+				Expect(timestamps[i]).To(BeNumerically(">", timestamps[i-1]),
+					"constant timestamp at fire %d should be strictly greater than fire %d", i, i-1)
+			}
+		})
 	})
 
 	Describe("Routing to Sequences", func() {

--- a/arc/go/stl/constant/constant.go
+++ b/arc/go/stl/constant/constant.go
@@ -57,7 +57,7 @@ func (h *Host) Create(_ context.Context, cfg node.Config) (node.Node, error) {
 	return &constant{
 		State:       cfg.State,
 		value:       cfg.Node.Config[0].Value,
-		isEntryNode: len(cfg.Program.Edges.GetInputs(cfg.Node.Key)) == 0,
+		isEntryNode: cfg.Node.IsEntryNode(cfg.Program.Edges),
 	}, nil
 }
 

--- a/arc/go/stl/constant/constant.go
+++ b/arc/go/stl/constant/constant.go
@@ -54,23 +54,30 @@ func (h *Host) Create(_ context.Context, cfg node.Config) (node.Node, error) {
 	if cfg.Node.Type != symbolName {
 		return nil, query.ErrNotFound
 	}
-	return &constant{State: cfg.State, value: cfg.Node.Config[0].Value}, nil
+	return &constant{
+		State:       cfg.State,
+		value:       cfg.Node.Config[0].Value,
+		isEntryNode: len(cfg.Program.Edges.GetInputs(cfg.Node.Key)) == 0,
+	}, nil
 }
 
 type constant struct {
 	*node.State
 	clock       telem.MonoClock
 	value       any
+	isEntryNode bool
 	initialized bool
 }
 
 var _ node.Node = (*constant)(nil)
 
 func (c *constant) Next(ctx node.Context) {
-	if c.initialized {
-		return
+	if c.isEntryNode {
+		if c.initialized {
+			return
+		}
+		c.initialized = true
 	}
-	c.initialized = true
 	d := c.Output(0)
 	*d = telem.NewSeriesFromAny(c.value, d.DataType)
 	t := c.OutputTime(0)

--- a/arc/go/stl/constant/constant_test.go
+++ b/arc/go/stl/constant/constant_test.go
@@ -287,7 +287,7 @@ var _ = Describe("Constant", func() {
 			Expect(vals[0]).To(Equal(int64(-42)))
 		})
 
-		It("Should only emit once across multiple Next calls when entry node", func(ctx SpecContext) {
+		It("Should only emit once across multiple Next calls when node has no incoming edges", func(ctx SpecContext) {
 			cfg := node.Config{
 				Node:  ir.Node{Type: "constant", Config: types.Params{{Name: "value", Type: types.I64(), Value: int64(42)}}},
 				State: s.Node("const"),
@@ -305,7 +305,7 @@ var _ = Describe("Constant", func() {
 			Expect(marked).To(HaveLen(1))
 		})
 
-		It("Should emit again after Reset is called when entry node", func(ctx SpecContext) {
+		It("Should emit again after Reset is called when node has no incoming edges", func(ctx SpecContext) {
 			cfg := node.Config{
 				Node:  ir.Node{Type: "constant", Config: types.Params{{Name: "value", Type: types.I64(), Value: int64(42)}}},
 				State: s.Node("const"),

--- a/arc/go/stl/constant/constant_test.go
+++ b/arc/go/stl/constant/constant_test.go
@@ -137,7 +137,7 @@ var _ = Describe("Constant", func() {
 				Node:  ir.Node{Type: "constant", Config: types.Params{{Name: "value", Type: types.I64(), Value: 42}}},
 				State: s.Node("const"),
 			}
-			n, _ := factory.Create(ctx, cfg)
+			n := MustSucceed(factory.Create(ctx, cfg))
 			n.Next(node.Context{Context: ctx, MarkChanged: func(i int) {
 				marked = append(marked, i)
 			}})
@@ -149,7 +149,7 @@ var _ = Describe("Constant", func() {
 				Node:  ir.Node{Type: "constant", Config: types.Params{{Name: "value", Type: types.I64(), Value: int64(100)}}},
 				State: s.Node("const"),
 			}
-			n, _ := factory.Create(ctx, cfg)
+			n := MustSucceed(factory.Create(ctx, cfg))
 			n.Next(node.Context{Context: ctx, MarkChanged: func(int) {}})
 			out := s.Node("const").Output(0)
 			Expect(out.Len()).To(Equal(int64(1)))
@@ -163,7 +163,7 @@ var _ = Describe("Constant", func() {
 				},
 				State: s.Node("const"),
 			}
-			n, _ := factory.Create(ctx, cfg)
+			n := MustSucceed(factory.Create(ctx, cfg))
 			n.Next(node.Context{Context: ctx, MarkChanged: func(int) {}})
 			outTime := s.Node("const").OutputTime(0)
 			Expect(outTime.Len()).To(Equal(int64(1)))
@@ -178,7 +178,7 @@ var _ = Describe("Constant", func() {
 			}
 			constNode := s.Node("const")
 			*constNode.Output(0) = telem.NewSeriesV[float64](0)
-			n, _ := factory.Create(ctx, cfg)
+			n := MustSucceed(factory.Create(ctx, cfg))
 			n.Next(node.Context{Context: ctx, MarkChanged: func(int) {}})
 			out := constNode.Output(0)
 			vals := telem.UnmarshalSeries[float64](*out)
@@ -192,7 +192,7 @@ var _ = Describe("Constant", func() {
 			}
 			constNode := s.Node("const")
 			*constNode.Output(0) = telem.NewSeriesV[int32](0)
-			n, _ := factory.Create(ctx, cfg)
+			n := MustSucceed(factory.Create(ctx, cfg))
 			n.Next(node.Context{Context: ctx, MarkChanged: func(int) {}})
 			out := constNode.Output(0)
 			vals := telem.UnmarshalSeries[int32](*out)
@@ -206,7 +206,7 @@ var _ = Describe("Constant", func() {
 			}
 			constNode := s.Node("const")
 			*constNode.Output(0) = telem.NewSeriesV[uint8](0)
-			n, _ := factory.Create(ctx, cfg)
+			n := MustSucceed(factory.Create(ctx, cfg))
 			n.Next(node.Context{Context: ctx, MarkChanged: func(int) {}})
 			out := constNode.Output(0)
 			vals := telem.UnmarshalSeries[uint8](*out)
@@ -249,7 +249,7 @@ var _ = Describe("Constant", func() {
 			}
 			constNode := s.Node("const")
 			*constNode.Output(0) = telem.NewSeriesV[int64](0)
-			n, _ := factory.Create(ctx, cfg)
+			n := MustSucceed(factory.Create(ctx, cfg))
 			n.Next(node.Context{Context: ctx, MarkChanged: func(int) {}})
 			sink := s.Node("sink")
 			recalc := sink.RefreshInputs()
@@ -266,7 +266,7 @@ var _ = Describe("Constant", func() {
 			}
 			constNode := s.Node("const")
 			*constNode.Output(0) = telem.NewSeriesV[int64](0)
-			n, _ := factory.Create(ctx, cfg)
+			n := MustSucceed(factory.Create(ctx, cfg))
 			n.Next(node.Context{Context: ctx, MarkChanged: func(int) {}})
 			out := constNode.Output(0)
 			vals := telem.UnmarshalSeries[int64](*out)
@@ -280,7 +280,7 @@ var _ = Describe("Constant", func() {
 			}
 			constNode := s.Node("const")
 			*constNode.Output(0) = telem.NewSeriesV[int64](0)
-			n, _ := factory.Create(ctx, cfg)
+			n := MustSucceed(factory.Create(ctx, cfg))
 			n.Next(node.Context{Context: ctx, MarkChanged: func(int) {}})
 			out := constNode.Output(0)
 			vals := telem.UnmarshalSeries[int64](*out)
@@ -294,7 +294,7 @@ var _ = Describe("Constant", func() {
 			}
 			constNode := s.Node("const")
 			*constNode.Output(0) = telem.NewSeriesV[int64](0)
-			n, _ := factory.Create(ctx, cfg)
+			n := MustSucceed(factory.Create(ctx, cfg))
 			n.Next(node.Context{Context: ctx, MarkChanged: func(i int) {
 				marked = append(marked, i)
 			}})
@@ -312,7 +312,7 @@ var _ = Describe("Constant", func() {
 			}
 			constNode := s.Node("const")
 			*constNode.Output(0) = telem.NewSeriesV[int64](0)
-			n, _ := factory.Create(ctx, cfg)
+			n := MustSucceed(factory.Create(ctx, cfg))
 			n.Next(node.Context{Context: ctx, MarkChanged: func(i int) {
 				marked = append(marked, i)
 			}})
@@ -339,7 +339,7 @@ var _ = Describe("Constant", func() {
 			}
 			constNode := s.Node("const")
 			*constNode.Output(0) = telem.NewSeriesV[int64](0)
-			n, _ := factory.Create(ctx, cfg)
+			n := MustSucceed(factory.Create(ctx, cfg))
 			for range 3 {
 				n.Next(node.Context{Context: ctx, MarkChanged: func(i int) {
 					marked = append(marked, i)
@@ -363,7 +363,7 @@ var _ = Describe("Constant", func() {
 			}
 			constNode := s.Node("const")
 			*constNode.Output(0) = telem.NewSeriesV[int64](0)
-			n, _ := factory.Create(ctx, cfg)
+			n := MustSucceed(factory.Create(ctx, cfg))
 			n.Next(node.Context{Context: ctx, MarkChanged: func(i int) {
 				marked = append(marked, i)
 			}})

--- a/arc/go/stl/constant/constant_test.go
+++ b/arc/go/stl/constant/constant_test.go
@@ -14,6 +14,7 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/synnaxlabs/arc/graph"
 	"github.com/synnaxlabs/arc/ir"
+	"github.com/synnaxlabs/arc/program"
 	"github.com/synnaxlabs/arc/runtime/node"
 	"github.com/synnaxlabs/arc/stl/constant"
 	"github.com/synnaxlabs/arc/symbol"
@@ -286,7 +287,7 @@ var _ = Describe("Constant", func() {
 			Expect(vals[0]).To(Equal(int64(-42)))
 		})
 
-		It("Should only emit once across multiple Next calls", func(ctx SpecContext) {
+		It("Should only emit once across multiple Next calls when entry node", func(ctx SpecContext) {
 			cfg := node.Config{
 				Node:  ir.Node{Type: "constant", Config: types.Params{{Name: "value", Type: types.I64(), Value: int64(42)}}},
 				State: s.Node("const"),
@@ -304,7 +305,7 @@ var _ = Describe("Constant", func() {
 			Expect(marked).To(HaveLen(1))
 		})
 
-		It("Should emit again after Reset is called", func(ctx SpecContext) {
+		It("Should emit again after Reset is called when entry node", func(ctx SpecContext) {
 			cfg := node.Config{
 				Node:  ir.Node{Type: "constant", Config: types.Params{{Name: "value", Type: types.I64(), Value: int64(42)}}},
 				State: s.Node("const"),
@@ -317,6 +318,55 @@ var _ = Describe("Constant", func() {
 			}})
 			Expect(marked).To(HaveLen(1))
 			n.Reset()
+			n.Next(node.Context{Context: ctx, MarkChanged: func(i int) {
+				marked = append(marked, i)
+			}})
+			Expect(marked).To(HaveLen(2))
+		})
+
+		It("Should emit on every Next call when node has incoming edges", func(ctx SpecContext) {
+			cfg := node.Config{
+				Node: ir.Node{
+					Key:    "const",
+					Type:   "constant",
+					Config: types.Params{{Name: "value", Type: types.I64(), Value: int64(42)}},
+				},
+				State: s.Node("const"),
+				Program: program.Program{IR: ir.IR{Edges: ir.Edges{{
+					Source: ir.Handle{Node: "upstream", Param: ir.DefaultOutputParam},
+					Target: ir.Handle{Node: "const", Param: ir.DefaultInputParam},
+				}}}},
+			}
+			constNode := s.Node("const")
+			*constNode.Output(0) = telem.NewSeriesV[int64](0)
+			n, _ := factory.Create(ctx, cfg)
+			for range 3 {
+				n.Next(node.Context{Context: ctx, MarkChanged: func(i int) {
+					marked = append(marked, i)
+				}})
+			}
+			Expect(marked).To(HaveLen(3))
+		})
+
+		It("Should not require Reset to re-fire when node has incoming edges", func(ctx SpecContext) {
+			cfg := node.Config{
+				Node: ir.Node{
+					Key:    "const",
+					Type:   "constant",
+					Config: types.Params{{Name: "value", Type: types.I64(), Value: int64(42)}},
+				},
+				State: s.Node("const"),
+				Program: program.Program{IR: ir.IR{Edges: ir.Edges{{
+					Source: ir.Handle{Node: "upstream", Param: ir.DefaultOutputParam},
+					Target: ir.Handle{Node: "const", Param: ir.DefaultInputParam},
+				}}}},
+			}
+			constNode := s.Node("const")
+			*constNode.Output(0) = telem.NewSeriesV[int64](0)
+			n, _ := factory.Create(ctx, cfg)
+			n.Next(node.Context{Context: ctx, MarkChanged: func(i int) {
+				marked = append(marked, i)
+			}})
 			n.Next(node.Context{Context: ctx, MarkChanged: func(i int) {
 				marked = append(marked, i)
 			}})

--- a/arc/go/stl/wasm/wasm.go
+++ b/arc/go/stl/wasm/wasm.go
@@ -12,7 +12,6 @@ package wasm
 import (
 	"context"
 	"math"
-	"strings"
 
 	"github.com/synnaxlabs/arc/runtime/node"
 	stlstrings "github.com/synnaxlabs/arc/stl/strings"
@@ -40,10 +39,7 @@ func (w *Module) Create(_ context.Context, cfg node.Config) (node.Node, error) {
 	if fn == nil {
 		return nil, query.ErrNotFound
 	}
-	// Entry nodes have no incoming edges and are not expression nodes.
-	// They should only execute once per stage entry.
-	isEntryNode := !strings.HasPrefix(cfg.Node.Key, "expression_") &&
-		len(cfg.Program.Edges.GetInputs(cfg.Node.Key)) == 0
+	isEntryNode := cfg.Node.IsEntryNode(cfg.Program.Edges)
 
 	configCount := len(cfg.Node.Config)
 	params := make([]uint64, configCount+len(irFn.Inputs))

--- a/arc/go/stl/wasm/wasm_test.go
+++ b/arc/go/stl/wasm/wasm_test.go
@@ -2173,7 +2173,7 @@ trigger_ch -> emit_period{period=1s}
 	})
 
 	Describe("Flow Expression Execution", func() {
-		It("Should execute every time for flow expression nodes", func(ctx SpecContext) {
+		It("Should execute only once for a flow expression node with no inputs", func(ctx SpecContext) {
 			g := singleFunctionGraph("expression_0", types.I64(), `{
 				count i64 $= 0
 				count = count + 1
@@ -2189,13 +2189,13 @@ trigger_ch -> emit_period{period=1s}
 			Expect(telem.UnmarshalSeries[int64](h.Output("expression_0", 0))[0]).To(Equal(int64(1)))
 
 			n.Next(nCtx)
-			Expect(telem.UnmarshalSeries[int64](h.Output("expression_0", 0))[0]).To(Equal(int64(2)))
+			Expect(telem.UnmarshalSeries[int64](h.Output("expression_0", 0))[0]).To(Equal(int64(1)))
 
 			n.Next(nCtx)
-			Expect(telem.UnmarshalSeries[int64](h.Output("expression_0", 0))[0]).To(Equal(int64(3)))
+			Expect(telem.UnmarshalSeries[int64](h.Output("expression_0", 0))[0]).To(Equal(int64(1)))
 		})
 
-		It("Should continue executing after reset for expression nodes", func(ctx SpecContext) {
+		It("Should execute again after reset for a flow expression node with no inputs", func(ctx SpecContext) {
 			g := singleFunctionGraph("expression_0", types.I64(), `{
 				count i64 $= 0
 				count = count + 1
@@ -2206,6 +2206,9 @@ trigger_ch -> emit_period{period=1s}
 
 			n := h.CreateNode(ctx, "expression_0")
 			nCtx := node.Context{Context: ctx, MarkChanged: func(int) {}}
+
+			n.Next(nCtx)
+			Expect(telem.UnmarshalSeries[int64](h.Output("expression_0", 0))[0]).To(Equal(int64(1)))
 
 			n.Next(nCtx)
 			Expect(telem.UnmarshalSeries[int64](h.Output("expression_0", 0))[0]).To(Equal(int64(1)))
@@ -2214,9 +2217,6 @@ trigger_ch -> emit_period{period=1s}
 
 			n.Next(nCtx)
 			Expect(telem.UnmarshalSeries[int64](h.Output("expression_0", 0))[0]).To(Equal(int64(2)))
-
-			n.Next(nCtx)
-			Expect(telem.UnmarshalSeries[int64](h.Output("expression_0", 0))[0]).To(Equal(int64(3)))
 		})
 
 		It("Should not treat non-expression nodes as expressions", func(ctx SpecContext) {

--- a/core/pkg/service/arc/runtime/task.go
+++ b/core/pkg/service/arc/runtime/task.go
@@ -13,7 +13,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"math"
 	stdtime "time"
 
 	"github.com/synnaxlabs/arc/ir"
@@ -227,10 +226,10 @@ func (t *taskImpl) start(ctx context.Context) (err error) {
 
 	pipeline := plumber.New()
 
-	var runtime confluence.Segment[framer.StreamerResponse, framer.WriterRequest] = &drt
-	if hasIntervals := timeMod.BaseInterval != telem.TimeSpan(math.MaxInt64); hasIntervals {
-		runtime = &tickerRuntime{dataRuntime: drt}
-	}
+	// The ticker's t=0 startup tick fires entry nodes; an input-driven program
+	// would otherwise not fire them until the first input is recieved.
+	ticker := &tickerRuntime{dataRuntime: drt}
+	var runtime confluence.Segment[framer.StreamerResponse, framer.WriterRequest] = ticker
 	plumber.SetSegment(pipeline, runtimeAddr, runtime)
 
 	var (
@@ -443,16 +442,6 @@ func (d *dataRuntime) flushAuthorityChanges(ctx context.Context) error {
 	}
 	req := framer.WriterRequest{Command: writer.CommandSetAuthority, Config: cfg}
 	return signal.SendUnderContext(ctx, d.Out.Inlet(), req)
-}
-
-func (d *dataRuntime) Flow(sCtx signal.Context, opts ...confluence.Option) {
-	o := confluence.NewOptions(opts)
-	if d.Out != nil {
-		o.AttachClosables(d.Out)
-	}
-	signal.GoRange(sCtx, d.In.Outlet(), func(ctx context.Context, res framer.StreamerResponse) error {
-		return d.next(ctx, res, node.ReasonChannelInput)
-	}, o.Signal...)
 }
 
 type tickerRuntime struct {

--- a/core/pkg/service/arc/runtime/task.go
+++ b/core/pkg/service/arc/runtime/task.go
@@ -227,10 +227,9 @@ func (t *taskImpl) start(ctx context.Context) (err error) {
 	pipeline := plumber.New()
 
 	// The ticker's t=0 startup tick fires entry nodes; an input-driven program
-	// would otherwise not fire them until the first input is recieved.
+	// would otherwise not fire them until the first input is received.
 	ticker := &tickerRuntime{dataRuntime: drt}
-	var runtime confluence.Segment[framer.StreamerResponse, framer.WriterRequest] = ticker
-	plumber.SetSegment(pipeline, runtimeAddr, runtime)
+	plumber.SetSegment(pipeline, runtimeAddr, ticker)
 
 	var (
 		streamerRequests    = confluence.NewStream[framer.StreamerRequest]()
@@ -252,7 +251,7 @@ func (t *taskImpl) start(ctx context.Context) (err error) {
 		streamerCloseSignal = xio.NoFailCloserFunc(streamerRequests.Close)
 	} else {
 		streamerResponses := confluence.NewStream[framer.StreamerResponse]()
-		runtime.InFrom(streamerResponses)
+		ticker.InFrom(streamerResponses)
 		streamerCloseSignal = xio.NoFailCloserFunc(streamerResponses.Close)
 	}
 

--- a/core/pkg/service/arc/runtime/task_test.go
+++ b/core/pkg/service/arc/runtime/task_test.go
@@ -687,6 +687,132 @@ var _ = Describe("Task", Ordered, func() {
 		})
 	})
 
+	Describe("Entry Node Startup", func() {
+		It("Should fire a constant entry node at startup with no reads or intervals", func(ctx SpecContext) {
+			outputCh := createVirtualCh(ctx, "startup_const", telem.Uint8T)
+			prog := arc.Text{Raw: fmt.Sprintf(`
+				42 -> %s
+			`, outputCh.Name)}
+
+			responses, closeStreamer := openTestStreamer(ctx, channel.Keys{outputCh.Key()}, 2)
+			defer closeStreamer()
+
+			t := newTask(ctx, newTextFactory(ctx, prog))
+			Expect(t.Exec(ctx, task.Command{Type: "start"})).To(Succeed())
+			defer func() { Expect(t.Stop()).To(Succeed()) }()
+
+			var fr framer.StreamerResponse
+			Eventually(responses).Should(Receive(&fr))
+			Expect(telem.ValueAt[uint8](fr.Frame.Get(outputCh.Key()).Series[0], 0)).
+				To(Equal(uint8(42)))
+			Consistently(responses, 100*time.Millisecond).ShouldNot(Receive())
+		})
+
+		It("Should fire entry nodes at startup while a channel-read path waits for input", func(ctx SpecContext) {
+			triggerCh := createVirtualCh(ctx, "startup_trigger", telem.Uint8T)
+			constOut := createVirtualCh(ctx, "startup_const_out", telem.Uint8T)
+			exprOut := createVirtualCh(ctx, "startup_expr_out", telem.Uint8T)
+			triggerOut := createVirtualCh(ctx, "startup_trigger_out", telem.Uint8T)
+
+			prog := arc.Text{Raw: fmt.Sprintf(`
+				func pass() {
+					%s = %s
+				}
+				42 -> %s
+				40 + 2 -> %s
+				%s -> pass{}
+			`, triggerOut.Name, triggerCh.Name, constOut.Name, exprOut.Name, triggerCh.Name)}
+
+			responses, closeStreamer := openTestStreamer(ctx, channel.Keys{
+				constOut.Key(), exprOut.Key(), triggerOut.Key(),
+			}, 10)
+			defer closeStreamer()
+
+			t := newTask(ctx, newTextFactory(ctx, prog))
+			Expect(t.Exec(ctx, task.Command{Type: "start"})).To(Succeed())
+			defer func() { Expect(t.Stop()).To(Succeed()) }()
+
+			var gotConst, gotExpr bool
+			for !gotConst || !gotExpr {
+				var fr framer.StreamerResponse
+				Eventually(responses).Should(Receive(&fr))
+				if s := fr.Frame.Get(constOut.Key()); s.Len() > 0 {
+					Expect(telem.ValueAt[uint8](s.Series[0], 0)).To(Equal(uint8(42)))
+					gotConst = true
+				}
+				if s := fr.Frame.Get(exprOut.Key()); s.Len() > 0 {
+					Expect(telem.ValueAt[uint8](s.Series[0], 0)).To(Equal(uint8(42)))
+					gotExpr = true
+				}
+				Expect(fr.Frame.Get(triggerOut.Key()).Len()).To(BeZero())
+			}
+
+			w := MustSucceed(dist.Framer.OpenWriter(ctx, framer.WriterConfig{
+				Keys:  channel.Keys{triggerCh.Key()},
+				Start: telem.Now(),
+			}))
+			Expect(w.Write(frame.NewUnary(triggerCh.Key(), telem.NewSeriesV[uint8](7)))).To(BeTrue())
+			Expect(w.Close()).To(Succeed())
+
+			var gotTrigger bool
+			for !gotTrigger {
+				var fr framer.StreamerResponse
+				Eventually(responses).Should(Receive(&fr))
+				if s := fr.Frame.Get(triggerOut.Key()); s.Len() > 0 {
+					Expect(telem.ValueAt[uint8](s.Series[0], 0)).To(Equal(uint8(7)))
+					gotTrigger = true
+				}
+			}
+		})
+
+		It("Should fire constant and expression entry nodes once when paired with an interval", func(ctx SpecContext) {
+			constOut := createVirtualCh(ctx, "once_const_out", telem.Uint8T)
+			exprOut := createVirtualCh(ctx, "once_expr_out", telem.Uint8T)
+			tickOut := createVirtualCh(ctx, "once_tick", telem.Uint8T)
+
+			prog := arc.Text{Raw: fmt.Sprintf(`
+				func tick() {
+					%s = 1
+				}
+				42 -> %s
+				40 + 2 -> %s
+				interval{period=20ms} -> tick{}
+			`, tickOut.Name, constOut.Name, exprOut.Name)}
+
+			responses, closeStreamer := openTestStreamer(ctx, channel.Keys{
+				constOut.Key(), exprOut.Key(), tickOut.Key(),
+			}, 20)
+			defer closeStreamer()
+
+			t := newTask(ctx, newTextFactory(ctx, prog))
+			Expect(t.Exec(ctx, task.Command{Type: "start"})).To(Succeed())
+			defer func() { Expect(t.Stop()).To(Succeed()) }()
+
+			var (
+				fr         framer.StreamerResponse
+				constCount int
+				exprCount  int
+				tickCount  int
+			)
+			for tickCount < 3 {
+				Eventually(responses).Should(Receive(&fr))
+				if s := fr.Frame.Get(constOut.Key()); s.Len() > 0 {
+					Expect(telem.ValueAt[uint8](s.Series[0], 0)).To(Equal(uint8(42)))
+					constCount++
+				}
+				if s := fr.Frame.Get(exprOut.Key()); s.Len() > 0 {
+					Expect(telem.ValueAt[uint8](s.Series[0], 0)).To(Equal(uint8(42)))
+					exprCount++
+				}
+				if fr.Frame.Get(tickOut.Key()).Len() > 0 {
+					tickCount++
+				}
+			}
+			Expect(constCount).To(Equal(1))
+			Expect(exprCount).To(Equal(1))
+		})
+	})
+
 	Describe("Control Authority", func() {
 		It("Should apply static authority from authority block", func(ctx SpecContext) {
 			ch := createVirtualCh(ctx, "auth_static", telem.Uint8T)


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4171](https://linear.app/synnax/issue/SY-4171/fix-arc-node-update-bug)

## Description

Constants and bare expressions in Arc flow chains behaved inconsistently depending on their position and on what else the program contained. Chained constants behaved as one-shots regardless of upstream activity: `time.interval{1s} -> "true" -> log` only wrote `"true"` to `log` on the first interval tick and silently stopped, while the equivalent expression form `time.interval{1s} -> "true"+"!" -> log` fired on every tick. Separately, standalone entry nodes never fired at startup, so a constant-only or input-driven program such as `"c" -> log` produced nothing until the first channel input arrived, which could be seconds away or never. All of these should be indistinguishable from the program author's perspective.

The first bug came from the constant runtime (`arc/go/stl/constant/constant.go`) applying an unconditional `initialized`-flag guard in `Next()`: once a constant emitted, it short-circuited every subsequent scheduler cycle and never propagated `MarkChanged` downstream. Entry-node detection was also duplicated and inconsistent. The WASM runtime used a string-prefix hack that treated every `expression_` node as non-entry, so bare expressions never became one-shots, while the constant runtime had no edge awareness at all. The startup bug came from the runtime granting the t=0 startup tick only to programs that contained an interval.

This change centralizes the rule in `ir.Node.IsEntryNode(edges)`: a node is an entry node when it has no incoming edges and reads no channels. Both `constant.go` and `arc/go/stl/wasm/wasm.go` now consult it, replacing the prefix hack, and the one-shot guard applies only when it returns true. Separately, every program now runs on the ticker runtime (`core/pkg/service/arc/runtime/task.go`), whose t=0 startup tick fires entry nodes once regardless of program shape; with no active timers the ticker idles on input rather than busy-looping. The now-unused `dataRuntime.Flow` was removed. No analyzer or grammar changes are required; the IR gains a single helper method.

The entry-node case is deliberately preserved: edge-fed constants re-fire on every upstream trigger, while standalone constants at stratum-0 and constants inside sequence stages (e.g., `stage active { 1 -> vlv_cmd }`) continue to fire exactly once per activation, with `Reset()` clearing the flag on stage re-entry.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where chained constant nodes in Arc flow programs behaved as one-shots regardless of upstream activity. The constant runtime now computes `isEntryNode` at construction by checking whether the node has any incoming edges, and only applies the one-shot guard when acting as a true entry node.

- `constant.go`: `isEntryNode` is derived from `cfg.Program.Edges.GetInputs(cfg.Node.Key)` at construction time, mirroring the existing WASM node pattern; `Next()` skips emit-and-return only when `isEntryNode == true`, so non-entry constants propagate `MarkChanged` on every scheduler cycle.
- `constant_test.go` / `routing_table_test.go`: existing entry-node tests are renamed for clarity; two new unit tests cover the non-entry firing behavior, and an integration test verifies the full `trig -> 1 -> log` chain with strictly increasing timestamps across four upstream ticks.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is small and well-contained, correctly mirrors the existing WASM node pattern, and backward compatibility for entry-node (one-shot) constants is preserved.

The diff is minimal: a single boolean flag set at construction, a guarded early-return restructured inside an if, and Reset() left untouched. Entry-node behavior for stratum-0 constants and sequence-stage constants is preserved exactly as before. The new code path for non-entry nodes is straightforward — no guard, emit every cycle — and is directly validated by both unit and integration tests. No edge-case gaps are apparent.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| arc/go/stl/constant/constant.go | Adds `isEntryNode` flag computed at construction from incoming-edge count; the one-shot guard now only applies when true, allowing non-entry constants to re-fire every cycle. |
| arc/go/stl/constant/constant_test.go | Existing one-shot tests renamed to clarify "entry node" context; two new tests verify that non-entry constants emit on every `Next()` call and don't require `Reset()`. |
| arc/go/routing_table_test.go | Integration test validates the end-to-end `trig -> 1 -> log` chain fires on every upstream tick and produces strictly monotonically increasing timestamps. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["constant.Create()"] --> B{{"len(GetInputs(key)) == 0?"}}
    B -- "yes (no incoming edges)" --> C["isEntryNode = true"]
    B -- "no (has upstream)" --> D["isEntryNode = false"]

    C --> E["Next() called"]
    D --> F["Next() called"]

    E --> G{{"initialized?"}}
    G -- "true" --> H["return (no-op)"]
    G -- "false" --> I["initialized = true\nwrite output\nMarkChanged"]

    F --> J["write output\nMarkChanged (every cycle)"]

    K["Reset()"] --> L["initialized = false\n(no-op for non-entry nodes)"]
```

<sub>Reviews (1): Last reviewed commit: ["SY-4171: Add test"](https://github.com/synnaxlabs/synnax/commit/6d377303024796867c9fb728413e5b92a5a743b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=34934365)</sub>

<!-- /greptile_comment -->