### PR TITLE
SY-4297: Arc Params Refactor (Part 1) - Oracle Changes

### DIFF
--- a/arc/cpp/ir/json.gen.h
+++ b/arc/cpp/ir/json.gen.h
@@ -126,7 +126,6 @@ inline Function Function::parse(x::json::Parser parser) {
     return Function{
         .key = parser.field<std::string>("key"),
         .body = parser.field<Body>("body"),
-        .config = parser.field<::arc::types::Params>("config"),
         .inputs = parser.field<::arc::types::Params>("inputs"),
         .outputs = parser.field<::arc::types::Params>("outputs"),
         .channels = parser.field<::arc::types::Channels>("channels"),
@@ -137,7 +136,6 @@ inline x::json::json Function::to_json() const {
     x::json::json j;
     j["key"] = this->key;
     j["body"] = this->body.to_json();
-    j["config"] = this->config.to_json();
     j["inputs"] = this->inputs.to_json();
     j["outputs"] = this->outputs.to_json();
     j["channels"] = this->channels.to_json();
@@ -148,7 +146,6 @@ inline Node Node::parse(x::json::Parser parser) {
     return Node{
         .key = parser.field<std::string>("key"),
         .type = parser.field<std::string>("type"),
-        .config = parser.field<::arc::types::Params>("config"),
         .inputs = parser.field<::arc::types::Params>("inputs"),
         .outputs = parser.field<::arc::types::Params>("outputs"),
         .channels = parser.field<::arc::types::Channels>("channels"),
@@ -159,7 +156,6 @@ inline x::json::json Node::to_json() const {
     x::json::json j;
     j["key"] = this->key;
     j["type"] = this->type;
-    j["config"] = this->config.to_json();
     j["inputs"] = this->inputs.to_json();
     j["outputs"] = this->outputs.to_json();
     j["channels"] = this->channels.to_json();

--- a/arc/cpp/ir/proto.gen.h
+++ b/arc/cpp/ir/proto.gen.h
@@ -198,11 +198,6 @@ inline std::pair<::arc::ir::pb::Function, x::errors::Error> Function::to_proto()
         if (err) return {{}, err};
         *pb.mutable_body() = v;
     }
-    for (const auto &item: this->config) {
-        auto [v, err] = item.to_proto();
-        if (err) return {{}, err};
-        *pb.add_config() = v;
-    }
     for (const auto &item: this->inputs) {
         auto [v, err] = item.to_proto();
         if (err) return {{}, err};
@@ -231,11 +226,6 @@ Function::from_proto(const ::arc::ir::pb::Function &pb) {
         cpp.body = v;
     }
     if (auto err = x::pb::from_proto_repeated<::arc::types::Param>(
-            cpp.config,
-            pb.config()
-        ))
-        return {{}, err};
-    if (auto err = x::pb::from_proto_repeated<::arc::types::Param>(
             cpp.inputs,
             pb.inputs()
         ))
@@ -257,11 +247,6 @@ inline std::pair<::arc::ir::pb::Node, x::errors::Error> Node::to_proto() const {
     ::arc::ir::pb::Node pb;
     pb.set_key(this->key);
     pb.set_type(this->type);
-    for (const auto &item: this->config) {
-        auto [v, err] = item.to_proto();
-        if (err) return {{}, err};
-        *pb.add_config() = v;
-    }
     for (const auto &item: this->inputs) {
         auto [v, err] = item.to_proto();
         if (err) return {{}, err};
@@ -285,11 +270,6 @@ Node::from_proto(const ::arc::ir::pb::Node &pb) {
     Node cpp;
     cpp.key = pb.key();
     cpp.type = pb.type();
-    if (auto err = x::pb::from_proto_repeated<::arc::types::Param>(
-            cpp.config,
-            pb.config()
-        ))
-        return {{}, err};
     if (auto err = x::pb::from_proto_repeated<::arc::types::Param>(
             cpp.inputs,
             pb.inputs()

--- a/arc/cpp/ir/types.gen.h
+++ b/arc/cpp/ir/types.gen.h
@@ -90,14 +90,12 @@ struct Body {
 };
 
 /// @brief Node is a concrete instantiation of a function with typed parameters and
-/// configuration values.
+/// values.
 struct Node {
     /// @brief key is the unique identifier for this node instance.
     std::string key;
     /// @brief type is the function type being instantiated.
     std::string type;
-    /// @brief config contains configuration parameter values.
-    ::arc::types::Params config;
     /// @brief inputs contains input parameter type signatures.
     ::arc::types::Params inputs;
     /// @brief outputs contains output parameter type signatures.
@@ -161,8 +159,6 @@ struct Function {
     std::string key;
     /// @brief body is raw source code for user-defined functions.
     Body body;
-    /// @brief config contains configuration parameter definitions.
-    ::arc::types::Params config;
     /// @brief inputs contains input parameter definitions.
     ::arc::types::Params inputs;
     /// @brief outputs contains output parameter definitions.

--- a/arc/cpp/types/json.gen.h
+++ b/arc/cpp/types/json.gen.h
@@ -25,7 +25,6 @@ inline FunctionProperties FunctionProperties::parse(x::json::Parser parser) {
     return FunctionProperties{
         .inputs = parser.field<Params>("inputs"),
         .outputs = parser.field<Params>("outputs"),
-        .config = parser.field<Params>("config"),
     };
 }
 
@@ -33,7 +32,6 @@ inline x::json::json FunctionProperties::to_json() const {
     x::json::json j;
     j["inputs"] = this->inputs.to_json();
     j["outputs"] = this->outputs.to_json();
-    j["config"] = this->config.to_json();
     return j;
 }
 

--- a/arc/cpp/types/proto.gen.h
+++ b/arc/cpp/types/proto.gen.h
@@ -36,11 +36,6 @@ FunctionProperties::to_proto() const {
         if (err) return {{}, err};
         *pb.add_outputs() = v;
     }
-    for (const auto &item: this->config) {
-        auto [v, err] = item.to_proto();
-        if (err) return {{}, err};
-        *pb.add_config() = v;
-    }
     return {pb, x::errors::NIL};
 }
 
@@ -50,8 +45,6 @@ FunctionProperties::from_proto(const ::arc::types::pb::FunctionProperties &pb) {
     if (auto err = x::pb::from_proto_repeated<Param>(cpp.inputs, pb.inputs()))
         return {{}, err};
     if (auto err = x::pb::from_proto_repeated<Param>(cpp.outputs, pb.outputs()))
-        return {{}, err};
-    if (auto err = x::pb::from_proto_repeated<Param>(cpp.config, pb.config()))
         return {{}, err};
     return {cpp, x::errors::NIL};
 }
@@ -67,11 +60,6 @@ inline std::pair<::arc::types::pb::Type, x::errors::Error> Type::to_proto() cons
         auto [v, err] = item.to_proto();
         if (err) return {{}, err};
         *pb.add_outputs() = v;
-    }
-    for (const auto &item: this->config) {
-        auto [v, err] = item.to_proto();
-        if (err) return {{}, err};
-        *pb.add_config() = v;
     }
     pb.set_kind(static_cast<::arc::types::pb::Kind>(this->kind));
     pb.set_name(this->name);
@@ -102,8 +90,6 @@ Type::from_proto(const ::arc::types::pb::Type &pb) {
     if (auto err = x::pb::from_proto_repeated<Param>(cpp.inputs, pb.inputs()))
         return {{}, err};
     if (auto err = x::pb::from_proto_repeated<Param>(cpp.outputs, pb.outputs()))
-        return {{}, err};
-    if (auto err = x::pb::from_proto_repeated<Param>(cpp.config, pb.config()))
         return {{}, err};
     cpp.kind = static_cast<Kind>(pb.kind());
     cpp.name = pb.name();

--- a/arc/cpp/types/types.gen.h
+++ b/arc/cpp/types/types.gen.h
@@ -200,8 +200,6 @@ struct FunctionProperties {
     Params inputs;
     /// @brief outputs contains output parameter definitions.
     Params outputs;
-    /// @brief config contains configuration parameter definitions.
-    Params config;
 
     static FunctionProperties parse(x::json::Parser parser);
     [[nodiscard]] x::json::json to_json() const;
@@ -226,7 +224,7 @@ struct Type : public FunctionProperties {
     std::optional<Unit> unit;
     /// @brief constraint is the type constraint for type variables.
     x::mem::indirect<Type> constraint;
-    /// @brief chan_direction indicates read/write direction for channel-typed config
+    /// @brief chan_direction indicates read/write direction for channel-typed
     /// parameters.
     ChanDirection chan_direction;
 

--- a/arc/go/graph/codec_gen_test.go
+++ b/arc/go/graph/codec_gen_test.go
@@ -44,82 +44,61 @@ var _ = Describe("Codec", func() {
 					{
 						Key:  "test_7",
 						Body: ir.Body{Raw: "test_9"},
-						Config: []types.Param{
+						Inputs: []types.Param{
 							{
 								Name: "test_11",
 								Type: types.Type{
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_17",
+									Name:          "test_16",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 									ChanDirection: types.ChanDirection(0),
 								},
-								Value: map[string]interface{}{"key_22": "value_22"},
-							},
-						},
-						Inputs: []types.Param{
-							{
-								Name: "test_24",
-								Type: types.Type{
-									FunctionProperties: types.FunctionProperties{
-										Inputs:  []types.Param{{}},
-										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
-									},
-									Kind:          types.Kind(0),
-									Name:          "test_30",
-									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-									ChanDirection: types.ChanDirection(0),
-								},
-								Value: map[string]interface{}{"key_35": "value_35"},
+								Value: map[string]interface{}{"key_21": "value_21"},
 							},
 						},
 						Outputs: []types.Param{
 							{
-								Name: "test_37",
+								Name: "test_23",
 								Type: types.Type{
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_43",
+									Name:          "test_28",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 									ChanDirection: types.ChanDirection(0),
 								},
-								Value: map[string]interface{}{"key_48": "value_48"},
+								Value: map[string]interface{}{"key_33": "value_33"},
 							},
 						},
 						Channels: types.Channels{
-							Read:  map[uint32]string{51: "test_50"},
-							Write: map[uint32]string{52: "test_51"},
+							Read:  map[uint32]string{36: "test_35"},
+							Write: map[uint32]string{37: "test_36"},
 						},
 					},
 				},
 				Edges: []ir.Edge{
 					{
-						Source: ir.Handle{Node: "test_54", Param: "test_55"},
-						Target: ir.Handle{Node: "test_57", Param: "test_58"},
+						Source: ir.Handle{Node: "test_39", Param: "test_40"},
+						Target: ir.Handle{Node: "test_42", Param: "test_43"},
 						Kind:   ir.EdgeKind(0),
 					},
 				},
 				Nodes: []graph.Node{
 					{
-						Key:      "test_61",
-						Type:     "test_62",
-						Config:   msgpack.EncodedJSON{"key_63": "value_63"},
-						Position: spatial.XY{X: 65.5, Y: 66.5},
+						Key:      "test_46",
+						Type:     "test_47",
+						Config:   msgpack.EncodedJSON{"key_48": "value_48"},
+						Position: spatial.XY{X: 50.5, Y: 51.5},
 					},
 				},
 			}),
@@ -186,82 +165,61 @@ func BenchmarkEncodeDecodeGraph(b *testing.B) {
 			{
 				Key:  "test_7",
 				Body: ir.Body{Raw: "test_9"},
-				Config: []types.Param{
+				Inputs: []types.Param{
 					{
 						Name: "test_11",
 						Type: types.Type{
 							FunctionProperties: types.FunctionProperties{
 								Inputs:  []types.Param{{}},
 								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
 							},
 							Kind:          types.Kind(0),
-							Name:          "test_17",
+							Name:          "test_16",
 							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 							ChanDirection: types.ChanDirection(0),
 						},
-						Value: map[string]interface{}{"key_22": "value_22"},
-					},
-				},
-				Inputs: []types.Param{
-					{
-						Name: "test_24",
-						Type: types.Type{
-							FunctionProperties: types.FunctionProperties{
-								Inputs:  []types.Param{{}},
-								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
-							},
-							Kind:          types.Kind(0),
-							Name:          "test_30",
-							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-							ChanDirection: types.ChanDirection(0),
-						},
-						Value: map[string]interface{}{"key_35": "value_35"},
+						Value: map[string]interface{}{"key_21": "value_21"},
 					},
 				},
 				Outputs: []types.Param{
 					{
-						Name: "test_37",
+						Name: "test_23",
 						Type: types.Type{
 							FunctionProperties: types.FunctionProperties{
 								Inputs:  []types.Param{{}},
 								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
 							},
 							Kind:          types.Kind(0),
-							Name:          "test_43",
+							Name:          "test_28",
 							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 							ChanDirection: types.ChanDirection(0),
 						},
-						Value: map[string]interface{}{"key_48": "value_48"},
+						Value: map[string]interface{}{"key_33": "value_33"},
 					},
 				},
 				Channels: types.Channels{
-					Read:  map[uint32]string{51: "test_50"},
-					Write: map[uint32]string{52: "test_51"},
+					Read:  map[uint32]string{36: "test_35"},
+					Write: map[uint32]string{37: "test_36"},
 				},
 			},
 		},
 		Edges: []ir.Edge{
 			{
-				Source: ir.Handle{Node: "test_54", Param: "test_55"},
-				Target: ir.Handle{Node: "test_57", Param: "test_58"},
+				Source: ir.Handle{Node: "test_39", Param: "test_40"},
+				Target: ir.Handle{Node: "test_42", Param: "test_43"},
 				Kind:   ir.EdgeKind(0),
 			},
 		},
 		Nodes: []graph.Node{
 			{
-				Key:      "test_61",
-				Type:     "test_62",
-				Config:   msgpack.EncodedJSON{"key_63": "value_63"},
-				Position: spatial.XY{X: 65.5, Y: 66.5},
+				Key:      "test_46",
+				Type:     "test_47",
+				Config:   msgpack.EncodedJSON{"key_48": "value_48"},
+				Position: spatial.XY{X: 50.5, Y: 51.5},
 			},
 		},
 	}
@@ -327,82 +285,61 @@ func FuzzDecodeGraph(f *testing.F) {
 				{
 					Key:  "test_7",
 					Body: ir.Body{Raw: "test_9"},
-					Config: []types.Param{
+					Inputs: []types.Param{
 						{
 							Name: "test_11",
 							Type: types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_17",
+								Name:          "test_16",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 								ChanDirection: types.ChanDirection(0),
 							},
-							Value: map[string]interface{}{"key_22": "value_22"},
-						},
-					},
-					Inputs: []types.Param{
-						{
-							Name: "test_24",
-							Type: types.Type{
-								FunctionProperties: types.FunctionProperties{
-									Inputs:  []types.Param{{}},
-									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
-								},
-								Kind:          types.Kind(0),
-								Name:          "test_30",
-								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-								ChanDirection: types.ChanDirection(0),
-							},
-							Value: map[string]interface{}{"key_35": "value_35"},
+							Value: map[string]interface{}{"key_21": "value_21"},
 						},
 					},
 					Outputs: []types.Param{
 						{
-							Name: "test_37",
+							Name: "test_23",
 							Type: types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_43",
+								Name:          "test_28",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 								ChanDirection: types.ChanDirection(0),
 							},
-							Value: map[string]interface{}{"key_48": "value_48"},
+							Value: map[string]interface{}{"key_33": "value_33"},
 						},
 					},
 					Channels: types.Channels{
-						Read:  map[uint32]string{51: "test_50"},
-						Write: map[uint32]string{52: "test_51"},
+						Read:  map[uint32]string{36: "test_35"},
+						Write: map[uint32]string{37: "test_36"},
 					},
 				},
 			},
 			Edges: []ir.Edge{
 				{
-					Source: ir.Handle{Node: "test_54", Param: "test_55"},
-					Target: ir.Handle{Node: "test_57", Param: "test_58"},
+					Source: ir.Handle{Node: "test_39", Param: "test_40"},
+					Target: ir.Handle{Node: "test_42", Param: "test_43"},
 					Kind:   ir.EdgeKind(0),
 				},
 			},
 			Nodes: []graph.Node{
 				{
-					Key:      "test_61",
-					Type:     "test_62",
-					Config:   msgpack.EncodedJSON{"key_63": "value_63"},
-					Position: spatial.XY{X: 65.5, Y: 66.5},
+					Key:      "test_46",
+					Type:     "test_47",
+					Config:   msgpack.EncodedJSON{"key_48": "value_48"},
+					Position: spatial.XY{X: 50.5, Y: 51.5},
 				},
 			},
 		}

--- a/arc/go/ir/codec.gen.go
+++ b/arc/go/ir/codec.gen.go
@@ -122,15 +122,6 @@ func (f Function) EncodeOrc(w *orc.Writer) error {
 	if err := f.Body.EncodeOrc(w); err != nil {
 		return err
 	}
-	w.Bool(f.Config != nil)
-	if f.Config != nil {
-		w.Uint32(uint32(len(f.Config)))
-		for i := range f.Config {
-			if err := f.Config[i].EncodeOrc(w); err != nil {
-				return err
-			}
-		}
-	}
 	w.Bool(f.Inputs != nil)
 	if f.Inputs != nil {
 		w.Uint32(uint32(len(f.Inputs)))
@@ -162,24 +153,6 @@ func (f *Function) DecodeOrc(r *orc.Reader) error {
 	}
 	if err = f.Body.DecodeOrc(r); err != nil {
 		return err
-	}
-	{
-		present, err := r.Bool()
-		if err != nil {
-			return err
-		}
-		if present {
-			n, err := r.CollectionLen()
-			if err != nil {
-				return err
-			}
-			f.Config = make([]types.Param, n)
-			for i := range f.Config {
-				if err = f.Config[i].DecodeOrc(r); err != nil {
-					return err
-				}
-			}
-		}
 	}
 	{
 		present, err := r.Bool()
@@ -393,15 +366,6 @@ func (mv *Member) DecodeOrc(r *orc.Reader) error {
 func (nv Node) EncodeOrc(w *orc.Writer) error {
 	w.String(nv.Key)
 	w.String(nv.Type)
-	w.Bool(nv.Config != nil)
-	if nv.Config != nil {
-		w.Uint32(uint32(len(nv.Config)))
-		for i := range nv.Config {
-			if err := nv.Config[i].EncodeOrc(w); err != nil {
-				return err
-			}
-		}
-	}
 	w.Bool(nv.Inputs != nil)
 	if nv.Inputs != nil {
 		w.Uint32(uint32(len(nv.Inputs)))
@@ -433,24 +397,6 @@ func (nv *Node) DecodeOrc(r *orc.Reader) error {
 	}
 	if nv.Type, err = r.String(); err != nil {
 		return err
-	}
-	{
-		present, err := r.Bool()
-		if err != nil {
-			return err
-		}
-		if present {
-			n, err := r.CollectionLen()
-			if err != nil {
-				return err
-			}
-			nv.Config = make([]types.Param, n)
-			for i := range nv.Config {
-				if err = nv.Config[i].DecodeOrc(r); err != nil {
-					return err
-				}
-			}
-		}
 	}
 	{
 		present, err := r.Bool()

--- a/arc/go/ir/codec_gen_test.go
+++ b/arc/go/ir/codec_gen_test.go
@@ -98,7 +98,7 @@ var _ = Describe("Codec", func() {
 			Entry("fully populated", ir.Function{
 				Key:  "test_1",
 				Body: ir.Body{Raw: "test_3"},
-				Config: []types.Param{
+				Inputs: []types.Param{
 					{
 						Name: "test_5",
 						Type: types.Type{
@@ -117,25 +117,17 @@ var _ = Describe("Codec", func() {
 										Value: map[string]interface{}{"key_14": "value_14"},
 									},
 								},
-								Config: []types.Param{
-									{
-										Name:  "test_16",
-										Type:  types.Type{},
-										Value: map[string]interface{}{"key_18": "value_18"},
-									},
-								},
 							},
 							Kind: types.Kind(0),
-							Name: "test_20",
+							Name: "test_16",
 							Elem: func() *types.Type {
 								v := types.Type{
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_26",
+									Name:          "test_21",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -146,8 +138,8 @@ var _ = Describe("Codec", func() {
 							Unit: func() *types.Unit {
 								v := types.Unit{
 									Dimensions: types.Dimensions{},
-									Scale:      33.5,
-									Name:       "test_34",
+									Scale:      28.5,
+									Name:       "test_29",
 								}
 								return &v
 							}(),
@@ -156,10 +148,9 @@ var _ = Describe("Codec", func() {
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_40",
+									Name:          "test_34",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -169,121 +160,39 @@ var _ = Describe("Codec", func() {
 							}(),
 							ChanDirection: types.ChanDirection(0),
 						},
-						Value: map[string]interface{}{"key_46": "value_46"},
-					},
-				},
-				Inputs: []types.Param{
-					{
-						Name: "test_48",
-						Type: types.Type{
-							FunctionProperties: types.FunctionProperties{
-								Inputs: []types.Param{
-									{
-										Name:  "test_51",
-										Type:  types.Type{},
-										Value: map[string]interface{}{"key_53": "value_53"},
-									},
-								},
-								Outputs: []types.Param{
-									{
-										Name:  "test_55",
-										Type:  types.Type{},
-										Value: map[string]interface{}{"key_57": "value_57"},
-									},
-								},
-								Config: []types.Param{
-									{
-										Name:  "test_59",
-										Type:  types.Type{},
-										Value: map[string]interface{}{"key_61": "value_61"},
-									},
-								},
-							},
-							Kind: types.Kind(0),
-							Name: "test_63",
-							Elem: func() *types.Type {
-								v := types.Type{
-									FunctionProperties: types.FunctionProperties{
-										Inputs:  []types.Param{{}},
-										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
-									},
-									Kind:          types.Kind(0),
-									Name:          "test_69",
-									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-									ChanDirection: types.ChanDirection(0),
-								}
-								return &v
-							}(),
-							Unit: func() *types.Unit {
-								v := types.Unit{
-									Dimensions: types.Dimensions{},
-									Scale:      76.5,
-									Name:       "test_77",
-								}
-								return &v
-							}(),
-							Constraint: func() *types.Type {
-								v := types.Type{
-									FunctionProperties: types.FunctionProperties{
-										Inputs:  []types.Param{{}},
-										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
-									},
-									Kind:          types.Kind(0),
-									Name:          "test_83",
-									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-									ChanDirection: types.ChanDirection(0),
-								}
-								return &v
-							}(),
-							ChanDirection: types.ChanDirection(0),
-						},
-						Value: map[string]interface{}{"key_89": "value_89"},
+						Value: map[string]interface{}{"key_40": "value_40"},
 					},
 				},
 				Outputs: []types.Param{
 					{
-						Name: "test_91",
+						Name: "test_42",
 						Type: types.Type{
 							FunctionProperties: types.FunctionProperties{
 								Inputs: []types.Param{
 									{
-										Name:  "test_94",
+										Name:  "test_45",
 										Type:  types.Type{},
-										Value: map[string]interface{}{"key_96": "value_96"},
+										Value: map[string]interface{}{"key_47": "value_47"},
 									},
 								},
 								Outputs: []types.Param{
 									{
-										Name:  "test_98",
+										Name:  "test_49",
 										Type:  types.Type{},
-										Value: map[string]interface{}{"key_100": "value_100"},
-									},
-								},
-								Config: []types.Param{
-									{
-										Name:  "test_102",
-										Type:  types.Type{},
-										Value: map[string]interface{}{"key_104": "value_104"},
+										Value: map[string]interface{}{"key_51": "value_51"},
 									},
 								},
 							},
 							Kind: types.Kind(0),
-							Name: "test_106",
+							Name: "test_53",
 							Elem: func() *types.Type {
 								v := types.Type{
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_112",
+									Name:          "test_58",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -294,8 +203,8 @@ var _ = Describe("Codec", func() {
 							Unit: func() *types.Unit {
 								v := types.Unit{
 									Dimensions: types.Dimensions{},
-									Scale:      119.5,
-									Name:       "test_120",
+									Scale:      65.5,
+									Name:       "test_66",
 								}
 								return &v
 							}(),
@@ -304,10 +213,9 @@ var _ = Describe("Codec", func() {
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_126",
+									Name:          "test_71",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -317,18 +225,17 @@ var _ = Describe("Codec", func() {
 							}(),
 							ChanDirection: types.ChanDirection(0),
 						},
-						Value: map[string]interface{}{"key_132": "value_132"},
+						Value: map[string]interface{}{"key_77": "value_77"},
 					},
 				},
 				Channels: types.Channels{
-					Read:  map[uint32]string{135: "test_134"},
-					Write: map[uint32]string{136: "test_135"},
+					Read:  map[uint32]string{80: "test_79"},
+					Write: map[uint32]string{81: "test_80"},
 				},
 			}),
 			Entry("zero values", ir.Function{
 				Key:      "",
 				Body:     ir.Body{Raw: ""},
-				Config:   nil,
 				Inputs:   nil,
 				Outputs:  nil,
 				Channels: types.Channels{Read: nil, Write: nil},
@@ -336,7 +243,6 @@ var _ = Describe("Codec", func() {
 			Entry("empty collections", ir.Function{
 				Key:      "test_1",
 				Body:     ir.Body{Raw: "test_3"},
-				Config:   []types.Param{},
 				Inputs:   []types.Param{},
 				Outputs:  []types.Param{},
 				Channels: types.Channels{Read: map[uint32]string{}, Write: map[uint32]string{}},
@@ -374,159 +280,117 @@ var _ = Describe("Codec", func() {
 					{
 						Key:  "test_2",
 						Body: ir.Body{Raw: "test_4"},
-						Config: []types.Param{
+						Inputs: []types.Param{
 							{
 								Name: "test_6",
 								Type: types.Type{
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_12",
+									Name:          "test_11",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 									ChanDirection: types.ChanDirection(0),
 								},
-								Value: map[string]interface{}{"key_17": "value_17"},
-							},
-						},
-						Inputs: []types.Param{
-							{
-								Name: "test_19",
-								Type: types.Type{
-									FunctionProperties: types.FunctionProperties{
-										Inputs:  []types.Param{{}},
-										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
-									},
-									Kind:          types.Kind(0),
-									Name:          "test_25",
-									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-									ChanDirection: types.ChanDirection(0),
-								},
-								Value: map[string]interface{}{"key_30": "value_30"},
+								Value: map[string]interface{}{"key_16": "value_16"},
 							},
 						},
 						Outputs: []types.Param{
 							{
-								Name: "test_32",
+								Name: "test_18",
 								Type: types.Type{
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_38",
+									Name:          "test_23",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 									ChanDirection: types.ChanDirection(0),
 								},
-								Value: map[string]interface{}{"key_43": "value_43"},
+								Value: map[string]interface{}{"key_28": "value_28"},
 							},
 						},
 						Channels: types.Channels{
-							Read:  map[uint32]string{46: "test_45"},
-							Write: map[uint32]string{47: "test_46"},
+							Read:  map[uint32]string{31: "test_30"},
+							Write: map[uint32]string{32: "test_31"},
 						},
 					},
 				},
 				Nodes: []ir.Node{
 					{
-						Key:  "test_48",
-						Type: "test_49",
-						Config: []types.Param{
-							{
-								Name: "test_51",
-								Type: types.Type{
-									FunctionProperties: types.FunctionProperties{
-										Inputs:  []types.Param{{}},
-										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
-									},
-									Kind:          types.Kind(0),
-									Name:          "test_57",
-									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-									ChanDirection: types.ChanDirection(0),
-								},
-								Value: map[string]interface{}{"key_62": "value_62"},
-							},
-						},
+						Key:  "test_33",
+						Type: "test_34",
 						Inputs: []types.Param{
 							{
-								Name: "test_64",
+								Name: "test_36",
 								Type: types.Type{
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_70",
+									Name:          "test_41",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 									ChanDirection: types.ChanDirection(0),
 								},
-								Value: map[string]interface{}{"key_75": "value_75"},
+								Value: map[string]interface{}{"key_46": "value_46"},
 							},
 						},
 						Outputs: []types.Param{
 							{
-								Name: "test_77",
+								Name: "test_48",
 								Type: types.Type{
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_83",
+									Name:          "test_53",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 									ChanDirection: types.ChanDirection(0),
 								},
-								Value: map[string]interface{}{"key_88": "value_88"},
+								Value: map[string]interface{}{"key_58": "value_58"},
 							},
 						},
 						Channels: types.Channels{
-							Read:  map[uint32]string{91: "test_90"},
-							Write: map[uint32]string{92: "test_91"},
+							Read:  map[uint32]string{61: "test_60"},
+							Write: map[uint32]string{62: "test_61"},
 						},
 					},
 				},
 				Edges: []ir.Edge{
 					{
-						Source: ir.Handle{Node: "test_94", Param: "test_95"},
-						Target: ir.Handle{Node: "test_97", Param: "test_98"},
+						Source: ir.Handle{Node: "test_64", Param: "test_65"},
+						Target: ir.Handle{Node: "test_67", Param: "test_68"},
 						Kind:   ir.EdgeKind(0),
 					},
 				},
 				Authorities: ir.Authorities{
-					Default:  func() *uint8 { v := uint8(102); return &v }(),
-					Channels: map[uint32]uint8{103: 103},
+					Default:  func() *uint8 { v := uint8(72); return &v }(),
+					Channels: map[uint32]uint8{73: 73},
 				},
 				Root: ir.Scope{
-					Key:        "test_104",
+					Key:        "test_74",
 					Mode:       ir.ScopeMode(0),
 					Liveness:   ir.Liveness(0),
-					Activation: func() *ir.Handle { v := ir.Handle{Node: "test_108", Param: "test_109"}; return &v }(),
+					Activation: func() *ir.Handle { v := ir.Handle{Node: "test_78", Param: "test_79"}; return &v }(),
 					Strata: [][]ir.Member{
 						{
 							{
-								NodeKey: func() *string { v := string("test_111"); return &v }(),
+								NodeKey: func() *string { v := string("test_81"); return &v }(),
 								Scope: func() *ir.Scope {
 									v := ir.Scope{
-										Key:         "test_113",
+										Key:         "test_83",
 										Mode:        ir.ScopeMode(0),
 										Liveness:    ir.Liveness(0),
 										Activation:  func() *ir.Handle { v := ir.Handle{}; return &v }(),
@@ -541,10 +405,10 @@ var _ = Describe("Codec", func() {
 					},
 					Steps: []ir.Member{
 						{
-							NodeKey: func() *string { v := string("test_121"); return &v }(),
+							NodeKey: func() *string { v := string("test_91"); return &v }(),
 							Scope: func() *ir.Scope {
 								v := ir.Scope{
-									Key:         "test_123",
+									Key:         "test_93",
 									Mode:        ir.ScopeMode(0),
 									Liveness:    ir.Liveness(0),
 									Activation:  func() *ir.Handle { v := ir.Handle{}; return &v }(),
@@ -558,8 +422,8 @@ var _ = Describe("Codec", func() {
 					},
 					Transitions: []ir.Transition{
 						{
-							On:        ir.Handle{Node: "test_132", Param: "test_133"},
-							TargetKey: func() *string { v := string("test_134"); return &v }(),
+							On:        ir.Handle{Node: "test_102", Param: "test_103"},
+							TargetKey: func() *string { v := string("test_104"); return &v }(),
 						},
 					},
 				},
@@ -681,7 +545,7 @@ var _ = Describe("Codec", func() {
 			Entry("fully populated", ir.Node{
 				Key:  "test_1",
 				Type: "test_2",
-				Config: []types.Param{
+				Inputs: []types.Param{
 					{
 						Name: "test_4",
 						Type: types.Type{
@@ -700,25 +564,17 @@ var _ = Describe("Codec", func() {
 										Value: map[string]interface{}{"key_13": "value_13"},
 									},
 								},
-								Config: []types.Param{
-									{
-										Name:  "test_15",
-										Type:  types.Type{},
-										Value: map[string]interface{}{"key_17": "value_17"},
-									},
-								},
 							},
 							Kind: types.Kind(0),
-							Name: "test_19",
+							Name: "test_15",
 							Elem: func() *types.Type {
 								v := types.Type{
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_25",
+									Name:          "test_20",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -729,8 +585,8 @@ var _ = Describe("Codec", func() {
 							Unit: func() *types.Unit {
 								v := types.Unit{
 									Dimensions: types.Dimensions{},
-									Scale:      32.5,
-									Name:       "test_33",
+									Scale:      27.5,
+									Name:       "test_28",
 								}
 								return &v
 							}(),
@@ -739,10 +595,9 @@ var _ = Describe("Codec", func() {
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_39",
+									Name:          "test_33",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -752,121 +607,39 @@ var _ = Describe("Codec", func() {
 							}(),
 							ChanDirection: types.ChanDirection(0),
 						},
-						Value: map[string]interface{}{"key_45": "value_45"},
-					},
-				},
-				Inputs: []types.Param{
-					{
-						Name: "test_47",
-						Type: types.Type{
-							FunctionProperties: types.FunctionProperties{
-								Inputs: []types.Param{
-									{
-										Name:  "test_50",
-										Type:  types.Type{},
-										Value: map[string]interface{}{"key_52": "value_52"},
-									},
-								},
-								Outputs: []types.Param{
-									{
-										Name:  "test_54",
-										Type:  types.Type{},
-										Value: map[string]interface{}{"key_56": "value_56"},
-									},
-								},
-								Config: []types.Param{
-									{
-										Name:  "test_58",
-										Type:  types.Type{},
-										Value: map[string]interface{}{"key_60": "value_60"},
-									},
-								},
-							},
-							Kind: types.Kind(0),
-							Name: "test_62",
-							Elem: func() *types.Type {
-								v := types.Type{
-									FunctionProperties: types.FunctionProperties{
-										Inputs:  []types.Param{{}},
-										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
-									},
-									Kind:          types.Kind(0),
-									Name:          "test_68",
-									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-									ChanDirection: types.ChanDirection(0),
-								}
-								return &v
-							}(),
-							Unit: func() *types.Unit {
-								v := types.Unit{
-									Dimensions: types.Dimensions{},
-									Scale:      75.5,
-									Name:       "test_76",
-								}
-								return &v
-							}(),
-							Constraint: func() *types.Type {
-								v := types.Type{
-									FunctionProperties: types.FunctionProperties{
-										Inputs:  []types.Param{{}},
-										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
-									},
-									Kind:          types.Kind(0),
-									Name:          "test_82",
-									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-									ChanDirection: types.ChanDirection(0),
-								}
-								return &v
-							}(),
-							ChanDirection: types.ChanDirection(0),
-						},
-						Value: map[string]interface{}{"key_88": "value_88"},
+						Value: map[string]interface{}{"key_39": "value_39"},
 					},
 				},
 				Outputs: []types.Param{
 					{
-						Name: "test_90",
+						Name: "test_41",
 						Type: types.Type{
 							FunctionProperties: types.FunctionProperties{
 								Inputs: []types.Param{
 									{
-										Name:  "test_93",
+										Name:  "test_44",
 										Type:  types.Type{},
-										Value: map[string]interface{}{"key_95": "value_95"},
+										Value: map[string]interface{}{"key_46": "value_46"},
 									},
 								},
 								Outputs: []types.Param{
 									{
-										Name:  "test_97",
+										Name:  "test_48",
 										Type:  types.Type{},
-										Value: map[string]interface{}{"key_99": "value_99"},
-									},
-								},
-								Config: []types.Param{
-									{
-										Name:  "test_101",
-										Type:  types.Type{},
-										Value: map[string]interface{}{"key_103": "value_103"},
+										Value: map[string]interface{}{"key_50": "value_50"},
 									},
 								},
 							},
 							Kind: types.Kind(0),
-							Name: "test_105",
+							Name: "test_52",
 							Elem: func() *types.Type {
 								v := types.Type{
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_111",
+									Name:          "test_57",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -877,8 +650,8 @@ var _ = Describe("Codec", func() {
 							Unit: func() *types.Unit {
 								v := types.Unit{
 									Dimensions: types.Dimensions{},
-									Scale:      118.5,
-									Name:       "test_119",
+									Scale:      64.5,
+									Name:       "test_65",
 								}
 								return &v
 							}(),
@@ -887,10 +660,9 @@ var _ = Describe("Codec", func() {
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_125",
+									Name:          "test_70",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -900,18 +672,17 @@ var _ = Describe("Codec", func() {
 							}(),
 							ChanDirection: types.ChanDirection(0),
 						},
-						Value: map[string]interface{}{"key_131": "value_131"},
+						Value: map[string]interface{}{"key_76": "value_76"},
 					},
 				},
 				Channels: types.Channels{
-					Read:  map[uint32]string{134: "test_133"},
-					Write: map[uint32]string{135: "test_134"},
+					Read:  map[uint32]string{79: "test_78"},
+					Write: map[uint32]string{80: "test_79"},
 				},
 			}),
 			Entry("zero values", ir.Node{
 				Key:      "",
 				Type:     "",
-				Config:   nil,
 				Inputs:   nil,
 				Outputs:  nil,
 				Channels: types.Channels{Read: nil, Write: nil},
@@ -919,7 +690,6 @@ var _ = Describe("Codec", func() {
 			Entry("empty collections", ir.Node{
 				Key:      "test_1",
 				Type:     "test_2",
-				Config:   []types.Param{},
 				Inputs:   []types.Param{},
 				Outputs:  []types.Param{},
 				Channels: types.Channels{Read: map[uint32]string{}, Write: map[uint32]string{}},
@@ -1121,7 +891,7 @@ func BenchmarkEncodeDecodeFunction(b *testing.B) {
 	f := ir.Function{
 		Key:  "test_1",
 		Body: ir.Body{Raw: "test_3"},
-		Config: []types.Param{
+		Inputs: []types.Param{
 			{
 				Name: "test_5",
 				Type: types.Type{
@@ -1140,25 +910,17 @@ func BenchmarkEncodeDecodeFunction(b *testing.B) {
 								Value: map[string]interface{}{"key_14": "value_14"},
 							},
 						},
-						Config: []types.Param{
-							{
-								Name:  "test_16",
-								Type:  types.Type{},
-								Value: map[string]interface{}{"key_18": "value_18"},
-							},
-						},
 					},
 					Kind: types.Kind(0),
-					Name: "test_20",
+					Name: "test_16",
 					Elem: func() *types.Type {
 						v := types.Type{
 							FunctionProperties: types.FunctionProperties{
 								Inputs:  []types.Param{{}},
 								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
 							},
 							Kind:          types.Kind(0),
-							Name:          "test_26",
+							Name:          "test_21",
 							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -1169,8 +931,8 @@ func BenchmarkEncodeDecodeFunction(b *testing.B) {
 					Unit: func() *types.Unit {
 						v := types.Unit{
 							Dimensions: types.Dimensions{},
-							Scale:      33.5,
-							Name:       "test_34",
+							Scale:      28.5,
+							Name:       "test_29",
 						}
 						return &v
 					}(),
@@ -1179,10 +941,9 @@ func BenchmarkEncodeDecodeFunction(b *testing.B) {
 							FunctionProperties: types.FunctionProperties{
 								Inputs:  []types.Param{{}},
 								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
 							},
 							Kind:          types.Kind(0),
-							Name:          "test_40",
+							Name:          "test_34",
 							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -1192,121 +953,39 @@ func BenchmarkEncodeDecodeFunction(b *testing.B) {
 					}(),
 					ChanDirection: types.ChanDirection(0),
 				},
-				Value: map[string]interface{}{"key_46": "value_46"},
-			},
-		},
-		Inputs: []types.Param{
-			{
-				Name: "test_48",
-				Type: types.Type{
-					FunctionProperties: types.FunctionProperties{
-						Inputs: []types.Param{
-							{
-								Name:  "test_51",
-								Type:  types.Type{},
-								Value: map[string]interface{}{"key_53": "value_53"},
-							},
-						},
-						Outputs: []types.Param{
-							{
-								Name:  "test_55",
-								Type:  types.Type{},
-								Value: map[string]interface{}{"key_57": "value_57"},
-							},
-						},
-						Config: []types.Param{
-							{
-								Name:  "test_59",
-								Type:  types.Type{},
-								Value: map[string]interface{}{"key_61": "value_61"},
-							},
-						},
-					},
-					Kind: types.Kind(0),
-					Name: "test_63",
-					Elem: func() *types.Type {
-						v := types.Type{
-							FunctionProperties: types.FunctionProperties{
-								Inputs:  []types.Param{{}},
-								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
-							},
-							Kind:          types.Kind(0),
-							Name:          "test_69",
-							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-							ChanDirection: types.ChanDirection(0),
-						}
-						return &v
-					}(),
-					Unit: func() *types.Unit {
-						v := types.Unit{
-							Dimensions: types.Dimensions{},
-							Scale:      76.5,
-							Name:       "test_77",
-						}
-						return &v
-					}(),
-					Constraint: func() *types.Type {
-						v := types.Type{
-							FunctionProperties: types.FunctionProperties{
-								Inputs:  []types.Param{{}},
-								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
-							},
-							Kind:          types.Kind(0),
-							Name:          "test_83",
-							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-							ChanDirection: types.ChanDirection(0),
-						}
-						return &v
-					}(),
-					ChanDirection: types.ChanDirection(0),
-				},
-				Value: map[string]interface{}{"key_89": "value_89"},
+				Value: map[string]interface{}{"key_40": "value_40"},
 			},
 		},
 		Outputs: []types.Param{
 			{
-				Name: "test_91",
+				Name: "test_42",
 				Type: types.Type{
 					FunctionProperties: types.FunctionProperties{
 						Inputs: []types.Param{
 							{
-								Name:  "test_94",
+								Name:  "test_45",
 								Type:  types.Type{},
-								Value: map[string]interface{}{"key_96": "value_96"},
+								Value: map[string]interface{}{"key_47": "value_47"},
 							},
 						},
 						Outputs: []types.Param{
 							{
-								Name:  "test_98",
+								Name:  "test_49",
 								Type:  types.Type{},
-								Value: map[string]interface{}{"key_100": "value_100"},
-							},
-						},
-						Config: []types.Param{
-							{
-								Name:  "test_102",
-								Type:  types.Type{},
-								Value: map[string]interface{}{"key_104": "value_104"},
+								Value: map[string]interface{}{"key_51": "value_51"},
 							},
 						},
 					},
 					Kind: types.Kind(0),
-					Name: "test_106",
+					Name: "test_53",
 					Elem: func() *types.Type {
 						v := types.Type{
 							FunctionProperties: types.FunctionProperties{
 								Inputs:  []types.Param{{}},
 								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
 							},
 							Kind:          types.Kind(0),
-							Name:          "test_112",
+							Name:          "test_58",
 							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -1317,8 +996,8 @@ func BenchmarkEncodeDecodeFunction(b *testing.B) {
 					Unit: func() *types.Unit {
 						v := types.Unit{
 							Dimensions: types.Dimensions{},
-							Scale:      119.5,
-							Name:       "test_120",
+							Scale:      65.5,
+							Name:       "test_66",
 						}
 						return &v
 					}(),
@@ -1327,10 +1006,9 @@ func BenchmarkEncodeDecodeFunction(b *testing.B) {
 							FunctionProperties: types.FunctionProperties{
 								Inputs:  []types.Param{{}},
 								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
 							},
 							Kind:          types.Kind(0),
-							Name:          "test_126",
+							Name:          "test_71",
 							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -1340,12 +1018,12 @@ func BenchmarkEncodeDecodeFunction(b *testing.B) {
 					}(),
 					ChanDirection: types.ChanDirection(0),
 				},
-				Value: map[string]interface{}{"key_132": "value_132"},
+				Value: map[string]interface{}{"key_77": "value_77"},
 			},
 		},
 		Channels: types.Channels{
-			Read:  map[uint32]string{135: "test_134"},
-			Write: map[uint32]string{136: "test_135"},
+			Read:  map[uint32]string{80: "test_79"},
+			Write: map[uint32]string{81: "test_80"},
 		},
 	}
 	w := orc.NewWriter(0)
@@ -1386,159 +1064,117 @@ func BenchmarkEncodeDecodeIR(b *testing.B) {
 			{
 				Key:  "test_2",
 				Body: ir.Body{Raw: "test_4"},
-				Config: []types.Param{
+				Inputs: []types.Param{
 					{
 						Name: "test_6",
 						Type: types.Type{
 							FunctionProperties: types.FunctionProperties{
 								Inputs:  []types.Param{{}},
 								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
 							},
 							Kind:          types.Kind(0),
-							Name:          "test_12",
+							Name:          "test_11",
 							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 							ChanDirection: types.ChanDirection(0),
 						},
-						Value: map[string]interface{}{"key_17": "value_17"},
-					},
-				},
-				Inputs: []types.Param{
-					{
-						Name: "test_19",
-						Type: types.Type{
-							FunctionProperties: types.FunctionProperties{
-								Inputs:  []types.Param{{}},
-								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
-							},
-							Kind:          types.Kind(0),
-							Name:          "test_25",
-							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-							ChanDirection: types.ChanDirection(0),
-						},
-						Value: map[string]interface{}{"key_30": "value_30"},
+						Value: map[string]interface{}{"key_16": "value_16"},
 					},
 				},
 				Outputs: []types.Param{
 					{
-						Name: "test_32",
+						Name: "test_18",
 						Type: types.Type{
 							FunctionProperties: types.FunctionProperties{
 								Inputs:  []types.Param{{}},
 								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
 							},
 							Kind:          types.Kind(0),
-							Name:          "test_38",
+							Name:          "test_23",
 							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 							ChanDirection: types.ChanDirection(0),
 						},
-						Value: map[string]interface{}{"key_43": "value_43"},
+						Value: map[string]interface{}{"key_28": "value_28"},
 					},
 				},
 				Channels: types.Channels{
-					Read:  map[uint32]string{46: "test_45"},
-					Write: map[uint32]string{47: "test_46"},
+					Read:  map[uint32]string{31: "test_30"},
+					Write: map[uint32]string{32: "test_31"},
 				},
 			},
 		},
 		Nodes: []ir.Node{
 			{
-				Key:  "test_48",
-				Type: "test_49",
-				Config: []types.Param{
-					{
-						Name: "test_51",
-						Type: types.Type{
-							FunctionProperties: types.FunctionProperties{
-								Inputs:  []types.Param{{}},
-								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
-							},
-							Kind:          types.Kind(0),
-							Name:          "test_57",
-							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-							ChanDirection: types.ChanDirection(0),
-						},
-						Value: map[string]interface{}{"key_62": "value_62"},
-					},
-				},
+				Key:  "test_33",
+				Type: "test_34",
 				Inputs: []types.Param{
 					{
-						Name: "test_64",
+						Name: "test_36",
 						Type: types.Type{
 							FunctionProperties: types.FunctionProperties{
 								Inputs:  []types.Param{{}},
 								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
 							},
 							Kind:          types.Kind(0),
-							Name:          "test_70",
+							Name:          "test_41",
 							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 							ChanDirection: types.ChanDirection(0),
 						},
-						Value: map[string]interface{}{"key_75": "value_75"},
+						Value: map[string]interface{}{"key_46": "value_46"},
 					},
 				},
 				Outputs: []types.Param{
 					{
-						Name: "test_77",
+						Name: "test_48",
 						Type: types.Type{
 							FunctionProperties: types.FunctionProperties{
 								Inputs:  []types.Param{{}},
 								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
 							},
 							Kind:          types.Kind(0),
-							Name:          "test_83",
+							Name:          "test_53",
 							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 							ChanDirection: types.ChanDirection(0),
 						},
-						Value: map[string]interface{}{"key_88": "value_88"},
+						Value: map[string]interface{}{"key_58": "value_58"},
 					},
 				},
 				Channels: types.Channels{
-					Read:  map[uint32]string{91: "test_90"},
-					Write: map[uint32]string{92: "test_91"},
+					Read:  map[uint32]string{61: "test_60"},
+					Write: map[uint32]string{62: "test_61"},
 				},
 			},
 		},
 		Edges: []ir.Edge{
 			{
-				Source: ir.Handle{Node: "test_94", Param: "test_95"},
-				Target: ir.Handle{Node: "test_97", Param: "test_98"},
+				Source: ir.Handle{Node: "test_64", Param: "test_65"},
+				Target: ir.Handle{Node: "test_67", Param: "test_68"},
 				Kind:   ir.EdgeKind(0),
 			},
 		},
 		Authorities: ir.Authorities{
-			Default:  func() *uint8 { v := uint8(102); return &v }(),
-			Channels: map[uint32]uint8{103: 103},
+			Default:  func() *uint8 { v := uint8(72); return &v }(),
+			Channels: map[uint32]uint8{73: 73},
 		},
 		Root: ir.Scope{
-			Key:        "test_104",
+			Key:        "test_74",
 			Mode:       ir.ScopeMode(0),
 			Liveness:   ir.Liveness(0),
-			Activation: func() *ir.Handle { v := ir.Handle{Node: "test_108", Param: "test_109"}; return &v }(),
+			Activation: func() *ir.Handle { v := ir.Handle{Node: "test_78", Param: "test_79"}; return &v }(),
 			Strata: [][]ir.Member{
 				{
 					{
-						NodeKey: func() *string { v := string("test_111"); return &v }(),
+						NodeKey: func() *string { v := string("test_81"); return &v }(),
 						Scope: func() *ir.Scope {
 							v := ir.Scope{
-								Key:         "test_113",
+								Key:         "test_83",
 								Mode:        ir.ScopeMode(0),
 								Liveness:    ir.Liveness(0),
 								Activation:  func() *ir.Handle { v := ir.Handle{}; return &v }(),
@@ -1553,10 +1189,10 @@ func BenchmarkEncodeDecodeIR(b *testing.B) {
 			},
 			Steps: []ir.Member{
 				{
-					NodeKey: func() *string { v := string("test_121"); return &v }(),
+					NodeKey: func() *string { v := string("test_91"); return &v }(),
 					Scope: func() *ir.Scope {
 						v := ir.Scope{
-							Key:         "test_123",
+							Key:         "test_93",
 							Mode:        ir.ScopeMode(0),
 							Liveness:    ir.Liveness(0),
 							Activation:  func() *ir.Handle { v := ir.Handle{}; return &v }(),
@@ -1570,8 +1206,8 @@ func BenchmarkEncodeDecodeIR(b *testing.B) {
 			},
 			Transitions: []ir.Transition{
 				{
-					On:        ir.Handle{Node: "test_132", Param: "test_133"},
-					TargetKey: func() *string { v := string("test_134"); return &v }(),
+					On:        ir.Handle{Node: "test_102", Param: "test_103"},
+					TargetKey: func() *string { v := string("test_104"); return &v }(),
 				},
 			},
 		},
@@ -1665,7 +1301,7 @@ func BenchmarkEncodeDecodeNode(b *testing.B) {
 	nv := ir.Node{
 		Key:  "test_1",
 		Type: "test_2",
-		Config: []types.Param{
+		Inputs: []types.Param{
 			{
 				Name: "test_4",
 				Type: types.Type{
@@ -1684,25 +1320,17 @@ func BenchmarkEncodeDecodeNode(b *testing.B) {
 								Value: map[string]interface{}{"key_13": "value_13"},
 							},
 						},
-						Config: []types.Param{
-							{
-								Name:  "test_15",
-								Type:  types.Type{},
-								Value: map[string]interface{}{"key_17": "value_17"},
-							},
-						},
 					},
 					Kind: types.Kind(0),
-					Name: "test_19",
+					Name: "test_15",
 					Elem: func() *types.Type {
 						v := types.Type{
 							FunctionProperties: types.FunctionProperties{
 								Inputs:  []types.Param{{}},
 								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
 							},
 							Kind:          types.Kind(0),
-							Name:          "test_25",
+							Name:          "test_20",
 							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -1713,8 +1341,8 @@ func BenchmarkEncodeDecodeNode(b *testing.B) {
 					Unit: func() *types.Unit {
 						v := types.Unit{
 							Dimensions: types.Dimensions{},
-							Scale:      32.5,
-							Name:       "test_33",
+							Scale:      27.5,
+							Name:       "test_28",
 						}
 						return &v
 					}(),
@@ -1723,10 +1351,9 @@ func BenchmarkEncodeDecodeNode(b *testing.B) {
 							FunctionProperties: types.FunctionProperties{
 								Inputs:  []types.Param{{}},
 								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
 							},
 							Kind:          types.Kind(0),
-							Name:          "test_39",
+							Name:          "test_33",
 							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -1736,121 +1363,39 @@ func BenchmarkEncodeDecodeNode(b *testing.B) {
 					}(),
 					ChanDirection: types.ChanDirection(0),
 				},
-				Value: map[string]interface{}{"key_45": "value_45"},
-			},
-		},
-		Inputs: []types.Param{
-			{
-				Name: "test_47",
-				Type: types.Type{
-					FunctionProperties: types.FunctionProperties{
-						Inputs: []types.Param{
-							{
-								Name:  "test_50",
-								Type:  types.Type{},
-								Value: map[string]interface{}{"key_52": "value_52"},
-							},
-						},
-						Outputs: []types.Param{
-							{
-								Name:  "test_54",
-								Type:  types.Type{},
-								Value: map[string]interface{}{"key_56": "value_56"},
-							},
-						},
-						Config: []types.Param{
-							{
-								Name:  "test_58",
-								Type:  types.Type{},
-								Value: map[string]interface{}{"key_60": "value_60"},
-							},
-						},
-					},
-					Kind: types.Kind(0),
-					Name: "test_62",
-					Elem: func() *types.Type {
-						v := types.Type{
-							FunctionProperties: types.FunctionProperties{
-								Inputs:  []types.Param{{}},
-								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
-							},
-							Kind:          types.Kind(0),
-							Name:          "test_68",
-							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-							ChanDirection: types.ChanDirection(0),
-						}
-						return &v
-					}(),
-					Unit: func() *types.Unit {
-						v := types.Unit{
-							Dimensions: types.Dimensions{},
-							Scale:      75.5,
-							Name:       "test_76",
-						}
-						return &v
-					}(),
-					Constraint: func() *types.Type {
-						v := types.Type{
-							FunctionProperties: types.FunctionProperties{
-								Inputs:  []types.Param{{}},
-								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
-							},
-							Kind:          types.Kind(0),
-							Name:          "test_82",
-							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-							ChanDirection: types.ChanDirection(0),
-						}
-						return &v
-					}(),
-					ChanDirection: types.ChanDirection(0),
-				},
-				Value: map[string]interface{}{"key_88": "value_88"},
+				Value: map[string]interface{}{"key_39": "value_39"},
 			},
 		},
 		Outputs: []types.Param{
 			{
-				Name: "test_90",
+				Name: "test_41",
 				Type: types.Type{
 					FunctionProperties: types.FunctionProperties{
 						Inputs: []types.Param{
 							{
-								Name:  "test_93",
+								Name:  "test_44",
 								Type:  types.Type{},
-								Value: map[string]interface{}{"key_95": "value_95"},
+								Value: map[string]interface{}{"key_46": "value_46"},
 							},
 						},
 						Outputs: []types.Param{
 							{
-								Name:  "test_97",
+								Name:  "test_48",
 								Type:  types.Type{},
-								Value: map[string]interface{}{"key_99": "value_99"},
-							},
-						},
-						Config: []types.Param{
-							{
-								Name:  "test_101",
-								Type:  types.Type{},
-								Value: map[string]interface{}{"key_103": "value_103"},
+								Value: map[string]interface{}{"key_50": "value_50"},
 							},
 						},
 					},
 					Kind: types.Kind(0),
-					Name: "test_105",
+					Name: "test_52",
 					Elem: func() *types.Type {
 						v := types.Type{
 							FunctionProperties: types.FunctionProperties{
 								Inputs:  []types.Param{{}},
 								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
 							},
 							Kind:          types.Kind(0),
-							Name:          "test_111",
+							Name:          "test_57",
 							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -1861,8 +1406,8 @@ func BenchmarkEncodeDecodeNode(b *testing.B) {
 					Unit: func() *types.Unit {
 						v := types.Unit{
 							Dimensions: types.Dimensions{},
-							Scale:      118.5,
-							Name:       "test_119",
+							Scale:      64.5,
+							Name:       "test_65",
 						}
 						return &v
 					}(),
@@ -1871,10 +1416,9 @@ func BenchmarkEncodeDecodeNode(b *testing.B) {
 							FunctionProperties: types.FunctionProperties{
 								Inputs:  []types.Param{{}},
 								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
 							},
 							Kind:          types.Kind(0),
-							Name:          "test_125",
+							Name:          "test_70",
 							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -1884,12 +1428,12 @@ func BenchmarkEncodeDecodeNode(b *testing.B) {
 					}(),
 					ChanDirection: types.ChanDirection(0),
 				},
-				Value: map[string]interface{}{"key_131": "value_131"},
+				Value: map[string]interface{}{"key_76": "value_76"},
 			},
 		},
 		Channels: types.Channels{
-			Read:  map[uint32]string{134: "test_133"},
-			Write: map[uint32]string{135: "test_134"},
+			Read:  map[uint32]string{79: "test_78"},
+			Write: map[uint32]string{80: "test_79"},
 		},
 	}
 	w := orc.NewWriter(0)
@@ -2190,7 +1734,7 @@ func FuzzDecodeFunction(f *testing.F) {
 		seed := ir.Function{
 			Key:  "test_1",
 			Body: ir.Body{Raw: "test_3"},
-			Config: []types.Param{
+			Inputs: []types.Param{
 				{
 					Name: "test_5",
 					Type: types.Type{
@@ -2209,25 +1753,17 @@ func FuzzDecodeFunction(f *testing.F) {
 									Value: map[string]interface{}{"key_14": "value_14"},
 								},
 							},
-							Config: []types.Param{
-								{
-									Name:  "test_16",
-									Type:  types.Type{},
-									Value: map[string]interface{}{"key_18": "value_18"},
-								},
-							},
 						},
 						Kind: types.Kind(0),
-						Name: "test_20",
+						Name: "test_16",
 						Elem: func() *types.Type {
 							v := types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_26",
+								Name:          "test_21",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -2238,8 +1774,8 @@ func FuzzDecodeFunction(f *testing.F) {
 						Unit: func() *types.Unit {
 							v := types.Unit{
 								Dimensions: types.Dimensions{},
-								Scale:      33.5,
-								Name:       "test_34",
+								Scale:      28.5,
+								Name:       "test_29",
 							}
 							return &v
 						}(),
@@ -2248,10 +1784,9 @@ func FuzzDecodeFunction(f *testing.F) {
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_40",
+								Name:          "test_34",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -2261,121 +1796,39 @@ func FuzzDecodeFunction(f *testing.F) {
 						}(),
 						ChanDirection: types.ChanDirection(0),
 					},
-					Value: map[string]interface{}{"key_46": "value_46"},
-				},
-			},
-			Inputs: []types.Param{
-				{
-					Name: "test_48",
-					Type: types.Type{
-						FunctionProperties: types.FunctionProperties{
-							Inputs: []types.Param{
-								{
-									Name:  "test_51",
-									Type:  types.Type{},
-									Value: map[string]interface{}{"key_53": "value_53"},
-								},
-							},
-							Outputs: []types.Param{
-								{
-									Name:  "test_55",
-									Type:  types.Type{},
-									Value: map[string]interface{}{"key_57": "value_57"},
-								},
-							},
-							Config: []types.Param{
-								{
-									Name:  "test_59",
-									Type:  types.Type{},
-									Value: map[string]interface{}{"key_61": "value_61"},
-								},
-							},
-						},
-						Kind: types.Kind(0),
-						Name: "test_63",
-						Elem: func() *types.Type {
-							v := types.Type{
-								FunctionProperties: types.FunctionProperties{
-									Inputs:  []types.Param{{}},
-									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
-								},
-								Kind:          types.Kind(0),
-								Name:          "test_69",
-								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-								ChanDirection: types.ChanDirection(0),
-							}
-							return &v
-						}(),
-						Unit: func() *types.Unit {
-							v := types.Unit{
-								Dimensions: types.Dimensions{},
-								Scale:      76.5,
-								Name:       "test_77",
-							}
-							return &v
-						}(),
-						Constraint: func() *types.Type {
-							v := types.Type{
-								FunctionProperties: types.FunctionProperties{
-									Inputs:  []types.Param{{}},
-									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
-								},
-								Kind:          types.Kind(0),
-								Name:          "test_83",
-								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-								ChanDirection: types.ChanDirection(0),
-							}
-							return &v
-						}(),
-						ChanDirection: types.ChanDirection(0),
-					},
-					Value: map[string]interface{}{"key_89": "value_89"},
+					Value: map[string]interface{}{"key_40": "value_40"},
 				},
 			},
 			Outputs: []types.Param{
 				{
-					Name: "test_91",
+					Name: "test_42",
 					Type: types.Type{
 						FunctionProperties: types.FunctionProperties{
 							Inputs: []types.Param{
 								{
-									Name:  "test_94",
+									Name:  "test_45",
 									Type:  types.Type{},
-									Value: map[string]interface{}{"key_96": "value_96"},
+									Value: map[string]interface{}{"key_47": "value_47"},
 								},
 							},
 							Outputs: []types.Param{
 								{
-									Name:  "test_98",
+									Name:  "test_49",
 									Type:  types.Type{},
-									Value: map[string]interface{}{"key_100": "value_100"},
-								},
-							},
-							Config: []types.Param{
-								{
-									Name:  "test_102",
-									Type:  types.Type{},
-									Value: map[string]interface{}{"key_104": "value_104"},
+									Value: map[string]interface{}{"key_51": "value_51"},
 								},
 							},
 						},
 						Kind: types.Kind(0),
-						Name: "test_106",
+						Name: "test_53",
 						Elem: func() *types.Type {
 							v := types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_112",
+								Name:          "test_58",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -2386,8 +1839,8 @@ func FuzzDecodeFunction(f *testing.F) {
 						Unit: func() *types.Unit {
 							v := types.Unit{
 								Dimensions: types.Dimensions{},
-								Scale:      119.5,
-								Name:       "test_120",
+								Scale:      65.5,
+								Name:       "test_66",
 							}
 							return &v
 						}(),
@@ -2396,10 +1849,9 @@ func FuzzDecodeFunction(f *testing.F) {
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_126",
+								Name:          "test_71",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -2409,12 +1861,12 @@ func FuzzDecodeFunction(f *testing.F) {
 						}(),
 						ChanDirection: types.ChanDirection(0),
 					},
-					Value: map[string]interface{}{"key_132": "value_132"},
+					Value: map[string]interface{}{"key_77": "value_77"},
 				},
 			},
 			Channels: types.Channels{
-				Read:  map[uint32]string{135: "test_134"},
-				Write: map[uint32]string{136: "test_135"},
+				Read:  map[uint32]string{80: "test_79"},
+				Write: map[uint32]string{81: "test_80"},
 			},
 		}
 		w := orc.NewWriter(0)
@@ -2427,7 +1879,6 @@ func FuzzDecodeFunction(f *testing.F) {
 		seed := ir.Function{
 			Key:      "",
 			Body:     ir.Body{Raw: ""},
-			Config:   nil,
 			Inputs:   nil,
 			Outputs:  nil,
 			Channels: types.Channels{Read: nil, Write: nil},
@@ -2442,7 +1893,6 @@ func FuzzDecodeFunction(f *testing.F) {
 		seed := ir.Function{
 			Key:      "test_1",
 			Body:     ir.Body{Raw: "test_3"},
-			Config:   []types.Param{},
 			Inputs:   []types.Param{},
 			Outputs:  []types.Param{},
 			Channels: types.Channels{Read: map[uint32]string{}, Write: map[uint32]string{}},
@@ -2535,159 +1985,117 @@ func FuzzDecodeIR(f *testing.F) {
 				{
 					Key:  "test_2",
 					Body: ir.Body{Raw: "test_4"},
-					Config: []types.Param{
+					Inputs: []types.Param{
 						{
 							Name: "test_6",
 							Type: types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_12",
+								Name:          "test_11",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 								ChanDirection: types.ChanDirection(0),
 							},
-							Value: map[string]interface{}{"key_17": "value_17"},
-						},
-					},
-					Inputs: []types.Param{
-						{
-							Name: "test_19",
-							Type: types.Type{
-								FunctionProperties: types.FunctionProperties{
-									Inputs:  []types.Param{{}},
-									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
-								},
-								Kind:          types.Kind(0),
-								Name:          "test_25",
-								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-								ChanDirection: types.ChanDirection(0),
-							},
-							Value: map[string]interface{}{"key_30": "value_30"},
+							Value: map[string]interface{}{"key_16": "value_16"},
 						},
 					},
 					Outputs: []types.Param{
 						{
-							Name: "test_32",
+							Name: "test_18",
 							Type: types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_38",
+								Name:          "test_23",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 								ChanDirection: types.ChanDirection(0),
 							},
-							Value: map[string]interface{}{"key_43": "value_43"},
+							Value: map[string]interface{}{"key_28": "value_28"},
 						},
 					},
 					Channels: types.Channels{
-						Read:  map[uint32]string{46: "test_45"},
-						Write: map[uint32]string{47: "test_46"},
+						Read:  map[uint32]string{31: "test_30"},
+						Write: map[uint32]string{32: "test_31"},
 					},
 				},
 			},
 			Nodes: []ir.Node{
 				{
-					Key:  "test_48",
-					Type: "test_49",
-					Config: []types.Param{
-						{
-							Name: "test_51",
-							Type: types.Type{
-								FunctionProperties: types.FunctionProperties{
-									Inputs:  []types.Param{{}},
-									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
-								},
-								Kind:          types.Kind(0),
-								Name:          "test_57",
-								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-								ChanDirection: types.ChanDirection(0),
-							},
-							Value: map[string]interface{}{"key_62": "value_62"},
-						},
-					},
+					Key:  "test_33",
+					Type: "test_34",
 					Inputs: []types.Param{
 						{
-							Name: "test_64",
+							Name: "test_36",
 							Type: types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_70",
+								Name:          "test_41",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 								ChanDirection: types.ChanDirection(0),
 							},
-							Value: map[string]interface{}{"key_75": "value_75"},
+							Value: map[string]interface{}{"key_46": "value_46"},
 						},
 					},
 					Outputs: []types.Param{
 						{
-							Name: "test_77",
+							Name: "test_48",
 							Type: types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_83",
+								Name:          "test_53",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 								ChanDirection: types.ChanDirection(0),
 							},
-							Value: map[string]interface{}{"key_88": "value_88"},
+							Value: map[string]interface{}{"key_58": "value_58"},
 						},
 					},
 					Channels: types.Channels{
-						Read:  map[uint32]string{91: "test_90"},
-						Write: map[uint32]string{92: "test_91"},
+						Read:  map[uint32]string{61: "test_60"},
+						Write: map[uint32]string{62: "test_61"},
 					},
 				},
 			},
 			Edges: []ir.Edge{
 				{
-					Source: ir.Handle{Node: "test_94", Param: "test_95"},
-					Target: ir.Handle{Node: "test_97", Param: "test_98"},
+					Source: ir.Handle{Node: "test_64", Param: "test_65"},
+					Target: ir.Handle{Node: "test_67", Param: "test_68"},
 					Kind:   ir.EdgeKind(0),
 				},
 			},
 			Authorities: ir.Authorities{
-				Default:  func() *uint8 { v := uint8(102); return &v }(),
-				Channels: map[uint32]uint8{103: 103},
+				Default:  func() *uint8 { v := uint8(72); return &v }(),
+				Channels: map[uint32]uint8{73: 73},
 			},
 			Root: ir.Scope{
-				Key:        "test_104",
+				Key:        "test_74",
 				Mode:       ir.ScopeMode(0),
 				Liveness:   ir.Liveness(0),
-				Activation: func() *ir.Handle { v := ir.Handle{Node: "test_108", Param: "test_109"}; return &v }(),
+				Activation: func() *ir.Handle { v := ir.Handle{Node: "test_78", Param: "test_79"}; return &v }(),
 				Strata: [][]ir.Member{
 					{
 						{
-							NodeKey: func() *string { v := string("test_111"); return &v }(),
+							NodeKey: func() *string { v := string("test_81"); return &v }(),
 							Scope: func() *ir.Scope {
 								v := ir.Scope{
-									Key:         "test_113",
+									Key:         "test_83",
 									Mode:        ir.ScopeMode(0),
 									Liveness:    ir.Liveness(0),
 									Activation:  func() *ir.Handle { v := ir.Handle{}; return &v }(),
@@ -2702,10 +2110,10 @@ func FuzzDecodeIR(f *testing.F) {
 				},
 				Steps: []ir.Member{
 					{
-						NodeKey: func() *string { v := string("test_121"); return &v }(),
+						NodeKey: func() *string { v := string("test_91"); return &v }(),
 						Scope: func() *ir.Scope {
 							v := ir.Scope{
-								Key:         "test_123",
+								Key:         "test_93",
 								Mode:        ir.ScopeMode(0),
 								Liveness:    ir.Liveness(0),
 								Activation:  func() *ir.Handle { v := ir.Handle{}; return &v }(),
@@ -2719,8 +2127,8 @@ func FuzzDecodeIR(f *testing.F) {
 				},
 				Transitions: []ir.Transition{
 					{
-						On:        ir.Handle{Node: "test_132", Param: "test_133"},
-						TargetKey: func() *string { v := string("test_134"); return &v }(),
+						On:        ir.Handle{Node: "test_102", Param: "test_103"},
+						TargetKey: func() *string { v := string("test_104"); return &v }(),
 					},
 				},
 			},
@@ -2911,7 +2319,7 @@ func FuzzDecodeNode(f *testing.F) {
 		seed := ir.Node{
 			Key:  "test_1",
 			Type: "test_2",
-			Config: []types.Param{
+			Inputs: []types.Param{
 				{
 					Name: "test_4",
 					Type: types.Type{
@@ -2930,25 +2338,17 @@ func FuzzDecodeNode(f *testing.F) {
 									Value: map[string]interface{}{"key_13": "value_13"},
 								},
 							},
-							Config: []types.Param{
-								{
-									Name:  "test_15",
-									Type:  types.Type{},
-									Value: map[string]interface{}{"key_17": "value_17"},
-								},
-							},
 						},
 						Kind: types.Kind(0),
-						Name: "test_19",
+						Name: "test_15",
 						Elem: func() *types.Type {
 							v := types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_25",
+								Name:          "test_20",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -2959,8 +2359,8 @@ func FuzzDecodeNode(f *testing.F) {
 						Unit: func() *types.Unit {
 							v := types.Unit{
 								Dimensions: types.Dimensions{},
-								Scale:      32.5,
-								Name:       "test_33",
+								Scale:      27.5,
+								Name:       "test_28",
 							}
 							return &v
 						}(),
@@ -2969,10 +2369,9 @@ func FuzzDecodeNode(f *testing.F) {
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_39",
+								Name:          "test_33",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -2982,121 +2381,39 @@ func FuzzDecodeNode(f *testing.F) {
 						}(),
 						ChanDirection: types.ChanDirection(0),
 					},
-					Value: map[string]interface{}{"key_45": "value_45"},
-				},
-			},
-			Inputs: []types.Param{
-				{
-					Name: "test_47",
-					Type: types.Type{
-						FunctionProperties: types.FunctionProperties{
-							Inputs: []types.Param{
-								{
-									Name:  "test_50",
-									Type:  types.Type{},
-									Value: map[string]interface{}{"key_52": "value_52"},
-								},
-							},
-							Outputs: []types.Param{
-								{
-									Name:  "test_54",
-									Type:  types.Type{},
-									Value: map[string]interface{}{"key_56": "value_56"},
-								},
-							},
-							Config: []types.Param{
-								{
-									Name:  "test_58",
-									Type:  types.Type{},
-									Value: map[string]interface{}{"key_60": "value_60"},
-								},
-							},
-						},
-						Kind: types.Kind(0),
-						Name: "test_62",
-						Elem: func() *types.Type {
-							v := types.Type{
-								FunctionProperties: types.FunctionProperties{
-									Inputs:  []types.Param{{}},
-									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
-								},
-								Kind:          types.Kind(0),
-								Name:          "test_68",
-								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-								ChanDirection: types.ChanDirection(0),
-							}
-							return &v
-						}(),
-						Unit: func() *types.Unit {
-							v := types.Unit{
-								Dimensions: types.Dimensions{},
-								Scale:      75.5,
-								Name:       "test_76",
-							}
-							return &v
-						}(),
-						Constraint: func() *types.Type {
-							v := types.Type{
-								FunctionProperties: types.FunctionProperties{
-									Inputs:  []types.Param{{}},
-									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
-								},
-								Kind:          types.Kind(0),
-								Name:          "test_82",
-								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-								ChanDirection: types.ChanDirection(0),
-							}
-							return &v
-						}(),
-						ChanDirection: types.ChanDirection(0),
-					},
-					Value: map[string]interface{}{"key_88": "value_88"},
+					Value: map[string]interface{}{"key_39": "value_39"},
 				},
 			},
 			Outputs: []types.Param{
 				{
-					Name: "test_90",
+					Name: "test_41",
 					Type: types.Type{
 						FunctionProperties: types.FunctionProperties{
 							Inputs: []types.Param{
 								{
-									Name:  "test_93",
+									Name:  "test_44",
 									Type:  types.Type{},
-									Value: map[string]interface{}{"key_95": "value_95"},
+									Value: map[string]interface{}{"key_46": "value_46"},
 								},
 							},
 							Outputs: []types.Param{
 								{
-									Name:  "test_97",
+									Name:  "test_48",
 									Type:  types.Type{},
-									Value: map[string]interface{}{"key_99": "value_99"},
-								},
-							},
-							Config: []types.Param{
-								{
-									Name:  "test_101",
-									Type:  types.Type{},
-									Value: map[string]interface{}{"key_103": "value_103"},
+									Value: map[string]interface{}{"key_50": "value_50"},
 								},
 							},
 						},
 						Kind: types.Kind(0),
-						Name: "test_105",
+						Name: "test_52",
 						Elem: func() *types.Type {
 							v := types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_111",
+								Name:          "test_57",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -3107,8 +2424,8 @@ func FuzzDecodeNode(f *testing.F) {
 						Unit: func() *types.Unit {
 							v := types.Unit{
 								Dimensions: types.Dimensions{},
-								Scale:      118.5,
-								Name:       "test_119",
+								Scale:      64.5,
+								Name:       "test_65",
 							}
 							return &v
 						}(),
@@ -3117,10 +2434,9 @@ func FuzzDecodeNode(f *testing.F) {
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_125",
+								Name:          "test_70",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -3130,12 +2446,12 @@ func FuzzDecodeNode(f *testing.F) {
 						}(),
 						ChanDirection: types.ChanDirection(0),
 					},
-					Value: map[string]interface{}{"key_131": "value_131"},
+					Value: map[string]interface{}{"key_76": "value_76"},
 				},
 			},
 			Channels: types.Channels{
-				Read:  map[uint32]string{134: "test_133"},
-				Write: map[uint32]string{135: "test_134"},
+				Read:  map[uint32]string{79: "test_78"},
+				Write: map[uint32]string{80: "test_79"},
 			},
 		}
 		w := orc.NewWriter(0)
@@ -3148,7 +2464,6 @@ func FuzzDecodeNode(f *testing.F) {
 		seed := ir.Node{
 			Key:      "",
 			Type:     "",
-			Config:   nil,
 			Inputs:   nil,
 			Outputs:  nil,
 			Channels: types.Channels{Read: nil, Write: nil},
@@ -3163,7 +2478,6 @@ func FuzzDecodeNode(f *testing.F) {
 		seed := ir.Node{
 			Key:      "test_1",
 			Type:     "test_2",
-			Config:   []types.Param{},
 			Inputs:   []types.Param{},
 			Outputs:  []types.Param{},
 			Channels: types.Channels{Read: map[uint32]string{}, Write: map[uint32]string{}},

--- a/arc/go/ir/pb/ir.pb.go
+++ b/arc/go/ir/pb/ir.pb.go
@@ -620,14 +620,12 @@ type Function struct {
 	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
 	// body is raw source code for user-defined functions.
 	Body *Body `protobuf:"bytes,2,opt,name=body,proto3" json:"body,omitempty"`
-	// config contains configuration parameter definitions.
-	Config []*pb.Param `protobuf:"bytes,3,rep,name=config,proto3" json:"config,omitempty"`
 	// inputs contains input parameter definitions.
-	Inputs []*pb.Param `protobuf:"bytes,4,rep,name=inputs,proto3" json:"inputs,omitempty"`
+	Inputs []*pb.Param `protobuf:"bytes,3,rep,name=inputs,proto3" json:"inputs,omitempty"`
 	// outputs contains output parameter definitions.
-	Outputs []*pb.Param `protobuf:"bytes,5,rep,name=outputs,proto3" json:"outputs,omitempty"`
+	Outputs []*pb.Param `protobuf:"bytes,4,rep,name=outputs,proto3" json:"outputs,omitempty"`
 	// channels contains channel read/write declarations.
-	Channels      *pb.Channels `protobuf:"bytes,6,opt,name=channels,proto3" json:"channels,omitempty"`
+	Channels      *pb.Channels `protobuf:"bytes,5,opt,name=channels,proto3" json:"channels,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -676,13 +674,6 @@ func (x *Function) GetBody() *Body {
 	return nil
 }
 
-func (x *Function) GetConfig() []*pb.Param {
-	if x != nil {
-		return x.Config
-	}
-	return nil
-}
-
 func (x *Function) GetInputs() []*pb.Param {
 	if x != nil {
 		return x.Inputs
@@ -704,22 +695,19 @@ func (x *Function) GetChannels() *pb.Channels {
 	return nil
 }
 
-// Node is a concrete instantiation of a function with typed parameters and
-// configuration values.
+// Node is a concrete instantiation of a function with typed parameters and values.
 type Node struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// key is the unique identifier for this node instance.
 	Key string `protobuf:"bytes,1,opt,name=key,proto3" json:"key,omitempty"`
 	// type is the function type being instantiated.
 	Type string `protobuf:"bytes,2,opt,name=type,proto3" json:"type,omitempty"`
-	// config contains configuration parameter values.
-	Config []*pb.Param `protobuf:"bytes,3,rep,name=config,proto3" json:"config,omitempty"`
 	// inputs contains input parameter type signatures.
-	Inputs []*pb.Param `protobuf:"bytes,4,rep,name=inputs,proto3" json:"inputs,omitempty"`
+	Inputs []*pb.Param `protobuf:"bytes,3,rep,name=inputs,proto3" json:"inputs,omitempty"`
 	// outputs contains output parameter type signatures.
-	Outputs []*pb.Param `protobuf:"bytes,5,rep,name=outputs,proto3" json:"outputs,omitempty"`
+	Outputs []*pb.Param `protobuf:"bytes,4,rep,name=outputs,proto3" json:"outputs,omitempty"`
 	// channels contains channel read/write mappings.
-	Channels      *pb.Channels `protobuf:"bytes,6,opt,name=channels,proto3" json:"channels,omitempty"`
+	Channels      *pb.Channels `protobuf:"bytes,5,opt,name=channels,proto3" json:"channels,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -766,13 +754,6 @@ func (x *Node) GetType() string {
 		return x.Type
 	}
 	return ""
-}
-
-func (x *Node) GetConfig() []*pb.Param {
-	if x != nil {
-		return x.Config
-	}
-	return nil
 }
 
 func (x *Node) GetInputs() []*pb.Param {
@@ -972,21 +953,19 @@ const file_arc_go_ir_pb_ir_proto_rawDesc = "" +
 	"\vtransitions\x18\a \x03(\v2\x15.arc.ir.pb.TransitionR\vtransitionsB\r\n" +
 	"\v_activation\"\x18\n" +
 	"\x04Body\x12\x10\n" +
-	"\x03raw\x18\x01 \x01(\tR\x03raw\"\xfe\x01\n" +
+	"\x03raw\x18\x01 \x01(\tR\x03raw\"\xd1\x01\n" +
 	"\bFunction\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12#\n" +
 	"\x04body\x18\x02 \x01(\v2\x0f.arc.ir.pb.BodyR\x04body\x12+\n" +
-	"\x06config\x18\x03 \x03(\v2\x13.arc.types.pb.ParamR\x06config\x12+\n" +
-	"\x06inputs\x18\x04 \x03(\v2\x13.arc.types.pb.ParamR\x06inputs\x12-\n" +
-	"\aoutputs\x18\x05 \x03(\v2\x13.arc.types.pb.ParamR\aoutputs\x122\n" +
-	"\bchannels\x18\x06 \x01(\v2\x16.arc.types.pb.ChannelsR\bchannels\"\xe9\x01\n" +
+	"\x06inputs\x18\x03 \x03(\v2\x13.arc.types.pb.ParamR\x06inputs\x12-\n" +
+	"\aoutputs\x18\x04 \x03(\v2\x13.arc.types.pb.ParamR\aoutputs\x122\n" +
+	"\bchannels\x18\x05 \x01(\v2\x16.arc.types.pb.ChannelsR\bchannels\"\xbc\x01\n" +
 	"\x04Node\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12\x12\n" +
 	"\x04type\x18\x02 \x01(\tR\x04type\x12+\n" +
-	"\x06config\x18\x03 \x03(\v2\x13.arc.types.pb.ParamR\x06config\x12+\n" +
-	"\x06inputs\x18\x04 \x03(\v2\x13.arc.types.pb.ParamR\x06inputs\x12-\n" +
-	"\aoutputs\x18\x05 \x03(\v2\x13.arc.types.pb.ParamR\aoutputs\x122\n" +
-	"\bchannels\x18\x06 \x01(\v2\x16.arc.types.pb.ChannelsR\bchannels\"\xb7\x01\n" +
+	"\x06inputs\x18\x03 \x03(\v2\x13.arc.types.pb.ParamR\x06inputs\x12-\n" +
+	"\aoutputs\x18\x04 \x03(\v2\x13.arc.types.pb.ParamR\aoutputs\x122\n" +
+	"\bchannels\x18\x05 \x01(\v2\x16.arc.types.pb.ChannelsR\bchannels\"\xb7\x01\n" +
 	"\vAuthorities\x12\x1d\n" +
 	"\adefault\x18\x01 \x01(\rH\x00R\adefault\x88\x01\x01\x12@\n" +
 	"\bchannels\x18\x02 \x03(\v2$.arc.ir.pb.Authorities.ChannelsEntryR\bchannels\x1a;\n" +
@@ -1062,25 +1041,23 @@ var file_arc_go_ir_pb_ir_proto_depIdxs = []int32{
 	6,  // 10: arc.ir.pb.Scope.steps:type_name -> arc.ir.pb.Member
 	5,  // 11: arc.ir.pb.Scope.transitions:type_name -> arc.ir.pb.Transition
 	9,  // 12: arc.ir.pb.Function.body:type_name -> arc.ir.pb.Body
-	15, // 13: arc.ir.pb.Function.config:type_name -> arc.types.pb.Param
-	15, // 14: arc.ir.pb.Function.inputs:type_name -> arc.types.pb.Param
-	15, // 15: arc.ir.pb.Function.outputs:type_name -> arc.types.pb.Param
-	16, // 16: arc.ir.pb.Function.channels:type_name -> arc.types.pb.Channels
-	15, // 17: arc.ir.pb.Node.config:type_name -> arc.types.pb.Param
-	15, // 18: arc.ir.pb.Node.inputs:type_name -> arc.types.pb.Param
-	15, // 19: arc.ir.pb.Node.outputs:type_name -> arc.types.pb.Param
-	16, // 20: arc.ir.pb.Node.channels:type_name -> arc.types.pb.Channels
-	14, // 21: arc.ir.pb.Authorities.channels:type_name -> arc.ir.pb.Authorities.ChannelsEntry
-	10, // 22: arc.ir.pb.IR.functions:type_name -> arc.ir.pb.Function
-	11, // 23: arc.ir.pb.IR.nodes:type_name -> arc.ir.pb.Node
-	4,  // 24: arc.ir.pb.IR.edges:type_name -> arc.ir.pb.Edge
-	12, // 25: arc.ir.pb.IR.authorities:type_name -> arc.ir.pb.Authorities
-	8,  // 26: arc.ir.pb.IR.root:type_name -> arc.ir.pb.Scope
-	27, // [27:27] is the sub-list for method output_type
-	27, // [27:27] is the sub-list for method input_type
-	27, // [27:27] is the sub-list for extension type_name
-	27, // [27:27] is the sub-list for extension extendee
-	0,  // [0:27] is the sub-list for field type_name
+	15, // 13: arc.ir.pb.Function.inputs:type_name -> arc.types.pb.Param
+	15, // 14: arc.ir.pb.Function.outputs:type_name -> arc.types.pb.Param
+	16, // 15: arc.ir.pb.Function.channels:type_name -> arc.types.pb.Channels
+	15, // 16: arc.ir.pb.Node.inputs:type_name -> arc.types.pb.Param
+	15, // 17: arc.ir.pb.Node.outputs:type_name -> arc.types.pb.Param
+	16, // 18: arc.ir.pb.Node.channels:type_name -> arc.types.pb.Channels
+	14, // 19: arc.ir.pb.Authorities.channels:type_name -> arc.ir.pb.Authorities.ChannelsEntry
+	10, // 20: arc.ir.pb.IR.functions:type_name -> arc.ir.pb.Function
+	11, // 21: arc.ir.pb.IR.nodes:type_name -> arc.ir.pb.Node
+	4,  // 22: arc.ir.pb.IR.edges:type_name -> arc.ir.pb.Edge
+	12, // 23: arc.ir.pb.IR.authorities:type_name -> arc.ir.pb.Authorities
+	8,  // 24: arc.ir.pb.IR.root:type_name -> arc.ir.pb.Scope
+	25, // [25:25] is the sub-list for method output_type
+	25, // [25:25] is the sub-list for method input_type
+	25, // [25:25] is the sub-list for extension type_name
+	25, // [25:25] is the sub-list for extension extendee
+	0,  // [0:25] is the sub-list for field type_name
 }
 
 func init() { file_arc_go_ir_pb_ir_proto_init() }

--- a/arc/go/ir/pb/ir.proto
+++ b/arc/go/ir/pb/ir.proto
@@ -116,31 +116,26 @@ message Function {
   string key = 1;
   // body is raw source code for user-defined functions.
   Body body = 2;
-  // config contains configuration parameter definitions.
-  repeated .arc.types.pb.Param config = 3;
   // inputs contains input parameter definitions.
-  repeated .arc.types.pb.Param inputs = 4;
+  repeated .arc.types.pb.Param inputs = 3;
   // outputs contains output parameter definitions.
-  repeated .arc.types.pb.Param outputs = 5;
+  repeated .arc.types.pb.Param outputs = 4;
   // channels contains channel read/write declarations.
-  .arc.types.pb.Channels channels = 6;
+  .arc.types.pb.Channels channels = 5;
 }
 
-// Node is a concrete instantiation of a function with typed parameters and
-// configuration values.
+// Node is a concrete instantiation of a function with typed parameters and values.
 message Node {
   // key is the unique identifier for this node instance.
   string key = 1;
   // type is the function type being instantiated.
   string type = 2;
-  // config contains configuration parameter values.
-  repeated .arc.types.pb.Param config = 3;
   // inputs contains input parameter type signatures.
-  repeated .arc.types.pb.Param inputs = 4;
+  repeated .arc.types.pb.Param inputs = 3;
   // outputs contains output parameter type signatures.
-  repeated .arc.types.pb.Param outputs = 5;
+  repeated .arc.types.pb.Param outputs = 4;
   // channels contains channel read/write mappings.
-  .arc.types.pb.Channels channels = 6;
+  .arc.types.pb.Channels channels = 5;
 }
 
 // Authorities holds the static authority declarations from an Arc program.

--- a/arc/go/ir/pb/translator.gen.go
+++ b/arc/go/ir/pb/translator.gen.go
@@ -426,10 +426,6 @@ func FunctionToPB(r ir.Function) (*Function, error) {
 	if err != nil {
 		return nil, err
 	}
-	configVal, err := typespb.ParamsToPB(r.Config)
-	if err != nil {
-		return nil, err
-	}
 	inputsVal, err := typespb.ParamsToPB(r.Inputs)
 	if err != nil {
 		return nil, err
@@ -445,7 +441,6 @@ func FunctionToPB(r ir.Function) (*Function, error) {
 	pb := &Function{
 		Key:      r.Key,
 		Body:     bodyVal,
-		Config:   configVal,
 		Inputs:   inputsVal,
 		Outputs:  outputsVal,
 		Channels: channelsVal,
@@ -461,10 +456,6 @@ func FunctionFromPB(pb *Function) (ir.Function, error) {
 	}
 	var err error
 	r.Body, err = BodyFromPB(pb.Body)
-	if err != nil {
-		return ir.Function{}, err
-	}
-	r.Config, err = typespb.ParamsFromPB(pb.Config)
 	if err != nil {
 		return ir.Function{}, err
 	}
@@ -512,10 +503,6 @@ func FunctionsFromPB(pbs []*Function) ([]ir.Function, error) {
 
 // NodeToPB converts Node to Node.
 func NodeToPB(r ir.Node) (*Node, error) {
-	configVal, err := typespb.ParamsToPB(r.Config)
-	if err != nil {
-		return nil, err
-	}
 	inputsVal, err := typespb.ParamsToPB(r.Inputs)
 	if err != nil {
 		return nil, err
@@ -531,7 +518,6 @@ func NodeToPB(r ir.Node) (*Node, error) {
 	pb := &Node{
 		Key:      r.Key,
 		Type:     r.Type,
-		Config:   configVal,
 		Inputs:   inputsVal,
 		Outputs:  outputsVal,
 		Channels: channelsVal,
@@ -546,10 +532,6 @@ func NodeFromPB(pb *Node) (ir.Node, error) {
 		return r, nil
 	}
 	var err error
-	r.Config, err = typespb.ParamsFromPB(pb.Config)
-	if err != nil {
-		return ir.Node{}, err
-	}
 	r.Inputs, err = typespb.ParamsFromPB(pb.Inputs)
 	if err != nil {
 		return ir.Node{}, err

--- a/arc/go/ir/types.gen.go
+++ b/arc/go/ir/types.gen.go
@@ -138,8 +138,6 @@ type Function struct {
 	Key string `json:"key" msgpack:"key"`
 	// Body is raw source code for user-defined functions.
 	Body Body `json:"body" msgpack:"body"`
-	// Config contains configuration parameter definitions.
-	Config types.Params `json:"config" msgpack:"config"`
 	// Inputs contains input parameter definitions.
 	Inputs types.Params `json:"inputs" msgpack:"inputs"`
 	// Outputs contains output parameter definitions.
@@ -148,15 +146,12 @@ type Function struct {
 	Channels types.Channels `json:"channels" msgpack:"channels"`
 }
 
-// Node is a concrete instantiation of a function with typed parameters and
-// configuration values.
+// Node is a concrete instantiation of a function with typed parameters and values.
 type Node struct {
 	// Key is the unique identifier for this node instance.
 	Key string `json:"key" msgpack:"key"`
 	// Type is the function type being instantiated.
 	Type string `json:"type" msgpack:"type"`
-	// Config contains configuration parameter values.
-	Config types.Params `json:"config" msgpack:"config"`
 	// Inputs contains input parameter type signatures.
 	Inputs types.Params `json:"inputs" msgpack:"inputs"`
 	// Outputs contains output parameter type signatures.

--- a/arc/go/program/codec_gen_test.go
+++ b/arc/go/program/codec_gen_test.go
@@ -43,159 +43,117 @@ var _ = Describe("Codec", func() {
 						{
 							Key:  "test_2",
 							Body: ir.Body{Raw: "test_4"},
-							Config: []types.Param{
+							Inputs: []types.Param{
 								{
 									Name: "test_6",
 									Type: types.Type{
 										FunctionProperties: types.FunctionProperties{
 											Inputs:  []types.Param{{}},
 											Outputs: []types.Param{{}},
-											Config:  []types.Param{{}},
 										},
 										Kind:          types.Kind(0),
-										Name:          "test_12",
+										Name:          "test_11",
 										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 										ChanDirection: types.ChanDirection(0),
 									},
-									Value: map[string]interface{}{"key_17": "value_17"},
-								},
-							},
-							Inputs: []types.Param{
-								{
-									Name: "test_19",
-									Type: types.Type{
-										FunctionProperties: types.FunctionProperties{
-											Inputs:  []types.Param{{}},
-											Outputs: []types.Param{{}},
-											Config:  []types.Param{{}},
-										},
-										Kind:          types.Kind(0),
-										Name:          "test_25",
-										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-										ChanDirection: types.ChanDirection(0),
-									},
-									Value: map[string]interface{}{"key_30": "value_30"},
+									Value: map[string]interface{}{"key_16": "value_16"},
 								},
 							},
 							Outputs: []types.Param{
 								{
-									Name: "test_32",
+									Name: "test_18",
 									Type: types.Type{
 										FunctionProperties: types.FunctionProperties{
 											Inputs:  []types.Param{{}},
 											Outputs: []types.Param{{}},
-											Config:  []types.Param{{}},
 										},
 										Kind:          types.Kind(0),
-										Name:          "test_38",
+										Name:          "test_23",
 										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 										ChanDirection: types.ChanDirection(0),
 									},
-									Value: map[string]interface{}{"key_43": "value_43"},
+									Value: map[string]interface{}{"key_28": "value_28"},
 								},
 							},
 							Channels: types.Channels{
-								Read:  map[uint32]string{46: "test_45"},
-								Write: map[uint32]string{47: "test_46"},
+								Read:  map[uint32]string{31: "test_30"},
+								Write: map[uint32]string{32: "test_31"},
 							},
 						},
 					},
 					Nodes: []ir.Node{
 						{
-							Key:  "test_48",
-							Type: "test_49",
-							Config: []types.Param{
-								{
-									Name: "test_51",
-									Type: types.Type{
-										FunctionProperties: types.FunctionProperties{
-											Inputs:  []types.Param{{}},
-											Outputs: []types.Param{{}},
-											Config:  []types.Param{{}},
-										},
-										Kind:          types.Kind(0),
-										Name:          "test_57",
-										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-										ChanDirection: types.ChanDirection(0),
-									},
-									Value: map[string]interface{}{"key_62": "value_62"},
-								},
-							},
+							Key:  "test_33",
+							Type: "test_34",
 							Inputs: []types.Param{
 								{
-									Name: "test_64",
+									Name: "test_36",
 									Type: types.Type{
 										FunctionProperties: types.FunctionProperties{
 											Inputs:  []types.Param{{}},
 											Outputs: []types.Param{{}},
-											Config:  []types.Param{{}},
 										},
 										Kind:          types.Kind(0),
-										Name:          "test_70",
+										Name:          "test_41",
 										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 										ChanDirection: types.ChanDirection(0),
 									},
-									Value: map[string]interface{}{"key_75": "value_75"},
+									Value: map[string]interface{}{"key_46": "value_46"},
 								},
 							},
 							Outputs: []types.Param{
 								{
-									Name: "test_77",
+									Name: "test_48",
 									Type: types.Type{
 										FunctionProperties: types.FunctionProperties{
 											Inputs:  []types.Param{{}},
 											Outputs: []types.Param{{}},
-											Config:  []types.Param{{}},
 										},
 										Kind:          types.Kind(0),
-										Name:          "test_83",
+										Name:          "test_53",
 										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 										ChanDirection: types.ChanDirection(0),
 									},
-									Value: map[string]interface{}{"key_88": "value_88"},
+									Value: map[string]interface{}{"key_58": "value_58"},
 								},
 							},
 							Channels: types.Channels{
-								Read:  map[uint32]string{91: "test_90"},
-								Write: map[uint32]string{92: "test_91"},
+								Read:  map[uint32]string{61: "test_60"},
+								Write: map[uint32]string{62: "test_61"},
 							},
 						},
 					},
 					Edges: []ir.Edge{
 						{
-							Source: ir.Handle{Node: "test_94", Param: "test_95"},
-							Target: ir.Handle{Node: "test_97", Param: "test_98"},
+							Source: ir.Handle{Node: "test_64", Param: "test_65"},
+							Target: ir.Handle{Node: "test_67", Param: "test_68"},
 							Kind:   ir.EdgeKind(0),
 						},
 					},
 					Authorities: ir.Authorities{
-						Default:  func() *uint8 { v := uint8(102); return &v }(),
-						Channels: map[uint32]uint8{103: 103},
+						Default:  func() *uint8 { v := uint8(72); return &v }(),
+						Channels: map[uint32]uint8{73: 73},
 					},
 					Root: ir.Scope{
-						Key:        "test_104",
+						Key:        "test_74",
 						Mode:       ir.ScopeMode(0),
 						Liveness:   ir.Liveness(0),
-						Activation: func() *ir.Handle { v := ir.Handle{Node: "test_108", Param: "test_109"}; return &v }(),
+						Activation: func() *ir.Handle { v := ir.Handle{Node: "test_78", Param: "test_79"}; return &v }(),
 						Strata: [][]ir.Member{
 							{
 								{
-									NodeKey: func() *string { v := string("test_111"); return &v }(),
+									NodeKey: func() *string { v := string("test_81"); return &v }(),
 									Scope: func() *ir.Scope {
 										v := ir.Scope{
-											Key:         "test_113",
+											Key:         "test_83",
 											Mode:        ir.ScopeMode(0),
 											Liveness:    ir.Liveness(0),
 											Activation:  func() *ir.Handle { v := ir.Handle{}; return &v }(),
@@ -210,10 +168,10 @@ var _ = Describe("Codec", func() {
 						},
 						Steps: []ir.Member{
 							{
-								NodeKey: func() *string { v := string("test_121"); return &v }(),
+								NodeKey: func() *string { v := string("test_91"); return &v }(),
 								Scope: func() *ir.Scope {
 									v := ir.Scope{
-										Key:         "test_123",
+										Key:         "test_93",
 										Mode:        ir.ScopeMode(0),
 										Liveness:    ir.Liveness(0),
 										Activation:  func() *ir.Handle { v := ir.Handle{}; return &v }(),
@@ -227,15 +185,15 @@ var _ = Describe("Codec", func() {
 						},
 						Transitions: []ir.Transition{
 							{
-								On:        ir.Handle{Node: "test_132", Param: "test_133"},
-								TargetKey: func() *string { v := string("test_134"); return &v }(),
+								On:        ir.Handle{Node: "test_102", Param: "test_103"},
+								TargetKey: func() *string { v := string("test_104"); return &v }(),
 							},
 						},
 					},
 				},
 				Output: compiler.Output{
-					WASM:              []byte{135, 136, 137},
-					OutputMemoryBases: map[string]uint32{"test_136": 137},
+					WASM:              []byte{105, 106, 107},
+					OutputMemoryBases: map[string]uint32{"test_106": 107},
 				},
 			}),
 			Entry("zero values", program.Program{
@@ -291,159 +249,117 @@ func BenchmarkEncodeDecodeProgram(b *testing.B) {
 				{
 					Key:  "test_2",
 					Body: ir.Body{Raw: "test_4"},
-					Config: []types.Param{
+					Inputs: []types.Param{
 						{
 							Name: "test_6",
 							Type: types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_12",
+								Name:          "test_11",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 								ChanDirection: types.ChanDirection(0),
 							},
-							Value: map[string]interface{}{"key_17": "value_17"},
-						},
-					},
-					Inputs: []types.Param{
-						{
-							Name: "test_19",
-							Type: types.Type{
-								FunctionProperties: types.FunctionProperties{
-									Inputs:  []types.Param{{}},
-									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
-								},
-								Kind:          types.Kind(0),
-								Name:          "test_25",
-								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-								ChanDirection: types.ChanDirection(0),
-							},
-							Value: map[string]interface{}{"key_30": "value_30"},
+							Value: map[string]interface{}{"key_16": "value_16"},
 						},
 					},
 					Outputs: []types.Param{
 						{
-							Name: "test_32",
+							Name: "test_18",
 							Type: types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_38",
+								Name:          "test_23",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 								ChanDirection: types.ChanDirection(0),
 							},
-							Value: map[string]interface{}{"key_43": "value_43"},
+							Value: map[string]interface{}{"key_28": "value_28"},
 						},
 					},
 					Channels: types.Channels{
-						Read:  map[uint32]string{46: "test_45"},
-						Write: map[uint32]string{47: "test_46"},
+						Read:  map[uint32]string{31: "test_30"},
+						Write: map[uint32]string{32: "test_31"},
 					},
 				},
 			},
 			Nodes: []ir.Node{
 				{
-					Key:  "test_48",
-					Type: "test_49",
-					Config: []types.Param{
-						{
-							Name: "test_51",
-							Type: types.Type{
-								FunctionProperties: types.FunctionProperties{
-									Inputs:  []types.Param{{}},
-									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
-								},
-								Kind:          types.Kind(0),
-								Name:          "test_57",
-								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-								ChanDirection: types.ChanDirection(0),
-							},
-							Value: map[string]interface{}{"key_62": "value_62"},
-						},
-					},
+					Key:  "test_33",
+					Type: "test_34",
 					Inputs: []types.Param{
 						{
-							Name: "test_64",
+							Name: "test_36",
 							Type: types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_70",
+								Name:          "test_41",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 								ChanDirection: types.ChanDirection(0),
 							},
-							Value: map[string]interface{}{"key_75": "value_75"},
+							Value: map[string]interface{}{"key_46": "value_46"},
 						},
 					},
 					Outputs: []types.Param{
 						{
-							Name: "test_77",
+							Name: "test_48",
 							Type: types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_83",
+								Name:          "test_53",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 								ChanDirection: types.ChanDirection(0),
 							},
-							Value: map[string]interface{}{"key_88": "value_88"},
+							Value: map[string]interface{}{"key_58": "value_58"},
 						},
 					},
 					Channels: types.Channels{
-						Read:  map[uint32]string{91: "test_90"},
-						Write: map[uint32]string{92: "test_91"},
+						Read:  map[uint32]string{61: "test_60"},
+						Write: map[uint32]string{62: "test_61"},
 					},
 				},
 			},
 			Edges: []ir.Edge{
 				{
-					Source: ir.Handle{Node: "test_94", Param: "test_95"},
-					Target: ir.Handle{Node: "test_97", Param: "test_98"},
+					Source: ir.Handle{Node: "test_64", Param: "test_65"},
+					Target: ir.Handle{Node: "test_67", Param: "test_68"},
 					Kind:   ir.EdgeKind(0),
 				},
 			},
 			Authorities: ir.Authorities{
-				Default:  func() *uint8 { v := uint8(102); return &v }(),
-				Channels: map[uint32]uint8{103: 103},
+				Default:  func() *uint8 { v := uint8(72); return &v }(),
+				Channels: map[uint32]uint8{73: 73},
 			},
 			Root: ir.Scope{
-				Key:        "test_104",
+				Key:        "test_74",
 				Mode:       ir.ScopeMode(0),
 				Liveness:   ir.Liveness(0),
-				Activation: func() *ir.Handle { v := ir.Handle{Node: "test_108", Param: "test_109"}; return &v }(),
+				Activation: func() *ir.Handle { v := ir.Handle{Node: "test_78", Param: "test_79"}; return &v }(),
 				Strata: [][]ir.Member{
 					{
 						{
-							NodeKey: func() *string { v := string("test_111"); return &v }(),
+							NodeKey: func() *string { v := string("test_81"); return &v }(),
 							Scope: func() *ir.Scope {
 								v := ir.Scope{
-									Key:         "test_113",
+									Key:         "test_83",
 									Mode:        ir.ScopeMode(0),
 									Liveness:    ir.Liveness(0),
 									Activation:  func() *ir.Handle { v := ir.Handle{}; return &v }(),
@@ -458,10 +374,10 @@ func BenchmarkEncodeDecodeProgram(b *testing.B) {
 				},
 				Steps: []ir.Member{
 					{
-						NodeKey: func() *string { v := string("test_121"); return &v }(),
+						NodeKey: func() *string { v := string("test_91"); return &v }(),
 						Scope: func() *ir.Scope {
 							v := ir.Scope{
-								Key:         "test_123",
+								Key:         "test_93",
 								Mode:        ir.ScopeMode(0),
 								Liveness:    ir.Liveness(0),
 								Activation:  func() *ir.Handle { v := ir.Handle{}; return &v }(),
@@ -475,15 +391,15 @@ func BenchmarkEncodeDecodeProgram(b *testing.B) {
 				},
 				Transitions: []ir.Transition{
 					{
-						On:        ir.Handle{Node: "test_132", Param: "test_133"},
-						TargetKey: func() *string { v := string("test_134"); return &v }(),
+						On:        ir.Handle{Node: "test_102", Param: "test_103"},
+						TargetKey: func() *string { v := string("test_104"); return &v }(),
 					},
 				},
 			},
 		},
 		Output: compiler.Output{
-			WASM:              []byte{135, 136, 137},
-			OutputMemoryBases: map[string]uint32{"test_136": 137},
+			WASM:              []byte{105, 106, 107},
+			OutputMemoryBases: map[string]uint32{"test_106": 107},
 		},
 	}
 	w := orc.NewWriter(0)
@@ -509,159 +425,117 @@ func FuzzDecodeProgram(f *testing.F) {
 					{
 						Key:  "test_2",
 						Body: ir.Body{Raw: "test_4"},
-						Config: []types.Param{
+						Inputs: []types.Param{
 							{
 								Name: "test_6",
 								Type: types.Type{
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_12",
+									Name:          "test_11",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 									ChanDirection: types.ChanDirection(0),
 								},
-								Value: map[string]interface{}{"key_17": "value_17"},
-							},
-						},
-						Inputs: []types.Param{
-							{
-								Name: "test_19",
-								Type: types.Type{
-									FunctionProperties: types.FunctionProperties{
-										Inputs:  []types.Param{{}},
-										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
-									},
-									Kind:          types.Kind(0),
-									Name:          "test_25",
-									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-									ChanDirection: types.ChanDirection(0),
-								},
-								Value: map[string]interface{}{"key_30": "value_30"},
+								Value: map[string]interface{}{"key_16": "value_16"},
 							},
 						},
 						Outputs: []types.Param{
 							{
-								Name: "test_32",
+								Name: "test_18",
 								Type: types.Type{
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_38",
+									Name:          "test_23",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 									ChanDirection: types.ChanDirection(0),
 								},
-								Value: map[string]interface{}{"key_43": "value_43"},
+								Value: map[string]interface{}{"key_28": "value_28"},
 							},
 						},
 						Channels: types.Channels{
-							Read:  map[uint32]string{46: "test_45"},
-							Write: map[uint32]string{47: "test_46"},
+							Read:  map[uint32]string{31: "test_30"},
+							Write: map[uint32]string{32: "test_31"},
 						},
 					},
 				},
 				Nodes: []ir.Node{
 					{
-						Key:  "test_48",
-						Type: "test_49",
-						Config: []types.Param{
-							{
-								Name: "test_51",
-								Type: types.Type{
-									FunctionProperties: types.FunctionProperties{
-										Inputs:  []types.Param{{}},
-										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
-									},
-									Kind:          types.Kind(0),
-									Name:          "test_57",
-									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-									ChanDirection: types.ChanDirection(0),
-								},
-								Value: map[string]interface{}{"key_62": "value_62"},
-							},
-						},
+						Key:  "test_33",
+						Type: "test_34",
 						Inputs: []types.Param{
 							{
-								Name: "test_64",
+								Name: "test_36",
 								Type: types.Type{
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_70",
+									Name:          "test_41",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 									ChanDirection: types.ChanDirection(0),
 								},
-								Value: map[string]interface{}{"key_75": "value_75"},
+								Value: map[string]interface{}{"key_46": "value_46"},
 							},
 						},
 						Outputs: []types.Param{
 							{
-								Name: "test_77",
+								Name: "test_48",
 								Type: types.Type{
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_83",
+									Name:          "test_53",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 									ChanDirection: types.ChanDirection(0),
 								},
-								Value: map[string]interface{}{"key_88": "value_88"},
+								Value: map[string]interface{}{"key_58": "value_58"},
 							},
 						},
 						Channels: types.Channels{
-							Read:  map[uint32]string{91: "test_90"},
-							Write: map[uint32]string{92: "test_91"},
+							Read:  map[uint32]string{61: "test_60"},
+							Write: map[uint32]string{62: "test_61"},
 						},
 					},
 				},
 				Edges: []ir.Edge{
 					{
-						Source: ir.Handle{Node: "test_94", Param: "test_95"},
-						Target: ir.Handle{Node: "test_97", Param: "test_98"},
+						Source: ir.Handle{Node: "test_64", Param: "test_65"},
+						Target: ir.Handle{Node: "test_67", Param: "test_68"},
 						Kind:   ir.EdgeKind(0),
 					},
 				},
 				Authorities: ir.Authorities{
-					Default:  func() *uint8 { v := uint8(102); return &v }(),
-					Channels: map[uint32]uint8{103: 103},
+					Default:  func() *uint8 { v := uint8(72); return &v }(),
+					Channels: map[uint32]uint8{73: 73},
 				},
 				Root: ir.Scope{
-					Key:        "test_104",
+					Key:        "test_74",
 					Mode:       ir.ScopeMode(0),
 					Liveness:   ir.Liveness(0),
-					Activation: func() *ir.Handle { v := ir.Handle{Node: "test_108", Param: "test_109"}; return &v }(),
+					Activation: func() *ir.Handle { v := ir.Handle{Node: "test_78", Param: "test_79"}; return &v }(),
 					Strata: [][]ir.Member{
 						{
 							{
-								NodeKey: func() *string { v := string("test_111"); return &v }(),
+								NodeKey: func() *string { v := string("test_81"); return &v }(),
 								Scope: func() *ir.Scope {
 									v := ir.Scope{
-										Key:         "test_113",
+										Key:         "test_83",
 										Mode:        ir.ScopeMode(0),
 										Liveness:    ir.Liveness(0),
 										Activation:  func() *ir.Handle { v := ir.Handle{}; return &v }(),
@@ -676,10 +550,10 @@ func FuzzDecodeProgram(f *testing.F) {
 					},
 					Steps: []ir.Member{
 						{
-							NodeKey: func() *string { v := string("test_121"); return &v }(),
+							NodeKey: func() *string { v := string("test_91"); return &v }(),
 							Scope: func() *ir.Scope {
 								v := ir.Scope{
-									Key:         "test_123",
+									Key:         "test_93",
 									Mode:        ir.ScopeMode(0),
 									Liveness:    ir.Liveness(0),
 									Activation:  func() *ir.Handle { v := ir.Handle{}; return &v }(),
@@ -693,15 +567,15 @@ func FuzzDecodeProgram(f *testing.F) {
 					},
 					Transitions: []ir.Transition{
 						{
-							On:        ir.Handle{Node: "test_132", Param: "test_133"},
-							TargetKey: func() *string { v := string("test_134"); return &v }(),
+							On:        ir.Handle{Node: "test_102", Param: "test_103"},
+							TargetKey: func() *string { v := string("test_104"); return &v }(),
 						},
 					},
 				},
 			},
 			Output: compiler.Output{
-				WASM:              []byte{135, 136, 137},
-				OutputMemoryBases: map[string]uint32{"test_136": 137},
+				WASM:              []byte{105, 106, 107},
+				OutputMemoryBases: map[string]uint32{"test_106": 107},
 			},
 		}
 		w := orc.NewWriter(0)

--- a/arc/go/types/codec.gen.go
+++ b/arc/go/types/codec.gen.go
@@ -153,17 +153,6 @@ func (fp FunctionProperties) EncodeOrc(w *orc.Writer) error {
 	} else {
 		w.Bool(false)
 	}
-	if fp.Config != nil {
-		w.Bool(true)
-		w.Uint32(uint32(len(fp.Config)))
-		for j := range fp.Config {
-			if err := fp.Config[j].EncodeOrc(w); err != nil {
-				return err
-			}
-		}
-	} else {
-		w.Bool(false)
-	}
 	return nil
 }
 
@@ -199,24 +188,6 @@ func (fp *FunctionProperties) DecodeOrc(r *orc.Reader) error {
 			fp.Outputs = make([]Param, n)
 			for j := range fp.Outputs {
 				if err = fp.Outputs[j].DecodeOrc(r); err != nil {
-					return err
-				}
-			}
-		}
-	}
-	{
-		present, err := r.Bool()
-		if err != nil {
-			return err
-		}
-		if present {
-			n, err := r.CollectionLen()
-			if err != nil {
-				return err
-			}
-			fp.Config = make([]Param, n)
-			for j := range fp.Config {
-				if err = fp.Config[j].DecodeOrc(r); err != nil {
 					return err
 				}
 			}
@@ -277,17 +248,6 @@ func (t Type) EncodeOrc(w *orc.Writer) error {
 		w.Uint32(uint32(len(t.Outputs)))
 		for j := range t.Outputs {
 			if err := t.Outputs[j].EncodeOrc(w); err != nil {
-				return err
-			}
-		}
-	} else {
-		w.Bool(false)
-	}
-	if t.Config != nil {
-		w.Bool(true)
-		w.Uint32(uint32(len(t.Config)))
-		for j := range t.Config {
-			if err := t.Config[j].EncodeOrc(w); err != nil {
 				return err
 			}
 		}
@@ -357,24 +317,6 @@ func (t *Type) DecodeOrc(r *orc.Reader) error {
 			t.Outputs = make([]Param, n)
 			for j := range t.Outputs {
 				if err = t.Outputs[j].DecodeOrc(r); err != nil {
-					return err
-				}
-			}
-		}
-	}
-	{
-		present, err := r.Bool()
-		if err != nil {
-			return err
-		}
-		if present {
-			n, err := r.CollectionLen()
-			if err != nil {
-				return err
-			}
-			t.Config = make([]Param, n)
-			for j := range t.Config {
-				if err = t.Config[j].DecodeOrc(r); err != nil {
 					return err
 				}
 			}

--- a/arc/go/types/codec_gen_test.go
+++ b/arc/go/types/codec_gen_test.go
@@ -106,25 +106,17 @@ var _ = Describe("Codec", func() {
 										Value: map[string]interface{}{"key_11": "value_11"},
 									},
 								},
-								Config: []types.Param{
-									{
-										Name:  "test_13",
-										Type:  types.Type{},
-										Value: map[string]interface{}{"key_15": "value_15"},
-									},
-								},
 							},
 							Kind: types.Kind(0),
-							Name: "test_17",
+							Name: "test_13",
 							Elem: func() *types.Type {
 								v := types.Type{
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_23",
+									Name:          "test_18",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -135,8 +127,8 @@ var _ = Describe("Codec", func() {
 							Unit: func() *types.Unit {
 								v := types.Unit{
 									Dimensions: types.Dimensions{},
-									Scale:      30.5,
-									Name:       "test_31",
+									Scale:      25.5,
+									Name:       "test_26",
 								}
 								return &v
 							}(),
@@ -145,10 +137,9 @@ var _ = Describe("Codec", func() {
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_37",
+									Name:          "test_31",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -158,47 +149,39 @@ var _ = Describe("Codec", func() {
 							}(),
 							ChanDirection: types.ChanDirection(0),
 						},
-						Value: map[string]interface{}{"key_43": "value_43"},
+						Value: map[string]interface{}{"key_37": "value_37"},
 					},
 				},
 				Outputs: []types.Param{
 					{
-						Name: "test_45",
+						Name: "test_39",
 						Type: types.Type{
 							FunctionProperties: types.FunctionProperties{
 								Inputs: []types.Param{
 									{
-										Name:  "test_48",
+										Name:  "test_42",
 										Type:  types.Type{},
-										Value: map[string]interface{}{"key_50": "value_50"},
+										Value: map[string]interface{}{"key_44": "value_44"},
 									},
 								},
 								Outputs: []types.Param{
 									{
-										Name:  "test_52",
+										Name:  "test_46",
 										Type:  types.Type{},
-										Value: map[string]interface{}{"key_54": "value_54"},
-									},
-								},
-								Config: []types.Param{
-									{
-										Name:  "test_56",
-										Type:  types.Type{},
-										Value: map[string]interface{}{"key_58": "value_58"},
+										Value: map[string]interface{}{"key_48": "value_48"},
 									},
 								},
 							},
 							Kind: types.Kind(0),
-							Name: "test_60",
+							Name: "test_50",
 							Elem: func() *types.Type {
 								v := types.Type{
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_66",
+									Name:          "test_55",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -209,8 +192,8 @@ var _ = Describe("Codec", func() {
 							Unit: func() *types.Unit {
 								v := types.Unit{
 									Dimensions: types.Dimensions{},
-									Scale:      73.5,
-									Name:       "test_74",
+									Scale:      62.5,
+									Name:       "test_63",
 								}
 								return &v
 							}(),
@@ -219,10 +202,9 @@ var _ = Describe("Codec", func() {
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_80",
+									Name:          "test_68",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -232,94 +214,12 @@ var _ = Describe("Codec", func() {
 							}(),
 							ChanDirection: types.ChanDirection(0),
 						},
-						Value: map[string]interface{}{"key_86": "value_86"},
-					},
-				},
-				Config: []types.Param{
-					{
-						Name: "test_88",
-						Type: types.Type{
-							FunctionProperties: types.FunctionProperties{
-								Inputs: []types.Param{
-									{
-										Name:  "test_91",
-										Type:  types.Type{},
-										Value: map[string]interface{}{"key_93": "value_93"},
-									},
-								},
-								Outputs: []types.Param{
-									{
-										Name:  "test_95",
-										Type:  types.Type{},
-										Value: map[string]interface{}{"key_97": "value_97"},
-									},
-								},
-								Config: []types.Param{
-									{
-										Name:  "test_99",
-										Type:  types.Type{},
-										Value: map[string]interface{}{"key_101": "value_101"},
-									},
-								},
-							},
-							Kind: types.Kind(0),
-							Name: "test_103",
-							Elem: func() *types.Type {
-								v := types.Type{
-									FunctionProperties: types.FunctionProperties{
-										Inputs:  []types.Param{{}},
-										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
-									},
-									Kind:          types.Kind(0),
-									Name:          "test_109",
-									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-									ChanDirection: types.ChanDirection(0),
-								}
-								return &v
-							}(),
-							Unit: func() *types.Unit {
-								v := types.Unit{
-									Dimensions: types.Dimensions{},
-									Scale:      116.5,
-									Name:       "test_117",
-								}
-								return &v
-							}(),
-							Constraint: func() *types.Type {
-								v := types.Type{
-									FunctionProperties: types.FunctionProperties{
-										Inputs:  []types.Param{{}},
-										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
-									},
-									Kind:          types.Kind(0),
-									Name:          "test_123",
-									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-									ChanDirection: types.ChanDirection(0),
-								}
-								return &v
-							}(),
-							ChanDirection: types.ChanDirection(0),
-						},
-						Value: map[string]interface{}{"key_129": "value_129"},
+						Value: map[string]interface{}{"key_74": "value_74"},
 					},
 				},
 			}),
-			Entry("zero values", types.FunctionProperties{
-				Inputs:  nil,
-				Outputs: nil,
-				Config:  nil,
-			}),
-			Entry("empty collections", types.FunctionProperties{
-				Inputs:  []types.Param{},
-				Outputs: []types.Param{},
-				Config:  []types.Param{},
-			}),
+			Entry("zero values", types.FunctionProperties{Inputs: nil, Outputs: nil}),
+			Entry("empty collections", types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}}),
 		)
 	})
 	Describe("Param", func() {
@@ -344,95 +244,66 @@ var _ = Describe("Codec", func() {
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_10",
+									Name:          "test_9",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 									ChanDirection: types.ChanDirection(0),
 								},
-								Value: map[string]interface{}{"key_15": "value_15"},
+								Value: map[string]interface{}{"key_14": "value_14"},
 							},
 						},
 						Outputs: []types.Param{
 							{
-								Name: "test_17",
+								Name: "test_16",
 								Type: types.Type{
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_23",
+									Name:          "test_21",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 									ChanDirection: types.ChanDirection(0),
 								},
-								Value: map[string]interface{}{"key_28": "value_28"},
-							},
-						},
-						Config: []types.Param{
-							{
-								Name: "test_30",
-								Type: types.Type{
-									FunctionProperties: types.FunctionProperties{
-										Inputs:  []types.Param{{}},
-										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
-									},
-									Kind:          types.Kind(0),
-									Name:          "test_36",
-									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-									ChanDirection: types.ChanDirection(0),
-								},
-								Value: map[string]interface{}{"key_41": "value_41"},
+								Value: map[string]interface{}{"key_26": "value_26"},
 							},
 						},
 					},
 					Kind: types.Kind(0),
-					Name: "test_43",
+					Name: "test_28",
 					Elem: func() *types.Type {
 						v := types.Type{
 							FunctionProperties: types.FunctionProperties{
 								Inputs: []types.Param{
 									{
-										Name:  "test_46",
+										Name:  "test_31",
 										Type:  types.Type{},
-										Value: map[string]interface{}{"key_48": "value_48"},
+										Value: map[string]interface{}{"key_33": "value_33"},
 									},
 								},
 								Outputs: []types.Param{
 									{
-										Name:  "test_50",
+										Name:  "test_35",
 										Type:  types.Type{},
-										Value: map[string]interface{}{"key_52": "value_52"},
-									},
-								},
-								Config: []types.Param{
-									{
-										Name:  "test_54",
-										Type:  types.Type{},
-										Value: map[string]interface{}{"key_56": "value_56"},
+										Value: map[string]interface{}{"key_37": "value_37"},
 									},
 								},
 							},
 							Kind: types.Kind(0),
-							Name: "test_58",
+							Name: "test_39",
 							Elem: func() *types.Type {
 								v := types.Type{
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_64",
+									Name:          "test_44",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -443,8 +314,8 @@ var _ = Describe("Codec", func() {
 							Unit: func() *types.Unit {
 								v := types.Unit{
 									Dimensions: types.Dimensions{},
-									Scale:      71.5,
-									Name:       "test_72",
+									Scale:      51.5,
+									Name:       "test_52",
 								}
 								return &v
 							}(),
@@ -453,10 +324,9 @@ var _ = Describe("Codec", func() {
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_78",
+									Name:          "test_57",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -471,17 +341,17 @@ var _ = Describe("Codec", func() {
 					Unit: func() *types.Unit {
 						v := types.Unit{
 							Dimensions: types.Dimensions{
-								Length:      87,
-								Mass:        88,
-								Time:        89,
-								Current:     90,
-								Temperature: 91,
-								Angle:       92,
-								Count:       93,
-								Data:        94,
+								Length:      66,
+								Mass:        67,
+								Time:        68,
+								Current:     69,
+								Temperature: 70,
+								Angle:       71,
+								Count:       72,
+								Data:        73,
 							},
-							Scale: 94.5,
-							Name:  "test_95",
+							Scale: 73.5,
+							Name:  "test_74",
 						}
 						return &v
 					}(),
@@ -490,37 +360,29 @@ var _ = Describe("Codec", func() {
 							FunctionProperties: types.FunctionProperties{
 								Inputs: []types.Param{
 									{
-										Name:  "test_98",
+										Name:  "test_77",
 										Type:  types.Type{},
-										Value: map[string]interface{}{"key_100": "value_100"},
+										Value: map[string]interface{}{"key_79": "value_79"},
 									},
 								},
 								Outputs: []types.Param{
 									{
-										Name:  "test_102",
+										Name:  "test_81",
 										Type:  types.Type{},
-										Value: map[string]interface{}{"key_104": "value_104"},
-									},
-								},
-								Config: []types.Param{
-									{
-										Name:  "test_106",
-										Type:  types.Type{},
-										Value: map[string]interface{}{"key_108": "value_108"},
+										Value: map[string]interface{}{"key_83": "value_83"},
 									},
 								},
 							},
 							Kind: types.Kind(0),
-							Name: "test_110",
+							Name: "test_85",
 							Elem: func() *types.Type {
 								v := types.Type{
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_116",
+									Name:          "test_90",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -531,8 +393,8 @@ var _ = Describe("Codec", func() {
 							Unit: func() *types.Unit {
 								v := types.Unit{
 									Dimensions: types.Dimensions{},
-									Scale:      123.5,
-									Name:       "test_124",
+									Scale:      97.5,
+									Name:       "test_98",
 								}
 								return &v
 							}(),
@@ -541,10 +403,9 @@ var _ = Describe("Codec", func() {
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_130",
+									Name:          "test_103",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -558,22 +419,18 @@ var _ = Describe("Codec", func() {
 					}(),
 					ChanDirection: types.ChanDirection(0),
 				},
-				Value: map[string]interface{}{"key_137": "value_137"},
+				Value: map[string]interface{}{"key_110": "value_110"},
 			}),
 			Entry("zero values", types.Param{
 				Name: "",
 				Type: types.Type{
-					FunctionProperties: types.FunctionProperties{
-						Inputs:  nil,
-						Outputs: nil,
-						Config:  nil,
-					},
-					Kind:          types.Kind(0),
-					Name:          "",
-					Elem:          nil,
-					Unit:          nil,
-					Constraint:    nil,
-					ChanDirection: types.ChanDirection(0),
+					FunctionProperties: types.FunctionProperties{Inputs: nil, Outputs: nil},
+					Kind:               types.Kind(0),
+					Name:               "",
+					Elem:               nil,
+					Unit:               nil,
+					Constraint:         nil,
+					ChanDirection:      types.ChanDirection(0),
 				},
 				Value: nil,
 			}),
@@ -611,25 +468,17 @@ var _ = Describe("Codec", func() {
 											Value: map[string]interface{}{"key_11": "value_11"},
 										},
 									},
-									Config: []types.Param{
-										{
-											Name:  "test_13",
-											Type:  types.Type{},
-											Value: map[string]interface{}{"key_15": "value_15"},
-										},
-									},
 								},
 								Kind: types.Kind(0),
-								Name: "test_17",
+								Name: "test_13",
 								Elem: func() *types.Type {
 									v := types.Type{
 										FunctionProperties: types.FunctionProperties{
 											Inputs:  []types.Param{{}},
 											Outputs: []types.Param{{}},
-											Config:  []types.Param{{}},
 										},
 										Kind:          types.Kind(0),
-										Name:          "test_23",
+										Name:          "test_18",
 										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -640,8 +489,8 @@ var _ = Describe("Codec", func() {
 								Unit: func() *types.Unit {
 									v := types.Unit{
 										Dimensions: types.Dimensions{},
-										Scale:      30.5,
-										Name:       "test_31",
+										Scale:      25.5,
+										Name:       "test_26",
 									}
 									return &v
 								}(),
@@ -650,10 +499,9 @@ var _ = Describe("Codec", func() {
 										FunctionProperties: types.FunctionProperties{
 											Inputs:  []types.Param{{}},
 											Outputs: []types.Param{{}},
-											Config:  []types.Param{{}},
 										},
 										Kind:          types.Kind(0),
-										Name:          "test_37",
+										Name:          "test_31",
 										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -663,47 +511,39 @@ var _ = Describe("Codec", func() {
 								}(),
 								ChanDirection: types.ChanDirection(0),
 							},
-							Value: map[string]interface{}{"key_43": "value_43"},
+							Value: map[string]interface{}{"key_37": "value_37"},
 						},
 					},
 					Outputs: []types.Param{
 						{
-							Name: "test_45",
+							Name: "test_39",
 							Type: types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs: []types.Param{
 										{
-											Name:  "test_48",
+											Name:  "test_42",
 											Type:  types.Type{},
-											Value: map[string]interface{}{"key_50": "value_50"},
+											Value: map[string]interface{}{"key_44": "value_44"},
 										},
 									},
 									Outputs: []types.Param{
 										{
-											Name:  "test_52",
+											Name:  "test_46",
 											Type:  types.Type{},
-											Value: map[string]interface{}{"key_54": "value_54"},
-										},
-									},
-									Config: []types.Param{
-										{
-											Name:  "test_56",
-											Type:  types.Type{},
-											Value: map[string]interface{}{"key_58": "value_58"},
+											Value: map[string]interface{}{"key_48": "value_48"},
 										},
 									},
 								},
 								Kind: types.Kind(0),
-								Name: "test_60",
+								Name: "test_50",
 								Elem: func() *types.Type {
 									v := types.Type{
 										FunctionProperties: types.FunctionProperties{
 											Inputs:  []types.Param{{}},
 											Outputs: []types.Param{{}},
-											Config:  []types.Param{{}},
 										},
 										Kind:          types.Kind(0),
-										Name:          "test_66",
+										Name:          "test_55",
 										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -714,8 +554,8 @@ var _ = Describe("Codec", func() {
 								Unit: func() *types.Unit {
 									v := types.Unit{
 										Dimensions: types.Dimensions{},
-										Scale:      73.5,
-										Name:       "test_74",
+										Scale:      62.5,
+										Name:       "test_63",
 									}
 									return &v
 								}(),
@@ -724,10 +564,9 @@ var _ = Describe("Codec", func() {
 										FunctionProperties: types.FunctionProperties{
 											Inputs:  []types.Param{{}},
 											Outputs: []types.Param{{}},
-											Config:  []types.Param{{}},
 										},
 										Kind:          types.Kind(0),
-										Name:          "test_80",
+										Name:          "test_68",
 										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -737,185 +576,82 @@ var _ = Describe("Codec", func() {
 								}(),
 								ChanDirection: types.ChanDirection(0),
 							},
-							Value: map[string]interface{}{"key_86": "value_86"},
-						},
-					},
-					Config: []types.Param{
-						{
-							Name: "test_88",
-							Type: types.Type{
-								FunctionProperties: types.FunctionProperties{
-									Inputs: []types.Param{
-										{
-											Name:  "test_91",
-											Type:  types.Type{},
-											Value: map[string]interface{}{"key_93": "value_93"},
-										},
-									},
-									Outputs: []types.Param{
-										{
-											Name:  "test_95",
-											Type:  types.Type{},
-											Value: map[string]interface{}{"key_97": "value_97"},
-										},
-									},
-									Config: []types.Param{
-										{
-											Name:  "test_99",
-											Type:  types.Type{},
-											Value: map[string]interface{}{"key_101": "value_101"},
-										},
-									},
-								},
-								Kind: types.Kind(0),
-								Name: "test_103",
-								Elem: func() *types.Type {
-									v := types.Type{
-										FunctionProperties: types.FunctionProperties{
-											Inputs:  []types.Param{{}},
-											Outputs: []types.Param{{}},
-											Config:  []types.Param{{}},
-										},
-										Kind:          types.Kind(0),
-										Name:          "test_109",
-										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-										ChanDirection: types.ChanDirection(0),
-									}
-									return &v
-								}(),
-								Unit: func() *types.Unit {
-									v := types.Unit{
-										Dimensions: types.Dimensions{},
-										Scale:      116.5,
-										Name:       "test_117",
-									}
-									return &v
-								}(),
-								Constraint: func() *types.Type {
-									v := types.Type{
-										FunctionProperties: types.FunctionProperties{
-											Inputs:  []types.Param{{}},
-											Outputs: []types.Param{{}},
-											Config:  []types.Param{{}},
-										},
-										Kind:          types.Kind(0),
-										Name:          "test_123",
-										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-										ChanDirection: types.ChanDirection(0),
-									}
-									return &v
-								}(),
-								ChanDirection: types.ChanDirection(0),
-							},
-							Value: map[string]interface{}{"key_129": "value_129"},
+							Value: map[string]interface{}{"key_74": "value_74"},
 						},
 					},
 				},
 				Kind: types.Kind(0),
-				Name: "test_131",
+				Name: "test_76",
 				Elem: func() *types.Type {
 					v := types.Type{
 						FunctionProperties: types.FunctionProperties{
 							Inputs: []types.Param{
 								{
-									Name: "test_134",
+									Name: "test_79",
 									Type: types.Type{
 										FunctionProperties: types.FunctionProperties{
 											Inputs:  []types.Param{{}},
 											Outputs: []types.Param{{}},
-											Config:  []types.Param{{}},
 										},
 										Kind:          types.Kind(0),
-										Name:          "test_140",
+										Name:          "test_84",
 										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 										ChanDirection: types.ChanDirection(0),
 									},
-									Value: map[string]interface{}{"key_145": "value_145"},
+									Value: map[string]interface{}{"key_89": "value_89"},
 								},
 							},
 							Outputs: []types.Param{
 								{
-									Name: "test_147",
+									Name: "test_91",
 									Type: types.Type{
 										FunctionProperties: types.FunctionProperties{
 											Inputs:  []types.Param{{}},
 											Outputs: []types.Param{{}},
-											Config:  []types.Param{{}},
 										},
 										Kind:          types.Kind(0),
-										Name:          "test_153",
+										Name:          "test_96",
 										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 										ChanDirection: types.ChanDirection(0),
 									},
-									Value: map[string]interface{}{"key_158": "value_158"},
-								},
-							},
-							Config: []types.Param{
-								{
-									Name: "test_160",
-									Type: types.Type{
-										FunctionProperties: types.FunctionProperties{
-											Inputs:  []types.Param{{}},
-											Outputs: []types.Param{{}},
-											Config:  []types.Param{{}},
-										},
-										Kind:          types.Kind(0),
-										Name:          "test_166",
-										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-										ChanDirection: types.ChanDirection(0),
-									},
-									Value: map[string]interface{}{"key_171": "value_171"},
+									Value: map[string]interface{}{"key_101": "value_101"},
 								},
 							},
 						},
 						Kind: types.Kind(0),
-						Name: "test_173",
+						Name: "test_103",
 						Elem: func() *types.Type {
 							v := types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs: []types.Param{
 										{
-											Name:  "test_176",
+											Name:  "test_106",
 											Type:  types.Type{},
-											Value: map[string]interface{}{"key_178": "value_178"},
+											Value: map[string]interface{}{"key_108": "value_108"},
 										},
 									},
 									Outputs: []types.Param{
 										{
-											Name:  "test_180",
+											Name:  "test_110",
 											Type:  types.Type{},
-											Value: map[string]interface{}{"key_182": "value_182"},
-										},
-									},
-									Config: []types.Param{
-										{
-											Name:  "test_184",
-											Type:  types.Type{},
-											Value: map[string]interface{}{"key_186": "value_186"},
+											Value: map[string]interface{}{"key_112": "value_112"},
 										},
 									},
 								},
 								Kind: types.Kind(0),
-								Name: "test_188",
+								Name: "test_114",
 								Elem: func() *types.Type {
 									v := types.Type{
 										FunctionProperties: types.FunctionProperties{
 											Inputs:  []types.Param{{}},
 											Outputs: []types.Param{{}},
-											Config:  []types.Param{{}},
 										},
 										Kind:          types.Kind(0),
-										Name:          "test_194",
+										Name:          "test_119",
 										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -926,8 +662,8 @@ var _ = Describe("Codec", func() {
 								Unit: func() *types.Unit {
 									v := types.Unit{
 										Dimensions: types.Dimensions{},
-										Scale:      201.5,
-										Name:       "test_202",
+										Scale:      126.5,
+										Name:       "test_127",
 									}
 									return &v
 								}(),
@@ -936,10 +672,9 @@ var _ = Describe("Codec", func() {
 										FunctionProperties: types.FunctionProperties{
 											Inputs:  []types.Param{{}},
 											Outputs: []types.Param{{}},
-											Config:  []types.Param{{}},
 										},
 										Kind:          types.Kind(0),
-										Name:          "test_208",
+										Name:          "test_132",
 										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -954,17 +689,17 @@ var _ = Describe("Codec", func() {
 						Unit: func() *types.Unit {
 							v := types.Unit{
 								Dimensions: types.Dimensions{
-									Length:      91,
-									Mass:        92,
-									Time:        93,
-									Current:     94,
-									Temperature: 95,
-									Angle:       96,
-									Count:       97,
-									Data:        98,
+									Length:      15,
+									Mass:        16,
+									Time:        17,
+									Current:     18,
+									Temperature: 19,
+									Angle:       20,
+									Count:       21,
+									Data:        22,
 								},
-								Scale: 224.5,
-								Name:  "test_225",
+								Scale: 148.5,
+								Name:  "test_149",
 							}
 							return &v
 						}(),
@@ -973,37 +708,29 @@ var _ = Describe("Codec", func() {
 								FunctionProperties: types.FunctionProperties{
 									Inputs: []types.Param{
 										{
-											Name:  "test_228",
+											Name:  "test_152",
 											Type:  types.Type{},
-											Value: map[string]interface{}{"key_230": "value_230"},
+											Value: map[string]interface{}{"key_154": "value_154"},
 										},
 									},
 									Outputs: []types.Param{
 										{
-											Name:  "test_232",
+											Name:  "test_156",
 											Type:  types.Type{},
-											Value: map[string]interface{}{"key_234": "value_234"},
-										},
-									},
-									Config: []types.Param{
-										{
-											Name:  "test_236",
-											Type:  types.Type{},
-											Value: map[string]interface{}{"key_238": "value_238"},
+											Value: map[string]interface{}{"key_158": "value_158"},
 										},
 									},
 								},
 								Kind: types.Kind(0),
-								Name: "test_240",
+								Name: "test_160",
 								Elem: func() *types.Type {
 									v := types.Type{
 										FunctionProperties: types.FunctionProperties{
 											Inputs:  []types.Param{{}},
 											Outputs: []types.Param{{}},
-											Config:  []types.Param{{}},
 										},
 										Kind:          types.Kind(0),
-										Name:          "test_246",
+										Name:          "test_165",
 										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -1014,8 +741,8 @@ var _ = Describe("Codec", func() {
 								Unit: func() *types.Unit {
 									v := types.Unit{
 										Dimensions: types.Dimensions{},
-										Scale:      253.5,
-										Name:       "test_254",
+										Scale:      172.5,
+										Name:       "test_173",
 									}
 									return &v
 								}(),
@@ -1024,10 +751,9 @@ var _ = Describe("Codec", func() {
 										FunctionProperties: types.FunctionProperties{
 											Inputs:  []types.Param{{}},
 											Outputs: []types.Param{{}},
-											Config:  []types.Param{{}},
 										},
 										Kind:          types.Kind(0),
-										Name:          "test_260",
+										Name:          "test_178",
 										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -1046,17 +772,17 @@ var _ = Describe("Codec", func() {
 				Unit: func() *types.Unit {
 					v := types.Unit{
 						Dimensions: types.Dimensions{
-							Length:      18,
-							Mass:        19,
-							Time:        20,
-							Current:     21,
-							Temperature: 22,
-							Angle:       23,
-							Count:       24,
-							Data:        25,
+							Length:      62,
+							Mass:        63,
+							Time:        64,
+							Current:     65,
+							Temperature: 66,
+							Angle:       67,
+							Count:       68,
+							Data:        69,
 						},
-						Scale: 277.5,
-						Name:  "test_278",
+						Scale: 195.5,
+						Name:  "test_196",
 					}
 					return &v
 				}(),
@@ -1065,100 +791,71 @@ var _ = Describe("Codec", func() {
 						FunctionProperties: types.FunctionProperties{
 							Inputs: []types.Param{
 								{
-									Name: "test_281",
+									Name: "test_199",
 									Type: types.Type{
 										FunctionProperties: types.FunctionProperties{
 											Inputs:  []types.Param{{}},
 											Outputs: []types.Param{{}},
-											Config:  []types.Param{{}},
 										},
 										Kind:          types.Kind(0),
-										Name:          "test_287",
+										Name:          "test_204",
 										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 										ChanDirection: types.ChanDirection(0),
 									},
-									Value: map[string]interface{}{"key_292": "value_292"},
+									Value: map[string]interface{}{"key_209": "value_209"},
 								},
 							},
 							Outputs: []types.Param{
 								{
-									Name: "test_294",
+									Name: "test_211",
 									Type: types.Type{
 										FunctionProperties: types.FunctionProperties{
 											Inputs:  []types.Param{{}},
 											Outputs: []types.Param{{}},
-											Config:  []types.Param{{}},
 										},
 										Kind:          types.Kind(0),
-										Name:          "test_300",
+										Name:          "test_216",
 										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 										ChanDirection: types.ChanDirection(0),
 									},
-									Value: map[string]interface{}{"key_305": "value_305"},
-								},
-							},
-							Config: []types.Param{
-								{
-									Name: "test_307",
-									Type: types.Type{
-										FunctionProperties: types.FunctionProperties{
-											Inputs:  []types.Param{{}},
-											Outputs: []types.Param{{}},
-											Config:  []types.Param{{}},
-										},
-										Kind:          types.Kind(0),
-										Name:          "test_313",
-										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-										ChanDirection: types.ChanDirection(0),
-									},
-									Value: map[string]interface{}{"key_318": "value_318"},
+									Value: map[string]interface{}{"key_221": "value_221"},
 								},
 							},
 						},
 						Kind: types.Kind(0),
-						Name: "test_320",
+						Name: "test_223",
 						Elem: func() *types.Type {
 							v := types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs: []types.Param{
 										{
-											Name:  "test_323",
+											Name:  "test_226",
 											Type:  types.Type{},
-											Value: map[string]interface{}{"key_325": "value_325"},
+											Value: map[string]interface{}{"key_228": "value_228"},
 										},
 									},
 									Outputs: []types.Param{
 										{
-											Name:  "test_327",
+											Name:  "test_230",
 											Type:  types.Type{},
-											Value: map[string]interface{}{"key_329": "value_329"},
-										},
-									},
-									Config: []types.Param{
-										{
-											Name:  "test_331",
-											Type:  types.Type{},
-											Value: map[string]interface{}{"key_333": "value_333"},
+											Value: map[string]interface{}{"key_232": "value_232"},
 										},
 									},
 								},
 								Kind: types.Kind(0),
-								Name: "test_335",
+								Name: "test_234",
 								Elem: func() *types.Type {
 									v := types.Type{
 										FunctionProperties: types.FunctionProperties{
 											Inputs:  []types.Param{{}},
 											Outputs: []types.Param{{}},
-											Config:  []types.Param{{}},
 										},
 										Kind:          types.Kind(0),
-										Name:          "test_341",
+										Name:          "test_239",
 										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -1169,8 +866,8 @@ var _ = Describe("Codec", func() {
 								Unit: func() *types.Unit {
 									v := types.Unit{
 										Dimensions: types.Dimensions{},
-										Scale:      348.5,
-										Name:       "test_349",
+										Scale:      246.5,
+										Name:       "test_247",
 									}
 									return &v
 								}(),
@@ -1179,10 +876,9 @@ var _ = Describe("Codec", func() {
 										FunctionProperties: types.FunctionProperties{
 											Inputs:  []types.Param{{}},
 											Outputs: []types.Param{{}},
-											Config:  []types.Param{{}},
 										},
 										Kind:          types.Kind(0),
-										Name:          "test_355",
+										Name:          "test_252",
 										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -1197,17 +893,17 @@ var _ = Describe("Codec", func() {
 						Unit: func() *types.Unit {
 							v := types.Unit{
 								Dimensions: types.Dimensions{
-									Length:      112,
-									Mass:        113,
-									Time:        114,
-									Current:     115,
-									Temperature: 116,
-									Angle:       117,
-									Count:       118,
-									Data:        119,
+									Length:      9,
+									Mass:        10,
+									Time:        11,
+									Current:     12,
+									Temperature: 13,
+									Angle:       14,
+									Count:       15,
+									Data:        16,
 								},
-								Scale: 371.5,
-								Name:  "test_372",
+								Scale: 268.5,
+								Name:  "test_269",
 							}
 							return &v
 						}(),
@@ -1216,37 +912,29 @@ var _ = Describe("Codec", func() {
 								FunctionProperties: types.FunctionProperties{
 									Inputs: []types.Param{
 										{
-											Name:  "test_375",
+											Name:  "test_272",
 											Type:  types.Type{},
-											Value: map[string]interface{}{"key_377": "value_377"},
+											Value: map[string]interface{}{"key_274": "value_274"},
 										},
 									},
 									Outputs: []types.Param{
 										{
-											Name:  "test_379",
+											Name:  "test_276",
 											Type:  types.Type{},
-											Value: map[string]interface{}{"key_381": "value_381"},
-										},
-									},
-									Config: []types.Param{
-										{
-											Name:  "test_383",
-											Type:  types.Type{},
-											Value: map[string]interface{}{"key_385": "value_385"},
+											Value: map[string]interface{}{"key_278": "value_278"},
 										},
 									},
 								},
 								Kind: types.Kind(0),
-								Name: "test_387",
+								Name: "test_280",
 								Elem: func() *types.Type {
 									v := types.Type{
 										FunctionProperties: types.FunctionProperties{
 											Inputs:  []types.Param{{}},
 											Outputs: []types.Param{{}},
-											Config:  []types.Param{{}},
 										},
 										Kind:          types.Kind(0),
-										Name:          "test_393",
+										Name:          "test_285",
 										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -1257,8 +945,8 @@ var _ = Describe("Codec", func() {
 								Unit: func() *types.Unit {
 									v := types.Unit{
 										Dimensions: types.Dimensions{},
-										Scale:      400.5,
-										Name:       "test_401",
+										Scale:      292.5,
+										Name:       "test_293",
 									}
 									return &v
 								}(),
@@ -1267,10 +955,9 @@ var _ = Describe("Codec", func() {
 										FunctionProperties: types.FunctionProperties{
 											Inputs:  []types.Param{{}},
 											Outputs: []types.Param{{}},
-											Config:  []types.Param{{}},
 										},
 										Kind:          types.Kind(0),
-										Name:          "test_407",
+										Name:          "test_298",
 										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -1289,81 +976,57 @@ var _ = Describe("Codec", func() {
 				ChanDirection: types.ChanDirection(0),
 			}),
 			Entry("zero values", types.Type{
-				FunctionProperties: types.FunctionProperties{
-					Inputs:  nil,
-					Outputs: nil,
-					Config:  nil,
-				},
-				Kind:          types.Kind(0),
-				Name:          "",
-				Elem:          nil,
-				Unit:          nil,
-				Constraint:    nil,
-				ChanDirection: types.ChanDirection(0),
+				FunctionProperties: types.FunctionProperties{Inputs: nil, Outputs: nil},
+				Kind:               types.Kind(0),
+				Name:               "",
+				Elem:               nil,
+				Unit:               nil,
+				Constraint:         nil,
+				ChanDirection:      types.ChanDirection(0),
 			}),
 			Entry("empty collections", types.Type{
-				FunctionProperties: types.FunctionProperties{
-					Inputs:  []types.Param{},
-					Outputs: []types.Param{},
-					Config:  []types.Param{},
-				},
-				Kind: types.Kind(0),
-				Name: "test_5",
+				FunctionProperties: types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}},
+				Kind:               types.Kind(0),
+				Name:               "test_4",
 				Elem: func() *types.Type {
 					v := types.Type{
-						FunctionProperties: types.FunctionProperties{
-							Inputs:  []types.Param{},
-							Outputs: []types.Param{},
-							Config:  []types.Param{},
-						},
-						Kind: types.Kind(0),
-						Name: "test_11",
+						FunctionProperties: types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}},
+						Kind:               types.Kind(0),
+						Name:               "test_9",
 						Elem: func() *types.Type {
 							v := types.Type{
-								FunctionProperties: types.FunctionProperties{
-									Inputs:  []types.Param{},
-									Outputs: []types.Param{},
-									Config:  []types.Param{},
-								},
-								Kind: types.Kind(0),
-								Name: "test_17",
+								FunctionProperties: types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}},
+								Kind:               types.Kind(0),
+								Name:               "test_14",
 								Elem: func() *types.Type {
 									v := types.Type{
-										FunctionProperties: types.FunctionProperties{
-											Inputs:  []types.Param{},
-											Outputs: []types.Param{},
-											Config:  []types.Param{},
-										},
-										Kind:          types.Kind(0),
-										Name:          "test_23",
-										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-										ChanDirection: types.ChanDirection(0),
+										FunctionProperties: types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}},
+										Kind:               types.Kind(0),
+										Name:               "test_19",
+										Elem:               func() *types.Type { v := types.Type{}; return &v }(),
+										Unit:               func() *types.Unit { v := types.Unit{}; return &v }(),
+										Constraint:         func() *types.Type { v := types.Type{}; return &v }(),
+										ChanDirection:      types.ChanDirection(0),
 									}
 									return &v
 								}(),
 								Unit: func() *types.Unit {
 									v := types.Unit{
 										Dimensions: types.Dimensions{},
-										Scale:      30.5,
-										Name:       "test_31",
+										Scale:      26.5,
+										Name:       "test_27",
 									}
 									return &v
 								}(),
 								Constraint: func() *types.Type {
 									v := types.Type{
-										FunctionProperties: types.FunctionProperties{
-											Inputs:  []types.Param{},
-											Outputs: []types.Param{},
-											Config:  []types.Param{},
-										},
-										Kind:          types.Kind(0),
-										Name:          "test_37",
-										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-										ChanDirection: types.ChanDirection(0),
+										FunctionProperties: types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}},
+										Kind:               types.Kind(0),
+										Name:               "test_32",
+										Elem:               func() *types.Type { v := types.Type{}; return &v }(),
+										Unit:               func() *types.Unit { v := types.Unit{}; return &v }(),
+										Constraint:         func() *types.Type { v := types.Type{}; return &v }(),
+										ChanDirection:      types.ChanDirection(0),
 									}
 									return &v
 								}(),
@@ -1374,66 +1037,54 @@ var _ = Describe("Codec", func() {
 						Unit: func() *types.Unit {
 							v := types.Unit{
 								Dimensions: types.Dimensions{
-									Length:      46,
-									Mass:        47,
-									Time:        48,
-									Current:     49,
-									Temperature: 50,
-									Angle:       51,
-									Count:       52,
-									Data:        53,
+									Length:      41,
+									Mass:        42,
+									Time:        43,
+									Current:     44,
+									Temperature: 45,
+									Angle:       46,
+									Count:       47,
+									Data:        48,
 								},
-								Scale: 53.5,
-								Name:  "test_54",
+								Scale: 48.5,
+								Name:  "test_49",
 							}
 							return &v
 						}(),
 						Constraint: func() *types.Type {
 							v := types.Type{
-								FunctionProperties: types.FunctionProperties{
-									Inputs:  []types.Param{},
-									Outputs: []types.Param{},
-									Config:  []types.Param{},
-								},
-								Kind: types.Kind(0),
-								Name: "test_60",
+								FunctionProperties: types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}},
+								Kind:               types.Kind(0),
+								Name:               "test_54",
 								Elem: func() *types.Type {
 									v := types.Type{
-										FunctionProperties: types.FunctionProperties{
-											Inputs:  []types.Param{},
-											Outputs: []types.Param{},
-											Config:  []types.Param{},
-										},
-										Kind:          types.Kind(0),
-										Name:          "test_66",
-										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-										ChanDirection: types.ChanDirection(0),
+										FunctionProperties: types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}},
+										Kind:               types.Kind(0),
+										Name:               "test_59",
+										Elem:               func() *types.Type { v := types.Type{}; return &v }(),
+										Unit:               func() *types.Unit { v := types.Unit{}; return &v }(),
+										Constraint:         func() *types.Type { v := types.Type{}; return &v }(),
+										ChanDirection:      types.ChanDirection(0),
 									}
 									return &v
 								}(),
 								Unit: func() *types.Unit {
 									v := types.Unit{
 										Dimensions: types.Dimensions{},
-										Scale:      73.5,
-										Name:       "test_74",
+										Scale:      66.5,
+										Name:       "test_67",
 									}
 									return &v
 								}(),
 								Constraint: func() *types.Type {
 									v := types.Type{
-										FunctionProperties: types.FunctionProperties{
-											Inputs:  []types.Param{},
-											Outputs: []types.Param{},
-											Config:  []types.Param{},
-										},
-										Kind:          types.Kind(0),
-										Name:          "test_80",
-										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-										ChanDirection: types.ChanDirection(0),
+										FunctionProperties: types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}},
+										Kind:               types.Kind(0),
+										Name:               "test_72",
+										Elem:               func() *types.Type { v := types.Type{}; return &v }(),
+										Unit:               func() *types.Unit { v := types.Unit{}; return &v }(),
+										Constraint:         func() *types.Type { v := types.Type{}; return &v }(),
+										ChanDirection:      types.ChanDirection(0),
 									}
 									return &v
 								}(),
@@ -1448,75 +1099,59 @@ var _ = Describe("Codec", func() {
 				Unit: func() *types.Unit {
 					v := types.Unit{
 						Dimensions: types.Dimensions{
-							Length:      90,
-							Mass:        91,
-							Time:        92,
-							Current:     93,
-							Temperature: 94,
-							Angle:       95,
-							Count:       96,
-							Data:        97,
+							Length:      82,
+							Mass:        83,
+							Time:        84,
+							Current:     85,
+							Temperature: 86,
+							Angle:       87,
+							Count:       88,
+							Data:        89,
 						},
-						Scale: 97.5,
-						Name:  "test_98",
+						Scale: 89.5,
+						Name:  "test_90",
 					}
 					return &v
 				}(),
 				Constraint: func() *types.Type {
 					v := types.Type{
-						FunctionProperties: types.FunctionProperties{
-							Inputs:  []types.Param{},
-							Outputs: []types.Param{},
-							Config:  []types.Param{},
-						},
-						Kind: types.Kind(0),
-						Name: "test_104",
+						FunctionProperties: types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}},
+						Kind:               types.Kind(0),
+						Name:               "test_95",
 						Elem: func() *types.Type {
 							v := types.Type{
-								FunctionProperties: types.FunctionProperties{
-									Inputs:  []types.Param{},
-									Outputs: []types.Param{},
-									Config:  []types.Param{},
-								},
-								Kind: types.Kind(0),
-								Name: "test_110",
+								FunctionProperties: types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}},
+								Kind:               types.Kind(0),
+								Name:               "test_100",
 								Elem: func() *types.Type {
 									v := types.Type{
-										FunctionProperties: types.FunctionProperties{
-											Inputs:  []types.Param{},
-											Outputs: []types.Param{},
-											Config:  []types.Param{},
-										},
-										Kind:          types.Kind(0),
-										Name:          "test_116",
-										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-										ChanDirection: types.ChanDirection(0),
+										FunctionProperties: types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}},
+										Kind:               types.Kind(0),
+										Name:               "test_105",
+										Elem:               func() *types.Type { v := types.Type{}; return &v }(),
+										Unit:               func() *types.Unit { v := types.Unit{}; return &v }(),
+										Constraint:         func() *types.Type { v := types.Type{}; return &v }(),
+										ChanDirection:      types.ChanDirection(0),
 									}
 									return &v
 								}(),
 								Unit: func() *types.Unit {
 									v := types.Unit{
 										Dimensions: types.Dimensions{},
-										Scale:      123.5,
-										Name:       "test_124",
+										Scale:      112.5,
+										Name:       "test_113",
 									}
 									return &v
 								}(),
 								Constraint: func() *types.Type {
 									v := types.Type{
-										FunctionProperties: types.FunctionProperties{
-											Inputs:  []types.Param{},
-											Outputs: []types.Param{},
-											Config:  []types.Param{},
-										},
-										Kind:          types.Kind(0),
-										Name:          "test_130",
-										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-										ChanDirection: types.ChanDirection(0),
+										FunctionProperties: types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}},
+										Kind:               types.Kind(0),
+										Name:               "test_118",
+										Elem:               func() *types.Type { v := types.Type{}; return &v }(),
+										Unit:               func() *types.Unit { v := types.Unit{}; return &v }(),
+										Constraint:         func() *types.Type { v := types.Type{}; return &v }(),
+										ChanDirection:      types.ChanDirection(0),
 									}
 									return &v
 								}(),
@@ -1527,66 +1162,54 @@ var _ = Describe("Codec", func() {
 						Unit: func() *types.Unit {
 							v := types.Unit{
 								Dimensions: types.Dimensions{
-									Length:      13,
-									Mass:        14,
-									Time:        15,
-									Current:     16,
-									Temperature: 17,
-									Angle:       18,
-									Count:       19,
-									Data:        20,
+									Length:      1,
+									Mass:        2,
+									Time:        3,
+									Current:     4,
+									Temperature: 5,
+									Angle:       6,
+									Count:       7,
+									Data:        8,
 								},
-								Scale: 146.5,
-								Name:  "test_147",
+								Scale: 134.5,
+								Name:  "test_135",
 							}
 							return &v
 						}(),
 						Constraint: func() *types.Type {
 							v := types.Type{
-								FunctionProperties: types.FunctionProperties{
-									Inputs:  []types.Param{},
-									Outputs: []types.Param{},
-									Config:  []types.Param{},
-								},
-								Kind: types.Kind(0),
-								Name: "test_153",
+								FunctionProperties: types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}},
+								Kind:               types.Kind(0),
+								Name:               "test_140",
 								Elem: func() *types.Type {
 									v := types.Type{
-										FunctionProperties: types.FunctionProperties{
-											Inputs:  []types.Param{},
-											Outputs: []types.Param{},
-											Config:  []types.Param{},
-										},
-										Kind:          types.Kind(0),
-										Name:          "test_159",
-										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-										ChanDirection: types.ChanDirection(0),
+										FunctionProperties: types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}},
+										Kind:               types.Kind(0),
+										Name:               "test_145",
+										Elem:               func() *types.Type { v := types.Type{}; return &v }(),
+										Unit:               func() *types.Unit { v := types.Unit{}; return &v }(),
+										Constraint:         func() *types.Type { v := types.Type{}; return &v }(),
+										ChanDirection:      types.ChanDirection(0),
 									}
 									return &v
 								}(),
 								Unit: func() *types.Unit {
 									v := types.Unit{
 										Dimensions: types.Dimensions{},
-										Scale:      166.5,
-										Name:       "test_167",
+										Scale:      152.5,
+										Name:       "test_153",
 									}
 									return &v
 								}(),
 								Constraint: func() *types.Type {
 									v := types.Type{
-										FunctionProperties: types.FunctionProperties{
-											Inputs:  []types.Param{},
-											Outputs: []types.Param{},
-											Config:  []types.Param{},
-										},
-										Kind:          types.Kind(0),
-										Name:          "test_173",
-										Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-										Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-										Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-										ChanDirection: types.ChanDirection(0),
+										FunctionProperties: types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}},
+										Kind:               types.Kind(0),
+										Name:               "test_158",
+										Elem:               func() *types.Type { v := types.Type{}; return &v }(),
+										Unit:               func() *types.Unit { v := types.Unit{}; return &v }(),
+										Constraint:         func() *types.Type { v := types.Type{}; return &v }(),
+										ChanDirection:      types.ChanDirection(0),
 									}
 									return &v
 								}(),
@@ -1712,25 +1335,17 @@ func BenchmarkEncodeDecodeFunctionProperties(b *testing.B) {
 								Value: map[string]interface{}{"key_11": "value_11"},
 							},
 						},
-						Config: []types.Param{
-							{
-								Name:  "test_13",
-								Type:  types.Type{},
-								Value: map[string]interface{}{"key_15": "value_15"},
-							},
-						},
 					},
 					Kind: types.Kind(0),
-					Name: "test_17",
+					Name: "test_13",
 					Elem: func() *types.Type {
 						v := types.Type{
 							FunctionProperties: types.FunctionProperties{
 								Inputs:  []types.Param{{}},
 								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
 							},
 							Kind:          types.Kind(0),
-							Name:          "test_23",
+							Name:          "test_18",
 							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -1741,8 +1356,8 @@ func BenchmarkEncodeDecodeFunctionProperties(b *testing.B) {
 					Unit: func() *types.Unit {
 						v := types.Unit{
 							Dimensions: types.Dimensions{},
-							Scale:      30.5,
-							Name:       "test_31",
+							Scale:      25.5,
+							Name:       "test_26",
 						}
 						return &v
 					}(),
@@ -1751,10 +1366,9 @@ func BenchmarkEncodeDecodeFunctionProperties(b *testing.B) {
 							FunctionProperties: types.FunctionProperties{
 								Inputs:  []types.Param{{}},
 								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
 							},
 							Kind:          types.Kind(0),
-							Name:          "test_37",
+							Name:          "test_31",
 							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -1764,47 +1378,39 @@ func BenchmarkEncodeDecodeFunctionProperties(b *testing.B) {
 					}(),
 					ChanDirection: types.ChanDirection(0),
 				},
-				Value: map[string]interface{}{"key_43": "value_43"},
+				Value: map[string]interface{}{"key_37": "value_37"},
 			},
 		},
 		Outputs: []types.Param{
 			{
-				Name: "test_45",
+				Name: "test_39",
 				Type: types.Type{
 					FunctionProperties: types.FunctionProperties{
 						Inputs: []types.Param{
 							{
-								Name:  "test_48",
+								Name:  "test_42",
 								Type:  types.Type{},
-								Value: map[string]interface{}{"key_50": "value_50"},
+								Value: map[string]interface{}{"key_44": "value_44"},
 							},
 						},
 						Outputs: []types.Param{
 							{
-								Name:  "test_52",
+								Name:  "test_46",
 								Type:  types.Type{},
-								Value: map[string]interface{}{"key_54": "value_54"},
-							},
-						},
-						Config: []types.Param{
-							{
-								Name:  "test_56",
-								Type:  types.Type{},
-								Value: map[string]interface{}{"key_58": "value_58"},
+								Value: map[string]interface{}{"key_48": "value_48"},
 							},
 						},
 					},
 					Kind: types.Kind(0),
-					Name: "test_60",
+					Name: "test_50",
 					Elem: func() *types.Type {
 						v := types.Type{
 							FunctionProperties: types.FunctionProperties{
 								Inputs:  []types.Param{{}},
 								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
 							},
 							Kind:          types.Kind(0),
-							Name:          "test_66",
+							Name:          "test_55",
 							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -1815,8 +1421,8 @@ func BenchmarkEncodeDecodeFunctionProperties(b *testing.B) {
 					Unit: func() *types.Unit {
 						v := types.Unit{
 							Dimensions: types.Dimensions{},
-							Scale:      73.5,
-							Name:       "test_74",
+							Scale:      62.5,
+							Name:       "test_63",
 						}
 						return &v
 					}(),
@@ -1825,10 +1431,9 @@ func BenchmarkEncodeDecodeFunctionProperties(b *testing.B) {
 							FunctionProperties: types.FunctionProperties{
 								Inputs:  []types.Param{{}},
 								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
 							},
 							Kind:          types.Kind(0),
-							Name:          "test_80",
+							Name:          "test_68",
 							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -1838,81 +1443,7 @@ func BenchmarkEncodeDecodeFunctionProperties(b *testing.B) {
 					}(),
 					ChanDirection: types.ChanDirection(0),
 				},
-				Value: map[string]interface{}{"key_86": "value_86"},
-			},
-		},
-		Config: []types.Param{
-			{
-				Name: "test_88",
-				Type: types.Type{
-					FunctionProperties: types.FunctionProperties{
-						Inputs: []types.Param{
-							{
-								Name:  "test_91",
-								Type:  types.Type{},
-								Value: map[string]interface{}{"key_93": "value_93"},
-							},
-						},
-						Outputs: []types.Param{
-							{
-								Name:  "test_95",
-								Type:  types.Type{},
-								Value: map[string]interface{}{"key_97": "value_97"},
-							},
-						},
-						Config: []types.Param{
-							{
-								Name:  "test_99",
-								Type:  types.Type{},
-								Value: map[string]interface{}{"key_101": "value_101"},
-							},
-						},
-					},
-					Kind: types.Kind(0),
-					Name: "test_103",
-					Elem: func() *types.Type {
-						v := types.Type{
-							FunctionProperties: types.FunctionProperties{
-								Inputs:  []types.Param{{}},
-								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
-							},
-							Kind:          types.Kind(0),
-							Name:          "test_109",
-							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-							ChanDirection: types.ChanDirection(0),
-						}
-						return &v
-					}(),
-					Unit: func() *types.Unit {
-						v := types.Unit{
-							Dimensions: types.Dimensions{},
-							Scale:      116.5,
-							Name:       "test_117",
-						}
-						return &v
-					}(),
-					Constraint: func() *types.Type {
-						v := types.Type{
-							FunctionProperties: types.FunctionProperties{
-								Inputs:  []types.Param{{}},
-								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
-							},
-							Kind:          types.Kind(0),
-							Name:          "test_123",
-							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-							ChanDirection: types.ChanDirection(0),
-						}
-						return &v
-					}(),
-					ChanDirection: types.ChanDirection(0),
-				},
-				Value: map[string]interface{}{"key_129": "value_129"},
+				Value: map[string]interface{}{"key_74": "value_74"},
 			},
 		},
 	}
@@ -1943,95 +1474,66 @@ func BenchmarkEncodeDecodeParam(b *testing.B) {
 							FunctionProperties: types.FunctionProperties{
 								Inputs:  []types.Param{{}},
 								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
 							},
 							Kind:          types.Kind(0),
-							Name:          "test_10",
+							Name:          "test_9",
 							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 							ChanDirection: types.ChanDirection(0),
 						},
-						Value: map[string]interface{}{"key_15": "value_15"},
+						Value: map[string]interface{}{"key_14": "value_14"},
 					},
 				},
 				Outputs: []types.Param{
 					{
-						Name: "test_17",
+						Name: "test_16",
 						Type: types.Type{
 							FunctionProperties: types.FunctionProperties{
 								Inputs:  []types.Param{{}},
 								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
 							},
 							Kind:          types.Kind(0),
-							Name:          "test_23",
+							Name:          "test_21",
 							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 							ChanDirection: types.ChanDirection(0),
 						},
-						Value: map[string]interface{}{"key_28": "value_28"},
-					},
-				},
-				Config: []types.Param{
-					{
-						Name: "test_30",
-						Type: types.Type{
-							FunctionProperties: types.FunctionProperties{
-								Inputs:  []types.Param{{}},
-								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
-							},
-							Kind:          types.Kind(0),
-							Name:          "test_36",
-							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-							ChanDirection: types.ChanDirection(0),
-						},
-						Value: map[string]interface{}{"key_41": "value_41"},
+						Value: map[string]interface{}{"key_26": "value_26"},
 					},
 				},
 			},
 			Kind: types.Kind(0),
-			Name: "test_43",
+			Name: "test_28",
 			Elem: func() *types.Type {
 				v := types.Type{
 					FunctionProperties: types.FunctionProperties{
 						Inputs: []types.Param{
 							{
-								Name:  "test_46",
+								Name:  "test_31",
 								Type:  types.Type{},
-								Value: map[string]interface{}{"key_48": "value_48"},
+								Value: map[string]interface{}{"key_33": "value_33"},
 							},
 						},
 						Outputs: []types.Param{
 							{
-								Name:  "test_50",
+								Name:  "test_35",
 								Type:  types.Type{},
-								Value: map[string]interface{}{"key_52": "value_52"},
-							},
-						},
-						Config: []types.Param{
-							{
-								Name:  "test_54",
-								Type:  types.Type{},
-								Value: map[string]interface{}{"key_56": "value_56"},
+								Value: map[string]interface{}{"key_37": "value_37"},
 							},
 						},
 					},
 					Kind: types.Kind(0),
-					Name: "test_58",
+					Name: "test_39",
 					Elem: func() *types.Type {
 						v := types.Type{
 							FunctionProperties: types.FunctionProperties{
 								Inputs:  []types.Param{{}},
 								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
 							},
 							Kind:          types.Kind(0),
-							Name:          "test_64",
+							Name:          "test_44",
 							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -2042,8 +1544,8 @@ func BenchmarkEncodeDecodeParam(b *testing.B) {
 					Unit: func() *types.Unit {
 						v := types.Unit{
 							Dimensions: types.Dimensions{},
-							Scale:      71.5,
-							Name:       "test_72",
+							Scale:      51.5,
+							Name:       "test_52",
 						}
 						return &v
 					}(),
@@ -2052,10 +1554,9 @@ func BenchmarkEncodeDecodeParam(b *testing.B) {
 							FunctionProperties: types.FunctionProperties{
 								Inputs:  []types.Param{{}},
 								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
 							},
 							Kind:          types.Kind(0),
-							Name:          "test_78",
+							Name:          "test_57",
 							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -2070,17 +1571,17 @@ func BenchmarkEncodeDecodeParam(b *testing.B) {
 			Unit: func() *types.Unit {
 				v := types.Unit{
 					Dimensions: types.Dimensions{
-						Length:      87,
-						Mass:        88,
-						Time:        89,
-						Current:     90,
-						Temperature: 91,
-						Angle:       92,
-						Count:       93,
-						Data:        94,
+						Length:      66,
+						Mass:        67,
+						Time:        68,
+						Current:     69,
+						Temperature: 70,
+						Angle:       71,
+						Count:       72,
+						Data:        73,
 					},
-					Scale: 94.5,
-					Name:  "test_95",
+					Scale: 73.5,
+					Name:  "test_74",
 				}
 				return &v
 			}(),
@@ -2089,37 +1590,29 @@ func BenchmarkEncodeDecodeParam(b *testing.B) {
 					FunctionProperties: types.FunctionProperties{
 						Inputs: []types.Param{
 							{
-								Name:  "test_98",
+								Name:  "test_77",
 								Type:  types.Type{},
-								Value: map[string]interface{}{"key_100": "value_100"},
+								Value: map[string]interface{}{"key_79": "value_79"},
 							},
 						},
 						Outputs: []types.Param{
 							{
-								Name:  "test_102",
+								Name:  "test_81",
 								Type:  types.Type{},
-								Value: map[string]interface{}{"key_104": "value_104"},
-							},
-						},
-						Config: []types.Param{
-							{
-								Name:  "test_106",
-								Type:  types.Type{},
-								Value: map[string]interface{}{"key_108": "value_108"},
+								Value: map[string]interface{}{"key_83": "value_83"},
 							},
 						},
 					},
 					Kind: types.Kind(0),
-					Name: "test_110",
+					Name: "test_85",
 					Elem: func() *types.Type {
 						v := types.Type{
 							FunctionProperties: types.FunctionProperties{
 								Inputs:  []types.Param{{}},
 								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
 							},
 							Kind:          types.Kind(0),
-							Name:          "test_116",
+							Name:          "test_90",
 							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -2130,8 +1623,8 @@ func BenchmarkEncodeDecodeParam(b *testing.B) {
 					Unit: func() *types.Unit {
 						v := types.Unit{
 							Dimensions: types.Dimensions{},
-							Scale:      123.5,
-							Name:       "test_124",
+							Scale:      97.5,
+							Name:       "test_98",
 						}
 						return &v
 					}(),
@@ -2140,10 +1633,9 @@ func BenchmarkEncodeDecodeParam(b *testing.B) {
 							FunctionProperties: types.FunctionProperties{
 								Inputs:  []types.Param{{}},
 								Outputs: []types.Param{{}},
-								Config:  []types.Param{{}},
 							},
 							Kind:          types.Kind(0),
-							Name:          "test_130",
+							Name:          "test_103",
 							Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 							Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 							Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -2157,7 +1649,7 @@ func BenchmarkEncodeDecodeParam(b *testing.B) {
 			}(),
 			ChanDirection: types.ChanDirection(0),
 		},
-		Value: map[string]interface{}{"key_137": "value_137"},
+		Value: map[string]interface{}{"key_110": "value_110"},
 	}
 	w := orc.NewWriter(0)
 	r := orc.NewReader(nil)
@@ -2196,25 +1688,17 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 									Value: map[string]interface{}{"key_11": "value_11"},
 								},
 							},
-							Config: []types.Param{
-								{
-									Name:  "test_13",
-									Type:  types.Type{},
-									Value: map[string]interface{}{"key_15": "value_15"},
-								},
-							},
 						},
 						Kind: types.Kind(0),
-						Name: "test_17",
+						Name: "test_13",
 						Elem: func() *types.Type {
 							v := types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_23",
+								Name:          "test_18",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -2225,8 +1709,8 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 						Unit: func() *types.Unit {
 							v := types.Unit{
 								Dimensions: types.Dimensions{},
-								Scale:      30.5,
-								Name:       "test_31",
+								Scale:      25.5,
+								Name:       "test_26",
 							}
 							return &v
 						}(),
@@ -2235,10 +1719,9 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_37",
+								Name:          "test_31",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -2248,47 +1731,39 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 						}(),
 						ChanDirection: types.ChanDirection(0),
 					},
-					Value: map[string]interface{}{"key_43": "value_43"},
+					Value: map[string]interface{}{"key_37": "value_37"},
 				},
 			},
 			Outputs: []types.Param{
 				{
-					Name: "test_45",
+					Name: "test_39",
 					Type: types.Type{
 						FunctionProperties: types.FunctionProperties{
 							Inputs: []types.Param{
 								{
-									Name:  "test_48",
+									Name:  "test_42",
 									Type:  types.Type{},
-									Value: map[string]interface{}{"key_50": "value_50"},
+									Value: map[string]interface{}{"key_44": "value_44"},
 								},
 							},
 							Outputs: []types.Param{
 								{
-									Name:  "test_52",
+									Name:  "test_46",
 									Type:  types.Type{},
-									Value: map[string]interface{}{"key_54": "value_54"},
-								},
-							},
-							Config: []types.Param{
-								{
-									Name:  "test_56",
-									Type:  types.Type{},
-									Value: map[string]interface{}{"key_58": "value_58"},
+									Value: map[string]interface{}{"key_48": "value_48"},
 								},
 							},
 						},
 						Kind: types.Kind(0),
-						Name: "test_60",
+						Name: "test_50",
 						Elem: func() *types.Type {
 							v := types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_66",
+								Name:          "test_55",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -2299,8 +1774,8 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 						Unit: func() *types.Unit {
 							v := types.Unit{
 								Dimensions: types.Dimensions{},
-								Scale:      73.5,
-								Name:       "test_74",
+								Scale:      62.5,
+								Name:       "test_63",
 							}
 							return &v
 						}(),
@@ -2309,10 +1784,9 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_80",
+								Name:          "test_68",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -2322,185 +1796,82 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 						}(),
 						ChanDirection: types.ChanDirection(0),
 					},
-					Value: map[string]interface{}{"key_86": "value_86"},
-				},
-			},
-			Config: []types.Param{
-				{
-					Name: "test_88",
-					Type: types.Type{
-						FunctionProperties: types.FunctionProperties{
-							Inputs: []types.Param{
-								{
-									Name:  "test_91",
-									Type:  types.Type{},
-									Value: map[string]interface{}{"key_93": "value_93"},
-								},
-							},
-							Outputs: []types.Param{
-								{
-									Name:  "test_95",
-									Type:  types.Type{},
-									Value: map[string]interface{}{"key_97": "value_97"},
-								},
-							},
-							Config: []types.Param{
-								{
-									Name:  "test_99",
-									Type:  types.Type{},
-									Value: map[string]interface{}{"key_101": "value_101"},
-								},
-							},
-						},
-						Kind: types.Kind(0),
-						Name: "test_103",
-						Elem: func() *types.Type {
-							v := types.Type{
-								FunctionProperties: types.FunctionProperties{
-									Inputs:  []types.Param{{}},
-									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
-								},
-								Kind:          types.Kind(0),
-								Name:          "test_109",
-								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-								ChanDirection: types.ChanDirection(0),
-							}
-							return &v
-						}(),
-						Unit: func() *types.Unit {
-							v := types.Unit{
-								Dimensions: types.Dimensions{},
-								Scale:      116.5,
-								Name:       "test_117",
-							}
-							return &v
-						}(),
-						Constraint: func() *types.Type {
-							v := types.Type{
-								FunctionProperties: types.FunctionProperties{
-									Inputs:  []types.Param{{}},
-									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
-								},
-								Kind:          types.Kind(0),
-								Name:          "test_123",
-								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-								ChanDirection: types.ChanDirection(0),
-							}
-							return &v
-						}(),
-						ChanDirection: types.ChanDirection(0),
-					},
-					Value: map[string]interface{}{"key_129": "value_129"},
+					Value: map[string]interface{}{"key_74": "value_74"},
 				},
 			},
 		},
 		Kind: types.Kind(0),
-		Name: "test_131",
+		Name: "test_76",
 		Elem: func() *types.Type {
 			v := types.Type{
 				FunctionProperties: types.FunctionProperties{
 					Inputs: []types.Param{
 						{
-							Name: "test_134",
+							Name: "test_79",
 							Type: types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_140",
+								Name:          "test_84",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 								ChanDirection: types.ChanDirection(0),
 							},
-							Value: map[string]interface{}{"key_145": "value_145"},
+							Value: map[string]interface{}{"key_89": "value_89"},
 						},
 					},
 					Outputs: []types.Param{
 						{
-							Name: "test_147",
+							Name: "test_91",
 							Type: types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_153",
+								Name:          "test_96",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 								ChanDirection: types.ChanDirection(0),
 							},
-							Value: map[string]interface{}{"key_158": "value_158"},
-						},
-					},
-					Config: []types.Param{
-						{
-							Name: "test_160",
-							Type: types.Type{
-								FunctionProperties: types.FunctionProperties{
-									Inputs:  []types.Param{{}},
-									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
-								},
-								Kind:          types.Kind(0),
-								Name:          "test_166",
-								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-								ChanDirection: types.ChanDirection(0),
-							},
-							Value: map[string]interface{}{"key_171": "value_171"},
+							Value: map[string]interface{}{"key_101": "value_101"},
 						},
 					},
 				},
 				Kind: types.Kind(0),
-				Name: "test_173",
+				Name: "test_103",
 				Elem: func() *types.Type {
 					v := types.Type{
 						FunctionProperties: types.FunctionProperties{
 							Inputs: []types.Param{
 								{
-									Name:  "test_176",
+									Name:  "test_106",
 									Type:  types.Type{},
-									Value: map[string]interface{}{"key_178": "value_178"},
+									Value: map[string]interface{}{"key_108": "value_108"},
 								},
 							},
 							Outputs: []types.Param{
 								{
-									Name:  "test_180",
+									Name:  "test_110",
 									Type:  types.Type{},
-									Value: map[string]interface{}{"key_182": "value_182"},
-								},
-							},
-							Config: []types.Param{
-								{
-									Name:  "test_184",
-									Type:  types.Type{},
-									Value: map[string]interface{}{"key_186": "value_186"},
+									Value: map[string]interface{}{"key_112": "value_112"},
 								},
 							},
 						},
 						Kind: types.Kind(0),
-						Name: "test_188",
+						Name: "test_114",
 						Elem: func() *types.Type {
 							v := types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_194",
+								Name:          "test_119",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -2511,8 +1882,8 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 						Unit: func() *types.Unit {
 							v := types.Unit{
 								Dimensions: types.Dimensions{},
-								Scale:      201.5,
-								Name:       "test_202",
+								Scale:      126.5,
+								Name:       "test_127",
 							}
 							return &v
 						}(),
@@ -2521,10 +1892,9 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_208",
+								Name:          "test_132",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -2539,17 +1909,17 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 				Unit: func() *types.Unit {
 					v := types.Unit{
 						Dimensions: types.Dimensions{
-							Length:      91,
-							Mass:        92,
-							Time:        93,
-							Current:     94,
-							Temperature: 95,
-							Angle:       96,
-							Count:       97,
-							Data:        98,
+							Length:      15,
+							Mass:        16,
+							Time:        17,
+							Current:     18,
+							Temperature: 19,
+							Angle:       20,
+							Count:       21,
+							Data:        22,
 						},
-						Scale: 224.5,
-						Name:  "test_225",
+						Scale: 148.5,
+						Name:  "test_149",
 					}
 					return &v
 				}(),
@@ -2558,37 +1928,29 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 						FunctionProperties: types.FunctionProperties{
 							Inputs: []types.Param{
 								{
-									Name:  "test_228",
+									Name:  "test_152",
 									Type:  types.Type{},
-									Value: map[string]interface{}{"key_230": "value_230"},
+									Value: map[string]interface{}{"key_154": "value_154"},
 								},
 							},
 							Outputs: []types.Param{
 								{
-									Name:  "test_232",
+									Name:  "test_156",
 									Type:  types.Type{},
-									Value: map[string]interface{}{"key_234": "value_234"},
-								},
-							},
-							Config: []types.Param{
-								{
-									Name:  "test_236",
-									Type:  types.Type{},
-									Value: map[string]interface{}{"key_238": "value_238"},
+									Value: map[string]interface{}{"key_158": "value_158"},
 								},
 							},
 						},
 						Kind: types.Kind(0),
-						Name: "test_240",
+						Name: "test_160",
 						Elem: func() *types.Type {
 							v := types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_246",
+								Name:          "test_165",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -2599,8 +1961,8 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 						Unit: func() *types.Unit {
 							v := types.Unit{
 								Dimensions: types.Dimensions{},
-								Scale:      253.5,
-								Name:       "test_254",
+								Scale:      172.5,
+								Name:       "test_173",
 							}
 							return &v
 						}(),
@@ -2609,10 +1971,9 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_260",
+								Name:          "test_178",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -2631,17 +1992,17 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 		Unit: func() *types.Unit {
 			v := types.Unit{
 				Dimensions: types.Dimensions{
-					Length:      18,
-					Mass:        19,
-					Time:        20,
-					Current:     21,
-					Temperature: 22,
-					Angle:       23,
-					Count:       24,
-					Data:        25,
+					Length:      62,
+					Mass:        63,
+					Time:        64,
+					Current:     65,
+					Temperature: 66,
+					Angle:       67,
+					Count:       68,
+					Data:        69,
 				},
-				Scale: 277.5,
-				Name:  "test_278",
+				Scale: 195.5,
+				Name:  "test_196",
 			}
 			return &v
 		}(),
@@ -2650,100 +2011,71 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 				FunctionProperties: types.FunctionProperties{
 					Inputs: []types.Param{
 						{
-							Name: "test_281",
+							Name: "test_199",
 							Type: types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_287",
+								Name:          "test_204",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 								ChanDirection: types.ChanDirection(0),
 							},
-							Value: map[string]interface{}{"key_292": "value_292"},
+							Value: map[string]interface{}{"key_209": "value_209"},
 						},
 					},
 					Outputs: []types.Param{
 						{
-							Name: "test_294",
+							Name: "test_211",
 							Type: types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_300",
+								Name:          "test_216",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 								ChanDirection: types.ChanDirection(0),
 							},
-							Value: map[string]interface{}{"key_305": "value_305"},
-						},
-					},
-					Config: []types.Param{
-						{
-							Name: "test_307",
-							Type: types.Type{
-								FunctionProperties: types.FunctionProperties{
-									Inputs:  []types.Param{{}},
-									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
-								},
-								Kind:          types.Kind(0),
-								Name:          "test_313",
-								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-								ChanDirection: types.ChanDirection(0),
-							},
-							Value: map[string]interface{}{"key_318": "value_318"},
+							Value: map[string]interface{}{"key_221": "value_221"},
 						},
 					},
 				},
 				Kind: types.Kind(0),
-				Name: "test_320",
+				Name: "test_223",
 				Elem: func() *types.Type {
 					v := types.Type{
 						FunctionProperties: types.FunctionProperties{
 							Inputs: []types.Param{
 								{
-									Name:  "test_323",
+									Name:  "test_226",
 									Type:  types.Type{},
-									Value: map[string]interface{}{"key_325": "value_325"},
+									Value: map[string]interface{}{"key_228": "value_228"},
 								},
 							},
 							Outputs: []types.Param{
 								{
-									Name:  "test_327",
+									Name:  "test_230",
 									Type:  types.Type{},
-									Value: map[string]interface{}{"key_329": "value_329"},
-								},
-							},
-							Config: []types.Param{
-								{
-									Name:  "test_331",
-									Type:  types.Type{},
-									Value: map[string]interface{}{"key_333": "value_333"},
+									Value: map[string]interface{}{"key_232": "value_232"},
 								},
 							},
 						},
 						Kind: types.Kind(0),
-						Name: "test_335",
+						Name: "test_234",
 						Elem: func() *types.Type {
 							v := types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_341",
+								Name:          "test_239",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -2754,8 +2086,8 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 						Unit: func() *types.Unit {
 							v := types.Unit{
 								Dimensions: types.Dimensions{},
-								Scale:      348.5,
-								Name:       "test_349",
+								Scale:      246.5,
+								Name:       "test_247",
 							}
 							return &v
 						}(),
@@ -2764,10 +2096,9 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_355",
+								Name:          "test_252",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -2782,17 +2113,17 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 				Unit: func() *types.Unit {
 					v := types.Unit{
 						Dimensions: types.Dimensions{
-							Length:      112,
-							Mass:        113,
-							Time:        114,
-							Current:     115,
-							Temperature: 116,
-							Angle:       117,
-							Count:       118,
-							Data:        119,
+							Length:      9,
+							Mass:        10,
+							Time:        11,
+							Current:     12,
+							Temperature: 13,
+							Angle:       14,
+							Count:       15,
+							Data:        16,
 						},
-						Scale: 371.5,
-						Name:  "test_372",
+						Scale: 268.5,
+						Name:  "test_269",
 					}
 					return &v
 				}(),
@@ -2801,37 +2132,29 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 						FunctionProperties: types.FunctionProperties{
 							Inputs: []types.Param{
 								{
-									Name:  "test_375",
+									Name:  "test_272",
 									Type:  types.Type{},
-									Value: map[string]interface{}{"key_377": "value_377"},
+									Value: map[string]interface{}{"key_274": "value_274"},
 								},
 							},
 							Outputs: []types.Param{
 								{
-									Name:  "test_379",
+									Name:  "test_276",
 									Type:  types.Type{},
-									Value: map[string]interface{}{"key_381": "value_381"},
-								},
-							},
-							Config: []types.Param{
-								{
-									Name:  "test_383",
-									Type:  types.Type{},
-									Value: map[string]interface{}{"key_385": "value_385"},
+									Value: map[string]interface{}{"key_278": "value_278"},
 								},
 							},
 						},
 						Kind: types.Kind(0),
-						Name: "test_387",
+						Name: "test_280",
 						Elem: func() *types.Type {
 							v := types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_393",
+								Name:          "test_285",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -2842,8 +2165,8 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 						Unit: func() *types.Unit {
 							v := types.Unit{
 								Dimensions: types.Dimensions{},
-								Scale:      400.5,
-								Name:       "test_401",
+								Scale:      292.5,
+								Name:       "test_293",
 							}
 							return &v
 						}(),
@@ -2852,10 +2175,9 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_407",
+								Name:          "test_298",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -3061,25 +2383,17 @@ func FuzzDecodeFunctionProperties(f *testing.F) {
 									Value: map[string]interface{}{"key_11": "value_11"},
 								},
 							},
-							Config: []types.Param{
-								{
-									Name:  "test_13",
-									Type:  types.Type{},
-									Value: map[string]interface{}{"key_15": "value_15"},
-								},
-							},
 						},
 						Kind: types.Kind(0),
-						Name: "test_17",
+						Name: "test_13",
 						Elem: func() *types.Type {
 							v := types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_23",
+								Name:          "test_18",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -3090,8 +2404,8 @@ func FuzzDecodeFunctionProperties(f *testing.F) {
 						Unit: func() *types.Unit {
 							v := types.Unit{
 								Dimensions: types.Dimensions{},
-								Scale:      30.5,
-								Name:       "test_31",
+								Scale:      25.5,
+								Name:       "test_26",
 							}
 							return &v
 						}(),
@@ -3100,10 +2414,9 @@ func FuzzDecodeFunctionProperties(f *testing.F) {
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_37",
+								Name:          "test_31",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -3113,47 +2426,39 @@ func FuzzDecodeFunctionProperties(f *testing.F) {
 						}(),
 						ChanDirection: types.ChanDirection(0),
 					},
-					Value: map[string]interface{}{"key_43": "value_43"},
+					Value: map[string]interface{}{"key_37": "value_37"},
 				},
 			},
 			Outputs: []types.Param{
 				{
-					Name: "test_45",
+					Name: "test_39",
 					Type: types.Type{
 						FunctionProperties: types.FunctionProperties{
 							Inputs: []types.Param{
 								{
-									Name:  "test_48",
+									Name:  "test_42",
 									Type:  types.Type{},
-									Value: map[string]interface{}{"key_50": "value_50"},
+									Value: map[string]interface{}{"key_44": "value_44"},
 								},
 							},
 							Outputs: []types.Param{
 								{
-									Name:  "test_52",
+									Name:  "test_46",
 									Type:  types.Type{},
-									Value: map[string]interface{}{"key_54": "value_54"},
-								},
-							},
-							Config: []types.Param{
-								{
-									Name:  "test_56",
-									Type:  types.Type{},
-									Value: map[string]interface{}{"key_58": "value_58"},
+									Value: map[string]interface{}{"key_48": "value_48"},
 								},
 							},
 						},
 						Kind: types.Kind(0),
-						Name: "test_60",
+						Name: "test_50",
 						Elem: func() *types.Type {
 							v := types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_66",
+								Name:          "test_55",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -3164,8 +2469,8 @@ func FuzzDecodeFunctionProperties(f *testing.F) {
 						Unit: func() *types.Unit {
 							v := types.Unit{
 								Dimensions: types.Dimensions{},
-								Scale:      73.5,
-								Name:       "test_74",
+								Scale:      62.5,
+								Name:       "test_63",
 							}
 							return &v
 						}(),
@@ -3174,10 +2479,9 @@ func FuzzDecodeFunctionProperties(f *testing.F) {
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_80",
+								Name:          "test_68",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -3187,81 +2491,7 @@ func FuzzDecodeFunctionProperties(f *testing.F) {
 						}(),
 						ChanDirection: types.ChanDirection(0),
 					},
-					Value: map[string]interface{}{"key_86": "value_86"},
-				},
-			},
-			Config: []types.Param{
-				{
-					Name: "test_88",
-					Type: types.Type{
-						FunctionProperties: types.FunctionProperties{
-							Inputs: []types.Param{
-								{
-									Name:  "test_91",
-									Type:  types.Type{},
-									Value: map[string]interface{}{"key_93": "value_93"},
-								},
-							},
-							Outputs: []types.Param{
-								{
-									Name:  "test_95",
-									Type:  types.Type{},
-									Value: map[string]interface{}{"key_97": "value_97"},
-								},
-							},
-							Config: []types.Param{
-								{
-									Name:  "test_99",
-									Type:  types.Type{},
-									Value: map[string]interface{}{"key_101": "value_101"},
-								},
-							},
-						},
-						Kind: types.Kind(0),
-						Name: "test_103",
-						Elem: func() *types.Type {
-							v := types.Type{
-								FunctionProperties: types.FunctionProperties{
-									Inputs:  []types.Param{{}},
-									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
-								},
-								Kind:          types.Kind(0),
-								Name:          "test_109",
-								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-								ChanDirection: types.ChanDirection(0),
-							}
-							return &v
-						}(),
-						Unit: func() *types.Unit {
-							v := types.Unit{
-								Dimensions: types.Dimensions{},
-								Scale:      116.5,
-								Name:       "test_117",
-							}
-							return &v
-						}(),
-						Constraint: func() *types.Type {
-							v := types.Type{
-								FunctionProperties: types.FunctionProperties{
-									Inputs:  []types.Param{{}},
-									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
-								},
-								Kind:          types.Kind(0),
-								Name:          "test_123",
-								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-								ChanDirection: types.ChanDirection(0),
-							}
-							return &v
-						}(),
-						ChanDirection: types.ChanDirection(0),
-					},
-					Value: map[string]interface{}{"key_129": "value_129"},
+					Value: map[string]interface{}{"key_74": "value_74"},
 				},
 			},
 		}
@@ -3272,11 +2502,7 @@ func FuzzDecodeFunctionProperties(f *testing.F) {
 		f.Add(w.Bytes())
 	}
 	{
-		seed := types.FunctionProperties{
-			Inputs:  nil,
-			Outputs: nil,
-			Config:  nil,
-		}
+		seed := types.FunctionProperties{Inputs: nil, Outputs: nil}
 		w := orc.NewWriter(0)
 		if err := seed.EncodeOrc(w); err != nil {
 			f.Fatal(err)
@@ -3284,11 +2510,7 @@ func FuzzDecodeFunctionProperties(f *testing.F) {
 		f.Add(w.Bytes())
 	}
 	{
-		seed := types.FunctionProperties{
-			Inputs:  []types.Param{},
-			Outputs: []types.Param{},
-			Config:  []types.Param{},
-		}
+		seed := types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}}
 		w := orc.NewWriter(0)
 		if err := seed.EncodeOrc(w); err != nil {
 			f.Fatal(err)
@@ -3337,95 +2559,66 @@ func FuzzDecodeParam(f *testing.F) {
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_10",
+								Name:          "test_9",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 								ChanDirection: types.ChanDirection(0),
 							},
-							Value: map[string]interface{}{"key_15": "value_15"},
+							Value: map[string]interface{}{"key_14": "value_14"},
 						},
 					},
 					Outputs: []types.Param{
 						{
-							Name: "test_17",
+							Name: "test_16",
 							Type: types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_23",
+								Name:          "test_21",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 								ChanDirection: types.ChanDirection(0),
 							},
-							Value: map[string]interface{}{"key_28": "value_28"},
-						},
-					},
-					Config: []types.Param{
-						{
-							Name: "test_30",
-							Type: types.Type{
-								FunctionProperties: types.FunctionProperties{
-									Inputs:  []types.Param{{}},
-									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
-								},
-								Kind:          types.Kind(0),
-								Name:          "test_36",
-								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-								ChanDirection: types.ChanDirection(0),
-							},
-							Value: map[string]interface{}{"key_41": "value_41"},
+							Value: map[string]interface{}{"key_26": "value_26"},
 						},
 					},
 				},
 				Kind: types.Kind(0),
-				Name: "test_43",
+				Name: "test_28",
 				Elem: func() *types.Type {
 					v := types.Type{
 						FunctionProperties: types.FunctionProperties{
 							Inputs: []types.Param{
 								{
-									Name:  "test_46",
+									Name:  "test_31",
 									Type:  types.Type{},
-									Value: map[string]interface{}{"key_48": "value_48"},
+									Value: map[string]interface{}{"key_33": "value_33"},
 								},
 							},
 							Outputs: []types.Param{
 								{
-									Name:  "test_50",
+									Name:  "test_35",
 									Type:  types.Type{},
-									Value: map[string]interface{}{"key_52": "value_52"},
-								},
-							},
-							Config: []types.Param{
-								{
-									Name:  "test_54",
-									Type:  types.Type{},
-									Value: map[string]interface{}{"key_56": "value_56"},
+									Value: map[string]interface{}{"key_37": "value_37"},
 								},
 							},
 						},
 						Kind: types.Kind(0),
-						Name: "test_58",
+						Name: "test_39",
 						Elem: func() *types.Type {
 							v := types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_64",
+								Name:          "test_44",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -3436,8 +2629,8 @@ func FuzzDecodeParam(f *testing.F) {
 						Unit: func() *types.Unit {
 							v := types.Unit{
 								Dimensions: types.Dimensions{},
-								Scale:      71.5,
-								Name:       "test_72",
+								Scale:      51.5,
+								Name:       "test_52",
 							}
 							return &v
 						}(),
@@ -3446,10 +2639,9 @@ func FuzzDecodeParam(f *testing.F) {
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_78",
+								Name:          "test_57",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -3464,17 +2656,17 @@ func FuzzDecodeParam(f *testing.F) {
 				Unit: func() *types.Unit {
 					v := types.Unit{
 						Dimensions: types.Dimensions{
-							Length:      87,
-							Mass:        88,
-							Time:        89,
-							Current:     90,
-							Temperature: 91,
-							Angle:       92,
-							Count:       93,
-							Data:        94,
+							Length:      66,
+							Mass:        67,
+							Time:        68,
+							Current:     69,
+							Temperature: 70,
+							Angle:       71,
+							Count:       72,
+							Data:        73,
 						},
-						Scale: 94.5,
-						Name:  "test_95",
+						Scale: 73.5,
+						Name:  "test_74",
 					}
 					return &v
 				}(),
@@ -3483,37 +2675,29 @@ func FuzzDecodeParam(f *testing.F) {
 						FunctionProperties: types.FunctionProperties{
 							Inputs: []types.Param{
 								{
-									Name:  "test_98",
+									Name:  "test_77",
 									Type:  types.Type{},
-									Value: map[string]interface{}{"key_100": "value_100"},
+									Value: map[string]interface{}{"key_79": "value_79"},
 								},
 							},
 							Outputs: []types.Param{
 								{
-									Name:  "test_102",
+									Name:  "test_81",
 									Type:  types.Type{},
-									Value: map[string]interface{}{"key_104": "value_104"},
-								},
-							},
-							Config: []types.Param{
-								{
-									Name:  "test_106",
-									Type:  types.Type{},
-									Value: map[string]interface{}{"key_108": "value_108"},
+									Value: map[string]interface{}{"key_83": "value_83"},
 								},
 							},
 						},
 						Kind: types.Kind(0),
-						Name: "test_110",
+						Name: "test_85",
 						Elem: func() *types.Type {
 							v := types.Type{
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_116",
+								Name:          "test_90",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -3524,8 +2708,8 @@ func FuzzDecodeParam(f *testing.F) {
 						Unit: func() *types.Unit {
 							v := types.Unit{
 								Dimensions: types.Dimensions{},
-								Scale:      123.5,
-								Name:       "test_124",
+								Scale:      97.5,
+								Name:       "test_98",
 							}
 							return &v
 						}(),
@@ -3534,10 +2718,9 @@ func FuzzDecodeParam(f *testing.F) {
 								FunctionProperties: types.FunctionProperties{
 									Inputs:  []types.Param{{}},
 									Outputs: []types.Param{{}},
-									Config:  []types.Param{{}},
 								},
 								Kind:          types.Kind(0),
-								Name:          "test_130",
+								Name:          "test_103",
 								Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 								Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 								Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -3551,7 +2734,7 @@ func FuzzDecodeParam(f *testing.F) {
 				}(),
 				ChanDirection: types.ChanDirection(0),
 			},
-			Value: map[string]interface{}{"key_137": "value_137"},
+			Value: map[string]interface{}{"key_110": "value_110"},
 		}
 		w := orc.NewWriter(0)
 		if err := seed.EncodeOrc(w); err != nil {
@@ -3563,17 +2746,13 @@ func FuzzDecodeParam(f *testing.F) {
 		seed := types.Param{
 			Name: "",
 			Type: types.Type{
-				FunctionProperties: types.FunctionProperties{
-					Inputs:  nil,
-					Outputs: nil,
-					Config:  nil,
-				},
-				Kind:          types.Kind(0),
-				Name:          "",
-				Elem:          nil,
-				Unit:          nil,
-				Constraint:    nil,
-				ChanDirection: types.ChanDirection(0),
+				FunctionProperties: types.FunctionProperties{Inputs: nil, Outputs: nil},
+				Kind:               types.Kind(0),
+				Name:               "",
+				Elem:               nil,
+				Unit:               nil,
+				Constraint:         nil,
+				ChanDirection:      types.ChanDirection(0),
 			},
 			Value: nil,
 		}
@@ -3635,25 +2814,17 @@ func FuzzDecodeType(f *testing.F) {
 										Value: map[string]interface{}{"key_11": "value_11"},
 									},
 								},
-								Config: []types.Param{
-									{
-										Name:  "test_13",
-										Type:  types.Type{},
-										Value: map[string]interface{}{"key_15": "value_15"},
-									},
-								},
 							},
 							Kind: types.Kind(0),
-							Name: "test_17",
+							Name: "test_13",
 							Elem: func() *types.Type {
 								v := types.Type{
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_23",
+									Name:          "test_18",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -3664,8 +2835,8 @@ func FuzzDecodeType(f *testing.F) {
 							Unit: func() *types.Unit {
 								v := types.Unit{
 									Dimensions: types.Dimensions{},
-									Scale:      30.5,
-									Name:       "test_31",
+									Scale:      25.5,
+									Name:       "test_26",
 								}
 								return &v
 							}(),
@@ -3674,10 +2845,9 @@ func FuzzDecodeType(f *testing.F) {
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_37",
+									Name:          "test_31",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -3687,47 +2857,39 @@ func FuzzDecodeType(f *testing.F) {
 							}(),
 							ChanDirection: types.ChanDirection(0),
 						},
-						Value: map[string]interface{}{"key_43": "value_43"},
+						Value: map[string]interface{}{"key_37": "value_37"},
 					},
 				},
 				Outputs: []types.Param{
 					{
-						Name: "test_45",
+						Name: "test_39",
 						Type: types.Type{
 							FunctionProperties: types.FunctionProperties{
 								Inputs: []types.Param{
 									{
-										Name:  "test_48",
+										Name:  "test_42",
 										Type:  types.Type{},
-										Value: map[string]interface{}{"key_50": "value_50"},
+										Value: map[string]interface{}{"key_44": "value_44"},
 									},
 								},
 								Outputs: []types.Param{
 									{
-										Name:  "test_52",
+										Name:  "test_46",
 										Type:  types.Type{},
-										Value: map[string]interface{}{"key_54": "value_54"},
-									},
-								},
-								Config: []types.Param{
-									{
-										Name:  "test_56",
-										Type:  types.Type{},
-										Value: map[string]interface{}{"key_58": "value_58"},
+										Value: map[string]interface{}{"key_48": "value_48"},
 									},
 								},
 							},
 							Kind: types.Kind(0),
-							Name: "test_60",
+							Name: "test_50",
 							Elem: func() *types.Type {
 								v := types.Type{
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_66",
+									Name:          "test_55",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -3738,8 +2900,8 @@ func FuzzDecodeType(f *testing.F) {
 							Unit: func() *types.Unit {
 								v := types.Unit{
 									Dimensions: types.Dimensions{},
-									Scale:      73.5,
-									Name:       "test_74",
+									Scale:      62.5,
+									Name:       "test_63",
 								}
 								return &v
 							}(),
@@ -3748,10 +2910,9 @@ func FuzzDecodeType(f *testing.F) {
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_80",
+									Name:          "test_68",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -3761,185 +2922,82 @@ func FuzzDecodeType(f *testing.F) {
 							}(),
 							ChanDirection: types.ChanDirection(0),
 						},
-						Value: map[string]interface{}{"key_86": "value_86"},
-					},
-				},
-				Config: []types.Param{
-					{
-						Name: "test_88",
-						Type: types.Type{
-							FunctionProperties: types.FunctionProperties{
-								Inputs: []types.Param{
-									{
-										Name:  "test_91",
-										Type:  types.Type{},
-										Value: map[string]interface{}{"key_93": "value_93"},
-									},
-								},
-								Outputs: []types.Param{
-									{
-										Name:  "test_95",
-										Type:  types.Type{},
-										Value: map[string]interface{}{"key_97": "value_97"},
-									},
-								},
-								Config: []types.Param{
-									{
-										Name:  "test_99",
-										Type:  types.Type{},
-										Value: map[string]interface{}{"key_101": "value_101"},
-									},
-								},
-							},
-							Kind: types.Kind(0),
-							Name: "test_103",
-							Elem: func() *types.Type {
-								v := types.Type{
-									FunctionProperties: types.FunctionProperties{
-										Inputs:  []types.Param{{}},
-										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
-									},
-									Kind:          types.Kind(0),
-									Name:          "test_109",
-									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-									ChanDirection: types.ChanDirection(0),
-								}
-								return &v
-							}(),
-							Unit: func() *types.Unit {
-								v := types.Unit{
-									Dimensions: types.Dimensions{},
-									Scale:      116.5,
-									Name:       "test_117",
-								}
-								return &v
-							}(),
-							Constraint: func() *types.Type {
-								v := types.Type{
-									FunctionProperties: types.FunctionProperties{
-										Inputs:  []types.Param{{}},
-										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
-									},
-									Kind:          types.Kind(0),
-									Name:          "test_123",
-									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-									ChanDirection: types.ChanDirection(0),
-								}
-								return &v
-							}(),
-							ChanDirection: types.ChanDirection(0),
-						},
-						Value: map[string]interface{}{"key_129": "value_129"},
+						Value: map[string]interface{}{"key_74": "value_74"},
 					},
 				},
 			},
 			Kind: types.Kind(0),
-			Name: "test_131",
+			Name: "test_76",
 			Elem: func() *types.Type {
 				v := types.Type{
 					FunctionProperties: types.FunctionProperties{
 						Inputs: []types.Param{
 							{
-								Name: "test_134",
+								Name: "test_79",
 								Type: types.Type{
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_140",
+									Name:          "test_84",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 									ChanDirection: types.ChanDirection(0),
 								},
-								Value: map[string]interface{}{"key_145": "value_145"},
+								Value: map[string]interface{}{"key_89": "value_89"},
 							},
 						},
 						Outputs: []types.Param{
 							{
-								Name: "test_147",
+								Name: "test_91",
 								Type: types.Type{
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_153",
+									Name:          "test_96",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 									ChanDirection: types.ChanDirection(0),
 								},
-								Value: map[string]interface{}{"key_158": "value_158"},
-							},
-						},
-						Config: []types.Param{
-							{
-								Name: "test_160",
-								Type: types.Type{
-									FunctionProperties: types.FunctionProperties{
-										Inputs:  []types.Param{{}},
-										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
-									},
-									Kind:          types.Kind(0),
-									Name:          "test_166",
-									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-									ChanDirection: types.ChanDirection(0),
-								},
-								Value: map[string]interface{}{"key_171": "value_171"},
+								Value: map[string]interface{}{"key_101": "value_101"},
 							},
 						},
 					},
 					Kind: types.Kind(0),
-					Name: "test_173",
+					Name: "test_103",
 					Elem: func() *types.Type {
 						v := types.Type{
 							FunctionProperties: types.FunctionProperties{
 								Inputs: []types.Param{
 									{
-										Name:  "test_176",
+										Name:  "test_106",
 										Type:  types.Type{},
-										Value: map[string]interface{}{"key_178": "value_178"},
+										Value: map[string]interface{}{"key_108": "value_108"},
 									},
 								},
 								Outputs: []types.Param{
 									{
-										Name:  "test_180",
+										Name:  "test_110",
 										Type:  types.Type{},
-										Value: map[string]interface{}{"key_182": "value_182"},
-									},
-								},
-								Config: []types.Param{
-									{
-										Name:  "test_184",
-										Type:  types.Type{},
-										Value: map[string]interface{}{"key_186": "value_186"},
+										Value: map[string]interface{}{"key_112": "value_112"},
 									},
 								},
 							},
 							Kind: types.Kind(0),
-							Name: "test_188",
+							Name: "test_114",
 							Elem: func() *types.Type {
 								v := types.Type{
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_194",
+									Name:          "test_119",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -3950,8 +3008,8 @@ func FuzzDecodeType(f *testing.F) {
 							Unit: func() *types.Unit {
 								v := types.Unit{
 									Dimensions: types.Dimensions{},
-									Scale:      201.5,
-									Name:       "test_202",
+									Scale:      126.5,
+									Name:       "test_127",
 								}
 								return &v
 							}(),
@@ -3960,10 +3018,9 @@ func FuzzDecodeType(f *testing.F) {
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_208",
+									Name:          "test_132",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -3978,17 +3035,17 @@ func FuzzDecodeType(f *testing.F) {
 					Unit: func() *types.Unit {
 						v := types.Unit{
 							Dimensions: types.Dimensions{
-								Length:      91,
-								Mass:        92,
-								Time:        93,
-								Current:     94,
-								Temperature: 95,
-								Angle:       96,
-								Count:       97,
-								Data:        98,
+								Length:      15,
+								Mass:        16,
+								Time:        17,
+								Current:     18,
+								Temperature: 19,
+								Angle:       20,
+								Count:       21,
+								Data:        22,
 							},
-							Scale: 224.5,
-							Name:  "test_225",
+							Scale: 148.5,
+							Name:  "test_149",
 						}
 						return &v
 					}(),
@@ -3997,37 +3054,29 @@ func FuzzDecodeType(f *testing.F) {
 							FunctionProperties: types.FunctionProperties{
 								Inputs: []types.Param{
 									{
-										Name:  "test_228",
+										Name:  "test_152",
 										Type:  types.Type{},
-										Value: map[string]interface{}{"key_230": "value_230"},
+										Value: map[string]interface{}{"key_154": "value_154"},
 									},
 								},
 								Outputs: []types.Param{
 									{
-										Name:  "test_232",
+										Name:  "test_156",
 										Type:  types.Type{},
-										Value: map[string]interface{}{"key_234": "value_234"},
-									},
-								},
-								Config: []types.Param{
-									{
-										Name:  "test_236",
-										Type:  types.Type{},
-										Value: map[string]interface{}{"key_238": "value_238"},
+										Value: map[string]interface{}{"key_158": "value_158"},
 									},
 								},
 							},
 							Kind: types.Kind(0),
-							Name: "test_240",
+							Name: "test_160",
 							Elem: func() *types.Type {
 								v := types.Type{
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_246",
+									Name:          "test_165",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -4038,8 +3087,8 @@ func FuzzDecodeType(f *testing.F) {
 							Unit: func() *types.Unit {
 								v := types.Unit{
 									Dimensions: types.Dimensions{},
-									Scale:      253.5,
-									Name:       "test_254",
+									Scale:      172.5,
+									Name:       "test_173",
 								}
 								return &v
 							}(),
@@ -4048,10 +3097,9 @@ func FuzzDecodeType(f *testing.F) {
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_260",
+									Name:          "test_178",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -4070,17 +3118,17 @@ func FuzzDecodeType(f *testing.F) {
 			Unit: func() *types.Unit {
 				v := types.Unit{
 					Dimensions: types.Dimensions{
-						Length:      18,
-						Mass:        19,
-						Time:        20,
-						Current:     21,
-						Temperature: 22,
-						Angle:       23,
-						Count:       24,
-						Data:        25,
+						Length:      62,
+						Mass:        63,
+						Time:        64,
+						Current:     65,
+						Temperature: 66,
+						Angle:       67,
+						Count:       68,
+						Data:        69,
 					},
-					Scale: 277.5,
-					Name:  "test_278",
+					Scale: 195.5,
+					Name:  "test_196",
 				}
 				return &v
 			}(),
@@ -4089,100 +3137,71 @@ func FuzzDecodeType(f *testing.F) {
 					FunctionProperties: types.FunctionProperties{
 						Inputs: []types.Param{
 							{
-								Name: "test_281",
+								Name: "test_199",
 								Type: types.Type{
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_287",
+									Name:          "test_204",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 									ChanDirection: types.ChanDirection(0),
 								},
-								Value: map[string]interface{}{"key_292": "value_292"},
+								Value: map[string]interface{}{"key_209": "value_209"},
 							},
 						},
 						Outputs: []types.Param{
 							{
-								Name: "test_294",
+								Name: "test_211",
 								Type: types.Type{
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_300",
+									Name:          "test_216",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
 									ChanDirection: types.ChanDirection(0),
 								},
-								Value: map[string]interface{}{"key_305": "value_305"},
-							},
-						},
-						Config: []types.Param{
-							{
-								Name: "test_307",
-								Type: types.Type{
-									FunctionProperties: types.FunctionProperties{
-										Inputs:  []types.Param{{}},
-										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
-									},
-									Kind:          types.Kind(0),
-									Name:          "test_313",
-									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-									ChanDirection: types.ChanDirection(0),
-								},
-								Value: map[string]interface{}{"key_318": "value_318"},
+								Value: map[string]interface{}{"key_221": "value_221"},
 							},
 						},
 					},
 					Kind: types.Kind(0),
-					Name: "test_320",
+					Name: "test_223",
 					Elem: func() *types.Type {
 						v := types.Type{
 							FunctionProperties: types.FunctionProperties{
 								Inputs: []types.Param{
 									{
-										Name:  "test_323",
+										Name:  "test_226",
 										Type:  types.Type{},
-										Value: map[string]interface{}{"key_325": "value_325"},
+										Value: map[string]interface{}{"key_228": "value_228"},
 									},
 								},
 								Outputs: []types.Param{
 									{
-										Name:  "test_327",
+										Name:  "test_230",
 										Type:  types.Type{},
-										Value: map[string]interface{}{"key_329": "value_329"},
-									},
-								},
-								Config: []types.Param{
-									{
-										Name:  "test_331",
-										Type:  types.Type{},
-										Value: map[string]interface{}{"key_333": "value_333"},
+										Value: map[string]interface{}{"key_232": "value_232"},
 									},
 								},
 							},
 							Kind: types.Kind(0),
-							Name: "test_335",
+							Name: "test_234",
 							Elem: func() *types.Type {
 								v := types.Type{
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_341",
+									Name:          "test_239",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -4193,8 +3212,8 @@ func FuzzDecodeType(f *testing.F) {
 							Unit: func() *types.Unit {
 								v := types.Unit{
 									Dimensions: types.Dimensions{},
-									Scale:      348.5,
-									Name:       "test_349",
+									Scale:      246.5,
+									Name:       "test_247",
 								}
 								return &v
 							}(),
@@ -4203,10 +3222,9 @@ func FuzzDecodeType(f *testing.F) {
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_355",
+									Name:          "test_252",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -4221,17 +3239,17 @@ func FuzzDecodeType(f *testing.F) {
 					Unit: func() *types.Unit {
 						v := types.Unit{
 							Dimensions: types.Dimensions{
-								Length:      112,
-								Mass:        113,
-								Time:        114,
-								Current:     115,
-								Temperature: 116,
-								Angle:       117,
-								Count:       118,
-								Data:        119,
+								Length:      9,
+								Mass:        10,
+								Time:        11,
+								Current:     12,
+								Temperature: 13,
+								Angle:       14,
+								Count:       15,
+								Data:        16,
 							},
-							Scale: 371.5,
-							Name:  "test_372",
+							Scale: 268.5,
+							Name:  "test_269",
 						}
 						return &v
 					}(),
@@ -4240,37 +3258,29 @@ func FuzzDecodeType(f *testing.F) {
 							FunctionProperties: types.FunctionProperties{
 								Inputs: []types.Param{
 									{
-										Name:  "test_375",
+										Name:  "test_272",
 										Type:  types.Type{},
-										Value: map[string]interface{}{"key_377": "value_377"},
+										Value: map[string]interface{}{"key_274": "value_274"},
 									},
 								},
 								Outputs: []types.Param{
 									{
-										Name:  "test_379",
+										Name:  "test_276",
 										Type:  types.Type{},
-										Value: map[string]interface{}{"key_381": "value_381"},
-									},
-								},
-								Config: []types.Param{
-									{
-										Name:  "test_383",
-										Type:  types.Type{},
-										Value: map[string]interface{}{"key_385": "value_385"},
+										Value: map[string]interface{}{"key_278": "value_278"},
 									},
 								},
 							},
 							Kind: types.Kind(0),
-							Name: "test_387",
+							Name: "test_280",
 							Elem: func() *types.Type {
 								v := types.Type{
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_393",
+									Name:          "test_285",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -4281,8 +3291,8 @@ func FuzzDecodeType(f *testing.F) {
 							Unit: func() *types.Unit {
 								v := types.Unit{
 									Dimensions: types.Dimensions{},
-									Scale:      400.5,
-									Name:       "test_401",
+									Scale:      292.5,
+									Name:       "test_293",
 								}
 								return &v
 							}(),
@@ -4291,10 +3301,9 @@ func FuzzDecodeType(f *testing.F) {
 									FunctionProperties: types.FunctionProperties{
 										Inputs:  []types.Param{{}},
 										Outputs: []types.Param{{}},
-										Config:  []types.Param{{}},
 									},
 									Kind:          types.Kind(0),
-									Name:          "test_407",
+									Name:          "test_298",
 									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
 									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
 									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
@@ -4320,17 +3329,13 @@ func FuzzDecodeType(f *testing.F) {
 	}
 	{
 		seed := types.Type{
-			FunctionProperties: types.FunctionProperties{
-				Inputs:  nil,
-				Outputs: nil,
-				Config:  nil,
-			},
-			Kind:          types.Kind(0),
-			Name:          "",
-			Elem:          nil,
-			Unit:          nil,
-			Constraint:    nil,
-			ChanDirection: types.ChanDirection(0),
+			FunctionProperties: types.FunctionProperties{Inputs: nil, Outputs: nil},
+			Kind:               types.Kind(0),
+			Name:               "",
+			Elem:               nil,
+			Unit:               nil,
+			Constraint:         nil,
+			ChanDirection:      types.ChanDirection(0),
 		}
 		w := orc.NewWriter(0)
 		if err := seed.EncodeOrc(w); err != nil {
@@ -4340,68 +3345,48 @@ func FuzzDecodeType(f *testing.F) {
 	}
 	{
 		seed := types.Type{
-			FunctionProperties: types.FunctionProperties{
-				Inputs:  []types.Param{},
-				Outputs: []types.Param{},
-				Config:  []types.Param{},
-			},
-			Kind: types.Kind(0),
-			Name: "test_5",
+			FunctionProperties: types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}},
+			Kind:               types.Kind(0),
+			Name:               "test_4",
 			Elem: func() *types.Type {
 				v := types.Type{
-					FunctionProperties: types.FunctionProperties{
-						Inputs:  []types.Param{},
-						Outputs: []types.Param{},
-						Config:  []types.Param{},
-					},
-					Kind: types.Kind(0),
-					Name: "test_11",
+					FunctionProperties: types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}},
+					Kind:               types.Kind(0),
+					Name:               "test_9",
 					Elem: func() *types.Type {
 						v := types.Type{
-							FunctionProperties: types.FunctionProperties{
-								Inputs:  []types.Param{},
-								Outputs: []types.Param{},
-								Config:  []types.Param{},
-							},
-							Kind: types.Kind(0),
-							Name: "test_17",
+							FunctionProperties: types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}},
+							Kind:               types.Kind(0),
+							Name:               "test_14",
 							Elem: func() *types.Type {
 								v := types.Type{
-									FunctionProperties: types.FunctionProperties{
-										Inputs:  []types.Param{},
-										Outputs: []types.Param{},
-										Config:  []types.Param{},
-									},
-									Kind:          types.Kind(0),
-									Name:          "test_23",
-									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-									ChanDirection: types.ChanDirection(0),
+									FunctionProperties: types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}},
+									Kind:               types.Kind(0),
+									Name:               "test_19",
+									Elem:               func() *types.Type { v := types.Type{}; return &v }(),
+									Unit:               func() *types.Unit { v := types.Unit{}; return &v }(),
+									Constraint:         func() *types.Type { v := types.Type{}; return &v }(),
+									ChanDirection:      types.ChanDirection(0),
 								}
 								return &v
 							}(),
 							Unit: func() *types.Unit {
 								v := types.Unit{
 									Dimensions: types.Dimensions{},
-									Scale:      30.5,
-									Name:       "test_31",
+									Scale:      26.5,
+									Name:       "test_27",
 								}
 								return &v
 							}(),
 							Constraint: func() *types.Type {
 								v := types.Type{
-									FunctionProperties: types.FunctionProperties{
-										Inputs:  []types.Param{},
-										Outputs: []types.Param{},
-										Config:  []types.Param{},
-									},
-									Kind:          types.Kind(0),
-									Name:          "test_37",
-									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-									ChanDirection: types.ChanDirection(0),
+									FunctionProperties: types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}},
+									Kind:               types.Kind(0),
+									Name:               "test_32",
+									Elem:               func() *types.Type { v := types.Type{}; return &v }(),
+									Unit:               func() *types.Unit { v := types.Unit{}; return &v }(),
+									Constraint:         func() *types.Type { v := types.Type{}; return &v }(),
+									ChanDirection:      types.ChanDirection(0),
 								}
 								return &v
 							}(),
@@ -4412,66 +3397,54 @@ func FuzzDecodeType(f *testing.F) {
 					Unit: func() *types.Unit {
 						v := types.Unit{
 							Dimensions: types.Dimensions{
-								Length:      46,
-								Mass:        47,
-								Time:        48,
-								Current:     49,
-								Temperature: 50,
-								Angle:       51,
-								Count:       52,
-								Data:        53,
+								Length:      41,
+								Mass:        42,
+								Time:        43,
+								Current:     44,
+								Temperature: 45,
+								Angle:       46,
+								Count:       47,
+								Data:        48,
 							},
-							Scale: 53.5,
-							Name:  "test_54",
+							Scale: 48.5,
+							Name:  "test_49",
 						}
 						return &v
 					}(),
 					Constraint: func() *types.Type {
 						v := types.Type{
-							FunctionProperties: types.FunctionProperties{
-								Inputs:  []types.Param{},
-								Outputs: []types.Param{},
-								Config:  []types.Param{},
-							},
-							Kind: types.Kind(0),
-							Name: "test_60",
+							FunctionProperties: types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}},
+							Kind:               types.Kind(0),
+							Name:               "test_54",
 							Elem: func() *types.Type {
 								v := types.Type{
-									FunctionProperties: types.FunctionProperties{
-										Inputs:  []types.Param{},
-										Outputs: []types.Param{},
-										Config:  []types.Param{},
-									},
-									Kind:          types.Kind(0),
-									Name:          "test_66",
-									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-									ChanDirection: types.ChanDirection(0),
+									FunctionProperties: types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}},
+									Kind:               types.Kind(0),
+									Name:               "test_59",
+									Elem:               func() *types.Type { v := types.Type{}; return &v }(),
+									Unit:               func() *types.Unit { v := types.Unit{}; return &v }(),
+									Constraint:         func() *types.Type { v := types.Type{}; return &v }(),
+									ChanDirection:      types.ChanDirection(0),
 								}
 								return &v
 							}(),
 							Unit: func() *types.Unit {
 								v := types.Unit{
 									Dimensions: types.Dimensions{},
-									Scale:      73.5,
-									Name:       "test_74",
+									Scale:      66.5,
+									Name:       "test_67",
 								}
 								return &v
 							}(),
 							Constraint: func() *types.Type {
 								v := types.Type{
-									FunctionProperties: types.FunctionProperties{
-										Inputs:  []types.Param{},
-										Outputs: []types.Param{},
-										Config:  []types.Param{},
-									},
-									Kind:          types.Kind(0),
-									Name:          "test_80",
-									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-									ChanDirection: types.ChanDirection(0),
+									FunctionProperties: types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}},
+									Kind:               types.Kind(0),
+									Name:               "test_72",
+									Elem:               func() *types.Type { v := types.Type{}; return &v }(),
+									Unit:               func() *types.Unit { v := types.Unit{}; return &v }(),
+									Constraint:         func() *types.Type { v := types.Type{}; return &v }(),
+									ChanDirection:      types.ChanDirection(0),
 								}
 								return &v
 							}(),
@@ -4486,75 +3459,59 @@ func FuzzDecodeType(f *testing.F) {
 			Unit: func() *types.Unit {
 				v := types.Unit{
 					Dimensions: types.Dimensions{
-						Length:      90,
-						Mass:        91,
-						Time:        92,
-						Current:     93,
-						Temperature: 94,
-						Angle:       95,
-						Count:       96,
-						Data:        97,
+						Length:      82,
+						Mass:        83,
+						Time:        84,
+						Current:     85,
+						Temperature: 86,
+						Angle:       87,
+						Count:       88,
+						Data:        89,
 					},
-					Scale: 97.5,
-					Name:  "test_98",
+					Scale: 89.5,
+					Name:  "test_90",
 				}
 				return &v
 			}(),
 			Constraint: func() *types.Type {
 				v := types.Type{
-					FunctionProperties: types.FunctionProperties{
-						Inputs:  []types.Param{},
-						Outputs: []types.Param{},
-						Config:  []types.Param{},
-					},
-					Kind: types.Kind(0),
-					Name: "test_104",
+					FunctionProperties: types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}},
+					Kind:               types.Kind(0),
+					Name:               "test_95",
 					Elem: func() *types.Type {
 						v := types.Type{
-							FunctionProperties: types.FunctionProperties{
-								Inputs:  []types.Param{},
-								Outputs: []types.Param{},
-								Config:  []types.Param{},
-							},
-							Kind: types.Kind(0),
-							Name: "test_110",
+							FunctionProperties: types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}},
+							Kind:               types.Kind(0),
+							Name:               "test_100",
 							Elem: func() *types.Type {
 								v := types.Type{
-									FunctionProperties: types.FunctionProperties{
-										Inputs:  []types.Param{},
-										Outputs: []types.Param{},
-										Config:  []types.Param{},
-									},
-									Kind:          types.Kind(0),
-									Name:          "test_116",
-									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-									ChanDirection: types.ChanDirection(0),
+									FunctionProperties: types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}},
+									Kind:               types.Kind(0),
+									Name:               "test_105",
+									Elem:               func() *types.Type { v := types.Type{}; return &v }(),
+									Unit:               func() *types.Unit { v := types.Unit{}; return &v }(),
+									Constraint:         func() *types.Type { v := types.Type{}; return &v }(),
+									ChanDirection:      types.ChanDirection(0),
 								}
 								return &v
 							}(),
 							Unit: func() *types.Unit {
 								v := types.Unit{
 									Dimensions: types.Dimensions{},
-									Scale:      123.5,
-									Name:       "test_124",
+									Scale:      112.5,
+									Name:       "test_113",
 								}
 								return &v
 							}(),
 							Constraint: func() *types.Type {
 								v := types.Type{
-									FunctionProperties: types.FunctionProperties{
-										Inputs:  []types.Param{},
-										Outputs: []types.Param{},
-										Config:  []types.Param{},
-									},
-									Kind:          types.Kind(0),
-									Name:          "test_130",
-									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-									ChanDirection: types.ChanDirection(0),
+									FunctionProperties: types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}},
+									Kind:               types.Kind(0),
+									Name:               "test_118",
+									Elem:               func() *types.Type { v := types.Type{}; return &v }(),
+									Unit:               func() *types.Unit { v := types.Unit{}; return &v }(),
+									Constraint:         func() *types.Type { v := types.Type{}; return &v }(),
+									ChanDirection:      types.ChanDirection(0),
 								}
 								return &v
 							}(),
@@ -4565,66 +3522,54 @@ func FuzzDecodeType(f *testing.F) {
 					Unit: func() *types.Unit {
 						v := types.Unit{
 							Dimensions: types.Dimensions{
-								Length:      13,
-								Mass:        14,
-								Time:        15,
-								Current:     16,
-								Temperature: 17,
-								Angle:       18,
-								Count:       19,
-								Data:        20,
+								Length:      1,
+								Mass:        2,
+								Time:        3,
+								Current:     4,
+								Temperature: 5,
+								Angle:       6,
+								Count:       7,
+								Data:        8,
 							},
-							Scale: 146.5,
-							Name:  "test_147",
+							Scale: 134.5,
+							Name:  "test_135",
 						}
 						return &v
 					}(),
 					Constraint: func() *types.Type {
 						v := types.Type{
-							FunctionProperties: types.FunctionProperties{
-								Inputs:  []types.Param{},
-								Outputs: []types.Param{},
-								Config:  []types.Param{},
-							},
-							Kind: types.Kind(0),
-							Name: "test_153",
+							FunctionProperties: types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}},
+							Kind:               types.Kind(0),
+							Name:               "test_140",
 							Elem: func() *types.Type {
 								v := types.Type{
-									FunctionProperties: types.FunctionProperties{
-										Inputs:  []types.Param{},
-										Outputs: []types.Param{},
-										Config:  []types.Param{},
-									},
-									Kind:          types.Kind(0),
-									Name:          "test_159",
-									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-									ChanDirection: types.ChanDirection(0),
+									FunctionProperties: types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}},
+									Kind:               types.Kind(0),
+									Name:               "test_145",
+									Elem:               func() *types.Type { v := types.Type{}; return &v }(),
+									Unit:               func() *types.Unit { v := types.Unit{}; return &v }(),
+									Constraint:         func() *types.Type { v := types.Type{}; return &v }(),
+									ChanDirection:      types.ChanDirection(0),
 								}
 								return &v
 							}(),
 							Unit: func() *types.Unit {
 								v := types.Unit{
 									Dimensions: types.Dimensions{},
-									Scale:      166.5,
-									Name:       "test_167",
+									Scale:      152.5,
+									Name:       "test_153",
 								}
 								return &v
 							}(),
 							Constraint: func() *types.Type {
 								v := types.Type{
-									FunctionProperties: types.FunctionProperties{
-										Inputs:  []types.Param{},
-										Outputs: []types.Param{},
-										Config:  []types.Param{},
-									},
-									Kind:          types.Kind(0),
-									Name:          "test_173",
-									Elem:          func() *types.Type { v := types.Type{}; return &v }(),
-									Unit:          func() *types.Unit { v := types.Unit{}; return &v }(),
-									Constraint:    func() *types.Type { v := types.Type{}; return &v }(),
-									ChanDirection: types.ChanDirection(0),
+									FunctionProperties: types.FunctionProperties{Inputs: []types.Param{}, Outputs: []types.Param{}},
+									Kind:               types.Kind(0),
+									Name:               "test_158",
+									Elem:               func() *types.Type { v := types.Type{}; return &v }(),
+									Unit:               func() *types.Unit { v := types.Unit{}; return &v }(),
+									Constraint:         func() *types.Type { v := types.Type{}; return &v }(),
+									ChanDirection:      types.ChanDirection(0),
 								}
 								return &v
 							}(),

--- a/arc/go/types/pb/translator.gen.go
+++ b/arc/go/types/pb/translator.gen.go
@@ -27,14 +27,9 @@ func FunctionPropertiesToPB(r types.FunctionProperties) (*FunctionProperties, er
 	if err != nil {
 		return nil, err
 	}
-	configVal, err := ParamsToPB(r.Config)
-	if err != nil {
-		return nil, err
-	}
 	pb := &FunctionProperties{
 		Inputs:  inputsVal,
 		Outputs: outputsVal,
-		Config:  configVal,
 	}
 	return pb, nil
 }
@@ -51,10 +46,6 @@ func FunctionPropertiesFromPB(pb *FunctionProperties) (types.FunctionProperties,
 		return types.FunctionProperties{}, err
 	}
 	r.Outputs, err = ParamsFromPB(pb.Outputs)
-	if err != nil {
-		return types.FunctionProperties{}, err
-	}
-	r.Config, err = ParamsFromPB(pb.Config)
 	if err != nil {
 		return types.FunctionProperties{}, err
 	}
@@ -97,10 +88,6 @@ func TypeToPB(r types.Type) (*Type, error) {
 	if err != nil {
 		return nil, err
 	}
-	configVal, err := ParamsToPB(r.Config)
-	if err != nil {
-		return nil, err
-	}
 	kindVal, err := KindToPB(r.Kind)
 	if err != nil {
 		return nil, err
@@ -113,7 +100,6 @@ func TypeToPB(r types.Type) (*Type, error) {
 		Name:          r.Name,
 		Inputs:        inputsVal,
 		Outputs:       outputsVal,
-		Config:        configVal,
 		Kind:          kindVal,
 		ChanDirection: chanDirectionVal,
 	}
@@ -153,10 +139,6 @@ func TypeFromPB(pb *Type) (types.Type, error) {
 		return types.Type{}, err
 	}
 	r.Outputs, err = ParamsFromPB(pb.Outputs)
-	if err != nil {
-		return types.Type{}, err
-	}
-	r.Config, err = ParamsFromPB(pb.Config)
 	if err != nil {
 		return types.Type{}, err
 	}

--- a/arc/go/types/pb/types.pb.go
+++ b/arc/go/types/pb/types.pb.go
@@ -140,7 +140,7 @@ func (Kind) EnumDescriptor() ([]byte, []int) {
 	return file_arc_go_types_pb_types_proto_rawDescGZIP(), []int{0}
 }
 
-// ChanDirection indicates read/write direction for channel-typed config parameters.
+// ChanDirection indicates read/write direction for channel-typed parameters.
 type ChanDirection int32
 
 const (
@@ -196,9 +196,7 @@ type FunctionProperties struct {
 	// inputs contains input parameter definitions.
 	Inputs []*Param `protobuf:"bytes,1,rep,name=inputs,proto3" json:"inputs,omitempty"`
 	// outputs contains output parameter definitions.
-	Outputs []*Param `protobuf:"bytes,2,rep,name=outputs,proto3" json:"outputs,omitempty"`
-	// config contains configuration parameter definitions.
-	Config        []*Param `protobuf:"bytes,3,rep,name=config,proto3" json:"config,omitempty"`
+	Outputs       []*Param `protobuf:"bytes,2,rep,name=outputs,proto3" json:"outputs,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -247,13 +245,6 @@ func (x *FunctionProperties) GetOutputs() []*Param {
 	return nil
 }
 
-func (x *FunctionProperties) GetConfig() []*Param {
-	if x != nil {
-		return x.Config
-	}
-	return nil
-}
-
 // Type is a type in Arc's type system with optional element type for compounds,
 // physical units, and constraints.
 type Type struct {
@@ -262,20 +253,18 @@ type Type struct {
 	Inputs []*Param `protobuf:"bytes,1,rep,name=inputs,proto3" json:"inputs,omitempty"`
 	// outputs contains output parameter definitions.
 	Outputs []*Param `protobuf:"bytes,2,rep,name=outputs,proto3" json:"outputs,omitempty"`
-	// config contains configuration parameter definitions.
-	Config []*Param `protobuf:"bytes,3,rep,name=config,proto3" json:"config,omitempty"`
 	// kind is the type category (primitive, compound, or meta-type).
-	Kind Kind `protobuf:"varint,4,opt,name=kind,proto3,enum=arc.types.pb.Kind" json:"kind,omitempty"`
+	Kind Kind `protobuf:"varint,3,opt,name=kind,proto3,enum=arc.types.pb.Kind" json:"kind,omitempty"`
 	// name is the type name for variables and user-defined types.
-	Name string `protobuf:"bytes,5,opt,name=name,proto3" json:"name,omitempty"`
+	Name string `protobuf:"bytes,4,opt,name=name,proto3" json:"name,omitempty"`
 	// elem is the element type for compound types (chan, series).
-	Elem *Type `protobuf:"bytes,6,opt,name=elem,proto3,oneof" json:"elem,omitempty"`
+	Elem *Type `protobuf:"bytes,5,opt,name=elem,proto3,oneof" json:"elem,omitempty"`
 	// unit is the physical unit metadata for dimensional analysis.
-	Unit *Unit `protobuf:"bytes,7,opt,name=unit,proto3,oneof" json:"unit,omitempty"`
+	Unit *Unit `protobuf:"bytes,6,opt,name=unit,proto3,oneof" json:"unit,omitempty"`
 	// constraint is the type constraint for type variables.
-	Constraint *Type `protobuf:"bytes,8,opt,name=constraint,proto3,oneof" json:"constraint,omitempty"`
-	// chan_direction indicates read/write direction for channel-typed config parameters.
-	ChanDirection ChanDirection `protobuf:"varint,9,opt,name=chan_direction,json=chanDirection,proto3,enum=arc.types.pb.ChanDirection" json:"chan_direction,omitempty"`
+	Constraint *Type `protobuf:"bytes,7,opt,name=constraint,proto3,oneof" json:"constraint,omitempty"`
+	// chan_direction indicates read/write direction for channel-typed parameters.
+	ChanDirection ChanDirection `protobuf:"varint,8,opt,name=chan_direction,json=chanDirection,proto3,enum=arc.types.pb.ChanDirection" json:"chan_direction,omitempty"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -320,13 +309,6 @@ func (x *Type) GetInputs() []*Param {
 func (x *Type) GetOutputs() []*Param {
 	if x != nil {
 		return x.Outputs
-	}
-	return nil
-}
-
-func (x *Type) GetConfig() []*Param {
-	if x != nil {
-		return x.Config
 	}
 	return nil
 }
@@ -671,23 +653,21 @@ var File_arc_go_types_pb_types_proto protoreflect.FileDescriptor
 
 const file_arc_go_types_pb_types_proto_rawDesc = "" +
 	"\n" +
-	"\x1barc/go/types/pb/types.proto\x12\farc.types.pb\"\x9d\x01\n" +
+	"\x1barc/go/types/pb/types.proto\x12\farc.types.pb\"p\n" +
 	"\x12FunctionProperties\x12+\n" +
 	"\x06inputs\x18\x01 \x03(\v2\x13.arc.types.pb.ParamR\x06inputs\x12-\n" +
-	"\aoutputs\x18\x02 \x03(\v2\x13.arc.types.pb.ParamR\aoutputs\x12+\n" +
-	"\x06config\x18\x03 \x03(\v2\x13.arc.types.pb.ParamR\x06config\"\xc3\x03\n" +
+	"\aoutputs\x18\x02 \x03(\v2\x13.arc.types.pb.ParamR\aoutputs\"\x96\x03\n" +
 	"\x04Type\x12+\n" +
 	"\x06inputs\x18\x01 \x03(\v2\x13.arc.types.pb.ParamR\x06inputs\x12-\n" +
-	"\aoutputs\x18\x02 \x03(\v2\x13.arc.types.pb.ParamR\aoutputs\x12+\n" +
-	"\x06config\x18\x03 \x03(\v2\x13.arc.types.pb.ParamR\x06config\x12&\n" +
-	"\x04kind\x18\x04 \x01(\x0e2\x12.arc.types.pb.KindR\x04kind\x12\x12\n" +
-	"\x04name\x18\x05 \x01(\tR\x04name\x12+\n" +
-	"\x04elem\x18\x06 \x01(\v2\x12.arc.types.pb.TypeH\x00R\x04elem\x88\x01\x01\x12+\n" +
-	"\x04unit\x18\a \x01(\v2\x12.arc.types.pb.UnitH\x01R\x04unit\x88\x01\x01\x127\n" +
+	"\aoutputs\x18\x02 \x03(\v2\x13.arc.types.pb.ParamR\aoutputs\x12&\n" +
+	"\x04kind\x18\x03 \x01(\x0e2\x12.arc.types.pb.KindR\x04kind\x12\x12\n" +
+	"\x04name\x18\x04 \x01(\tR\x04name\x12+\n" +
+	"\x04elem\x18\x05 \x01(\v2\x12.arc.types.pb.TypeH\x00R\x04elem\x88\x01\x01\x12+\n" +
+	"\x04unit\x18\x06 \x01(\v2\x12.arc.types.pb.UnitH\x01R\x04unit\x88\x01\x01\x127\n" +
 	"\n" +
-	"constraint\x18\b \x01(\v2\x12.arc.types.pb.TypeH\x02R\n" +
+	"constraint\x18\a \x01(\v2\x12.arc.types.pb.TypeH\x02R\n" +
 	"constraint\x88\x01\x01\x12B\n" +
-	"\x0echan_direction\x18\t \x01(\x0e2\x1b.arc.types.pb.ChanDirectionR\rchanDirectionB\a\n" +
+	"\x0echan_direction\x18\b \x01(\x0e2\x1b.arc.types.pb.ChanDirectionR\rchanDirectionB\a\n" +
 	"\x05_elemB\a\n" +
 	"\x05_unitB\r\n" +
 	"\v_constraint\"Y\n" +
@@ -782,24 +762,22 @@ var file_arc_go_types_pb_types_proto_goTypes = []any{
 var file_arc_go_types_pb_types_proto_depIdxs = []int32{
 	4,  // 0: arc.types.pb.FunctionProperties.inputs:type_name -> arc.types.pb.Param
 	4,  // 1: arc.types.pb.FunctionProperties.outputs:type_name -> arc.types.pb.Param
-	4,  // 2: arc.types.pb.FunctionProperties.config:type_name -> arc.types.pb.Param
-	4,  // 3: arc.types.pb.Type.inputs:type_name -> arc.types.pb.Param
-	4,  // 4: arc.types.pb.Type.outputs:type_name -> arc.types.pb.Param
-	4,  // 5: arc.types.pb.Type.config:type_name -> arc.types.pb.Param
-	0,  // 6: arc.types.pb.Type.kind:type_name -> arc.types.pb.Kind
-	3,  // 7: arc.types.pb.Type.elem:type_name -> arc.types.pb.Type
-	7,  // 8: arc.types.pb.Type.unit:type_name -> arc.types.pb.Unit
-	3,  // 9: arc.types.pb.Type.constraint:type_name -> arc.types.pb.Type
-	1,  // 10: arc.types.pb.Type.chan_direction:type_name -> arc.types.pb.ChanDirection
-	3,  // 11: arc.types.pb.Param.type:type_name -> arc.types.pb.Type
-	8,  // 12: arc.types.pb.Channels.read:type_name -> arc.types.pb.Channels.ReadEntry
-	9,  // 13: arc.types.pb.Channels.write:type_name -> arc.types.pb.Channels.WriteEntry
-	6,  // 14: arc.types.pb.Unit.dimensions:type_name -> arc.types.pb.Dimensions
-	15, // [15:15] is the sub-list for method output_type
-	15, // [15:15] is the sub-list for method input_type
-	15, // [15:15] is the sub-list for extension type_name
-	15, // [15:15] is the sub-list for extension extendee
-	0,  // [0:15] is the sub-list for field type_name
+	4,  // 2: arc.types.pb.Type.inputs:type_name -> arc.types.pb.Param
+	4,  // 3: arc.types.pb.Type.outputs:type_name -> arc.types.pb.Param
+	0,  // 4: arc.types.pb.Type.kind:type_name -> arc.types.pb.Kind
+	3,  // 5: arc.types.pb.Type.elem:type_name -> arc.types.pb.Type
+	7,  // 6: arc.types.pb.Type.unit:type_name -> arc.types.pb.Unit
+	3,  // 7: arc.types.pb.Type.constraint:type_name -> arc.types.pb.Type
+	1,  // 8: arc.types.pb.Type.chan_direction:type_name -> arc.types.pb.ChanDirection
+	3,  // 9: arc.types.pb.Param.type:type_name -> arc.types.pb.Type
+	8,  // 10: arc.types.pb.Channels.read:type_name -> arc.types.pb.Channels.ReadEntry
+	9,  // 11: arc.types.pb.Channels.write:type_name -> arc.types.pb.Channels.WriteEntry
+	6,  // 12: arc.types.pb.Unit.dimensions:type_name -> arc.types.pb.Dimensions
+	13, // [13:13] is the sub-list for method output_type
+	13, // [13:13] is the sub-list for method input_type
+	13, // [13:13] is the sub-list for extension type_name
+	13, // [13:13] is the sub-list for extension extendee
+	0,  // [0:13] is the sub-list for field type_name
 }
 
 func init() { file_arc_go_types_pb_types_proto_init() }

--- a/arc/go/types/pb/types.proto
+++ b/arc/go/types/pb/types.proto
@@ -42,7 +42,7 @@ enum Kind {
   KIND_STAGE = 23;
 }
 
-// ChanDirection indicates read/write direction for channel-typed config parameters.
+// ChanDirection indicates read/write direction for channel-typed parameters.
 enum ChanDirection {
   CHAN_DIRECTION_NONE = 0;
   CHAN_DIRECTION_READ = 1;
@@ -55,8 +55,6 @@ message FunctionProperties {
   repeated Param inputs = 1;
   // outputs contains output parameter definitions.
   repeated Param outputs = 2;
-  // config contains configuration parameter definitions.
-  repeated Param config = 3;
 }
 
 // Type is a type in Arc's type system with optional element type for compounds,
@@ -66,20 +64,18 @@ message Type {
   repeated Param inputs = 1;
   // outputs contains output parameter definitions.
   repeated Param outputs = 2;
-  // config contains configuration parameter definitions.
-  repeated Param config = 3;
   // kind is the type category (primitive, compound, or meta-type).
-  Kind kind = 4;
+  Kind kind = 3;
   // name is the type name for variables and user-defined types.
-  string name = 5;
+  string name = 4;
   // elem is the element type for compound types (chan, series).
-  optional Type elem = 6;
+  optional Type elem = 5;
   // unit is the physical unit metadata for dimensional analysis.
-  optional Unit unit = 7;
+  optional Unit unit = 6;
   // constraint is the type constraint for type variables.
-  optional Type constraint = 8;
-  // chan_direction indicates read/write direction for channel-typed config parameters.
-  ChanDirection chan_direction = 9;
+  optional Type constraint = 7;
+  // chan_direction indicates read/write direction for channel-typed parameters.
+  ChanDirection chan_direction = 8;
 }
 
 // Param is a named, typed parameter with optional default value.

--- a/arc/go/types/types.gen.go
+++ b/arc/go/types/types.gen.go
@@ -11,8 +11,7 @@
 
 package types
 
-// Params is a collection of named, typed parameters for function inputs, outputs, or
-// configuration.
+// Params is a collection of named, typed parameters for function inputs or outputs.
 type Params []Param
 
 // Kind is the type category for Arc's type system, including primitives, compound
@@ -46,7 +45,7 @@ const (
 	KindStage
 )
 
-// ChanDirection indicates read/write direction for channel-typed config parameters.
+// ChanDirection indicates read/write direction for channel-typed parameters.
 type ChanDirection uint8
 
 //go:generate stringer -type=ChanDirection
@@ -63,8 +62,6 @@ type FunctionProperties struct {
 	Inputs Params `json:"inputs" msgpack:"inputs"`
 	// Outputs contains output parameter definitions.
 	Outputs Params `json:"outputs" msgpack:"outputs"`
-	// Config contains configuration parameter definitions.
-	Config Params `json:"config" msgpack:"config"`
 }
 
 // Type is a type in Arc's type system with optional element type for compounds,
@@ -81,7 +78,7 @@ type Type struct {
 	Unit *Unit `json:"unit,omitempty" msgpack:"unit,omitempty"`
 	// Constraint is the type constraint for type variables.
 	Constraint *Type `json:"constraint,omitempty" msgpack:"constraint,omitempty"`
-	// ChanDirection indicates read/write direction for channel-typed config parameters.
+	// ChanDirection indicates read/write direction for channel-typed parameters.
 	ChanDirection ChanDirection `json:"chan_direction" msgpack:"chan_direction"`
 }
 

--- a/client/ts/src/arc/ir/types.gen.ts
+++ b/client/ts/src/arc/ir/types.gen.ts
@@ -51,17 +51,12 @@ export const bodyZ = z.object({
 });
 export interface Body extends z.infer<typeof bodyZ> {}
 
-/**
- * Node is a concrete instantiation of a function with typed parameters and
- * configuration values.
- */
+/** Node is a concrete instantiation of a function with typed parameters and values. */
 export const nodeZ = z.object({
   /** key is the unique identifier for this node instance. */
   key: z.string(),
   /** type is the function type being instantiated. */
   type: z.string(),
-  /** config contains configuration parameter values. */
-  config: types.paramsZ,
   /** inputs contains input parameter type signatures. */
   inputs: types.paramsZ,
   /** outputs contains output parameter type signatures. */
@@ -112,8 +107,6 @@ export const functionZ = z.object({
   key: z.string(),
   /** body is raw source code for user-defined functions. */
   body: bodyZ.optional(),
-  /** config contains configuration parameter definitions. */
-  config: types.paramsZ,
   /** inputs contains input parameter definitions. */
   inputs: types.paramsZ,
   /** outputs contains output parameter definitions. */

--- a/client/ts/src/arc/types/types.gen.ts
+++ b/client/ts/src/arc/types/types.gen.ts
@@ -96,10 +96,6 @@ export const functionPropertiesZ = z.object({
   get outputs(): z.ZodOptional<typeof paramsZ> {
     return paramsZ.optional();
   },
-  /** config contains configuration parameter definitions. */
-  get config(): z.ZodOptional<typeof paramsZ> {
-    return paramsZ.optional();
-  },
 });
 export interface FunctionProperties extends z.infer<typeof functionPropertiesZ> {}
 

--- a/core/pkg/service/arc/codec_gen_test.go
+++ b/core/pkg/service/arc/codec_gen_test.go
@@ -51,50 +51,43 @@ var _ = Describe("Codec", func() {
 						{
 							Key:  "test_11",
 							Body: ir.Body{Raw: "test_13"},
-							Config: []types.Param{
+							Inputs: []types.Param{
 								{
 									Name:  "test_15",
 									Type:  types.Type{},
 									Value: map[string]interface{}{"key_17": "value_17"},
 								},
 							},
-							Inputs: []types.Param{
+							Outputs: []types.Param{
 								{
 									Name:  "test_19",
 									Type:  types.Type{},
 									Value: map[string]interface{}{"key_21": "value_21"},
 								},
 							},
-							Outputs: []types.Param{
-								{
-									Name:  "test_23",
-									Type:  types.Type{},
-									Value: map[string]interface{}{"key_25": "value_25"},
-								},
-							},
 							Channels: types.Channels{
-								Read:  map[uint32]string{28: "test_27"},
-								Write: map[uint32]string{29: "test_28"},
+								Read:  map[uint32]string{24: "test_23"},
+								Write: map[uint32]string{25: "test_24"},
 							},
 						},
 					},
 					Edges: []ir.Edge{
 						{
-							Source: ir.Handle{Node: "test_31", Param: "test_32"},
-							Target: ir.Handle{Node: "test_34", Param: "test_35"},
+							Source: ir.Handle{Node: "test_27", Param: "test_28"},
+							Target: ir.Handle{Node: "test_30", Param: "test_31"},
 							Kind:   ir.EdgeKind(0),
 						},
 					},
 					Nodes: []graph.Node{
 						{
-							Key:      "test_38",
-							Type:     "test_39",
-							Config:   msgpack.EncodedJSON{"key_40": "value_40"},
-							Position: spatial.XY{X: 42.5, Y: 43.5},
+							Key:      "test_34",
+							Type:     "test_35",
+							Config:   msgpack.EncodedJSON{"key_36": "value_36"},
+							Position: spatial.XY{X: 38.5, Y: 39.5},
 						},
 					},
 				},
-				Text: text.Text{Raw: "test_45"},
+				Text: text.Text{Raw: "test_41"},
 			}),
 			Entry("zero values", arc.Arc{
 				Key:  uuid.Nil,
@@ -138,50 +131,43 @@ func BenchmarkEncodeDecodeArc(b *testing.B) {
 				{
 					Key:  "test_11",
 					Body: ir.Body{Raw: "test_13"},
-					Config: []types.Param{
+					Inputs: []types.Param{
 						{
 							Name:  "test_15",
 							Type:  types.Type{},
 							Value: map[string]interface{}{"key_17": "value_17"},
 						},
 					},
-					Inputs: []types.Param{
+					Outputs: []types.Param{
 						{
 							Name:  "test_19",
 							Type:  types.Type{},
 							Value: map[string]interface{}{"key_21": "value_21"},
 						},
 					},
-					Outputs: []types.Param{
-						{
-							Name:  "test_23",
-							Type:  types.Type{},
-							Value: map[string]interface{}{"key_25": "value_25"},
-						},
-					},
 					Channels: types.Channels{
-						Read:  map[uint32]string{28: "test_27"},
-						Write: map[uint32]string{29: "test_28"},
+						Read:  map[uint32]string{24: "test_23"},
+						Write: map[uint32]string{25: "test_24"},
 					},
 				},
 			},
 			Edges: []ir.Edge{
 				{
-					Source: ir.Handle{Node: "test_31", Param: "test_32"},
-					Target: ir.Handle{Node: "test_34", Param: "test_35"},
+					Source: ir.Handle{Node: "test_27", Param: "test_28"},
+					Target: ir.Handle{Node: "test_30", Param: "test_31"},
 					Kind:   ir.EdgeKind(0),
 				},
 			},
 			Nodes: []graph.Node{
 				{
-					Key:      "test_38",
-					Type:     "test_39",
-					Config:   msgpack.EncodedJSON{"key_40": "value_40"},
-					Position: spatial.XY{X: 42.5, Y: 43.5},
+					Key:      "test_34",
+					Type:     "test_35",
+					Config:   msgpack.EncodedJSON{"key_36": "value_36"},
+					Position: spatial.XY{X: 38.5, Y: 39.5},
 				},
 			},
 		},
-		Text: text.Text{Raw: "test_45"},
+		Text: text.Text{Raw: "test_41"},
 	}
 	w := orc.NewWriter(0)
 	r := orc.NewReader(nil)
@@ -227,50 +213,43 @@ func FuzzDecodeArc(f *testing.F) {
 					{
 						Key:  "test_11",
 						Body: ir.Body{Raw: "test_13"},
-						Config: []types.Param{
+						Inputs: []types.Param{
 							{
 								Name:  "test_15",
 								Type:  types.Type{},
 								Value: map[string]interface{}{"key_17": "value_17"},
 							},
 						},
-						Inputs: []types.Param{
+						Outputs: []types.Param{
 							{
 								Name:  "test_19",
 								Type:  types.Type{},
 								Value: map[string]interface{}{"key_21": "value_21"},
 							},
 						},
-						Outputs: []types.Param{
-							{
-								Name:  "test_23",
-								Type:  types.Type{},
-								Value: map[string]interface{}{"key_25": "value_25"},
-							},
-						},
 						Channels: types.Channels{
-							Read:  map[uint32]string{28: "test_27"},
-							Write: map[uint32]string{29: "test_28"},
+							Read:  map[uint32]string{24: "test_23"},
+							Write: map[uint32]string{25: "test_24"},
 						},
 					},
 				},
 				Edges: []ir.Edge{
 					{
-						Source: ir.Handle{Node: "test_31", Param: "test_32"},
-						Target: ir.Handle{Node: "test_34", Param: "test_35"},
+						Source: ir.Handle{Node: "test_27", Param: "test_28"},
+						Target: ir.Handle{Node: "test_30", Param: "test_31"},
 						Kind:   ir.EdgeKind(0),
 					},
 				},
 				Nodes: []graph.Node{
 					{
-						Key:      "test_38",
-						Type:     "test_39",
-						Config:   msgpack.EncodedJSON{"key_40": "value_40"},
-						Position: spatial.XY{X: 42.5, Y: 43.5},
+						Key:      "test_34",
+						Type:     "test_35",
+						Config:   msgpack.EncodedJSON{"key_36": "value_36"},
+						Position: spatial.XY{X: 38.5, Y: 39.5},
 					},
 				},
 			},
-			Text: text.Text{Raw: "test_45"},
+			Text: text.Text{Raw: "test_41"},
 		}
 		w := orc.NewWriter(0)
 		if err := seed.EncodeOrc(w); err != nil {

--- a/schemas/arc/ir.oracle
+++ b/schemas/arc/ir.oracle
@@ -160,9 +160,6 @@ Function struct {
     body     Body?          {
         @doc value "is raw source code for user-defined functions."
     }
-    config   types.Params   {
-        @doc value "contains configuration parameter definitions."
-    }
     inputs   types.Params   {
         @doc value "contains input parameter definitions."
     }
@@ -191,9 +188,6 @@ Node struct {
     type     string          {
         @doc value "is the function type being instantiated."
     }
-    config   types.Params   {
-        @doc value "contains configuration parameter values."
-    }
     inputs   types.Params   {
         @doc value "contains input parameter type signatures."
     }
@@ -205,8 +199,7 @@ Node struct {
     }
 
     @doc value    """
-        is a concrete instantiation of a function with typed parameters and
-        configuration values.
+        is a concrete instantiation of a function with typed parameters and values.
     """
     @cpp methods  "[[nodiscard]] std::string to_string() const" "[[nodiscard]] std::string to_string_with_prefix(const std::string& prefix) const" "friend std::ostream& operator<<(std::ostream& os, const Node& n)"
 }

--- a/schemas/arc/types.oracle
+++ b/schemas/arc/types.oracle
@@ -47,7 +47,7 @@ ChanDirection enum {
     read  = 1
     write = 2
 
-    @doc value "indicates read/write direction for channel-typed config parameters."
+    @doc value "indicates read/write direction for channel-typed parameters."
 }
 
 FunctionProperties struct {
@@ -56,9 +56,6 @@ FunctionProperties struct {
     }
     outputs Params? {
         @doc value "contains output parameter definitions."
-    }
-    config  Params? {
-        @doc value "contains configuration parameter definitions."
     }
 
     @doc value "contains common parameter definitions for function-like types."
@@ -81,7 +78,7 @@ Type struct extends FunctionProperties {
         @doc value "is the type constraint for type variables."
     }
     chan_direction  ChanDirection? {
-        @doc value "indicates read/write direction for channel-typed config parameters."
+        @doc value "indicates read/write direction for channel-typed parameters."
     }
 
     @doc value           """
@@ -110,8 +107,7 @@ Param struct {
 
 Params Param[] {
     @doc value """
-        is a collection of named, typed parameters for function inputs, outputs,
-        or configuration.
+        is a collection of named, typed parameters for function inputs or outputs.
     """
     @cpp methods  "[[nodiscard]] const Param& operator[](const std::string& name) const" "[[nodiscard]] std::string to_string() const" "friend std::ostream& operator<<(std::ostream& os, const Params& p)"
 }


### PR DESCRIPTION
# Remove Config from Arc Schemas
## Linear Issue
[SY-4297](https://linear.app/synnax/issue/SY-4297)
## What this is
Phase 1 of the Arc function-call unification (RFC 0039), stacked on the base branch. It establishes the new generated type shape that the rest of the stack is written against: a single `Inputs` parameter list, with `Config` gone everywhere.
## The change
- **Schema (hand-authored):** remove `config` from `FunctionProperties` in `schemas/arc/types.oracle`, and from `Function` and `Node` in `schemas/arc/ir.oracle`.
- **Codegen (generated):** `oracle sync` regenerates every Go/C++/TS binding, codec, protobuf, and codec test fixture. `Param` now carries `Name` / `Type` / `Value` only; no `Config` field survives in `FunctionProperties`, `Function`, or `Node` across any of the three languages.
## Heads-up
**This branch does not build on its own, by design.** Removing `Config` from the generated types breaks every `.Config` reader until later phases convert them. The first green build is the final phase; intermediate PRs are reviewed on their diff, not on a green CI run (see plan §5).
## Review note
The only hand-written diff is the two `.oracle` schema files. Everything else is regenerated output; review the schema edit, then spot-check that the regenerated `Param` shape and the absence of `Config` look right.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the `config` field from `FunctionProperties`, `Function`, and `Node` across the Arc schema and all generated bindings (Go, C++, TypeScript, protobuf, codec tests). It is Phase 1 of the Arc function-call unification (RFC 0039), intentionally breaking the build as intermediate work.

- **Hand-authored changes** are confined to two oracle schema files (`schemas/arc/types.oracle`, `schemas/arc/ir.oracle`), which drop the `config` field and update associated doc-strings.
- **Generated output** (`oracle sync`) consistently propagates the removal through every Go/C++/TS type, codec, protobuf definition, and codec test fixture; proto field numbers are renumbered accordingly, which is safe here because persistence uses name-keyed msgpack and the proto codec is same-version only.
- The graph-level `graph.Node.Config` (`msgpack.EncodedJSON`) is unrelated to the removed IR/types `Config` (`types.Params`) and is correctly preserved in tests and runtime code.

<h3>Confidence Score: 5/5</h3>

Safe to merge as a reviewed diff; the branch intentionally does not build standalone, and the generated changes are mechanically consistent with the two hand-authored schema edits.

The only hand-written change is the deletion of three field declarations across two oracle schema files. Every other file is generated output that follows deterministically from those deletions. Persistence uses name-keyed msgpack so dropped fields are silently ignored on decode, and the proto codec operates same-version only with cross-version evolution handled by the migration framework. All codec encode/decode paths, translators, and test fixtures are consistently updated across Go, C++, TypeScript, and protobuf.

No files require special attention; the schema files are the authoritative diff and the generated files follow mechanically.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| schemas/arc/types.oracle | Hand-authored schema: removes config from FunctionProperties and updates doc-strings on ChanDirection, Params, and Type.chan_direction. |
| schemas/arc/ir.oracle | Hand-authored schema: removes config from Function and Node, updates Node doc-string. Consistent with types.oracle change. |
| arc/go/ir/pb/ir.proto | Generated proto: removes config (field 3) from Function and Node; remaining fields renumber down by 1. Safe given same-version wire codec and name-keyed msgpack persistence. |
| arc/go/types/pb/types.proto | Generated proto: removes config (field 3) from FunctionProperties and Type; kind/name/elem/unit/constraint/chan_direction renumber from 4-9 to 3-8. Safe for same reasons as ir.proto. |
| arc/go/ir/types.gen.go | Generated Go: drops Config types.Params from Function and Node structs; msgpack and json tags on remaining fields are unchanged. |
| arc/go/types/types.gen.go | Generated Go: drops Config Params from FunctionProperties; updates Params and ChanDirection doc-strings. |
| arc/go/graph/codec_gen_test.go | Generated test fixtures: removes Config param arrays from ir.Function/ir.Node fixtures; graph.Node.Config (msgpack.EncodedJSON) correctly preserved as a distinct field. |
| arc/go/ir/codec.gen.go | Generated orc codec: removes Config encode/decode blocks from Function and Node; remaining encode order is consistent. |
| arc/cpp/ir/types.gen.h | Generated C++ types: removes config member from Node and Function structs; doc-strings updated correctly. |
| client/ts/src/arc/types/types.gen.ts | Generated TypeScript: removes config from FunctionProperties type; change consistent with Go and C++ generated types. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["schemas/arc/types.oracle\n(hand-authored)"] -->|oracle sync| B["arc/go/types/types.gen.go\narc/go/types/pb/types.proto\narc/cpp/types/types.gen.h\nclient/ts/src/arc/types/types.gen.ts"]
    C["schemas/arc/ir.oracle\n(hand-authored)"] -->|oracle sync| D["arc/go/ir/types.gen.go\narc/go/ir/pb/ir.proto\narc/cpp/ir/types.gen.h\nclient/ts/src/arc/ir/types.gen.ts"]
    B --> E["arc/go/types/codec.gen.go\narc/go/types/pb/translator.gen.go\narc/cpp/types/json.gen.h\narc/cpp/types/proto.gen.h"]
    D --> F["arc/go/ir/codec.gen.go\narc/go/ir/pb/translator.gen.go\narc/cpp/ir/json.gen.h\narc/cpp/ir/proto.gen.h"]
    E --> G["codec_gen_test.go (types, ir, graph, program, service)"]
    F --> G
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `arc/go/ir/pb/ir.proto`, line 114-139 ([link](https://github.com/synnaxlabs/synnax/blob/0f77830cb1436310df2ec6e8554e708b933a8c12/arc/go/ir/pb/ir.proto#L114-L139)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Missing `reserved` declarations after field removal**

   Removing `config` (field 3) from `Function` and `Node` and sliding `inputs`/`outputs`/`channels` down means any payload encoded with the old schema (field 3 = config, field 4 = inputs, …) will be silently misread by a new decoder: the old `config` bytes arrive on the wire as field 3 and get decoded as `inputs`, while old `inputs` bytes (field 4) become unknown and are dropped. Even if no live data exists today, protobuf best-practice is to add `reserved 3; reserved "config";` in both messages so the codegen tool can never accidentally recycle those tags and cause the same corruption on a future schema change.

2. `arc/go/types/pb/types.proto`, line 62-79 ([link](https://github.com/synnaxlabs/synnax/blob/0f77830cb1436310df2ec6e8554e708b933a8c12/arc/go/types/pb/types.proto#L62-L79)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Missing `reserved` declarations after field removal in `Type`**

   `config` was field 3 in `Type`. After removal, `kind` moves from 4→3, `name` from 5→4, `elem` from 6→5, `unit` from 7→6, `constraint` from 8→7, and `chan_direction` from 9→8. A payload encoded with the old schema would decode `kind` bytes (originally field 4) as unknown and silently drop them, and old `config` bytes (field 3) would land in `kind` — a varint — producing a wrong or zero `Kind`. Adding `reserved 3; reserved "config";` to both `Type` and `FunctionProperties` follows protobuf spec and guards against future tag recycling that could cause the same silent corruption.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["\[oracle sync\]"](https://github.com/synnaxlabs/synnax/commit/0f77830cb1436310df2ec6e8554e708b933a8c12) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35292365)</sub>

<!-- /greptile_comment -->