### PR TITLE
SY-4310: Fix Schematic Symbol Label Alignment

### DIFF
--- a/pluto/src/flex/Box.css
+++ b/pluto/src/flex/Box.css
@@ -61,6 +61,18 @@
     &.pluto--align-stretch {
         align-items: stretch;
     }
+    &.pluto--align-self-start {
+        align-self: flex-start;
+    }
+    &.pluto--align-self-center {
+        align-self: center;
+    }
+    &.pluto--align-self-end {
+        align-self: flex-end;
+    }
+    &.pluto--align-self-stretch {
+        align-self: stretch;
+    }
     &.pluto--direction-x {
         flex-direction: row;
         &.pluto--reverse {

--- a/pluto/src/flex/Box.spec.tsx
+++ b/pluto/src/flex/Box.spec.tsx
@@ -174,6 +174,38 @@ describe("Box", () => {
     });
   });
 
+  describe("alignSelf", () => {
+    it("should not add a classname by default", () => {
+      const c = render(<Flex.Box>Hello</Flex.Box>);
+      const el = c.getByText("Hello");
+      expect(el.className).not.toContain("pluto--align-self");
+    });
+
+    it("should set center if the alignSelf is center", () => {
+      const c = render(<Flex.Box alignSelf="center">Hello</Flex.Box>);
+      const el = c.getByText("Hello");
+      expect(el.className).toContain("pluto--align-self-center");
+    });
+
+    it("should set end if the alignSelf is end", () => {
+      const c = render(<Flex.Box alignSelf="end">Hello</Flex.Box>);
+      const el = c.getByText("Hello");
+      expect(el.className).toContain("pluto--align-self-end");
+    });
+
+    it("should set start if the alignSelf is start", () => {
+      const c = render(<Flex.Box alignSelf="start">Hello</Flex.Box>);
+      const el = c.getByText("Hello");
+      expect(el.className).toContain("pluto--align-self-start");
+    });
+
+    it("should set stretch if the alignSelf is stretch", () => {
+      const c = render(<Flex.Box alignSelf="stretch">Hello</Flex.Box>);
+      const el = c.getByText("Hello");
+      expect(el.className).toContain("pluto--align-self-stretch");
+    });
+  });
+
   describe("grow", () => {
     it("should not add a classname by default", () => {
       const c = render(<Flex.Box>Hello</Flex.Box>);

--- a/pluto/src/flex/Box.tsx
+++ b/pluto/src/flex/Box.tsx
@@ -114,6 +114,10 @@ export interface BoxExtensionProps {
   /** Cross-axis alignment of children. See {@link Alignment} for options: 'start',
    * 'center', 'end', 'stretch' */
   align?: Alignment;
+  /** Cross-axis alignment of this box within its own parent flex container,
+   * overriding the parent's align. See {@link Alignment} for options: 'start',
+   * 'center', 'end', 'stretch' */
+  alignSelf?: Alignment;
 
   /** Flex grow behavior. true sets flex-grow: 1, false leaves unset, number sets
    * specific flex-grow value */
@@ -183,6 +187,7 @@ export const Box = <E extends Generic.ElementType = "div">({
   gap,
   color,
   justify,
+  alignSelf,
   reverse,
   empty,
   pack,
@@ -212,6 +217,7 @@ export const Box = <E extends Generic.ElementType = "div">({
     pack && CSS.M("pack"),
     justify != null && CSS.M("justify", justify),
     align != null && CSS.M("align", align),
+    alignSelf != null && CSS.M("align-self", alignSelf),
     wrap === true && CSS.M("wrap"),
     empty === true && CSS.M("empty"),
     center === true && CSS.M("center"),

--- a/pluto/src/schematic/node/common/label/Label.tsx
+++ b/pluto/src/schematic/node/common/label/Label.tsx
@@ -63,6 +63,7 @@ const Internal = ({ config, onChange, style: baseStyle, ...rest }: InternalProps
     <Text.Editable
       {...rest}
       style={style}
+      alignSelf={align}
       className={CSS(CSS.BE("symbol", "label"), CSS.dir(dir))}
       level={level}
       value={label}


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4310](https://linear.app/synnax/issue/SY-4310)

## Description

The "Label alignment" field on schematic symbols had no visible effect: changing it never shifted the label relative to the symbol.

The label's `align` value was being applied as `text-align` on the label element. Because the label element is sized `width: max-content`, it shrinks to exactly fit its text, so `text-align` has no room to do anything for normal single-line labels. Meanwhile the label sits inside a grid slot (a flex box spanning the symbol's edge) whose `align-items: center` is hardcoded, so the label stayed centered regardless of the chosen alignment.

The fix routes the alignment through the label's cross-axis position within its slot (`align-self`) instead. To keep the mapping in the right layer, `Flex.Box` gains an `alignSelf` prop — a "self" layout property in the same family as the existing `grow`/`shrink` props — that emits a `pluto--align-self-*` modifier class. Since `Text` (and therefore `Text.Editable`) is a `Flex.Box`, the schematic label just declares `alignSelf={align}` and the alignment now shifts the label toward the start/center/end of the symbol's edge (horizontally for top/bottom labels, vertically for left/right). `text-align` is retained so multi-line wrapped labels still align their lines consistently.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes schematic symbol label alignment by routing the `align` value through `align-self` (cross-axis position within the flex slot) instead of relying solely on `text-align`, which had no visual effect because the label element is sized to `width: max-content`.

- `Flex.Box` gains an `alignSelf?: Alignment` prop that emits a `pluto--align-self-*` modifier class, mirroring the existing `align` / `align-items` pattern already in the component.
- `Label.tsx` passes `alignSelf={align}` to `Text.Editable` so the label element moves toward the start/center/end of its parent flex slot; `textAlign` is also retained in the inline style so multi-line wrapped labels still align their lines correctly.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is minimal and surgically targeted to the broken alignment path.

The fix correctly addresses the root cause: the label element is max-content wide so text-align has nothing to do, and the new align-self approach moves the element within its parent flex slot as intended. The alignSelf prop on Flex.Box follows the exact same class-emission pattern as the existing align prop, and the CSS selectors are correctly scoped inside .pluto-flex. Both textAlign (for multi-line line alignment) and alignSelf (for element placement) serve distinct purposes and are correct to keep together.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pluto/src/flex/Box.css | Adds four new pluto--align-self-* modifier classes inside .pluto-flex, mapping to flex-start, center, flex-end, and stretch — correctly scoped and mirrors the existing align-items pattern. |
| pluto/src/flex/Box.tsx | Adds alignSelf?: Alignment prop to BoxExtensionProps and wires it to emit CSS.M("align-self", alignSelf) in the class list; matches the pattern used by the existing align prop. |
| pluto/src/schematic/node/common/label/Label.tsx | Passes alignSelf={align} to Text.Editable so the label shifts within its parent flex slot; retains textAlign in the inline style for multi-line text consistency. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Label.tsx: align config value"] --> B["textAlign in inline style\n(aligns lines within text node)"]
    A --> C["alignSelf prop on Text.Editable\n(new)"]
    C --> D["Flex.Box: CSS.M('align-self', alignSelf)\n(new)"]
    D --> E["pluto--align-self-{start|center|end|stretch}\nclass added to element"]
    E --> F["Box.css: align-self: flex-start/center/flex-end/stretch\napplied to the label element"]
    F --> G["Label shifts within parent flex slot\n(visible alignment change)"]
```

<sub>Reviews (1): Last reviewed commit: ["Add Flex.Box alignSelf tests"](https://github.com/synnaxlabs/synnax/commit/3fc9c18bd9892227ad80c799b5bc1ef233f0290f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35371549)</sub>

<!-- /greptile_comment -->