### PR TITLE
SY-4298: Switch Bazel Remote Cache to gRPC with Zstd Compression

### DIFF
--- a/.github/workflows/build.synnax.yaml
+++ b/.github/workflows/build.synnax.yaml
@@ -207,7 +207,9 @@ jobs:
       BAZEL_BUILD_FLAGS:
         --enable_platform_specific_config ${{ inputs.debug && '-c dbg' || '--config=opt'
         }} --announce_rc --verbose_failures
-      BAZEL_REMOTE_CACHE_FLAGS: --remote_cache=${{ vars.BAZEL_REMOTE_CACHE_URL }}
+      BAZEL_REMOTE_CACHE_FLAGS:
+        --remote_cache=${{ vars.BAZEL_REMOTE_CACHE_GRPC_URL }}
+        --remote_cache_compression=true
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/test.arc.yaml
+++ b/.github/workflows/test.arc.yaml
@@ -41,7 +41,7 @@ on:
   workflow_dispatch:
 
 env:
-  BAZEL_REMOTE_CACHE: ${{ vars.BAZEL_REMOTE_CACHE_URL }}
+  BAZEL_REMOTE_CACHE: ${{ vars.BAZEL_REMOTE_CACHE_GRPC_URL }}
 
 jobs:
   server:
@@ -121,7 +121,7 @@ jobs:
       - name: Test
         run: |
           bazel test --config=asan-leak --test_output=all //arc/cpp/... \
-            --remote_cache=${{ env.BAZEL_REMOTE_CACHE }} \
+            --remote_cache=${{ env.BAZEL_REMOTE_CACHE }} --remote_cache_compression=true \
             --test_env=LSAN_OPTIONS="suppressions=${{ github.workspace }}/scripts/sanitizers/lsan_suppressions.txt" \
             --spawn_strategy=local \
             --jobs=1
@@ -162,6 +162,6 @@ jobs:
         if: matrix.os == 'windows-build-bot'
         run: |
           bazel --output_user_root=C:/tmp test --test_output=all //arc/cpp/... \
-            --remote_cache=${{ env.BAZEL_REMOTE_CACHE }} \
+            --remote_cache=${{ env.BAZEL_REMOTE_CACHE }} --remote_cache_compression=true \
             --test_tag_filters=-requires-core
         shell: bash

--- a/.github/workflows/test.driver.yaml
+++ b/.github/workflows/test.driver.yaml
@@ -53,7 +53,7 @@ on:
   workflow_dispatch:
 
 env:
-  BAZEL_REMOTE_CACHE: ${{ vars.BAZEL_REMOTE_CACHE_URL }}
+  BAZEL_REMOTE_CACHE: ${{ vars.BAZEL_REMOTE_CACHE_GRPC_URL }}
 
 jobs:
   server:
@@ -138,7 +138,7 @@ jobs:
       - name: Test Driver
         run: |
           bazel test --config=asan-leak --test_output=all //driver/... \
-            --remote_cache=${{ env.BAZEL_REMOTE_CACHE }} \
+            --remote_cache=${{ env.BAZEL_REMOTE_CACHE }} --remote_cache_compression=true \
             --test_env=LSAN_OPTIONS="suppressions=${{ github.workspace }}/scripts/sanitizers/lsan_suppressions.txt" \
             --spawn_strategy=local \
             --jobs=1 --test_tag_filters=-hardware

--- a/.github/workflows/test.freighter.cpp.yaml
+++ b/.github/workflows/test.freighter.cpp.yaml
@@ -35,7 +35,9 @@ on:
   workflow_dispatch:
 
 env:
-  BAZEL_REMOTE_CACHE_FLAGS: --remote_cache=${{ vars.BAZEL_REMOTE_CACHE_URL }}
+  BAZEL_REMOTE_CACHE_FLAGS:
+    --remote_cache=${{ vars.BAZEL_REMOTE_CACHE_GRPC_URL }}
+    --remote_cache_compression=true
 
 jobs:
   test:

--- a/.github/workflows/test.x.cpp.yaml
+++ b/.github/workflows/test.x.cpp.yaml
@@ -33,7 +33,7 @@ on:
   workflow_dispatch:
 
 env:
-  BAZEL_REMOTE_CACHE: ${{ vars.BAZEL_REMOTE_CACHE_URL }}
+  BAZEL_REMOTE_CACHE: ${{ vars.BAZEL_REMOTE_CACHE_GRPC_URL }}
 
 jobs:
   test:
@@ -85,12 +85,12 @@ jobs:
         if: matrix.os == 'ubuntu-build-bot'
         run: |
           bazel test --config=asan-leak --test_output=all //x/cpp/... \
-            --remote_cache=${{ env.BAZEL_REMOTE_CACHE }}
+            --remote_cache=${{ env.BAZEL_REMOTE_CACHE }} --remote_cache_compression=true
         shell: bash
 
       - name: Test (Windows)
         if: matrix.os == 'windows-build-bot'
         run: |
           bazel --output_user_root=C:/tmp test --test_output=all //x/cpp/... \
-            --remote_cache=${{ env.BAZEL_REMOTE_CACHE }}
+            --remote_cache=${{ env.BAZEL_REMOTE_CACHE }} --remote_cache_compression=true
         shell: bash


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4298](https://linear.app/synnax/issue/SY-4298)

## Description

**The one-line YAML diff is the visible tip of a much larger infrastructure change.** The code only repoints the Bazel remote cache flag; the substance is a new parallel cache server with gRPC plus zstd compression and durable S3-backed storage. The infrastructure ("offline") work is summarized below so the change is reviewable and reversible.

### What the code change does

In `build.synnax.yaml`, the `build` job switches its remote cache flag to the gRPC endpoint and enables zstd wire compression:

```diff
- BAZEL_REMOTE_CACHE_FLAGS: --remote_cache=${{ vars.BAZEL_REMOTE_CACHE_URL }}
+ BAZEL_REMOTE_CACHE_FLAGS:
+   --remote_cache=${{ vars.BAZEL_REMOTE_CACHE_GRPC_URL }}
+   --remote_cache_compression=true
```

The server had to change, not just the flag: `--remote_cache_compression` only applies over gRPC and is ignored over HTTP. Consumed by the Windows, Linux, and NI Linux Real-Time driver builds (macOS does not use the remote cache).

The same swap is also applied to the four C++ test workflows (`test.driver`, `test.arc`, `test.x.cpp`, `test.freighter.cpp`). Their macOS jobs are unchanged, since they do not use the remote cache.

### Why

The Windows `Linking driver.exe` step was transfer-bound: it pulls large `/GL` + `/LTCG` `.lib` inputs (e.g. `api_grpc.lib` at 248 MiB) over HTTP, which stalled. The cache already stores blobs ~5x compressed on disk, so gRPC + zstd shrinks the wire transfer.

### Results

Same `//driver` Windows opt build (~6,716 total actions). **Downloaded** = remote cache hits pulled from the cache; **Local** = actions compiled on the bot; **api_grpc.lib transfer** = wall-clock span to pull the link's largest cache-hit input (248 MiB logical). The warm runs all do identical work (~4,957 downloaded / 52 local), so their elapsed spread is variance, not workload. Pre-fix samples are pulled from `main`, `rc`, and feature-branch CI (`test.integration`) across multiple authors.

**Pre-fix (HTTP cache), 10 warm runs:**

| Run | Branch | Downloaded | Local | api_grpc.lib transfer | Elapsed |
|-----|--------|-----------|-------|-----------------------|---------|
| [26442452953](https://github.com/synnaxlabs/synnax/actions/runs/26442452953) | sy-4179-refactor-freighter-to-throw-exceptions | 4955 | 52 | 39 s | 740 s |
| [26616763584](https://github.com/synnaxlabs/synnax/actions/runs/26616763584) | sy-4245-improved-schematic-context-menu | 4957 | 52 | 76 s | 873 s |
| [26866572397](https://github.com/synnaxlabs/synnax/actions/runs/26866572397) | rc | 4957 | 52 | 75 s | 910 s |
| [26848266576](https://github.com/synnaxlabs/synnax/actions/runs/26848266576) | sy-4065-strongly-type-line-plots | 4957 | 52 | 65 s | 910 s |
| [26559807778](https://github.com/synnaxlabs/synnax/actions/runs/26559807778) | sy-4122-arc-statuses-v2 | 4955 | 52 | 54 s | 919 s |
| [26528724527](https://github.com/synnaxlabs/synnax/actions/runs/26528724527) | sy-4231-improve-aether-test-scaffolding | 4955 | 52 | 89 s | 961 s |
| [26762117777](https://github.com/synnaxlabs/synnax/actions/runs/26762117777) | main | 4957 | 52 | 83 s | 994 s |
| [26600358348](https://github.com/synnaxlabs/synnax/actions/runs/26600358348) | sy-4255-fix-race-in-driver-command-processing | 4955 | 52 | 90 s | 1008 s |
| [26835115236](https://github.com/synnaxlabs/synnax/actions/runs/26835115236) | main | 4957 | 52 | 68 s | 1063 s |
| [26844119520](https://github.com/synnaxlabs/synnax/actions/runs/26844119520) | main | 4957 | 52 | 81 s | 1199 s |

**Post-fix (gRPC + zstd):**

| Run | Branch | State | Downloaded | Local | api_grpc.lib transfer | Elapsed |
|-----|--------|-------|-----------|-------|-----------------------|---------|
| [26864905450](https://github.com/synnaxlabs/synnax/actions/runs/26864905450) | sy-4298-build-cache-grpc | cold | 0 | 5009 | built locally | 2289 s |
| [26866737177](https://github.com/synnaxlabs/synnax/actions/runs/26866737177) | sy-4298-build-cache-grpc | warm | 4957 | 52 | 22 s | 1023 s |
| [26869221943](https://github.com/synnaxlabs/synnax/actions/runs/26869221943) | sy-4298-build-cache-grpc | warm | 4957 | 52 | 23 s | 955 s |
| [26868531024](https://github.com/synnaxlabs/synnax/actions/runs/26868531024) | sy-4298 PR CI (test.integration) | warm | 4957 | 52 | 21 s | 1101 s |

**Read:** Warm HTTP runs span 740 to 1199 s and the warm gRPC + zstd runs (955, 1023 s) land inside that band, so there is **no measurable steady-state speed gain**. The value of this change is **durability** (data volume + S3 backend, vs the old box's ephemeral storage) and having **wire compression in place** to blunt worst-case download stalls; the cold run reflects a one-time S3 warm-up, and the remaining ~6 min link is LTCG-bound (addressable separately by dropping `/GL` + `/LTCG`).

gRPC + zstd holds the `api_grpc.lib transfer` at a steady 21 to 23 s versus 39 to 90 s (with stalls) over HTTP, a reliable 2 to 4x and the concrete worst-case-stall protection the change buys. But that transfer overlaps with compilation (off the critical path), so cutting it does not reduce total build time.

### Test workflows

This PR also migrates the four C++ test workflows above to the gRPC cache. One behavioral caveat: they run on **persistent build bots with a local on-disk action cache**, so the remote cache (HTTP or gRPC) is only consulted when that local cache is cold. On a warm bot, bazel reports `action cache hit` and never touches the remote.

Validated on `test.driver`: a warm PR-CI run ([26904668110](https://github.com/synnaxlabs/synnax/actions/runs/26904668110)) was fully local-action-cache served (0 remote, 706 s), while a cold-bot run ([26907693620](https://github.com/synnaxlabs/synnax/actions/runs/26907693620)) pulled **3,633 objects from the gRPC cache** with live `remote-cache` downloads. So the gRPC endpoint works end-to-end for these workflows; in steady state they mostly ride the bots' local action cache and the remote (HTTP or gRPC) is rarely the bottleneck.

### Infrastructure work (not in the diff)

1. **New cache server**: a clone of the existing cache box's spec, running bazel-remote and serving both HTTP and gRPC, with two durability fixes over the old box: a mounted data volume (survives container recreate) and an S3 backend (survives instance loss). The old box used ephemeral container storage with neither.
2. **gRPC endpoint** enabled on the new server (the old server is HTTP-only).
3. **Validation**: two runs failed and pinpointed prerequisites (the old server had no gRPC endpoint; the build runners could not egress to the gRPC port), then the cold and warm runs above succeeded.

### Security and ports

Port **9092** (gRPC) was added inbound on the cache and outbound on the build runners, scoped to the VPC. Existing 8080 (HTTP) rules are unchanged.

### Deprecation plan

The old HTTP-only cache box is left serving, so every branch that has not merged this change is unaffected via the unchanged `BAZEL_REMOTE_CACHE_URL`. With this PR, the driver build and the four C++ test workflows all point at the gRPC cache. Once it has run in regular use, the old box and its security group are retired. The S3 bucket is retained (now the new cache's backend, plus the existing Go/pnpm tarballs).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR switches the Bazel remote cache endpoint in `build.synnax.yaml` from HTTP (`BAZEL_REMOTE_CACHE_URL`) to a new gRPC endpoint (`BAZEL_REMOTE_CACHE_GRPC_URL`) and enables zstd wire compression via `--remote_cache_compression=true`, targeting the Windows, Linux, and NI Linux RT driver builds.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a three-line env-var swap that has already been exercised through validated cold and warm CI runs with identical action graphs.

The diff touches only the BAZEL_REMOTE_CACHE_FLAGS env block in the build job. The gRPC URL variable and the compression flag have been confirmed working by three explicit CI runs documented in the PR description. macOS correctly omits the cache flags as before, and the four remaining workflows that still reference the HTTP cache are intentionally left unchanged for a follow-up migration.

No files require special attention. The four other cache-consuming workflows (test.driver.yaml, test.arc.yaml, test.x.cpp.yaml, test.freighter.cpp.yaml) still use the old HTTP endpoint and will need their own migration pass.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/build.synnax.yaml | Three-line change: replaces the HTTP remote cache URL variable with the new gRPC URL variable and adds --remote_cache_compression=true; usage sites (Windows, Linux, NI Linux RT build steps) are unchanged and macOS correctly omits the flag as before. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant GHA as GitHub Actions Runner
    participant BZL as Bazel Client
    participant OLD as Old Cache (HTTP :8080)
    participant NEW as New Cache (gRPC :9092)
    participant S3 as S3 Backend

    Note over GHA,S3: Before this PR (HTTP)
    GHA->>BZL: "bazel build --remote_cache=http://<old-cache>:8080"
    BZL->>OLD: HTTP GET/PUT (uncompressed wire)
    OLD-->>BZL: blob bytes (no wire compression)

    Note over GHA,S3: After this PR (gRPC + zstd)
    GHA->>BZL: "bazel build --remote_cache=grpc://<new-cache>:9092 --remote_cache_compression=true"
    BZL->>NEW: gRPC FindMissingBlobs / Read/WriteBlob (zstd compressed)
    NEW->>S3: Durable blob storage (zstd)
    S3-->>NEW: blob fetch on miss
    NEW-->>BZL: zstd-compressed response
```

<!-- /greptile_comment -->