### PR TITLE
SY-4319: Fix Flaky Arc LSP Test

### DIFF
--- a/arc/go/lsp/server.go
+++ b/arc/go/lsp/server.go
@@ -113,6 +113,7 @@ type Server struct {
 	republishMu              sync.Mutex
 	cancelRepublish          context.CancelFunc
 	externalChangeDisconnect observe.Disconnect
+	republishWG              sync.WaitGroup
 }
 
 var _ protocol.Server = (*Server)(nil)
@@ -178,7 +179,7 @@ func (s *Server) SetClient(client lsp.Client) {
 			ctx, cancel := context.WithTimeout(ctx, s.cfg.RepublishTimeout)
 			s.cancelRepublish = cancel
 			s.republishMu.Unlock()
-			go s.republishAllDiagnostics(ctx)
+			s.republishWG.Go(func() { s.republishAllDiagnostics(ctx) })
 		})
 	}
 }
@@ -224,7 +225,7 @@ func (s *Server) Initialized(context.Context, *protocol.InitializedParams) error
 	return nil
 }
 
-// Shutdown handles the shutdown request
+// Shutdown handles the shutdown request.
 func (s *Server) Shutdown(_ context.Context) error {
 	s.cfg.L.Info("Shutting down server")
 	if s.externalChangeDisconnect != nil {
@@ -235,6 +236,7 @@ func (s *Server) Shutdown(_ context.Context) error {
 		s.cancelRepublish()
 	}
 	s.republishMu.Unlock()
+	s.republishWG.Wait()
 	s.mu.RLock()
 	docs := make([]*Document, 0, len(s.documents))
 	for _, doc := range s.documents {

--- a/arc/go/lsp/server.go
+++ b/arc/go/lsp/server.go
@@ -35,46 +35,59 @@ import (
 	"go.uber.org/zap"
 )
 
-// OnRename is invoked by the LSP when a Rename request resolves to a known
-// symbol. It runs before the server computes source-text edits and lets the
-// caller propagate the rename to the resource the symbol refers to (e.g.,
-// the underlying Synnax channel). Returning an error aborts the rename and
-// surfaces the error to the client. Callbacks should return nil for symbols
-// they do not handle.
-type OnRename func(ctx context.Context, sym *symbol.Symbol, oldName, newName string) error
+// OnRename is invoked by the LSP when a Rename request resolves to a known symbol. It
+// runs before the server computes source-text edits and lets the caller propagate the
+// rename to the resource the symbol refers to (e.g., the underlying Synnax channel).
+// Returning an error aborts the rename and surfaces the error to the client. Callbacks
+// should return nil for symbols they do not handle.
+type OnRename func(_ context.Context, _ *symbol.Symbol, oldName, newName string) error
 
 // Config defines the configuration for opening an arc LSP Server.
 type Config struct {
-	// NewRoot builds a fresh analyzer root scope. The LSP calls it once per
-	// document analysis (so per-document imports don't bleed across files)
-	// and again for completion fallback when the document has no analyzed
-	// scope yet. Callers compose STL, their custom globals, and any
-	// dynamic resolvers (cluster channels, etc.) into the returned root.
+	// NewRoot builds a fresh analyzer root scope. The LSP calls it once per document
+	// analysis (so per-document imports don't bleed across files) and again for
+	// completion fallback when the document has no analyzed scope yet. Callers compose
+	// STL, their custom globals, and any dynamic resolvers (cluster channels, etc.)
+	// into the returned root.
+	//
+	// [REQUIRED]
 	NewRoot func() *symbol.Symbol
-	// OnRename is invoked when a rename request targets a symbol the LSP itself
-	// cannot fully relocate by text edits alone (e.g., a channel). When nil,
-	// rename is restricted to source-defined symbols.
+	// OnRename is invoked when a rename request targets a symbol the LSP itself cannot
+	// fully relocate by text edits alone (e.g., a channel). When nil, rename is
+	// restricted to source-defined symbols.
+	//
+	// [OPTIONAL]
 	OnRename OnRename
-	// OnExternalChange is an observable that fires when external state (such as
-	// Synnax channels) changes. When this fires, the server will republish diagnostics
-	// for all open documents to ensure they reflect the current state.
+	// OnExternalChange is an observable that fires when external state (such as Synnax
+	// channels) changes. When this fires, the server will republish diagnostics for all
+	// open documents to ensure they reflect the current state.
+	//
+	// [OPTIONAL]
 	OnExternalChange observe.Observable[struct{}]
-	// RepublishTimeout is the maximum time to wait for a republish operation to complete.
-	// If zero, defaults to 30 seconds.
+	// RepublishTimeout is the maximum time to wait for a republish operation to
+	// complete. If zero, defaults to 30 seconds.
+	//
+	// [OPTIONAL] - Defaults to 30 seconds.
 	RepublishTimeout time.Duration
 	// DebounceDelay is the trailing-edge delay after the last keystroke before
 	// diagnostics are published. Defaults to 200ms.
+	//
+	// [OPTIONAL] - Defaults to 200ms.
 	DebounceDelay time.Duration
-	// MaxDebounceDelay caps the total delay from the first unprocessed change,
-	// ensuring fast typists still get periodic diagnostic updates. Defaults to 1s.
+	// MaxDebounceDelay caps the total delay from the first unprocessed change, ensuring
+	// fast typists still get periodic diagnostic updates. Defaults to 1s.
+	//
+	// [OPTIONAL] - Defaults to 1s.
 	MaxDebounceDelay time.Duration
 	// Instrumentation is used for logging, tracing, metrics, etc.
+	//
+	// [OPTIONAL]
 	alamos.Instrumentation
 }
 
 var (
 	_             config.Config[Config] = &Config{}
-	DefaultConfig                       = Config{
+	defaultConfig                       = Config{
 		RepublishTimeout: 30 * time.Second,
 		DebounceDelay:    200 * time.Millisecond,
 		MaxDebounceDelay: 1 * time.Second,
@@ -120,7 +133,7 @@ var _ protocol.Server = (*Server)(nil)
 
 // New creates a new LSP server
 func New(cfgs ...Config) (*Server, error) {
-	cfg, err := config.New(DefaultConfig, cfgs...)
+	cfg, err := config.New(defaultConfig, cfgs...)
 	if err != nil {
 		return nil, err
 	}
@@ -192,13 +205,13 @@ func (s *Server) Logger() *zap.Logger {
 	return s.cfg.L.Zap()
 }
 
-// getDocument returns an immutable snapshot of the document with the given URI,
-// and true if found, or nil and false if not found. The returned *Document is a
-// copy taken under the read lock, so callers may read its fields (IR, Content,
-// Diagnostics, ...) without further locking: analysis replaces these fields on
-// the live document under the write lock, and a reader holding the snapshot is
-// unaffected. Callers must not mutate the returned document — writes do not
-// reach the live document and would be lost.
+// getDocument returns an immutable snapshot of the document with the given URI, and
+// true if found, or nil and false if not found. The returned *Document is a copy taken
+// under the read lock, so callers may read its fields (IR, Content, Diagnostics, ...)
+// without further locking: analysis replaces these fields on the live document under
+// the write lock, and a reader holding the snapshot is unaffected. Callers must not
+// mutate the returned document — writes do not reach the live document and would be
+// lost.
 func (s *Server) getDocument(uri protocol.DocumentURI) (*Document, bool) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -211,8 +224,11 @@ func (s *Server) getDocument(uri protocol.DocumentURI) (*Document, bool) {
 }
 
 // Initialize handles the initialize request
-func (s *Server) Initialize(_ context.Context, params *protocol.InitializeParams) (*protocol.InitializeResult, error) {
-	s.cfg.L.Debug("initializing arc lsp", zap.String("client", params.ClientInfo.Name))
+func (s *Server) Initialize(
+	_ context.Context,
+	params *protocol.InitializeParams,
+) (*protocol.InitializeResult, error) {
+	s.cfg.L.Debug("initializing Arc LSP", zap.String("client", params.ClientInfo.Name))
 	return &protocol.InitializeResult{
 		Capabilities: s.capabilities,
 		ServerInfo:   &protocol.ServerInfo{Name: "arc-lsp", Version: "0.1.0"},
@@ -221,12 +237,12 @@ func (s *Server) Initialize(_ context.Context, params *protocol.InitializeParams
 
 // Initialized handles the initialized notification
 func (s *Server) Initialized(context.Context, *protocol.InitializedParams) error {
-	s.cfg.L.Debug("arc lsp initialized")
+	s.cfg.L.Debug("Arc LSP initialized")
 	return nil
 }
 
 // Shutdown handles the shutdown request.
-func (s *Server) Shutdown(_ context.Context) error {
+func (s *Server) Shutdown(context.Context) error {
 	s.cfg.L.Info("Shutting down server")
 	if s.externalChangeDisconnect != nil {
 		s.externalChangeDisconnect()
@@ -250,7 +266,10 @@ func (s *Server) Shutdown(_ context.Context) error {
 }
 
 // DidOpen handles opening a document
-func (s *Server) DidOpen(ctx context.Context, params *protocol.DidOpenTextDocumentParams) error {
+func (s *Server) DidOpen(
+	ctx context.Context,
+	params *protocol.DidOpenTextDocumentParams,
+) error {
 	uri := params.TextDocument.URI
 	s.cfg.L.Debug("document opened", zap.String("uri", string(uri)))
 	metadata := extractMetadataFromURI(uri)
@@ -283,7 +302,10 @@ func (s *Server) DidOpen(ctx context.Context, params *protocol.DidOpenTextDocume
 }
 
 // DidChange handles document changes
-func (s *Server) DidChange(_ context.Context, params *protocol.DidChangeTextDocumentParams) error {
+func (s *Server) DidChange(
+	_ context.Context,
+	params *protocol.DidChangeTextDocumentParams,
+) error {
 	uri := params.TextDocument.URI
 	s.cfg.L.Debug("Document changed", zap.String("uri", string(uri)))
 
@@ -308,7 +330,10 @@ func (s *Server) DidChange(_ context.Context, params *protocol.DidChangeTextDocu
 }
 
 // DidSave handles document save - force-flushes any pending analysis.
-func (s *Server) DidSave(ctx context.Context, params *protocol.DidSaveTextDocumentParams) error {
+func (s *Server) DidSave(
+	ctx context.Context,
+	params *protocol.DidSaveTextDocumentParams,
+) error {
 	uri := params.TextDocument.URI
 	s.cfg.L.Debug("Document saved", zap.String("uri", string(uri)))
 
@@ -327,7 +352,10 @@ func (s *Server) DidSave(ctx context.Context, params *protocol.DidSaveTextDocume
 }
 
 // DidClose handles closing a document
-func (s *Server) DidClose(ctx context.Context, params *protocol.DidCloseTextDocumentParams) error {
+func (s *Server) DidClose(
+	ctx context.Context,
+	params *protocol.DidCloseTextDocumentParams,
+) error {
 	uri := params.TextDocument.URI
 	s.cfg.L.Debug("Document closed", zap.String("uri", string(uri)))
 
@@ -400,9 +428,8 @@ func (s *Server) refreshSemanticTokens(ctx context.Context, uri protocol.Documen
 	}
 }
 
-// analyze performs parse+analyze on the given content and returns protocol
-// diagnostics, the resulting IR, and the raw diagnostics. It does NOT
-// mutate any Document fields.
+// analyze performs parse+analyze on the given content and returns protocol diagnostics,
+// the resulting IR, and the raw diagnostics. It does NOT mutate any Document fields.
 func (s *Server) analyze(
 	ctx context.Context,
 	content string,
@@ -421,9 +448,7 @@ func (s *Server) analyze(
 		if err != nil {
 			pDiagnostics = lsp.TranslateDiagnostics(*err, translateCfg)
 		} else {
-			aCtx := acontext.NewRoot[parser.IBlockContext](
-				ctx, t, s.cfg.NewRoot(),
-			)
+			aCtx := acontext.NewRoot(ctx, t, s.cfg.NewRoot())
 			statement.AnalyzeFunctionBody(aCtx)
 			docIR = ir.IR{Symbols: aCtx.Scope}
 			docDiag = *aCtx.Diagnostics
@@ -445,8 +470,8 @@ func (s *Server) analyze(
 	return pDiagnostics, docIR, docDiag
 }
 
-// publishDiagnostics synchronously parses and publishes diagnostics.
-// Used for DidOpen, DidSave, and republish where immediate feedback is expected.
+// publishDiagnostics synchronously parses and publishes diagnostics. Used for DidOpen,
+// DidSave, and republish where immediate feedback is expected.
 func (s *Server) publishDiagnostics(
 	ctx context.Context,
 	uri protocol.DocumentURI,

--- a/arc/go/lsp/server_test.go
+++ b/arc/go/lsp/server_test.go
@@ -342,6 +342,9 @@ var _ = Describe("External Change Notifications", func() {
 			},
 			OnExternalChange: observer,
 		})
+		DeferCleanup(func(ctx SpecContext) {
+			Expect(server.Shutdown(ctx)).To(Succeed())
+		})
 	})
 
 	It("Should republish diagnostics when external state changes", func(ctx SpecContext) {

--- a/arc/go/lsp/server_test.go
+++ b/arc/go/lsp/server_test.go
@@ -259,11 +259,10 @@ var _ = Describe("Incremental Sync", func() {
 		Expect(client.Diagnostics()).To(BeEmpty())
 		baseline := client.PublishCount()
 
-		// Insert a newline at the very start of the document. The editor
-		// sends Range{(0,0)-(0,0)} with Text="\n". Because the protocol
-		// library deserializes an absent range to the same zero value,
-		// IsFullReplacement incorrectly treats this as a full replacement,
-		// wiping the document content to just "\n".
+		// Insert a newline at the very start of the document. The editor sends
+		// Range{(0,0)-(0,0)} with Text="\n". Because the protocol library deserializes
+		// an absent range to the same zero value, IsFullReplacement incorrectly treats
+		// this as a full replacement, wiping the document content to just "\n".
 		Expect(server.DidChange(ctx, &protocol.DidChangeTextDocumentParams{
 			TextDocument: protocol.VersionedTextDocumentIdentifier{
 				TextDocumentIdentifier: protocol.TextDocumentIdentifier{URI: uri},
@@ -281,9 +280,9 @@ var _ = Describe("Incremental Sync", func() {
 		})).To(Succeed())
 
 		Expect(client.WaitForDiagnostics(baseline, 500*time.Millisecond)).To(BeTrue())
-		// The document should now be "\nfunc test() {\n\tx := 42\n}".
-		// If IsFullReplacement incorrectly fires, it becomes just "\n"
-		// and semantic tokens will be empty.
+		// The document should now be "\nfunc test() {\n\tx := 42\n}". If
+		// IsFullReplacement incorrectly fires, it becomes just "\n" and semantic tokens
+		// will be empty.
 		tokens := SemanticTokens(server, ctx, uri)
 		Expect(tokens).ToNot(BeNil())
 		Expect(tokens.Data).ToNot(BeEmpty())
@@ -294,8 +293,8 @@ var _ = Describe("Incremental Sync", func() {
 		OpenArcDocument(server, ctx, uri, program)
 		baseline := client.PublishCount()
 
-		// Simulate selecting from col 0 to the end of the first line
-		// and pressing Enter (replacing the selection with a newline).
+		// Simulate selecting from col 0 to the end of the first line and pressing Enter
+		// (replacing the selection with a newline).
 		Expect(server.DidChange(ctx, &protocol.DidChangeTextDocumentParams{
 			TextDocument: protocol.VersionedTextDocumentIdentifier{
 				TextDocumentIdentifier: protocol.TextDocumentIdentifier{URI: uri},
@@ -314,10 +313,10 @@ var _ = Describe("Incremental Sync", func() {
 
 		Expect(client.WaitForDiagnostics(baseline, 500*time.Millisecond)).To(BeTrue())
 
-		// After the edit the document is "\n\n    stage first {...". The
-		// exact diagnostics don't matter as much as verifying that the
-		// server still produces them (analysis didn't silently break).
-		// With the bug, the document would be wiped to just "\n".
+		// After the edit the document is "\n\n    stage first {...". The exact
+		// diagnostics don't matter as much as verifying that the server still produces
+		// them (analysis didn't silently break). With the bug, the document would be
+		// wiped to just "\n".
 		tokens := SemanticTokens(server, ctx, uri)
 		Expect(tokens).ToNot(BeNil())
 		Expect(tokens.Data).ToNot(BeEmpty())
@@ -337,9 +336,7 @@ var _ = Describe("External Change Notifications", func() {
 		resolver = StaticResolver{}
 		observer = observe.New[struct{}]()
 		server, uri, client = SetupTestServerWithClient(lsp.Config{
-			NewRoot: func() *symbol.Symbol {
-				return NewRoot(resolver)
-			},
+			NewRoot:          func() *symbol.Symbol { return NewRoot(resolver) },
 			OnExternalChange: observer,
 		})
 		DeferCleanup(func(ctx SpecContext) {


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4319](https://linear.app/synnax/issue/SY-4319)

## Description

The `External Change Notifications` suite in `arc/go/lsp` had a data race that
surfaced under `ginkgo -p --race --until-it-fails` (typically within ~8 attempts).
`Server.SetClient` registered an `OnExternalChange` handler that spawned a bare
`go s.republishAllDiagnostics(ctx)` goroutine on every `observer.Notify`. Those
goroutines outlived the spec body and called the test's `NewRoot` closure, which
captured the suite-scoped `resolver` variable. The next spec's `BeforeEach` then
reassigned `resolver = StaticResolver{}` while a leftover republish goroutine was
still reading it from inside `analyze`, tripping the race detector.

Fixed by:
- Adding `republishWG sync.WaitGroup` to `Server`, switching the spawn to
  `s.republishWG.Go(...)`, and having `Shutdown` `Wait()` for in-flight republish
  goroutines before returning so callers can rely on `Config.NewRoot` and other
  captured state being safe to tear down.
- Adding a `DeferCleanup(server.Shutdown)` in the suite's `BeforeEach` so the
  next spec can safely reassign `resolver`.

Verified with 60 consecutive successful runs of
`ginkgo -p --randomize-all --race --until-it-fails` (vs. ~8 attempts on `rc`).

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a data race in the `External Change Notifications` suite of `arc/go/lsp` by tracking in-flight `republishAllDiagnostics` goroutines with a `sync.WaitGroup` and blocking `Shutdown` on `WG.Wait()`, combined with a `DeferCleanup(server.Shutdown)` in the test's `BeforeEach` that synchronizes teardown before the next spec reassigns `resolver`.

- `server.go`: adds `republishWG sync.WaitGroup` to `Server`, changes the goroutine spawn from a bare `go` to `republishWG.Go(...)`, inserts `republishWG.Wait()` in `Shutdown` after cancelling in-flight contexts, and makes several cosmetic improvements (unexported `defaultConfig`, inferred type parameter on `acontext.NewRoot`, reformatted comments and function signatures).
- `server_test.go`: adds `DeferCleanup(func(ctx SpecContext) { Expect(server.Shutdown(ctx)).To(Succeed()) })` inside the suite's `BeforeEach` so `Shutdown` — and therefore `Wait()` — completes before the next spec can reassign the `resolver` variable.

<h3>Confidence Score: 5/5</h3>

Safe to merge. The fix is well-reasoned: the observe package's read/write mutex guarantees that any in-flight handler including its republishWG.Go call completes before externalChangeDisconnect() returns, so Wait() is always called after all goroutines have been registered.

Both changed files are tightly scoped to the race fix. The sync.WaitGroup lifecycle is correct — goroutines are added inside the handler which the disconnect barrier fully drains, and waited on in Shutdown after context cancellation. The test cleanup correctly hooks into Ginkgo's DeferCleanup with a SpecContext. No behavioral regressions are introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| arc/go/lsp/server.go | Adds republishWG sync.WaitGroup to Server, switches goroutine spawn to republishWG.Go, and blocks Shutdown on Wait() before returning; also renames DefaultConfig to defaultConfig (unexported), removes explicit type parameter in acontext.NewRoot, and reformats comments/signatures. |
| arc/go/lsp/server_test.go | Adds DeferCleanup(server.Shutdown) inside BeforeEach of the External Change Notifications suite, guaranteeing in-flight republish goroutines complete before the next spec's BeforeEach reassigns resolver; remaining changes are comment reformatting. |

</details>

<sub>Reviews (1): Last reviewed commit: ["Clean up server code"](https://github.com/synnaxlabs/synnax/commit/14e212688d7e6372b15c1d7a91b40aec371427e5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35892042)</sub>

<!-- /greptile_comment -->