### PR TITLE
SY-4323: Fix Schematic Edge Anchoring on Bottom/Right Handles

### DIFF
--- a/pluto/src/schematic/Schematic.css
+++ b/pluto/src/schematic/Schematic.css
@@ -29,6 +29,11 @@
         border-color: transparent !important;
         pointer-events: none !important;
         border-radius: 50%;
+        /* React Flow pins the opposite edge (bottom/right) for handles facing those
+           directions. Pluto positions every handle via top/left, so the extra pin
+           stretches the element across the node and throws off the edge anchor. */
+        right: auto !important;
+        bottom: auto !important;
     }
 
     .react-flow__background circle {

--- a/pluto/src/schematic/node/common/handle/Handle.tsx
+++ b/pluto/src/schematic/node/common/handle/Handle.tsx
@@ -13,7 +13,7 @@ import {
   type HandleProps as RFHandleProps,
   type Position as RFPosition,
 } from "@xyflow/react";
-import { type ReactElement } from "react";
+import { type ReactElement, useMemo } from "react";
 
 import { CSS } from "@/css";
 import { adjust, smart, swap } from "@/schematic/node/common/handle/position";
@@ -41,6 +41,10 @@ export const Handle = ({
   ...rest
 }: HandleProps): ReactElement => {
   const adjusted = adjust(top, left, orientation, preventAutoAdjust);
+  const mergedStyle = useMemo(
+    () => ({ left: `${adjusted.left}%`, top: `${adjusted.top}%`, ...style }),
+    [adjusted.left, adjusted.top, style],
+  );
   return (
     <RFHandle
       position={swap(smart(location, orientation), !swapPos)}
@@ -48,11 +52,7 @@ export const Handle = ({
       type="source"
       onClick={stopPropagation}
       className={(CSS.B("handle"), CSS.BE("handle", rest.id))}
-      style={{
-        left: `${adjusted.left}%`,
-        top: `${adjusted.top}%`,
-        ...style,
-      }}
+      style={mergedStyle}
     />
   );
 };


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4323](https://linear.app/synnax/issue/SY-4323)

## Description

Pipes connected to a schematic symbol's non-flow handles (e.g. the actuator/"hammer" input on a solenoid valve) rendered ~12px short of the port, never visually touching the handle. Rotating the symbol a full turn temporarily fixed it until reload.

Root cause: React Flow's base stylesheet pins the *opposite* edge (`bottom`/`right`) for handles whose resolved position faces those directions. Pluto positions every handle with an inline `top`/`left` percentage, so for a bottom- or right-facing handle both edges end up pinned and the handle element stretches across the node (its height/width becomes `(100% − offset) × node size`). React Flow then anchors the edge to the stretched box's far edge, landing the pipe ~half the stretch distance short of the actual port.

This only surfaced on handles that are both inset from the node perimeter *and* face bottom/right — in practice the solenoid-valve actuator handles — which is why it appeared on just two valves in affected schematics. Flow-port handles sit on the perimeter and were unaffected.

Fix:
- Reset `right`/`bottom` to `auto` in the schematic handle stylesheet so only the `top`/`left` positioning Pluto actually controls applies. The handle box returns to its intended size and React Flow anchors edges to the real port.
- Memoize the per-handle inline style object so it isn't rebuilt on every render across every handle.

Verified manually against an affected schematic: the previously-stretched handles measure the correct size and the edges land on the port. The regression is a CSS layout effect (`getBoundingClientRect` stretch) that isn't reproducible under jsdom, so it isn't covered by a unit test.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a visual bug where schematic edges connected to bottom- or right-facing handles landed ~12px short of the port. The root cause is that React Flow's base stylesheet pins both the `top`/`left` *and* the opposite `bottom`/`right` edges for handles facing those directions, causing the handle element to stretch across the node and shifting React Flow's edge anchor point.

- **CSS fix**: Adds `right: auto !important` and `bottom: auto !important` to `.pluto-schematic .react-flow__handle`, so only Pluto's inline `top`/`left` positioning applies and the handle box stays the intended size.
- **TSX optimization**: Extracts the inline `style` object construction in `Handle.tsx` into a `useMemo`, avoiding a new object allocation on every render across every handle in the schematic.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the CSS reset is targeted and well-scoped, and the memoization change is purely additive.

Both changes are small and narrowly scoped. The CSS adds two `auto` resets under the existing `.pluto-schematic .react-flow__handle` rule, which only affects how React Flow's own opposite-edge pins interact with Pluto's inline positioning — it cannot widen or shift any handle that wasn't already broken. The `useMemo` extraction is a straightforward refactor of an object literal into a cached value; the dependency array is correct for all current callers.

No files require special attention; both changes are self-contained.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pluto/src/schematic/Schematic.css | Adds `right: auto !important` and `bottom: auto !important` to the shared `.react-flow__handle` rule to cancel React Flow's opposite-edge pin; fix is correctly scoped and well-commented. |
| pluto/src/schematic/node/common/handle/Handle.tsx | Extracts inline style object into a `useMemo`; memoization works well when `style` is undefined or a stable reference, but callers passing an inline object literal would defeat it each render — minor concern in practice since no current caller does this. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["React Flow renders Handle\n(position = Bottom or Right)"] --> B["RF base CSS pins\nbottom/right edge"]
    B --> C{"Before fix"}
    C -->|"Pluto also sets top/left\nvia inline style"| D["Handle stretches\nacross node"]
    D --> E["Edge anchors to\nfar edge of stretched box"]
    E --> F["Pipe lands ~12px\nshort of port"]
    C2{"After fix"} -->|"right: auto; bottom: auto\nin Schematic.css"| G["Only top/left applies"]
    G --> H["Handle stays\nintended size"]
    H --> I["Edge anchors to\ncorrect port position"]
    A --> C2
```

<sub>Reviews (1): Last reviewed commit: ["SY-4323: Fix Schematic Edge Anchoring on..."](https://github.com/synnaxlabs/synnax/commit/2109ba8eaf4ca02127c031edaebe40efe75c870b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35630334)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->