### PR TITLE
SY-4297: Arc Params Refactor (Part 2) - Unify Symbol Hooks and Add Trigger Binding

### DIFF
--- a/arc/go/symbol/symbol.go
+++ b/arc/go/symbol/symbol.go
@@ -37,18 +37,41 @@ import (
 	"github.com/synnaxlabs/arc/parser"
 	"github.com/synnaxlabs/arc/types"
 	"github.com/synnaxlabs/x/compare"
-	"github.com/synnaxlabs/x/diagnostics"
 	"github.com/synnaxlabs/x/errors"
 	"github.com/synnaxlabs/x/lsp/doc"
 	"github.com/synnaxlabs/x/query"
 	"github.com/synnaxlabs/x/set"
 )
 
-// CallHook runs after the generic func-form validation passes.
-type CallHook func(diags *diagnostics.Diagnostics, funcCall parser.IFunctionCallSuffixContext)
+// Argument is one call argument: a value expression bound to a param by Name,
+// or by position (Index) when Name is empty.
+type Argument struct {
+	// Index is the argument's position in the call's argument list.
+	Index int
+	// Name is the param this argument binds to, or empty if positional.
+	Name string
+	// Expr is the argument's value expression.
+	Expr parser.IExpressionContext
+	// AST is the argument's parser node, for diagnostic source locations.
+	AST antlr.ParserRuleContext
+}
 
-// FlowConfigHook runs after the generic flow-form config validation passes.
-type FlowConfigHook func(diags *diagnostics.Diagnostics, config parser.IConfigValuesContext)
+// ArgumentsHook runs optional symbol-specific argument validation; ctx is the
+// untyped analyzer context, type-asserted by the hook.
+type ArgumentsHook func(ctx any, args []Argument)
+
+// TriggerBinding declares what an upstream wire does to a symbol in flow context.
+type TriggerBinding struct {
+	// Target names the param the wire binds its value to, or empty (TriggerOnly)
+	// for pure activation.
+	Target string
+}
+
+// TriggerOnly is the zero TriggerBinding: the wire activates without binding a value.
+var TriggerOnly = TriggerBinding{}
+
+// TriggerInput declares that an upstream wire binds its value to the named param.
+func TriggerInput(name string) TriggerBinding { return TriggerBinding{Target: name} }
 
 // ExecContext indicates which execution context a symbol is valid in.
 type ExecContext int
@@ -179,10 +202,11 @@ type Symbol struct {
 	// Flow, or Both). A zero value is invalid and will cause resolution to
 	// fail, forcing every symbol to be explicitly tagged.
 	Exec ExecContext
-	// AnalyzeCall runs after generic func-form validation. Optional.
-	AnalyzeCall CallHook
-	// AnalyzeFlowConfig runs after generic flow-form config validation. Optional.
-	AnalyzeFlowConfig FlowConfigHook
+	// AnalyzeArguments runs optional symbol-specific argument validation.
+	AnalyzeArguments ArgumentsHook
+	// Trigger names the param an upstream wire binds to in flow context; the
+	// zero value (TriggerOnly) means pure activation.
+	Trigger TriggerBinding
 	// Deprecated points at the canonical replacement Symbol for a deprecated
 	// reference. Nil means not deprecated. When non-nil, analysis helpers
 	// emit a deprecation warning naming Deprecated.QualifiedName(), and the
@@ -634,7 +658,7 @@ func ResolveConfigChannel(
 	}
 	if !replaced {
 		dir := types.ChanDirectionRead
-		if param, ok := fnSym.Type.Config.Get(paramName); ok && param.Type.ChanDirection.IsSet() {
+		if param, ok := fnSym.Type.Inputs.Get(paramName); ok && param.Type.ChanDirection.IsSet() {
 			dir = param.Type.ChanDirection
 		}
 		if dir.IsRead() {

--- a/arc/go/types/fresh.go
+++ b/arc/go/types/fresh.go
@@ -24,7 +24,7 @@ import (
 // The function recursively freshens type variables in:
 //   - Direct type variables (including their constraints)
 //   - Channel and series element types
-//   - Function input, output, and config parameters
+//   - Function input and output parameters
 //
 // Primitive types (i64, f64, string, etc.) are returned unchanged.
 func Freshen(t Type, prefix string) Type {
@@ -69,7 +69,6 @@ func freshen(t Type, prefix string, mapping map[string]Type) Type {
 		props := FunctionProperties{
 			Inputs:  freshenParams(t.Inputs, prefix, mapping),
 			Outputs: freshenParams(t.Outputs, prefix, mapping),
-			Config:  freshenParams(t.Config, prefix, mapping),
 		}
 		return Type{Kind: KindFunction, FunctionProperties: props}
 	}

--- a/arc/go/types/type.go
+++ b/arc/go/types/type.go
@@ -536,10 +536,7 @@ func Equal(t Type, v Type) bool {
 		if !paramsEqual(t.Inputs, v.Inputs) {
 			return false
 		}
-		if !paramsEqual(t.Outputs, v.Outputs) {
-			return false
-		}
-		return paramsEqual(t.Config, v.Config)
+		return paramsEqual(t.Outputs, v.Outputs)
 	}
 	if t.Unit == nil && v.Unit == nil {
 		return true


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4297](https://linear.app/synnax/issue/SY-4297)

## Description

**Part 2 of a 9-part stack** implementing RFC 0039 (Arc Function-Call Unification). It is stacked on **Part 1** (`sy-4297-arc-flowfunc-refactor-part-1`, the schema + codegen that removed `Config` from the generated types) and **targets that branch**, not `rc`/`main`.

Design context for reviewers:

- **RFC:** [docs/tech/rfc/0039-260513-arc-function-call-unification.md](docs/tech/rfc/0039-260513-arc-function-call-unification.md)
  — §4.0 (unified Inputs), §4.1 (Trigger binding), §4.3 (unified hook).
- **Plan:** [docs/tech/rfc/0039-260513-plan.md](docs/tech/rfc/0039-260513-plan.md)
  — this PR implements **Phase 2: "Type helpers, symbol, hooks, Trigger."**

### ⚠️ This PR does not compile on its own — by design

Part 1 removed `Config` from the generated `FunctionProperties`, and ~35 non-generated files still read `.Config` until Phases 3–8 convert them. The first green build is Phase 9 (see the plan's staging section). **Review this on its diff, not on a CI run.** The non-compiling state is the intended intermediate, not a regression.

### What changed

- **Symbol hook collapse** ([arc/go/symbol/symbol.go](arc/go/symbol/symbol.go)):
  replace `CallHook` + `FlowConfigHook` with a single `ArgumentsHook func(ctx any, args []Argument)` over a unified, surface-form-independent `Argument` view; the two `AnalyzeCall` /  `AnalyzeFlowConfig` fields collapse to one `AnalyzeArguments`.
- **Trigger binding** ([arc/go/symbol/symbol.go](arc/go/symbol/symbol.go)): add `Trigger TriggerBinding` to `Symbol`, plus the `TriggerBinding{Target string}` type and the `TriggerOnly` / `TriggerInput(name)` helpers. This is the explicit replacement for the `ExecBoth` + `len(Config) > 0` trigger heuristic (the heuristic is removed in Phase 3, not here).
- **Config removal propagated through the type layer:**
  - `Equal` drops the `Config` comparison ([arc/go/types/type.go](arc/go/types/type.go)).
  - `Freshen` drops the `Config` freshen ([arc/go/types/fresh.go](arc/go/types/fresh.go)).
  - `ResolveConfigChannel` reads `Inputs.Get(...)` instead of `Config.Get(...)` ([arc/go/symbol/symbol.go](arc/go/symbol/symbol.go)).

### Deliberately out of scope (later phases)

- **No `call.Analyze`, no flow `Trigger` consult** — that's the analyzer collapse in **Phase 3** (the design-evaluation gate sits after Phase 3).
- **No test changes** — the fixture sweep and new tests are consolidated into **Phase 7** by design (the tree can't compile to run them yet).

### Plan vs. modified files (non-issue)

The plan's Phase 2 file list names `arc/go/symbol/hooks/hooks.go` and `arc/go/symbol/scope.go`. **Neither file exists in the repo** — they are stale paths in the plan. The hook types and `ResolveConfigChannel` both actually live in `arc/go/symbol/symbol.go`, so that is where this work landed. The change is identical to what the plan describes; only the plan's file attribution was off. No behavior or scope difference.

### Reviewer note

`ArgumentsHook` takes `ctx any` deliberately (RFC §4.3 / Risk #3): it keeps the `symbol` package decoupled from the analyzer's generic context type, which would otherwise be an import cycle. Hooks type-assert the surface they need. A few doc comments still reference the removed `Config` field (e.g. the `ExecBoth` comment, the `Function` constructor doc); those are left for the phase that demotes `Exec` to keep this diff minimal.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

_Readiness left unchecked intentionally: this is a non-compiling intermediate PR reviewed on its diff; the test sweep is Phase 7 and the RFC/plan docs landed earlier in the stack._

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is Phase 2 of RFC 0039's Arc function-call unification stack, collapsing two separate symbol hooks (`CallHook` + `FlowConfigHook`) into a single `ArgumentsHook func(ctx any, args []Argument)` and introducing `TriggerBinding` as an explicit replacement for the `ExecBoth`+`len(Config)>0` trigger heuristic. It also propagates the `Config` field removal from Part 1 through `Equal` and `Freshen` in the type layer, and redirects `ResolveConfigChannel` to read param direction from `Inputs` instead of `Config`.

- **Hook unification** (`symbol.go`): `AnalyzeCall` + `AnalyzeFlowConfig` collapse to `AnalyzeArguments`; the `ctx any` parameter keeps the `symbol` package free of an import cycle with the analyzer's generic context type — hooks type-assert the surface they need at call sites.
- **Trigger binding** (`symbol.go`): `TriggerBinding{Target}`, `TriggerOnly`, and `TriggerInput(name)` give each symbol an explicit upstream-wire contract in flow context, replacing the implicit heuristic removed in Phase 3.
- **Type-layer cleanup** (`type.go`, `fresh.go`): `Equal` and `Freshen` drop their `Config` branches, keeping the type helpers consistent with the now-`Config`-free `FunctionProperties`.

<h3>Confidence Score: 5/5</h3>

Safe to merge on its own diff; the non-compiling intermediate state is by design and well-documented.

All three changed files make narrowly scoped, mechanically correct edits: the hook collapse is a clean rename with no dropped logic (diagnostics now flow through the type-asserted ctx), the TriggerBinding addition is purely additive, and the Config removal from Equal/Freshen directly matches the schema change from Part 1. No behavioral regressions are introduced in the changed paths.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| arc/go/symbol/symbol.go | Replaces two typed hooks (CallHook, FlowConfigHook) with a single ArgumentsHook, adds TriggerBinding/TriggerOnly/TriggerInput, and switches ResolveConfigChannel to read param direction from Inputs instead of Config — all consistent with the Config-removal plan. |
| arc/go/types/fresh.go | Removes the Config field from FunctionProperties construction in freshen() and updates the doc comment — a minimal, correct follow-through of the Config removal. |
| arc/go/types/type.go | Drops the paramsEqual(t.Config, v.Config) comparison from Equal() since Config no longer exists on FunctionProperties; the remaining Inputs/Outputs comparison is logically complete. |

</details>

<h3>Class Diagram</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    class Symbol {
        +Type types.Type
        +Exec ExecContext
        +AnalyzeArguments ArgumentsHook
        +Trigger TriggerBinding
        +Deprecated *Symbol
    }

    class ArgumentsHook {
        <<type>>
        func(ctx any, args []Argument)
    }

    class Argument {
        +Index int
        +Name string
        +Expr IExpressionContext
        +AST ParserRuleContext
    }

    class TriggerBinding {
        +Target string
    }

    class ExecContext {
        <<const>>
        ExecWASM
        ExecFlow
        ExecBoth
    }

    note for ArgumentsHook "Replaces CallHook + FlowConfigHook"
    note for TriggerBinding "TriggerOnly: Target empty\nTriggerInput(name): Target = name"

    Symbol --> ArgumentsHook : AnalyzeArguments
    Symbol --> TriggerBinding : Trigger
    Symbol --> ExecContext : Exec
    ArgumentsHook --> Argument : args
```

<sub>Reviews (2): Last reviewed commit: ["SY-4297: Unify Symbol Hooks and Add Trig..."](https://github.com/synnaxlabs/synnax/commit/0fdb14b5c69c02bee32a60ea6e734eb8ab4af3fb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35731155)</sub>

<!-- /greptile_comment -->