### PR TITLE
SY-4321: Suppress Native Text-Editing Shortcuts When Typing in Inputs

### DIFF
--- a/pluto/src/triggers/Provider.tsx
+++ b/pluto/src/triggers/Provider.tsx
@@ -60,6 +60,12 @@ const ZERO_REF_STATE: RefState = {
 
 const EXCLUDE_TRIGGERS = ["CapsLock"];
 
+// Native text-editing shortcuts (select-all, copy, paste, cut) the browser owns inside
+// any text field. We drop them while a text-entry element is focused so app-level
+// handlers can't hijack them. Undo/redo is excluded — Synnax's controlled inputs often
+// lack working native undo, so app-level undo is usually what the user wants.
+const NATIVE_TEXT_EDIT_KEYS: Key[] = ["A", "C", "V", "X"];
+
 export interface ProviderProps extends PropsWithChildren {
   preventDefaultOn?: Trigger[];
   preventDefaultOptions?: MatchOptions;
@@ -79,12 +85,11 @@ const isInputOrContentEditable = (e: KeyboardEvent): boolean => {
 
 const shouldTriggerOnKeyDown = (key: Key, e: KeyboardEvent): boolean => {
   if (EXCLUDE_TRIGGERS.includes(key)) return false;
-  if (isInputOrContentEditable(e)) {
-    // If there is an alphanumeric key and the user is not holding down ctrl or meta,
-    // we don't want to trigger the key.
-    if (isAlphanumericKey(key) && !e.ctrlKey && !e.metaKey) return false;
-    return true;
-  }
+  if (!isInputOrContentEditable(e)) return true;
+  // Bare alphanumerics in a text field are text entry, not triggers.
+  if (isAlphanumericKey(key) && !e.ctrlKey && !e.metaKey) return false;
+  // Let the browser own native text-editing shortcuts within the field.
+  if ((e.ctrlKey || e.metaKey) && NATIVE_TEXT_EDIT_KEYS.includes(key)) return false;
   return true;
 };
 

--- a/pluto/src/triggers/Triggers.spec.tsx
+++ b/pluto/src/triggers/Triggers.spec.tsx
@@ -572,12 +572,12 @@ describe("Triggers", () => {
       expect(callback).not.toHaveBeenCalled();
     });
 
-    it("should handle ctrl+key combinations in input elements", async () => {
+    it("should handle non-text-editing ctrl+key combinations in input elements", async () => {
       const callback = vi.fn();
       const C = () => {
         Triggers.use({
           callback,
-          triggers: [["Control", "A"]],
+          triggers: [["Control", "B"]],
         });
         return <input type="text" data-testid="input" />;
       };
@@ -594,13 +594,13 @@ describe("Triggers", () => {
       fireEvent.keyDown(input, { code: "ControlLeft" });
       expect(callback).not.toHaveBeenCalled();
 
-      // Then press A with Control held
-      fireEvent.keyDown(input, { code: "KeyA", ctrlKey: true });
+      // Then press B with Control held
+      fireEvent.keyDown(input, { code: "KeyB", ctrlKey: true });
       vi.advanceTimersByTime(500);
 
       expect(callback).toHaveBeenCalledWith({
         target: input,
-        triggers: [["Control", "A"]],
+        triggers: [["Control", "B"]],
         prevTriggers: [["Control"]],
         cursor: { x: 10, y: 10 },
         stage: "start",
@@ -608,7 +608,75 @@ describe("Triggers", () => {
       });
 
       // Release in correct order
-      fireEvent.keyUp(input, { code: "KeyA", ctrlKey: true });
+      fireEvent.keyUp(input, { code: "KeyB", ctrlKey: true });
+      fireEvent.keyUp(input, { code: "ControlLeft" });
+    });
+
+    it("should suppress native text-editing shortcuts in input elements", async () => {
+      const C = ({ callback }: { callback: () => void }) => {
+        Triggers.use({
+          callback,
+          triggers: [
+            ["Control", "A"],
+            ["Control", "C"],
+            ["Control", "V"],
+            ["Control", "X"],
+          ],
+        });
+        return <input type="text" data-testid="input" />;
+      };
+      const press = (code: string) => {
+        const callback = vi.fn();
+        const { getByTestId, unmount } = render(
+          <Triggers.Provider>
+            <C callback={callback} />
+          </Triggers.Provider>,
+        );
+        const input = getByTestId("input");
+        fireEvent.mouseMove(input, { clientX: 10, clientY: 10 });
+        fireEvent.keyDown(input, { code: "ControlLeft" });
+        fireEvent.keyDown(input, { code, ctrlKey: true });
+        vi.advanceTimersByTime(500);
+        fireEvent.keyUp(input, { code, ctrlKey: true });
+        fireEvent.keyUp(input, { code: "ControlLeft" });
+        unmount();
+        return callback;
+      };
+
+      expect(press("KeyA")).not.toHaveBeenCalled();
+      expect(press("KeyC")).not.toHaveBeenCalled();
+      expect(press("KeyV")).not.toHaveBeenCalled();
+      expect(press("KeyX")).not.toHaveBeenCalled();
+    });
+
+    it("should still trigger undo/redo in input elements", async () => {
+      const callback = vi.fn();
+      const C = () => {
+        Triggers.use({ callback, triggers: [["Control", "Z"]] });
+        return <input type="text" data-testid="input" />;
+      };
+      const { getByTestId } = render(
+        <Triggers.Provider>
+          <C />
+        </Triggers.Provider>,
+      );
+
+      const input = getByTestId("input");
+      fireEvent.mouseMove(input, { clientX: 10, clientY: 10 });
+      fireEvent.keyDown(input, { code: "ControlLeft" });
+      fireEvent.keyDown(input, { code: "KeyZ", ctrlKey: true });
+      vi.advanceTimersByTime(500);
+
+      expect(callback).toHaveBeenCalledWith({
+        target: input,
+        triggers: [["Control", "Z"]],
+        prevTriggers: [["Control"]],
+        cursor: { x: 10, y: 10 },
+        stage: "start",
+        stopPropagation: expect.any(Function),
+      });
+
+      fireEvent.keyUp(input, { code: "KeyZ", ctrlKey: true });
       fireEvent.keyUp(input, { code: "ControlLeft" });
     });
 

--- a/pluto/src/vis/diagram/Diagram.css
+++ b/pluto/src/vis/diagram/Diagram.css
@@ -21,5 +21,11 @@
             border: calc(var(--pluto-border-width) * 2) dashed var(--pluto-primary-z-40) !important;
             border-radius: var(--pluto-border-radius);
         }
+
+        /* React Flow focuses the pane on Escape; suppress the default focus ring. */
+        .react-flow__pane:focus,
+        .react-flow__pane:focus-visible {
+            outline: none;
+        }
     }
 }


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4321](https://linear.app/synnax/issue/SY-4321)

## Description

While editing in the schematic, a common habit is `Cmd+A` → `Delete` to clear a toolbar input. Instead, `Cmd+A` was selecting every element on the diagram and `Delete` wiped them, because the Triggers provider deliberately lets `Ctrl`/`Meta`+alphanumeric combos reach focused text fields, and the diagram's select-all trigger fired on them.

This moves the fix to the provider level: when a text-entry element (`input`, `textarea`, `contentEditable`, or `role="textbox"`) is focused, the native text-editing shortcuts the browser owns — `Ctrl`/`Meta` + `A`/`C`/`V`/`X` (select-all, copy, paste, cut) — are dropped before any trigger subscriber sees them. Undo/redo (`Cmd+Z` / `Cmd+Shift+Z`) is intentionally left to propagate, since Synnax's controlled inputs frequently lack working native undo, so app-level undo is usually what the user wants.

Gating at the provider rather than in the diagram fixes the same latent issue everywhere those combos are registered (e.g. log select-all/copy) in one place, instead of per consumer.

Also folds in a related diagram annoyance: pressing `Escape` in edit mode focuses React Flow's `.react-flow__pane` (which has `tabIndex=0`), drawing the browser's default blue focus ring around the whole canvas. Suppressed via an `outline: none` rule in the diagram base CSS, mirroring the existing `.react-flow__node:focus` override.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a long-standing UX bug where `Cmd+A` → `Delete` inside a toolbar input would accidentally select-all and delete every element on a schematic diagram, because the Triggers provider was forwarding `Ctrl`/`Meta`+alphanumeric combos even when a text field had focus.

- **Provider-level shortcut suppression**: `shouldTriggerOnKeyDown` now drops `Ctrl`/`Meta` + `A`/`C`/`V`/`X` (native select-all, copy, paste, cut) whenever a text-entry element (`input`, `textarea`, `contenteditable`, or `role=\"textbox\"`) is focused, while intentionally passing `Ctrl+Z`/`Ctrl+Shift+Z` through to app-level undo/redo handlers.
- **CSS fix**: Adds `outline: none` on `.react-flow__pane:focus` (and `:focus-visible`) to suppress the blue focus ring that appeared when pressing `Escape` in edit mode; test coverage is extended with two new cases for the suppressed and pass-through key combinations.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the logic change is narrowly scoped to text-field focus detection with good test coverage. The only open question is the :focus-visible removal in the CSS.

The provider logic and tests are clean and correct. The only concern is the Diagram.css change suppressing :focus-visible alongside :focus, which removes the keyboard-navigation focus indicator on the React Flow pane — a minor but real accessibility regression for users who reach the pane via keyboard.

pluto/src/vis/diagram/Diagram.css — the :focus-visible suppression on .react-flow__pane deserves a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pluto/src/triggers/Provider.tsx | Adds provider-level suppression of Ctrl/Meta+A/C/V/X when a text-entry element is focused; refactors shouldTriggerOnKeyDown for clarity with no behaviour regression on non-text-field paths. |
| pluto/src/triggers/Triggers.spec.tsx | Updates the existing Ctrl+key test to use a non-suppressed key (B) and adds two new cases: suppression of native text-editing shortcuts and propagation of Ctrl+Z (undo). |
| pluto/src/vis/diagram/Diagram.css | Suppresses the default focus ring on .react-flow__pane when focused via Escape; uses outline:none on both :focus and :focus-visible, removing keyboard-navigation focus indicator on the pane. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Window keydown event] --> B{EXCLUDE_TRIGGERS?}
    B -- yes --> C[Return false — suppress]
    B -- no --> D{isInputOrContentEditable?}
    D -- no --> E[Return true — fire trigger]
    D -- yes --> F{Bare alphanumeric?\nno Ctrl / Meta}
    F -- yes --> C
    F -- no --> G{Ctrl/Meta +\nA / C / V / X?}
    G -- yes --> C
    G -- no --> H[Return true — fire trigger\ne.g. Ctrl+Z, Ctrl+S, Ctrl+B …]
```

<sub>Reviews (1): Last reviewed commit: ["SY-4321: Suppress Native Text-Editing Sh..."](https://github.com/synnaxlabs/synnax/commit/6b9380c6a90be4cf06e171cef7d553cfe8e767c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35619606)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->