### PR TITLE
SY-4316: Bugfix - Make Schematic Symbols Follow the Console Theme

### DIFF
--- a/pluto/src/schematic/node/common/color.spec.ts
+++ b/pluto/src/schematic/node/common/color.spec.ts
@@ -1,0 +1,38 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { color } from "@synnaxlabs/x";
+import { describe, expect, it } from "vitest";
+
+import { resolveColor } from "@/schematic/node/common/color";
+import { Theming } from "@/theming";
+
+describe("resolveColor", () => {
+  const light = Theming.themeZ.parse(Theming.SYNNAX_LIGHT);
+  const dark = Theming.themeZ.parse(Theming.SYNNAX_DARK);
+
+  it("should resolve the ZERO follow-theme sentinel to the theme's default color", () => {
+    expect(resolveColor(color.ZERO, light)).toEqual(light.colors.gray.l11);
+    expect(resolveColor(color.ZERO, dark)).toEqual(dark.colors.gray.l11);
+  });
+
+  it("should resolve an unset color to the theme's default color", () => {
+    expect(resolveColor(undefined, light)).toEqual(light.colors.gray.l11);
+    expect(resolveColor(undefined, dark)).toEqual(dark.colors.gray.l11);
+  });
+
+  it("should re-color a default symbol when the theme changes", () => {
+    expect(resolveColor(color.ZERO, light)).not.toEqual(resolveColor(color.ZERO, dark));
+  });
+
+  it("should honor an explicit color regardless of theme", () => {
+    expect(resolveColor("#ff0000", light)).toEqual("#ff0000");
+    expect(resolveColor("#ff0000", dark)).toEqual("#ff0000");
+  });
+});

--- a/pluto/src/schematic/node/common/color.ts
+++ b/pluto/src/schematic/node/common/color.ts
@@ -1,0 +1,24 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { color } from "@synnaxlabs/x";
+
+import { Theming } from "@/theming";
+
+/// resolveColor returns the theme's default symbol color when c is unset or the ZERO
+/// "follow-theme" sentinel, and otherwise honors the explicit color.
+export const resolveColor = (
+  c: color.Crude | undefined,
+  theme: Theming.Theme,
+): color.Crude => (c == null || color.isZero(c) ? theme.colors.gray.l11 : c);
+
+/// useColor resolves a symbol's configured color against the active theme; primitives
+/// that already hold a theme should call resolveColor directly.
+export const useColor = (c?: color.Crude): color.Crude =>
+  resolveColor(c, Theming.use());

--- a/pluto/src/schematic/node/common/create.ts
+++ b/pluto/src/schematic/node/common/create.ts
@@ -48,9 +48,9 @@ export const createStatic = <V extends string>({
     scale: z.number().optional(),
   });
   type Config = z.infer<typeof configZ>;
-  const defaultConfig = (t: Theming.Theme): Config => ({
+  const defaultConfig = (_t: Theming.Theme): Config => ({
     variant,
-    color: t.colors.gray.l11,
+    color: color.ZERO,
     label: Label.defaultConfig(label),
     ...BasePrimitive.ZERO_PROPS,
   });
@@ -90,9 +90,9 @@ export const createToggle = <V extends string>({
     scale: z.number().optional(),
   });
   type Config = z.infer<typeof configZ>;
-  const defaultConfig = (t: Theming.Theme): Config => ({
+  const defaultConfig = (_t: Theming.Theme): Config => ({
     variant,
-    color: t.colors.gray.l11,
+    color: color.ZERO,
     label: Label.defaultConfig(label),
     ...BasePrimitive.ZERO_PROPS,
     ...Toggle.ZERO_TOGGLE_DEFAULTS,
@@ -128,9 +128,9 @@ export const createDummyToggle = <V extends string>({
     scale: z.number().optional(),
   });
   type Config = z.infer<typeof configZ>;
-  const defaultConfig = (t: Theming.Theme): Config => ({
+  const defaultConfig = (_t: Theming.Theme): Config => ({
     variant,
-    color: t.colors.gray.l11,
+    color: color.ZERO,
     label: Label.defaultConfig(label),
     ...BasePrimitive.ZERO_PROPS,
     ...Toggle.ZERO_DUMMY_TOGGLE_DEFAULTS,

--- a/pluto/src/schematic/node/common/form/Color.tsx
+++ b/pluto/src/schematic/node/common/form/Color.tsx
@@ -12,11 +12,21 @@ import { type ReactElement } from "react";
 
 import { Color } from "@/color";
 import { Form } from "@/form";
+import { resolveColor } from "@/schematic/node/common/color";
+import { Theming } from "@/theming";
 
-export const ColorField: Form.FieldT<color.Crude> = (props): ReactElement => (
-  <Form.Field hideIfNull label="Color" align="start" padHelpText={false} {...props}>
-    {({ value, onChange, variant: _, ...rest }) => (
-      <Color.Swatch value={value} onChange={onChange} {...rest} bordered />
-    )}
-  </Form.Field>
-);
+export const ColorField: Form.FieldT<color.Crude> = (props): ReactElement => {
+  const theme = Theming.use();
+  return (
+    <Form.Field hideIfNull label="Color" align="start" padHelpText={false} {...props}>
+      {({ value, onChange, variant: _, ...rest }) => (
+        <Color.Swatch
+          value={resolveColor(value, theme)}
+          onChange={onChange}
+          {...rest}
+          bordered
+        />
+      )}
+    </Form.Field>
+  );
+};

--- a/pluto/src/schematic/node/common/primitive/SVG.tsx
+++ b/pluto/src/schematic/node/common/primitive/SVG.tsx
@@ -11,6 +11,7 @@ import { color, dimensions, direction } from "@synnaxlabs/x";
 import { type ComponentPropsWithoutRef, type ReactElement } from "react";
 
 import { CSS } from "@/css";
+import { resolveColor } from "@/schematic/node/common/color";
 import { type SVGBasedProps } from "@/schematic/node/common/primitive/orientable";
 import { Theming } from "@/theming";
 
@@ -38,21 +39,18 @@ export const SVG = ({
 }: SVGProps): ReactElement => {
   const dir = direction.construct(orientation);
   dims = dir === "y" ? dimensions.swap(dims) : dims;
-  const colorStr = color.cssString(colorVal);
   const theme = Theming.use();
-  let pStyle = {
+  const resolved = resolveColor(colorVal, theme);
+  const colorStr = color.cssString(resolved);
+  const pStyle = {
     ...style,
     aspectRatio: `${dims.width} / ${dims.height}`,
     width: dimensions.scale(dims, scale * BASE_SCALE).width,
+    [CSS.var("symbol-color")]: color.rgbString(resolved),
+    [CSS.var("symbol-color-contrast")]: color.rgbString(
+      color.pickByContrast(resolved, theme.colors.gray.l0, theme.colors.gray.l11),
+    ),
   };
-  if (colorVal != null)
-    pStyle = {
-      ...pStyle,
-      [CSS.var("symbol-color")]: color.rgbString(colorVal),
-      [CSS.var("symbol-color-contrast")]: color.rgbString(
-        color.pickByContrast(colorVal, theme.colors.gray.l0, theme.colors.gray.l11),
-      ),
-    };
 
   return (
     <svg

--- a/pluto/src/schematic/node/common/primitive/primitive.spec.tsx
+++ b/pluto/src/schematic/node/common/primitive/primitive.spec.tsx
@@ -7,6 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+import { color } from "@synnaxlabs/x";
 import { render } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
@@ -130,13 +131,27 @@ describe("Primitive.SVG", () => {
   });
 
   describe("color handling", () => {
-    it("should leave fill and stroke unset when no color is provided", () => {
+    it("should resolve a missing color to the theme's default symbol color", () => {
       const { container } = render(
         <Primitive.SVG dimensions={{ width: 10, height: 10 }} />,
       );
       const svg = container.querySelector("svg") as SVGSVGElement;
-      expect(svg.getAttribute("fill")).toBeNull();
-      expect(svg.getAttribute("stroke")).toBeNull();
+      expect(svg.getAttribute("fill")).toMatch(/^rgba?\(/);
+      expect(svg.getAttribute("stroke")).toMatch(/^rgba?\(/);
+      expect(svg.style.getPropertyValue("--pluto-symbol-color")).not.toBe("");
+    });
+
+    it("should resolve the ZERO follow-theme sentinel like a missing color", () => {
+      const zero = render(
+        <Primitive.SVG dimensions={{ width: 10, height: 10 }} color={color.ZERO} />,
+      ).container.querySelector("svg") as SVGSVGElement;
+      const unset = render(
+        <Primitive.SVG dimensions={{ width: 10, height: 10 }} />,
+      ).container.querySelector("svg") as SVGSVGElement;
+      expect(zero.getAttribute("stroke")).toBe(unset.getAttribute("stroke"));
+      expect(zero.style.getPropertyValue("--pluto-symbol-color")).toBe(
+        unset.style.getPropertyValue("--pluto-symbol-color"),
+      );
     });
 
     it("should set fill, stroke, and the symbol-color CSS variables for a color", () => {

--- a/pluto/src/schematic/node/flowmeters/Label.spec.tsx
+++ b/pluto/src/schematic/node/flowmeters/Label.spec.tsx
@@ -36,10 +36,10 @@ describe("Label", () => {
   });
 
   describe("color", () => {
-    it("should leave fill unset when no color is provided", () => {
+    it("should fall back to the theme's default color when none is provided", () => {
       const { container } = renderInSVG(<Label />);
       const text = queryText(container) as SVGTextElement;
-      expect(text.style.fill).toBe("");
+      expect(text.style.fill).toMatch(/^rgba?\(/);
     });
 
     it("should serialize a hex color into the fill style as rgba", () => {

--- a/pluto/src/schematic/node/flowmeters/Label.tsx
+++ b/pluto/src/schematic/node/flowmeters/Label.tsx
@@ -10,13 +10,15 @@
 import { color, type xy } from "@synnaxlabs/x";
 import { type ReactElement, useMemo } from "react";
 
+import { useColor } from "@/schematic/node/common/color";
+
 export interface LabelProps {
   position?: xy.XY;
   color?: color.Crude;
 }
 
 export const Label = ({ position, color: colorVal }: LabelProps): ReactElement => {
-  const colorStr = color.cssString(colorVal);
+  const colorStr = color.cssString(useColor(colorVal));
   const style = useMemo(() => ({ fill: colorStr }), [colorStr]);
   return (
     <text x={position?.x ?? 57} y={position?.y ?? 27} style={style} stroke="none">

--- a/pluto/src/schematic/node/general/box/external.tsx
+++ b/pluto/src/schematic/node/general/box/external.tsx
@@ -25,7 +25,7 @@ const NAME = "Box";
 export const defaultConfig = (t: Theming.Theme): Config => ({
   variant: VARIANT,
   orientation: "left",
-  color: t.colors.gray.l11,
+  color: color.ZERO,
   backgroundColor: color.setAlpha(t.colors.gray.l1, 0),
   label: Label.defaultConfig(NAME),
   dimensions: { width: 125, height: 200 },

--- a/pluto/src/schematic/node/general/circle/Primitive.spec.tsx
+++ b/pluto/src/schematic/node/general/circle/Primitive.spec.tsx
@@ -1,0 +1,37 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { color } from "@synnaxlabs/x";
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Circle } from "@/schematic/node/general/circle/Primitive";
+
+const queryStroke = (container: HTMLElement): string | null | undefined =>
+  container.querySelector("circle")?.getAttribute("stroke");
+
+describe("Circle", () => {
+  describe("color", () => {
+    it("should resolve a missing color to a themed stroke", () => {
+      const { container } = render(<Circle radius={20} />);
+      expect(queryStroke(container)).toMatch(/^rgba?\(/);
+    });
+
+    it("should resolve the ZERO follow-theme sentinel like a missing color", () => {
+      const zero = render(<Circle radius={20} color={color.ZERO} />).container;
+      const unset = render(<Circle radius={20} />).container;
+      expect(queryStroke(zero)).toBe(queryStroke(unset));
+    });
+
+    it("should honor an explicit color", () => {
+      const { container } = render(<Circle radius={20} color="#ff0000" />);
+      expect(queryStroke(container)).toMatch(/255\s*,\s*0\s*,\s*0/);
+    });
+  });
+});

--- a/pluto/src/schematic/node/general/circle/Primitive.tsx
+++ b/pluto/src/schematic/node/general/circle/Primitive.tsx
@@ -27,7 +27,6 @@ export const Circle = ({
   className,
   strokeWidth,
 }: RenderProps): ReactElement => {
-  const stroke = useColor(colorVal);
   const padding = (strokeWidth ?? 2) + 1;
   const diameter = radius * 2;
   const width = diameter + 2 * padding;
@@ -69,7 +68,7 @@ export const Circle = ({
           cx={width / 2}
           cy={height / 2}
           r={radius}
-          stroke={color.cssString(stroke)}
+          stroke={color.cssString(useColor(colorVal))}
           strokeWidth={strokeWidth ?? 2}
           fill={color.cssString(backgroundColor)}
         />

--- a/pluto/src/schematic/node/general/circle/Primitive.tsx
+++ b/pluto/src/schematic/node/general/circle/Primitive.tsx
@@ -11,6 +11,7 @@ import { color } from "@synnaxlabs/x";
 import { type ReactElement } from "react";
 
 import { CSS } from "@/css";
+import { useColor } from "@/schematic/node/common/color";
 import { Handle } from "@/schematic/node/common/handle";
 import { Primitive } from "@/schematic/node/common/primitive";
 import { type Config } from "@/schematic/node/general/circle/config";
@@ -26,6 +27,7 @@ export const Circle = ({
   className,
   strokeWidth,
 }: RenderProps): ReactElement => {
+  const stroke = useColor(colorVal);
   const padding = (strokeWidth ?? 2) + 1;
   const diameter = radius * 2;
   const width = diameter + 2 * padding;
@@ -67,7 +69,7 @@ export const Circle = ({
           cx={width / 2}
           cy={height / 2}
           r={radius}
-          stroke={color.cssString(colorVal)}
+          stroke={color.cssString(stroke)}
           strokeWidth={strokeWidth ?? 2}
           fill={color.cssString(backgroundColor)}
         />

--- a/pluto/src/schematic/node/general/circle/external.ts
+++ b/pluto/src/schematic/node/general/circle/external.ts
@@ -24,7 +24,7 @@ const NAME = "Circle";
 export const defaultConfig = (t: Theming.Theme): Config => ({
   variant: VARIANT,
   radius: 20,
-  color: t.colors.gray.l11,
+  color: color.ZERO,
   backgroundColor: color.setAlpha(t.colors.gray.l1, 0),
   label: Label.defaultConfig(NAME),
   strokeWidth: 2,

--- a/pluto/src/schematic/node/general/gauge/Primitive.tsx
+++ b/pluto/src/schematic/node/general/gauge/Primitive.tsx
@@ -35,7 +35,6 @@ const METRICS_STYLE: CSSProperties = {
 };
 
 export const Gauge = ({ color: c }: RenderProps): ReactElement => {
-  const valueColor = useColor(c);
   const radius = 27;
   const strokeWidth = 5;
   const centerX = 33.5;
@@ -69,7 +68,7 @@ export const Gauge = ({ color: c }: RenderProps): ReactElement => {
         <path
           d={valuePath}
           fill="none"
-          stroke={color.cssString(valueColor)}
+          stroke={color.cssString(useColor(c))}
           strokeWidth={strokeWidth}
           strokeLinecap="round"
         />

--- a/pluto/src/schematic/node/general/gauge/Primitive.tsx
+++ b/pluto/src/schematic/node/general/gauge/Primitive.tsx
@@ -10,6 +10,7 @@
 import { color } from "@synnaxlabs/x";
 import { type CSSProperties, type ReactElement } from "react";
 
+import { useColor } from "@/schematic/node/common/color";
 import { type Config } from "@/schematic/node/general/gauge/config";
 import { Text } from "@/text";
 
@@ -34,6 +35,7 @@ const METRICS_STYLE: CSSProperties = {
 };
 
 export const Gauge = ({ color: c }: RenderProps): ReactElement => {
+  const valueColor = useColor(c);
   const radius = 27;
   const strokeWidth = 5;
   const centerX = 33.5;
@@ -67,7 +69,7 @@ export const Gauge = ({ color: c }: RenderProps): ReactElement => {
         <path
           d={valuePath}
           fill="none"
-          stroke={color.cssString(c ?? "var(--pluto-primary-z)")}
+          stroke={color.cssString(valueColor)}
           strokeWidth={strokeWidth}
           strokeLinecap="round"
         />

--- a/pluto/src/schematic/node/general/gauge/external.ts
+++ b/pluto/src/schematic/node/general/gauge/external.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { bounds } from "@synnaxlabs/x";
+import { bounds, color } from "@synnaxlabs/x";
 
 import { Label } from "@/schematic/node/common/label";
 import { type Config, VARIANT } from "@/schematic/node/general/gauge/config";
@@ -20,10 +20,10 @@ import { type Theming } from "@/theming";
 
 export * from "@/schematic/node/general/gauge/config";
 
-export const defaultConfig = (t: Theming.Theme): Config => ({
+export const defaultConfig = (_t: Theming.Theme): Config => ({
   variant: VARIANT,
   orientation: "left",
-  color: t.colors.gray.l11,
+  color: color.ZERO,
   units: "RPM",
   level: "h5",
   bounds: bounds.construct(0, 100),

--- a/pluto/src/schematic/node/general/input/Primitive.tsx
+++ b/pluto/src/schematic/node/general/input/Primitive.tsx
@@ -14,6 +14,7 @@ import { type ReactElement, useState } from "react";
 import { Button as BaseButton } from "@/button";
 import { CSS } from "@/css";
 import { Input as BaseInput } from "@/input";
+import { useColor } from "@/schematic/node/common/color";
 import { Handle } from "@/schematic/node/common/handle";
 import { Primitive } from "@/schematic/node/common/primitive";
 import { type Config } from "@/schematic/node/general/input/config";
@@ -34,6 +35,7 @@ export const Input = ({
   disabled,
 }: PrimitiveProps): ReactElement => {
   const [value, setValue] = useState(initialValue);
+  const resolved = useColor(color);
   return (
     <Primitive.Div
       orientation={orientation}
@@ -52,13 +54,13 @@ export const Input = ({
         size={size}
         borderWidth={1}
         disabled={disabled}
-        color={color}
+        color={resolved}
       >
         <BaseButton.Button
           size={size}
           variant="filled"
           onClick={() => onSend?.(value)}
-          color={color}
+          color={resolved}
         >
           Send
         </BaseButton.Button>

--- a/pluto/src/schematic/node/general/input/external.tsx
+++ b/pluto/src/schematic/node/general/input/external.tsx
@@ -7,6 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+import { color } from "@synnaxlabs/x";
 import { type ReactElement } from "react";
 
 import { CSS } from "@/css";
@@ -22,10 +23,10 @@ import { type Theming } from "@/theming";
 
 export * from "@/schematic/node/general/input/config";
 
-export const defaultConfig = (t: Theming.Theme): Config => ({
+export const defaultConfig = (_t: Theming.Theme): Config => ({
   variant: VARIANT,
   orientation: "left",
-  color: t.colors.gray.l11,
+  color: color.ZERO,
   size: "small",
   label: Label.defaultConfig("Input"),
   control: { show: true },

--- a/pluto/src/schematic/node/general/light/external.ts
+++ b/pluto/src/schematic/node/general/light/external.ts
@@ -7,6 +7,8 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+import { color } from "@synnaxlabs/x";
+
 import { Label } from "@/schematic/node/common/label";
 import { type Config, VARIANT } from "@/schematic/node/general/light/config";
 import { LightForm } from "@/schematic/node/general/light/Form";
@@ -18,11 +20,11 @@ import { type Theming } from "@/theming";
 
 export * from "@/schematic/node/general/light/config";
 
-export const defaultConfig = (t: Theming.Theme): Config => ({
+export const defaultConfig = (_t: Theming.Theme): Config => ({
   variant: VARIANT,
   orientation: "left",
   scale: 1,
-  color: t.colors.gray.l11,
+  color: color.ZERO,
   label: Label.defaultConfig("Light"),
   source: telem.sourcePipeline("boolean", {
     connections: [{ from: "valueStream", to: "threshold" }],

--- a/pluto/src/schematic/node/general/offPageReference/Primitive.tsx
+++ b/pluto/src/schematic/node/general/offPageReference/Primitive.tsx
@@ -13,6 +13,7 @@ import { color, direction } from "@synnaxlabs/x";
 import { type CSSProperties, type ReactElement } from "react";
 
 import { CSS } from "@/css";
+import { resolveColor } from "@/schematic/node/common/color";
 import { Handle } from "@/schematic/node/common/handle";
 import { Primitive } from "@/schematic/node/common/primitive";
 import { type Config } from "@/schematic/node/general/offPageReference/config";
@@ -53,7 +54,7 @@ export const OffPageReference = ({
 
   const swap = direction.construct(orientation) === "y";
   const theme = Theming.use();
-  const resolvedColor = colorVal ?? theme.colors.gray.l11;
+  const resolvedColor = resolveColor(colorVal, theme);
   const textColor = color.pickByContrast(
     resolvedColor,
     theme.colors.text,

--- a/pluto/src/schematic/node/general/offPageReference/external.tsx
+++ b/pluto/src/schematic/node/general/offPageReference/external.tsx
@@ -7,6 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+import { color } from "@synnaxlabs/x";
 import { type ReactElement } from "react";
 
 import { Label } from "@/schematic/node/common/label";
@@ -19,9 +20,9 @@ import { type Theming } from "@/theming";
 
 export * from "@/schematic/node/general/offPageReference/config";
 
-export const defaultConfig = (t: Theming.Theme): Config => ({
+export const defaultConfig = (_t: Theming.Theme): Config => ({
   variant: VARIANT,
-  color: t.colors.gray.l11,
+  color: color.ZERO,
   orientation: "right",
   label: Label.defaultConfig("Off Page Reference"),
 });

--- a/pluto/src/schematic/node/general/polygon/Primitive.tsx
+++ b/pluto/src/schematic/node/general/polygon/Primitive.tsx
@@ -11,6 +11,7 @@ import { color } from "@synnaxlabs/x";
 import { type ReactElement, useMemo } from "react";
 
 import { CSS } from "@/css";
+import { resolveColor } from "@/schematic/node/common/color";
 import { Primitive } from "@/schematic/node/common/primitive";
 import { type Config } from "@/schematic/node/general/polygon/config";
 import { Theming } from "@/theming";
@@ -114,7 +115,7 @@ export const Polygon = ({
         <Primitive.Path
           d={path}
           fill={color.cssString(backgroundColor ?? theme.colors.gray.l1)}
-          stroke={color.cssString(colorVal ?? theme.colors.gray.l9)}
+          stroke={color.cssString(resolveColor(colorVal, theme))}
           strokeWidth={strokeWidth ?? 2}
         />
       </Primitive.SVG>

--- a/pluto/src/schematic/node/general/polygon/external.ts
+++ b/pluto/src/schematic/node/general/polygon/external.ts
@@ -28,7 +28,7 @@ export const defaultConfig = (t: Theming.Theme): Config => ({
   sideLength: DEFAULT_POLYGON_SIDE_LENGTH,
   cornerRounding: 0,
   rotation: 0,
-  color: t.colors.gray.l11,
+  color: color.ZERO,
   backgroundColor: color.setAlpha(t.colors.gray.l1, 0),
   strokeWidth: 2,
   label: Label.defaultConfig("Polygon"),

--- a/pluto/src/schematic/node/general/select/Primitive.tsx
+++ b/pluto/src/schematic/node/general/select/Primitive.tsx
@@ -14,6 +14,7 @@ import { type CSSProperties, type ReactElement, useMemo } from "react";
 import { Button as BaseButton } from "@/button";
 import { CSS } from "@/css";
 import { Flex } from "@/flex";
+import { useColor } from "@/schematic/node/common/color";
 import { Handle } from "@/schematic/node/common/handle";
 import { Primitive } from "@/schematic/node/common/primitive";
 import { type Config } from "@/schematic/node/general/select/config";
@@ -45,6 +46,7 @@ export const Select = ({
     [options],
   );
   const matched = options.find((o) => o.key === value);
+  const resolved = useColor(color);
   return (
     <Primitive.Div
       orientation={orientation}
@@ -88,7 +90,7 @@ export const Select = ({
           onChange={(key: string | null) => onChange(key)}
           disabled={disabled}
           resourceName="option"
-          triggerProps={{ color, size }}
+          triggerProps={{ color: resolved, size }}
           style={{ minWidth: inlineSize }}
         />
         {onSend != null && (
@@ -98,7 +100,7 @@ export const Select = ({
             onClick={() => {
               if (matched != null) onSend?.(matched.value);
             }}
-            color={color}
+            color={resolved}
             disabled={disabled}
           >
             Send

--- a/pluto/src/schematic/node/general/select/external.tsx
+++ b/pluto/src/schematic/node/general/select/external.tsx
@@ -7,6 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+import { color } from "@synnaxlabs/x";
 import { type ReactElement } from "react";
 
 import { CSS } from "@/css";
@@ -22,10 +23,10 @@ import { type Theming } from "@/theming";
 
 export * from "@/schematic/node/general/select/config";
 
-export const defaultConfig = (t: Theming.Theme): Config => ({
+export const defaultConfig = (_t: Theming.Theme): Config => ({
   variant: VARIANT,
   orientation: "left",
-  color: t.colors.gray.l11,
+  color: color.ZERO,
   size: "small",
   inlineSize: 100,
   options: [],

--- a/pluto/src/schematic/node/general/setpoint/Primitive.tsx
+++ b/pluto/src/schematic/node/general/setpoint/Primitive.tsx
@@ -14,6 +14,7 @@ import { type CSSProperties, type ReactElement, useState } from "react";
 import { Button as BaseButton } from "@/button";
 import { CSS } from "@/css";
 import { Input as BaseInput } from "@/input";
+import { useColor } from "@/schematic/node/common/color";
 import { Handle } from "@/schematic/node/common/handle";
 import { Primitive } from "@/schematic/node/common/primitive";
 import { type Config } from "@/schematic/node/general/setpoint/config";
@@ -37,6 +38,7 @@ export const Setpoint = ({
   disabled,
 }: RenderProps): ReactElement => {
   const [currValue, setCurrValue] = useState(value);
+  const resolved = useColor(color);
   return (
     <Primitive.Div
       className={CSS(CSS.B("setpoint"), className)}
@@ -81,7 +83,7 @@ export const Setpoint = ({
         showDragHandle={false}
         selectOnFocus
         endContent={units}
-        color={color}
+        color={resolved}
         borderWidth={1}
         disabled={disabled}
       >
@@ -89,7 +91,7 @@ export const Setpoint = ({
           size={size}
           variant="filled"
           onClick={() => onChange(currValue)}
-          color={color}
+          color={resolved}
         >
           Set
         </BaseButton.Button>

--- a/pluto/src/schematic/node/general/setpoint/external.tsx
+++ b/pluto/src/schematic/node/general/setpoint/external.tsx
@@ -7,6 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+import { color } from "@synnaxlabs/x";
 import { type ReactElement } from "react";
 
 import { CSS } from "@/css";
@@ -22,11 +23,11 @@ import { type Theming } from "@/theming";
 
 export * from "@/schematic/node/general/setpoint/config";
 
-export const defaultConfig = (t: Theming.Theme): Config => ({
+export const defaultConfig = (_t: Theming.Theme): Config => ({
   variant: VARIANT,
   orientation: "left",
   units: "mV",
-  color: t.colors.gray.l11,
+  color: color.ZERO,
   size: "small",
   label: Label.defaultConfig("Setpoint"),
   control: { show: true },

--- a/pluto/src/schematic/node/general/stateIndicator/Primitive.tsx
+++ b/pluto/src/schematic/node/general/stateIndicator/Primitive.tsx
@@ -13,6 +13,7 @@ import { color } from "@synnaxlabs/x";
 import { type ReactElement } from "react";
 
 import { CSS } from "@/css";
+import { resolveColor } from "@/schematic/node/common/color";
 import { Handle } from "@/schematic/node/common/handle";
 import { Primitive } from "@/schematic/node/common/primitive";
 import { type Config } from "@/schematic/node/general/stateIndicator/config";
@@ -34,9 +35,9 @@ export const StateIndicator = ({
 }: RenderProps): ReactElement => {
   const matched = options.find((o) => o.key === matchedOptionKey);
   const stateColor = matched?.color;
-  const borderColor = colorVal != null ? color.cssString(colorVal) : undefined;
-  const backgroundColor = stateColor != null ? color.cssString(stateColor) : undefined;
   const theme = Theming.use();
+  const borderColor = color.cssString(resolveColor(colorVal, theme));
+  const backgroundColor = stateColor != null ? color.cssString(stateColor) : undefined;
   const textColor =
     stateColor != null
       ? color.cssString(

--- a/pluto/src/schematic/node/general/stateIndicator/external.tsx
+++ b/pluto/src/schematic/node/general/stateIndicator/external.tsx
@@ -7,6 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+import { color } from "@synnaxlabs/x";
 import { type ReactElement } from "react";
 
 import { Label } from "@/schematic/node/common/label";
@@ -20,10 +21,10 @@ import { type Theming } from "@/theming";
 
 export * from "@/schematic/node/general/stateIndicator/config";
 
-export const defaultConfig = (t: Theming.Theme): Config => ({
+export const defaultConfig = (_t: Theming.Theme): Config => ({
   variant: VARIANT,
   orientation: "left",
-  color: t.colors.gray.l11,
+  color: color.ZERO,
   inlineSize: 100,
   options: [],
   label: Label.defaultConfig("State Indicator"),

--- a/pluto/src/schematic/node/general/textBox/Primitive.tsx
+++ b/pluto/src/schematic/node/general/textBox/Primitive.tsx
@@ -13,6 +13,7 @@ import { color, direction } from "@synnaxlabs/x";
 import { type CSSProperties, type ReactElement } from "react";
 
 import { CSS } from "@/css";
+import { useColor } from "@/schematic/node/common/color";
 import { Handle } from "@/schematic/node/common/handle";
 import { Primitive } from "@/schematic/node/common/primitive";
 import { type Config } from "@/schematic/node/general/textBox/config";
@@ -34,6 +35,7 @@ export const TextBox = ({
   value,
   onChange,
 }: RenderProps): ReactElement => {
+  const resolved = useColor(colorVal);
   const divStyle: CSSProperties = {
     textAlign: align as CSSProperties["textAlign"],
   };
@@ -56,7 +58,7 @@ export const TextBox = ({
       />
       <Text.MaybeEditable
         className={CSS.BE("symbol", "label")}
-        color={color.cssString(colorVal)}
+        color={color.cssString(resolved)}
         level={level}
         value={value ?? ""}
         onChange={onChange}

--- a/pluto/src/schematic/node/general/textBox/Primitive.tsx
+++ b/pluto/src/schematic/node/general/textBox/Primitive.tsx
@@ -35,7 +35,6 @@ export const TextBox = ({
   value,
   onChange,
 }: RenderProps): ReactElement => {
-  const resolved = useColor(colorVal);
   const divStyle: CSSProperties = {
     textAlign: align as CSSProperties["textAlign"],
   };
@@ -58,7 +57,7 @@ export const TextBox = ({
       />
       <Text.MaybeEditable
         className={CSS.BE("symbol", "label")}
-        color={color.cssString(resolved)}
+        color={color.cssString(useColor(colorVal))}
         level={level}
         value={value ?? ""}
         onChange={onChange}

--- a/pluto/src/schematic/node/general/textBox/external.tsx
+++ b/pluto/src/schematic/node/general/textBox/external.tsx
@@ -7,6 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+import { color } from "@synnaxlabs/x";
 import { type ReactElement } from "react";
 
 import { Label } from "@/schematic/node/common/label";
@@ -19,10 +20,10 @@ import { type Theming } from "@/theming";
 
 export * from "@/schematic/node/general/textBox/config";
 
-export const defaultConfig = (t: Theming.Theme): Config => ({
+export const defaultConfig = (_t: Theming.Theme): Config => ({
   variant: VARIANT,
   orientation: "left",
-  color: t.colors.gray.l11,
+  color: color.ZERO,
   autoFit: true,
   align: "center",
   label: Label.defaultConfig("Text Box"),

--- a/pluto/src/schematic/node/general/value/Primitive.spec.tsx
+++ b/pluto/src/schematic/node/general/value/Primitive.spec.tsx
@@ -1,0 +1,30 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { render } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { Value } from "@/schematic/node/general/value/Primitive";
+
+const queryBorder = (container: HTMLElement): string | undefined =>
+  container.querySelector<HTMLElement>(".pluto-value")?.style.borderColor;
+
+describe("Value", () => {
+  describe("color", () => {
+    it("should resolve a missing color to a themed border", () => {
+      const { container } = render(<Value units="psi" />);
+      expect(queryBorder(container)).toMatch(/^rgba?\(/);
+    });
+
+    it("should honor an explicit border color", () => {
+      const { container } = render(<Value units="psi" color="#ff0000" />);
+      expect(queryBorder(container)).toMatch(/255\s*,\s*0\s*,\s*0/);
+    });
+  });
+});

--- a/pluto/src/schematic/node/general/value/Primitive.tsx
+++ b/pluto/src/schematic/node/general/value/Primitive.tsx
@@ -13,6 +13,7 @@ import { color, type dimensions, type text } from "@synnaxlabs/x";
 import { type PropsWithChildren, type ReactElement } from "react";
 
 import { CSS } from "@/css";
+import { resolveColor } from "@/schematic/node/common/color";
 import { Handle } from "@/schematic/node/common/handle";
 import { Primitive } from "@/schematic/node/common/primitive";
 import { type Config } from "@/schematic/node/general/value/config";
@@ -35,14 +36,12 @@ export const Value = ({
   children,
   inlineSize = 80,
 }: RenderProps): ReactElement => {
-  const borderColor = color.cssString(colorVal);
   const theme = Theming.use();
-  const textColor: string | undefined =
-    colorVal == null
-      ? "var(--pluto-gray-l0)"
-      : color.cssString(
-          color.pickByContrast(colorVal, theme.colors.gray.l0, theme.colors.gray.l11),
-        );
+  const resolved = resolveColor(colorVal, theme);
+  const borderColor = color.cssString(resolved);
+  const textColor = color.cssString(
+    color.pickByContrast(resolved, theme.colors.gray.l0, theme.colors.gray.l11),
+  );
   return (
     <Primitive.Div
       className={CSS(CSS.B("value"), className)}

--- a/pluto/src/schematic/node/general/value/external.tsx
+++ b/pluto/src/schematic/node/general/value/external.tsx
@@ -7,6 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+import { color } from "@synnaxlabs/x";
 import { type ReactElement } from "react";
 
 import { Label } from "@/schematic/node/common/label";
@@ -25,7 +26,7 @@ export * from "@/schematic/node/general/value/config";
 export const defaultConfig = (t: Theming.Theme): Config => ({
   variant: VARIANT,
   orientation: "left",
-  color: t.colors.gray.l11,
+  color: color.ZERO,
   units: "psi",
   level: "h5",
   inlineSize: 70,

--- a/pluto/src/schematic/node/safety/BurstDisc.tsx
+++ b/pluto/src/schematic/node/safety/BurstDisc.tsx
@@ -11,6 +11,7 @@ import { color } from "@synnaxlabs/x";
 import { type ReactElement } from "react";
 
 import { CSS } from "@/css";
+import { useColor } from "@/schematic/node/common/color";
 import { Handle } from "@/schematic/node/common/handle";
 import { Primitive } from "@/schematic/node/common/primitive";
 
@@ -25,7 +26,8 @@ export const BurstDisc = ({
   scale,
   ...rest
 }: Props): ReactElement => {
-  const colorStr = color.cssString(colorVal);
+  const resolved = useColor(colorVal);
+  const colorStr = color.cssString(resolved);
   return (
     <Primitive.Div {...rest} className={CSS(CSS.B("symbol"), className)}>
       <Handle.Boundary orientation={orientation}>
@@ -39,7 +41,7 @@ export const BurstDisc = ({
       </Handle.Boundary>
       <Primitive.SVG
         dimensions={DIMENSIONS}
-        color={colorVal}
+        color={resolved}
         orientation={orientation}
         scale={scale}
       >

--- a/pluto/src/schematic/node/valves/AngledSpringLoadedRelief.tsx
+++ b/pluto/src/schematic/node/valves/AngledSpringLoadedRelief.tsx
@@ -11,6 +11,7 @@ import { color } from "@synnaxlabs/x";
 import { type ReactElement } from "react";
 
 import { CSS } from "@/css";
+import { useColor } from "@/schematic/node/common/color";
 import { Handle } from "@/schematic/node/common/handle";
 import { Primitive } from "@/schematic/node/common/primitive";
 import { Toggle } from "@/schematic/node/common/toggle";
@@ -26,7 +27,8 @@ export const AngledSpringLoadedRelief = ({
   enabled = false,
   ...rest
 }: Props): ReactElement => {
-  const colorStr = color.cssString(colorVal);
+  const resolved = useColor(colorVal);
+  const colorStr = color.cssString(resolved);
   return (
     <Toggle.Button
       {...rest}
@@ -52,7 +54,7 @@ export const AngledSpringLoadedRelief = ({
       </Handle.Boundary>
       <Primitive.SVG
         dimensions={DIMENSIONS}
-        color={colorVal}
+        color={resolved}
         orientation={orientation}
         scale={scale}
       >

--- a/pluto/src/schematic/node/valves/Breather.tsx
+++ b/pluto/src/schematic/node/valves/Breather.tsx
@@ -11,6 +11,7 @@ import { color } from "@synnaxlabs/x";
 import { type ReactElement } from "react";
 
 import { CSS } from "@/css";
+import { useColor } from "@/schematic/node/common/color";
 import { Handle } from "@/schematic/node/common/handle";
 import { Primitive } from "@/schematic/node/common/primitive";
 import { Toggle } from "@/schematic/node/common/toggle";
@@ -25,23 +26,26 @@ export const Breather = ({
   scale,
   enabled = false,
   ...rest
-}: Props): ReactElement => (
-  <Toggle.Button
-    {...rest}
-    orientation={orientation}
-    className={CSS(CSS.B("breather-valve"), className)}
-    enabled={enabled}
-  >
-    <Handle.Linear orientation={orientation} left={8.081} right={91.919} />
-    <Primitive.SVG
-      dimensions={DIMENSIONS}
-      color={colorVal}
+}: Props): ReactElement => {
+  const resolved = useColor(colorVal);
+  return (
+    <Toggle.Button
+      {...rest}
       orientation={orientation}
-      scale={scale}
+      className={CSS(CSS.B("breather-valve"), className)}
+      enabled={enabled}
     >
-      <Primitive.Circle cx="91" cy="49.5" r="6" fill={color.cssString(colorVal)} />
-      <Primitive.Circle cx="8" cy="7.5" r="6" fill={color.cssString(colorVal)} />
-      <Primitive.Path d="M49.5 28.5L12.3545 9.70349C10.359 8.69372 8 10.1438 8 12.3803V44.6197C8 46.8562 10.359 48.3063 12.3545 47.2965L49.5 28.5ZM49.5 28.5L86.6455 9.70349C88.641 8.69372 91 10.1438 91 12.3803V44.6197C91 46.8562 88.641 48.3063 86.6455 47.2965L49.5 28.5Z" />
-    </Primitive.SVG>
-  </Toggle.Button>
-);
+      <Handle.Linear orientation={orientation} left={8.081} right={91.919} />
+      <Primitive.SVG
+        dimensions={DIMENSIONS}
+        color={resolved}
+        orientation={orientation}
+        scale={scale}
+      >
+        <Primitive.Circle cx="91" cy="49.5" r="6" fill={color.cssString(resolved)} />
+        <Primitive.Circle cx="8" cy="7.5" r="6" fill={color.cssString(resolved)} />
+        <Primitive.Path d="M49.5 28.5L12.3545 9.70349C10.359 8.69372 8 10.1438 8 12.3803V44.6197C8 46.8562 10.359 48.3063 12.3545 47.2965L49.5 28.5ZM49.5 28.5L86.6455 9.70349C88.641 8.69372 91 10.1438 91 12.3803V44.6197C91 46.8562 88.641 48.3063 86.6455 47.2965L49.5 28.5Z" />
+      </Primitive.SVG>
+    </Toggle.Button>
+  );
+};

--- a/pluto/src/schematic/node/valves/ButterflyOne.tsx
+++ b/pluto/src/schematic/node/valves/ButterflyOne.tsx
@@ -11,6 +11,7 @@ import { color } from "@synnaxlabs/x";
 import { type ReactElement } from "react";
 
 import { CSS } from "@/css";
+import { useColor } from "@/schematic/node/common/color";
 import { Handle } from "@/schematic/node/common/handle";
 import { Primitive } from "@/schematic/node/common/primitive";
 import { Toggle } from "@/schematic/node/common/toggle";
@@ -25,23 +26,26 @@ export const ButterflyOne = ({
   scale,
   enabled = false,
   ...rest
-}: Props): ReactElement => (
-  <Toggle.Button
-    {...rest}
-    orientation={orientation}
-    className={CSS(CSS.B("butterfly-valve-one"), className)}
-    enabled={enabled}
-  >
-    <Handle.Linear orientation={orientation} left={2.2989} right={97.7011} />
-    <Primitive.SVG
-      dimensions={DIMENSIONS}
-      color={colorVal}
+}: Props): ReactElement => {
+  const resolved = useColor(colorVal);
+  return (
+    <Toggle.Button
+      {...rest}
       orientation={orientation}
-      scale={scale}
+      className={CSS(CSS.B("butterfly-valve-one"), className)}
+      enabled={enabled}
     >
-      <Primitive.Path d="M43.5 21L6.35453 2.20349C4.35901 1.19372 2 2.64384 2 4.88029V37.1197C2 39.3562 4.35901 40.8063 6.35453 39.7965L43.5 21ZM43.5 21L80.6455 2.20349C82.641 1.19372 85 2.64384 85 4.8803V37.1197C85 39.3562 82.641 40.8063 80.6455 39.7965L43.5 21Z" />
-      <Primitive.Path d="M43.5 2V40" />
-      <Primitive.Circle cx="43.5" cy="21" r="10" fill={color.cssString(colorVal)} />
-    </Primitive.SVG>
-  </Toggle.Button>
-);
+      <Handle.Linear orientation={orientation} left={2.2989} right={97.7011} />
+      <Primitive.SVG
+        dimensions={DIMENSIONS}
+        color={resolved}
+        orientation={orientation}
+        scale={scale}
+      >
+        <Primitive.Path d="M43.5 21L6.35453 2.20349C4.35901 1.19372 2 2.64384 2 4.88029V37.1197C2 39.3562 4.35901 40.8063 6.35453 39.7965L43.5 21ZM43.5 21L80.6455 2.20349C82.641 1.19372 85 2.64384 85 4.8803V37.1197C85 39.3562 82.641 40.8063 80.6455 39.7965L43.5 21Z" />
+        <Primitive.Path d="M43.5 2V40" />
+        <Primitive.Circle cx="43.5" cy="21" r="10" fill={color.cssString(resolved)} />
+      </Primitive.SVG>
+    </Toggle.Button>
+  );
+};

--- a/pluto/src/schematic/node/valves/ButterflyTwo.tsx
+++ b/pluto/src/schematic/node/valves/ButterflyTwo.tsx
@@ -11,6 +11,7 @@ import { color } from "@synnaxlabs/x";
 import { type ReactElement } from "react";
 
 import { CSS } from "@/css";
+import { useColor } from "@/schematic/node/common/color";
 import { Handle } from "@/schematic/node/common/handle";
 import { Primitive } from "@/schematic/node/common/primitive";
 import { Toggle } from "@/schematic/node/common/toggle";
@@ -25,23 +26,26 @@ export const ButterflyTwo = ({
   scale,
   enabled = false,
   ...rest
-}: Props): ReactElement => (
-  <Toggle.Button
-    {...rest}
-    orientation={orientation}
-    className={CSS(CSS.B("butterfly-valve-two"), className)}
-    enabled={enabled}
-  >
-    <Handle.Linear orientation={orientation} left={2.2989} right={97.7011} />
-    <Primitive.SVG
-      dimensions={DIMENSIONS}
-      color={colorVal}
+}: Props): ReactElement => {
+  const resolved = useColor(colorVal);
+  return (
+    <Toggle.Button
+      {...rest}
       orientation={orientation}
-      scale={scale}
+      className={CSS(CSS.B("butterfly-valve-two"), className)}
+      enabled={enabled}
     >
-      <Primitive.Circle cx="43.5" cy="21" r="10" fill={color.cssString(colorVal)} />
-      <Primitive.Rect x="2" y="2" width="83" height="38" rx="1" />
-      <Primitive.Path d="M2.29001 2.29004L84.7069 39.676" />
-    </Primitive.SVG>
-  </Toggle.Button>
-);
+      <Handle.Linear orientation={orientation} left={2.2989} right={97.7011} />
+      <Primitive.SVG
+        dimensions={DIMENSIONS}
+        color={resolved}
+        orientation={orientation}
+        scale={scale}
+      >
+        <Primitive.Circle cx="43.5" cy="21" r="10" fill={color.cssString(resolved)} />
+        <Primitive.Rect x="2" y="2" width="83" height="38" rx="1" />
+        <Primitive.Path d="M2.29001 2.29004L84.7069 39.676" />
+      </Primitive.SVG>
+    </Toggle.Button>
+  );
+};

--- a/pluto/src/schematic/node/valves/CheckWithArrow.tsx
+++ b/pluto/src/schematic/node/valves/CheckWithArrow.tsx
@@ -11,6 +11,7 @@ import { color } from "@synnaxlabs/x";
 import { type ReactElement } from "react";
 
 import { CSS } from "@/css";
+import { useColor } from "@/schematic/node/common/color";
 import { Handle } from "@/schematic/node/common/handle";
 import { Primitive } from "@/schematic/node/common/primitive";
 export interface Props extends Primitive.DivProps, Primitive.SVGBasedProps {}
@@ -24,7 +25,8 @@ export const CheckWithArrow = ({
   scale,
   ...rest
 }: Props): ReactElement => {
-  const colorStr = color.cssString(colorVal);
+  const resolved = useColor(colorVal);
+  const colorStr = color.cssString(resolved);
   return (
     <Primitive.Div
       orientation={orientation}
@@ -39,7 +41,7 @@ export const CheckWithArrow = ({
       />
       <Primitive.SVG
         dimensions={DIMENSIONS}
-        color={colorVal}
+        color={resolved}
         orientation={orientation}
         scale={scale}
       >

--- a/pluto/src/schematic/node/valves/FourWay.tsx
+++ b/pluto/src/schematic/node/valves/FourWay.tsx
@@ -11,6 +11,7 @@ import { color } from "@synnaxlabs/x";
 import { type ReactElement } from "react";
 
 import { CSS } from "@/css";
+import { useColor } from "@/schematic/node/common/color";
 import { Handle } from "@/schematic/node/common/handle";
 import { Primitive } from "@/schematic/node/common/primitive";
 import { Toggle } from "@/schematic/node/common/toggle";
@@ -25,7 +26,8 @@ export const FourWay = ({
   color: colorVal,
   ...rest
 }: Props): ReactElement => {
-  const colorStr = color.cssString(colorVal);
+  const resolved = useColor(colorVal);
+  const colorStr = color.cssString(resolved);
   return (
     <Toggle.Button
       {...rest}
@@ -41,7 +43,7 @@ export const FourWay = ({
       />
       <Primitive.SVG
         dimensions={DIMENSIONS}
-        color={colorVal}
+        color={resolved}
         scale={scale}
         orientation={orientation}
       >

--- a/pluto/src/schematic/node/valves/IsoCheck.tsx
+++ b/pluto/src/schematic/node/valves/IsoCheck.tsx
@@ -10,6 +10,7 @@
 import { color } from "@synnaxlabs/x";
 import { type ReactElement } from "react";
 
+import { useColor } from "@/schematic/node/common/color";
 import { Handle } from "@/schematic/node/common/handle";
 import { Primitive } from "@/schematic/node/common/primitive";
 export interface Props extends Primitive.DivProps, Primitive.SVGBasedProps {}
@@ -23,13 +24,14 @@ export const IsoCheck = ({
   scale,
   ...rest
 }: Props): ReactElement => {
-  const colorStr = color.cssString(colorVal);
+  const resolved = useColor(colorVal);
+  const colorStr = color.cssString(resolved);
   return (
     <Primitive.Div {...rest} orientation={orientation}>
       <Handle.Linear orientation={orientation} left={8.3333} right={96.4286} />
       <Primitive.SVG
         dimensions={DIMENSIONS}
-        color={colorVal}
+        color={resolved}
         orientation={orientation}
         scale={scale}
       >

--- a/pluto/src/schematic/node/valves/Needle.tsx
+++ b/pluto/src/schematic/node/valves/Needle.tsx
@@ -11,6 +11,7 @@ import { color } from "@synnaxlabs/x";
 import { type ReactElement } from "react";
 
 import { CSS } from "@/css";
+import { useColor } from "@/schematic/node/common/color";
 import { Handle } from "@/schematic/node/common/handle";
 import { Primitive } from "@/schematic/node/common/primitive";
 import { Toggle } from "@/schematic/node/common/toggle";
@@ -25,30 +26,33 @@ export const Needle = ({
   scale,
   enabled = false,
   ...rest
-}: Props): ReactElement => (
-  <Toggle.Button
-    {...rest}
-    orientation={orientation}
-    className={CSS(CSS.B("needle-valve"), className)}
-    enabled={enabled}
-  >
-    <Handle.Linear
+}: Props): ReactElement => {
+  const resolved = useColor(colorVal);
+  return (
+    <Toggle.Button
+      {...rest}
       orientation={orientation}
-      left={2.2989}
-      right={97.7011}
-      top={51.1905}
-    />
-    <Primitive.SVG
-      dimensions={DIMENSIONS}
-      orientation={orientation}
-      color={colorVal}
-      scale={scale}
+      className={CSS(CSS.B("needle-valve"), className)}
+      enabled={enabled}
     >
-      <Primitive.Path
-        d="M43.0152 21.5391L38.237 2.62245C38.1573 2.30658 38.396 2 38.7218 2L48.2782 2C48.604 2 48.8427 2.30658 48.763 2.62245L43.9848 21.5391C43.8576 22.0425 43.1424 22.0425 43.0152 21.5391Z"
-        fill={color.cssString(colorVal)}
+      <Handle.Linear
+        orientation={orientation}
+        left={2.2989}
+        right={97.7011}
+        top={51.1905}
       />
-      <Primitive.Path d="M43.5 21.5L6.35453 2.70349C4.35901 1.69372 2 3.14384 2 5.38029V37.6197C2 39.8562 4.35901 41.3063 6.35453 40.2965L43.5 21.5ZM43.5 21.5L80.6455 2.70349C82.641 1.69372 85 3.14384 85 5.3803V37.6197C85 39.8562 82.641 41.3063 80.6455 40.2965L43.5 21.5Z" />
-    </Primitive.SVG>
-  </Toggle.Button>
-);
+      <Primitive.SVG
+        dimensions={DIMENSIONS}
+        orientation={orientation}
+        color={resolved}
+        scale={scale}
+      >
+        <Primitive.Path
+          d="M43.0152 21.5391L38.237 2.62245C38.1573 2.30658 38.396 2 38.7218 2L48.2782 2C48.604 2 48.8427 2.30658 48.763 2.62245L43.9848 21.5391C43.8576 22.0425 43.1424 22.0425 43.0152 21.5391Z"
+          fill={color.cssString(resolved)}
+        />
+        <Primitive.Path d="M43.5 21.5L6.35453 2.70349C4.35901 1.69372 2 3.14384 2 5.38029V37.6197C2 39.8562 4.35901 41.3063 6.35453 40.2965L43.5 21.5ZM43.5 21.5L80.6455 2.70349C82.641 1.69372 85 3.14384 85 5.3803V37.6197C85 39.8562 82.641 41.3063 80.6455 40.2965L43.5 21.5Z" />
+      </Primitive.SVG>
+    </Toggle.Button>
+  );
+};

--- a/pluto/src/schematic/node/valves/SpringLoadedRelief.tsx
+++ b/pluto/src/schematic/node/valves/SpringLoadedRelief.tsx
@@ -11,6 +11,7 @@ import { color } from "@synnaxlabs/x";
 import { type ReactElement } from "react";
 
 import { CSS } from "@/css";
+import { useColor } from "@/schematic/node/common/color";
 import { Handle } from "@/schematic/node/common/handle";
 import { Primitive } from "@/schematic/node/common/primitive";
 import { Toggle } from "@/schematic/node/common/toggle";
@@ -26,7 +27,8 @@ export const SpringLoadedRelief = ({
   enabled = false,
   ...rest
 }: Props): ReactElement => {
-  const colorStr = color.cssString(colorVal);
+  const resolved = useColor(colorVal);
+  const colorStr = color.cssString(resolved);
   return (
     <Toggle.Button
       {...rest}
@@ -52,7 +54,7 @@ export const SpringLoadedRelief = ({
       </Handle.Boundary>
       <Primitive.SVG
         dimensions={DIMENSIONS}
-        color={colorVal}
+        color={resolved}
         orientation={orientation}
         scale={scale}
       >

--- a/pluto/src/schematic/node/valves/symbols.ts
+++ b/pluto/src/schematic/node/valves/symbols.ts
@@ -176,9 +176,9 @@ const solenoidSpec: Spec<"solenoidValve", SolenoidConfig> = {
   Form: Form.ToggleForm,
   Node: Toggle.createToggle<SolenoidConfig>(Solenoid),
   Preview: Solenoid,
-  defaultConfig: (t: Theming.Theme): SolenoidConfig => ({
+  defaultConfig: (_t: Theming.Theme): SolenoidConfig => ({
     variant: "solenoidValve",
-    color: t.colors.gray.l11,
+    color: color.ZERO,
     label: Label.defaultConfig("Solenoid Valve"),
     normallyOpen: false,
     ...Primitive.ZERO_PROPS,

--- a/pluto/src/schematic/node/vessels/crossJunction/Primitive.tsx
+++ b/pluto/src/schematic/node/vessels/crossJunction/Primitive.tsx
@@ -11,6 +11,7 @@ import { color } from "@synnaxlabs/x";
 import { type ReactElement } from "react";
 
 import { CSS } from "@/css";
+import { useColor } from "@/schematic/node/common/color";
 import { Handle } from "@/schematic/node/common/handle";
 import { Primitive } from "@/schematic/node/common/primitive";
 
@@ -25,49 +26,52 @@ export const CrossJunction = ({
   color: colorVal,
   scale,
   ...rest
-}: CrossJunctionProps): ReactElement => (
-  <Primitive.Div className={CSS(CSS.B("t-junction"), className)} {...rest}>
-    <Handle.Boundary orientation={orientation}>
-      <Handle.Handle
-        location="left"
+}: CrossJunctionProps): ReactElement => {
+  const fill = useColor(colorVal);
+  return (
+    <Primitive.Div className={CSS(CSS.B("t-junction"), className)} {...rest}>
+      <Handle.Boundary orientation={orientation}>
+        <Handle.Handle
+          location="left"
+          orientation={orientation}
+          left={3.8462}
+          top={50}
+          id="1"
+        />
+        <Handle.Handle
+          location="right"
+          orientation={orientation}
+          left={96.1539}
+          top={50}
+          id="2"
+        />
+        <Handle.Handle
+          location="bottom"
+          orientation={orientation}
+          left={50.5}
+          top={96.1539}
+          id="3"
+        />
+        <Handle.Handle
+          location="top"
+          orientation={orientation}
+          left={50.5}
+          top={3.8462}
+          id="4"
+        />
+      </Handle.Boundary>
+      <Primitive.SVG
+        dimensions={DIMENSIONS}
+        color={fill}
         orientation={orientation}
-        left={3.8462}
-        top={50}
-        id="1"
-      />
-      <Handle.Handle
-        location="right"
-        orientation={orientation}
-        left={96.1539}
-        top={50}
-        id="2"
-      />
-      <Handle.Handle
-        location="bottom"
-        orientation={orientation}
-        left={50.5}
-        top={96.1539}
-        id="3"
-      />
-      <Handle.Handle
-        location="top"
-        orientation={orientation}
-        left={50.5}
-        top={3.8462}
-        id="4"
-      />
-    </Handle.Boundary>
-    <Primitive.SVG
-      dimensions={DIMENSIONS}
-      color={colorVal}
-      orientation={orientation}
-      scale={scale}
-    >
-      <Primitive.Path
-        d="M22.5 35.5C22.5 36.6046 21.6046 37.5 20.5 37.5H18.5C17.3954 37.5 16.5 36.6046 16.5 35.5V24.5C16.5 23.3954 15.6046 22.5 14.5 22.5H3.5C2.39543 22.5 1.5 21.6046 1.5 20.5V18.5C1.5 17.3954 2.39543 16.5 3.5 16.5H14.5C15.6046 16.5 16.5 15.6046 16.5 14.5V3.5C16.5 2.39543 17.3954 1.5 18.5 1.5H20.5C21.6046 1.5 22.5 2.39543 22.5 3.5V14.5C22.5 15.6046 23.3954 16.5 24.5 16.5H35.5C36.6046 16.5 37.5 17.3954 37.5 18.5V20.5C37.5 21.6046 36.6046 22.5 35.5 22.5H24.5C23.3954 22.5 22.5 23.3954 22.5 24.5V35.5Z"
-        fill={color.cssString(colorVal)}
-        stroke="none"
-      />
-    </Primitive.SVG>
-  </Primitive.Div>
-);
+        scale={scale}
+      >
+        <Primitive.Path
+          d="M22.5 35.5C22.5 36.6046 21.6046 37.5 20.5 37.5H18.5C17.3954 37.5 16.5 36.6046 16.5 35.5V24.5C16.5 23.3954 15.6046 22.5 14.5 22.5H3.5C2.39543 22.5 1.5 21.6046 1.5 20.5V18.5C1.5 17.3954 2.39543 16.5 3.5 16.5H14.5C15.6046 16.5 16.5 15.6046 16.5 14.5V3.5C16.5 2.39543 17.3954 1.5 18.5 1.5H20.5C21.6046 1.5 22.5 2.39543 22.5 3.5V14.5C22.5 15.6046 23.3954 16.5 24.5 16.5H35.5C36.6046 16.5 37.5 17.3954 37.5 18.5V20.5C37.5 21.6046 36.6046 22.5 35.5 22.5H24.5C23.3954 22.5 22.5 23.3954 22.5 24.5V35.5Z"
+          fill={color.cssString(fill)}
+          stroke="none"
+        />
+      </Primitive.SVG>
+    </Primitive.Div>
+  );
+};

--- a/pluto/src/schematic/node/vessels/crossJunction/external.ts
+++ b/pluto/src/schematic/node/vessels/crossJunction/external.ts
@@ -7,6 +7,8 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+import { color } from "@synnaxlabs/x";
+
 import { Form } from "@/schematic/node/common/form";
 import { Label } from "@/schematic/node/common/label";
 import { Primitive } from "@/schematic/node/common/primitive";
@@ -17,9 +19,9 @@ import { type Theming } from "@/theming";
 
 export * from "@/schematic/node/vessels/crossJunction/config";
 
-export const defaultConfig = (t: Theming.Theme): Config => ({
+export const defaultConfig = (_t: Theming.Theme): Config => ({
   variant: VARIANT,
-  color: t.colors.gray.l11,
+  color: color.ZERO,
   label: Label.defaultConfig(""),
   ...Primitive.ZERO_PROPS,
 });

--- a/pluto/src/schematic/node/vessels/cylinder/Primitive.tsx
+++ b/pluto/src/schematic/node/vessels/cylinder/Primitive.tsx
@@ -12,6 +12,7 @@ import { type ReactElement, useMemo } from "react";
 
 import { CSS } from "@/css";
 import { Border } from "@/schematic/node/common/border";
+import { resolveColor } from "@/schematic/node/common/color";
 import { Handle } from "@/schematic/node/common/handle";
 import { Primitive } from "@/schematic/node/common/primitive";
 import { type Config } from "@/schematic/node/vessels/cylinder/config";
@@ -46,7 +47,7 @@ export const Cylinder = ({
       orientation,
     ],
   );
-  const boardColor = color.cssString(colorVal ?? t.colors.gray.l11);
+  const boardColor = color.cssString(resolveColor(colorVal, t));
   const bgColor =
     backgroundColor == null ? undefined : color.cssString(backgroundColor);
   const transform = `scale(${dimensions.width / 66},${dimensions.height / 180})`;

--- a/pluto/src/schematic/node/vessels/cylinder/external.ts
+++ b/pluto/src/schematic/node/vessels/cylinder/external.ts
@@ -22,7 +22,7 @@ export * from "@/schematic/node/vessels/cylinder/config";
 export const defaultConfig = (t: Theming.Theme): Config => ({
   variant: VARIANT,
   orientation: "left",
-  color: t.colors.gray.l11,
+  color: color.ZERO,
   backgroundColor: color.setAlpha(t.colors.gray.l1, 0),
   label: Label.defaultConfig("Cylinder"),
   dimensions: { width: 66, height: 181 },

--- a/pluto/src/schematic/node/vessels/tJunction/Primitive.tsx
+++ b/pluto/src/schematic/node/vessels/tJunction/Primitive.tsx
@@ -11,6 +11,7 @@ import { color } from "@synnaxlabs/x";
 import { type ReactElement } from "react";
 
 import { CSS } from "@/css";
+import { useColor } from "@/schematic/node/common/color";
 import { Handle } from "@/schematic/node/common/handle";
 import { Primitive } from "@/schematic/node/common/primitive";
 export interface Props extends Primitive.DivProps, Primitive.SVGBasedProps {}
@@ -23,42 +24,45 @@ export const TJunction = ({
   color: colorVal,
   scale,
   ...rest
-}: Props): ReactElement => (
-  <Primitive.Div className={CSS(CSS.B("t-junction"), className)} {...rest}>
-    <Handle.Boundary orientation={orientation}>
-      <Handle.Handle
-        location="left"
+}: Props): ReactElement => {
+  const fill = useColor(colorVal);
+  return (
+    <Primitive.Div className={CSS(CSS.B("t-junction"), className)} {...rest}>
+      <Handle.Boundary orientation={orientation}>
+        <Handle.Handle
+          location="left"
+          orientation={orientation}
+          left={3.8462}
+          top={22.3095}
+          id="1"
+        />
+        <Handle.Handle
+          location="right"
+          orientation={orientation}
+          left={96.1538}
+          top={22.3095}
+          id="2"
+        />
+        <Handle.Handle
+          location="bottom"
+          orientation={orientation}
+          left={50}
+          top={92.8571}
+          id="3"
+        />
+      </Handle.Boundary>
+      <Primitive.SVG
+        dimensions={DIMENSIONS}
+        color={fill}
         orientation={orientation}
-        left={3.8462}
-        top={22.3095}
-        id="1"
-      />
-      <Handle.Handle
-        location="right"
-        orientation={orientation}
-        left={96.1538}
-        top={22.3095}
-        id="2"
-      />
-      <Handle.Handle
-        location="bottom"
-        orientation={orientation}
-        left={50}
-        top={92.8571}
-        id="3"
-      />
-    </Handle.Boundary>
-    <Primitive.SVG
-      dimensions={DIMENSIONS}
-      color={colorVal}
-      orientation={orientation}
-      scale={scale}
-    >
-      <Primitive.Path
-        d="M1.5 5.5V3.5C1.5 2.39543 2.39543 1.5 3.5 1.5H35.5C36.6046 1.5 37.5 2.39543 37.5 3.5V5.5C37.5 6.60457 36.6046 7.5 35.5 7.5H24.5C23.3954 7.5 22.5 8.39543 22.5 9.5V17.5C22.5 18.6046 21.6046 19.5 20.5 19.5H18.5C17.3954 19.5 16.5 18.6046 16.5 17.5V9.5C16.5 8.39543 15.6046 7.5 14.5 7.5H3.5C2.39543 7.5 1.5 6.60457 1.5 5.5Z"
-        fill={color.cssString(colorVal)}
-        stroke="none"
-      />
-    </Primitive.SVG>
-  </Primitive.Div>
-);
+        scale={scale}
+      >
+        <Primitive.Path
+          d="M1.5 5.5V3.5C1.5 2.39543 2.39543 1.5 3.5 1.5H35.5C36.6046 1.5 37.5 2.39543 37.5 3.5V5.5C37.5 6.60457 36.6046 7.5 35.5 7.5H24.5C23.3954 7.5 22.5 8.39543 22.5 9.5V17.5C22.5 18.6046 21.6046 19.5 20.5 19.5H18.5C17.3954 19.5 16.5 18.6046 16.5 17.5V9.5C16.5 8.39543 15.6046 7.5 14.5 7.5H3.5C2.39543 7.5 1.5 6.60457 1.5 5.5Z"
+          fill={color.cssString(fill)}
+          stroke="none"
+        />
+      </Primitive.SVG>
+    </Primitive.Div>
+  );
+};

--- a/pluto/src/schematic/node/vessels/tJunction/external.ts
+++ b/pluto/src/schematic/node/vessels/tJunction/external.ts
@@ -7,6 +7,8 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+import { color } from "@synnaxlabs/x";
+
 import { Form } from "@/schematic/node/common/form";
 import { Label } from "@/schematic/node/common/label";
 import { Primitive } from "@/schematic/node/common/primitive";
@@ -17,9 +19,9 @@ import { type Theming } from "@/theming";
 
 export * from "@/schematic/node/vessels/tJunction/config";
 
-export const defaultConfig = (t: Theming.Theme): Config => ({
+export const defaultConfig = (_t: Theming.Theme): Config => ({
   variant: VARIANT,
-  color: t.colors.gray.l11,
+  color: color.ZERO,
   label: Label.defaultConfig(""),
   ...Primitive.ZERO_PROPS,
 });

--- a/pluto/src/schematic/node/vessels/tank/Primitive.tsx
+++ b/pluto/src/schematic/node/vessels/tank/Primitive.tsx
@@ -14,6 +14,7 @@ import { type ReactElement, useMemo } from "react";
 
 import { CSS } from "@/css";
 import { Border } from "@/schematic/node/common/border";
+import { resolveColor } from "@/schematic/node/common/color";
 import { Handle } from "@/schematic/node/common/handle";
 import { Primitive } from "@/schematic/node/common/primitive";
 import { type Config } from "@/schematic/node/vessels/tank/config";
@@ -60,7 +61,7 @@ export const Tank = ({
       style={{
         ...dimensions,
         borderRadius: boxBorderRadius ?? Border.cssRadius(detailedRadius),
-        borderColor: color.cssString(colorVal ?? t.colors.gray.l11),
+        borderColor: color.cssString(resolveColor(colorVal, t)),
         backgroundColor: color.cssString(backgroundColor),
         borderWidth: strokeWidth,
       }}

--- a/pluto/src/schematic/node/vessels/tank/external.ts
+++ b/pluto/src/schematic/node/vessels/tank/external.ts
@@ -24,7 +24,7 @@ export * from "@/schematic/node/vessels/tank/config";
 export const defaultConfig = (t: Theming.Theme): Config => ({
   variant: VARIANT,
   orientation: "left",
-  color: t.colors.gray.l11,
+  color: color.ZERO,
   backgroundColor: color.setAlpha(t.colors.gray.l1, 0),
   label: Label.defaultConfig("Tank"),
   dimensions: { width: 125, height: 200 },


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4316](https://linear.app/synnax/issue/SY-4316/schematic-symbol-colors-not-responding-to-theme-change)

## Description

Schematic symbols baked a concrete color into their config when placed, so they did not re-color when the console light or dark theme was toggled. A symbol placed in light mode rendered with a near-black stroke that became nearly invisible on a dark background, and the reverse happened for symbols placed in dark mode. 


https://github.com/user-attachments/assets/139535ce-49bd-4b12-869f-63144aacaf96


Symbols now store the `color.ZERO` follow-theme sentinel by default and resolve it to the live theme color at render time, so they re-color on theme toggles while a symbol the user explicitly colors keeps its color. This matches the behavior the value and gauge visualizations and edges already use.


Key changes:
- Resolve the color in the shared `Primitive.SVG` keystone, which covers most symbols, plus the primitives that draw color outside the SVG inheritance path (junctions, several valves, safety, value, state indicator, tank, cylinder, gauge, and the form control symbols).
- Add a shared `resolveColor(c, theme)` and `useColor(c)` helper so the resolution lives in one place instead of being duplicated per primitive.
- Change every symbol `defaultConfig` color from `gray.l11` to `color.ZERO`.
- Preview the resolved theme color in the color picker swatch so a default symbol shows its real rendered color instead of a transparent swatch. Background color fields keep their transparent default.

Already placed symbols keep their captured color, since their persisted config holds an explicit value. Only newly placed symbols follow the theme.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes schematic symbols baking a concrete theme color into their config at placement time, which caused symbols placed in light mode to become nearly invisible in dark mode and vice versa. Symbols now default to `color.ZERO` as a "follow-theme" sentinel and resolve it to the live theme color at render time.

- A shared `resolveColor(c, theme)` / `useColor(c)` helper is introduced in `common/color.ts`, and every primitive that draws color outside the SVG inheritance path (junctions, valves, gauge, value, state indicator, tank, cylinder, etc.) is updated to call it before rendering.
- Every `defaultConfig` factory that previously captured `t.colors.gray.l11` at placement time now stores `color.ZERO`; the `ColorField` form swatch is updated to display the resolved visual color so the picker shows the actual rendered color rather than a transparent swatch.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive and backward-compatible: existing symbols with an explicit color in their persisted config are unaffected, and new symbols resolve correctly to the active theme color at render time.

The sentinel value color.ZERO is cleanly identified by color.isZero, resolution is centralized in one helper, and the update is consistently applied across all 51 files. Unit tests cover the sentinel, undefined, explicit-color, and theme-divergence cases. Backward compatibility is preserved because previously placed symbols carry gray.l11 explicitly (which is non-zero) and pass through unchanged.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pluto/src/schematic/node/common/color.ts | New shared color resolution helper — resolveColor and useColor are clean, minimal, and correctly use color.isZero to detect the follow-theme sentinel. |
| pluto/src/schematic/node/common/color.spec.ts | New unit tests for resolveColor covering the ZERO sentinel, undefined, theme-divergence, and explicit-color cases — thorough coverage. |
| pluto/src/schematic/node/common/primitive/SVG.tsx | Now always resolves color before rendering and always sets --pluto-symbol-color / --pluto-symbol-color-contrast CSS variables, eliminating the conditional guard that left them unset for missing colors. |
| pluto/src/schematic/node/common/form/Color.tsx | ColorField now resolves the color before passing it to the swatch so the picker preview shows the actual rendered color instead of a transparent swatch. |
| pluto/src/schematic/node/general/gauge/Primitive.tsx | Gauge arc stroke now resolves via useColor; replaces the old c ?? 'var(--pluto-primary-z)' fallback, aligning gauge default color with all other symbols. |
| pluto/src/schematic/node/general/value/Primitive.tsx | Value border and text color now derive from resolveColor; the old 'var(--pluto-gray-l0)' CSS-variable fallback for null color is replaced with pickByContrast against the resolved theme color. |
| pluto/src/schematic/node/vessels/crossJunction/Primitive.tsx | Refactored from arrow-function to block body to hoist useColor call; both the SVG and the inline path fill use the pre-resolved color correctly. |
| pluto/src/schematic/node/vessels/tJunction/Primitive.tsx | Same refactor as crossJunction — pre-resolves color before rendering, eliminating direct color.cssString(colorVal) calls with potentially-zero input. |
| pluto/src/schematic/node/general/polygon/Primitive.tsx | Default stroke color changes from gray.l9 (old ad-hoc fallback) to gray.l11 (via resolveColor) to align with all other symbols. |
| pluto/src/schematic/node/valves/symbols.ts | Solenoid valve defaultConfig updated to color.ZERO; _t unused-parameter convention applied consistently. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Symbol defaultConfig\n(color: color.ZERO)"] --> B["Symbol placed on schematic\n(config persisted with color.ZERO)"]
    B --> C{Render time}
    C --> D["resolveColor / useColor called"]
    D --> E{color == null\nor isZero?}
    E -- Yes --> F["theme.colors.gray.l11\n(follows active theme)"]
    E -- No --> G["Explicit user color\n(unchanged)"]
    F --> H["Primitive.SVG / inline fills\nrendered with theme color"]
    G --> H
    H --> I["Theme toggled\n(light ↔ dark)"]
    I --> C

    J["Legacy symbol\n(config has explicit gray.l11)"] --> C
    J -.-> K["color.isZero = false\n→ keeps captured color"]
```

<sub>Reviews (3): Last reviewed commit: ["SY-4316: Inline single-use useColor call..."](https://github.com/synnaxlabs/synnax/commit/5a970eb237b75bce7dd655cf4117e6e8b88dfc68) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35479667)</sub>

<!-- /greptile_comment -->