### PR TITLE
SY-4311: Fix Workspace Import

### DIFF
--- a/console/src/import/ingester.ts
+++ b/console/src/import/ingester.ts
@@ -8,7 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { type Store } from "@reduxjs/toolkit";
-import { type Synnax, type workspace } from "@synnaxlabs/client";
+import { type ontology, type Synnax, type workspace } from "@synnaxlabs/client";
 import { type Pluto } from "@synnaxlabs/pluto";
 
 import { type Layout } from "@/layout";
@@ -27,7 +27,10 @@ export interface FileIngesterContext {
 }
 
 export interface FileIngester {
-  (data: unknown, ctx: FileIngesterContext): void | Promise<void>;
+  (
+    data: unknown,
+    ctx: FileIngesterContext,
+  ): void | ontology.ID | Promise<void | ontology.ID>;
 }
 
 export interface FileIngesters extends Record<string, FileIngester> {}

--- a/console/src/schematic/services/import.ts
+++ b/console/src/schematic/services/import.ts
@@ -49,4 +49,5 @@ export const ingest: Import.FileIngester = async (
   const { key, name } = created;
   store.schematics.set(key, created);
   placeLayout(create({ ...layout, key, name, type: LAYOUT_TYPE }));
+  return schematic.ontologyID(key);
 };

--- a/console/src/table/services/import.ts
+++ b/console/src/table/services/import.ts
@@ -51,4 +51,5 @@ export const ingest: Import.FileIngester = async (
   placeLayout(
     create({ ...layout, key: created.key, name: created.name, type: LAYOUT_TYPE }),
   );
+  return table.ontologyID(created.key);
 };

--- a/console/src/workspace/services/import.spec.tsx
+++ b/console/src/workspace/services/import.spec.tsx
@@ -1,0 +1,205 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import {
+  combineReducers,
+  configureStore,
+  type Reducer,
+  type Store,
+  type UnknownAction,
+} from "@reduxjs/toolkit";
+import { createTestClient, type Synnax, workspace } from "@synnaxlabs/client";
+import { Drift } from "@synnaxlabs/drift";
+import { Access, Flux, Pluto, Status, Synnax as PSynnax } from "@synnaxlabs/pluto";
+import { deep, id } from "@synnaxlabs/x";
+import { act, renderHook, waitFor } from "@testing-library/react";
+import { type PropsWithChildren, type ReactElement } from "react";
+import { Provider } from "react-redux";
+import { beforeAll, describe, expect, it } from "vitest";
+
+import { type Import } from "@/import";
+import { Layout } from "@/layout";
+import { Schematic } from "@/schematic";
+import { SchematicServices } from "@/schematic/services";
+import { Table } from "@/table";
+import { TableServices } from "@/table/services";
+import { Workspace } from "@/workspace";
+import { WorkspaceServices } from "@/workspace/services";
+
+const client: Synnax = createTestClient();
+
+const WINDOW_KEY = "main";
+const SCHEMATIC_TYPE = "schematic";
+const TABLE_TYPE = "table";
+const OPERATOR_KEY = "34c0a87c-3f72-42d2-8cac-75bc1e2631b1";
+const THERMO_KEY = "cdb27884-a73f-4696-bcee-a71c1f6625bd";
+
+// The real ingesters for these types; the full FILE_INGESTERS registry would drag in
+// the Arc/Monaco editor, which Vitest can't load.
+const FILE_INGESTERS: Import.FileIngesters = {
+  ...SchematicServices.FILE_INGESTERS,
+  ...TableServices.FILE_INGESTERS,
+};
+
+const SCHEMATIC_DATA = {
+  key: OPERATOR_KEY,
+  name: "Operator",
+  type: SCHEMATIC_TYPE,
+  version: "6.0.0",
+  snapshot: false,
+  nodes: [{ key: "n1", position: { x: 0, y: 0 } }],
+  edges: [],
+  configs: { n1: { variant: "valve", color: [28, 28, 28, 1] } },
+};
+
+const TABLE_DATA = {
+  key: THERMO_KEY,
+  name: "Thermocouples",
+  type: TABLE_TYPE,
+  version: "1.0.0",
+  rows: [{ size: 36, cells: ["c1"] }],
+  columns: [{ size: 72 }],
+  cells: { c1: { key: "c1", variant: "text", props: { value: "hello" } } },
+};
+
+const rootReducer = combineReducers({
+  [Layout.SLICE_NAME]: Layout.reducer,
+  [Schematic.SLICE_NAME]: Schematic.reducer,
+  [Table.SLICE_NAME]: Table.reducer,
+  [Workspace.SLICE_NAME]: Workspace.reducer,
+  drift: Drift.reducer,
+}) as unknown as Reducer<Record<string, unknown>, UnknownAction>;
+
+// An exported layout slice with a schematic and a table tab, each keyed to match the
+// resource key in the corresponding component file.
+const exportedSlice = (): Layout.SliceState => {
+  let s = Layout.reducer(undefined, { type: "@@INIT" });
+  s = Layout.reducer(
+    s,
+    Layout.place({
+      windowKey: WINDOW_KEY,
+      key: OPERATOR_KEY,
+      type: SCHEMATIC_TYPE,
+      name: "Operator",
+      location: "mosaic",
+    }),
+  );
+  s = Layout.reducer(
+    s,
+    Layout.place({
+      windowKey: WINDOW_KEY,
+      key: THERMO_KEY,
+      type: TABLE_TYPE,
+      name: "Thermocouples",
+      location: "mosaic",
+    }),
+  );
+  return s;
+};
+
+const layoutsOfType = (store: Store, type: string): Layout.State[] =>
+  Object.values(Layout.selectSliceState(store.getState() as never).layouts).filter(
+    (l) => l.type === type,
+  );
+
+interface HarnessValue {
+  placer: Layout.Placer;
+  fluxStore: Pluto.FluxStore;
+  granted: boolean;
+}
+
+describe("workspace import", () => {
+  let fluxClient: Flux.Client;
+
+  beforeAll(async () => {
+    fluxClient = new Flux.Client({
+      client,
+      storeConfig: Pluto.FLUX_STORE_CONFIG,
+      handleError: () => {},
+      handleAsyncError: async () => {},
+    });
+    await fluxClient.awaitInitialized();
+  });
+
+  const runImport = async (fileList: Import.File[] = files()): Promise<Store> => {
+    const store = configureStore({ reducer: rootReducer });
+    const wrapper = ({ children }: PropsWithChildren): ReactElement => (
+      <Provider store={store}>
+        <Status.Aggregator>
+          <PSynnax.TestProvider client={client}>
+            <Flux.Provider client={fluxClient}>{children}</Flux.Provider>
+          </PSynnax.TestProvider>
+        </Status.Aggregator>
+      </Provider>
+    );
+    const { result } = renderHook<HarnessValue, unknown>(
+      () => ({
+        placer: Layout.usePlacer(),
+        fluxStore: Flux.useStore<Pluto.FluxStore>(),
+        granted: Access.useUpdateGranted(workspace.TYPE_ONTOLOGY_ID),
+      }),
+      { wrapper },
+    );
+    await waitFor(() => expect(result.current.granted).toBe(true));
+    await act(async () => {
+      await WorkspaceServices.ingest(`ws-${id.create()}`, fileList, {
+        client,
+        fileIngesters: FILE_INGESTERS,
+        placeLayout: result.current.placer,
+        store,
+        fluxStore: result.current.fluxStore,
+      });
+    });
+    return store;
+  };
+
+  const files = (layoutSlice: unknown = exportedSlice()): Import.File[] => [
+    { name: Workspace.LAYOUT_FILE_NAME, data: layoutSlice },
+    { name: "Operator.json", data: SCHEMATIC_DATA },
+    { name: "Thermocouples.json", data: TABLE_DATA },
+  ];
+
+  // An exported slice whose themes predate newer color fields; anySliceStateZ would
+  // reject them outright.
+  const staleThemesSlice = (): unknown => {
+    const slice = deep.copy(exportedSlice()) as unknown as {
+      themes: Record<string, { colors: Record<string, unknown> }>;
+    };
+    Object.values(slice.themes).forEach(({ colors }) => {
+      delete colors.primaryText;
+      delete colors.errorText;
+      delete colors.warningText;
+    });
+    return slice;
+  };
+
+  it("places exactly one tab per imported schematic and table", async () => {
+    const store = await runImport();
+    expect(layoutsOfType(store, SCHEMATIC_TYPE)).toHaveLength(1);
+    expect(layoutsOfType(store, TABLE_TYPE)).toHaveLength(1);
+  });
+
+  it("links every imported tab to a resource that exists in the cluster", async () => {
+    const store = await runImport();
+    const [schematicLayout] = layoutsOfType(store, SCHEMATIC_TYPE);
+    const [tableLayout] = layoutsOfType(store, TABLE_TYPE);
+    await expect(
+      client.schematics.retrieve({ key: schematicLayout.key }),
+    ).resolves.toBeDefined();
+    await expect(
+      client.tables.retrieve({ key: tableLayout.key }),
+    ).resolves.toBeDefined();
+  });
+
+  it("imports a workspace whose exported themes predate current theme fields", async () => {
+    const store = await runImport(files(staleThemesSlice()));
+    expect(layoutsOfType(store, SCHEMATIC_TYPE)).toHaveLength(1);
+    expect(layoutsOfType(store, TABLE_TYPE)).toHaveLength(1);
+  });
+});

--- a/console/src/workspace/services/import.ts
+++ b/console/src/workspace/services/import.ts
@@ -9,13 +9,57 @@
 
 import { type Store } from "@reduxjs/toolkit";
 import { type Synnax, workspace } from "@synnaxlabs/client";
-import { Access, type Pluto, type Status } from "@synnaxlabs/pluto";
-import { uuid } from "@synnaxlabs/x";
+import { Access, Mosaic, type Pluto, type Status } from "@synnaxlabs/pluto";
+import { deep, uuid } from "@synnaxlabs/x";
 
 import { type Import } from "@/import";
 import { Layout } from "@/layout";
 import { Runtime } from "@/runtime";
 import { Workspace } from "@/workspace";
+
+// Rewrites every reference to an imported component's original key with the key of the
+// resource actually created for it. Without it the original-key tabs resolve to nothing
+// and the ingesters' new-key tabs pile up as duplicates.
+const remapLayoutKeys = (
+  slice: Layout.SliceState,
+  remap: Map<string, string>,
+): Layout.SliceState => {
+  if (remap.size === 0) return slice;
+  const next = deep.copy(slice);
+  next.layouts = Object.fromEntries(
+    Object.entries(next.layouts).map(([key, layout]) => {
+      const newKey = remap.get(key) ?? key;
+      return [newKey, { ...layout, key: newKey }];
+    }),
+  );
+  Object.values(next.mosaics).forEach((mosaic) => {
+    Mosaic.forEachNode(mosaic.root, (node) => {
+      node.tabs?.forEach((tab) => {
+        const newKey = remap.get(tab.tabKey);
+        if (newKey != null) tab.tabKey = newKey;
+      });
+      if (node.selected != null)
+        node.selected = remap.get(node.selected) ?? node.selected;
+    });
+    if (mosaic.activeTab != null)
+      mosaic.activeTab = remap.get(mosaic.activeTab) ?? mosaic.activeTab;
+    if (mosaic.focused != null)
+      mosaic.focused = remap.get(mosaic.focused) ?? mosaic.focused;
+  });
+  return next;
+};
+
+// Swaps imported themes for the current defaults before validation. setWorkspace
+// discards imported themes anyway, so a stale theme blob from an older export must not
+// fail anySliceStateZ and block the import.
+const stripThemes = (data: unknown): unknown => {
+  if (typeof data !== "object" || data == null) return data;
+  return {
+    ...data,
+    themes: Layout.ZERO_SLICE_STATE.themes,
+    activeTheme: Layout.ZERO_SLICE_STATE.activeTheme,
+  };
+};
 
 export const ingest: Import.DirectoryIngester = async (
   name,
@@ -28,19 +72,15 @@ export const ingest: Import.DirectoryIngester = async (
     throw new Error("You do not have permission to import workspaces");
   const layoutData = files.find((file) => file.name === Workspace.LAYOUT_FILE_NAME);
   if (layoutData == null) throw new Error(`${Workspace.LAYOUT_FILE_NAME} not found`);
-  const layout = Layout.migrateSlice(Layout.anySliceStateZ.parse(layoutData.data));
-  const wsKey = uuid.create();
-  const wsName = name;
-  const ws: workspace.Workspace = { key: wsKey, name: wsName, layout };
-  const createdWs = await client?.workspaces.create(ws);
-  store.dispatch(Workspace.setActive(createdWs ?? ws));
-  store.dispatch(
-    Layout.setWorkspace({
-      slice: (createdWs?.layout as Layout.SliceState) ?? layout,
-      keepNav: false,
-    }),
+  const layout = Layout.migrateSlice(
+    Layout.anySliceStateZ.parse(stripThemes(layoutData.data)),
   );
+  const wsKey = uuid.create();
+  // Create the workspace first so components can be parented to it; its layout is
+  // rewritten below once their real keys are known.
+  await client?.workspaces.create({ key: wsKey, name, layout });
 
+  const remap = new Map<string, string>();
   for (const [key, childLayout] of Object.entries(layout.layouts)) {
     const ingest = fileIngesters[childLayout.type];
     if (ingest == null) continue;
@@ -54,14 +94,21 @@ export const ingest: Import.DirectoryIngester = async (
             ("name" in file.data && file.data.name === childLayout.name))),
     )?.data;
     if (data == null) throw new Error(`Data for ${key} not found`);
-    await ingest(data, {
+    const id = await ingest(data, {
       layout: childLayout,
       placeLayout,
       store: fluxStore,
       client,
       workspaceKey: wsKey,
     });
+    if (id != null && id.key !== key) remap.set(key, id.key);
   }
+
+  const remappedLayout = remapLayoutKeys(layout, remap);
+  if (remap.size > 0) await client?.workspaces.setLayout(wsKey, remappedLayout);
+  const ws: workspace.Workspace = { key: wsKey, name, layout: remappedLayout };
+  store.dispatch(Workspace.setActive(ws));
+  store.dispatch(Layout.setWorkspace({ slice: remappedLayout, keepNav: false }));
 };
 
 export interface IngestContext {

--- a/console/src/workspace/services/import.ts
+++ b/console/src/workspace/services/import.ts
@@ -8,7 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { type Store } from "@reduxjs/toolkit";
-import { type Synnax, workspace } from "@synnaxlabs/client";
+import { DisconnectedError, type Synnax, workspace } from "@synnaxlabs/client";
 import { Access, Mosaic, type Pluto, type Status } from "@synnaxlabs/pluto";
 import { deep, uuid } from "@synnaxlabs/x";
 
@@ -70,15 +70,17 @@ export const ingest: Import.DirectoryIngester = async (
     !Access.updateGranted({ id: workspace.TYPE_ONTOLOGY_ID, store: fluxStore, client })
   )
     throw new Error("You do not have permission to import workspaces");
+  if (client == null) throw new DisconnectedError();
   const layoutData = files.find((file) => file.name === Workspace.LAYOUT_FILE_NAME);
   if (layoutData == null) throw new Error(`${Workspace.LAYOUT_FILE_NAME} not found`);
   const layout = Layout.migrateSlice(
     Layout.anySliceStateZ.parse(stripThemes(layoutData.data)),
   );
   const wsKey = uuid.create();
-  // Create the workspace first so components can be parented to it; its layout is
-  // rewritten below once their real keys are known.
-  await client?.workspaces.create({ key: wsKey, name, layout });
+  const ws: workspace.Workspace = { key: wsKey, name, layout };
+  // Create the workspace first so imported components can be parented to it; its layout
+  // is rewritten and installed below once their real keys are known.
+  await client.workspaces.create(ws);
 
   const remap = new Map<string, string>();
   for (const [key, childLayout] of Object.entries(layout.layouts)) {
@@ -105,10 +107,9 @@ export const ingest: Import.DirectoryIngester = async (
   }
 
   const remappedLayout = remapLayoutKeys(layout, remap);
-  if (remap.size > 0) await client?.workspaces.setLayout(wsKey, remappedLayout);
-  const ws: workspace.Workspace = { key: wsKey, name, layout: remappedLayout };
   store.dispatch(Workspace.setActive(ws));
   store.dispatch(Layout.setWorkspace({ slice: remappedLayout, keepNav: false }));
+  if (remap.size > 0) await client.workspaces.setLayout(wsKey, remappedLayout);
 };
 
 export interface IngestContext {


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4311](https://linear.app/synnax/issue/SY-4311)

## Description

Importing a workspace produced **duplicate, broken schematic and table tabs** — one "Failed to retrieve schematic/table" (`sy.query.not_found`) tab and one working tab for each component.

Since schematics (SY-3833-3) and tables (SY-4066) moved to cluster-owned state, importing a component mints a fresh server-assigned key. The exported mosaic still referenced the component's original key, so the original-key tab resolved to a resource that was never created, while the ingester placed a second tab under the new key.

The fix:

- Component ingesters now return the created resource's `ontology.ID`.
- The workspace importer collects each `old -> new` key, rewrites the slice's `layouts` map and every mosaic tab reference (`tabKey`, `selected`, `activeTab`, `focused`), and installs the workspace **once** with the remapped layout (persisted via `setLayout`).

The result is exactly one correctly-positioned tab per resource, pointing at a key that exists, and re-importing is safe because each import mints fresh keys.

Folded in a second, related failure surfaced while testing: an export made before a newer theme color field was added failed `anySliceStateZ.parse` outright (on `themes.*.colors.primaryText` etc.), blocking the entire import. Since `setWorkspace` discards imported themes in favor of the live store's themes, the importer now replaces them with the current defaults before validation, so a stale theme blob can no longer block importing a workspace's actual content.

Single-file component imports are unaffected: they ignore the returned ID, never call `setWorkspace`, and keep minting fresh keys.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two workspace-import bugs: duplicate/broken tabs caused by the exported mosaic referencing original component keys while ingesters minted fresh server keys, and a total import failure when an exported theme blob predated a newer color field.

- Component ingesters now return their server-assigned `ontology.ID`; the workspace importer collects old→new key pairs, remaps every mosaic reference (`tabKey`, `selected`, `activeTab`, `focused`), and persists the corrected layout via `setLayout` before dispatching `setWorkspace` — so exactly one correctly-keyed tab appears per resource.
- `stripThemes` replaces the imported theme blob with current defaults before `anySliceStateZ.parse`, preventing stale fields from blocking the entire import (themes are discarded by `setWorkspace` anyway).
- A new integration test suite validates both fixes against a live cluster, covering the duplicate-tab case, the link-to-live-resource case, and the stale-theme case.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the duplicate-tab and stale-theme fixes are logically correct, the remapping covers all mosaic references, and setWorkspace's use of layoutsToPreserve cleanly discards the transient placeLayout entries.

The key-remapping logic in remapLayoutKeys correctly rewrites the layouts map, mosaic tab keys, selected, activeTab, and focused fields before setWorkspace is dispatched. The two observations flagged are about incomplete error cleanup (a pre-existing pattern, not introduced here) and missing test-cluster cleanup — neither affects functional correctness of the shipped feature.

console/src/workspace/services/import.spec.tsx — lacks afterAll cleanup that would delete workspaces, schematics, and tables from the test cluster after each run.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| console/src/workspace/services/import.ts | Core fix: moves setWorkspace dispatch to after ingesters run, adds remapLayoutKeys to rewrite old component keys to server-assigned keys, and stripThemes to prevent stale theme blobs from blocking import. Logic is sound; minor concerns around orphaned server state on failure and placeLayout transient dispatch. |
| console/src/import/ingester.ts | FileIngester return type extended to void | ontology.ID | Promise<void | ontology.ID> to allow callers to receive the server-assigned key; backward-compatible change. |
| console/src/schematic/services/import.ts | Single-line addition returning schematic.ontologyID(key) so the workspace importer can map the old exported key to the freshly-minted server key. |
| console/src/table/services/import.ts | Parallel change to the schematic ingester: returns table.ontologyID(created.key) for key remapping. |
| console/src/workspace/services/import.spec.tsx | New integration test suite covering the duplicate-tab fix and stale-theme recovery. Tests connect to a live cluster; no afterAll cleanup removes the workspaces/schematics/tables created in each test run. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as Workspace Importer
    participant Redux as Redux Store
    participant Server as Synnax Server
    participant Ingester as Component Ingester

    UI->>UI: stripThemes(layoutData) → parse → migrateSlice
    UI->>Server: "workspaces.create({ key: wsKey, layout: originalLayout })"
    loop for each childLayout in layout.layouts
        UI->>Ingester: "ingest(data, { workspaceKey: wsKey, ... })"
        Ingester->>Server: schematics/tables.create(workspaceKey, payload)
        Server-->>Ingester: "created { key: newServerKey }"
        Ingester->>Redux: "placeLayout({ key: newServerKey, ... })"
        Ingester-->>UI: ontologyID(newServerKey)
        UI->>UI: remap.set(oldKey, newServerKey)
    end
    UI->>UI: remapLayoutKeys(layout, remap)
    alt "remap.size > 0"
        UI->>Server: workspaces.setLayout(wsKey, remappedLayout)
    end
    UI->>Redux: dispatch(Workspace.setActive(ws))
    UI->>Redux: "dispatch(Layout.setWorkspace({ slice: remappedLayout }))"
    Note over Redux: setWorkspace drops transient placeLayout entries,<br/>uses remappedLayout mosaics & layouts
```

<sub>Reviews (1): Last reviewed commit: ["SY-4311: Require a connected client and ..."](https://github.com/synnaxlabs/synnax/commit/4195fd0e30ec17d10b9b4d0342ac13145b5747f3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35394772)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->