### PR TITLE
SY-4320: Modify createDispatch to Automatically Handle Empty Actions

### DIFF
--- a/console/src/table/Toolbar.tsx
+++ b/console/src/table/Toolbar.tsx
@@ -149,9 +149,11 @@ const CellForm = ({ tableKey, cellKey }: CellFormProps): ReactElement | null => 
 
   const handleVariantChange = useCallback(
     (variant: Base.Cell.Variant) => {
-      if (cell == null) return;
-      const actions = buildVariantSwapActions([[cellKey, cell]], variant, theme);
-      if (actions.length > 0) dispatch({ key: tableKey, actions });
+      if (cell != null)
+        dispatch({
+          key: tableKey,
+          actions: buildVariantSwapActions([[cellKey, cell]], variant, theme),
+        });
     },
     [cell, cellKey, dispatch, tableKey, theme],
   );
@@ -270,7 +272,6 @@ const MultiCellForm = ({ tableKey, cellKeys }: MultiCellFormProps): ReactElement
           }),
         );
       }
-      if (actions.length === 0) return;
       dispatch({ key: tableKey, actions });
     },
     [cellsByKey, dispatch, tableKey],
@@ -286,8 +287,10 @@ const MultiCellForm = ({ tableKey, cellKeys }: MultiCellFormProps): ReactElement
 
   const handleVariantChange = useCallback(
     (variant: Base.Cell.Variant) => {
-      const actions = buildVariantSwapActions(cellsByKey, variant, theme);
-      if (actions.length > 0) dispatch({ key: tableKey, actions });
+      dispatch({
+        key: tableKey,
+        actions: buildVariantSwapActions(cellsByKey, variant, theme),
+      });
     },
     [cellsByKey, dispatch, tableKey, theme],
   );

--- a/pluto/src/flux/dispatch.spec.tsx
+++ b/pluto/src/flux/dispatch.spec.tsx
@@ -202,6 +202,24 @@ describe("Flux.createDispatch", () => {
       expect(doc?.nodes[1].position).toEqual({ x: 2, y: 2 });
     });
 
+    it("returns true without sending when given an empty actions array", async () => {
+      const send = vi.fn<SendFn>(async () => {});
+      const { result, key } = await setupHook(
+        (td, k) => ({
+          dispatch: td.useDispatch(),
+          undo: td.useUndo({ key: k }),
+        }),
+        send,
+      );
+      let ok = false;
+      await act(async () => {
+        ok = await result.current.dispatch.dispatchAsync({ key, actions: [] });
+      });
+      expect(ok).toBe(true);
+      expect(send).not.toHaveBeenCalled();
+      expect(result.current.undo.canUndo).toBe(false);
+    });
+
     it("returns false from dispatchAsync when the doc is not cached", async () => {
       const send = vi.fn<SendFn>(async () => {});
       const Wrapper = await createAsyncSynnaxWrapper({ client });

--- a/pluto/src/flux/dispatch.ts
+++ b/pluto/src/flux/dispatch.ts
@@ -110,6 +110,7 @@ export const createDispatch = <
       async (input: DispatchInput<Key, Action>): Promise<boolean> => {
         if (client == null) return false;
         const actions = Array.isArray(input.actions) ? input.actions : [input.actions];
+        if (actions.length === 0) return true;
         return await apply(
           store,
           client,

--- a/pluto/src/schematic/Schematic.tsx
+++ b/pluto/src/schematic/Schematic.tsx
@@ -83,18 +83,14 @@ export const Schematic = ({
   const edgesRef = useSyncedRef(edges);
   const { dispatch } = useDispatch();
   const handleNodesChange = useCallback(
-    (changes: BaseDiagram.NodeChange[]) => {
-      const actions = nodeChangesToActions(changes);
-      if (actions.length > 0) dispatch({ key, actions });
-    },
+    (changes: BaseDiagram.NodeChange[]) =>
+      dispatch({ key, actions: nodeChangesToActions(changes) }),
     [key, dispatch],
   );
 
   const handleEdgesChange = useCallback(
-    (changes: BaseDiagram.EdgeChange[]) => {
-      const actions = edgeChangesToActions(changes);
-      if (actions.length > 0) dispatch({ key, actions });
-    },
+    (changes: BaseDiagram.EdgeChange[]) =>
+      dispatch({ key, actions: edgeChangesToActions(changes) }),
     [key, dispatch],
   );
 

--- a/pluto/src/schematic/clipboard.ts
+++ b/pluto/src/schematic/clipboard.ts
@@ -142,7 +142,6 @@ export const useClipboard = ({
         if (cfg != null)
           actions.push(schematic.setConfig({ key: newKey, config: cfg }));
       }
-      if (actions.length === 0) return;
       dispatch({ key, actions });
       onPaste?.(Object.values(remap));
     },

--- a/pluto/src/schematic/clipboard.ts
+++ b/pluto/src/schematic/clipboard.ts
@@ -143,7 +143,7 @@ export const useClipboard = ({
           actions.push(schematic.setConfig({ key: newKey, config: cfg }));
       }
       dispatch({ key, actions });
-      onPaste?.(Object.values(remap));
+      if (actions.length > 0) onPaste?.(Object.values(remap));
     },
     [key, dispatch, onPaste],
   );

--- a/pluto/src/table/clipboard.ts
+++ b/pluto/src/table/clipboard.ts
@@ -207,7 +207,7 @@ export const useClipboard = ({
         overwritten.push(k);
       }
       dispatch({ key, actions });
-      onPaste?.(overwritten);
+      if (actions.length > 0) onPaste?.(overwritten);
     },
     [key, store, theme, dispatch, onPaste],
   );

--- a/pluto/src/table/clipboard.ts
+++ b/pluto/src/table/clipboard.ts
@@ -206,8 +206,6 @@ export const useClipboard = ({
         );
         overwritten.push(k);
       }
-
-      if (actions.length === 0) return;
       dispatch({ key, actions });
       onPaste?.(overwritten);
     },


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4320](https://linear.app/synnax/issue/SY-4320)

## Description

`createDispatch` now short-circuits when given an empty actions array, returning early instead of dispatching a no-op. This removes the need for callers to guard against empty actions themselves, so the redundant `if (actions.length === 0) return` checks are dropped from every call site (schematic/table clipboards, schematic node/edge change handlers, and the table toolbar variant/cell forms).

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralises empty-action handling inside `createDispatch` by adding an early `return true` when `actions.length === 0`, then removes the per-call-site `if (actions.length === 0)` guards that were previously needed at each dispatch call site.

- **`pluto/src/flux/dispatch.ts`**: New early-exit path (`return true`) makes the empty-actions case a silent no-op across all consumers without any caller changes.
- **`pluto/src/schematic/Schematic.tsx`, `console/src/table/Toolbar.tsx`**: Removed redundant guards; the simplification is safe because the change to `createDispatch` covers the same cases.
- **`pluto/src/schematic/clipboard.ts` and `pluto/src/table/clipboard.ts`**: Guards removed, but the `onPaste` callback that follows is no longer protected — in the schematic case this can fire with an empty array when nothing was actually pasted.

<h3>Confidence Score: 3/5</h3>

Mostly safe — the core dispatch change and most call-site clean-ups are correct, but the schematic clipboard removal unguards the `onPaste` side-effect and can fire it with an empty selection after a no-op paste.

The schematic clipboard now calls `onPaste?.([])` in a reachable path (copy only edges, paste) where it previously returned silently. Any consumer that uses `onPaste` to update the visible selection could inadvertently clear or reset it when the user intended nothing to happen.

`pluto/src/schematic/clipboard.ts` — the removed guard also removed protection for the `onPaste` callback, not just the `dispatch` call.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pluto/src/flux/dispatch.ts | Adds `if (actions.length === 0) return true` early exit in `dispatchAsync`; returning `true` correctly signals "trivially successful" so callers using the boolean result are not misled by a `false`/failure signal. |
| pluto/src/schematic/Schematic.tsx | Removed redundant `actions.length > 0` guards from `handleNodesChange` and `handleEdgesChange`; these changes are safe because `createDispatch` now handles the empty-actions case centrally. |
| pluto/src/schematic/clipboard.ts | Removed the `actions.length === 0` guard, but this also unguards the `onPaste` call — meaning `onPaste?.([])` can now fire after a no-op paste (e.g., edges-only clipboard), which was not possible before. |
| pluto/src/table/clipboard.ts | Removed the `actions.length === 0` guard; the existing `payload.cells.length === 0` check at line 115 and subsequent `addCol`/`addRow`/`setCell` logic make an empty-actions path virtually unreachable in practice. |
| console/src/table/Toolbar.tsx | Removed `actions.length` guards from `CellForm.handleVariantChange`, `MultiCellForm.applyPropPatch`, and `MultiCellForm.handleVariantChange`; all changes are safe given the central fix in `createDispatch`. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Caller: dispatch / dispatchAsync] --> B{client == null?}
    B -- yes --> C[return false]
    B -- no --> D[Normalize actions array]
    D --> E{actions.length === 0?}
    E -- yes --> F[return true ✓ NEW early exit]
    E -- no --> G[apply: replay + registerOutstandingDispatch]
    G --> H{replay == null?}
    H -- yes --> I[return false]
    H -- no --> J[commitStack / recordEntry]
    J --> K[send to server]
    K -- success --> L[return true]
    K -- failure --> M[stackRollback + rollback + addStatus]
    M --> N[return false]

    style F fill:#c8f7c5,stroke:#2ecc71
```

<sub>Reviews (1): Last reviewed commit: ["SY-4320: Modify createDispatch to Automa..."](https://github.com/synnaxlabs/synnax/commit/289bb083bc1a06018504a4dd39721ce95ce8163a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35486348)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->