### PR TITLE
SY-4312: Fix Legacy Schematic Edge Pigtail Routing

### DIFF
--- a/console/src/schematic/types/migrations.spec.ts
+++ b/console/src/schematic/types/migrations.spec.ts
@@ -103,7 +103,12 @@ describe("migrations", () => {
             source: "n1",
             target: "n2",
             data: {
-              segments: [{ direction: "x", length: 10 }],
+              segments: [
+                { direction: "x", length: 10 },
+                { direction: "y", length: -50 },
+                { direction: "x", length: 30 },
+                { direction: "y", length: 10 },
+              ],
               color: "#00ff00",
               variant: "pipe",
             },
@@ -112,10 +117,67 @@ describe("migrations", () => {
       };
       const migrated = migrateState(populated);
       expect(migrated.pendingUpload?.configs.e1).toMatchObject({
-        segments: [{ direction: "x", length: 10 }],
+        segments: [
+          { direction: "y", length: -50 },
+          { direction: "x", length: 30 },
+        ],
         color: color.construct("#00ff00"),
         variant: "pipe",
       });
+    });
+
+    it("should strip legacy stumps from full-path edge segments", () => {
+      // Real OX Pre-Valve -> OX MPV edge from a 0.55 schematic: the stored full path
+      // includes both stumps, which would double on render and fold a pigtail.
+      const populated: v5.State = {
+        ...v5.ZERO_STATE,
+        edges: [
+          {
+            key: "e1",
+            source: "n1",
+            target: "n2",
+            sourceHandle: "2",
+            targetHandle: "2",
+            data: {
+              segments: [
+                { direction: "x", length: 10 },
+                { direction: "y", length: -281.7166395035551 },
+                { direction: "x", length: 140.06190790464655 },
+                { direction: "y", length: 10 },
+              ],
+              color: "#004ad6",
+              variant: "jacketed",
+            },
+          },
+        ],
+      };
+      const migrated = migrateState(populated);
+      expect(migrated.pendingUpload?.configs.e1).toMatchObject({
+        segments: [
+          { direction: "y", length: -281.7166395035551 },
+          { direction: "x", length: 140.06190790464655 },
+        ],
+        variant: "jacketed",
+      });
+    });
+
+    it("should clear degenerate short edges so they auto-route", () => {
+      // A single segment shorter than two stumps (real 0.55 edge, 11.88px) has no
+      // strippable middle; subtracting a full stump from each end would flip it into a
+      // self-crossing spur, so it must be cleared to an empty (auto-routed) edge.
+      const populated: v5.State = {
+        ...v5.ZERO_STATE,
+        edges: [
+          {
+            key: "e1",
+            source: "n1",
+            target: "n2",
+            data: { segments: [{ direction: "y", length: 11.88 }], variant: "pipe" },
+          },
+        ],
+      };
+      const migrated = migrateState(populated);
+      expect(migrated.pendingUpload?.configs.e1).toMatchObject({ segments: [] });
     });
 
     it("should add an empty selected array when migrating to v6", () => {

--- a/console/src/schematic/types/v6.ts
+++ b/console/src/schematic/types/v6.ts
@@ -9,7 +9,15 @@
 
 import { schematic } from "@synnaxlabs/client";
 import { control, Schematic, Viewport } from "@synnaxlabs/pluto";
-import { color, control as xcontrol, migrate, record, sticky, xy } from "@synnaxlabs/x";
+import {
+  color,
+  control as xcontrol,
+  location,
+  migrate,
+  record,
+  sticky,
+  xy,
+} from "@synnaxlabs/x";
 import { z } from "zod";
 
 import * as v0 from "@/schematic/types/v0";
@@ -97,6 +105,46 @@ const migrateNode = (node: v0.Node): Node => {
   return next;
 };
 
+type Segment = Schematic.Edge.Segmented.Segment;
+
+const segmentOrientation = (seg: Segment): location.Outer =>
+  seg.direction === "x"
+    ? seg.length > 0
+      ? "right"
+      : "left"
+    : seg.length > 0
+      ? "bottom"
+      : "top";
+
+const STUMP_LENGTH = Schematic.Edge.Segmented.STUMP_LENGTH;
+
+// An edge whose stumps overlap has no middle to preserve: a single segment shorter than
+// two stumps, or a first/last segment shorter than one stump. Subtracting a full stump
+// from those would flip the segment and fold a spur, so they are cleared to auto-route
+// instead (which handles short, facing handles cleanly).
+const hasNoStrippableMiddle = (segments: Segment[]): boolean =>
+  segments.length === 1
+    ? Math.abs(segments[0].length) <= 2 * STUMP_LENGTH - 0.5
+    : Math.abs(segments[0].length) <= STUMP_LENGTH - 0.5 ||
+      Math.abs(segments[segments.length - 1].length) <= STUMP_LENGTH - 0.5;
+
+// Pre-0.56 edges stored the full path including both stumps; the current model stores
+// only the middle and re-derives stumps on render, so leaving them doubles the stumps
+// and folds a pigtail over the target. The stumps are the first and last segments.
+const stripLegacyStumps = (segments: Segment[]): Segment[] => {
+  if (segments.length === 0) return segments;
+  if (hasNoStrippableMiddle(segments)) return [];
+  const sourceOrientation = segmentOrientation(segments[0]);
+  const targetOrientation = location.swap(
+    segmentOrientation(segments[segments.length - 1]),
+  ) as location.Outer;
+  return Schematic.Edge.Segmented.extractMiddle(
+    segments,
+    sourceOrientation,
+    targetOrientation,
+  );
+};
+
 const migrateEdge = (edge: v0.Edge): [Edge, EdgeConfig] => {
   const next: Edge = {
     key: edge.key,
@@ -112,7 +160,7 @@ const migrateEdge = (edge: v0.Edge): [Edge, EdgeConfig] => {
   if (!parseDataResult.success) return [next, edgeConfig];
   const data = parseDataResult.data;
   const segments = z.array(Schematic.Edge.Segmented.segmentZ).safeParse(data.segments);
-  if (segments.success) edgeConfig.segments = segments.data;
+  if (segments.success) edgeConfig.segments = stripLegacyStumps(segments.data);
   const parsedColor = color.colorZ.safeParse(data.color);
   if (parsedColor.success) edgeConfig.color = parsedColor.data;
   const parsedVariant = Schematic.Edge.variantZ.safeParse(data.variant);

--- a/core/pkg/service/schematic/migrate.go
+++ b/core/pkg/service/schematic/migrate.go
@@ -12,6 +12,7 @@ package schematic
 import (
 	"context"
 	"encoding/json"
+	"math"
 
 	"github.com/synnaxlabs/synnax/pkg/service/schematic/migrations/legacy"
 	v0 "github.com/synnaxlabs/synnax/pkg/service/schematic/migrations/legacy/v0"
@@ -116,7 +117,112 @@ func migrateEdge(e v3.Edge) (Edge, msgpack.EncodedJSON, error) {
 			lifted[key] = v
 		}
 	}
+	if raw, ok := lifted["segments"].([]any); ok {
+		lifted["segments"] = stripLegacyStumps(raw)
+	}
 	return out, lifted, nil
+}
+
+// stumpLength mirrors STUMP_LENGTH in the pluto segmented connector: the fixed
+// length of the auto-generated stub that leaves each handle.
+const stumpLength = 10.0
+
+// segment is the decoded form of one entry in an edge's segments list.
+type segment struct {
+	direction string
+	length    float64
+}
+
+// stripLegacyStumps converts a pre-0.56 full edge path into the middle-only form
+// the current renderer expects. Pre-0.56 edges stored the complete path including
+// both stumps; the current model stores only the middle and re-derives the stumps
+// on render, so leaving them in doubles the stumps and folds a pigtail over the
+// target. The stumps are the first and last segments. Mirrors stripLegacyStumps in
+// the console v6 migration. The input is returned unchanged if it does not parse as
+// a segment list.
+func stripLegacyStumps(raw []any) []any {
+	segs, ok := parseSegments(raw)
+	if !ok || len(segs) == 0 {
+		return raw
+	}
+	if hasNoStrippableMiddle(segs) {
+		return []any{}
+	}
+	return segmentsToRaw(extractMiddle(segs))
+}
+
+// hasNoStrippableMiddle reports whether an edge's stumps overlap, leaving no middle
+// to preserve: a single segment shorter than two stumps, or a first/last segment
+// shorter than one stump. Subtracting a full stump from those would flip the segment
+// and fold a spur, so such edges are cleared to auto-route instead.
+func hasNoStrippableMiddle(segs []segment) bool {
+	if len(segs) == 1 {
+		return math.Abs(segs[0].length) <= 2*stumpLength-0.5
+	}
+	return math.Abs(segs[0].length) <= stumpLength-0.5 ||
+		math.Abs(segs[len(segs)-1].length) <= stumpLength-0.5
+}
+
+// extractMiddle removes the source and target stumps from a full path, leaving the
+// middle segments. The stumps share the direction and sign of the first and last
+// segments, so a same-signed stump length is subtracted from each end; a resulting
+// near-zero segment is dropped entirely.
+func extractMiddle(segs []segment) []segment {
+	result := append([]segment(nil), segs...)
+	srcStump := sign(result[0].length) * stumpLength
+	if rem := result[0].length - srcStump; math.Abs(rem) < 0.5 {
+		result = result[1:]
+	} else {
+		result[0].length = rem
+	}
+	if len(result) == 0 {
+		return result
+	}
+	tgtStump := sign(segs[len(segs)-1].length) * stumpLength
+	last := len(result) - 1
+	if rem := result[last].length - tgtStump; math.Abs(rem) < 0.5 {
+		result = result[:last]
+	} else {
+		result[last].length = rem
+	}
+	return result
+}
+
+func sign(v float64) float64 {
+	if v < 0 {
+		return -1
+	}
+	return 1
+}
+
+// parseSegments decodes the opaque segments list into typed segments, returning
+// false if any entry is not a well-formed {direction, length} object.
+func parseSegments(raw []any) ([]segment, bool) {
+	out := make([]segment, 0, len(raw))
+	for _, item := range raw {
+		m, ok := item.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		direction, ok := m["direction"].(string)
+		if !ok {
+			return nil, false
+		}
+		length, ok := m["length"].(float64)
+		if !ok {
+			return nil, false
+		}
+		out = append(out, segment{direction: direction, length: length})
+	}
+	return out, true
+}
+
+func segmentsToRaw(segs []segment) []any {
+	out := make([]any, len(segs))
+	for i, s := range segs {
+		out[i] = map[string]any{"direction": s.direction, "length": s.length}
+	}
+	return out
 }
 
 // migrateProps decodes each opaque prop entry from raw JSON bytes into the

--- a/core/pkg/service/schematic/migrations/migrate_test.go
+++ b/core/pkg/service/schematic/migrations/migrate_test.go
@@ -131,6 +131,7 @@ var _ = Describe("MigrateSchematic", func() {
 			Entry("v2 value-only", "v2_value_test.json"),
 			Entry("v4 empty", "v4_empty.json"),
 			Entry("v5 hardware workspace", "v5_hardware_workspace.json"),
+			Entry("v5 operator console", "v5_operator.json"),
 		)
 	})
 
@@ -237,6 +238,46 @@ var _ = Describe("MigrateSchematic", func() {
 				HaveKeyWithValue("color", "#0000ff"),
 				HaveKey("segments"),
 			))
+		})
+
+		It("Should strip legacy stumps from a full-path edge", func(ctx SpecContext) {
+			// Real OX Pre-Valve -> OX MPV edge from a 0.55 schematic: the stored full
+			// path includes both stumps, which would double on render and fold a pigtail.
+			out := MustSucceed(schematic.MigrateSchematic(ctx, v55.Schematic{
+				Key: uuid.New(),
+				Data: jsonMap(`{
+					"version": "5.0.0", "nodes": [], "props": {},
+					"edges": [{
+						"key": "e1", "source": "n1", "target": "n2",
+						"sourceHandle": "2", "targetHandle": "2",
+						"data": {"segments": [
+							{"direction": "x", "length": 10},
+							{"direction": "y", "length": -281.7166395035551},
+							{"direction": "x", "length": 140.06190790464655},
+							{"direction": "y", "length": 10}
+						], "variant": "jacketed"}
+					}]
+				}`),
+			}))
+			Expect(out.Configs["e1"]["segments"]).To(Equal([]any{
+				map[string]any{"direction": "y", "length": -281.7166395035551},
+				map[string]any{"direction": "x", "length": 140.06190790464655},
+			}))
+		})
+
+		It("Should clear degenerate short edges so they auto-route", func(ctx SpecContext) {
+			// A single segment shorter than two stumps (real 0.55 edge, 11.88px) has no
+			// strippable middle; subtracting a full stump from each end would flip it
+			// into a self-crossing spur, so it is cleared to an empty (auto-routed) edge.
+			out := MustSucceed(schematic.MigrateSchematic(ctx, v55.Schematic{
+				Key: uuid.New(),
+				Data: jsonMap(`{
+					"version": "5.0.0", "nodes": [], "props": {},
+					"edges": [{"key": "e1", "source": "n1", "target": "n2",
+						"data": {"segments": [{"direction": "y", "length": 11.88}], "variant": "pipe"}}]
+				}`),
+			}))
+			Expect(out.Configs["e1"]["segments"]).To(Equal([]any{}))
 		})
 
 		It("Should default edge-prop variant to pipe when edge.data is non-null but empty", func(ctx SpecContext) {
@@ -378,6 +419,8 @@ var _ = Describe("legacy.MigrateData", func() {
 				"v4_empty.json", 0, 0, 0),
 			Entry("v5 hardware workspace (real mode/toolbar/authority)",
 				"v5_hardware_workspace.json", 2, 0, 0),
+			Entry("v5 operator console (48 nodes, 40 edges, edge.data preserved)",
+				"v5_operator.json", 48, 40, 0),
 		)
 	})
 

--- a/core/pkg/service/schematic/migrations/testdata/v2_gse_condensed.migrated.json
+++ b/core/pkg/service/schematic/migrations/testdata/v2_gse_condensed.migrated.json
@@ -1198,7 +1198,7 @@
       "segments": [
         {
           "direction": "x",
-          "length": 107.2012004303274
+          "length": 87.2012004303274
         }
       ],
       "variant": "pipe"
@@ -1378,7 +1378,7 @@
       "segments": [
         {
           "direction": "x",
-          "length": 33.18229166666664
+          "length": 13.182291666666643
         }
       ],
       "variant": "pipe"
@@ -1725,7 +1725,7 @@
       "segments": [
         {
           "direction": "y",
-          "length": 38.143085277639145
+          "length": 28.143085277639145
         },
         {
           "direction": "x",
@@ -1733,7 +1733,7 @@
         },
         {
           "direction": "y",
-          "length": 35.84155871783544
+          "length": 25.84155871783544
         }
       ],
       "variant": "pipe"
@@ -1756,7 +1756,7 @@
       "segments": [
         {
           "direction": "y",
-          "length": 47.309751944305816
+          "length": 37.309751944305816
         },
         {
           "direction": "x",
@@ -1764,7 +1764,7 @@
         },
         {
           "direction": "y",
-          "length": 26.67489205116877
+          "length": 16.67489205116877
         }
       ],
       "variant": "pipe"
@@ -1846,7 +1846,7 @@
       "segments": [
         {
           "direction": "x",
-          "length": 30.450701944078276
+          "length": 10.450701944078276
         }
       ],
       "variant": "pipe"
@@ -2058,7 +2058,7 @@
       "segments": [
         {
           "direction": "y",
-          "length": 37.575572950428665
+          "length": 27.575572950428665
         },
         {
           "direction": "x",
@@ -2066,7 +2066,7 @@
         },
         {
           "direction": "y",
-          "length": 36.67489205116877
+          "length": 26.67489205116877
         }
       ],
       "variant": "pipe"
@@ -2174,7 +2174,7 @@
       "segments": [
         {
           "direction": "x",
-          "length": 108.43674813647124
+          "length": 88.43674813647124
         }
       ],
       "variant": "pipe"
@@ -2484,7 +2484,7 @@
       "segments": [
         {
           "direction": "x",
-          "length": 357.45175233513794
+          "length": 337.45175233513794
         }
       ],
       "variant": "pipe"
@@ -2673,7 +2673,7 @@
       "segments": [
         {
           "direction": "y",
-          "length": 38.74223961709531
+          "length": 28.742239617095308
         },
         {
           "direction": "x",
@@ -2681,7 +2681,7 @@
         },
         {
           "direction": "y",
-          "length": 35.84155871783544
+          "length": 25.84155871783544
         }
       ],
       "variant": "pipe"
@@ -3155,7 +3155,7 @@
       "segments": [
         {
           "direction": "x",
-          "length": 50.43779054331253
+          "length": 30.43779054331253
         }
       ],
       "variant": "pipe"
@@ -3165,7 +3165,7 @@
       "segments": [
         {
           "direction": "x",
-          "length": 39.690306844743645
+          "length": 19.690306844743645
         }
       ],
       "variant": "pipe"
@@ -3295,11 +3295,7 @@
       "segments": [
         {
           "direction": "x",
-          "length": -10
-        },
-        {
-          "direction": "x",
-          "length": 74.80591624381395
+          "length": 64.80591624381395
         }
       ],
       "variant": "pipe"
@@ -3322,11 +3318,11 @@
       "segments": [
         {
           "direction": "x",
-          "length": -242.20074637388143
+          "length": -232.20074637388143
         },
         {
           "direction": "y",
-          "length": 139.69774734683722
+          "length": 129.69774734683722
         }
       ],
       "variant": "pipe"
@@ -3336,7 +3332,7 @@
       "segments": [
         {
           "direction": "x",
-          "length": 56.85011377335081
+          "length": 36.85011377335081
         }
       ],
       "variant": "pipe"
@@ -3365,11 +3361,11 @@
       "segments": [
         {
           "direction": "y",
-          "length": -41.85371855634398
+          "length": -31.853718556343978
         },
         {
           "direction": "x",
-          "length": -378.6798423203026
+          "length": -368.6798423203026
         }
       ],
       "variant": "pipe"
@@ -3379,7 +3375,7 @@
       "segments": [
         {
           "direction": "x",
-          "length": 76.31827668168148
+          "length": 56.31827668168148
         }
       ],
       "variant": "pipe"
@@ -3402,7 +3398,7 @@
       "segments": [
         {
           "direction": "x",
-          "length": 27.35230402006914
+          "length": 7.352304020069141
         }
       ],
       "variant": "pipe"
@@ -3431,7 +3427,7 @@
       "segments": [
         {
           "direction": "x",
-          "length": 39.68718423848805
+          "length": 19.68718423848805
         }
       ],
       "variant": "pipe"
@@ -3598,7 +3594,7 @@
       "segments": [
         {
           "direction": "x",
-          "length": 44.30423076936671
+          "length": 24.30423076936671
         }
       ],
       "variant": "pipe"
@@ -3640,7 +3636,7 @@
       "segments": [
         {
           "direction": "y",
-          "length": -36.63177258690027
+          "length": -26.63177258690027
         },
         {
           "direction": "x",
@@ -3648,7 +3644,7 @@
         },
         {
           "direction": "y",
-          "length": -36.63177258690027
+          "length": -26.63177258690027
         }
       ],
       "variant": "pipe"
@@ -3658,7 +3654,7 @@
       "segments": [
         {
           "direction": "x",
-          "length": -139.39617338491416
+          "length": -129.39617338491416
         },
         {
           "direction": "y",
@@ -3666,7 +3662,7 @@
         },
         {
           "direction": "x",
-          "length": -35.7718844225766
+          "length": -25.771884422576598
         }
       ],
       "variant": "pipe"
@@ -3676,7 +3672,7 @@
       "segments": [
         {
           "direction": "x",
-          "length": 44.35815471928552
+          "length": 24.358154719285523
         }
       ],
       "variant": "pipe"
@@ -3698,7 +3694,7 @@
       "segments": [
         {
           "direction": "x",
-          "length": 44.411889306570856
+          "length": 24.411889306570856
         }
       ],
       "variant": "pipe"
@@ -3708,7 +3704,7 @@
       "segments": [
         {
           "direction": "x",
-          "length": 36.01241279495269
+          "length": 26.012412794952688
         },
         {
           "direction": "y",
@@ -3716,7 +3712,7 @@
         },
         {
           "direction": "x",
-          "length": 48.31966925437275
+          "length": 38.31966925437275
         }
       ],
       "variant": "pipe"
@@ -3726,7 +3722,7 @@
       "segments": [
         {
           "direction": "x",
-          "length": 35.88168143704071
+          "length": 25.88168143704071
         },
         {
           "direction": "y",
@@ -3734,7 +3730,7 @@
         },
         {
           "direction": "x",
-          "length": 49.16336009631732
+          "length": 39.16336009631732
         }
       ],
       "variant": "pipe"
@@ -3744,7 +3740,7 @@
       "segments": [
         {
           "direction": "x",
-          "length": 65.44918872855098
+          "length": 45.44918872855098
         }
       ],
       "variant": "pipe"
@@ -3754,11 +3750,11 @@
       "segments": [
         {
           "direction": "y",
-          "length": -26.771107323538445
+          "length": -16.771107323538445
         },
         {
           "direction": "x",
-          "length": 134.08749491346907
+          "length": 124.08749491346907
         }
       ],
       "variant": "pipe"
@@ -3768,7 +3764,7 @@
       "segments": [
         {
           "direction": "y",
-          "length": -98.83623839430456
+          "length": -88.83623839430456
         },
         {
           "direction": "x",
@@ -3780,7 +3776,7 @@
         },
         {
           "direction": "x",
-          "length": -118.5822749410846
+          "length": -108.5822749410846
         }
       ],
       "variant": "pipe"
@@ -3790,7 +3786,7 @@
       "segments": [
         {
           "direction": "y",
-          "length": -41.333333333333336
+          "length": -31.333333333333336
         },
         {
           "direction": "x",
@@ -3802,7 +3798,7 @@
         },
         {
           "direction": "x",
-          "length": -35.2004630877215
+          "length": -25.200463087721502
         }
       ],
       "variant": "pipe"
@@ -3812,11 +3808,11 @@
       "segments": [
         {
           "direction": "y",
-          "length": -139.69774734683722
+          "length": -129.69774734683722
         },
         {
           "direction": "x",
-          "length": 344.03414074237094
+          "length": 334.03414074237094
         }
       ],
       "variant": "pipe"
@@ -3826,7 +3822,7 @@
       "segments": [
         {
           "direction": "x",
-          "length": 44.11046865837386
+          "length": 34.11046865837386
         },
         {
           "direction": "y",
@@ -3838,7 +3834,7 @@
         },
         {
           "direction": "y",
-          "length": 24.767527356211477
+          "length": 14.767527356211477
         }
       ],
       "variant": "pipe"
@@ -3848,7 +3844,7 @@
       "segments": [
         {
           "direction": "x",
-          "length": 45.66666666666671
+          "length": 35.66666666666671
         },
         {
           "direction": "y",
@@ -3860,7 +3856,7 @@
         },
         {
           "direction": "y",
-          "length": 25.166666666666643
+          "length": 15.166666666666643
         }
       ],
       "variant": "pipe"
@@ -3870,7 +3866,7 @@
       "segments": [
         {
           "direction": "x",
-          "length": 172.69771856604015
+          "length": 162.69771856604015
         },
         {
           "direction": "y",
@@ -3886,7 +3882,7 @@
         },
         {
           "direction": "x",
-          "length": -73.24559551973184
+          "length": -63.245595519731836
         }
       ],
       "variant": "pipe"
@@ -3896,11 +3892,11 @@
       "segments": [
         {
           "direction": "y",
-          "length": -27.10444065687176
+          "length": -17.10444065687176
         },
         {
           "direction": "x",
-          "length": 30.254161580135815
+          "length": 20.254161580135815
         }
       ],
       "variant": "pipe"
@@ -3915,7 +3911,7 @@
       "segments": [
         {
           "direction": "y",
-          "length": -99.55721247982692
+          "length": -89.55721247982692
         },
         {
           "direction": "x",
@@ -3927,7 +3923,7 @@
         },
         {
           "direction": "x",
-          "length": -118.5822749410846
+          "length": -108.5822749410846
         }
       ],
       "variant": "pipe"
@@ -3937,7 +3933,7 @@
       "segments": [
         {
           "direction": "y",
-          "length": -98.83623839430456
+          "length": -88.83623839430456
         },
         {
           "direction": "x",
@@ -3949,7 +3945,7 @@
         },
         {
           "direction": "x",
-          "length": -118.5822749410846
+          "length": -108.5822749410846
         }
       ],
       "variant": "pipe"
@@ -4139,11 +4135,11 @@
       "segments": [
         {
           "direction": "y",
-          "length": -41.13268070315257
+          "length": -31.132680703152573
         },
         {
           "direction": "x",
-          "length": -77.3347878919866
+          "length": -67.3347878919866
         }
       ],
       "variant": "pipe"
@@ -4535,7 +4531,7 @@
       "segments": [
         {
           "direction": "x",
-          "length": 22.707627484943885
+          "length": 2.7076274849438846
         }
       ],
       "variant": "pipe"

--- a/core/pkg/service/schematic/migrations/testdata/v5_operator.json
+++ b/core/pkg/service/schematic/migrations/testdata/v5_operator.json
@@ -1,0 +1,9121 @@
+{
+  "version": "5.0.0",
+  "snapshot": false,
+  "nodes": [
+    {
+      "key": "dlptAUF47pk",
+      "id": "dlptAUF47pk",
+      "type": "custom",
+      "zIndex": 2,
+      "measured": {
+        "height": 251,
+        "width": 151
+      },
+      "position": {
+        "x": 881.6607236537078,
+        "y": 224.09574871332688
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "VmLXT8TtVfn",
+      "id": "VmLXT8TtVfn",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 27,
+        "width": 104
+      },
+      "position": {
+        "x": 905.9740228344708,
+        "y": 256.26283909396636
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "Px7l7pDawuy",
+      "id": "Px7l7pDawuy",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 27,
+        "width": 104
+      },
+      "position": {
+        "x": 907.4580807144808,
+        "y": 310.8580105818506
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "GXakOVjitf5",
+      "id": "GXakOVjitf5",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 27,
+        "width": 117
+      },
+      "position": {
+        "x": 902.3649435265172,
+        "y": 365.6827997860045
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "2i094l8SRqF",
+      "id": "2i094l8SRqF",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 27,
+        "width": 117
+      },
+      "position": {
+        "x": 902.3649435265172,
+        "y": 422.4392742496658
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "CST75HX7oD1",
+      "id": "CST75HX7oD1",
+      "type": "custom",
+      "zIndex": 2,
+      "measured": {
+        "height": 251,
+        "width": 151
+      },
+      "position": {
+        "x": -9.729666288384024,
+        "y": 79.92633707042512
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "rCUKZktR3sZ",
+      "id": "rCUKZktR3sZ",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 27,
+        "width": 104
+      },
+      "position": {
+        "x": 13.270333711615962,
+        "y": 116.0176843772881
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "K9nj3YBK0KG",
+      "id": "K9nj3YBK0KG",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 27,
+        "width": 104
+      },
+      "position": {
+        "x": 11.661254403662523,
+        "y": 170.0176843772881
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "DeJ4iOHodtz",
+      "id": "DeJ4iOHodtz",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 27,
+        "width": 117
+      },
+      "position": {
+        "x": 11.547797109162389,
+        "y": 224.07441302453816
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "vVP5HNMj1sk",
+      "id": "vVP5HNMj1sk",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 27,
+        "width": 117
+      },
+      "position": {
+        "x": 12.129672583372582,
+        "y": 278.7491039457149
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "ed2fKMvty6b",
+      "id": "ed2fKMvty6b",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 58,
+        "width": 71
+      },
+      "position": {
+        "x": 716.1416454448381,
+        "y": -38.32273345673128
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "qo0xVKkc4oR",
+      "id": "qo0xVKkc4oR",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 73,
+        "width": 56
+      },
+      "position": {
+        "x": 270.7265563621524,
+        "y": 278.4920462406048
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "BLMwEwSkGNS",
+      "id": "BLMwEwSkGNS",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 49,
+        "width": 71
+      },
+      "position": {
+        "x": 194.9121993900031,
+        "y": 199.16936379148157
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "D2jnA2ygsRn",
+      "id": "D2jnA2ygsRn",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 73,
+        "width": 56
+      },
+      "position": {
+        "x": 1056.588660002796,
+        "y": 277.2370726204909
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "ojXq08A1bLP",
+      "id": "ojXq08A1bLP",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 54,
+        "width": 64
+      },
+      "position": {
+        "x": 1101.309843180454,
+        "y": 210.6629761180268
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "L0MCB6oJASM",
+      "id": "L0MCB6oJASM",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 58,
+        "width": 71
+      },
+      "position": {
+        "x": 864.6566390383351,
+        "y": 523.2927121788872
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "n4pmPCUcMaw",
+      "id": "n4pmPCUcMaw",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 58,
+        "width": 71
+      },
+      "position": {
+        "x": 434.7041052797298,
+        "y": 507.0251432502485
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "0KwRzIrJ4ii",
+      "id": "0KwRzIrJ4ii",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 27,
+        "width": 120
+      },
+      "position": {
+        "x": 488.8122837483062,
+        "y": 683.3125469319169
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "SKO1UjHj1o3",
+      "id": "SKO1UjHj1o3",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 67,
+        "width": 71
+      },
+      "position": {
+        "x": 376.799972855844,
+        "y": 653.0095204959324
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "kbJw2Oi5Ueu",
+      "id": "kbJw2Oi5Ueu",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 67,
+        "width": 71
+      },
+      "position": {
+        "x": 124.58560325160995,
+        "y": 533.735369623691
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "dkPgXB2tjWf",
+      "id": "dkPgXB2tjWf",
+      "type": "custom",
+      "zIndex": 2,
+      "measured": {
+        "height": 201,
+        "width": 126
+      },
+      "position": {
+        "x": -56.307654121011275,
+        "y": 500.2641971370136
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "Uf71mmzzyez",
+      "id": "Uf71mmzzyez",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 27,
+        "width": 130
+      },
+      "position": {
+        "x": 237.48927285856396,
+        "y": 557.4057282455545
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "yAfA5biPqIA",
+      "id": "yAfA5biPqIA",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 27,
+        "width": 120
+      },
+      "position": {
+        "x": -54.086546886277496,
+        "y": 563.6120611799672
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "wGdFMnYeLk8",
+      "id": "wGdFMnYeLk8",
+      "type": "custom",
+      "zIndex": 24,
+      "measured": {
+        "height": 20,
+        "width": 32
+      },
+      "position": {
+        "x": 941.0670110697548,
+        "y": 181.06103701783505
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "p2dLrZf6mMv",
+      "id": "p2dLrZf6mMv",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 73,
+        "width": 56
+      },
+      "position": {
+        "x": 860.6481601631167,
+        "y": 86.42306342896143
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "nikWEdQSwLr",
+      "id": "nikWEdQSwLr",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 73,
+        "width": 56
+      },
+      "position": {
+        "x": 986.8577922925748,
+        "y": 86.348184023629
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "HH9i7jrQ0rH",
+      "id": "HH9i7jrQ0rH",
+      "type": "custom",
+      "zIndex": 24,
+      "measured": {
+        "height": 20,
+        "width": 32
+      },
+      "position": {
+        "x": 932.8388721209018,
+        "y": 47.4543137352087
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "5lnJLvZggVN",
+      "id": "5lnJLvZggVN",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 73,
+        "width": 56
+      },
+      "position": {
+        "x": 330.5107729180439,
+        "y": 97.56377635289778
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "qUGRcDkaBIx",
+      "id": "qUGRcDkaBIx",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 73,
+        "width": 56
+      },
+      "position": {
+        "x": 451.7077945265089,
+        "y": 97.7859192792202
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "rTobk1G30ly",
+      "id": "rTobk1G30ly",
+      "type": "custom",
+      "zIndex": 24,
+      "measured": {
+        "height": 20,
+        "width": 32
+      },
+      "position": {
+        "x": 402.43046814297566,
+        "y": 62.464630819799766
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "0jdKiNGUXdE",
+      "id": "0jdKiNGUXdE",
+      "type": "custom",
+      "zIndex": 24,
+      "measured": {
+        "height": 20,
+        "width": 32
+      },
+      "position": {
+        "x": 403.5077886236238,
+        "y": 181.40448884810743
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "VcyomMLraaN",
+      "id": "VcyomMLraaN",
+      "type": "custom",
+      "zIndex": 2,
+      "measured": {
+        "height": 251,
+        "width": 151
+      },
+      "position": {
+        "x": 344.10153353736075,
+        "y": 217.92749514690803
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "UN8NV3qxaz7",
+      "id": "UN8NV3qxaz7",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 27,
+        "width": 104
+      },
+      "position": {
+        "x": 368.4930383619268,
+        "y": 248.16220425088895
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "qKNvIK45GCK",
+      "id": "qKNvIK45GCK",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 27,
+        "width": 104
+      },
+      "position": {
+        "x": 369.50000000000006,
+        "y": 305.16220425088903
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "KnJjTf7CJv9",
+      "id": "KnJjTf7CJv9",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 27,
+        "width": 117
+      },
+      "position": {
+        "x": 367.66666666666674,
+        "y": 358.8288709175556
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "MEfIDo71Css",
+      "id": "MEfIDo71Css",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 27,
+        "width": 117
+      },
+      "position": {
+        "x": 368.8333333333333,
+        "y": 415.8288709175556
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "W1dSGKqGk1f",
+      "id": "W1dSGKqGk1f",
+      "type": "custom",
+      "zIndex": 24,
+      "measured": {
+        "height": 34,
+        "width": 18
+      },
+      "position": {
+        "x": 135.52283117318578,
+        "y": 35.167808075727706
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "YtBdiWNERfU",
+      "id": "YtBdiWNERfU",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 58,
+        "width": 71
+      },
+      "position": {
+        "x": 203.3401768139715,
+        "y": 12.027170576396433
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "rJ8HEDBlxlw",
+      "id": "rJ8HEDBlxlw",
+      "type": "custom",
+      "zIndex": 2,
+      "measured": {
+        "height": 201,
+        "width": 140
+      },
+      "position": {
+        "x": 229.1760073720529,
+        "y": 477.62432532701166
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "QLFXTKWz3DJ",
+      "id": "QLFXTKWz3DJ",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 73,
+        "width": 56
+      },
+      "position": {
+        "x": -32.279846943321495,
+        "y": 413.72341717816954
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "tKyeVybyb2Z",
+      "id": "tKyeVybyb2Z",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 54,
+        "width": 52
+      },
+      "position": {
+        "x": 39.676555290128434,
+        "y": 353.1257902036398
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "e4JtXVcg02b",
+      "id": "e4JtXVcg02b",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 230,
+        "width": 116
+      },
+      "position": {
+        "x": 652.6816177637583,
+        "y": 375.6488170035559
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "KWwYAhIaXR1",
+      "id": "KWwYAhIaXR1",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 73,
+        "width": 56
+      },
+      "position": {
+        "x": 617.1097000170178,
+        "y": 277.55853049940737
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "VeRfM4LedsR",
+      "id": "VeRfM4LedsR",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 73,
+        "width": 56
+      },
+      "position": {
+        "x": 752.6804763546971,
+        "y": 277.5195101664691
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "WubiiPZ6MyL",
+      "id": "WubiiPZ6MyL",
+      "type": "custom",
+      "zIndex": 24,
+      "measured": {
+        "height": 20,
+        "width": 32
+      },
+      "position": {
+        "x": 697.0018688628214,
+        "y": 188.867129790864
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "IpSylSnCSc3",
+      "id": "IpSylSnCSc3",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 73,
+        "width": 56
+      },
+      "position": {
+        "x": 509.2145240269522,
+        "y": 583.4183035794158
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "7yLD0xOFddf",
+      "id": "7yLD0xOFddf",
+      "type": "custom",
+      "zIndex": 24,
+      "measured": {
+        "height": 20,
+        "width": 32
+      },
+      "position": {
+        "x": 610.6803516098993,
+        "y": 734.0881488512645
+      },
+      "selected": false,
+      "data": {}
+    },
+    {
+      "key": "k9XCuVYxOzB",
+      "id": "k9XCuVYxOzB",
+      "type": "custom",
+      "zIndex": 4,
+      "measured": {
+        "height": 31,
+        "width": 143
+      },
+      "position": {
+        "x": 1011,
+        "y": 632
+      },
+      "selected": false,
+      "data": {}
+    }
+  ],
+  "edges": [
+    {
+      "color": "#00d623",
+      "data": {
+        "color": "#00d623",
+        "segments": [
+          {
+            "direction": "x",
+            "length": 10.090450797825524
+          },
+          {
+            "direction": "y",
+            "length": -0.68135597075036
+          },
+          {
+            "direction": "x",
+            "length": 26.39057730435846
+          }
+        ],
+        "variant": "pneumatic"
+      },
+      "id": "reactflow__edge-SKO1UjHj1o32-0KwRzIrJ4ii1",
+      "key": "reactflow__edge-SKO1UjHj1o32-0KwRzIrJ4ii1",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "x",
+          "length": 10.090450797825524
+        },
+        {
+          "direction": "y",
+          "length": -0.68135597075036
+        },
+        {
+          "direction": "x",
+          "length": 26.39057730435846
+        }
+      ],
+      "selected": false,
+      "source": "SKO1UjHj1o3",
+      "sourceHandle": "2",
+      "target": "0KwRzIrJ4ii",
+      "targetHandle": "1",
+      "variant": "pneumatic"
+    },
+    {
+      "color": "#ff005f",
+      "data": {
+        "color": "#ff005f",
+        "segments": [
+          {
+            "direction": "y",
+            "length": -17.476031885797475
+          },
+          {
+            "direction": "x",
+            "length": 42.70918634908844
+          },
+          {
+            "direction": "y",
+            "length": 47.25798079296152
+          }
+        ],
+        "variant": "pipe"
+      },
+      "id": "xy-edge__dlptAUF47pk3-D2jnA2ygsRn1",
+      "key": "xy-edge__dlptAUF47pk3-D2jnA2ygsRn1",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "y",
+          "length": -17.476031885797475
+        },
+        {
+          "direction": "x",
+          "length": 42.70918634908844
+        },
+        {
+          "direction": "y",
+          "length": 47.25798079296152
+        }
+      ],
+      "selected": false,
+      "source": "dlptAUF47pk",
+      "sourceHandle": "3",
+      "target": "D2jnA2ygsRn",
+      "targetHandle": "1",
+      "variant": "pipe"
+    },
+    {
+      "color": "#ff005f",
+      "data": {
+        "color": "#ff005f",
+        "segments": [
+          {
+            "direction": "y",
+            "length": -17.042165376339312
+          },
+          {
+            "direction": "x",
+            "length": 68.16473197597054
+          }
+        ],
+        "variant": "pipe"
+      },
+      "id": "xy-edge__dlptAUF47pk3-ojXq08A1bLP1",
+      "key": "xy-edge__dlptAUF47pk3-ojXq08A1bLP1",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "y",
+          "length": -17.042165376339312
+        },
+        {
+          "direction": "x",
+          "length": 68.16473197597054
+        }
+      ],
+      "selected": false,
+      "source": "dlptAUF47pk",
+      "sourceHandle": "3",
+      "target": "ojXq08A1bLP",
+      "targetHandle": "1",
+      "variant": "pipe"
+    },
+    {
+      "color": "#ff005f",
+      "data": {
+        "color": "#ff005f",
+        "segments": [
+          {
+            "direction": "y",
+            "length": 26.028598588873564
+          },
+          {
+            "direction": "x",
+            "length": 40.71572590663834
+          }
+        ],
+        "variant": "pipe"
+      },
+      "id": "xy-edge__p2dLrZf6mMv1-wGdFMnYeLk81",
+      "key": "xy-edge__p2dLrZf6mMv1-wGdFMnYeLk81",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "y",
+          "length": 26.028598588873564
+        },
+        {
+          "direction": "x",
+          "length": 40.71572590663834
+        }
+      ],
+      "selected": false,
+      "source": "p2dLrZf6mMv",
+      "sourceHandle": "1",
+      "target": "wGdFMnYeLk8",
+      "targetHandle": "1",
+      "variant": "pipe"
+    },
+    {
+      "color": "#ff005f",
+      "data": {
+        "color": "#ff005f",
+        "segments": [
+          {
+            "direction": "y",
+            "length": 26.10347799420603
+          },
+          {
+            "direction": "x",
+            "length": -30.087778293132487
+          }
+        ],
+        "variant": "pipe"
+      },
+      "id": "xy-edge__nikWEdQSwLr2-wGdFMnYeLk82",
+      "key": "xy-edge__nikWEdQSwLr2-wGdFMnYeLk82",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "y",
+          "length": 26.10347799420603
+        },
+        {
+          "direction": "x",
+          "length": -30.087778293132487
+        }
+      ],
+      "selected": false,
+      "source": "nikWEdQSwLr",
+      "sourceHandle": "2",
+      "target": "wGdFMnYeLk8",
+      "targetHandle": "2",
+      "variant": "pipe"
+    },
+    {
+      "color": "#ff005f",
+      "data": {
+        "color": "#ff005f",
+        "segments": [
+          {
+            "direction": "x",
+            "length": -32.48758695778497
+          },
+          {
+            "direction": "y",
+            "length": 23.359374693752756
+          }
+        ],
+        "variant": "pipe"
+      },
+      "id": "xy-edge__HH9i7jrQ0rH2-p2dLrZf6mMv2",
+      "key": "xy-edge__HH9i7jrQ0rH2-p2dLrZf6mMv2",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "x",
+          "length": -32.48758695778497
+        },
+        {
+          "direction": "y",
+          "length": 23.359374693752756
+        }
+      ],
+      "selected": false,
+      "source": "HH9i7jrQ0rH",
+      "sourceHandle": "2",
+      "target": "p2dLrZf6mMv",
+      "targetHandle": "2",
+      "variant": "pipe"
+    },
+    {
+      "color": "#ff005f",
+      "data": {
+        "color": "#ff005f",
+        "segments": [
+          {
+            "direction": "x",
+            "length": 38.31579517167302
+          },
+          {
+            "direction": "y",
+            "length": 23.284495288420302
+          }
+        ],
+        "variant": "pipe"
+      },
+      "id": "xy-edge__HH9i7jrQ0rH1-nikWEdQSwLr1",
+      "key": "xy-edge__HH9i7jrQ0rH1-nikWEdQSwLr1",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "x",
+          "length": 38.31579517167302
+        },
+        {
+          "direction": "y",
+          "length": 23.284495288420302
+        }
+      ],
+      "selected": false,
+      "source": "HH9i7jrQ0rH",
+      "sourceHandle": "1",
+      "target": "nikWEdQSwLr",
+      "targetHandle": "1",
+      "variant": "pipe"
+    },
+    {
+      "color": "#004ad6",
+      "data": {
+        "color": "#004ad6",
+        "segments": [
+          {
+            "direction": "x",
+            "length": -30.716482044354507
+          },
+          {
+            "direction": "y",
+            "length": 17.989755136102218
+          }
+        ],
+        "variant": "pipe"
+      },
+      "id": "1Ajh5kZyqzw",
+      "key": "1Ajh5kZyqzw",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "x",
+          "length": -30.716482044354507
+        },
+        {
+          "direction": "y",
+          "length": 17.989755136102218
+        }
+      ],
+      "selected": false,
+      "source": "rTobk1G30ly",
+      "sourceHandle": "2",
+      "target": "5lnJLvZggVN",
+      "targetHandle": "2",
+      "variant": "pipe"
+    },
+    {
+      "color": "#004ad6",
+      "data": {
+        "color": "#004ad6",
+        "segments": [
+          {
+            "direction": "x",
+            "length": 33.57420138353319
+          },
+          {
+            "direction": "y",
+            "length": 19.71191345942043
+          }
+        ],
+        "variant": "pipe"
+      },
+      "id": "Q6Ru747fTlZ",
+      "key": "Q6Ru747fTlZ",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "x",
+          "length": 30.698524212067923
+        },
+        {
+          "direction": "y",
+          "length": 16.836238971600864
+        }
+      ],
+      "selected": false,
+      "source": "rTobk1G30ly",
+      "sourceHandle": "1",
+      "target": "qUGRcDkaBIx",
+      "targetHandle": "1",
+      "variant": "pipe"
+    },
+    {
+      "color": "#004ad6",
+      "data": {
+        "color": "#004ad6",
+        "segments": [
+          {
+            "direction": "x",
+            "length": -31.793890705579884
+          },
+          {
+            "direction": "y",
+            "length": -13.731337495209658
+          }
+        ],
+        "variant": "pipe"
+      },
+      "id": "xy-edge__0jdKiNGUXdE1-5lnJLvZggVN1",
+      "key": "xy-edge__0jdKiNGUXdE1-5lnJLvZggVN1",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "x",
+          "length": -31.793890705579884
+        },
+        {
+          "direction": "y",
+          "length": -13.731337495209658
+        }
+      ],
+      "selected": false,
+      "source": "0jdKiNGUXdE",
+      "sourceHandle": "1",
+      "target": "5lnJLvZggVN",
+      "targetHandle": "1",
+      "variant": "pipe"
+    },
+    {
+      "color": "#004ad6",
+      "data": {
+        "color": "#004ad6",
+        "segments": [
+          {
+            "direction": "x",
+            "length": 32.49688090288504
+          },
+          {
+            "direction": "y",
+            "length": -15.00919456888724
+          }
+        ],
+        "variant": "pipe"
+      },
+      "id": "xy-edge__0jdKiNGUXdE2-qUGRcDkaBIx2",
+      "key": "xy-edge__0jdKiNGUXdE2-qUGRcDkaBIx2",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "x",
+          "length": 29.62118552304105
+        },
+        {
+          "direction": "y",
+          "length": -14.884889948731228
+        }
+      ],
+      "selected": false,
+      "source": "0jdKiNGUXdE",
+      "sourceHandle": "2",
+      "target": "qUGRcDkaBIx",
+      "targetHandle": "2",
+      "variant": "pipe"
+    },
+    {
+      "color": "#004ad6",
+      "data": {
+        "color": "#004ad6",
+        "segments": [
+          {
+            "direction": "y",
+            "length": 75.73827310334042
+          },
+          {
+            "direction": "x",
+            "length": 13.196321742369037
+          }
+        ],
+        "variant": "jacketed"
+      },
+      "id": "xy-edge__VcyomMLraaN4-n4pmPCUcMaw1",
+      "key": "xy-edge__VcyomMLraaN4-n4pmPCUcMaw1",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "y",
+          "length": 75.73827310334042
+        },
+        {
+          "direction": "x",
+          "length": 13.196321742369037
+        }
+      ],
+      "selected": false,
+      "source": "VcyomMLraaN",
+      "sourceHandle": "4",
+      "target": "n4pmPCUcMaw",
+      "targetHandle": "1",
+      "variant": "jacketed"
+    },
+    {
+      "color": "#004ad6",
+      "data": {
+        "color": "#004ad6",
+        "segments": [
+          {
+            "direction": "y",
+            "length": -47.20517609369677
+          },
+          {
+            "direction": "x",
+            "length": 57.59372717520836
+          },
+          {
+            "direction": "y",
+            "length": 10
+          }
+        ],
+        "variant": "pipe"
+      },
+      "id": "xy-edge__qo0xVKkc4oR1-VcyomMLraaN2",
+      "key": "xy-edge__qo0xVKkc4oR1-VcyomMLraaN2",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "y",
+          "length": -47.20517609369677
+        },
+        {
+          "direction": "x",
+          "length": 57.59372717520836
+        },
+        {
+          "direction": "y",
+          "length": 10
+        }
+      ],
+      "selected": false,
+      "source": "qo0xVKkc4oR",
+      "sourceHandle": "1",
+      "target": "VcyomMLraaN",
+      "targetHandle": "2",
+      "variant": "pipe"
+    },
+    {
+      "color": "#004ad6",
+      "data": {
+        "color": "#004ad6",
+        "segments": [
+          {
+            "direction": "x",
+            "length": 79.70495914735761
+          },
+          {
+            "direction": "y",
+            "length": 10.648756355426457
+          }
+        ],
+        "variant": "pipe"
+      },
+      "id": "xy-edge__BLMwEwSkGNS2-VcyomMLraaN2",
+      "key": "xy-edge__BLMwEwSkGNS2-VcyomMLraaN2",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "x",
+          "length": 79.70495914735761
+        },
+        {
+          "direction": "y",
+          "length": 10.648756355426457
+        }
+      ],
+      "selected": false,
+      "source": "BLMwEwSkGNS",
+      "sourceHandle": "2",
+      "target": "VcyomMLraaN",
+      "targetHandle": "2",
+      "variant": "pipe"
+    },
+    {
+      "color": "#b300ff",
+      "data": {
+        "color": "#b300ff",
+        "segments": [
+          {
+            "direction": "x",
+            "length": 160.30660167606368
+          },
+          {
+            "direction": "y",
+            "length": 43.48017219193998
+          }
+        ],
+        "variant": "pneumatic"
+      },
+      "id": "xy-edge__ed2fKMvty6b2-HH9i7jrQ0rH3",
+      "key": "xy-edge__ed2fKMvty6b2-HH9i7jrQ0rH3",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "x",
+          "length": 160.30660167606368
+        },
+        {
+          "direction": "y",
+          "length": 43.48017219193998
+        }
+      ],
+      "selected": false,
+      "source": "ed2fKMvty6b",
+      "sourceHandle": "2",
+      "target": "HH9i7jrQ0rH",
+      "targetHandle": "3",
+      "variant": "pneumatic"
+    },
+    {
+      "color": "#004ad6",
+      "data": {
+        "color": "#004ad6",
+        "segments": [
+          {
+            "direction": "y",
+            "length": 11.882381298800595
+          }
+        ],
+        "variant": "pipe"
+      },
+      "id": "xy-edge__0jdKiNGUXdE3-VcyomMLraaN1",
+      "key": "xy-edge__0jdKiNGUXdE3-VcyomMLraaN1",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "y",
+          "length": 11.882381298800595
+        }
+      ],
+      "selected": false,
+      "source": "0jdKiNGUXdE",
+      "sourceHandle": "3",
+      "target": "VcyomMLraaN",
+      "targetHandle": "1",
+      "variant": "pipe"
+    },
+    {
+      "color": "#b300ff",
+      "data": {
+        "color": "#b300ff",
+        "segments": [
+          {
+            "direction": "y",
+            "length": -30.039775396275516
+          }
+        ],
+        "variant": "pipe"
+      },
+      "id": "xy-edge__CST75HX7oD13-W1dSGKqGk1f1",
+      "key": "xy-edge__CST75HX7oD13-W1dSGKqGk1f1",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "y",
+          "length": -30.039775396275516
+        }
+      ],
+      "selected": false,
+      "source": "CST75HX7oD1",
+      "sourceHandle": "3",
+      "target": "W1dSGKqGk1f",
+      "targetHandle": "1",
+      "variant": "pipe"
+    },
+    {
+      "color": "#b300ff",
+      "data": {
+        "color": "#b300ff",
+        "segments": [
+          {
+            "direction": "y",
+            "length": -32.615541532458984
+          },
+          {
+            "direction": "x",
+            "length": 575.9781892716524
+          }
+        ],
+        "variant": "pneumatic"
+      },
+      "id": "xy-edge__W1dSGKqGk1f2-ed2fKMvty6b1",
+      "key": "xy-edge__W1dSGKqGk1f2-ed2fKMvty6b1",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "y",
+          "length": -32.615541532458984
+        },
+        {
+          "direction": "x",
+          "length": 575.9781892716524
+        }
+      ],
+      "selected": false,
+      "source": "W1dSGKqGk1f",
+      "sourceHandle": "2",
+      "target": "ed2fKMvty6b",
+      "targetHandle": "1",
+      "variant": "pneumatic"
+    },
+    {
+      "color": "#b300ff",
+      "data": {
+        "color": "#b300ff",
+        "segments": [
+          {
+            "direction": "x",
+            "length": 144.19966632900412
+          },
+          {
+            "direction": "y",
+            "length": 9.640585243403336
+          }
+        ],
+        "variant": "pneumatic"
+      },
+      "id": "xy-edge__YtBdiWNERfU2-rTobk1G30ly3",
+      "key": "xy-edge__YtBdiWNERfU2-rTobk1G30ly3",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "x",
+          "length": 144.19966632900412
+        },
+        {
+          "direction": "y",
+          "length": 9.640585243403336
+        }
+      ],
+      "selected": false,
+      "source": "YtBdiWNERfU",
+      "sourceHandle": "2",
+      "target": "rTobk1G30ly",
+      "targetHandle": "3",
+      "variant": "pneumatic"
+    },
+    {
+      "color": "#b300ff",
+      "data": {
+        "color": "#b300ff",
+        "segments": [
+          {
+            "direction": "x",
+            "length": -48.81734564078576
+          }
+        ],
+        "variant": "pneumatic"
+      },
+      "id": "xy-edge__YtBdiWNERfU1-W1dSGKqGk1f3",
+      "key": "xy-edge__YtBdiWNERfU1-W1dSGKqGk1f3",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "x",
+          "length": -48.81734564078576
+        }
+      ],
+      "selected": false,
+      "source": "YtBdiWNERfU",
+      "sourceHandle": "1",
+      "target": "W1dSGKqGk1f",
+      "targetHandle": "3",
+      "variant": "pneumatic"
+    },
+    {
+      "color": "#b300ff",
+      "data": {
+        "color": "#b300ff",
+        "segments": [
+          {
+            "direction": "x",
+            "length": 28.809159885799176
+          }
+        ],
+        "variant": "pipe"
+      },
+      "id": "xy-edge__kbJw2Oi5Ueu2-rJ8HEDBlxlw7",
+      "key": "xy-edge__kbJw2Oi5Ueu2-rJ8HEDBlxlw7",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "x",
+          "length": 28.809159885799176
+        }
+      ],
+      "selected": false,
+      "source": "kbJw2Oi5Ueu",
+      "sourceHandle": "2",
+      "target": "rJ8HEDBlxlw",
+      "targetHandle": "7",
+      "variant": "pipe"
+    },
+    {
+      "color": "#ffa800",
+      "data": {
+        "color": "#ffa800",
+        "segments": [
+          {
+            "direction": "x",
+            "length": 26.27623344266015
+          },
+          {
+            "direction": "y",
+            "length": -22.810077513322653
+          },
+          {
+            "direction": "x",
+            "length": 25.00767944753921
+          }
+        ],
+        "variant": "pneumatic"
+      },
+      "id": "xy-edge__dkPgXB2tjWf8-kbJw2Oi5Ueu1",
+      "key": "xy-edge__dkPgXB2tjWf8-kbJw2Oi5Ueu1",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "x",
+          "length": 26.27623344266015
+        },
+        {
+          "direction": "y",
+          "length": -22.810077513322653
+        },
+        {
+          "direction": "x",
+          "length": 25.00767944753921
+        }
+      ],
+      "selected": false,
+      "source": "dkPgXB2tjWf",
+      "sourceHandle": "8",
+      "target": "kbJw2Oi5Ueu",
+      "targetHandle": "1",
+      "variant": "pneumatic"
+    },
+    {
+      "color": "#b300ff",
+      "data": {
+        "color": "#b300ff",
+        "segments": [
+          {
+            "direction": "y",
+            "length": -17.85571748999547
+          }
+        ],
+        "variant": "pipe"
+      },
+      "id": "xy-edge__tKyeVybyb2Z2-CST75HX7oD14",
+      "key": "xy-edge__tKyeVybyb2Z2-CST75HX7oD14",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "y",
+          "length": -17.85571748999547
+        }
+      ],
+      "selected": false,
+      "source": "tKyeVybyb2Z",
+      "sourceHandle": "2",
+      "target": "CST75HX7oD1",
+      "targetHandle": "4",
+      "variant": "pipe"
+    },
+    {
+      "color": "#b300ff",
+      "data": {
+        "color": "#b300ff",
+        "segments": [
+          {
+            "direction": "y",
+            "length": -36.01040111660703
+          },
+          {
+            "direction": "x",
+            "length": -233.4057355441728
+          },
+          {
+            "direction": "y",
+            "length": -30.1443659962018
+          }
+        ],
+        "variant": "pipe"
+      },
+      "id": "xy-edge__rJ8HEDBlxlw1-tKyeVybyb2Z1",
+      "key": "xy-edge__rJ8HEDBlxlw1-tKyeVybyb2Z1",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "y",
+          "length": -36.01040111660703
+        },
+        {
+          "direction": "x",
+          "length": -233.4057355441728
+        },
+        {
+          "direction": "y",
+          "length": -30.1443659962018
+        }
+      ],
+      "selected": false,
+      "source": "rJ8HEDBlxlw",
+      "sourceHandle": "1",
+      "target": "tKyeVybyb2Z",
+      "targetHandle": "1",
+      "variant": "pipe"
+    },
+    {
+      "color": "#ffa800",
+      "data": {
+        "color": "#ffa800",
+        "segments": [
+          {
+            "direction": "y",
+            "length": -31.738221317205273
+          },
+          {
+            "direction": "x",
+            "length": 31.15953941272413
+          }
+        ],
+        "variant": "pneumatic"
+      },
+      "id": "xy-edge__QLFXTKWz3DJ2-tKyeVybyb2Z3",
+      "key": "xy-edge__QLFXTKWz3DJ2-tKyeVybyb2Z3",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "y",
+          "length": -31.738221317205273
+        },
+        {
+          "direction": "x",
+          "length": 31.15953941272413
+        }
+      ],
+      "selected": false,
+      "source": "QLFXTKWz3DJ",
+      "sourceHandle": "2",
+      "target": "tKyeVybyb2Z",
+      "targetHandle": "3",
+      "variant": "pneumatic"
+    },
+    {
+      "color": "#004ad6",
+      "data": {
+        "color": "#004ad6",
+        "segments": [
+          {
+            "direction": "y",
+            "length": 63.96528189980745
+          },
+          {
+            "direction": "x",
+            "length": 16.52497957938192
+          }
+        ],
+        "variant": "jacketed"
+      },
+      "id": "xy-edge__KWwYAhIaXR11-e4JtXVcg02b1",
+      "key": "xy-edge__KWwYAhIaXR11-e4JtXVcg02b1",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "y",
+          "length": 63.71529969221109
+        },
+        {
+          "direction": "x",
+          "length": 14.77505320369312
+        }
+      ],
+      "selected": false,
+      "source": "KWwYAhIaXR1",
+      "sourceHandle": "1",
+      "target": "e4JtXVcg02b",
+      "targetHandle": "1",
+      "variant": "jacketed"
+    },
+    {
+      "color": "#ff005f",
+      "data": {
+        "color": "#ff005f",
+        "segments": [
+          {
+            "direction": "y",
+            "length": 63.754320025149354
+          },
+          {
+            "direction": "x",
+            "length": -19.201999214856187
+          }
+        ],
+        "variant": "jacketed"
+      },
+      "id": "xy-edge__VeRfM4LedsR2-e4JtXVcg02b3",
+      "key": "xy-edge__VeRfM4LedsR2-e4JtXVcg02b3",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "y",
+          "length": 63.754320025149354
+        },
+        {
+          "direction": "x",
+          "length": -19.201999214856187
+        }
+      ],
+      "selected": false,
+      "source": "VeRfM4LedsR",
+      "sourceHandle": "2",
+      "target": "e4JtXVcg02b",
+      "targetHandle": "3",
+      "variant": "jacketed"
+    },
+    {
+      "color": "#004ad6",
+      "data": {
+        "color": "#004ad6",
+        "segments": [
+          {
+            "direction": "x",
+            "length": 10
+          },
+          {
+            "direction": "y",
+            "length": -281.7166395035551
+          },
+          {
+            "direction": "x",
+            "length": 140.06190790464655
+          },
+          {
+            "direction": "y",
+            "length": 10
+          }
+        ],
+        "variant": "jacketed"
+      },
+      "id": "xy-edge__n4pmPCUcMaw2-KWwYAhIaXR12",
+      "key": "xy-edge__n4pmPCUcMaw2-KWwYAhIaXR12",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "x",
+          "length": 16.34276997560471
+        },
+        {
+          "direction": "y",
+          "length": -296.68926069229235
+        },
+        {
+          "direction": "x",
+          "length": 132.4691357968395
+        },
+        {
+          "direction": "y",
+          "length": 25.22264794145128
+        }
+      ],
+      "selected": false,
+      "source": "n4pmPCUcMaw",
+      "sourceHandle": "2",
+      "target": "KWwYAhIaXR1",
+      "targetHandle": "2",
+      "variant": "jacketed"
+    },
+    {
+      "color": "#ff005f",
+      "data": {
+        "color": "#ff005f",
+        "segments": [
+          {
+            "direction": "x",
+            "length": 20.019709615372676
+          },
+          {
+            "direction": "y",
+            "length": -85.83755794798219
+          }
+        ],
+        "variant": "jacketed"
+      },
+      "id": "xy-edge__L0MCB6oJASM2-dlptAUF47pk4",
+      "key": "xy-edge__L0MCB6oJASM2-dlptAUF47pk4",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "x",
+          "length": 20.019709615372676
+        },
+        {
+          "direction": "y",
+          "length": -85.83755794798219
+        }
+      ],
+      "selected": false,
+      "source": "L0MCB6oJASM",
+      "sourceHandle": "2",
+      "target": "dlptAUF47pk",
+      "targetHandle": "4",
+      "variant": "jacketed"
+    },
+    {
+      "color": "#ff005f",
+      "data": {
+        "color": "#ff005f",
+        "segments": [
+          {
+            "direction": "x",
+            "length": -17.611323970725607
+          },
+          {
+            "direction": "y",
+            "length": -309.19018796850656
+          },
+          {
+            "direction": "x",
+            "length": -75.17733871291239
+          },
+          {
+            "direction": "y",
+            "length": 21.41698595608846
+          }
+        ],
+        "variant": "jacketed"
+      },
+      "id": "xy-edge__L0MCB6oJASM1-VeRfM4LedsR1",
+      "key": "xy-edge__L0MCB6oJASM1-VeRfM4LedsR1",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "x",
+          "length": -17.611323970725607
+        },
+        {
+          "direction": "y",
+          "length": -309.19018796850656
+        },
+        {
+          "direction": "x",
+          "length": -75.17733871291239
+        },
+        {
+          "direction": "y",
+          "length": 21.41698595608846
+        }
+      ],
+      "selected": false,
+      "source": "L0MCB6oJASM",
+      "sourceHandle": "1",
+      "target": "VeRfM4LedsR",
+      "targetHandle": "1",
+      "variant": "jacketed"
+    },
+    {
+      "color": "#ff005f",
+      "data": {
+        "color": "#ff005f",
+        "segments": [],
+        "variant": "pipe"
+      },
+      "id": "xy-edge__wGdFMnYeLk83-dlptAUF47pk1",
+      "key": "xy-edge__wGdFMnYeLk83-dlptAUF47pk1",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [],
+      "selected": false,
+      "source": "wGdFMnYeLk8",
+      "sourceHandle": "3",
+      "target": "dlptAUF47pk",
+      "targetHandle": "1",
+      "variant": "pipe"
+    },
+    {
+      "color": "#00d623",
+      "data": {
+        "color": "#00d623",
+        "segments": [
+          {
+            "direction": "x",
+            "length": 38.4755515077627
+          },
+          {
+            "direction": "y",
+            "length": 71.5429756286506
+          }
+        ],
+        "variant": "pipe"
+      },
+      "id": "xy-edge__WubiiPZ6MyL1-VeRfM4LedsR1",
+      "key": "xy-edge__WubiiPZ6MyL1-VeRfM4LedsR1",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "x",
+          "length": 38.4755515077627
+        },
+        {
+          "direction": "y",
+          "length": 71.5429756286506
+        }
+      ],
+      "selected": false,
+      "source": "WubiiPZ6MyL",
+      "sourceHandle": "1",
+      "target": "VeRfM4LedsR",
+      "targetHandle": "1",
+      "variant": "pipe"
+    },
+    {
+      "color": "#00d623",
+      "data": {
+        "color": "#00d623",
+        "segments": [
+          {
+            "direction": "x",
+            "length": -40.43898067844509
+          },
+          {
+            "direction": "y",
+            "length": 71.33199895582936
+          }
+        ],
+        "variant": "pipe"
+      },
+      "id": "xy-edge__WubiiPZ6MyL2-KWwYAhIaXR12",
+      "key": "xy-edge__WubiiPZ6MyL2-KWwYAhIaXR12",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "x",
+          "length": -38.68902266124792
+        },
+        {
+          "direction": "y",
+          "length": 71.58199596158886
+        }
+      ],
+      "selected": false,
+      "source": "WubiiPZ6MyL",
+      "sourceHandle": "2",
+      "target": "KWwYAhIaXR1",
+      "targetHandle": "2",
+      "variant": "pipe"
+    },
+    {
+      "color": "#00d623",
+      "data": {
+        "color": "#00d623",
+        "segments": [
+          {
+            "direction": "y",
+            "length": 12.017443714567946
+          },
+          {
+            "direction": "x",
+            "length": 0.6914358648206189
+          },
+          {
+            "direction": "y",
+            "length": 12.017443714567946
+          }
+        ],
+        "variant": "pneumatic"
+      },
+      "id": "xy-edge__IpSylSnCSc31-0KwRzIrJ4ii3",
+      "key": "xy-edge__IpSylSnCSc31-0KwRzIrJ4ii3",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "y",
+          "length": 12.017443338151622
+        },
+        {
+          "direction": "x",
+          "length": 0.691485844972135
+        },
+        {
+          "direction": "y",
+          "length": 12.017443338151622
+        }
+      ],
+      "selected": false,
+      "source": "IpSylSnCSc3",
+      "sourceHandle": "1",
+      "target": "0KwRzIrJ4ii",
+      "targetHandle": "3",
+      "variant": "pneumatic"
+    },
+    {
+      "color": "#00d623",
+      "data": {
+        "color": "#00d623",
+        "segments": [
+          {
+            "direction": "y",
+            "length": -404.8873653848603
+          },
+          {
+            "direction": "x",
+            "length": 164.99041929803252
+          },
+          {
+            "direction": "y",
+            "length": 10.03928334319892
+          }
+        ],
+        "variant": "pneumatic"
+      },
+      "id": "xy-edge__IpSylSnCSc32-WubiiPZ6MyL3",
+      "key": "xy-edge__IpSylSnCSc32-WubiiPZ6MyL3",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "y",
+          "length": -404.8873653848603
+        },
+        {
+          "direction": "x",
+          "length": 164.99041929803252
+        },
+        {
+          "direction": "y",
+          "length": 10.03928334319892
+        }
+      ],
+      "selected": false,
+      "source": "IpSylSnCSc3",
+      "sourceHandle": "2",
+      "target": "WubiiPZ6MyL",
+      "targetHandle": "3",
+      "variant": "pneumatic"
+    },
+    {
+      "color": "#00d623",
+      "data": {
+        "color": "#00d623",
+        "segments": [
+          {
+            "direction": "y",
+            "length": 17.603945168920745
+          },
+          {
+            "direction": "x",
+            "length": 78.0145904837911
+          }
+        ],
+        "variant": "pneumatic"
+      },
+      "id": "xy-edge__rJ8HEDBlxlw4-SKO1UjHj1o31",
+      "key": "xy-edge__rJ8HEDBlxlw4-SKO1UjHj1o31",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "y",
+          "length": 17.603945168920745
+        },
+        {
+          "direction": "x",
+          "length": 78.0145904837911
+        }
+      ],
+      "selected": false,
+      "source": "rJ8HEDBlxlw",
+      "sourceHandle": "4",
+      "target": "SKO1UjHj1o3",
+      "targetHandle": "1",
+      "variant": "pneumatic"
+    },
+    {
+      "color": "#ffa800",
+      "data": {
+        "color": "#ffa800",
+        "segments": [
+          {
+            "direction": "x",
+            "length": 153.39074974479786
+          },
+          {
+            "direction": "y",
+            "length": -419.31863868479536
+          }
+        ],
+        "variant": "pneumatic"
+      },
+      "id": "xy-edge__7yLD0xOFddf1-VeRfM4LedsR5",
+      "key": "xy-edge__7yLD0xOFddf1-VeRfM4LedsR5",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "x",
+          "length": 153.39074974479786
+        },
+        {
+          "direction": "y",
+          "length": -419.31863868479536
+        }
+      ],
+      "selected": false,
+      "source": "7yLD0xOFddf",
+      "sourceHandle": "1",
+      "target": "VeRfM4LedsR",
+      "targetHandle": "5",
+      "variant": "pneumatic"
+    },
+    {
+      "color": "#ffa800",
+      "data": {
+        "color": "#ffa800",
+        "segments": [
+          {
+            "direction": "x",
+            "length": -601.675536248489
+          },
+          {
+            "direction": "y",
+            "length": -45.573951714250825
+          }
+        ],
+        "variant": "pneumatic"
+      },
+      "id": "xy-edge__7yLD0xOFddf2-dkPgXB2tjWf4",
+      "key": "xy-edge__7yLD0xOFddf2-dkPgXB2tjWf4",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "x",
+          "length": -601.675536248489
+        },
+        {
+          "direction": "y",
+          "length": -45.573951714250825
+        }
+      ],
+      "selected": false,
+      "source": "7yLD0xOFddf",
+      "sourceHandle": "2",
+      "target": "dkPgXB2tjWf",
+      "targetHandle": "4",
+      "variant": "pneumatic"
+    },
+    {
+      "color": "#ffa800",
+      "data": {
+        "color": "#ffa800",
+        "segments": [
+          {
+            "direction": "y",
+            "length": 10
+          },
+          {
+            "direction": "y",
+            "length": -19.197029958844112
+          }
+        ],
+        "variant": "pipe"
+      },
+      "id": "xy-edge__dkPgXB2tjWf1-QLFXTKWz3DJ1",
+      "key": "xy-edge__dkPgXB2tjWf1-QLFXTKWz3DJ1",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "segments": [
+        {
+          "direction": "y",
+          "length": 10
+        },
+        {
+          "direction": "y",
+          "length": -19.197029958844112
+        }
+      ],
+      "selected": false,
+      "source": "dkPgXB2tjWf",
+      "sourceHandle": "1",
+      "target": "QLFXTKWz3DJ",
+      "targetHandle": "1",
+      "variant": "pipe"
+    },
+    {
+      "data": {
+        "color": "#ff8700",
+        "segments": [
+          {
+            "direction": "y",
+            "length": -201.81169481483067
+          },
+          {
+            "direction": "x",
+            "length": 0.3825097941260083
+          },
+          {
+            "direction": "y",
+            "length": -201.81169481483067
+          }
+        ],
+        "variant": "pipe"
+      },
+      "id": "xy-edge__7yLD0xOFddf3-KWwYAhIaXR13",
+      "key": "xy-edge__7yLD0xOFddf3-KWwYAhIaXR13",
+      "markerEnd": {
+        "color": "var(--pluto-gray-l8)",
+        "strokeWidth": 2,
+        "type": "arrowclosed"
+      },
+      "selected": false,
+      "source": "7yLD0xOFddf",
+      "sourceHandle": "3",
+      "target": "KWwYAhIaXR1",
+      "targetHandle": "3",
+      "type": "default"
+    }
+  ],
+  "props": {
+    "0DfbZ8yiwSP": {
+      "color": "#ff005f",
+      "key": "value",
+      "label": {
+        "label": "Fuel PT 1",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048676
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["fuel_pt_1"],
+      "units": "psi"
+    },
+    "0KHm9MFPXRw": {
+      "color": "#004ad6",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 0
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 0
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 0
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "showChip": true,
+        "showIndicator": true
+      },
+      "key": "solenoidValve",
+      "label": {
+        "label": "OX Fill",
+        "level": "p",
+        "orientation": "top"
+      },
+      "normallyOpen": false,
+      "orientation": "left",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "0KwRzIrJ4ii": {
+      "color": "#00d623",
+      "key": "value",
+      "label": {
+        "label": "Purge PT",
+        "level": "p",
+        "orientation": "bottom"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048616
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["pneumatics_pt"],
+      "units": "psi"
+    },
+    "0jdKiNGUXdE": {
+      "color": "#004ad6",
+      "key": "tJunction",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "orientation": "left",
+      "scale": 1
+    },
+    "2VVcUzshHsS": {
+      "color": "#b300ff",
+      "dimensions": {
+        "height": 200,
+        "width": 145
+      },
+      "key": "tank",
+      "label": {
+        "label": "Supply",
+        "level": "p",
+        "orientation": "top"
+      },
+      "orientation": "left"
+    },
+    "2i094l8SRqF": {
+      "color": "#ff005f",
+      "key": "value",
+      "label": {
+        "label": "Fuel TC 2",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048606
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["fuel_tc_2"],
+      "units": "°C"
+    },
+    "2tj3wwbNsVf": {
+      "color": [28, 28, 28, 1],
+      "key": "solenoidValve",
+      "label": {
+        "label": "Solenoid Valve",
+        "level": "p",
+        "orientation": "top"
+      },
+      "normallyOpen": false,
+      "orientation": "left",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "3BOalGA2TlR": {
+      "color": [250, 250, 250, 1],
+      "inlineSize": 70,
+      "key": "value",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Value",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "scale": 1,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048609
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["ox_pt_1"],
+      "units": "psi"
+    },
+    "3mJa8YZ6QW4": {
+      "color": [55, 116, 208, 1],
+      "control": {
+        "show": true
+      },
+      "key": "button",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Button",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "onClickDelay": 0,
+      "orientation": "left",
+      "scale": null,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      }
+    },
+    "4NlCnochhRU": {
+      "color": [5, 5, 5, 1],
+      "key": "nozzle",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Nozzle",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "orientation": "top",
+      "scale": 1
+    },
+    "5lnJLvZggVN": {
+      "color": "#004ad6",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048583
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048583
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048583
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "right",
+        "show": true,
+        "showChip": true,
+        "showIndicator": true
+      },
+      "key": "solenoidValve",
+      "label": {
+        "align": "center",
+        "direction": "y",
+        "label": "OX TPC 1",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "left"
+      },
+      "normallyOpen": false,
+      "orientation": "top",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048583
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048584
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "6N2uycrsxNb": {
+      "color": [5, 5, 5, 1],
+      "control": {
+        "show": true
+      },
+      "key": "valve",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Valve",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "right"
+      },
+      "orientation": "bottom",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "7yLD0xOFddf": {
+      "color": "#ffa800",
+      "key": "tJunction",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "orientation": "right",
+      "scale": 1
+    },
+    "80031njI5Uo": {
+      "color": "#004ad6",
+      "dimensions": {
+        "height": 250,
+        "width": 150
+      },
+      "key": "tank",
+      "label": {
+        "label": "",
+        "level": "p",
+        "orientation": "top"
+      },
+      "orientation": "left"
+    },
+    "8uYMBpb8zmt": {
+      "color": {
+        "rgba255": [5, 5, 5, 1]
+      },
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048666
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048666
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048666
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "right",
+        "showChip": true,
+        "showIndicator": true
+      },
+      "key": "solenoidValve",
+      "label": {
+        "label": "GB ISO 2",
+        "level": "p",
+        "orientation": "left"
+      },
+      "normallyOpen": false,
+      "orientation": "bottom",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048666
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048667
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "AEjPdKnWFcT": {
+      "color": "#b300ff",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 0
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 0
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 0
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "right",
+        "showChip": true,
+        "showIndicator": true
+      },
+      "key": "pistonPump",
+      "label": {
+        "label": "Gas Booster",
+        "level": "p",
+        "orientation": "right"
+      },
+      "orientation": "top",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "BLMwEwSkGNS": {
+      "color": "#004ad6",
+      "key": "reliefValve",
+      "label": {
+        "label": "",
+        "level": "p",
+        "orientation": "top"
+      },
+      "orientation": "left"
+    },
+    "CST75HX7oD1": {
+      "color": "#b300ff",
+      "dimensions": {
+        "height": 250,
+        "width": 150
+      },
+      "key": "tank",
+      "label": {
+        "label": "",
+        "level": "p",
+        "orientation": "top"
+      },
+      "orientation": "left"
+    },
+    "D2jnA2ygsRn": {
+      "color": "#ff005f",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048597
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048597
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048597
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "right",
+        "showChip": true,
+        "showIndicator": true
+      },
+      "key": "solenoidValve",
+      "label": {
+        "label": "Fuel Vent",
+        "level": "p",
+        "orientation": "bottom"
+      },
+      "normallyOpen": true,
+      "orientation": "bottom",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048597
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048598
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "DeJ4iOHodtz": {
+      "color": "#b300ff",
+      "key": "value",
+      "label": {
+        "label": "Press TC 1",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048607
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["press_tc_1"],
+      "units": "°C"
+    },
+    "EssNNAH7Oq9": {
+      "color": "#00d623",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 0
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 0
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 0
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "showChip": true,
+        "showIndicator": true
+      },
+      "key": "threeWayValve",
+      "label": {
+        "label": "Purge Valve",
+        "level": "p",
+        "orientation": "bottom"
+      },
+      "orientation": "bottom",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "FV9nUNS95MO": {
+      "color": "#004ad6",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048650
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048650
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048650
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "right",
+        "showChip": true,
+        "showIndicator": true
+      },
+      "key": "solenoidValve",
+      "label": {
+        "label": "OX MPV",
+        "level": "p",
+        "orientation": "left"
+      },
+      "normallyOpen": false,
+      "orientation": "top",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048650
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048651
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "FblmMlBenHA": {
+      "color": [250, 250, 250, 1],
+      "inlineSize": 70,
+      "key": "value",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Value",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "scale": 1,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048605
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["fuel_tc_1"],
+      "units": "psi"
+    },
+    "FiMLXRwc4xJ": {
+      "color": "#004ad6",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048648
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048648
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048648
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "showChip": true,
+        "showIndicator": true
+      },
+      "key": "solenoidValve",
+      "label": {
+        "label": "OX TPC 2",
+        "level": "p",
+        "orientation": "top"
+      },
+      "normallyOpen": false,
+      "orientation": "left",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048648
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048649
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "GJ2YKKP0Z6y": {
+      "color": [5, 5, 5, 1],
+      "control": {
+        "show": true
+      },
+      "key": "solenoidValve",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Solenoid Valve",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "normallyOpen": false,
+      "orientation": "top",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "GXakOVjitf5": {
+      "color": "#ff005f",
+      "key": "value",
+      "label": {
+        "label": "Fuel TC 1",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048605
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["fuel_tc_1"],
+      "units": "°C"
+    },
+    "GivrZPeMCEw": {
+      "color": "#004ad6",
+      "key": "value",
+      "label": {
+        "label": "OX TC 1",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048668
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["ox_tc_1"],
+      "units": "psi"
+    },
+    "HH9i7jrQ0rH": {
+      "color": "#ff005f",
+      "key": "tJunction",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "orientation": "right",
+      "scale": 1
+    },
+    "HNeMkVQJMZZ": {
+      "color": "#b300ff",
+      "key": "value",
+      "label": {
+        "label": "Value",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048680
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["supply_pt"],
+      "units": "psi"
+    },
+    "HUushIhVDc6": {
+      "color": [250, 250, 250, 1],
+      "inlineSize": 70,
+      "key": "value",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Value",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "scale": 1,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048603
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["ox_tc_1"],
+      "units": "psi"
+    },
+    "IoFGQ3ntavy": {
+      "color": "#ff005f",
+      "dimensions": {
+        "height": 250,
+        "width": 150
+      },
+      "key": "tank",
+      "label": {
+        "label": "",
+        "level": "p",
+        "orientation": "top"
+      },
+      "orientation": "left"
+    },
+    "IpSylSnCSc3": {
+      "color": "#00d623",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048585
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048585
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048585
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "right",
+        "show": true,
+        "showChip": true,
+        "showIndicator": true
+      },
+      "key": "solenoidValve",
+      "label": {
+        "align": "center",
+        "direction": "y",
+        "label": "Purge",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "left"
+      },
+      "normallyOpen": false,
+      "orientation": "top",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048585
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048586
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "K9nj3YBK0KG": {
+      "color": "#b300ff",
+      "key": "value",
+      "label": {
+        "label": "Press PT 2",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048614
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["press_pt_2"],
+      "units": "psi"
+    },
+    "KWwYAhIaXR1": {
+      "color": "#004ad6",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048585
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048585
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048585
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "right",
+        "show": true,
+        "showChip": true,
+        "showIndicator": true
+      },
+      "key": "solenoidValve",
+      "label": {
+        "align": "center",
+        "direction": "y",
+        "label": "OX MPV",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "left"
+      },
+      "normallyOpen": false,
+      "orientation": "top",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048585
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048586
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "KnJjTf7CJv9": {
+      "color": "#004ad6",
+      "inlineSize": 70,
+      "key": "value",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "OX TC 1",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "scale": 1,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048603
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["ox_tc_1"],
+      "units": "°C"
+    },
+    "L0MCB6oJASM": {
+      "color": "#ff005f",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048593
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048593
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048593
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "showChip": true,
+        "showIndicator": true
+      },
+      "key": "solenoidValve",
+      "label": {
+        "label": "Fuel Pre-Valve",
+        "level": "p",
+        "orientation": "top"
+      },
+      "normallyOpen": false,
+      "orientation": "left",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048593
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048594
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "M4YDBbNwtI5": {
+      "color": [28, 28, 28, 1],
+      "key": "angledReliefValve",
+      "label": {
+        "label": "Angled Relief Valve",
+        "level": "p",
+        "orientation": "top"
+      },
+      "orientation": "left"
+    },
+    "MEfIDo71Css": {
+      "color": "#004ad6",
+      "inlineSize": 70,
+      "key": "value",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "OX TC 2",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "scale": 1,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048604
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["ox_tc_2"],
+      "units": "°C"
+    },
+    "MN7bYyk3QeZ": {
+      "color": "#ff005f",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048658
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048658
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048658
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "left",
+        "showChip": true,
+        "showIndicator": true
+      },
+      "key": "solenoidValve",
+      "label": {
+        "label": "Fuel MPV",
+        "level": "p",
+        "orientation": "right"
+      },
+      "normallyOpen": false,
+      "orientation": "bottom",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048658
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048659
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "NGZToy6pCHe": {
+      "color": "#004ad6",
+      "key": "value",
+      "label": {
+        "label": "OX TC 2",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048669
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["ox_tc_2"],
+      "units": "psi"
+    },
+    "PYidicujg8Q": {
+      "color": "#ff005f",
+      "key": "value",
+      "label": {
+        "label": "Fuel TC 1",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048670
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["fuel_tc_1"],
+      "units": "psi"
+    },
+    "Px7l7pDawuy": {
+      "color": "#ff005f",
+      "key": "value",
+      "label": {
+        "label": "Fuel PT 2",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "redline": {
+        "bounds": {
+          "lower": 0,
+          "upper": 1
+        },
+        "gradient": []
+      },
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048612
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["fuel_pt_2"],
+      "units": "psi"
+    },
+    "QLFXTKWz3DJ": {
+      "color": "#ffa800",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048601
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048601
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048601
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "right",
+        "show": true,
+        "showChip": true,
+        "showIndicator": true
+      },
+      "key": "solenoidValve",
+      "label": {
+        "align": "center",
+        "direction": "y",
+        "label": "Gas Booster ISO",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "left"
+      },
+      "normallyOpen": false,
+      "orientation": "top",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048601
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048602
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "QPKzX2O2699": {
+      "color": "#ff005f",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048656
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048656
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048656
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "left",
+        "showChip": true,
+        "showIndicator": true
+      },
+      "key": "solenoidValve",
+      "label": {
+        "label": "Fuel TPC 1",
+        "level": "p",
+        "orientation": "right"
+      },
+      "normallyOpen": false,
+      "orientation": "bottom",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048656
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048657
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "Qt13TVgVdZD": {
+      "color": {
+        "rgba255": [5, 5, 5, 1]
+      },
+      "key": "value",
+      "label": {
+        "label": "Accumulator PT",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048681
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["pneumatics_pt"],
+      "units": "psi"
+    },
+    "SKO1UjHj1o3": {
+      "color": "#00d623",
+      "key": "regulator",
+      "label": {
+        "label": "Purge Reg",
+        "level": "p",
+        "orientation": "top"
+      },
+      "orientation": "left"
+    },
+    "T7tp2FvVzzl": {
+      "color": "#004ad6",
+      "key": "value",
+      "label": {
+        "label": "OX PT 2",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048675
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["ox_pt_2"],
+      "units": "psi"
+    },
+    "UN8NV3qxaz7": {
+      "color": "#004ad6",
+      "inlineSize": 70,
+      "key": "value",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "OX PT 1",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "scale": 1,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048609
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["ox_pt_1"],
+      "units": "psi"
+    },
+    "Uf71mmzzyez": {
+      "color": "#b300ff",
+      "inlineSize": 90,
+      "key": "value",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Supply PT",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "scale": 1,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048615
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["supply_pt"],
+      "units": "psi"
+    },
+    "Uhas206b5VS": {
+      "color": [250, 250, 250, 1],
+      "inlineSize": 70,
+      "key": "value",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Value",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "scale": 1,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048608
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["press_tc_2"],
+      "units": "psi"
+    },
+    "VcyomMLraaN": {
+      "backgroundColor": [250, 250, 250, 0],
+      "borderRadius": {
+        "x": 50,
+        "y": 10
+      },
+      "color": "#004ad6",
+      "dimensions": {
+        "height": 250,
+        "width": 150
+      },
+      "key": "tank",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "orientation": "left",
+      "scale": 1
+    },
+    "VeRfM4LedsR": {
+      "color": "#ff005f",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048593
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048593
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048593
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "left",
+        "show": true,
+        "showChip": true,
+        "showIndicator": true
+      },
+      "key": "solenoidValve",
+      "label": {
+        "align": "center",
+        "direction": "y",
+        "label": "Fuel MPV",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "right"
+      },
+      "normallyOpen": false,
+      "orientation": "bottom",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048593
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048594
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "VmLXT8TtVfn": {
+      "color": "#ff005f",
+      "key": "value",
+      "label": {
+        "label": "Fuel PT 1",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048611
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["fuel_pt_1"],
+      "units": "psi"
+    },
+    "W1dSGKqGk1f": {
+      "color": "#b300ff",
+      "key": "tJunction",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "orientation": "top",
+      "scale": 1
+    },
+    "WjNhadY8bYt": {
+      "color": [250, 250, 250, 1],
+      "inlineSize": 70,
+      "key": "value",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Value",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "redline": {
+        "bounds": {
+          "lower": 0,
+          "upper": 1
+        },
+        "gradient": []
+      },
+      "scale": 1,
+      "stalenessColor": [194, 157, 10, 1],
+      "stalenessTimeout": 5,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048610
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["ox_pt_2"],
+      "units": "psi"
+    },
+    "WubiiPZ6MyL": {
+      "color": "#00d623",
+      "key": "tJunction",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "orientation": "right",
+      "scale": 1
+    },
+    "XHvgACsGqDW": {
+      "color": "#004ad6",
+      "key": "value",
+      "label": {
+        "label": "OX PT 1",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048674
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["ox_pt_1"],
+      "units": "psi"
+    },
+    "YtBdiWNERfU": {
+      "color": "#b300ff",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048587
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048587
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048587
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "show": true,
+        "showChip": true,
+        "showIndicator": true
+      },
+      "key": "solenoidValve",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "OX Press Iso",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "bottom"
+      },
+      "normallyOpen": false,
+      "orientation": "left",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048587
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048588
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "YwDKMURj1vp": {
+      "color": [5, 5, 5, 1],
+      "control": {
+        "show": true
+      },
+      "key": "angledValve",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Angled Valve",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "orientation": "right",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "ZXOfFkiBk9R": {
+      "color": [28, 28, 28, 1],
+      "key": "solenoidValve",
+      "label": {
+        "label": "Solenoid Valve",
+        "level": "p",
+        "orientation": "top"
+      },
+      "normallyOpen": false,
+      "orientation": "left",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "a8tAqnEJba0": {
+      "color": [250, 250, 250, 1],
+      "inlineSize": 70,
+      "key": "value",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Value",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "scale": 1,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048613
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["press_pt_1"],
+      "units": "psi"
+    },
+    "c6BIYnWmuQX": {
+      "color": [5, 5, 5, 1],
+      "control": {
+        "show": true
+      },
+      "key": "solenoidValve",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Solenoid Valve",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "normallyOpen": false,
+      "orientation": "bottom",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "dkPgXB2tjWf": {
+      "color": "#ffa800",
+      "dimensions": {
+        "height": 200,
+        "width": 125
+      },
+      "key": "tank",
+      "label": {
+        "label": "",
+        "level": "p",
+        "orientation": "top"
+      },
+      "orientation": "left"
+    },
+    "dlptAUF47pk": {
+      "color": "#ff005f",
+      "dimensions": {
+        "height": 250,
+        "width": 150
+      },
+      "key": "tank",
+      "label": {
+        "label": "",
+        "level": "p",
+        "orientation": "top"
+      },
+      "orientation": "left"
+    },
+    "dofQxFOyrpw": {
+      "color": [28, 28, 28, 1],
+      "dimensions": {
+        "height": 200,
+        "width": 100
+      },
+      "key": "tank",
+      "label": {
+        "label": "Tank",
+        "level": "p",
+        "orientation": "top"
+      },
+      "orientation": "left"
+    },
+    "dsiLFWHbVAK": {
+      "color": "#ff005f",
+      "key": "value",
+      "label": {
+        "label": "Value",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": [""],
+      "units": "psi"
+    },
+    "e4JtXVcg02b": {
+      "color": [250, 250, 250, 1],
+      "key": "nozzle",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "orientation": "left",
+      "scale": 2.25
+    },
+    "e6edPu5g4WW": {
+      "color": [28, 28, 28, 1],
+      "key": "solenoidValve",
+      "label": {
+        "label": "Solenoid Valve",
+        "level": "p",
+        "orientation": "top"
+      },
+      "normallyOpen": false,
+      "orientation": "left",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "ed2fKMvty6b": {
+      "color": "#b300ff",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048595
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048595
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048595
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "showChip": true,
+        "showIndicator": true
+      },
+      "key": "solenoidValve",
+      "label": {
+        "label": "Fuel Press ISO",
+        "level": "p",
+        "orientation": "top"
+      },
+      "normallyOpen": false,
+      "orientation": "left",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048595
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048596
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "f1ENRWs0FIf": {
+      "color": [250, 250, 250, 1],
+      "control": {
+        "show": true
+      },
+      "key": "threeWayValve",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Three Way Valve",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "orientation": "left",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "gskjCS25iAe": {
+      "color": [250, 250, 250, 1],
+      "inlineSize": 70,
+      "key": "value",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Value",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "scale": 1,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048603
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["ox_tc_1"],
+      "units": "psi"
+    },
+    "juGKtTasf2m": {
+      "color": [28, 28, 28, 1],
+      "dimensions": {
+        "height": 200,
+        "width": 100
+      },
+      "key": "tank",
+      "label": {
+        "label": "Tank",
+        "level": "p",
+        "orientation": "top"
+      },
+      "orientation": "left"
+    },
+    "k9XCuVYxOzB": {
+      "color": [55, 116, 208, 1],
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048618
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048618
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048618
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "show": true,
+        "showChip": true,
+        "showIndicator": true
+      },
+      "key": "button",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Start Sequence",
+        "level": "h4",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "onClickDelay": 0,
+      "orientation": "left",
+      "scale": null,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048618
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      }
+    },
+    "kbJw2Oi5Ueu": {
+      "color": "#b300ff",
+      "key": "regulator",
+      "label": {
+        "label": "",
+        "level": "p",
+        "orientation": "top"
+      },
+      "orientation": "left"
+    },
+    "mDHz94NwfKE": {
+      "color": [250, 250, 250, 1],
+      "inlineSize": 70,
+      "key": "value",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Value",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "redline": {
+        "bounds": {
+          "lower": 0,
+          "upper": 1
+        },
+        "gradient": []
+      },
+      "scale": 1,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048606
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["fuel_tc_2"],
+      "units": "psi"
+    },
+    "mJ0fxQiPaDP": {
+      "color": "#ff005f",
+      "key": "value",
+      "label": {
+        "label": "Fuel TC 2",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048671
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["fuel_tc_2"],
+      "units": "psi"
+    },
+    "mRrQTum99UZ": {
+      "color": {
+        "rgba255": [5, 5, 5, 1]
+      },
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048666
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048666
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048666
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "right",
+        "showChip": true,
+        "showIndicator": true
+      },
+      "key": "solenoidValve",
+      "label": {
+        "label": "GB ISO 1",
+        "level": "p",
+        "orientation": "left"
+      },
+      "normallyOpen": false,
+      "orientation": "bottom",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048666
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048667
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "n4pmPCUcMaw": {
+      "color": "#004ad6",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048585
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048585
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048585
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "showChip": true,
+        "showIndicator": true
+      },
+      "key": "solenoidValve",
+      "label": {
+        "label": "OX Pre-Valve",
+        "level": "p",
+        "orientation": "top"
+      },
+      "normallyOpen": false,
+      "orientation": "left",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048585
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048586
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "nDyx6eSCxsX": {
+      "color": "#004ad6",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048648
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048648
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048648
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "showChip": true,
+        "showIndicator": true
+      },
+      "key": "solenoidValve",
+      "label": {
+        "label": "OX TPC 1",
+        "level": "p",
+        "orientation": "top"
+      },
+      "normallyOpen": false,
+      "orientation": "left",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048648
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048649
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "nikWEdQSwLr": {
+      "color": "#ff005f",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048591
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048591
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048591
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "left",
+        "show": true,
+        "showChip": true,
+        "showIndicator": true
+      },
+      "key": "solenoidValve",
+      "label": {
+        "align": "center",
+        "direction": "y",
+        "label": "Fuel TPC 1",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "right"
+      },
+      "normallyOpen": false,
+      "orientation": "bottom",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048591
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048592
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "oB0skpbvoqc": {
+      "color": "#b300ff",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048664
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048664
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048664
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "left",
+        "showChip": true,
+        "showIndicator": true
+      },
+      "key": "solenoidValve",
+      "label": {
+        "label": "OX Press ISO",
+        "level": "p",
+        "orientation": "right"
+      },
+      "normallyOpen": false,
+      "orientation": "top",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048664
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048665
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "ojXq08A1bLP": {
+      "color": "#ff005f",
+      "key": "angledReliefValve",
+      "label": {
+        "label": "",
+        "level": "p",
+        "orientation": "top"
+      },
+      "orientation": "bottom"
+    },
+    "p2dLrZf6mMv": {
+      "color": "#ff005f",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048591
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048591
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048591
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "right",
+        "show": true,
+        "showChip": true,
+        "showIndicator": true
+      },
+      "key": "solenoidValve",
+      "label": {
+        "align": "center",
+        "direction": "y",
+        "label": "Fuel TPC 2",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "left"
+      },
+      "normallyOpen": false,
+      "orientation": "top",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048591
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048592
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "ptsh5LVBq2y": {
+      "color": "#004ad6",
+      "key": "value",
+      "label": {
+        "label": "Value",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "units": "psi"
+    },
+    "q2BvScO3Tvx": {
+      "color": [250, 250, 250, 1],
+      "inlineSize": 70,
+      "key": "value",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Value",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "scale": 1,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048612
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["fuel_pt_2"],
+      "units": "psi"
+    },
+    "qKNvIK45GCK": {
+      "color": "#004ad6",
+      "inlineSize": 70,
+      "key": "value",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "OX PT 2",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "scale": 1,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048610
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["ox_pt_2"],
+      "units": "psi"
+    },
+    "qUGRcDkaBIx": {
+      "color": "#004ad6",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048583
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048583
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048583
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "left",
+        "show": true,
+        "showChip": true,
+        "showIndicator": true
+      },
+      "key": "solenoidValve",
+      "label": {
+        "align": "center",
+        "direction": "y",
+        "label": "OX TPC 2",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "right"
+      },
+      "normallyOpen": false,
+      "orientation": "bottom",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048583
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048584
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "qo0xVKkc4oR": {
+      "color": "#004ad6",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048589
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048589
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048589
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "left",
+        "showChip": true,
+        "showIndicator": true
+      },
+      "key": "solenoidValve",
+      "label": {
+        "label": "OX Vent",
+        "level": "p",
+        "orientation": "bottom"
+      },
+      "normallyOpen": true,
+      "orientation": "bottom",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048589
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048590
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "rCUKZktR3sZ": {
+      "color": "#b300ff",
+      "key": "value",
+      "label": {
+        "label": "Press PT 1",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048613
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["press_pt_1"],
+      "units": "psi"
+    },
+    "rJ8HEDBlxlw": {
+      "backgroundColor": [255, 0, 255, 0.01],
+      "borderRadius": {
+        "x": 50,
+        "y": 25
+      },
+      "color": "#b300ff",
+      "dimensions": {
+        "height": 200,
+        "width": 139
+      },
+      "key": "tank",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "orientation": "left",
+      "scale": 1
+    },
+    "rTobk1G30ly": {
+      "color": "#004ad6",
+      "key": "tJunction",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "orientation": "right",
+      "scale": 1
+    },
+    "sXCSKGCQGy2": {
+      "color": "#EDEDED",
+      "key": "solenoidValve",
+      "label": {
+        "label": "Solenoid Valve",
+        "level": "p",
+        "orientation": "top"
+      },
+      "normallyOpen": false,
+      "orientation": "left",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "solQ4AaAaWx": {
+      "color": [5, 5, 5, 1],
+      "control": {
+        "show": true
+      },
+      "key": "valve",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Valve",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "orientation": "left",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "tKyeVybyb2Z": {
+      "color": "#b300ff",
+      "control": {
+        "orientation": "right",
+        "show": true
+      },
+      "key": "pistonPump",
+      "label": {
+        "align": "center",
+        "direction": "y",
+        "label": "Gas Booster",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "right"
+      },
+      "orientation": "top",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "tcY77CQT5aV": {
+      "color": "#ff005f",
+      "key": "value",
+      "label": {
+        "label": "Fuel PT 2",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048677
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["fuel_pt_2"],
+      "units": "psi"
+    },
+    "tqDmVLRLuXg": {
+      "color": [28, 28, 28, 1],
+      "key": "solenoidValve",
+      "label": {
+        "label": "Solenoid Valve",
+        "level": "p",
+        "orientation": "top"
+      },
+      "normallyOpen": false,
+      "orientation": "left",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "vITJzpd1U32": {
+      "color": "#ff005f",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048656
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048656
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048656
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "right",
+        "showChip": true,
+        "showIndicator": true
+      },
+      "key": "solenoidValve",
+      "label": {
+        "label": "Fuel TPC 2",
+        "level": "p",
+        "orientation": "left"
+      },
+      "normallyOpen": false,
+      "orientation": "bottom",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048656
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048657
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      }
+    },
+    "vKY6rgCFLAP": {
+      "color": [250, 250, 250, 1],
+      "inlineSize": 70,
+      "key": "value",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Value",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "scale": 1,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048604
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["ox_tc_2"],
+      "units": "psi"
+    },
+    "vVP5HNMj1sk": {
+      "color": "#b300ff",
+      "key": "value",
+      "label": {
+        "label": "Press TC 2",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048608
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["press_tc_2"],
+      "units": "°C"
+    },
+    "wGdFMnYeLk8": {
+      "color": "#ff005f",
+      "key": "tJunction",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "orientation": "left",
+      "scale": 1
+    },
+    "yAfA5biPqIA": {
+      "color": "#ffa800",
+      "inlineSize": 78,
+      "key": "value",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Accumulator PT",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "scale": 1,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048616
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["pneumatics_pt"],
+      "units": "psi"
+    }
+  },
+  "remoteCreated": true,
+  "viewport": {
+    "position": {
+      "x": 62.57561931565772,
+      "y": 76.75181834247024
+    },
+    "zoom": 0.7383653246556344
+  },
+  "editable": false,
+  "control": "acquired",
+  "controlAcquireTrigger": 0,
+  "fitViewOnResize": true,
+  "legend": {
+    "position": {
+      "root": {
+        "x": "left",
+        "y": "top"
+      },
+      "units": {
+        "x": "px",
+        "y": "px"
+      },
+      "x": 25,
+      "y": 19
+    },
+    "visible": false
+  },
+  "key": "34c0a87c-3f72-42d2-8cac-75bc1e2631b1",
+  "viewportMode": "select",
+  "authority": 1,
+  "mode": "select",
+  "toolbar": {
+    "activeTab": "symbols",
+    "selectedSymbolGroup": "general"
+  }
+}

--- a/core/pkg/service/schematic/migrations/testdata/v5_operator.migrated.json
+++ b/core/pkg/service/schematic/migrations/testdata/v5_operator.migrated.json
@@ -1,0 +1,8253 @@
+{
+  "key": "00000000-0000-0000-0000-000000000001",
+  "name": "v5_operator.json",
+  "snapshot": false,
+  "nodes": [
+    {
+      "key": "dlptAUF47pk",
+      "position": {
+        "x": 881.6607236537078,
+        "y": 224.09574871332688
+      },
+      "z_index": 2,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "VmLXT8TtVfn",
+      "position": {
+        "x": 905.9740228344708,
+        "y": 256.26283909396636
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "Px7l7pDawuy",
+      "position": {
+        "x": 907.4580807144808,
+        "y": 310.8580105818506
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "GXakOVjitf5",
+      "position": {
+        "x": 902.3649435265172,
+        "y": 365.6827997860045
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "2i094l8SRqF",
+      "position": {
+        "x": 902.3649435265172,
+        "y": 422.4392742496658
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "CST75HX7oD1",
+      "position": {
+        "x": -9.729666288384024,
+        "y": 79.92633707042512
+      },
+      "z_index": 2,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "rCUKZktR3sZ",
+      "position": {
+        "x": 13.270333711615962,
+        "y": 116.0176843772881
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "K9nj3YBK0KG",
+      "position": {
+        "x": 11.661254403662523,
+        "y": 170.0176843772881
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "DeJ4iOHodtz",
+      "position": {
+        "x": 11.547797109162389,
+        "y": 224.07441302453816
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "vVP5HNMj1sk",
+      "position": {
+        "x": 12.129672583372582,
+        "y": 278.7491039457149
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "ed2fKMvty6b",
+      "position": {
+        "x": 716.1416454448381,
+        "y": -38.32273345673128
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "qo0xVKkc4oR",
+      "position": {
+        "x": 270.7265563621524,
+        "y": 278.4920462406048
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "BLMwEwSkGNS",
+      "position": {
+        "x": 194.9121993900031,
+        "y": 199.16936379148157
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "D2jnA2ygsRn",
+      "position": {
+        "x": 1056.588660002796,
+        "y": 277.2370726204909
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "ojXq08A1bLP",
+      "position": {
+        "x": 1101.309843180454,
+        "y": 210.6629761180268
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "L0MCB6oJASM",
+      "position": {
+        "x": 864.6566390383351,
+        "y": 523.2927121788872
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "n4pmPCUcMaw",
+      "position": {
+        "x": 434.7041052797298,
+        "y": 507.0251432502485
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "0KwRzIrJ4ii",
+      "position": {
+        "x": 488.8122837483062,
+        "y": 683.3125469319169
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "SKO1UjHj1o3",
+      "position": {
+        "x": 376.799972855844,
+        "y": 653.0095204959324
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "kbJw2Oi5Ueu",
+      "position": {
+        "x": 124.58560325160995,
+        "y": 533.735369623691
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "dkPgXB2tjWf",
+      "position": {
+        "x": -56.307654121011275,
+        "y": 500.2641971370136
+      },
+      "z_index": 2,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "Uf71mmzzyez",
+      "position": {
+        "x": 237.48927285856396,
+        "y": 557.4057282455545
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "yAfA5biPqIA",
+      "position": {
+        "x": -54.086546886277496,
+        "y": 563.6120611799672
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "wGdFMnYeLk8",
+      "position": {
+        "x": 941.0670110697548,
+        "y": 181.06103701783505
+      },
+      "z_index": 24,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "p2dLrZf6mMv",
+      "position": {
+        "x": 860.6481601631167,
+        "y": 86.42306342896143
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "nikWEdQSwLr",
+      "position": {
+        "x": 986.8577922925748,
+        "y": 86.348184023629
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "HH9i7jrQ0rH",
+      "position": {
+        "x": 932.8388721209018,
+        "y": 47.4543137352087
+      },
+      "z_index": 24,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "5lnJLvZggVN",
+      "position": {
+        "x": 330.5107729180439,
+        "y": 97.56377635289778
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "qUGRcDkaBIx",
+      "position": {
+        "x": 451.7077945265089,
+        "y": 97.7859192792202
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "rTobk1G30ly",
+      "position": {
+        "x": 402.43046814297566,
+        "y": 62.464630819799766
+      },
+      "z_index": 24,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "0jdKiNGUXdE",
+      "position": {
+        "x": 403.5077886236238,
+        "y": 181.40448884810743
+      },
+      "z_index": 24,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "VcyomMLraaN",
+      "position": {
+        "x": 344.10153353736075,
+        "y": 217.92749514690803
+      },
+      "z_index": 2,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "UN8NV3qxaz7",
+      "position": {
+        "x": 368.4930383619268,
+        "y": 248.16220425088895
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "qKNvIK45GCK",
+      "position": {
+        "x": 369.50000000000006,
+        "y": 305.16220425088903
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "KnJjTf7CJv9",
+      "position": {
+        "x": 367.66666666666674,
+        "y": 358.8288709175556
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "MEfIDo71Css",
+      "position": {
+        "x": 368.8333333333333,
+        "y": 415.8288709175556
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "W1dSGKqGk1f",
+      "position": {
+        "x": 135.52283117318578,
+        "y": 35.167808075727706
+      },
+      "z_index": 24,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "YtBdiWNERfU",
+      "position": {
+        "x": 203.3401768139715,
+        "y": 12.027170576396433
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "rJ8HEDBlxlw",
+      "position": {
+        "x": 229.1760073720529,
+        "y": 477.62432532701166
+      },
+      "z_index": 2,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "QLFXTKWz3DJ",
+      "position": {
+        "x": -32.279846943321495,
+        "y": 413.72341717816954
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "tKyeVybyb2Z",
+      "position": {
+        "x": 39.676555290128434,
+        "y": 353.1257902036398
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "e4JtXVcg02b",
+      "position": {
+        "x": 652.6816177637583,
+        "y": 375.6488170035559
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "KWwYAhIaXR1",
+      "position": {
+        "x": 617.1097000170178,
+        "y": 277.55853049940737
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "VeRfM4LedsR",
+      "position": {
+        "x": 752.6804763546971,
+        "y": 277.5195101664691
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "WubiiPZ6MyL",
+      "position": {
+        "x": 697.0018688628214,
+        "y": 188.867129790864
+      },
+      "z_index": 24,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "IpSylSnCSc3",
+      "position": {
+        "x": 509.2145240269522,
+        "y": 583.4183035794158
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "7yLD0xOFddf",
+      "position": {
+        "x": 610.6803516098993,
+        "y": 734.0881488512645
+      },
+      "z_index": 24,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    },
+    {
+      "key": "k9XCuVYxOzB",
+      "position": {
+        "x": 1011,
+        "y": 632
+      },
+      "z_index": 4,
+      "measured": {
+        "width": 0,
+        "height": 0
+      }
+    }
+  ],
+  "edges": [
+    {
+      "key": "reactflow__edge-SKO1UjHj1o32-0KwRzIrJ4ii1",
+      "source": {
+        "node": "SKO1UjHj1o3",
+        "param": "2"
+      },
+      "target": {
+        "node": "0KwRzIrJ4ii",
+        "param": "1"
+      }
+    },
+    {
+      "key": "xy-edge__dlptAUF47pk3-D2jnA2ygsRn1",
+      "source": {
+        "node": "dlptAUF47pk",
+        "param": "3"
+      },
+      "target": {
+        "node": "D2jnA2ygsRn",
+        "param": "1"
+      }
+    },
+    {
+      "key": "xy-edge__dlptAUF47pk3-ojXq08A1bLP1",
+      "source": {
+        "node": "dlptAUF47pk",
+        "param": "3"
+      },
+      "target": {
+        "node": "ojXq08A1bLP",
+        "param": "1"
+      }
+    },
+    {
+      "key": "xy-edge__p2dLrZf6mMv1-wGdFMnYeLk81",
+      "source": {
+        "node": "p2dLrZf6mMv",
+        "param": "1"
+      },
+      "target": {
+        "node": "wGdFMnYeLk8",
+        "param": "1"
+      }
+    },
+    {
+      "key": "xy-edge__nikWEdQSwLr2-wGdFMnYeLk82",
+      "source": {
+        "node": "nikWEdQSwLr",
+        "param": "2"
+      },
+      "target": {
+        "node": "wGdFMnYeLk8",
+        "param": "2"
+      }
+    },
+    {
+      "key": "xy-edge__HH9i7jrQ0rH2-p2dLrZf6mMv2",
+      "source": {
+        "node": "HH9i7jrQ0rH",
+        "param": "2"
+      },
+      "target": {
+        "node": "p2dLrZf6mMv",
+        "param": "2"
+      }
+    },
+    {
+      "key": "xy-edge__HH9i7jrQ0rH1-nikWEdQSwLr1",
+      "source": {
+        "node": "HH9i7jrQ0rH",
+        "param": "1"
+      },
+      "target": {
+        "node": "nikWEdQSwLr",
+        "param": "1"
+      }
+    },
+    {
+      "key": "1Ajh5kZyqzw",
+      "source": {
+        "node": "rTobk1G30ly",
+        "param": "2"
+      },
+      "target": {
+        "node": "5lnJLvZggVN",
+        "param": "2"
+      }
+    },
+    {
+      "key": "Q6Ru747fTlZ",
+      "source": {
+        "node": "rTobk1G30ly",
+        "param": "1"
+      },
+      "target": {
+        "node": "qUGRcDkaBIx",
+        "param": "1"
+      }
+    },
+    {
+      "key": "xy-edge__0jdKiNGUXdE1-5lnJLvZggVN1",
+      "source": {
+        "node": "0jdKiNGUXdE",
+        "param": "1"
+      },
+      "target": {
+        "node": "5lnJLvZggVN",
+        "param": "1"
+      }
+    },
+    {
+      "key": "xy-edge__0jdKiNGUXdE2-qUGRcDkaBIx2",
+      "source": {
+        "node": "0jdKiNGUXdE",
+        "param": "2"
+      },
+      "target": {
+        "node": "qUGRcDkaBIx",
+        "param": "2"
+      }
+    },
+    {
+      "key": "xy-edge__VcyomMLraaN4-n4pmPCUcMaw1",
+      "source": {
+        "node": "VcyomMLraaN",
+        "param": "4"
+      },
+      "target": {
+        "node": "n4pmPCUcMaw",
+        "param": "1"
+      }
+    },
+    {
+      "key": "xy-edge__qo0xVKkc4oR1-VcyomMLraaN2",
+      "source": {
+        "node": "qo0xVKkc4oR",
+        "param": "1"
+      },
+      "target": {
+        "node": "VcyomMLraaN",
+        "param": "2"
+      }
+    },
+    {
+      "key": "xy-edge__BLMwEwSkGNS2-VcyomMLraaN2",
+      "source": {
+        "node": "BLMwEwSkGNS",
+        "param": "2"
+      },
+      "target": {
+        "node": "VcyomMLraaN",
+        "param": "2"
+      }
+    },
+    {
+      "key": "xy-edge__ed2fKMvty6b2-HH9i7jrQ0rH3",
+      "source": {
+        "node": "ed2fKMvty6b",
+        "param": "2"
+      },
+      "target": {
+        "node": "HH9i7jrQ0rH",
+        "param": "3"
+      }
+    },
+    {
+      "key": "xy-edge__0jdKiNGUXdE3-VcyomMLraaN1",
+      "source": {
+        "node": "0jdKiNGUXdE",
+        "param": "3"
+      },
+      "target": {
+        "node": "VcyomMLraaN",
+        "param": "1"
+      }
+    },
+    {
+      "key": "xy-edge__CST75HX7oD13-W1dSGKqGk1f1",
+      "source": {
+        "node": "CST75HX7oD1",
+        "param": "3"
+      },
+      "target": {
+        "node": "W1dSGKqGk1f",
+        "param": "1"
+      }
+    },
+    {
+      "key": "xy-edge__W1dSGKqGk1f2-ed2fKMvty6b1",
+      "source": {
+        "node": "W1dSGKqGk1f",
+        "param": "2"
+      },
+      "target": {
+        "node": "ed2fKMvty6b",
+        "param": "1"
+      }
+    },
+    {
+      "key": "xy-edge__YtBdiWNERfU2-rTobk1G30ly3",
+      "source": {
+        "node": "YtBdiWNERfU",
+        "param": "2"
+      },
+      "target": {
+        "node": "rTobk1G30ly",
+        "param": "3"
+      }
+    },
+    {
+      "key": "xy-edge__YtBdiWNERfU1-W1dSGKqGk1f3",
+      "source": {
+        "node": "YtBdiWNERfU",
+        "param": "1"
+      },
+      "target": {
+        "node": "W1dSGKqGk1f",
+        "param": "3"
+      }
+    },
+    {
+      "key": "xy-edge__kbJw2Oi5Ueu2-rJ8HEDBlxlw7",
+      "source": {
+        "node": "kbJw2Oi5Ueu",
+        "param": "2"
+      },
+      "target": {
+        "node": "rJ8HEDBlxlw",
+        "param": "7"
+      }
+    },
+    {
+      "key": "xy-edge__dkPgXB2tjWf8-kbJw2Oi5Ueu1",
+      "source": {
+        "node": "dkPgXB2tjWf",
+        "param": "8"
+      },
+      "target": {
+        "node": "kbJw2Oi5Ueu",
+        "param": "1"
+      }
+    },
+    {
+      "key": "xy-edge__tKyeVybyb2Z2-CST75HX7oD14",
+      "source": {
+        "node": "tKyeVybyb2Z",
+        "param": "2"
+      },
+      "target": {
+        "node": "CST75HX7oD1",
+        "param": "4"
+      }
+    },
+    {
+      "key": "xy-edge__rJ8HEDBlxlw1-tKyeVybyb2Z1",
+      "source": {
+        "node": "rJ8HEDBlxlw",
+        "param": "1"
+      },
+      "target": {
+        "node": "tKyeVybyb2Z",
+        "param": "1"
+      }
+    },
+    {
+      "key": "xy-edge__QLFXTKWz3DJ2-tKyeVybyb2Z3",
+      "source": {
+        "node": "QLFXTKWz3DJ",
+        "param": "2"
+      },
+      "target": {
+        "node": "tKyeVybyb2Z",
+        "param": "3"
+      }
+    },
+    {
+      "key": "xy-edge__KWwYAhIaXR11-e4JtXVcg02b1",
+      "source": {
+        "node": "KWwYAhIaXR1",
+        "param": "1"
+      },
+      "target": {
+        "node": "e4JtXVcg02b",
+        "param": "1"
+      }
+    },
+    {
+      "key": "xy-edge__VeRfM4LedsR2-e4JtXVcg02b3",
+      "source": {
+        "node": "VeRfM4LedsR",
+        "param": "2"
+      },
+      "target": {
+        "node": "e4JtXVcg02b",
+        "param": "3"
+      }
+    },
+    {
+      "key": "xy-edge__n4pmPCUcMaw2-KWwYAhIaXR12",
+      "source": {
+        "node": "n4pmPCUcMaw",
+        "param": "2"
+      },
+      "target": {
+        "node": "KWwYAhIaXR1",
+        "param": "2"
+      }
+    },
+    {
+      "key": "xy-edge__L0MCB6oJASM2-dlptAUF47pk4",
+      "source": {
+        "node": "L0MCB6oJASM",
+        "param": "2"
+      },
+      "target": {
+        "node": "dlptAUF47pk",
+        "param": "4"
+      }
+    },
+    {
+      "key": "xy-edge__L0MCB6oJASM1-VeRfM4LedsR1",
+      "source": {
+        "node": "L0MCB6oJASM",
+        "param": "1"
+      },
+      "target": {
+        "node": "VeRfM4LedsR",
+        "param": "1"
+      }
+    },
+    {
+      "key": "xy-edge__wGdFMnYeLk83-dlptAUF47pk1",
+      "source": {
+        "node": "wGdFMnYeLk8",
+        "param": "3"
+      },
+      "target": {
+        "node": "dlptAUF47pk",
+        "param": "1"
+      }
+    },
+    {
+      "key": "xy-edge__WubiiPZ6MyL1-VeRfM4LedsR1",
+      "source": {
+        "node": "WubiiPZ6MyL",
+        "param": "1"
+      },
+      "target": {
+        "node": "VeRfM4LedsR",
+        "param": "1"
+      }
+    },
+    {
+      "key": "xy-edge__WubiiPZ6MyL2-KWwYAhIaXR12",
+      "source": {
+        "node": "WubiiPZ6MyL",
+        "param": "2"
+      },
+      "target": {
+        "node": "KWwYAhIaXR1",
+        "param": "2"
+      }
+    },
+    {
+      "key": "xy-edge__IpSylSnCSc31-0KwRzIrJ4ii3",
+      "source": {
+        "node": "IpSylSnCSc3",
+        "param": "1"
+      },
+      "target": {
+        "node": "0KwRzIrJ4ii",
+        "param": "3"
+      }
+    },
+    {
+      "key": "xy-edge__IpSylSnCSc32-WubiiPZ6MyL3",
+      "source": {
+        "node": "IpSylSnCSc3",
+        "param": "2"
+      },
+      "target": {
+        "node": "WubiiPZ6MyL",
+        "param": "3"
+      }
+    },
+    {
+      "key": "xy-edge__rJ8HEDBlxlw4-SKO1UjHj1o31",
+      "source": {
+        "node": "rJ8HEDBlxlw",
+        "param": "4"
+      },
+      "target": {
+        "node": "SKO1UjHj1o3",
+        "param": "1"
+      }
+    },
+    {
+      "key": "xy-edge__7yLD0xOFddf1-VeRfM4LedsR5",
+      "source": {
+        "node": "7yLD0xOFddf",
+        "param": "1"
+      },
+      "target": {
+        "node": "VeRfM4LedsR",
+        "param": "5"
+      }
+    },
+    {
+      "key": "xy-edge__7yLD0xOFddf2-dkPgXB2tjWf4",
+      "source": {
+        "node": "7yLD0xOFddf",
+        "param": "2"
+      },
+      "target": {
+        "node": "dkPgXB2tjWf",
+        "param": "4"
+      }
+    },
+    {
+      "key": "xy-edge__dkPgXB2tjWf1-QLFXTKWz3DJ1",
+      "source": {
+        "node": "dkPgXB2tjWf",
+        "param": "1"
+      },
+      "target": {
+        "node": "QLFXTKWz3DJ",
+        "param": "1"
+      }
+    },
+    {
+      "key": "xy-edge__7yLD0xOFddf3-KWwYAhIaXR13",
+      "source": {
+        "node": "7yLD0xOFddf",
+        "param": "3"
+      },
+      "target": {
+        "node": "KWwYAhIaXR1",
+        "param": "3"
+      }
+    }
+  ],
+  "configs": {
+    "0DfbZ8yiwSP": {
+      "color": "#ff005f",
+      "label": {
+        "label": "Fuel PT 1",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048676
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["fuel_pt_1"],
+      "units": "psi",
+      "variant": "value"
+    },
+    "0KHm9MFPXRw": {
+      "color": "#004ad6",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 0
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 0
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 0
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "showChip": true,
+        "showIndicator": true
+      },
+      "label": {
+        "label": "OX Fill",
+        "level": "p",
+        "orientation": "top"
+      },
+      "normallyOpen": false,
+      "orientation": "left",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "solenoidValve"
+    },
+    "0KwRzIrJ4ii": {
+      "color": "#00d623",
+      "label": {
+        "label": "Purge PT",
+        "level": "p",
+        "orientation": "bottom"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048616
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["pneumatics_pt"],
+      "units": "psi",
+      "variant": "value"
+    },
+    "0jdKiNGUXdE": {
+      "color": "#004ad6",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "orientation": "left",
+      "scale": 1,
+      "variant": "tJunction"
+    },
+    "1Ajh5kZyqzw": {
+      "color": "#004ad6",
+      "segments": [
+        {
+          "direction": "x",
+          "length": -20.716482044354507
+        },
+        {
+          "direction": "y",
+          "length": 7.989755136102218
+        }
+      ],
+      "variant": "pipe"
+    },
+    "2VVcUzshHsS": {
+      "color": "#b300ff",
+      "dimensions": {
+        "height": 200,
+        "width": 145
+      },
+      "label": {
+        "label": "Supply",
+        "level": "p",
+        "orientation": "top"
+      },
+      "orientation": "left",
+      "variant": "tank"
+    },
+    "2i094l8SRqF": {
+      "color": "#ff005f",
+      "label": {
+        "label": "Fuel TC 2",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048606
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["fuel_tc_2"],
+      "units": "°C",
+      "variant": "value"
+    },
+    "2tj3wwbNsVf": {
+      "color": [28, 28, 28, 1],
+      "label": {
+        "label": "Solenoid Valve",
+        "level": "p",
+        "orientation": "top"
+      },
+      "normallyOpen": false,
+      "orientation": "left",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "solenoidValve"
+    },
+    "3BOalGA2TlR": {
+      "color": [250, 250, 250, 1],
+      "inlineSize": 70,
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Value",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "scale": 1,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048609
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["ox_pt_1"],
+      "units": "psi",
+      "variant": "value"
+    },
+    "3mJa8YZ6QW4": {
+      "color": [55, 116, 208, 1],
+      "control": {
+        "show": true
+      },
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Button",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "onClickDelay": 0,
+      "orientation": "left",
+      "scale": null,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "variant": "button"
+    },
+    "4NlCnochhRU": {
+      "color": [5, 5, 5, 1],
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Nozzle",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "orientation": "top",
+      "scale": 1,
+      "variant": "nozzle"
+    },
+    "5lnJLvZggVN": {
+      "color": "#004ad6",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048583
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048583
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048583
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "right",
+        "show": true,
+        "showChip": true,
+        "showIndicator": true
+      },
+      "label": {
+        "align": "center",
+        "direction": "y",
+        "label": "OX TPC 1",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "left"
+      },
+      "normallyOpen": false,
+      "orientation": "top",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048583
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048584
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "solenoidValve"
+    },
+    "6N2uycrsxNb": {
+      "color": [5, 5, 5, 1],
+      "control": {
+        "show": true
+      },
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Valve",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "right"
+      },
+      "orientation": "bottom",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "valve"
+    },
+    "7yLD0xOFddf": {
+      "color": "#ffa800",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "orientation": "right",
+      "scale": 1,
+      "variant": "tJunction"
+    },
+    "80031njI5Uo": {
+      "color": "#004ad6",
+      "dimensions": {
+        "height": 250,
+        "width": 150
+      },
+      "label": {
+        "label": "",
+        "level": "p",
+        "orientation": "top"
+      },
+      "orientation": "left",
+      "variant": "tank"
+    },
+    "8uYMBpb8zmt": {
+      "color": {
+        "rgba255": [5, 5, 5, 1]
+      },
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048666
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048666
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048666
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "right",
+        "showChip": true,
+        "showIndicator": true
+      },
+      "label": {
+        "label": "GB ISO 2",
+        "level": "p",
+        "orientation": "left"
+      },
+      "normallyOpen": false,
+      "orientation": "bottom",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048666
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048667
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "solenoidValve"
+    },
+    "AEjPdKnWFcT": {
+      "color": "#b300ff",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 0
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 0
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 0
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "right",
+        "showChip": true,
+        "showIndicator": true
+      },
+      "label": {
+        "label": "Gas Booster",
+        "level": "p",
+        "orientation": "right"
+      },
+      "orientation": "top",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "pistonPump"
+    },
+    "BLMwEwSkGNS": {
+      "color": "#004ad6",
+      "label": {
+        "label": "",
+        "level": "p",
+        "orientation": "top"
+      },
+      "orientation": "left",
+      "variant": "reliefValve"
+    },
+    "CST75HX7oD1": {
+      "color": "#b300ff",
+      "dimensions": {
+        "height": 250,
+        "width": 150
+      },
+      "label": {
+        "label": "",
+        "level": "p",
+        "orientation": "top"
+      },
+      "orientation": "left",
+      "variant": "tank"
+    },
+    "D2jnA2ygsRn": {
+      "color": "#ff005f",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048597
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048597
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048597
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "right",
+        "showChip": true,
+        "showIndicator": true
+      },
+      "label": {
+        "label": "Fuel Vent",
+        "level": "p",
+        "orientation": "bottom"
+      },
+      "normallyOpen": true,
+      "orientation": "bottom",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048597
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048598
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "solenoidValve"
+    },
+    "DeJ4iOHodtz": {
+      "color": "#b300ff",
+      "label": {
+        "label": "Press TC 1",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048607
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["press_tc_1"],
+      "units": "°C",
+      "variant": "value"
+    },
+    "EssNNAH7Oq9": {
+      "color": "#00d623",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 0
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 0
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 0
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "showChip": true,
+        "showIndicator": true
+      },
+      "label": {
+        "label": "Purge Valve",
+        "level": "p",
+        "orientation": "bottom"
+      },
+      "orientation": "bottom",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "threeWayValve"
+    },
+    "FV9nUNS95MO": {
+      "color": "#004ad6",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048650
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048650
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048650
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "right",
+        "showChip": true,
+        "showIndicator": true
+      },
+      "label": {
+        "label": "OX MPV",
+        "level": "p",
+        "orientation": "left"
+      },
+      "normallyOpen": false,
+      "orientation": "top",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048650
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048651
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "solenoidValve"
+    },
+    "FblmMlBenHA": {
+      "color": [250, 250, 250, 1],
+      "inlineSize": 70,
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Value",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "scale": 1,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048605
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["fuel_tc_1"],
+      "units": "psi",
+      "variant": "value"
+    },
+    "FiMLXRwc4xJ": {
+      "color": "#004ad6",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048648
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048648
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048648
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "showChip": true,
+        "showIndicator": true
+      },
+      "label": {
+        "label": "OX TPC 2",
+        "level": "p",
+        "orientation": "top"
+      },
+      "normallyOpen": false,
+      "orientation": "left",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048648
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048649
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "solenoidValve"
+    },
+    "GJ2YKKP0Z6y": {
+      "color": [5, 5, 5, 1],
+      "control": {
+        "show": true
+      },
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Solenoid Valve",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "normallyOpen": false,
+      "orientation": "top",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "solenoidValve"
+    },
+    "GXakOVjitf5": {
+      "color": "#ff005f",
+      "label": {
+        "label": "Fuel TC 1",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048605
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["fuel_tc_1"],
+      "units": "°C",
+      "variant": "value"
+    },
+    "GivrZPeMCEw": {
+      "color": "#004ad6",
+      "label": {
+        "label": "OX TC 1",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048668
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["ox_tc_1"],
+      "units": "psi",
+      "variant": "value"
+    },
+    "HH9i7jrQ0rH": {
+      "color": "#ff005f",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "orientation": "right",
+      "scale": 1,
+      "variant": "tJunction"
+    },
+    "HNeMkVQJMZZ": {
+      "color": "#b300ff",
+      "label": {
+        "label": "Value",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048680
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["supply_pt"],
+      "units": "psi",
+      "variant": "value"
+    },
+    "HUushIhVDc6": {
+      "color": [250, 250, 250, 1],
+      "inlineSize": 70,
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Value",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "scale": 1,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048603
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["ox_tc_1"],
+      "units": "psi",
+      "variant": "value"
+    },
+    "IoFGQ3ntavy": {
+      "color": "#ff005f",
+      "dimensions": {
+        "height": 250,
+        "width": 150
+      },
+      "label": {
+        "label": "",
+        "level": "p",
+        "orientation": "top"
+      },
+      "orientation": "left",
+      "variant": "tank"
+    },
+    "IpSylSnCSc3": {
+      "color": "#00d623",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048585
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048585
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048585
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "right",
+        "show": true,
+        "showChip": true,
+        "showIndicator": true
+      },
+      "label": {
+        "align": "center",
+        "direction": "y",
+        "label": "Purge",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "left"
+      },
+      "normallyOpen": false,
+      "orientation": "top",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048585
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048586
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "solenoidValve"
+    },
+    "K9nj3YBK0KG": {
+      "color": "#b300ff",
+      "label": {
+        "label": "Press PT 2",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048614
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["press_pt_2"],
+      "units": "psi",
+      "variant": "value"
+    },
+    "KWwYAhIaXR1": {
+      "color": "#004ad6",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048585
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048585
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048585
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "right",
+        "show": true,
+        "showChip": true,
+        "showIndicator": true
+      },
+      "label": {
+        "align": "center",
+        "direction": "y",
+        "label": "OX MPV",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "left"
+      },
+      "normallyOpen": false,
+      "orientation": "top",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048585
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048586
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "solenoidValve"
+    },
+    "KnJjTf7CJv9": {
+      "color": "#004ad6",
+      "inlineSize": 70,
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "OX TC 1",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "scale": 1,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048603
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["ox_tc_1"],
+      "units": "°C",
+      "variant": "value"
+    },
+    "L0MCB6oJASM": {
+      "color": "#ff005f",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048593
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048593
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048593
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "showChip": true,
+        "showIndicator": true
+      },
+      "label": {
+        "label": "Fuel Pre-Valve",
+        "level": "p",
+        "orientation": "top"
+      },
+      "normallyOpen": false,
+      "orientation": "left",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048593
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048594
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "solenoidValve"
+    },
+    "M4YDBbNwtI5": {
+      "color": [28, 28, 28, 1],
+      "label": {
+        "label": "Angled Relief Valve",
+        "level": "p",
+        "orientation": "top"
+      },
+      "orientation": "left",
+      "variant": "angledReliefValve"
+    },
+    "MEfIDo71Css": {
+      "color": "#004ad6",
+      "inlineSize": 70,
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "OX TC 2",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "scale": 1,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048604
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["ox_tc_2"],
+      "units": "°C",
+      "variant": "value"
+    },
+    "MN7bYyk3QeZ": {
+      "color": "#ff005f",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048658
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048658
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048658
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "left",
+        "showChip": true,
+        "showIndicator": true
+      },
+      "label": {
+        "label": "Fuel MPV",
+        "level": "p",
+        "orientation": "right"
+      },
+      "normallyOpen": false,
+      "orientation": "bottom",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048658
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048659
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "solenoidValve"
+    },
+    "NGZToy6pCHe": {
+      "color": "#004ad6",
+      "label": {
+        "label": "OX TC 2",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048669
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["ox_tc_2"],
+      "units": "psi",
+      "variant": "value"
+    },
+    "PYidicujg8Q": {
+      "color": "#ff005f",
+      "label": {
+        "label": "Fuel TC 1",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048670
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["fuel_tc_1"],
+      "units": "psi",
+      "variant": "value"
+    },
+    "Px7l7pDawuy": {
+      "color": "#ff005f",
+      "label": {
+        "label": "Fuel PT 2",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "redline": {
+        "bounds": {
+          "lower": 0,
+          "upper": 1
+        },
+        "gradient": []
+      },
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048612
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["fuel_pt_2"],
+      "units": "psi",
+      "variant": "value"
+    },
+    "Q6Ru747fTlZ": {
+      "color": "#004ad6",
+      "segments": [
+        {
+          "direction": "x",
+          "length": 23.574201383533193
+        },
+        {
+          "direction": "y",
+          "length": 9.71191345942043
+        }
+      ],
+      "variant": "pipe"
+    },
+    "QLFXTKWz3DJ": {
+      "color": "#ffa800",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048601
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048601
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048601
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "right",
+        "show": true,
+        "showChip": true,
+        "showIndicator": true
+      },
+      "label": {
+        "align": "center",
+        "direction": "y",
+        "label": "Gas Booster ISO",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "left"
+      },
+      "normallyOpen": false,
+      "orientation": "top",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048601
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048602
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "solenoidValve"
+    },
+    "QPKzX2O2699": {
+      "color": "#ff005f",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048656
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048656
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048656
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "left",
+        "showChip": true,
+        "showIndicator": true
+      },
+      "label": {
+        "label": "Fuel TPC 1",
+        "level": "p",
+        "orientation": "right"
+      },
+      "normallyOpen": false,
+      "orientation": "bottom",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048656
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048657
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "solenoidValve"
+    },
+    "Qt13TVgVdZD": {
+      "color": {
+        "rgba255": [5, 5, 5, 1]
+      },
+      "label": {
+        "label": "Accumulator PT",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048681
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["pneumatics_pt"],
+      "units": "psi",
+      "variant": "value"
+    },
+    "SKO1UjHj1o3": {
+      "color": "#00d623",
+      "label": {
+        "label": "Purge Reg",
+        "level": "p",
+        "orientation": "top"
+      },
+      "orientation": "left",
+      "variant": "regulator"
+    },
+    "T7tp2FvVzzl": {
+      "color": "#004ad6",
+      "label": {
+        "label": "OX PT 2",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048675
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["ox_pt_2"],
+      "units": "psi",
+      "variant": "value"
+    },
+    "UN8NV3qxaz7": {
+      "color": "#004ad6",
+      "inlineSize": 70,
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "OX PT 1",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "scale": 1,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048609
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["ox_pt_1"],
+      "units": "psi",
+      "variant": "value"
+    },
+    "Uf71mmzzyez": {
+      "color": "#b300ff",
+      "inlineSize": 90,
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Supply PT",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "scale": 1,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048615
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["supply_pt"],
+      "units": "psi",
+      "variant": "value"
+    },
+    "Uhas206b5VS": {
+      "color": [250, 250, 250, 1],
+      "inlineSize": 70,
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Value",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "scale": 1,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048608
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["press_tc_2"],
+      "units": "psi",
+      "variant": "value"
+    },
+    "VcyomMLraaN": {
+      "backgroundColor": [250, 250, 250, 0],
+      "borderRadius": {
+        "x": 50,
+        "y": 10
+      },
+      "color": "#004ad6",
+      "dimensions": {
+        "height": 250,
+        "width": 150
+      },
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "orientation": "left",
+      "scale": 1,
+      "variant": "tank"
+    },
+    "VeRfM4LedsR": {
+      "color": "#ff005f",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048593
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048593
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048593
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "left",
+        "show": true,
+        "showChip": true,
+        "showIndicator": true
+      },
+      "label": {
+        "align": "center",
+        "direction": "y",
+        "label": "Fuel MPV",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "right"
+      },
+      "normallyOpen": false,
+      "orientation": "bottom",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048593
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048594
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "solenoidValve"
+    },
+    "VmLXT8TtVfn": {
+      "color": "#ff005f",
+      "label": {
+        "label": "Fuel PT 1",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048611
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["fuel_pt_1"],
+      "units": "psi",
+      "variant": "value"
+    },
+    "W1dSGKqGk1f": {
+      "color": "#b300ff",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "orientation": "top",
+      "scale": 1,
+      "variant": "tJunction"
+    },
+    "WjNhadY8bYt": {
+      "color": [250, 250, 250, 1],
+      "inlineSize": 70,
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Value",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "redline": {
+        "bounds": {
+          "lower": 0,
+          "upper": 1
+        },
+        "gradient": []
+      },
+      "scale": 1,
+      "stalenessColor": [194, 157, 10, 1],
+      "stalenessTimeout": 5,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048610
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["ox_pt_2"],
+      "units": "psi",
+      "variant": "value"
+    },
+    "WubiiPZ6MyL": {
+      "color": "#00d623",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "orientation": "right",
+      "scale": 1,
+      "variant": "tJunction"
+    },
+    "XHvgACsGqDW": {
+      "color": "#004ad6",
+      "label": {
+        "label": "OX PT 1",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048674
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["ox_pt_1"],
+      "units": "psi",
+      "variant": "value"
+    },
+    "YtBdiWNERfU": {
+      "color": "#b300ff",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048587
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048587
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048587
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "show": true,
+        "showChip": true,
+        "showIndicator": true
+      },
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "OX Press Iso",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "bottom"
+      },
+      "normallyOpen": false,
+      "orientation": "left",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048587
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048588
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "solenoidValve"
+    },
+    "YwDKMURj1vp": {
+      "color": [5, 5, 5, 1],
+      "control": {
+        "show": true
+      },
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Angled Valve",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "orientation": "right",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "angledValve"
+    },
+    "ZXOfFkiBk9R": {
+      "color": [28, 28, 28, 1],
+      "label": {
+        "label": "Solenoid Valve",
+        "level": "p",
+        "orientation": "top"
+      },
+      "normallyOpen": false,
+      "orientation": "left",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "solenoidValve"
+    },
+    "a8tAqnEJba0": {
+      "color": [250, 250, 250, 1],
+      "inlineSize": 70,
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Value",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "scale": 1,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048613
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["press_pt_1"],
+      "units": "psi",
+      "variant": "value"
+    },
+    "c6BIYnWmuQX": {
+      "color": [5, 5, 5, 1],
+      "control": {
+        "show": true
+      },
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Solenoid Valve",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "normallyOpen": false,
+      "orientation": "bottom",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "solenoidValve"
+    },
+    "dkPgXB2tjWf": {
+      "color": "#ffa800",
+      "dimensions": {
+        "height": 200,
+        "width": 125
+      },
+      "label": {
+        "label": "",
+        "level": "p",
+        "orientation": "top"
+      },
+      "orientation": "left",
+      "variant": "tank"
+    },
+    "dlptAUF47pk": {
+      "color": "#ff005f",
+      "dimensions": {
+        "height": 250,
+        "width": 150
+      },
+      "label": {
+        "label": "",
+        "level": "p",
+        "orientation": "top"
+      },
+      "orientation": "left",
+      "variant": "tank"
+    },
+    "dofQxFOyrpw": {
+      "color": [28, 28, 28, 1],
+      "dimensions": {
+        "height": 200,
+        "width": 100
+      },
+      "label": {
+        "label": "Tank",
+        "level": "p",
+        "orientation": "top"
+      },
+      "orientation": "left",
+      "variant": "tank"
+    },
+    "dsiLFWHbVAK": {
+      "color": "#ff005f",
+      "label": {
+        "label": "Value",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": [""],
+      "units": "psi",
+      "variant": "value"
+    },
+    "e4JtXVcg02b": {
+      "color": [250, 250, 250, 1],
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "orientation": "left",
+      "scale": 2.25,
+      "variant": "nozzle"
+    },
+    "e6edPu5g4WW": {
+      "color": [28, 28, 28, 1],
+      "label": {
+        "label": "Solenoid Valve",
+        "level": "p",
+        "orientation": "top"
+      },
+      "normallyOpen": false,
+      "orientation": "left",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "solenoidValve"
+    },
+    "ed2fKMvty6b": {
+      "color": "#b300ff",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048595
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048595
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048595
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "showChip": true,
+        "showIndicator": true
+      },
+      "label": {
+        "label": "Fuel Press ISO",
+        "level": "p",
+        "orientation": "top"
+      },
+      "normallyOpen": false,
+      "orientation": "left",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048595
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048596
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "solenoidValve"
+    },
+    "f1ENRWs0FIf": {
+      "color": [250, 250, 250, 1],
+      "control": {
+        "show": true
+      },
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Three Way Valve",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "orientation": "left",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "threeWayValve"
+    },
+    "gskjCS25iAe": {
+      "color": [250, 250, 250, 1],
+      "inlineSize": 70,
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Value",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "scale": 1,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048603
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["ox_tc_1"],
+      "units": "psi",
+      "variant": "value"
+    },
+    "juGKtTasf2m": {
+      "color": [28, 28, 28, 1],
+      "dimensions": {
+        "height": 200,
+        "width": 100
+      },
+      "label": {
+        "label": "Tank",
+        "level": "p",
+        "orientation": "top"
+      },
+      "orientation": "left",
+      "variant": "tank"
+    },
+    "k9XCuVYxOzB": {
+      "color": [55, 116, 208, 1],
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048618
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048618
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048618
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "show": true,
+        "showChip": true,
+        "showIndicator": true
+      },
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Start Sequence",
+        "level": "h4",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "onClickDelay": 0,
+      "orientation": "left",
+      "scale": null,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048618
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "variant": "button"
+    },
+    "kbJw2Oi5Ueu": {
+      "color": "#b300ff",
+      "label": {
+        "label": "",
+        "level": "p",
+        "orientation": "top"
+      },
+      "orientation": "left",
+      "variant": "regulator"
+    },
+    "mDHz94NwfKE": {
+      "color": [250, 250, 250, 1],
+      "inlineSize": 70,
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Value",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "redline": {
+        "bounds": {
+          "lower": 0,
+          "upper": 1
+        },
+        "gradient": []
+      },
+      "scale": 1,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048606
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["fuel_tc_2"],
+      "units": "psi",
+      "variant": "value"
+    },
+    "mJ0fxQiPaDP": {
+      "color": "#ff005f",
+      "label": {
+        "label": "Fuel TC 2",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048671
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["fuel_tc_2"],
+      "units": "psi",
+      "variant": "value"
+    },
+    "mRrQTum99UZ": {
+      "color": {
+        "rgba255": [5, 5, 5, 1]
+      },
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048666
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048666
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048666
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "right",
+        "showChip": true,
+        "showIndicator": true
+      },
+      "label": {
+        "label": "GB ISO 1",
+        "level": "p",
+        "orientation": "left"
+      },
+      "normallyOpen": false,
+      "orientation": "bottom",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048666
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048667
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "solenoidValve"
+    },
+    "n4pmPCUcMaw": {
+      "color": "#004ad6",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048585
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048585
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048585
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "showChip": true,
+        "showIndicator": true
+      },
+      "label": {
+        "label": "OX Pre-Valve",
+        "level": "p",
+        "orientation": "top"
+      },
+      "normallyOpen": false,
+      "orientation": "left",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048585
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048586
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "solenoidValve"
+    },
+    "nDyx6eSCxsX": {
+      "color": "#004ad6",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048648
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048648
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048648
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "showChip": true,
+        "showIndicator": true
+      },
+      "label": {
+        "label": "OX TPC 1",
+        "level": "p",
+        "orientation": "top"
+      },
+      "normallyOpen": false,
+      "orientation": "left",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048648
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048649
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "solenoidValve"
+    },
+    "nikWEdQSwLr": {
+      "color": "#ff005f",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048591
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048591
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048591
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "left",
+        "show": true,
+        "showChip": true,
+        "showIndicator": true
+      },
+      "label": {
+        "align": "center",
+        "direction": "y",
+        "label": "Fuel TPC 1",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "right"
+      },
+      "normallyOpen": false,
+      "orientation": "bottom",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048591
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048592
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "solenoidValve"
+    },
+    "oB0skpbvoqc": {
+      "color": "#b300ff",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048664
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048664
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048664
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "left",
+        "showChip": true,
+        "showIndicator": true
+      },
+      "label": {
+        "label": "OX Press ISO",
+        "level": "p",
+        "orientation": "right"
+      },
+      "normallyOpen": false,
+      "orientation": "top",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048664
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048665
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "solenoidValve"
+    },
+    "ojXq08A1bLP": {
+      "color": "#ff005f",
+      "label": {
+        "label": "",
+        "level": "p",
+        "orientation": "top"
+      },
+      "orientation": "bottom",
+      "variant": "angledReliefValve"
+    },
+    "p2dLrZf6mMv": {
+      "color": "#ff005f",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048591
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048591
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048591
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "right",
+        "show": true,
+        "showChip": true,
+        "showIndicator": true
+      },
+      "label": {
+        "align": "center",
+        "direction": "y",
+        "label": "Fuel TPC 2",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "left"
+      },
+      "normallyOpen": false,
+      "orientation": "top",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048591
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048592
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "solenoidValve"
+    },
+    "ptsh5LVBq2y": {
+      "color": "#004ad6",
+      "label": {
+        "label": "Value",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "units": "psi",
+      "variant": "value"
+    },
+    "q2BvScO3Tvx": {
+      "color": [250, 250, 250, 1],
+      "inlineSize": 70,
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Value",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "scale": 1,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048612
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["fuel_pt_2"],
+      "units": "psi",
+      "variant": "value"
+    },
+    "qKNvIK45GCK": {
+      "color": "#004ad6",
+      "inlineSize": 70,
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "OX PT 2",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "scale": 1,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048610
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["ox_pt_2"],
+      "units": "psi",
+      "variant": "value"
+    },
+    "qUGRcDkaBIx": {
+      "color": "#004ad6",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048583
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048583
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048583
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "left",
+        "show": true,
+        "showChip": true,
+        "showIndicator": true
+      },
+      "label": {
+        "align": "center",
+        "direction": "y",
+        "label": "OX TPC 2",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "right"
+      },
+      "normallyOpen": false,
+      "orientation": "bottom",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048583
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048584
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "solenoidValve"
+    },
+    "qo0xVKkc4oR": {
+      "color": "#004ad6",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048589
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048589
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048589
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "left",
+        "showChip": true,
+        "showIndicator": true
+      },
+      "label": {
+        "label": "OX Vent",
+        "level": "p",
+        "orientation": "bottom"
+      },
+      "normallyOpen": true,
+      "orientation": "bottom",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048589
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048590
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "solenoidValve"
+    },
+    "rCUKZktR3sZ": {
+      "color": "#b300ff",
+      "label": {
+        "label": "Press PT 1",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048613
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["press_pt_1"],
+      "units": "psi",
+      "variant": "value"
+    },
+    "rJ8HEDBlxlw": {
+      "backgroundColor": [255, 0, 255, 0.01],
+      "borderRadius": {
+        "x": 50,
+        "y": 25
+      },
+      "color": "#b300ff",
+      "dimensions": {
+        "height": 200,
+        "width": 139
+      },
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "orientation": "left",
+      "scale": 1,
+      "variant": "tank"
+    },
+    "rTobk1G30ly": {
+      "color": "#004ad6",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "orientation": "right",
+      "scale": 1,
+      "variant": "tJunction"
+    },
+    "reactflow__edge-SKO1UjHj1o32-0KwRzIrJ4ii1": {
+      "color": "#00d623",
+      "segments": [
+        {
+          "direction": "y",
+          "length": -0.68135597075036
+        },
+        {
+          "direction": "x",
+          "length": 16.39057730435846
+        }
+      ],
+      "variant": "pneumatic"
+    },
+    "sXCSKGCQGy2": {
+      "color": "#EDEDED",
+      "label": {
+        "label": "Solenoid Valve",
+        "level": "p",
+        "orientation": "top"
+      },
+      "normallyOpen": false,
+      "orientation": "left",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "solenoidValve"
+    },
+    "solQ4AaAaWx": {
+      "color": [5, 5, 5, 1],
+      "control": {
+        "show": true
+      },
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Valve",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "orientation": "left",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "valve"
+    },
+    "tKyeVybyb2Z": {
+      "color": "#b300ff",
+      "control": {
+        "orientation": "right",
+        "show": true
+      },
+      "label": {
+        "align": "center",
+        "direction": "y",
+        "label": "Gas Booster",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "right"
+      },
+      "orientation": "top",
+      "scale": 1,
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "pistonPump"
+    },
+    "tcY77CQT5aV": {
+      "color": "#ff005f",
+      "label": {
+        "label": "Fuel PT 2",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048677
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["fuel_pt_2"],
+      "units": "psi",
+      "variant": "value"
+    },
+    "tqDmVLRLuXg": {
+      "color": [28, 28, 28, 1],
+      "label": {
+        "label": "Solenoid Valve",
+        "level": "p",
+        "orientation": "top"
+      },
+      "normallyOpen": false,
+      "orientation": "left",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 0
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 0
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "solenoidValve"
+    },
+    "vITJzpd1U32": {
+      "color": "#ff005f",
+      "control": {
+        "chip": {
+          "sink": {
+            "props": {
+              "authority": 255,
+              "channel": 1048656
+            },
+            "type": "acquire-channel-control",
+            "valueType": "boolean",
+            "variant": "sink"
+          },
+          "source": {
+            "props": {
+              "channel": 1048656
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "indicator": {
+          "statusSource": {
+            "props": {
+              "channel": 1048656
+            },
+            "type": "controlled-status-source",
+            "valueType": "status",
+            "variant": "source"
+          }
+        },
+        "orientation": "right",
+        "showChip": true,
+        "showIndicator": true
+      },
+      "label": {
+        "label": "Fuel TPC 2",
+        "level": "p",
+        "orientation": "left"
+      },
+      "normallyOpen": false,
+      "orientation": "bottom",
+      "sink": {
+        "props": {
+          "connections": [
+            {
+              "from": "setpoint",
+              "to": "setter"
+            }
+          ],
+          "inlet": "setpoint",
+          "segments": {
+            "setpoint": {
+              "props": {
+                "falsy": 0,
+                "truthy": 1
+              },
+              "type": "boolean-numeric-converter-sink",
+              "valueType": "boolean",
+              "variant": "sink"
+            },
+            "setter": {
+              "props": {
+                "channel": 1048656
+              },
+              "type": "controlled-numeric-telem-sink",
+              "valueType": "number",
+              "variant": "sink"
+            }
+          }
+        },
+        "type": "sink-pipeline",
+        "valueType": "boolean",
+        "variant": "sink"
+      },
+      "source": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "threshold"
+            }
+          ],
+          "outlet": "threshold",
+          "segments": {
+            "threshold": {
+              "props": {
+                "trueBound": {
+                  "lower": 0.9,
+                  "upper": 1.1
+                }
+              },
+              "type": "boolean-source",
+              "valueType": "boolean",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048657
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "boolean",
+        "variant": "source"
+      },
+      "variant": "solenoidValve"
+    },
+    "vKY6rgCFLAP": {
+      "color": [250, 250, 250, 1],
+      "inlineSize": 70,
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Value",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "scale": 1,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048604
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["ox_tc_2"],
+      "units": "psi",
+      "variant": "value"
+    },
+    "vVP5HNMj1sk": {
+      "color": "#b300ff",
+      "label": {
+        "label": "Press TC 2",
+        "level": "p",
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048608
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["press_tc_2"],
+      "units": "°C",
+      "variant": "value"
+    },
+    "wGdFMnYeLk8": {
+      "color": "#ff005f",
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "orientation": "left",
+      "scale": 1,
+      "variant": "tJunction"
+    },
+    "xy-edge__0jdKiNGUXdE1-5lnJLvZggVN1": {
+      "color": "#004ad6",
+      "segments": [
+        {
+          "direction": "x",
+          "length": -21.793890705579884
+        },
+        {
+          "direction": "y",
+          "length": -3.731337495209658
+        }
+      ],
+      "variant": "pipe"
+    },
+    "xy-edge__0jdKiNGUXdE2-qUGRcDkaBIx2": {
+      "color": "#004ad6",
+      "segments": [
+        {
+          "direction": "x",
+          "length": 22.49688090288504
+        },
+        {
+          "direction": "y",
+          "length": -5.00919456888724
+        }
+      ],
+      "variant": "pipe"
+    },
+    "xy-edge__0jdKiNGUXdE3-VcyomMLraaN1": {
+      "color": "#004ad6",
+      "segments": [],
+      "variant": "pipe"
+    },
+    "xy-edge__7yLD0xOFddf1-VeRfM4LedsR5": {
+      "color": "#ffa800",
+      "segments": [
+        {
+          "direction": "x",
+          "length": 143.39074974479786
+        },
+        {
+          "direction": "y",
+          "length": -409.31863868479536
+        }
+      ],
+      "variant": "pneumatic"
+    },
+    "xy-edge__7yLD0xOFddf2-dkPgXB2tjWf4": {
+      "color": "#ffa800",
+      "segments": [
+        {
+          "direction": "x",
+          "length": -591.675536248489
+        },
+        {
+          "direction": "y",
+          "length": -35.573951714250825
+        }
+      ],
+      "variant": "pneumatic"
+    },
+    "xy-edge__7yLD0xOFddf3-KWwYAhIaXR13": {
+      "color": "#ff8700",
+      "segments": [
+        {
+          "direction": "y",
+          "length": -191.81169481483067
+        },
+        {
+          "direction": "x",
+          "length": 0.3825097941260083
+        },
+        {
+          "direction": "y",
+          "length": -191.81169481483067
+        }
+      ],
+      "variant": "pipe"
+    },
+    "xy-edge__BLMwEwSkGNS2-VcyomMLraaN2": {
+      "color": "#004ad6",
+      "segments": [
+        {
+          "direction": "x",
+          "length": 69.70495914735761
+        },
+        {
+          "direction": "y",
+          "length": 0.6487563554264568
+        }
+      ],
+      "variant": "pipe"
+    },
+    "xy-edge__CST75HX7oD13-W1dSGKqGk1f1": {
+      "color": "#b300ff",
+      "segments": [
+        {
+          "direction": "y",
+          "length": -10.039775396275516
+        }
+      ],
+      "variant": "pipe"
+    },
+    "xy-edge__HH9i7jrQ0rH1-nikWEdQSwLr1": {
+      "color": "#ff005f",
+      "segments": [
+        {
+          "direction": "x",
+          "length": 28.315795171673017
+        },
+        {
+          "direction": "y",
+          "length": 13.284495288420302
+        }
+      ],
+      "variant": "pipe"
+    },
+    "xy-edge__HH9i7jrQ0rH2-p2dLrZf6mMv2": {
+      "color": "#ff005f",
+      "segments": [
+        {
+          "direction": "x",
+          "length": -22.48758695778497
+        },
+        {
+          "direction": "y",
+          "length": 13.359374693752756
+        }
+      ],
+      "variant": "pipe"
+    },
+    "xy-edge__IpSylSnCSc31-0KwRzIrJ4ii3": {
+      "color": "#00d623",
+      "segments": [
+        {
+          "direction": "y",
+          "length": 2.0174437145679462
+        },
+        {
+          "direction": "x",
+          "length": 0.6914358648206189
+        },
+        {
+          "direction": "y",
+          "length": 2.0174437145679462
+        }
+      ],
+      "variant": "pneumatic"
+    },
+    "xy-edge__IpSylSnCSc32-WubiiPZ6MyL3": {
+      "color": "#00d623",
+      "segments": [
+        {
+          "direction": "y",
+          "length": -394.8873653848603
+        },
+        {
+          "direction": "x",
+          "length": 164.99041929803252
+        }
+      ],
+      "variant": "pneumatic"
+    },
+    "xy-edge__KWwYAhIaXR11-e4JtXVcg02b1": {
+      "color": "#004ad6",
+      "segments": [
+        {
+          "direction": "y",
+          "length": 53.96528189980745
+        },
+        {
+          "direction": "x",
+          "length": 6.52497957938192
+        }
+      ],
+      "variant": "jacketed"
+    },
+    "xy-edge__L0MCB6oJASM1-VeRfM4LedsR1": {
+      "color": "#ff005f",
+      "segments": [
+        {
+          "direction": "x",
+          "length": -7.611323970725607
+        },
+        {
+          "direction": "y",
+          "length": -309.19018796850656
+        },
+        {
+          "direction": "x",
+          "length": -75.17733871291239
+        },
+        {
+          "direction": "y",
+          "length": 11.41698595608846
+        }
+      ],
+      "variant": "jacketed"
+    },
+    "xy-edge__L0MCB6oJASM2-dlptAUF47pk4": {
+      "color": "#ff005f",
+      "segments": [
+        {
+          "direction": "x",
+          "length": 10.019709615372676
+        },
+        {
+          "direction": "y",
+          "length": -75.83755794798219
+        }
+      ],
+      "variant": "jacketed"
+    },
+    "xy-edge__QLFXTKWz3DJ2-tKyeVybyb2Z3": {
+      "color": "#ffa800",
+      "segments": [
+        {
+          "direction": "y",
+          "length": -21.738221317205273
+        },
+        {
+          "direction": "x",
+          "length": 21.15953941272413
+        }
+      ],
+      "variant": "pneumatic"
+    },
+    "xy-edge__VcyomMLraaN4-n4pmPCUcMaw1": {
+      "color": "#004ad6",
+      "segments": [
+        {
+          "direction": "y",
+          "length": 65.73827310334042
+        },
+        {
+          "direction": "x",
+          "length": 3.1963217423690367
+        }
+      ],
+      "variant": "jacketed"
+    },
+    "xy-edge__VeRfM4LedsR2-e4JtXVcg02b3": {
+      "color": "#ff005f",
+      "segments": [
+        {
+          "direction": "y",
+          "length": 53.754320025149354
+        },
+        {
+          "direction": "x",
+          "length": -9.201999214856187
+        }
+      ],
+      "variant": "jacketed"
+    },
+    "xy-edge__W1dSGKqGk1f2-ed2fKMvty6b1": {
+      "color": "#b300ff",
+      "segments": [
+        {
+          "direction": "y",
+          "length": -22.615541532458984
+        },
+        {
+          "direction": "x",
+          "length": 565.9781892716524
+        }
+      ],
+      "variant": "pneumatic"
+    },
+    "xy-edge__WubiiPZ6MyL1-VeRfM4LedsR1": {
+      "color": "#00d623",
+      "segments": [
+        {
+          "direction": "x",
+          "length": 28.475551507762702
+        },
+        {
+          "direction": "y",
+          "length": 61.542975628650595
+        }
+      ],
+      "variant": "pipe"
+    },
+    "xy-edge__WubiiPZ6MyL2-KWwYAhIaXR12": {
+      "color": "#00d623",
+      "segments": [
+        {
+          "direction": "x",
+          "length": -30.43898067844509
+        },
+        {
+          "direction": "y",
+          "length": 61.33199895582936
+        }
+      ],
+      "variant": "pipe"
+    },
+    "xy-edge__YtBdiWNERfU1-W1dSGKqGk1f3": {
+      "color": "#b300ff",
+      "segments": [
+        {
+          "direction": "x",
+          "length": -28.81734564078576
+        }
+      ],
+      "variant": "pneumatic"
+    },
+    "xy-edge__YtBdiWNERfU2-rTobk1G30ly3": {
+      "color": "#b300ff",
+      "segments": [
+        {
+          "direction": "x",
+          "length": 134.19966632900412
+        }
+      ],
+      "variant": "pneumatic"
+    },
+    "xy-edge__dkPgXB2tjWf1-QLFXTKWz3DJ1": {
+      "color": "#ffa800",
+      "segments": [
+        {
+          "direction": "y",
+          "length": -9.197029958844112
+        }
+      ],
+      "variant": "pipe"
+    },
+    "xy-edge__dkPgXB2tjWf8-kbJw2Oi5Ueu1": {
+      "color": "#ffa800",
+      "segments": [
+        {
+          "direction": "x",
+          "length": 16.27623344266015
+        },
+        {
+          "direction": "y",
+          "length": -22.810077513322653
+        },
+        {
+          "direction": "x",
+          "length": 15.00767944753921
+        }
+      ],
+      "variant": "pneumatic"
+    },
+    "xy-edge__dlptAUF47pk3-D2jnA2ygsRn1": {
+      "color": "#ff005f",
+      "segments": [
+        {
+          "direction": "y",
+          "length": -7.476031885797475
+        },
+        {
+          "direction": "x",
+          "length": 42.70918634908844
+        },
+        {
+          "direction": "y",
+          "length": 37.25798079296152
+        }
+      ],
+      "variant": "pipe"
+    },
+    "xy-edge__dlptAUF47pk3-ojXq08A1bLP1": {
+      "color": "#ff005f",
+      "segments": [
+        {
+          "direction": "y",
+          "length": -7.042165376339312
+        },
+        {
+          "direction": "x",
+          "length": 58.16473197597054
+        }
+      ],
+      "variant": "pipe"
+    },
+    "xy-edge__ed2fKMvty6b2-HH9i7jrQ0rH3": {
+      "color": "#b300ff",
+      "segments": [
+        {
+          "direction": "x",
+          "length": 150.30660167606368
+        },
+        {
+          "direction": "y",
+          "length": 33.48017219193998
+        }
+      ],
+      "variant": "pneumatic"
+    },
+    "xy-edge__kbJw2Oi5Ueu2-rJ8HEDBlxlw7": {
+      "color": "#b300ff",
+      "segments": [
+        {
+          "direction": "x",
+          "length": 8.809159885799176
+        }
+      ],
+      "variant": "pipe"
+    },
+    "xy-edge__n4pmPCUcMaw2-KWwYAhIaXR12": {
+      "color": "#004ad6",
+      "segments": [
+        {
+          "direction": "y",
+          "length": -281.7166395035551
+        },
+        {
+          "direction": "x",
+          "length": 140.06190790464655
+        }
+      ],
+      "variant": "jacketed"
+    },
+    "xy-edge__nikWEdQSwLr2-wGdFMnYeLk82": {
+      "color": "#ff005f",
+      "segments": [
+        {
+          "direction": "y",
+          "length": 16.10347799420603
+        },
+        {
+          "direction": "x",
+          "length": -20.087778293132487
+        }
+      ],
+      "variant": "pipe"
+    },
+    "xy-edge__p2dLrZf6mMv1-wGdFMnYeLk81": {
+      "color": "#ff005f",
+      "segments": [
+        {
+          "direction": "y",
+          "length": 16.028598588873564
+        },
+        {
+          "direction": "x",
+          "length": 30.71572590663834
+        }
+      ],
+      "variant": "pipe"
+    },
+    "xy-edge__qo0xVKkc4oR1-VcyomMLraaN2": {
+      "color": "#004ad6",
+      "segments": [
+        {
+          "direction": "y",
+          "length": -37.20517609369677
+        },
+        {
+          "direction": "x",
+          "length": 57.59372717520836
+        }
+      ],
+      "variant": "pipe"
+    },
+    "xy-edge__rJ8HEDBlxlw1-tKyeVybyb2Z1": {
+      "color": "#b300ff",
+      "segments": [
+        {
+          "direction": "y",
+          "length": -26.010401116607028
+        },
+        {
+          "direction": "x",
+          "length": -233.4057355441728
+        },
+        {
+          "direction": "y",
+          "length": -20.1443659962018
+        }
+      ],
+      "variant": "pipe"
+    },
+    "xy-edge__rJ8HEDBlxlw4-SKO1UjHj1o31": {
+      "color": "#00d623",
+      "segments": [
+        {
+          "direction": "y",
+          "length": 7.603945168920745
+        },
+        {
+          "direction": "x",
+          "length": 68.0145904837911
+        }
+      ],
+      "variant": "pneumatic"
+    },
+    "xy-edge__tKyeVybyb2Z2-CST75HX7oD14": {
+      "color": "#b300ff",
+      "segments": [],
+      "variant": "pipe"
+    },
+    "xy-edge__wGdFMnYeLk83-dlptAUF47pk1": {
+      "color": "#ff005f",
+      "segments": [],
+      "variant": "pipe"
+    },
+    "yAfA5biPqIA": {
+      "color": "#ffa800",
+      "inlineSize": 78,
+      "label": {
+        "align": "center",
+        "direction": "x",
+        "label": "Accumulator PT",
+        "level": "p",
+        "maxInlineSize": 150,
+        "orientation": "top"
+      },
+      "level": "h5",
+      "orientation": "left",
+      "scale": 1,
+      "telem": {
+        "props": {
+          "connections": [
+            {
+              "from": "valueStream",
+              "to": "rollingAverage"
+            },
+            {
+              "from": "rollingAverage",
+              "to": "stringifier"
+            }
+          ],
+          "outlet": "stringifier",
+          "segments": {
+            "rollingAverage": {
+              "props": {
+                "windowSize": 1
+              },
+              "type": "rolling-average",
+              "valueType": "number",
+              "variant": "source"
+            },
+            "stringifier": {
+              "props": {
+                "notation": "standard",
+                "precision": 2
+              },
+              "type": "stringify-number",
+              "valueType": "string",
+              "variant": "source"
+            },
+            "valueStream": {
+              "props": {
+                "channel": 1048616
+              },
+              "type": "stream-channel-value",
+              "valueType": "number",
+              "variant": "source"
+            }
+          }
+        },
+        "type": "source-pipeline",
+        "valueType": "string",
+        "variant": "source"
+      },
+      "tooltip": ["pneumatics_pt"],
+      "units": "psi",
+      "variant": "value"
+    }
+  }
+}


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4312](https://linear.app/synnax/issue/SY-4312)

## Description

Importing a schematic authored before 0.56 (e.g. a 0.55 export) produced "pigtail" / off routing on edge segments — a self-crossing hook on the target end, plus an over-long source stub.

**Root cause:** pre-0.56 schematics stored the *complete* edge path, including both the source and target stumps, in the segments field. The 0.56 model changed that field to store only the *middle*, with the stumps auto-derived and stitched back on render. Both the console v5→v6 migration (`migrateEdge`) and the Go core migration (`core/pkg/service/schematic/migrate.go`) lifted the old full-path segments through verbatim, so on render the connector added a *second* pair of stumps — doubling the source stub and folding a pigtail back over the target handle.

**Fix:** strip the stored stumps during v5→v6 migration so the persisted config matches the middle-only model. The stumps are always the first and last segments, so their orientation is read directly off the segment data — no rendered handle geometry required, and robust to handle drift between versions (the middle is preserved and the renderer re-derives stumps for the current handle positions).

**Degenerate edges:** an edge whose stumps overlap — a single segment shorter than two stumps, or a first/last segment shorter than one stump — has no middle to preserve, and subtracting a full stump would flip the segment into a self-crossing spur. These are cleared to `[]` so they auto-route, which handles short / facing handles cleanly.

**Parity:** the same fix is applied to the Go core migration, which performed the identical verbatim lift. This keeps the console and server v5→v6 paths in parity (the bug reaches the renderer via either path).

### Verification

Validated against a real 40-edge 0.55 schematic run through the actual `extractMiddle` + `stitchEdge`:

- 37 edges strip faithfully — the rendered path reproduces the original 0.55 routing exactly.
- 2 short single-segment edges (11.88px, 17.86px) — without the degenerate guard these stripped into self-crossing spurs; they now clear and auto-route.
- 0 corruptions across all edges.

The same schematic is committed as a Go fixture (`v5_operator.json`) and exercised end-to-end through the core migration, with its canonical migrated output checked in.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.