### PR TITLE
SY-4306: Fix Command Palette Triggers in Browser Mode

### DIFF
--- a/pluto/src/triggers/Provider.tsx
+++ b/pluto/src/triggers/Provider.tsx
@@ -59,8 +59,8 @@ const ZERO_REF_STATE: RefState = {
 
 const EXCLUDE_TRIGGERS = ["CapsLock"];
 
-// "Meta" is intentionally excluded — keyboardKey() maps any Meta (Cmd/Win) event
-// to "Control", so the Meta key is already represented as "Control" in tracked state.
+// "Meta" is intentionally excluded — keyboardKey() maps any Meta (Cmd/Win) event to
+// "Control", so the Meta key is already represented as "Control" in tracked state.
 const MODIFIER_KEYS: Key[] = ["Control", "Shift", "Alt"];
 
 export interface ProviderProps extends PropsWithChildren {

--- a/pluto/src/triggers/Provider.tsx
+++ b/pluto/src/triggers/Provider.tsx
@@ -26,6 +26,7 @@ import {
   type Key,
   match,
   type MatchOptions,
+  MODIFIER_KEYS,
   MOUSE_KEYS,
   type MouseKey,
   type Trigger,
@@ -58,10 +59,6 @@ const ZERO_REF_STATE: RefState = {
 };
 
 const EXCLUDE_TRIGGERS = ["CapsLock"];
-
-// "Meta" is intentionally excluded — keyboardKey() maps any Meta (Cmd/Win) event to
-// "Control", so the Meta key is already represented as "Control" in tracked state.
-const MODIFIER_KEYS: Key[] = ["Control", "Shift", "Alt"];
 
 export interface ProviderProps extends PropsWithChildren {
   preventDefaultOn?: Trigger[];

--- a/pluto/src/triggers/Provider.tsx
+++ b/pluto/src/triggers/Provider.tsx
@@ -59,6 +59,8 @@ const ZERO_REF_STATE: RefState = {
 
 const EXCLUDE_TRIGGERS = ["CapsLock"];
 
+const MODIFIER_KEYS: Key[] = ["Control", "Shift", "Alt"];
+
 export interface ProviderProps extends PropsWithChildren {
   preventDefaultOn?: Trigger[];
   preventDefaultOptions?: MatchOptions;
@@ -155,6 +157,7 @@ export const Provider = ({
     if (["ArrowUp", "ArrowDown"].includes(key)) e.preventDefault();
     // We don't want to trigger any events for excluded keys.
     if (EXCLUDE_TRIGGERS.includes(key)) return;
+    const isMetaRelease = "code" in e && e.code.includes("Meta");
     setCurr((prevS) => {
       let next = prevS.next.filter(
         (k) => k !== key && !MOUSE_KEYS.includes(k as MouseKey),
@@ -164,6 +167,11 @@ export const Provider = ({
       // the event.shiftKey flag.
       if (!e.shiftKey && next.includes("Shift"))
         next = next.filter((k) => k !== "Shift");
+      // macOS suppresses key up events for non-modifier keys while the Cmd (Meta) key
+      // is held. When Cmd is released, drop any non-modifier keys left in the state —
+      // their key up events will never arrive, so without this they stay stuck and can
+      // match later shortcuts (e.g. a lone Cmd press matching Cmd+P).
+      if (isMetaRelease) next = next.filter((k) => MODIFIER_KEYS.includes(k));
       const prev = prevS.next;
       const nextS: RefState = { ...prevS, next, prev };
       if (shouldPreventDefault(next, preventDefaultOn, preventDefaultOptions))

--- a/pluto/src/triggers/Provider.tsx
+++ b/pluto/src/triggers/Provider.tsx
@@ -59,6 +59,8 @@ const ZERO_REF_STATE: RefState = {
 
 const EXCLUDE_TRIGGERS = ["CapsLock"];
 
+// "Meta" is intentionally excluded — keyboardKey() maps any Meta (Cmd/Win) event
+// to "Control", so the Meta key is already represented as "Control" in tracked state.
 const MODIFIER_KEYS: Key[] = ["Control", "Shift", "Alt"];
 
 export interface ProviderProps extends PropsWithChildren {

--- a/pluto/src/triggers/Triggers.spec.tsx
+++ b/pluto/src/triggers/Triggers.spec.tsx
@@ -849,6 +849,66 @@ describe("Triggers", () => {
       fireEvent.keyUp(target, { code: "MetaRight" });
     });
 
+    it("should clear stuck non-modifier keys when Meta (Cmd) is released", async () => {
+      const callback = vi.fn();
+      const C = () => {
+        Triggers.use({
+          callback,
+          triggers: [
+            ["Control", "Shift", "P"],
+            ["Control", "P"],
+          ],
+        });
+        return <div>Hello</div>;
+      };
+      render(
+        <Triggers.Provider>
+          <C />
+        </Triggers.Provider>,
+      );
+
+      // Cmd + Shift + P fires and opens whatever Control+Shift+P controls.
+      fireEvent.keyDown(document.body, { code: "MetaLeft", metaKey: true });
+      fireEvent.keyDown(document.body, {
+        code: "ShiftLeft",
+        metaKey: true,
+        shiftKey: true,
+      });
+      fireEvent.keyDown(document.body, { code: "KeyP", metaKey: true, shiftKey: true });
+      expect(callback).toHaveBeenCalledWith({
+        target: document.body,
+        triggers: [["Control", "Shift", "P"]],
+        prevTriggers: [["Control", "Shift"]],
+        cursor: { x: 0, y: 0 },
+        stage: "start",
+        stopPropagation: expect.any(Function),
+      });
+
+      // macOS suppresses the key up event for P while Cmd is held — only Shift and Cmd
+      // key up events arrive. Without the fix, "P" stays stuck in the state.
+      fireEvent.keyUp(document.body, {
+        code: "ShiftLeft",
+        metaKey: true,
+        shiftKey: false,
+      });
+      fireEvent.keyUp(document.body, {
+        code: "MetaLeft",
+        metaKey: false,
+        shiftKey: false,
+      });
+
+      const callsAfterRelease = callback.mock.calls.length;
+
+      // Now press Cmd alone. Without the fix, the stuck "P" + new "Control" would match
+      // the Control+P trigger and fire start. With the fix, the state was cleared on
+      // Cmd release, so this should not match.
+      fireEvent.keyDown(document.body, { code: "MetaLeft", metaKey: true });
+      vi.advanceTimersByTime(500);
+      expect(callback.mock.calls.length).toBe(callsAfterRelease);
+
+      fireEvent.keyUp(document.body, { code: "MetaLeft", metaKey: false });
+    });
+
     it("should handle Safari's sticky shift key behavior", async () => {
       const callback = vi.fn();
       const C = () => {

--- a/pluto/src/triggers/triggers.ts
+++ b/pluto/src/triggers/triggers.ts
@@ -208,9 +208,9 @@ export const eventKey = (
   return mouseKey((e as MouseEvent).button);
 };
 
-/* Tracks a list of keys that have an opinionated location i.e. "Left"  or "Right"
- as Triggers is location agnostic. */
-const INCLUDES_KEYS: Key[] = ["Control", "Alt", "Shift"];
+// Location-agnostic modifier keys. "Meta" is excluded because keyboardKey() maps it to
+// "Control", so it's already tracked as "Control".
+export const MODIFIER_KEYS: Key[] = ["Control", "Alt", "Shift"];
 
 /**
  * Parses the TriggerKey from the provided KeyboardEvent.
@@ -223,7 +223,7 @@ export const keyboardKey = (
   if (["Digit", "Key"].some((k) => e.code.startsWith(k)))
     return e.code.slice(-1) as Key;
   if (e.code.includes("Meta")) return "Control";
-  const includeKey = INCLUDES_KEYS.find((k) => e.code.includes(k));
+  const includeKey = MODIFIER_KEYS.find((k) => e.code.includes(k));
   if (includeKey != null) return includeKey;
   return e.code as Key;
 };


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4306](https://linear.app/synnax/issue/SY-4306)

## Description

In browser mode on macOS, opening the command palette with `Cmd+Shift+P`, pressing `Escape` to close it, and then pressing `Cmd` alone would reopen the palette in search mode.

**Root cause:** macOS suppresses `keyup` events for non-modifier keys while the Cmd (Meta) key is held. The `Triggers.Provider` tracks held keys in state and only removes them on `keyup`, so after `Cmd+Shift+P` the `P` would stay stuck in the tracked state. A subsequent lone `Cmd` press would then combine with the stuck `P` to match the `Cmd+P` search trigger and reopen the palette.

**Fix:** In `pluto/src/triggers/Provider.tsx`, when a Meta key release is detected, drop any non-modifier keys from the tracked state — their `keyup` events will never arrive, so leaving them in state causes false trigger matches later. This mirrors the existing Safari sticky-Shift workaround already in the same handler.

Added a regression test in `pluto/src/triggers/Triggers.spec.tsx` that reproduces the exact sequence (`Cmd+Shift+P` down, `Shift` up + `Cmd` up with `P` keyup suppressed, then lone `Cmd` press) and asserts that no spurious trigger fires.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a browser-mode bug on macOS where pressing `Cmd+Shift+P`, closing the command palette, and then pressing `Cmd` alone would erroneously reopen it. The root cause was that macOS suppresses `keyup` events for non-modifier keys while `Meta` is held, causing those keys to remain stuck in the `Triggers.Provider` tracked state.

- **`Provider.tsx`**: When a Meta key release is detected, non-modifier keys are flushed from `next` state via a new `MODIFIER_KEYS` filter — mirroring the existing Safari sticky-Shift workaround already in the same handler.
- **`Triggers.spec.tsx`**: Adds a regression test that replays the exact `Cmd+Shift+P` → `Shift` up → `Cmd` up (P keyup suppressed) → lone `Cmd` sequence and asserts no spurious trigger fires.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a small, self-contained flush of stuck non-modifier keys on Meta release, following an identical pattern already proven correct for the Safari sticky-Shift case.

The fix touches a single logical branch in handleKeyUp, the new MODIFIER_KEYS filter is correctly scoped (Meta itself is already removed by the preceding filter and only non-modifier keys need flushing), and the regression test faithfully replicates the suppressed macOS keyup scenario end-to-end. No other code paths are affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pluto/src/triggers/Provider.tsx | Adds MODIFIER_KEYS constant and flushes stuck non-modifier keys on Meta release in handleKeyUp; fix is minimal, well-commented, and follows the existing Shift-sticky pattern. |
| pluto/src/triggers/Triggers.spec.tsx | Adds a targeted regression test for the suppressed macOS keyup scenario; event sequence accurately mirrors the real browser behavior and the assertion is sound. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser as macOS Browser
    participant Provider as Triggers.Provider (handleKeyUp)
    participant State as Tracked Key State

    Note over Browser,State: Bug scenario (before fix)
    Browser->>Provider: keydown MetaLeft → "Control" added
    Browser->>Provider: keydown ShiftLeft → "Shift" added
    Browser->>Provider: keydown KeyP → "P" added → ["Control","Shift","P"] triggers
    Browser->>Provider: keyup ShiftLeft → "Shift" removed
    Note over Browser: macOS suppresses keyup for "P"
    Browser->>Provider: keyup MetaLeft → "Control" removed
    State-->>State: Stuck state: ["P"]
    Browser->>Provider: keydown MetaLeft → "Control" added
    State-->>State: State: ["Control","P"] → matches Cmd+P trigger!

    Note over Browser,State: After fix
    Browser->>Provider: keydown MetaLeft → "Control" added
    Browser->>Provider: keydown ShiftLeft → "Shift" added
    Browser->>Provider: keydown KeyP → "P" added → ["Control","Shift","P"] triggers
    Browser->>Provider: keyup ShiftLeft → "Shift" removed
    Note over Browser: macOS suppresses keyup for "P"
    Browser->>Provider: "keyup MetaLeft → "Control" removed, isMetaRelease=true"
    Provider->>State: filter: keep only MODIFIER_KEYS → "P" flushed
    State-->>State: Clean state: []
    Browser->>Provider: keydown MetaLeft → "Control" added
    State-->>State: State: ["Control"] → no match
```

<sub>Reviews (2): Last reviewed commit: ["format comment"](https://github.com/synnaxlabs/synnax/commit/5450d7289c088ba2d4d6f75950606cf6c845eda8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35305255)</sub>

<!-- /greptile_comment -->