### PR TITLE
SY-4297: Arc Params Refactor (Part 3) - Collapse the Analyzer Call Paths

### DIFF
--- a/arc/go/analyzer/call/call.go
+++ b/arc/go/analyzer/call/call.go
@@ -1,0 +1,122 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+// Package call centralizes argument validation shared by the expression analyzer
+// (parens form, positional args) and the flow analyzer (brace form, named or
+// anonymous input values). Both surface forms erase to a single Inputs list, so one
+// routine validates them; the only per-argument difference is whether it binds by
+// name (Argument.Name != "") or by position.
+package call
+
+import (
+	"fmt"
+
+	"github.com/antlr4-go/antlr/v4"
+	"github.com/synnaxlabs/arc/analyzer/codes"
+	acontext "github.com/synnaxlabs/arc/analyzer/context"
+	atypes "github.com/synnaxlabs/arc/analyzer/types"
+	"github.com/synnaxlabs/arc/ir"
+	"github.com/synnaxlabs/arc/symbol"
+	"github.com/synnaxlabs/arc/types"
+	"github.com/synnaxlabs/x/diagnostics"
+	"github.com/synnaxlabs/x/set"
+)
+
+// Analyze validates a call's arguments against fnType.Inputs (count, type, name, and
+// required-param coverage) and runs the symbol's optional hook. args bind by name or
+// position. externallySatisfied names params filled by something other than a
+// call-site argument (in flow, the wire-fed trigger), so they aren't reported missing.
+func Analyze[T antlr.ParserRuleContext](
+	ctx acontext.Context[T],
+	fnName string,
+	fnType types.Type,
+	args []symbol.Argument,
+	hook symbol.ArgumentsHook,
+	site antlr.ParserRuleContext,
+	externallySatisfied ...string,
+) {
+	signature := ir.FormatFunctionSignature(fnName, fnType)
+	supplied := set.New[string]()
+	for _, arg := range args {
+		param, ok := matchParam(ctx, fnName, fnType, arg, signature)
+		if !ok {
+			continue
+		}
+		if supplied.Contains(param.Name) {
+			ctx.Diagnostics.Add(diagnostics.Errorf(arg.AST,
+				"duplicate argument for parameter '%s' of func '%s'", param.Name, fnName).
+				WithNote("signature: " + signature))
+			continue
+		}
+		supplied.Add(param.Name)
+		checkArgType(ctx, fnName, param, arg, signature)
+	}
+	satisfied := set.New(externallySatisfied...)
+	for _, param := range fnType.Inputs {
+		if param.Value == nil && !supplied.Contains(param.Name) && !satisfied.Contains(param.Name) {
+			ctx.Diagnostics.Add(diagnostics.Errorf(site,
+				"missing required argument for parameter '%s' of func '%s'", param.Name, fnName).
+				WithCode(codes.FuncArgCount).WithNote("signature: " + signature))
+		}
+	}
+	if hook != nil {
+		hook(ctx, args)
+	}
+}
+
+// matchParam resolves arg to the param it binds, by name or by position, reporting
+// an unknown name or an out-of-range positional argument.
+func matchParam[T antlr.ParserRuleContext](
+	ctx acontext.Context[T],
+	fnName string,
+	fnType types.Type,
+	arg symbol.Argument,
+	signature string,
+) (types.Param, bool) {
+	if arg.Name != "" {
+		param, ok := fnType.Inputs.Get(arg.Name)
+		if !ok {
+			ctx.Diagnostics.Add(diagnostics.Errorf(arg.AST,
+				"unknown parameter '%s' for func '%s'", arg.Name, fnName).
+				WithNote("signature: " + signature))
+			return types.Param{}, false
+		}
+		return param, true
+	}
+	if arg.Index >= len(fnType.Inputs) {
+		if arg.Index == len(fnType.Inputs) {
+			ctx.Diagnostics.Add(diagnostics.Errorf(arg.AST,
+				"too many arguments for func '%s': expected at most %d",
+				fnName, len(fnType.Inputs)).
+				WithCode(codes.FuncArgCount).WithNote("signature: " + signature))
+		}
+		return types.Param{}, false
+	}
+	return fnType.Inputs[arg.Index], true
+}
+
+// checkArgType checks arg's type against param, dereferencing a channel argument to
+// its value type unless param is itself channel-typed.
+func checkArgType[T antlr.ParserRuleContext](
+	ctx acontext.Context[T],
+	fnName string,
+	param types.Param,
+	arg symbol.Argument,
+	signature string,
+) {
+	argType := atypes.InferFromExpression(acontext.Child(ctx, arg.Expr))
+	if param.Type.Kind != types.KindChan {
+		argType = argType.UnwrapChan()
+	}
+	if err := atypes.Check(ctx.Constraints, param.Type, argType, arg.AST,
+		fmt.Sprintf("argument '%s' of '%s'", param.Name, fnName)); err != nil {
+		ctx.Diagnostics.Add(diagnostics.Error(err, arg.AST).
+			WithCode(codes.FuncArgType).WithNote("signature: " + signature))
+	}
+}

--- a/arc/go/analyzer/constraints/constraints.go
+++ b/arc/go/analyzer/constraints/constraints.go
@@ -183,7 +183,6 @@ func (s *System) applySubstitutions(t types.Type, visited set.Set[string]) types
 		return types.Function(types.FunctionProperties{
 			Inputs:  s.applySubstitutionsToParams(t.Inputs, visited),
 			Outputs: s.applySubstitutionsToParams(t.Outputs, visited),
-			Config:  s.applySubstitutionsToParams(t.Config, visited),
 		})
 	}
 	return t

--- a/arc/go/analyzer/expression/call.go
+++ b/arc/go/analyzer/expression/call.go
@@ -7,12 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-// Package call centralizes argument validation shared by the expression analyzer
-// (parens form, positional args) and the flow analyzer (brace form, named or
-// anonymous input values). Both surface forms erase to a single Inputs list, so one
-// routine validates them; the only per-argument difference is whether it binds by
-// name (Argument.Name != "") or by position.
-package call
+package expression
 
 import (
 	"fmt"
@@ -28,11 +23,11 @@ import (
 	"github.com/synnaxlabs/x/set"
 )
 
-// Analyze validates a call's arguments against fnType.Inputs (count, type, name, and
+// AnalyzeCall validates a call's arguments against fnType.Inputs (count, type, name, and
 // required-param coverage) and runs the symbol's optional hook. args bind by name or
 // position. externallySatisfied names params filled by something other than a
 // call-site argument (in flow, the wire-fed trigger), so they aren't reported missing.
-func Analyze[T antlr.ParserRuleContext](
+func AnalyzeCall[T antlr.ParserRuleContext](
 	ctx acontext.Context[T],
 	fnName string,
 	fnType types.Type,

--- a/arc/go/analyzer/expression/call_test.go
+++ b/arc/go/analyzer/expression/call_test.go
@@ -1,0 +1,87 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+package expression_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	"github.com/synnaxlabs/arc/symbol"
+	"github.com/synnaxlabs/arc/types"
+)
+
+// These specs exercise AnalyzeCall through the parens (positional) surface form. The
+// brace form, named-argument matching, and the externallySatisfied trigger path are
+// driven by the flow analyzer and are covered in the flow package's specs.
+var _ = Describe("AnalyzeCall", func() {
+	Describe("Argument count", func() {
+		DescribeTable("valid argument counts",
+			func(ctx SpecContext, code string) { expectSuccess(ctx, code, nil) },
+			Entry("exact positional arguments", `
+				func add(x i32, y i32) i32 { return x + y }
+				func main() { result := add(10, 20) }
+			`),
+			Entry("required param with optional omitted", `
+				func add(x i64, y i64 = 0) i64 { return x + y }
+				func main() { result := add(10) }
+			`),
+			Entry("all optional params omitted", `
+				func defaults(a i64 = 1, b i64 = 2) i64 { return a + b }
+				func main() { result := defaults() }
+			`),
+		)
+
+		DescribeTable("invalid argument counts",
+			func(ctx SpecContext, code string, expectedMsg string) {
+				expectFailure(ctx, code, nil, expectedMsg)
+			},
+			Entry("missing required argument", `
+				func add(x i32, y i32) i32 { return x + y }
+				func main() { result := add(5) }
+			`, "missing required argument for parameter 'y' of func 'add'"),
+			Entry("missing the only required argument", `
+				func getValue(x i32) i32 { return x }
+				func main() { result := getValue() }
+			`, "missing required argument for parameter 'x' of func 'getValue'"),
+			Entry("too many arguments", `
+				func add(x i32, y i32) i32 { return x + y }
+				func main() { result := add(5, 10, 15) }
+			`, "too many arguments for func 'add': expected at most 2"),
+		)
+	})
+
+	Describe("Argument types", func() {
+		DescribeTable("type mismatches",
+			func(ctx SpecContext, code string, expectedMsg string) {
+				expectFailure(ctx, code, nil, expectedMsg)
+			},
+			Entry("string literal to i32 parameter", `
+				func add(x i32, y i32) i32 { return x + y }
+				func main() { result := add(5, "hello") }
+			`, "argument 'y' of 'add'"),
+			Entry("i32 variable to f32 parameter", `
+				func process(x f32) f32 { return x * 2.0 }
+				func main() {
+					x i32 := 5
+					result := process(x)
+				}
+			`, "argument 'x' of 'process'"),
+		)
+	})
+
+	Describe("Channel arguments", func() {
+		It("Should dereference a channel argument to a value-typed parameter", func(ctx SpecContext) {
+			expectSuccess(ctx, `
+				func read(x f32) f32 { return x }
+				func main() { result := read(temp) }
+			`, []symbol.Symbol{
+				{Name: "temp", Kind: symbol.KindChannel, Type: types.Chan(types.F32()), ID: 10},
+			})
+		})
+	})
+})

--- a/arc/go/analyzer/expression/expression.go
+++ b/arc/go/analyzer/expression/expression.go
@@ -11,10 +11,8 @@
 package expression
 
 import (
-	"fmt"
-
 	"github.com/antlr4-go/antlr/v4"
-	"github.com/synnaxlabs/arc/analyzer/codes"
+	"github.com/synnaxlabs/arc/analyzer/call"
 	"github.com/synnaxlabs/arc/analyzer/context"
 	"github.com/synnaxlabs/arc/analyzer/types"
 	"github.com/synnaxlabs/arc/analyzer/units"
@@ -399,10 +397,12 @@ func analyzePostfix(ctx context.Context[parser.IPostfixExpressionContext]) {
 				return
 			}
 			if funcName != "len" && funcName != "series.len" {
-				validateFunctionCall(ctx, scope.Type, funcName, funcCalls[0])
-			}
-			if scope.AnalyzeCall != nil {
-				scope.AnalyzeCall(ctx.Diagnostics, funcCalls[0])
+				if hasMultipleNamedOutputs(scope.Type) {
+					ctx.Diagnostics.Add(diagnostics.Errorf(funcCalls[0],
+						"cannot call function %s: functions with multiple named outputs are not callable", funcName))
+				} else {
+					call.Analyze(ctx, funcName, scope.Type, inputArguments(funcCalls[0]), scope.AnalyzeArguments, funcCalls[0])
+				}
 			}
 			if callerFn != nil {
 				argChannels := buildArgChannels(ctx, scope, funcCalls[0])
@@ -422,72 +422,25 @@ func analyzePostfix(ctx context.Context[parser.IPostfixExpressionContext]) {
 	}
 }
 
-func validateFunctionCall(
-	ctx context.Context[parser.IPostfixExpressionContext],
-	funcType basetypes.Type,
-	funcName string,
-	funcCall parser.IFunctionCallSuffixContext,
-) {
-	_, hasDefaultOutput := funcType.Outputs.Get(ir.DefaultOutputParam)
-	hasMultipleOutputs := len(funcType.Outputs) > 1 || (len(funcType.Outputs) == 1 && !hasDefaultOutput)
-	if hasMultipleOutputs {
-		ctx.Diagnostics.Add(diagnostics.Errorf(funcCall, "cannot call function %s: functions with multiple named outputs are not callable", funcName))
-		return
-	}
+// hasMultipleNamedOutputs reports whether t has multiple or non-default named outputs.
+func hasMultipleNamedOutputs(t basetypes.Type) bool {
+	_, hasDefault := t.Outputs.Get(ir.DefaultOutputParam)
+	return len(t.Outputs) > 1 || (len(t.Outputs) == 1 && !hasDefault)
+}
 
-	var args []parser.IExpressionContext
-	if argList := funcCall.ArgumentList(); argList != nil {
-		args = argList.AllExpression()
+// inputArguments adapts the arguments in a call's parens `(...)` form into the
+// unified []symbol.Argument shape.
+func inputArguments(funcCall parser.IFunctionCallSuffixContext) []symbol.Argument {
+	argList := funcCall.ArgumentList()
+	if argList == nil {
+		return nil
 	}
-
-	totalCount := len(funcType.Inputs)
-	requiredCount := funcType.Inputs.RequiredCount()
-	actualCount := len(args)
-	signature := ir.FormatFunctionSignature(funcName, funcType)
-
-	if actualCount < requiredCount || actualCount > totalCount {
-		var msg string
-		if requiredCount == totalCount {
-			msg = fmt.Sprintf("function %s expects %d argument(s), got %d",
-				funcName, totalCount, actualCount)
-		} else {
-			msg = fmt.Sprintf("function %s expects %d to %d argument(s), got %d",
-				funcName, requiredCount, totalCount, actualCount)
-		}
-		ctx.Diagnostics.Add(diagnostics.Errorf(funcCall, "%s", msg).WithCode(codes.FuncArgCount).WithNote("signature: " + signature))
-		return
+	exprs := argList.AllExpression()
+	args := make([]symbol.Argument, len(exprs))
+	for i, expr := range exprs {
+		args[i] = symbol.Argument{Index: i, Expr: expr, AST: expr}
 	}
-
-	for i, arg := range args {
-		paramType := funcType.Inputs[i].Type
-		argType := types.InferFromExpression(context.Child(ctx, arg)).UnwrapChan()
-		if paramType.Kind == basetypes.KindVariable || argType.Kind == basetypes.KindVariable {
-			if err := ctx.Constraints.AddCompatible(argType, paramType, arg,
-				fmt.Sprintf("argument %d of %s", i+1, funcName)); err != nil {
-				ctx.Diagnostics.Add(diagnostics.Error(err, arg).WithNote("signature: " + signature))
-				return
-			}
-			continue
-		}
-		if !types.Compatible(argType, paramType) {
-			diag := diagnostics.Diagnostic{
-				Severity: diagnostics.SeverityError,
-				Code:     codes.FuncArgType,
-				Message: fmt.Sprintf("argument %d of %s: expected %s, got %s",
-					i+1, funcName, paramType, argType),
-				Notes: []diagnostics.Note{{Message: "signature: " + signature}},
-			}
-			if paramType.IsNumeric() && argType.IsNumeric() {
-				diag.Notes = append(
-					[]diagnostics.Note{{Message: fmt.Sprintf("hint: use %s(value) to convert", paramType)}},
-					diag.Notes...,
-				)
-			}
-			diag.SetRange(arg)
-			ctx.Diagnostics.Add(diag)
-			return
-		}
-	}
+	return args
 }
 
 func analyzePrimary(ctx context.Context[parser.IPrimaryExpressionContext]) {

--- a/arc/go/analyzer/expression/expression.go
+++ b/arc/go/analyzer/expression/expression.go
@@ -12,7 +12,6 @@ package expression
 
 import (
 	"github.com/antlr4-go/antlr/v4"
-	"github.com/synnaxlabs/arc/analyzer/call"
 	"github.com/synnaxlabs/arc/analyzer/context"
 	"github.com/synnaxlabs/arc/analyzer/types"
 	"github.com/synnaxlabs/arc/analyzer/units"
@@ -401,7 +400,7 @@ func analyzePostfix(ctx context.Context[parser.IPostfixExpressionContext]) {
 					ctx.Diagnostics.Add(diagnostics.Errorf(funcCalls[0],
 						"cannot call function %s: functions with multiple named outputs are not callable", funcName))
 				} else {
-					call.Analyze(ctx, funcName, scope.Type, inputArguments(funcCalls[0]), scope.AnalyzeArguments, funcCalls[0])
+					AnalyzeCall(ctx, funcName, scope.Type, inputArguments(funcCalls[0]), scope.AnalyzeArguments, funcCalls[0])
 				}
 			}
 			if callerFn != nil {

--- a/arc/go/analyzer/flow/expression.go
+++ b/arc/go/analyzer/flow/expression.go
@@ -58,7 +58,7 @@ func AnalyzeSingleExpression(ctx acontext.Context[parser.IExpressionContext]) {
 				}
 			}
 		}
-		t.Config = append(t.Config, types.Param{Name: "value", Type: exprType})
+		t.Inputs = append(t.Inputs, types.Param{Name: "value", Type: exprType})
 		scope, err := ctx.Scope.Root().Add(ctx, symbol.Symbol{
 			Kind: symbol.KindConstant,
 			Type: t,

--- a/arc/go/analyzer/flow/flow.go
+++ b/arc/go/analyzer/flow/flow.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 
 	"github.com/antlr4-go/antlr/v4"
-	"github.com/synnaxlabs/arc/analyzer/call"
 	"github.com/synnaxlabs/arc/analyzer/context"
 	"github.com/synnaxlabs/arc/analyzer/expression"
 	atypes "github.com/synnaxlabs/arc/analyzer/types"
@@ -43,7 +42,7 @@ func AnalyzeSingleFunction(ctx context.Context[parser.IFunctionContext]) {
 	}
 	freshType := types.Freshen(funcType.Type, freshenKey(ctx.AST, name))
 	args := inputArguments(ctx, ctx.AST.ConfigValues())
-	call.Analyze(ctx, name, freshType, args, funcType.AnalyzeArguments, ctx.AST)
+	expression.AnalyzeCall(ctx, name, freshType, args, funcType.AnalyzeArguments, ctx.AST)
 }
 
 // Analyze validates a flow statement's node chain and routing tables.
@@ -93,7 +92,7 @@ func parseFunction(ctx context.Context[parser.IFunctionContext], prevNode parser
 	if prevNode != nil && funcType.Trigger.Target != "" {
 		externallySatisfied = append(externallySatisfied, funcType.Trigger.Target)
 	}
-	call.Analyze(ctx, name, freshType, args, funcType.AnalyzeArguments, ctx.AST, externallySatisfied...)
+	expression.AnalyzeCall(ctx, name, freshType, args, funcType.AnalyzeArguments, ctx.AST, externallySatisfied...)
 
 	if prevNode == nil {
 		return
@@ -591,7 +590,7 @@ func analyzeRoutingTargetWithParam(
 		if fnType.Trigger.Target != "" {
 			externallySatisfied = append(externallySatisfied, fnType.Trigger.Target)
 		}
-		call.Analyze(ctx, fnName, fnType.Type, args, fnType.AnalyzeArguments, fn, externallySatisfied...)
+		expression.AnalyzeCall(ctx, fnName, fnType.Type, args, fnType.AnalyzeArguments, fn, externallySatisfied...)
 
 		if targetParam != nil {
 			var outputType types.Type

--- a/arc/go/analyzer/flow/flow.go
+++ b/arc/go/analyzer/flow/flow.go
@@ -15,6 +15,7 @@ import (
 	"fmt"
 
 	"github.com/antlr4-go/antlr/v4"
+	"github.com/synnaxlabs/arc/analyzer/call"
 	"github.com/synnaxlabs/arc/analyzer/context"
 	"github.com/synnaxlabs/arc/analyzer/expression"
 	atypes "github.com/synnaxlabs/arc/analyzer/types"
@@ -41,15 +42,8 @@ func AnalyzeSingleFunction(ctx context.Context[parser.IFunctionContext]) {
 		return
 	}
 	freshType := types.Freshen(funcType.Type, freshenKey(ctx.AST, name))
-	validateFuncConfig(ctx, name, freshType, ctx.AST.ConfigValues(), ctx.AST)
-	for _, input := range freshType.Inputs {
-		if input.Value == nil {
-			ctx.Diagnostics.Add(diagnostics.Errorf(ctx.AST,
-				"standalone function '%s' has required input '%s' with no source; "+
-					"use in a flow statement or provide a default value",
-				name, input.Name))
-		}
-	}
+	args := inputArguments(ctx, ctx.AST.ConfigValues())
+	call.Analyze(ctx, name, freshType, args, funcType.AnalyzeArguments, ctx.AST)
 }
 
 // Analyze validates a flow statement's node chain and routing tables.
@@ -93,123 +87,118 @@ func parseFunction(ctx context.Context[parser.IFunctionContext], prevNode parser
 	}
 
 	freshType := types.Freshen(funcType.Type, freshenKey(ctx.AST, name))
+	args := inputArguments(ctx, ctx.AST.ConfigValues())
 
-	validateFuncConfig(
-		ctx,
-		name,
-		freshType,
-		ctx.AST.ConfigValues(),
-		ctx.AST,
-	)
-	if funcType.AnalyzeFlowConfig != nil {
-		funcType.AnalyzeFlowConfig(ctx.Diagnostics, ctx.AST.ConfigValues())
+	var externallySatisfied []string
+	if prevNode != nil && funcType.Trigger.Target != "" {
+		externallySatisfied = append(externallySatisfied, funcType.Trigger.Target)
 	}
+	call.Analyze(ctx, name, freshType, args, funcType.AnalyzeArguments, ctx.AST, externallySatisfied...)
+
 	if prevNode == nil {
 		return
 	}
+	upstreamType, ok := resolveUpstreamType(ctx, prevNode, name)
+	if !ok {
+		return
+	}
+	consultTrigger(ctx, funcType, freshType, name, upstreamType, suppliedNames(args, freshType))
+}
 
-	// Dual-shape ExecBoth (see symbol.ExecBoth): upstream is a trigger, not
-	// a typed input.
-	upstreamIsTrigger := funcType.Exec == symbol.ExecBoth && len(freshType.Config) > 0
-
+// resolveUpstreamType returns the value type flowing from prevNode into the func
+// node, and whether the trigger consult should proceed.
+func resolveUpstreamType(
+	ctx context.Context[parser.IFunctionContext],
+	prevNode parser.IFlowNodeContext,
+	name string,
+) (types.Type, bool) {
 	if prevIDNode := prevNode.Identifier(); prevIDNode != nil {
 		idName := prevIDNode.IDENTIFIER().GetText()
 		idSym, err := ctx.Resolve(idName)
 		if err != nil {
 			ctx.Diagnostics.Add(diagnostics.Error(err, prevIDNode))
-			return
+			return types.Type{}, false
 		}
-		// When used as a source, identifier must be a channel
 		if idSym.Kind != symbol.KindChannel {
 			ctx.Diagnostics.Add(diagnostics.Errorf(prevIDNode, "%s is not a channel", idName))
-			return
+			return types.Type{}, false
 		}
-		if !upstreamIsTrigger && len(freshType.Inputs) > 0 {
-			param := freshType.Inputs[0]
-			if idSym.Type.Kind != types.KindChan {
-				ctx.Diagnostics.Add(diagnostics.Errorf(ctx.AST,
-					"%s is not a valid channel",
-					idName,
-				))
-				return
-			}
-			chanValueType := idSym.Type.Unwrap()
-			if err = atypes.Check(
-				ctx.Constraints,
-				chanValueType,
-				param.Type,
-				ctx.AST,
-				"channel to func parameter connection",
-			); err != nil {
-				ctx.Diagnostics.Add(diagnostics.Errorf(ctx.AST,
-					"channel %s value type %s does not match func %s parameter type %s",
-					idName,
-					chanValueType,
-					name,
-					funcType.Type.Inputs[0],
-				))
-				return
-			}
+		if idSym.Type.Kind != types.KindChan {
+			ctx.Diagnostics.Add(diagnostics.Errorf(ctx.AST, "%s is not a valid channel", idName))
+			return types.Type{}, false
 		}
-	} else if prevExpr := prevNode.Expression(); prevExpr != nil {
-		exprType := atypes.InferFromExpression(context.Child(ctx, prevExpr)).Unwrap()
-		if !upstreamIsTrigger && len(freshType.Inputs) > 0 {
-			param := freshType.Inputs[0]
-			if err := atypes.Check(
-				ctx.Constraints,
-				exprType,
-				param.Type,
-				ctx.AST,
-				"expression to func parameter connection",
-			); err != nil {
-				ctx.Diagnostics.Add(diagnostics.Errorf(ctx.AST,
-					"expression type %s does not match func %s parameter type %s",
-					exprType,
-					name,
-					funcType.Type.Inputs[0].Type,
-				))
-				return
-			}
+		return idSym.Type.Unwrap(), true
+	}
+	if prevExpr := prevNode.Expression(); prevExpr != nil {
+		return atypes.InferFromExpression(context.Child(ctx, prevExpr)).Unwrap(), true
+	}
+	if prevFuncNode := prevNode.Function(); prevFuncNode != nil {
+		if hasRoutingTableBetween(ctx) {
+			return types.Type{}, false
 		}
-	} else if prevFuncNode := prevNode.Function(); prevFuncNode != nil {
 		prevFuncType, prevFuncName := resolveFunc(ctx, prevFuncNode)
 		if prevFuncType == nil {
-			return
+			return types.Type{}, false
 		}
-		hasRoutingTableBetween := false
-		if parent := ctx.AST.GetParent(); parent != nil {
-			if grandparent := parent.GetParent(); grandparent != nil {
-				if flowStmt, ok := grandparent.(parser.IFlowStatementContext); ok {
-					if len(flowStmt.AllRoutingTable()) > 0 {
-						hasRoutingTableBetween = true
-					}
-				}
-			}
+		prevFreshType := types.Freshen(prevFuncType.Type, freshenKey(prevFuncNode, prevFuncName))
+		prevOutputType := resolveFuncOutput(ctx, prevFreshType, prevFuncName,
+			"'"+name+"' expects an input parameter")
+		if !prevOutputType.IsValid() {
+			return types.Type{}, false
 		}
+		return prevOutputType, true
+	}
+	return types.Type{}, false
+}
 
-		if !upstreamIsTrigger && !hasRoutingTableBetween && len(freshType.Inputs) > 1 {
-			ctx.Diagnostics.Add(diagnostics.Errorf(ctx.AST, "%s has more than one parameter", name))
+// hasRoutingTableBetween reports whether the flow statement enclosing the func
+// node also contains a routing table.
+func hasRoutingTableBetween(ctx context.Context[parser.IFunctionContext]) bool {
+	parent := ctx.AST.GetParent()
+	if parent == nil {
+		return false
+	}
+	grandparent := parent.GetParent()
+	if grandparent == nil {
+		return false
+	}
+	flowStmt, ok := grandparent.(parser.IFlowStatementContext)
+	if !ok {
+		return false
+	}
+	return len(flowStmt.AllRoutingTable()) > 0
+}
+
+// consultTrigger type-checks an upstream wire's value against funcType's trigger
+// param; a param also bound at the call site is a conflict.
+func consultTrigger[T antlr.ParserRuleContext](
+	ctx context.Context[T],
+	funcType *symbol.Symbol,
+	callSig types.Type,
+	name string,
+	upstreamType types.Type,
+	suppliedAtCallSite set.Set[string],
+) {
+	target := funcType.Trigger.Target
+	switch {
+	case target == "":
+		// TriggerOnly: the wire is pure activation; do not type-check its value.
+	case suppliedAtCallSite.Contains(target):
+		ctx.Diagnostics.Add(diagnostics.Errorf(ctx.AST,
+			"parameter '%s' of func '%s' is bound by both a call-site argument and an upstream wire",
+			target, name))
+	default:
+		targetParam, ok := callSig.Inputs.Get(target)
+		if !ok {
+			ctx.Diagnostics.Add(diagnostics.Errorf(ctx.AST,
+				"func '%s' declares trigger target '%s' but has no such parameter", name, target))
 			return
 		}
-		if !upstreamIsTrigger && !hasRoutingTableBetween && len(freshType.Inputs) > 0 {
-			t := freshType.Inputs[0].Type
-			prevFreshType := types.Freshen(prevFuncType.Type, freshenKey(prevFuncNode, prevFuncName))
-			prevOutputType := resolveFuncOutput(ctx, prevFreshType, prevFuncName,
-				"'"+name+"' expects an input parameter")
-			if !prevOutputType.IsValid() {
-				return
-			}
-			if err := atypes.Check(ctx.Constraints, prevOutputType, t, ctx.AST,
-				"flow connection between fns"); err != nil {
-				ctx.Diagnostics.Add(diagnostics.Errorf(ctx.AST,
-					"return type %s of %s is not equal to argument type %s of %s",
-					prevOutputType,
-					prevFuncName,
-					funcType.Type.Inputs[0].Type,
-					name,
-				))
-				return
-			}
+		if err := atypes.Check(ctx.Constraints, targetParam.Type, upstreamType, ctx.AST,
+			"upstream connection to func '"+name+"'"); err != nil {
+			ctx.Diagnostics.Add(diagnostics.Errorf(ctx.AST,
+				"upstream value type %s does not match func '%s' trigger parameter '%s' type %s",
+				upstreamType, name, target, targetParam.Type))
 		}
 	}
 }
@@ -304,85 +293,56 @@ func resolveFuncOutput[T antlr.ParserRuleContext](
 	return types.Type{}
 }
 
-func validateFuncConfig[T antlr.ParserRuleContext](
+// inputArguments adapts the arguments in a call's brace `{...}` form into the
+// unified []symbol.Argument shape, analyzing each value expression as it goes.
+func inputArguments[T antlr.ParserRuleContext](
 	ctx context.Context[T],
-	fnName string,
-	fnType types.Type,
-	configBlock parser.IConfigValuesContext,
-	configNode antlr.ParserRuleContext,
-) {
-	if configBlock == nil {
-		return
+	braceBlock parser.IConfigValuesContext,
+) []symbol.Argument {
+	if braceBlock == nil {
+		return nil
 	}
-
-	configParams := make(set.Set[string])
-	if namedVals := configBlock.NamedConfigValues(); namedVals != nil {
-		for _, configVal := range namedVals.AllNamedConfigValue() {
-			key := configVal.IDENTIFIER().GetText()
-			configParams.Add(key)
-			expectedType, exists := fnType.Config.Get(key)
-			if !exists {
-				ctx.Diagnostics.Add(diagnostics.Errorf(
-					configVal,
-					"unknown config parameter '%s' for func '%s'",
-					key,
-					fnName,
-				))
+	var args []symbol.Argument
+	if namedVals := braceBlock.NamedConfigValues(); namedVals != nil {
+		for _, val := range namedVals.AllNamedConfigValue() {
+			expr := val.Expression()
+			if expr == nil {
 				continue
 			}
-			if expr := configVal.Expression(); expr != nil {
-				childCtx := context.Child(ctx, expr)
-				expression.Analyze(childCtx)
-				exprType := atypes.InferFromExpression(childCtx)
-				if err := atypes.Check(ctx.Constraints, expectedType.Type, exprType, configVal,
-					"config parameter '"+key+"' for func '"+fnName+"'"); err != nil {
-					ctx.Diagnostics.Add(diagnostics.Errorf(
-						configVal,
-						"type mismatch: config parameter '%s' expects %s but got %s",
-						key,
-						expectedType.Type,
-						exprType,
-					))
-				}
-			}
+			expression.Analyze(context.Child(ctx, expr))
+			args = append(args, symbol.Argument{
+				Name: val.IDENTIFIER().GetText(),
+				Expr: expr,
+				AST:  val,
+			})
 		}
-	} else if anonVals := configBlock.AnonymousConfigValues(); anonVals != nil {
-		exprs := anonVals.AllExpression()
-		if len(exprs) > len(fnType.Config) {
-			ctx.Diagnostics.Add(diagnostics.Errorf(
-				anonVals,
-				"too many config values for func '%s': got %d, expected at most %d",
-				fnName, len(exprs), len(fnType.Config),
-			))
-			return
-		}
-		for i, expr := range exprs {
-			param := fnType.Config[i]
-			configParams.Add(param.Name)
-			childCtx := context.Child(ctx, expr)
-			expression.Analyze(childCtx)
-			exprType := atypes.InferFromExpression(childCtx)
-			if err := atypes.Check(ctx.Constraints, param.Type, exprType, expr,
-				"config parameter '"+param.Name+"' for func '"+fnName+"'"); err != nil {
-				ctx.Diagnostics.Add(diagnostics.Errorf(
-					expr,
-					"type mismatch: config parameter '%s' expects %s but got %s",
-					param.Name, param.Type, exprType,
-				))
-			}
+		return args
+	}
+	if anonVals := braceBlock.AnonymousConfigValues(); anonVals != nil {
+		for i, expr := range anonVals.AllExpression() {
+			expression.Analyze(context.Child(ctx, expr))
+			args = append(args, symbol.Argument{
+				Index: i,
+				Expr:  expr,
+				AST:   expr,
+			})
 		}
 	}
+	return args
+}
 
-	for _, param := range fnType.Config {
-		if !configParams.Contains(param.Name) && param.Value == nil {
-			ctx.Diagnostics.Add(diagnostics.Errorf(
-				configNode,
-				"missing required config parameter '%s' for func '%s'",
-				param.Name,
-				fnName,
-			))
+// suppliedNames returns the set of param names bound by args, resolving positional
+// args to their param name via fnType.Inputs.
+func suppliedNames(args []symbol.Argument, fnType types.Type) set.Set[string] {
+	supplied := set.New[string]()
+	for _, arg := range args {
+		if arg.Name != "" {
+			supplied.Add(arg.Name)
+		} else if arg.Index < len(fnType.Inputs) {
+			supplied.Add(fnType.Inputs[arg.Index].Name)
 		}
 	}
+	return supplied
 }
 
 func analyzeRoutingTable(ctx context.Context[parser.IRoutingTableContext]) {
@@ -626,13 +586,12 @@ func analyzeRoutingTargetWithParam(
 			return
 		}
 
-		validateFuncConfig(
-			ctx,
-			fnName,
-			fnType.Type,
-			fn.ConfigValues(),
-			fn,
-		)
+		args := inputArguments(ctx, fn.ConfigValues())
+		var externallySatisfied []string
+		if fnType.Trigger.Target != "" {
+			externallySatisfied = append(externallySatisfied, fnType.Trigger.Target)
+		}
+		call.Analyze(ctx, fnName, fnType.Type, args, fnType.AnalyzeArguments, fn, externallySatisfied...)
 
 		if targetParam != nil {
 			var outputType types.Type
@@ -660,21 +619,7 @@ func analyzeRoutingTargetWithParam(
 				}
 			}
 		} else {
-			//  A select branch into such an ExecBoth node is a trigger, not a typed input.
-			upstreamIsTrigger := fnType.Exec == symbol.ExecBoth && len(fnType.Type.Config) > 0
-			if !upstreamIsTrigger && len(fnType.Type.Inputs) > 0 {
-				param := fnType.Type.Inputs[0]
-				if err := atypes.Check(ctx.Constraints, sourceType, param.Type, ctx.AST,
-					"routing table output to func parameter"); err != nil {
-					ctx.Diagnostics.Add(diagnostics.Errorf(ctx.AST,
-						"type mismatch: output type %s does not match func %s parameter type %s",
-						sourceType,
-						fnName,
-						param.Type,
-					))
-					return
-				}
-			}
+			consultTrigger(ctx, fnType, fnType.Type, fnName, sourceType, suppliedNames(args, fnType.Type))
 		}
 	} else if idNode := ctx.AST.Identifier(); idNode != nil {
 		idName := idNode.IDENTIFIER().GetText()

--- a/arc/go/analyzer/function/function.go
+++ b/arc/go/analyzer/function/function.go
@@ -9,16 +9,14 @@
 
 // Package function implements semantic analysis for Arc function declarations.
 //
-// Functions in Arc have three parameter categories:
-//   - Config: Compile-time configuration (in curly braces)
-//   - Inputs: Runtime parameters (in parentheses)
-//   - Outputs: Return values (after the parameter list)
+// A function has a list of inputs and a list of outputs. One input may be the
+// trigger: the param an upstream wire feeds in flow context. The analyzer collects
+// the declared params into Inputs and records the trigger.
 //
 // The analyzer validates:
 //   - Function names are unique
-//   - Parameter names are unique within their category
-//   - Input types are valid
-//   - Output types are valid
+//   - Parameter names are unique
+//   - Input and output types are valid
 //   - Optional parameters come after required parameters
 //   - Functions with return types return on all code paths
 //   - Named outputs are assigned in the function body

--- a/arc/go/analyzer/function/function.go
+++ b/arc/go/analyzer/function/function.go
@@ -47,22 +47,29 @@ func CollectDeclarations(ctx acontext.Context[parser.IProgramContext]) {
 		if fn := item.FunctionDeclaration(); fn != nil {
 			name := fn.IDENTIFIER().GetText()
 
-			// Collect signature (config, inputs, outputs) without adding params to scope
-			var config, inputs, outputs types.Params
-			collectConfig(ctx, fn.ConfigBlock(), &config)
+			// The brace block holds inputs and the parens block holds the trigger;
+			// they concatenate into one Inputs list, inputs first.
+			var inputs, outputs types.Params
+			collectConfig(ctx, fn.ConfigBlock(), &inputs)
+			parensStart := len(inputs)
 			collectInputs(acontext.Child(ctx, fn.InputList()), &inputs)
 			collectOutputs(ctx, fn.OutputType(), &outputs)
+
+			trigger := symbol.TriggerOnly
+			if len(inputs) > parensStart {
+				trigger = symbol.TriggerInput(inputs[parensStart].Name)
+			}
 
 			if _, err := ctx.Scope.Add(ctx, symbol.Symbol{
 				Name: name,
 				Kind: symbol.KindFunction,
 				Exec: symbol.ExecBoth,
 				Type: types.Function(types.FunctionProperties{
-					Config:  config,
 					Inputs:  inputs,
 					Outputs: outputs,
 				}),
-				AST: fn,
+				Trigger: trigger,
+				AST:     fn,
 			}); err != nil {
 				ctx.Diagnostics.Add(diagnostics.Error(err, fn))
 			}
@@ -388,7 +395,7 @@ func IfStmtAlwaysReturns(ifStmt parser.IIfStatementContext) bool {
 }
 
 // addConfigToScope adds config parameters to the function's scope.
-// The config types are already collected in fn.Type.Config by CollectDeclarations.
+// The config types are already collected in fn.Type.Inputs by CollectDeclarations.
 func addConfigToScope[T antlr.ParserRuleContext](
 	ctx acontext.Context[T],
 	configBlock parser.IConfigBlockContext,

--- a/arc/go/analyzer/resolve.go
+++ b/arc/go/analyzer/resolve.go
@@ -18,8 +18,8 @@ import (
 )
 
 // ResolveNodeTypes checks type compatibility across edges, unifies the constraint
-// system, applies substitutions to resolve concrete types in node inputs,
-// outputs, and config parameters, and verifies that every required input is
+// system, applies substitutions to resolve concrete types in node inputs and
+// outputs, and verifies that every required input is
 // satisfied by an incoming edge. A required input is one whose parameter has no
 // default Value; leaving it unconnected would force the runtime to materialize a
 // series from a nil value, so it is rejected here as a diagnostic instead.
@@ -68,9 +68,6 @@ func ResolveNodeTypes(
 		}
 		for j, p := range n.Inputs {
 			nodes[idx].Inputs[j].Type = cs.ApplySubstitutions(p.Type)
-		}
-		for j, p := range n.Config {
-			nodes[idx].Config[j].Type = cs.ApplySubstitutions(p.Type)
 		}
 	}
 	connected := set.New[ir.Handle]()

--- a/docs/tech/rfc/0039-260513-arc-function-call-unification.md
+++ b/docs/tech/rfc/0039-260513-arc-function-call-unification.md
@@ -975,3 +975,65 @@ question; no decision taken here.
 part of the major release this refactor ships with, skipping the next sequential number.
 The exact target version is fixed once the release is named; this RFC uses `vN` as a
 placeholder throughout.
+
+# Appendix A - Running Notes
+
+An append-only log of decisions, observations, and deferred ideas surfaced while
+implementing this RFC. Add new entries at the bottom; do not edit or reorder existing
+ones. Strict append-only keeps this section free of merge conflicts across the stacked
+phase branches and leaves the numbered sections above untouched. When a note hardens
+into a real design decision, promote it into the relevant section above (or §8 Future
+Work) and leave the note here as a record. Entry heading:
+`### <phase or date> - <short title>`.
+
+### Phase 3 - Brace/parens surface convention may invert
+
+Today a user-defined function's brace block holds the non-trigger inputs and the parens
+block holds the trigger (its first param is the wire-fed one):
+
+```go
+func my_func{inputs}(trigger) { ... }
+```
+
+A future direction worth weighing is inverting this, so `{}` denotes the flow/trigger
+surface and `()` the inputs. That would match how `{}` already reads for sequences and
+stages, leaving `()` intuitively for inputs:
+
+```go
+// Function definition
+func my_func{trigger}(inputs) { ... }
+func {trigger} my_func(inputs) { ... }
+func {trigger} -> my_func(inputs) { ... }
+
+// Usage in flow context:
+my_channel -> my_func(inputs) -> output
+{ch1, ch2} -> my_func(inputs) -> output
+```
+
+This is surface syntax only. The unified Inputs list and explicit `Trigger` binding from
+this RFC are unaffected either way, which is exactly why the foundation was kept
+policy-free (see §8.0). Deferred; no decision yet.
+
+### Phase 3 - Grammar still uses "config" terminology
+
+Phase 1 removed the `Config` field from the type/IR model (Oracle schema). The ANTLR
+grammar, a separate generator, still names its productions `config`: the parser exposes
+`ConfigBlock()`, `ConfigValues()`, `NamedConfigValues()`, `AnonymousConfigValues()`,
+`ConfigList()`, and `AllConfig()`, which the analyzer calls to read the `{...}` form. §2
+currently lists the grammar as a Non-Goal, so these names survive this RFC.
+
+Since `config` is being deprecated, the grammar terminology should follow. This is a
+standalone effort, not a sub-part of the analyzer collapse: the analyzer is indifferent
+to what the parser methods are named. It is a wide mechanical sweep (edit the `.g4`,
+regenerate the parser, update every caller across arc/go and other grammar consumers).
+
+Do it last, after Phase 9, when the tree is green. A mechanical rename on a compiling
+tree can lean on the compiler and tests to catch every missed caller; done mid-stack on
+the broken-by-design tree there is no such safety net. This is strictly better than
+doing it earlier, not just acceptable: the rename is independent of the type/analyzer
+collapse, so nothing in Phases 1 to 9 is blocked by the `config` names surviving, and
+nothing in the rename is blocked by the refactor. Promote §2 from Non-Goal to goal when
+it lands.
+
+Open question for that phase: what the rules rename to (e.g. `braceBlock` / `parenBlock`
+by surface form). Not just find-and-replace.


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4297](https://linear.app/synnax/issue/SY-4297)

## Description

Part 3 of the Arc Function-Call Unification stack ([RFC 0039](docs/tech/rfc/0039-260513-arc-function-call-unification.md)). Stacked on **Part 2 (#2447)**; the schema/codegen that removed the `Config` field landed in **Part 1 (#2421)**.

This is the analyzer collapse; the core of the refactor and its design-evaluation gate (RFC §4.2, §4.4).

**Unified call validation.** A new `analyzer/call` package provides `call.Analyze`, one routine that validates a call's arguments against the unified `Inputs` list for both surface forms. The two parallel validators are removed: `validateFunctionCall` (parens) and `validateFuncConfig` (brace) now adapt their arguments to `[]symbol.Argument` via `inputArguments` and delegate to `call.Analyze`, which also runs the unified `AnalyzeArguments` hook (replacing the old `AnalyzeCall` + `AnalyzeFlowConfig` pair).

**Explicit trigger consult.** The flow analyzer's `upstreamIsTrigger` heuristic and its three-branch upstream-handling block are replaced by `consultTrigger`, which keys off the symbol's explicit `Trigger` (added in Part 2) instead of guessing from `Exec` + `len(Config)`. User-defined functions are assigned `Trigger` in `CollectDeclarations` (the first parens-block param, else `TriggerOnly`).

**Cleanup.** The now-dangling analyzer `.Config` readers are dropped (the substitution
loop in `resolve.go`, the function-type clone in `constraints.go`).

### Reviewer notes

- **Does not compile yet, by design.** Downstream consumers (ir, graph, text, compiler) still read `.Config` and are converted in Parts 4–8; first green build is Part 9. CI red is expected — review on the diff. `gofmt -s` passes and gopls reports the changed files clean; `golangci-lint` is blocked only by the `ir` import.
- **No tests in this part** — the fixture sweep and new analyzer tests are Part 7.
- **Behavior decisions to scrutinize at the gate:**
  - Type-checking is unified on `atypes.Check`, stricter than the old parens `AddCompatible` (drops implicit concrete numeric promotion; literals still adapt).
  - Calls match the full unified `Inputs` (config-first); coverage is per-param.
  - A channel argument is dereferenced only when the target param is not itself channel-typed (reconciles the old parens-deref vs brace-channel-param split).
  - New diagnostic: a param bound by both a call-site argument and an upstream wire.
  - Dropped the `>1 parameter` func-to-func error and the standalone "use in a flow statement" hint (both subsumed by coverage + `consultTrigger`).

## Basic Readiness

- [x] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Part 3 of the Arc function-call unification stack: collapses the two parallel call validators (`validateFunctionCall` for parens and `validateFuncConfig` for brace) into a single `call.Analyze` routine in the new `analyzer/call` package, and replaces the `upstreamIsTrigger` heuristic in the flow analyzer with an explicit `consultTrigger` dispatch keyed off the symbol's `Trigger` field added in Part 2.

- **`analyzer/call`**: New `Analyze[T]` function handles both surface forms; `matchParam` resolves named or positional args, `checkArgType` dereferences channel arguments only when the target param is not channel-typed, and `externallySatisfied` suppresses \"missing required argument\" for wire-fed trigger params.
- **`flow/flow.go`**: `parseFunction` and `analyzeRoutingTargetWithParam` now adapt brace-block values via `inputArguments` and delegate to `call.Analyze`; upstream wiring is validated in `consultTrigger` which distinguishes TriggerOnly (pure activation, no type check) from TriggerInput (value-typed, reports conflicts with call-site args).
- **`function/function.go` + `constraints/constraints.go` + `resolve.go`**: Config params are merged into `Inputs`, `Config` substitution loop removed, and user-defined functions gain an explicit `Trigger` set in `CollectDeclarations`.

<h3>Confidence Score: 5/5</h3>

The PR does not compile by design; the changed files are analyzer logic only and the diff is internally consistent with the RFC.

All changed files follow the same contract: brace-block and parens-block args are adapted into []symbol.Argument and routed through the single call.Analyze path. The consultTrigger replacement for upstreamIsTrigger reads explicit symbol metadata instead of inferring from Exec+len(Config). No logic regressions are visible in the changed code.

arc/go/analyzer/function/function.go has two function-level doc comments that still reference the old (config, inputs, outputs) signature pattern.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| arc/go/analyzer/call/call.go | New unified Analyze function; clean design with well-scoped matchParam/checkArgType helpers and correct externallySatisfied variadic for trigger params. |
| arc/go/analyzer/flow/flow.go | Replaces upstreamIsTrigger heuristic with consultTrigger; extracting resolveUpstreamType and hasRoutingTableBetween into helpers significantly improves clarity with no logic regressions visible. |
| arc/go/analyzer/function/function.go | Package-level doc comment updated; two function-level doc comments still say (config, inputs, outputs) which is stale after the Config to Inputs merge. |
| arc/go/analyzer/expression/expression.go | validateFunctionCall removed; delegates to call.Analyze via inputArguments adapter, unifying the parens-call path with the brace path cleanly. |
| arc/go/analyzer/resolve.go | Config substitution loop removed from ResolveNodeTypes; doc comment updated but has a minor awkward line break. |
| arc/go/analyzer/flow/expression.go | Single-line fix: constant value param now appended to Inputs instead of the removed Config field. |
| arc/go/analyzer/constraints/constraints.go | One-line removal of Config substitution from applySubstitutions; correct given Config is gone from the function type. |
| docs/tech/rfc/0039-260513-arc-function-call-unification.md | Appendix A added with Phase 3 running notes on brace/parens syntax and grammar terminology; informational only. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Call site: parens form"] -->|inputArguments| C["[]symbol.Argument"]
    B["Call site: brace form"] -->|inputArguments| C
    C --> D["call.Analyze"]
    D --> E["matchParam: by name or index"]
    D --> F["checkArgType: UnwrapChan unless param is chan-typed"]
    D --> G["Coverage check: missing required params"]
    D --> H["ArgumentsHook: optional symbol hook"]
    G -->|externallySatisfied| I["Trigger param fed by upstream wire"]
    J["parseFunction"] -->|"prevNode != nil AND Trigger.Target set"| I
    J --> D
    K["resolveUpstreamType"] -->|"identifier / expr / func"| L["upstreamType"]
    L --> M["consultTrigger"]
    M -->|"target is empty"| N["TriggerOnly: pure activation, skip type check"]
    M -->|"target in suppliedAtCallSite"| O["Error: param bound by both call-site arg and wire"]
    M -->|"default"| P["atypes.Check: targetParam.Type vs upstreamType"]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `arc/go/analyzer/function/function.go`, line 10-15 ([link](https://github.com/synnaxlabs/synnax/blob/16601ddeab177fc140beff2c0b7d04effe2bd8b2/arc/go/analyzer/function/function.go#L10-L15)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> The package-level doc comment still describes a three-category parameter model (Config / Inputs / Outputs) that no longer reflects the type system after this refactor. Config params are now merged into `Inputs`, so the listed "Config" bullet describes a concept that has been removed. A reader new to this code would be misled into expecting a separate `Config` field on the function type.

   **Rule Used:** Flag misleading doc comments that promise fallback... ([source](https://app.greptile.com/synnax/github/synnaxlabs/synnax/-/custom-context?memory=16df2708-f8e1-4fe6-a509-cee5a869fa6e))
   
   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["SY-4297: Fix function doc string"](https://github.com/synnaxlabs/synnax/commit/8f45ece687e35ec2db6fadf187831680435e2757) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35754638)</sub>

<!-- /greptile_comment -->