### PR TITLE
SY-4324: Make permission checks reactive to policy/role changes

### DIFF
--- a/pluto/src/access/queries.spec.ts
+++ b/pluto/src/access/queries.spec.ts
@@ -16,6 +16,7 @@ import {
   type ontology,
   ranger,
   user,
+  workspace,
 } from "@synnaxlabs/client";
 import { id } from "@synnaxlabs/x";
 import { renderHook, waitFor } from "@testing-library/react";
@@ -141,6 +142,46 @@ describe("Access Queries", () => {
       await waitFor(() => {
         expect(result.current).toBe(false);
       });
+    });
+
+    it("should ignore relationship changes that cannot affect permissions", async () => {
+      const userClient = await createTestClientWithPolicy(client, {
+        name: id.create(),
+        objects: [ranger.TYPE_ONTOLOGY_ID, workspace.TYPE_ONTOLOGY_ID, ...baseObjects],
+        actions: ["retrieve", "create"],
+      });
+      let renders = 0;
+      const { result } = renderHook(
+        () => {
+          renders++;
+          const granted = Access.useGranted({
+            objects: ranger.TYPE_ONTOLOGY_ID,
+            action: "retrieve",
+          });
+          return { granted, store: Flux.useStore<Pluto.FluxStore>() };
+        },
+        { wrapper: await createAsyncSynnaxWrapper({ client: userClient }) },
+      );
+      await waitFor(() => {
+        expect(result.current.granted).toBe(true);
+      });
+      const rendersWhenSettled = renders;
+      // A workspace's group -> workspace link is not a role link, so the gate must
+      // drop it: no re-evaluation, no re-render.
+      const ws = await userClient.workspaces.create({
+        name: id.create(),
+        layout: {},
+      });
+      // Wait until the link reaches the store (event delivered)...
+      await waitFor(() => {
+        const rels = result.current.store.relationships.get(
+          (rel) => rel.to.type === "workspace" && rel.to.key === ws.key,
+        );
+        expect(rels.length).toBeGreaterThan(0);
+      });
+      // ...then confirm it caused no re-evaluation.
+      expect(renders).toBe(rendersWhenSettled);
+      expect(result.current.granted).toBe(true);
     });
 
     it("should handle multiple objects correctly", async () => {

--- a/pluto/src/access/queries.spec.ts
+++ b/pluto/src/access/queries.spec.ts
@@ -103,6 +103,46 @@ describe("Access Queries", () => {
       expect(policies[0].name).toBe(policyName);
     });
 
+    it("should re-evaluate the grant when a policy is removed, without a remount", async () => {
+      const u = await client.users.create({
+        username: id.create(),
+        password: "test",
+        firstName: "test",
+        lastName: "test",
+      });
+      const p = await client.access.policies.create({
+        name: id.create(),
+        objects: [ranger.TYPE_ONTOLOGY_ID, ...baseObjects],
+        actions: ["retrieve"],
+      });
+      const r = await client.access.roles.create({
+        name: id.create(),
+        description: "test",
+      });
+      await client.ontology.addChildren(
+        access.role.ontologyID(r.key),
+        access.policy.ontologyID(p.key),
+      );
+      await client.access.roles.assign({ user: u.key, role: r.key });
+      const subject = user.ontologyID(u.key);
+      const { result } = renderHook(
+        () =>
+          Access.useGranted({
+            subject,
+            objects: ranger.TYPE_ONTOLOGY_ID,
+            action: "retrieve",
+          }),
+        { wrapper: await createAsyncSynnaxWrapper({ client }) },
+      );
+      await waitFor(() => {
+        expect(result.current).toBe(true);
+      });
+      await client.access.policies.delete(p.key);
+      await waitFor(() => {
+        expect(result.current).toBe(false);
+      });
+    });
+
     it("should handle multiple objects correctly", async () => {
       const userClient = await createTestClientWithPolicy(client, {
         name: id.create(),

--- a/pluto/src/access/queries.ts
+++ b/pluto/src/access/queries.ts
@@ -105,8 +105,6 @@ const { useRetrieve: useGrantedBase } = Flux.createRetrieve<
     return [
       store.policies.onSet(update),
       store.policies.onDelete(update),
-      store.roles.onSet(update),
-      store.roles.onDelete(update),
       store.relationships.onSet((rel) => {
         if (affectsPermissions(rel)) update();
       }),

--- a/pluto/src/access/queries.ts
+++ b/pluto/src/access/queries.ts
@@ -9,7 +9,7 @@
 
 import {
   access,
-  type ontology,
+  ontology,
   type Synnax,
   UnexpectedError,
   user,
@@ -79,6 +79,14 @@ export const isGranted = ({
 
 export interface IsGrantedExtensionParams extends Omit<IsGrantedParams, "query"> {}
 
+// affectsPermissions reports whether a relationship change can alter a subject's
+// effective permissions. Only role links matter: role -> policy (which policies a
+// role carries) and role -> subject (a role assignment). All other ontology
+// relationships, e.g. workspace or channel parentage, cannot change permissions and
+// must not trigger a re-evaluation, otherwise every resource mutation would refetch.
+const affectsPermissions = (rel: ontology.Relationship): boolean =>
+  rel.type === ontology.PARENT_OF_RELATIONSHIP_TYPE && rel.from.type === "role";
+
 const { useRetrieve: useGrantedBase } = Flux.createRetrieve<
   PermissionsQuery,
   boolean,
@@ -94,6 +102,22 @@ const { useRetrieve: useGrantedBase } = Flux.createRetrieve<
     if (subject == null) return false;
     const policies = await policy.retrieveForSubject({ client, subject, store });
     return access.allowRequest({ subject, objects, action }, policies);
+  },
+  mountListeners: ({ store, client, query, onChange }) => {
+    const update = () => onChange(isGranted({ store, client, query }));
+    return [
+      store.policies.onSet(update),
+      store.policies.onDelete(update),
+      store.roles.onSet(update),
+      store.roles.onDelete(update),
+      store.relationships.onSet((rel) => {
+        if (affectsPermissions(rel)) update();
+      }),
+      store.relationships.onDelete((key) => {
+        const parsed = ontology.relationshipZ.safeParse(key);
+        if (parsed.success && affectsPermissions(parsed.data)) update();
+      }),
+    ];
   },
 });
 

--- a/pluto/src/access/queries.ts
+++ b/pluto/src/access/queries.ts
@@ -79,11 +79,8 @@ export const isGranted = ({
 
 export interface IsGrantedExtensionParams extends Omit<IsGrantedParams, "query"> {}
 
-// affectsPermissions reports whether a relationship change can alter a subject's
-// effective permissions. Only role links matter: role -> policy (which policies a
-// role carries) and role -> subject (a role assignment). All other ontology
-// relationships, e.g. workspace or channel parentage, cannot change permissions and
-// must not trigger a re-evaluation, otherwise every resource mutation would refetch.
+// affectsPermissions reports whether a relationship change can alter permissions:
+// only role links can (role -> policy, role -> subject). Others must not re-trigger.
 const affectsPermissions = (rel: ontology.Relationship): boolean =>
   rel.type === ontology.PARENT_OF_RELATIONSHIP_TYPE && rel.from.type === "role";
 


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4324](https://linear.app/synnax/issue/SY-4324)

## Description

The Workspaces toolbar (the `<Icon.Workspace />` button in the top nav, `workspace/Selector.tsx`) would intermittently disappear and stay gone until the app was reloaded. The Selector hides itself on `!useRetrieveGranted(workspace)`, and the underlying permission check (`useGranted` in `pluto/src/access/queries.ts`) was computed once on mount and then never re-evaluated.

Root cause: the granted-permission `createRetrieve` had **no `mountListeners`**, so it never subscribed to the policy/role/relationship caches it derives its answer from. Once the result settled on a value (including a wrong/stale `false` produced during a transient or a remount), nothing could correct it short of a full reload. This is the "stays gone until reload" behavior.

Fix: add `mountListeners` to the granted retrieve so the answer stays live. It re-evaluates (via the synchronous `isGranted` cache read, no network) whenever:

- the `policies` store changes (`sy_policy_set` / `sy_policy_delete`),
- the `roles` store changes (`sy_role_set` / `sy_role_delete`),
- a **permission-relevant** relationship changes.

Relationship events are the noisy ones (every workspace/channel/etc. parentage change fires `sy_relationship_set`), so they are gated by `affectsPermissions`: only `role -> *` parent links (role→policy, role→subject) trigger a re-evaluation. Creating a workspace fires workspace relationship events, which are correctly ignored.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

## Test plan

- Added `queries.spec.ts` regression test: a granted permission flips to denied when its policy is removed, **without a remount** (fails before the fix because the result was fire-once; passes after). Needs a local cluster to run, which I did not exercise against your running server.
- `pnpm --filter @synnaxlabs/pluto check-types` and `lint` pass.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug where the Workspace Selector would permanently disappear after a transient permission mis-evaluation. The root cause was that `useGrantedBase` had no `mountListeners`, so the granted permission result was computed once on mount and never re-evaluated.

- Adds `mountListeners` to `useGrantedBase`, subscribing to `store.policies`, `store.roles`, and `store.relationships` so the synchronous `isGranted` cache-read fires on every relevant store event.
- Gates relationship-triggered re-evaluations through `affectsPermissions`, which only re-evaluates on `role → *` parent links (role→policy, role→subject), ignoring noisy workspace/channel relationship events.
- Adds a regression test that deletes a policy without remounting the hook and verifies the grant flips to `false`.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the fix correctly converts a fire-once permission check into a live reactive one and the regression test validates the key scenario.

The core logic is sound: affectsPermissions correctly gates noisy relationship events, and isGranted synchronously reads from the already-updated store so the value is always fresh when onChange is called. The one open question is whether the store.roles.onSet/onDelete subscriptions are intentional belt-and-suspenders or an oversight — since cachedRetrieveForSubject ignores the roles store entirely, those listeners only fire unnecessary re-evaluations and don't add correctness.

pluto/src/access/queries.ts — specifically the store.roles listener pair in mountListeners.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pluto/src/access/queries.ts | Adds mountListeners to useGrantedBase with policy/role/relationship subscriptions; store.roles.onSet/onDelete listeners may be redundant since cachedRetrieveForSubject reads only from relationships and policies, not from the roles store. |
| pluto/src/access/queries.spec.ts | Adds a well-structured regression test validating that a granted permission flips to false when its backing policy is deleted, without a remount. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Server
    participant ChannelListener
    participant Store as FluxStore
    participant mountListeners
    participant isGranted
    participant Component

    Note over Component: Mount — retrieve() fetches policies,<br/>mountListeners installs store observers

    Server->>ChannelListener: sy_policy_delete(key)
    ChannelListener->>Store: store.policies.delete(key)
    Store->>mountListeners: onDelete fires
    mountListeners->>isGranted: "isGranted({ store, client, query })"
    isGranted->>Store: cachedRetrieveForSubject(store, subject)
    Store-->>isGranted: [] (policy removed)
    isGranted-->>mountListeners: false
    mountListeners->>Component: onChange(false) → re-render

    Server->>ChannelListener: sy_relationship_set (role→subject)
    ChannelListener->>Store: store.relationships.set(rel)
    Store->>mountListeners: onSet fires
    mountListeners->>mountListeners: "affectsPermissions(rel)? rel.from.type === role → true"
    mountListeners->>isGranted: "isGranted({ store, client, query })"
    isGranted-->>mountListeners: true/false (updated)
    mountListeners->>Component: onChange(result) → re-render
```

<sub>Reviews (1): Last reviewed commit: ["SY-4324: Make permission checks reactive..."](https://github.com/synnaxlabs/synnax/commit/badd18dc4fc60bff4a447326b66f6d96fd3748b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35625937)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->