### PR TITLE
SY-4318: Remove Table SetData API and Route Rename Through Dispatch

### DIFF
--- a/client/ts/src/table/actions.ts
+++ b/client/ts/src/table/actions.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { NO_OP_RESULT as NO_OP, snapshotDraft as snapshot } from "@/actions/actions";
+import { actions } from "@/actions";
 import {
   type Action,
   addCol,
@@ -83,12 +83,12 @@ const handlers: Handlers = {
   },
 
   removeRow: (state, payload) => {
-    if (payload.index >= state.rows.length) return NO_OP;
-    const removed = snapshot(state.rows[payload.index]);
+    if (payload.index >= state.rows.length) return actions.NO_OP_RESULT;
+    const removed = actions.snapshotDraft(state.rows[payload.index]);
     const cells: Cell[] = [];
     for (const k of removed.cells) {
       const c = state.cells[k];
-      if (c != null) cells.push(snapshot(c));
+      if (c != null) cells.push(actions.snapshotDraft(c));
     }
     state.rows.splice(payload.index, 1);
     for (const k of removed.cells) delete state.cells[k];
@@ -123,7 +123,7 @@ const handlers: Handlers = {
   },
 
   removeCol: (state, payload) => {
-    if (payload.index >= state.columns.length) return NO_OP;
+    if (payload.index >= state.columns.length) return actions.NO_OP_RESULT;
     const oldSize = state.columns[payload.index].size;
     const removedCells: Cell[] = [];
     state.columns.splice(payload.index, 1);
@@ -134,7 +134,7 @@ const handlers: Handlers = {
       if (payload.index >= state.rows[i].cells.length) continue;
       const k = state.rows[i].cells[payload.index];
       const c = state.cells[k];
-      if (c != null) removedCells.push(snapshot(c));
+      if (c != null) removedCells.push(actions.snapshotDraft(c));
       delete state.cells[k];
       state.rows[i].cells.splice(payload.index, 1);
     }
@@ -145,7 +145,7 @@ const handlers: Handlers = {
   },
 
   resizeRow: (state, payload) => {
-    if (payload.index >= state.rows.length) return NO_OP;
+    if (payload.index >= state.rows.length) return actions.NO_OP_RESULT;
     const oldSize = state.rows[payload.index].size;
     state.rows[payload.index].size = Math.max(payload.size, MIN_CELL_DIM);
     return {
@@ -155,7 +155,7 @@ const handlers: Handlers = {
   },
 
   resizeCol: (state, payload) => {
-    if (payload.index >= state.columns.length) return NO_OP;
+    if (payload.index >= state.columns.length) return actions.NO_OP_RESULT;
     const oldSize = state.columns[payload.index].size;
     state.columns[payload.index].size = Math.max(payload.size, MIN_CELL_DIM);
     const targets = state.rows
@@ -169,8 +169,8 @@ const handlers: Handlers = {
 
   setCell: (state, payload) => {
     const existing = state.cells[payload.cell.key];
-    if (existing == null) return NO_OP;
-    const oldCell = snapshot(existing);
+    if (existing == null) return actions.NO_OP_RESULT;
+    const oldCell = actions.snapshotDraft(existing);
     state.cells[payload.cell.key] = payload.cell;
     return {
       inverse: [setCell({ cell: oldCell })],
@@ -179,7 +179,7 @@ const handlers: Handlers = {
   },
 
   eraseCells: (state, payload) => {
-    if (payload.cells.length === 0) return NO_OP;
+    if (payload.cells.length === 0) return actions.NO_OP_RESULT;
     const selected = new Set(payload.cells);
     const rowPosOf = new Map<string, { row: number; col: number }>();
     for (let r = 0; r < state.rows.length; r++) {
@@ -209,11 +209,11 @@ const handlers: Handlers = {
     // unshift the inverse so undo replays it in ascending order.
     for (let i = fullRowIdx.length - 1; i >= 0; i--) {
       const idx = fullRowIdx[i];
-      const removed = snapshot(state.rows[idx]);
+      const removed = actions.snapshotDraft(state.rows[idx]);
       const cells: Cell[] = [];
       for (const k of removed.cells) {
         const c = state.cells[k];
-        if (c != null) cells.push(snapshot(c));
+        if (c != null) cells.push(actions.snapshotDraft(c));
       }
       state.rows.splice(idx, 1);
       for (const k of removed.cells) delete state.cells[k];
@@ -229,7 +229,7 @@ const handlers: Handlers = {
         if (idx >= state.rows[r].cells.length) continue;
         const k = state.rows[r].cells[idx];
         const c = state.cells[k];
-        if (c != null) removedCells.push(snapshot(c));
+        if (c != null) removedCells.push(actions.snapshotDraft(c));
         delete state.cells[k];
         state.rows[r].cells.splice(idx, 1);
       }
@@ -239,7 +239,7 @@ const handlers: Handlers = {
     for (const k of selected) {
       const existing = state.cells[k];
       if (existing == null) continue;
-      const oldCell = snapshot(existing);
+      const oldCell = actions.snapshotDraft(existing);
       state.cells[k] = {
         key: k,
         variant: payload.template.variant,

--- a/client/ts/src/table/client.ts
+++ b/client/ts/src/table/client.ts
@@ -11,18 +11,13 @@ import { type UnaryClient } from "@synnaxlabs/freighter";
 import { array } from "@synnaxlabs/x";
 import { z } from "zod";
 
-import { type Action, dispatchReqZ } from "@/table/actions.gen";
+import { type Action, dispatchReqZ, rename as renameAction } from "@/table/actions.gen";
 import { type Key, keyZ, type New, newZ, type Table, tableZ } from "@/table/types.gen";
 import { checkForMultipleOrNoResults } from "@/util/retrieve";
 import { workspace } from "@/workspace";
 
 export const SET_CHANNEL_NAME = "sy_table_set";
 
-const renameReqZ = z.object({ key: keyZ, name: z.string() });
-
-const setDataBodyZ = tableZ.omit({ key: true, name: true });
-export type SetDataBody = z.input<typeof setDataBodyZ>;
-const setDataReqZ = z.object({ key: keyZ, data: setDataBodyZ });
 const deleteReqZ = z.object({ keys: keyZ.array() });
 
 const retrieveReqZ = z.object({ keys: keyZ.array() });
@@ -66,11 +61,7 @@ export class Client {
   }
 
   async rename(key: Key, name: string): Promise<void> {
-    await this.client.send("/table/rename", { key, name }, renameReqZ, emptyResZ);
-  }
-
-  async setData(key: Key, data: SetDataBody): Promise<void> {
-    await this.client.send("/table/set-data", { key, data }, setDataReqZ, emptyResZ);
+    await this.dispatch(key, "", [renameAction({ name })]);
   }
 
   async dispatch(key: Key, dispatchKey: string, actions: Action[]): Promise<void> {

--- a/client/ts/src/table/table.spec.ts
+++ b/client/ts/src/table/table.spec.ts
@@ -42,31 +42,6 @@ describe("Table", () => {
     });
   });
 
-  describe("setData", () => {
-    test("set data replaces body fields while preserving key and name", async () => {
-      const ws = await client.workspaces.create({ name: "Table", layout: { one: 1 } });
-      const t = await client.tables.create(ws.key, {
-        name: "Table",
-      });
-      await client.tables.setData(t.key, {
-        rows: [{ size: 40, cells: ["a", "b"] }],
-        columns: [{ size: 80 }, { size: 100 }],
-        cells: {
-          a: { key: "a", variant: "text", props: { value: "hello" } },
-          b: { key: "b", variant: "value", props: { units: "psi" } },
-        },
-      });
-      const res = await client.tables.retrieve({ key: t.key });
-      expect(res.name).toEqual("Table");
-      expect(res.rows).toHaveLength(1);
-      expect(res.rows[0].cells).toEqual(["a", "b"]);
-      expect(res.columns).toHaveLength(2);
-      expect(res.cells.a.variant).toEqual("text");
-      expect((res.cells.a.props as Record<string, unknown>).value).toEqual("hello");
-      expect(res.cells.b.variant).toEqual("value");
-    });
-  });
-
   describe("delete", () => {
     test("delete one", async () => {
       const ws = await client.workspaces.create({ name: "Table", layout: { one: 1 } });

--- a/core/pkg/api/layer.go
+++ b/core/pkg/api/layer.go
@@ -129,8 +129,6 @@ type Transport struct {
 	TableCreate   freighter.UnaryServer[table.CreateRequest, table.CreateResponse]
 	TableRetrieve freighter.UnaryServer[table.RetrieveRequest, table.RetrieveResponse]
 	TableDelete   freighter.UnaryServer[table.DeleteRequest, types.Nil]
-	TableRename   freighter.UnaryServer[table.RenameRequest, types.Nil]
-	TableSetData  freighter.UnaryServer[table.SetDataRequest, types.Nil]
 	TableDispatch freighter.UnaryServer[table.DispatchRequest, types.Nil]
 	// LINE PLOT
 	LinePlotCreate   freighter.UnaryServer[lineplot.CreateRequest, lineplot.CreateResponse]
@@ -328,8 +326,6 @@ func (l *Layer) BindTo(t Transport) {
 		t.TableCreate,
 		t.TableRetrieve,
 		t.TableDelete,
-		t.TableRename,
-		t.TableSetData,
 		t.TableDispatch,
 
 		// LABEL
@@ -480,8 +476,6 @@ func (l *Layer) BindTo(t Transport) {
 	t.TableCreate.BindHandler(l.Table.Create)
 	t.TableRetrieve.BindHandler(l.Table.Retrieve)
 	t.TableDelete.BindHandler(l.Table.Delete)
-	t.TableRename.BindHandler(l.Table.Rename)
-	t.TableSetData.BindHandler(l.Table.SetData)
 	t.TableDispatch.BindHandler(l.Table.Dispatch)
 
 	// LABEL

--- a/core/pkg/api/table/table.go
+++ b/core/pkg/api/table/table.go
@@ -73,42 +73,6 @@ func (s *Service) Create(ctx context.Context, req CreateRequest) (res CreateResp
 	})
 }
 
-type RenameRequest struct {
-	Name string    `json:"name" msgpack:"name"`
-	Key  table.Key `json:"key" msgpack:"key"`
-}
-
-func (s *Service) Rename(ctx context.Context, req RenameRequest) (res types.Nil, err error) {
-	if err = s.access.Enforce(ctx, access.Request{
-		Subject: auth.GetSubject(ctx),
-		Action:  access.ActionUpdate,
-		Objects: []ontology.ID{table.OntologyID(req.Key)},
-	}); err != nil {
-		return res, err
-	}
-	return res, s.db.WithTx(ctx, func(tx gorp.Tx) error {
-		return s.internal.NewWriter(tx).Rename(ctx, req.Key, req.Name)
-	})
-}
-
-type SetDataRequest struct {
-	Data table.Table `json:"data" msgpack:"data"`
-	Key  table.Key   `json:"key" msgpack:"key"`
-}
-
-func (s *Service) SetData(ctx context.Context, req SetDataRequest) (res types.Nil, err error) {
-	if err = s.access.Enforce(ctx, access.Request{
-		Subject: auth.GetSubject(ctx),
-		Action:  access.ActionUpdate,
-		Objects: []ontology.ID{table.OntologyID(req.Key)},
-	}); err != nil {
-		return res, err
-	}
-	return res, s.db.WithTx(ctx, func(tx gorp.Tx) error {
-		return s.internal.NewWriter(tx).SetData(ctx, req.Key, req.Data)
-	})
-}
-
 // DispatchRequest carries an action sequence to apply to a single table.
 // DispatchKey is a client-generated identifier for the batch, registered as
 // outstanding on the originator before the request is sent. The server echoes

--- a/core/pkg/service/table/writer.go
+++ b/core/pkg/service/table/writer.go
@@ -68,38 +68,6 @@ func (w Writer) Create(
 	)
 }
 
-// Rename renames the table with the given key to the provided name.
-func (w Writer) Rename(
-	ctx context.Context,
-	key Key,
-	name string,
-) error {
-	return w.tbl.NewUpdate().
-		Where(gorp.MatchKeys[Key, Table](key)).
-		Change(func(_ gorp.Context, t Table) Table {
-			t.Name = name
-			return t
-		}).
-		Exec(ctx, w.tx)
-}
-
-// SetData replaces the body of the table with the given key with the provided
-// value. Key and Name are preserved from the existing entry; Rows, Columns,
-// and Cells on data overwrite the stored entry verbatim.
-func (w Writer) SetData(
-	ctx context.Context,
-	key Key,
-	data Table,
-) error {
-	return w.tbl.NewUpdate().
-		Where(gorp.MatchKeys[Key, Table](key)).
-		Change(func(_ gorp.Context, t Table) Table {
-			data.Key = t.Key
-			data.Name = t.Name
-			return data
-		}).Exec(ctx, w.tx)
-}
-
 // Dispatch applies a sequence of actions atomically to the table with the
 // given key. After a successful update the actions are notified to the
 // service-level observer so subscribers (cluster signals) can broadcast them.

--- a/core/pkg/service/table/writer_test.go
+++ b/core/pkg/service/table/writer_test.go
@@ -67,46 +67,16 @@ var _ = Describe("Writer", func() {
 		})
 	})
 
-	Describe("Update", func() {
-		It("Should rename a Table", func(ctx SpecContext) {
+	Describe("Dispatch", func() {
+		It("Should rename a Table via a Rename action", func(ctx SpecContext) {
 			s := table.Table{Name: "test"}
 			Expect(svc.NewWriter(tx).Create(ctx, ws.Key, &s)).To(Succeed())
-			Expect(svc.NewWriter(tx).Rename(ctx, s.Key, "test2")).To(Succeed())
+			Expect(svc.NewWriter(tx).Dispatch(ctx, s.Key, "dk-1", []table.Action{
+				table.NewRenameAction(table.RenamePayload{Name: "test2"}),
+			})).To(Succeed())
 			Expect(retrieve(ctx, s.Key).Name).To(Equal("test2"))
 		})
-	})
 
-	Describe("SetData", func() {
-		It("Should replace the body of a Table while preserving key and name", func(ctx SpecContext) {
-			s := table.Table{
-				Name:    "test",
-				Rows:    []table.Row{{Size: 30, Cells: []string{"a"}}},
-				Columns: []table.Column{{Size: 80}},
-				Cells: map[string]table.Cell{
-					"a": {Key: "a", Variant: "text", Props: msgpack.EncodedJSON{"value": "v1"}},
-				},
-			}
-			Expect(svc.NewWriter(tx).Create(ctx, ws.Key, &s)).To(Succeed())
-			updated := table.Table{
-				Rows:    []table.Row{{Size: 40, Cells: []string{"a", "b"}}},
-				Columns: []table.Column{{Size: 100}, {Size: 120}},
-				Cells: map[string]table.Cell{
-					"a": {Key: "a", Variant: "text", Props: msgpack.EncodedJSON{"value": "v2"}},
-					"b": {Key: "b", Variant: "value", Props: msgpack.EncodedJSON{"units": "psi"}},
-				},
-			}
-			Expect(svc.NewWriter(tx).SetData(ctx, s.Key, updated)).To(Succeed())
-			got := retrieve(ctx, s.Key)
-			Expect(got.Key).To(Equal(s.Key))
-			Expect(got.Name).To(Equal("test"))
-			Expect(got.Rows[0].Cells).To(Equal([]string{"a", "b"}))
-			Expect(got.Columns).To(HaveLen(2))
-			Expect(got.Cells["a"].Props["value"]).To(Equal("v2"))
-			Expect(got.Cells["b"].Variant).To(Equal("value"))
-		})
-	})
-
-	Describe("Dispatch", func() {
 		It("Should apply a multi-action sequence atomically and persist the result", func(ctx SpecContext) {
 			s := seed(ctx)
 			Expect(svc.NewWriter(tx).Dispatch(ctx, s.Key, "dk-1", []table.Action{

--- a/core/pkg/transport/grpc/grpc.go
+++ b/core/pkg/transport/grpc/grpc.go
@@ -132,8 +132,6 @@ func Bind(layer *api.Layer, channelSvc *distchannel.Service) []grpc.BindableTran
 	t.TableCreate = noop.UnaryServer[table.CreateRequest, table.CreateResponse]{}
 	t.TableRetrieve = noop.UnaryServer[table.RetrieveRequest, table.RetrieveResponse]{}
 	t.TableDelete = noop.UnaryServer[table.DeleteRequest, types.Nil]{}
-	t.TableRename = noop.UnaryServer[table.RenameRequest, types.Nil]{}
-	t.TableSetData = noop.UnaryServer[table.SetDataRequest, types.Nil]{}
 	t.TableDispatch = noop.UnaryServer[table.DispatchRequest, types.Nil]{}
 
 	// LABEL

--- a/core/pkg/transport/http/http.go
+++ b/core/pkg/transport/http/http.go
@@ -144,8 +144,6 @@ func Bind(layer *api.Layer, router *http.Router, ch *distchannel.Service) {
 		TableCreate:   http.NewUnaryServer[table.CreateRequest, table.CreateResponse](router, "/api/v1/table/create"),
 		TableRetrieve: http.NewUnaryServer[table.RetrieveRequest, table.RetrieveResponse](router, "/api/v1/table/retrieve"),
 		TableDelete:   http.NewUnaryServer[table.DeleteRequest, types.Nil](router, "/api/v1/table/delete"),
-		TableRename:   http.NewUnaryServer[table.RenameRequest, types.Nil](router, "/api/v1/table/rename"),
-		TableSetData:  http.NewUnaryServer[table.SetDataRequest, types.Nil](router, "/api/v1/table/set-data"),
 		TableDispatch: http.NewUnaryServer[table.DispatchRequest, types.Nil](router, "/api/v1/table/dispatch"),
 
 		// LABEL


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4318](https://linear.app/synnax/issue/SY-4318)

## Description

Removes the table `setData` API entirely and consolidates table renaming onto the `dispatch` action pipeline, mirroring the schematic work in #2435.

**`setData` removal.** The endpoint was unused by any production code — the Console mutates tables exclusively through the `dispatch` action pipeline, and `setData` survived only in its own unit tests. With `dispatch` as the single body-mutation path, `setData` was redundant surface area.

Removed:

- **TS client** (`client/ts/src/table/client.ts`): the `setData` method, the `setDataBodyZ`/`setDataReqZ` zod schemas, and the exported `SetDataBody` type.
- **Go API** (`core/pkg/api/table/table.go`): `SetDataRequest` and the `Service.SetData` handler.
- **Go service** (`core/pkg/service/table/writer.go`): the `Writer.SetData` method.
- **Transport wiring**: the `TableSetData` field, middleware entry, and handler binding in `api/layer.go`; the HTTP route `/api/v1/table/set-data`; and the gRPC noop placeholder.

**Rename consolidation.** Unlike `setData`, table rename is live (the ontology context menu calls it via Pluto's `useRename`). Previously table had two rename mechanisms — a dedicated `/table/rename` endpoint *and* a `rename` action through `dispatch`. Schematic already routes rename exclusively through `dispatch`; this change brings table in line. `client.tables.rename` now issues a `rename` action through `dispatch` (empty dispatch key), so the dedicated endpoint and its server handlers are no longer needed.

Removed:

- **Go API** (`core/pkg/api/table/table.go`): `RenameRequest` and the `Service.Rename` handler.
- **Go service** (`core/pkg/service/table/writer.go`): the `Writer.Rename` method.
- **Transport wiring**: the `TableRename` field, middleware entry, and handler binding in `api/layer.go`; the HTTP route `/api/v1/table/rename`; and the gRPC noop placeholder.

The `client.tables.rename(key, name)` signature is unchanged, so the Pluto `useRename` caller needs no changes.

**Tests.** The `setData` unit tests (TS + Go) were removed — body mutation is already covered by the `dispatch` action suite. The standalone `Writer.Rename` test was migrated to the `Dispatch` path with a `Rename` action, preserving explicit rename coverage. The TS rename test is unchanged and now exercises the dispatch path through the same public method.

**Also included.** `table/actions.ts` was switched to the `@/actions` namespace import (`actions.NO_OP_RESULT` / `actions.snapshotDraft`), matching the namespace-scoping convention.

`schematic`, `lineplot`, and `log` keep their own `SetData` APIs — untouched.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes the `setData` API from the table service (dead code unused by production) and consolidates `rename` through the existing `dispatch` action pipeline, mirroring how schematic already handles these operations. The public `client.tables.rename(key, name)` signature is preserved — the change is internal only.

- **`setData` removal**: The `SetData` handler, schemas, HTTP route, gRPC noop, and both TypeScript and Go unit tests are deleted; the `dispatch` action suite already provides equivalent mutation coverage.
- **Rename consolidation**: `client.tables.rename` now issues a `rename` action via `dispatch` with an empty dispatch key, exactly matching `schematic/client.ts:92`. The dedicated `/table/rename` HTTP endpoint, gRPC placeholder, and server-side `Rename`/`RenameRequest` types are removed. The Go rename test is migrated into the `Describe("Dispatch")` block using `NewRenameAction`.
- **`actions.ts` import cleanup**: Named imports `NO_OP_RESULT as NO_OP` and `snapshotDraft as snapshot` are replaced by the namespace form (`actions.NO_OP_RESULT` / `actions.snapshotDraft`), matching the convention already used in the generated `actions.gen.ts`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — removes dead code and consolidates rename onto the existing, well-tested dispatch pipeline without altering any public API signatures.

All deletions are cleanly traced: setData had no production callers, and the dedicated rename endpoint is fully replaced by the dispatch path that was already handling rename actions. The empty dispatch key for rename matches the established schematic pattern. Rename test coverage is preserved in both the Go unit test (migrated to Dispatch block) and the TypeScript integration test (unchanged). Transport wiring, gRPC noops, and HTTP routes are all consistently trimmed.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| client/ts/src/table/client.ts | Removes setData method and related schemas; rename now delegates to dispatch with an empty key and a renameAction, matching the schematic client pattern exactly. |
| core/pkg/api/table/table.go | Removes RenameRequest/Rename handler and SetDataRequest/SetData handler; Dispatch handler is unchanged and now serves as the sole mutation path. |
| core/pkg/service/table/writer.go | Rename and SetData writer methods removed; Dispatch remains and handles rename via RenamePayload.Handle, which correctly sets state.Name. |
| core/pkg/service/table/writer_test.go | SetData test removed; rename test migrated into the Dispatch describe block using NewRenameAction; observer notification test is preserved unchanged. |
| core/pkg/api/layer.go | TableRename and TableSetData fields, middleware entries, and handler bindings cleanly removed from the Transport struct and BindTo method. |
| core/pkg/transport/http/http.go | Removes HTTP route registrations for /api/v1/table/rename and /api/v1/table/set-data. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller as Pluto / useRename
    participant TSClient as tables.Client (TS)
    participant HTTP as /api/v1/table/dispatch
    participant GoAPI as api/table.Service.Dispatch
    participant Writer as service/table.Writer.Dispatch
    participant DB as gorp DB

    Note over TSClient: rename(key, name)
    TSClient->>HTTP: "POST dispatch {key, dispatchKey:"", actions:[{type:"rename",rename:{name}}]}"
    HTTP->>GoAPI: DispatchRequest
    GoAPI->>GoAPI: access.Enforce(ActionUpdate)
    GoAPI->>Writer: Dispatch(ctx, key, "", [RenameAction])
    Writer->>DB: NewUpdate.ChangeErr → Reduce(table, RenameAction)
    DB-->>Writer: "updated Table (Name = new name)"
    Writer->>Writer: dispatcher.Notify(ctx, key, "", actions)
    Writer-->>GoAPI: nil
    GoAPI-->>HTTP: types.Nil
    HTTP-->>TSClient: "{}"
    TSClient-->>Caller: void
```

<sub>Reviews (1): Last reviewed commit: ["SY-4318: Remove Table SetData API and Ro..."](https://github.com/synnaxlabs/synnax/commit/dc02388bbc03ccf785b41f256b46bb904898b935) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35480590)</sub>

<!-- /greptile_comment -->