### PR TITLE
SY-4226: Remove pnpm Major Mismatch Workaround

### DIFF
--- a/.github/actions/test-typescript/action.yaml
+++ b/.github/actions/test-typescript/action.yaml
@@ -29,21 +29,12 @@ inputs:
     description: Additional arguments to pass to the test command
     required: false
     default: ""
-  pnpm_dest:
-    description:
-      Directory pnpm is installed into (pnpm/action-setup `dest`). Override when a
-      single job sets up more than one pnpm major version so the installs don't share a
-      PNPM_HOME and clobber each other's store.
-    required: false
-    default: ~/setup-pnpm
 
 runs:
   using: composite
   steps:
     - name: Set up pnpm
       uses: pnpm/action-setup@v6
-      with:
-        dest: ${{ inputs.pnpm_dest }}
 
     - name: Set up Node.js
       uses: actions/setup-node@v6

--- a/.github/workflows/test.migration.clients.yaml
+++ b/.github/workflows/test.migration.clients.yaml
@@ -169,12 +169,6 @@ jobs:
         with:
           package: client
           lint: false
-          # The "on main" run above installs pnpm 10 into the default ~/setup-pnpm.
-          # Install the current branch's pnpm (11+) into a separate dest so it doesn't
-          # refresh that PNPM_HOME and delete the v10 store, which the main run's
-          # setup-node cache-save still points at (otherwise its post step fails the
-          # job). Remove once main and rc are on the same pnpm major.
-          pnpm_dest: ~/setup-pnpm-current
 
       - name: Stop Core on current branch
         if: always() && steps.start_current.outcome == 'success'


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4226](https://linear.app/synnax/issue/SY-4226)

## Description

Reverts the SY-4225 workaround that installed the current branch's pnpm into a separate `dest` (`~/setup-pnpm-current`) so it would not clobber the v10 store left behind by the `on main` run of the migration clients workflow. Both `main` and `rc` are now on `pnpm@11.1.3`, so the major mismatch that motivated the workaround no longer exists and the `pnpm_dest` input on `test-typescript` can go away.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Reverts the SY-4225 workaround that directed the current-branch pnpm install into a separate `~/setup-pnpm-current` directory to avoid a pnpm v10/v11 store conflict in the migration-clients workflow. With both `main` and `rc` now on `pnpm@11.1.3`, the isolation is no longer needed.

- Removes the `pnpm_dest` input from the `test-typescript` composite action (including its `dest` pass-through to `pnpm/action-setup`), simplifying the action interface.
- Drops the `pnpm_dest: ~/setup-pnpm-current` override and its explanatory comment from the second `test-typescript` invocation in `test.migration.clients.yaml`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change removes a targeted workaround that is no longer needed now that both branches share the same pnpm major version.

Both changed files are CI configuration only. The removal of pnpm_dest and its dest override is a clean, minimal revert; no application logic is touched. The prerequisite condition (both main and rc on pnpm@11.1.3) is described in the PR and verifiable from the repo. The resulting workflow is simpler and matches how every other job in the repo calls test-typescript.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/actions/test-typescript/action.yaml | Removes the pnpm_dest input and its dest override from pnpm/action-setup; the step now uses pnpm's default install location unconditionally. |
| .github/workflows/test.migration.clients.yaml | Removes the pnpm_dest: ~/setup-pnpm-current override and its explanatory comment from the 'Test TypeScript with Core on current branch' step; both calls to test-typescript now share the default pnpm install location. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant W as migration-clients workflow
    participant TT as test-typescript action
    participant PA as pnpm/action-setup@v6

    Note over W: "Test TypeScript with Core on main" step
    W->>TT: "uses test-typescript (package=client, lint=false)"
    TT->>PA: "uses pnpm/action-setup@v6 (default dest ~/setup-pnpm)"
    PA-->>TT: pnpm installed
    TT-->>W: tests complete

    Note over W: (checkout current branch, build & start current core)

    Note over W: "Test TypeScript with Core on current branch" step
    W->>TT: "uses test-typescript (package=client, lint=false)"
    TT->>PA: "uses pnpm/action-setup@v6 (same default dest ~/setup-pnpm)"
    PA-->>TT: pnpm already present, same major
    TT-->>W: tests complete
```

<sub>Reviews (1): Last reviewed commit: ["SY-4226: Remove pnpm Major Mismatch Work..."](https://github.com/synnaxlabs/synnax/commit/71854f381cc589c84fb03fb1a8ae7d3ce97c8035) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35180830)</sub>

<!-- /greptile_comment -->