### PR TITLE
SY-4315: Remove Schematic SetData API

### DIFF
--- a/client/ts/src/schematic/actions.ts
+++ b/client/ts/src/schematic/actions.ts
@@ -8,13 +8,12 @@
 // included in the file licenses/APL.txt.
 
 import { color, type record } from "@synnaxlabs/x";
-import { current, type Draft, isDraft } from "immer";
 
+import { actions } from "@/actions";
 import {
   type Action,
   addEdge,
   createReduceAll,
-  type HandlerResult,
   type Handlers,
   removeEdge,
   removeNode,
@@ -23,15 +22,6 @@ import {
   setNode,
   setNodePosition,
 } from "@/schematic/actions.gen";
-
-const NO_OP: HandlerResult = { inverse: [], targets: [] };
-
-// Snapshots a value out of an Immer draft so the result is safe to embed in an
-// action stored on the undo stack. When reduceAll applies multiple actions in
-// one produce(), an earlier action's wholesale assignment (e.g. state.configs[k]
-// = {...existing, ...payload.config}) leaves the slot as a plain object — the
-// next action would crash if it called current() unconditionally.
-const snapshot = <T>(v: T): T => (isDraft(v) ? current(v as Draft<T>) : v);
 
 const handlers: Handlers = {
   rename: (state, payload) => {
@@ -44,7 +34,7 @@ const handlers: Handlers = {
   },
   setNodePosition: (state, payload) => {
     const node = state.nodes.find((n) => n.key === payload.key);
-    if (node == null) return NO_OP;
+    if (node == null) return actions.NO_OP_RESULT;
     const oldPosition = { x: node.position.x, y: node.position.y };
     node.position = payload.position;
     return {
@@ -59,7 +49,7 @@ const handlers: Handlers = {
   // a remote session emits it.
   setNodeMeasured: (state, payload) => {
     const node = state.nodes.find((n) => n.key === payload.key);
-    if (node == null) return NO_OP;
+    if (node == null) return actions.NO_OP_RESULT;
     node.measured = payload.measured;
     return { inverse: [], targets: [] };
   },
@@ -73,9 +63,10 @@ const handlers: Handlers = {
         targets: [payload.node.key],
       };
     }
-    const oldNode = snapshot(state.nodes[idx]);
+    const oldNode = actions.snapshotDraft(state.nodes[idx]);
     const oldConfigRaw = state.configs[payload.node.key];
-    const oldConfig = oldConfigRaw != null ? snapshot(oldConfigRaw) : undefined;
+    const oldConfig =
+      oldConfigRaw != null ? actions.snapshotDraft(oldConfigRaw) : undefined;
     state.nodes[idx] = payload.node;
     if (payload.config != null) state.configs[payload.node.key] = payload.config;
     return {
@@ -91,10 +82,11 @@ const handlers: Handlers = {
   },
   removeNode: (state, payload) => {
     const idx = state.nodes.findIndex((n) => n.key === payload.key);
-    if (idx === -1) return NO_OP;
-    const oldNode = snapshot(state.nodes[idx]);
+    if (idx === -1) return actions.NO_OP_RESULT;
+    const oldNode = actions.snapshotDraft(state.nodes[idx]);
     const oldConfigRaw = state.configs[payload.key];
-    const oldConfig = oldConfigRaw != null ? snapshot(oldConfigRaw) : undefined;
+    const oldConfig =
+      oldConfigRaw != null ? actions.snapshotDraft(oldConfigRaw) : undefined;
     state.nodes.splice(idx, 1);
     delete state.configs[payload.key];
     return {
@@ -109,7 +101,8 @@ const handlers: Handlers = {
     };
   },
   addEdge: (state, payload) => {
-    if (state.edges.some((e) => e.key === payload.edge.key)) return NO_OP;
+    if (state.edges.some((e) => e.key === payload.edge.key))
+      return actions.NO_OP_RESULT;
     state.edges.push(payload.edge);
     return {
       inverse: [removeEdge({ key: payload.edge.key })],
@@ -119,8 +112,8 @@ const handlers: Handlers = {
 
   removeEdge: (state, payload) => {
     const idx = state.edges.findIndex((e) => e.key === payload.key);
-    if (idx === -1) return NO_OP;
-    const oldEdge = snapshot(state.edges[idx]);
+    if (idx === -1) return actions.NO_OP_RESULT;
+    const oldEdge = actions.snapshotDraft(state.edges[idx]);
     state.edges.splice(idx, 1);
     return {
       inverse: [addEdge({ edge: oldEdge })],
@@ -136,7 +129,7 @@ const handlers: Handlers = {
   setConfig: (state, payload) => {
     const existingRaw = state.configs[payload.key];
     if (existingRaw != null) {
-      const existing = snapshot(existingRaw);
+      const existing = actions.snapshotDraft(existingRaw);
       const restoreFields: record.Unknown = {};
       for (const k of Object.keys(payload.config))
         if (existing[k] !== undefined) restoreFields[k] = existing[k];

--- a/client/ts/src/schematic/client.ts
+++ b/client/ts/src/schematic/client.ts
@@ -30,9 +30,6 @@ import { workspace } from "@/workspace";
 
 export const SET_CHANNEL_NAME = "sy_schematic_set";
 
-const setDataBodyZ = schematicZ.omit({ key: true, name: true, snapshot: true });
-export type SetDataBody = z.input<typeof setDataBodyZ>;
-const setDataReqZ = z.object({ key: keyZ, data: setDataBodyZ });
 const deleteReqZ = z.object({ keys: keyZ.array() });
 
 const copyReqZ = z.object({
@@ -90,15 +87,6 @@ export class Client {
 
   async rename(key: Key, name: string): Promise<void> {
     await this.dispatch(key, "", [renameAction({ name })]);
-  }
-
-  async setData(key: Key, data: SetDataBody): Promise<void> {
-    await this.client.send(
-      "/schematic/set-data",
-      { key, data },
-      setDataReqZ,
-      emptyResZ,
-    );
   }
 
   async dispatch(key: Key, dispatchKey: string, actions: Action[]): Promise<void> {

--- a/client/ts/src/schematic/schematic.spec.ts
+++ b/client/ts/src/schematic/schematic.spec.ts
@@ -59,29 +59,6 @@ describe("Schematic", () => {
     });
   });
 
-  describe("setData", () => {
-    test("set data replaces body fields while preserving key and name", async () => {
-      const ws = await client.workspaces.create({
-        name: "Schematic",
-        layout: { one: 1 },
-      });
-      const schem = await client.schematics.create(ws.key, {
-        ...schematic.ZERO_NEW,
-        name: "Schematic",
-      });
-      await client.schematics.setData(schem.key, {
-        ...schematic.ZERO_NEW,
-        nodes: [{ key: "n1", position: { x: 10, y: 20 }, zIndex: 0 }],
-        configs: { n1: { variant: "valve" } },
-      });
-      const res = await client.schematics.retrieve({ key: schem.key });
-      expect(res.name).toEqual("Schematic");
-      expect(res.nodes).toHaveLength(1);
-      expect(res.nodes[0].key).toEqual("n1");
-      expect((res.configs.n1 as Record<string, unknown>).variant).toEqual("valve");
-    });
-  });
-
   describe("delete", () => {
     test("delete one", async () => {
       const ws = await client.workspaces.create({
@@ -168,7 +145,9 @@ describe("Schematic", () => {
           snapshot: true,
         });
         await expect(
-          client.schematics.setData(schem2.key, { ...schematic.ZERO_NEW }),
+          client.schematics.dispatch(schem2.key, "sess-1", [
+            schematic.setNode({ node: { key: "n1", position: { x: 0, y: 0 } } }),
+          ]),
         ).rejects.toThrow(ValidationError);
       });
     });
@@ -177,10 +156,9 @@ describe("Schematic", () => {
   describe("dispatch", () => {
     test("setNodePosition moves the matching node", async () => {
       const { schem } = await newWorkspaceSchematic(client);
-      await client.schematics.setData(schem.key, {
-        ...schematic.ZERO_NEW,
-        nodes: [{ key: "n1", position: { x: 0, y: 0 } }],
-      });
+      await client.schematics.dispatch(schem.key, "sess-1", [
+        schematic.setNode({ node: { key: "n1", position: { x: 0, y: 0 } } }),
+      ]);
       await client.schematics.dispatch(schem.key, "sess-1", [
         schematic.setNodePosition({ key: "n1", position: { x: 100, y: 200 } }),
       ]);
@@ -205,14 +183,16 @@ describe("Schematic", () => {
 
     test("removeNode removes the node and drops its config", async () => {
       const { schem } = await newWorkspaceSchematic(client);
-      await client.schematics.setData(schem.key, {
-        ...schematic.ZERO_NEW,
-        nodes: [
-          { key: "n1", position: { x: 0, y: 0 } },
-          { key: "n2", position: { x: 1, y: 1 } },
-        ],
-        configs: { n1: { label: "Pump" }, n2: { label: "Tank" } },
-      });
+      await client.schematics.dispatch(schem.key, "sess-1", [
+        schematic.setNode({
+          node: { key: "n1", position: { x: 0, y: 0 } },
+          config: { label: "Pump" },
+        }),
+        schematic.setNode({
+          node: { key: "n2", position: { x: 1, y: 1 } },
+          config: { label: "Tank" },
+        }),
+      ]);
       await client.schematics.dispatch(schem.key, "sess-1", [
         schematic.removeNode({ key: "n1" }),
       ]);
@@ -235,10 +215,10 @@ describe("Schematic", () => {
         source: { node: srcNode, param: srcParam },
         target: { node: tgtNode, param: tgtParam },
       });
-      await client.schematics.setData(schem.key, {
-        ...schematic.ZERO_NEW,
-        edges: [e("e1", "a", "o", "b", "i"), e("e2", "b", "o", "c", "i")],
-      });
+      await client.schematics.dispatch(schem.key, "sess-1", [
+        schematic.addEdge({ edge: e("e1", "a", "o", "b", "i") }),
+        schematic.addEdge({ edge: e("e2", "b", "o", "c", "i") }),
+      ]);
       await client.schematics.dispatch(schem.key, "sess-1", [
         schematic.addEdge({ edge: e("e2", "x", "y", "z", "w") }),
         schematic.addEdge({ edge: e("e3", "c", "o", "d", "i") }),
@@ -253,16 +233,15 @@ describe("Schematic", () => {
 
     test("removeEdge removes the matching edge", async () => {
       const { schem } = await newWorkspaceSchematic(client);
-      await client.schematics.setData(schem.key, {
-        ...schematic.ZERO_NEW,
-        edges: [
-          {
+      await client.schematics.dispatch(schem.key, "sess-1", [
+        schematic.addEdge({
+          edge: {
             key: "e1",
             source: { node: "a", param: "o" },
             target: { node: "b", param: "i" },
           },
-        ],
-      });
+        }),
+      ]);
       await client.schematics.dispatch(schem.key, "sess-1", [
         schematic.removeEdge({ key: "e1" }),
       ]);
@@ -302,10 +281,9 @@ describe("Schematic", () => {
 
     test("converges to the final position after a 30-action drag storm", async () => {
       const { schem } = await newWorkspaceSchematic(client);
-      await client.schematics.setData(schem.key, {
-        ...schematic.ZERO_NEW,
-        nodes: [{ key: "pump", position: { x: 0, y: 0 } }],
-      });
+      await client.schematics.dispatch(schem.key, "sess-1", [
+        schematic.setNode({ node: { key: "pump", position: { x: 0, y: 0 } } }),
+      ]);
       const actions = Array.from({ length: 30 }, (_, i) =>
         schematic.setNodePosition({ key: "pump", position: { x: i, y: i * 2 } }),
       );

--- a/core/pkg/api/layer.go
+++ b/core/pkg/api/layer.go
@@ -110,7 +110,6 @@ type Transport struct {
 	SchematicCreate   freighter.UnaryServer[schematic.CreateRequest, schematic.CreateResponse]
 	SchematicRetrieve freighter.UnaryServer[schematic.RetrieveRequest, schematic.RetrieveResponse]
 	SchematicDelete   freighter.UnaryServer[schematic.DeleteRequest, types.Nil]
-	SchematicSetData  freighter.UnaryServer[schematic.SetDataRequest, types.Nil]
 	SchematicDispatch freighter.UnaryServer[schematic.DispatchRequest, types.Nil]
 	SchematicCopy     freighter.UnaryServer[schematic.CopyRequest, schematic.CopyResponse]
 	// SCHEMATIC SYMBOL
@@ -299,7 +298,6 @@ func (l *Layer) BindTo(t Transport) {
 		t.SchematicCreate,
 		t.SchematicRetrieve,
 		t.SchematicDelete,
-		t.SchematicSetData,
 		t.SchematicDispatch,
 		t.SchematicCopy,
 
@@ -451,7 +449,6 @@ func (l *Layer) BindTo(t Transport) {
 	t.SchematicCreate.BindHandler(l.Schematic.Create)
 	t.SchematicRetrieve.BindHandler(l.Schematic.Retrieve)
 	t.SchematicDelete.BindHandler(l.Schematic.Delete)
-	t.SchematicSetData.BindHandler(l.Schematic.SetData)
 	t.SchematicDispatch.BindHandler(l.Schematic.Dispatch)
 	t.SchematicCopy.BindHandler(l.Schematic.Copy)
 

--- a/core/pkg/api/schematic/schematic.go
+++ b/core/pkg/api/schematic/schematic.go
@@ -75,24 +75,6 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (res CreateResp
 	})
 }
 
-type SetDataRequest struct {
-	Data schematic.Schematic `json:"data" msgpack:"data"`
-	Key  schematic.Key       `json:"key" msgpack:"key"`
-}
-
-func (s *Service) SetData(ctx context.Context, req SetDataRequest) (res types.Nil, err error) {
-	if err = s.access.Enforce(ctx, access.Request{
-		Subject: auth.GetSubject(ctx),
-		Action:  access.ActionUpdate,
-		Objects: []ontology.ID{schematic.OntologyID(req.Key)},
-	}); err != nil {
-		return res, err
-	}
-	return res, s.db.WithTx(ctx, func(tx gorp.Tx) error {
-		return s.internal.NewWriter(tx).SetData(ctx, req.Key, req.Data)
-	})
-}
-
 // DispatchRequest carries an action sequence to apply to a single schematic.
 // DispatchKey is a client-generated identifier for the batch, registered as
 // outstanding on the originator before the request is sent. The server echoes

--- a/core/pkg/service/schematic/writer.go
+++ b/core/pkg/service/schematic/writer.go
@@ -129,28 +129,6 @@ func (w Writer) Copy(
 	)
 }
 
-// SetData replaces the body of the schematic with the given key with the
-// provided value. Key, Name, and Snapshot are preserved from the existing
-// entry; every other field on data overwrites the stored entry verbatim.
-// Returns validate.ErrValidation when the target schematic is a snapshot,
-// since snapshots are immutable.
-func (w Writer) SetData(
-	ctx context.Context,
-	key Key,
-	data Schematic,
-) error {
-	return w.table.NewUpdate().Where(gorp.MatchKeys[Key, Schematic](key)).
-		ChangeErr(func(_ gorp.Context, s Schematic) (Schematic, error) {
-			if s.Snapshot {
-				return s, errors.Wrapf(validate.ErrValidation, "[Schematic] - cannot set data on snapshot %s:%s", key, s.Name)
-			}
-			data.Key = s.Key
-			data.Name = s.Name
-			data.Snapshot = s.Snapshot
-			return data, nil
-		}).Exec(ctx, w.tx)
-}
-
 // Dispatch applies a sequence of actions atomically to the schematic with the
 // given key. After a successful update the actions are notified to the
 // service-level observer so subscribers (cluster signals) can broadcast them.

--- a/core/pkg/service/schematic/writer_test.go
+++ b/core/pkg/service/schematic/writer_test.go
@@ -59,35 +59,6 @@ var _ = Describe("Writer", func() {
 			Expect(s.Key).ToNot(Equal(uuid.Nil))
 		})
 	})
-	Describe("SetData", func() {
-		It("Should replace every body field on the Schematic while preserving Key and Name", func(ctx SpecContext) {
-			s := schematic.Schematic{Name: "test"}
-			Expect(svc.NewWriter(tx).Create(ctx, ws.Key, &s)).To(Succeed())
-			Expect(svc.NewWriter(tx).SetData(ctx, s.Key, schematic.Schematic{
-				Name:  "ignored-name",
-				Nodes: []schematic.Node{{Key: "n1"}},
-			})).To(Succeed())
-			var res schematic.Schematic
-			Expect(svc.NewRetrieve().
-				Where(schematic.MatchKeys(s.Key)).
-				Entry(&res).Exec(ctx, tx)).To(Succeed())
-			Expect(res.Name).To(Equal("test"))
-			Expect(res.Nodes).To(HaveLen(1))
-		})
-		It("Should preserve the Snapshot flag against caller overrides", func(ctx SpecContext) {
-			s := schematic.Schematic{Name: "test"}
-			Expect(svc.NewWriter(tx).Create(ctx, ws.Key, &s)).To(Succeed())
-			Expect(svc.NewWriter(tx).SetData(ctx, s.Key, schematic.Schematic{
-				Snapshot: true,
-			})).To(Succeed())
-			var res schematic.Schematic
-			Expect(svc.NewRetrieve().
-				Where(schematic.MatchKeys(s.Key)).
-				Entry(&res).Exec(ctx, tx)).To(Succeed())
-			Expect(res.Snapshot).To(BeFalse())
-		})
-	})
-
 	Describe("Dispatch", func() {
 		It("Should apply a single SetNodePosition action", func(ctx SpecContext) {
 			s := schematic.Schematic{
@@ -308,8 +279,10 @@ var _ = Describe("Writer", func() {
 			Expect(svc.NewWriter(tx).Create(ctx, ws.Key, &s)).To(Succeed())
 			var cpy schematic.Schematic
 			Expect(svc.NewWriter(tx).Copy(ctx, s.Key, "test2", true, &cpy)).To(Succeed())
-			Expect(svc.NewWriter(tx).SetData(ctx, cpy.Key, schematic.Schematic{
-				Nodes: []schematic.Node{{Key: "n1"}},
+			Expect(svc.NewWriter(tx).Dispatch(ctx, cpy.Key, "session-1", []schematic.Action{
+				schematic.NewSetNodeAction(schematic.SetNodePayload{
+					Node: schematic.Node{Key: "n1"},
+				}),
 			})).To(MatchError(validate.ErrValidation))
 		})
 	})

--- a/core/pkg/transport/grpc/grpc.go
+++ b/core/pkg/transport/grpc/grpc.go
@@ -103,7 +103,6 @@ func Bind(layer *api.Layer, channelSvc *distchannel.Service) []grpc.BindableTran
 	t.SchematicCreate = noop.UnaryServer[schematic.CreateRequest, schematic.CreateResponse]{}
 	t.SchematicDelete = noop.UnaryServer[schematic.DeleteRequest, types.Nil]{}
 	t.SchematicRetrieve = noop.UnaryServer[schematic.RetrieveRequest, schematic.RetrieveResponse]{}
-	t.SchematicSetData = noop.UnaryServer[schematic.SetDataRequest, types.Nil]{}
 	t.SchematicDispatch = noop.UnaryServer[schematic.DispatchRequest, types.Nil]{}
 	t.SchematicCopy = noop.UnaryServer[schematic.CopyRequest, schematic.CopyResponse]{}
 

--- a/core/pkg/transport/http/http.go
+++ b/core/pkg/transport/http/http.go
@@ -115,7 +115,6 @@ func Bind(layer *api.Layer, router *http.Router, ch *distchannel.Service) {
 		SchematicCreate:   http.NewUnaryServer[schematic.CreateRequest, schematic.CreateResponse](router, "/api/v1/schematic/create"),
 		SchematicRetrieve: http.NewUnaryServer[schematic.RetrieveRequest, schematic.RetrieveResponse](router, "/api/v1/schematic/retrieve"),
 		SchematicDelete:   http.NewUnaryServer[schematic.DeleteRequest, types.Nil](router, "/api/v1/schematic/delete"),
-		SchematicSetData:  http.NewUnaryServer[schematic.SetDataRequest, types.Nil](router, "/api/v1/schematic/set-data"),
 		SchematicDispatch: http.NewUnaryServer[schematic.DispatchRequest, types.Nil](router, "/api/v1/schematic/dispatch"),
 		SchematicCopy:     http.NewUnaryServer[schematic.CopyRequest, schematic.CopyResponse](router, "/api/v1/schematic/copy"),
 


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4315](https://linear.app/synnax/issue/SY-4315)

## Description

Removes the schematic `setData` API entirely across the stack. The endpoint was unused by any production code — the Console and integration suites mutate schematics exclusively through the `dispatch` action pipeline, and `setData` survived only in its own unit tests. With `dispatch` as the single mutation path (including its existing snapshot-immutability enforcement), `setData` was redundant surface area.

Removed:

- **TS client** (`client/ts/src/schematic/client.ts`): the `setData` method, the `setDataBodyZ`/`setDataReqZ` zod schemas, and the exported `SetDataBody` type.
- **Go API** (`core/pkg/api/schematic/schematic.go`): `SetDataRequest` and the `Service.SetData` handler.
- **Go service** (`core/pkg/service/schematic/writer.go`): the `Writer.SetData` method.
- **Transport wiring**: the `SchematicSetData` field, middleware entry, and handler binding in `api/layer.go`; the HTTP route `/api/v1/schematic/set-data`; and the gRPC noop placeholder.

Tests that used `setData` purely to seed state were refactored to seed via `dispatch` actions, and the snapshot-immutability assertions were moved onto `dispatch` (which already rejects non-`Rename` actions on snapshots with `validate.ErrValidation`), so no coverage was lost. `table`, `lineplot`, and `log` keep their own `SetData` APIs — untouched.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the `setData` API for schematics across the full stack — TypeScript client, Go API handler, Go service writer, and HTTP/gRPC transport wiring — since it was unused by production code and redundant with the `dispatch` pipeline.

- **TS client** removes `setData`, `setDataBodyZ`, `setDataReqZ`, and the `SetDataBody` export; integration tests are rewritten to seed state via `dispatch` actions instead.
- **Go layer** removes `SetDataRequest`, `Service.SetData`, `Writer.SetData`, the `SchematicSetData` transport field, the `/api/v1/schematic/set-data` HTTP route, and its gRPC noop stub.
- **`actions.ts` refactor**: the local `NO_OP` constant and `snapshot` helper are promoted to the shared `@/actions` module as `NO_OP_RESULT` and `snapshotDraft`; all call-sites are updated accordingly.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a clean removal of an unused API endpoint with no production callers.

Every deletion is matched by a corresponding removal on every layer (TS client, Go API handler, service writer, HTTP route, gRPC noop). The snapshot-immutability guarantee was already enforced inside Dispatch and the tests confirm it; no coverage gap is introduced. No dangling references to setData or SetDataBody remain anywhere in the schematic package.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| core/pkg/service/schematic/writer.go | Removes Writer.SetData; Dispatch already enforces snapshot immutability for non-Rename actions, so coverage is preserved. |
| core/pkg/api/schematic/schematic.go | Removes SetDataRequest struct and Service.SetData handler; auth-enforcement and DB write path cleanly deleted. |
| core/pkg/api/layer.go | Removes SchematicSetData field from Transport and all three binding sites (middleware, handler, struct literal). |
| client/ts/src/schematic/client.ts | Removes setData method, Zod schemas, and SetDataBody type export; no dangling references remain. |
| client/ts/src/schematic/schematic.spec.ts | All setData seeding replaced with dispatch actions; snapshot-immutability assertion moved to dispatch path and correctly targets a non-Rename action. |
| client/ts/src/schematic/actions.ts | NO_OP and snapshot helpers extracted to shared @/actions module; all handler call-sites updated consistently. |
| core/pkg/service/schematic/writer_test.go | SetData test suite removed; snapshot-immutability test migrated to Dispatch with a setNode action that correctly triggers ErrValidation. |
| core/pkg/transport/http/http.go | SchematicSetData route removed cleanly. |
| core/pkg/transport/grpc/grpc.go | SchematicSetData noop gRPC stub removed cleanly. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Client: schematic.dispatch] --> B[HTTP POST /api/v1/schematic/dispatch]
    B --> C[api/schematic.Service.Dispatch]
    C --> D{Target is snapshot?}
    D -- Yes, non-Rename action --> E[validate.ErrValidation]
    D -- No / Rename only --> F[service/schematic.Writer.Dispatch]
    F --> G[Reduce actions onto Schematic]
    G --> H[Persist via gorp.Tx]
    H --> I[Notify observers / broadcast]

    style E fill:#f88,stroke:#c00
    style I fill:#8f8,stroke:#080
```

<sub>Reviews (1): Last reviewed commit: ["SY-4315: Remove Schematic SetData API"](https://github.com/synnaxlabs/synnax/commit/23498f377a2efda1448ded95ac42da8d7bb73a79) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35475512)</sub>

<!-- /greptile_comment -->