### PR TITLE
SY-4328: Fix Pluto telem client streamer race

### DIFF
--- a/pluto/src/telem/client/streamer.spec.ts
+++ b/pluto/src/telem/client/streamer.spec.ts
@@ -181,9 +181,84 @@ describe("Streamer", () => {
       expect(openCalls).toBe(1);
       // The orphaned second streamer's run loop should never have started.
       expect(ms2.iteratorVi).not.toHaveBeenCalled();
+      // The single streamer should have been updated with the second subscriber's key —
+      // otherwise key 2 would be silently dropped.
+      expect(ms1.updateVi).toHaveBeenCalled();
+      expect(ms1.keys.slice().sort()).toEqual([1, 2]);
 
       disconnect1();
       disconnect2();
+    });
+  });
+
+  describe("closed guard", () => {
+    it("should not open a streamer if close() is called before the debounce fires", async () => {
+      let openCalls = 0;
+      const opener: framer.StreamOpener = async () => {
+        openCalls++;
+        return new MockStreamer([1]);
+      };
+      const streamer = new Streamer({
+        cache: new Cache({ channelRetriever: new MockRetriever() }),
+        openStreamer: opener,
+      });
+
+      await streamer.stream(() => {}, [1]);
+      // Close before the 100ms debounce window elapses.
+      await streamer.close();
+      // Advance well past the debounce — the queued updateStreamer must observe
+      // this.closed inside the mutex and bail out.
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(openCalls).toBe(0);
+    });
+
+    it("should close a freshly-opened streamer when close() runs during a slow openStreamer", async () => {
+      const ms1 = new MockStreamer([1], async () => {
+        await sleep.sleep(TimeSpan.milliseconds(10));
+        return { done: true, value: undefined };
+      });
+      let openCalls = 0;
+      const slowOpener: framer.StreamOpener = async () => {
+        openCalls++;
+        await sleep.sleep(TimeSpan.milliseconds(300));
+        return ms1;
+      };
+      const streamer = new Streamer({
+        cache: new Cache({ channelRetriever: new MockRetriever() }),
+        openStreamer: slowOpener,
+      });
+
+      await streamer.stream(() => {}, [1]);
+      // Advance into the openStreamer suspension window.
+      await vi.advanceTimersByTimeAsync(150);
+      // close() must wait for the in-flight updateStreamer to finish so that it can
+      // observe the newly-assigned streamer and tear it down.
+      const closePromise = streamer.close();
+      await vi.advanceTimersByTimeAsync(500);
+      await closePromise;
+
+      expect(openCalls).toBe(1);
+      expect(ms1.closeVi).toHaveBeenCalled();
+    });
+
+    it("should be a no-op when stream() is called after close()", async () => {
+      let openCalls = 0;
+      const opener: framer.StreamOpener = async () => {
+        openCalls++;
+        return new MockStreamer([1]);
+      };
+      const streamer = new Streamer({
+        cache: new Cache({ channelRetriever: new MockRetriever() }),
+        openStreamer: opener,
+      });
+
+      await streamer.close();
+      const disconnect = await streamer.stream(() => {}, [1]);
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(openCalls).toBe(0);
+      disconnect();
     });
   });
 });

--- a/pluto/src/telem/client/streamer.spec.ts
+++ b/pluto/src/telem/client/streamer.spec.ts
@@ -7,6 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+import { alamos } from "@synnaxlabs/alamos";
 import { type channel, Frame, type framer } from "@synnaxlabs/client";
 import { type MultiSeries, Series, sleep, TimeSpan } from "@synnaxlabs/x";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -242,6 +243,30 @@ describe("Streamer", () => {
       expect(ms1.closeVi).toHaveBeenCalled();
     });
 
+    it("should close the underlying streamer when the last listener disconnects", async () => {
+      const ms1 = new MockStreamer([1], async () => {
+        await sleep.sleep(TimeSpan.milliseconds(10));
+        return { done: true, value: undefined };
+      });
+      const streamer = new Streamer({
+        cache: new Cache({ channelRetriever: new MockRetriever() }),
+        openStreamer: createStreamOpener([ms1]),
+        streamUpdateDelay: TimeSpan.milliseconds(50),
+      });
+
+      const disconnect = await streamer.stream(() => {}, [1]);
+      // Advance past debounce + the single nextFn cycle so the run loop ends.
+      await vi.advanceTimersByTimeAsync(200);
+      expect(ms1.closeVi).not.toHaveBeenCalled();
+
+      disconnect();
+      // streamUpdateDelay (50ms) + debounce (100ms) + slack so the no-keys branch in
+      // updateStreamer fires and tears down the streamer.
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(ms1.closeVi).toHaveBeenCalled();
+    });
+
     it("should be a no-op when stream() is called after close()", async () => {
       let openCalls = 0;
       const opener: framer.StreamOpener = async () => {
@@ -258,6 +283,127 @@ describe("Streamer", () => {
       await vi.advanceTimersByTimeAsync(500);
 
       expect(openCalls).toBe(0);
+      disconnect();
+    });
+  });
+
+  describe("update path", () => {
+    it("should not call update again when the merged key set is unchanged", async () => {
+      const ms1 = new MockStreamer([1], async () => {
+        await sleep.sleep(TimeSpan.milliseconds(10));
+        return { done: true, value: undefined };
+      });
+      const ins = new alamos.Instrumentation({
+        key: "test",
+        logger: new alamos.Logger(),
+      });
+      const debugSpy = vi.spyOn(ins.L, "debug").mockImplementation(() => {});
+      const streamer = new Streamer({
+        cache: new Cache({ channelRetriever: new MockRetriever() }),
+        openStreamer: createStreamOpener([ms1]),
+        instrumentation: ins,
+      });
+
+      const d1 = await streamer.stream(() => {}, [1]);
+      // Initial open path also issues a single update([1]).
+      await vi.advanceTimersByTimeAsync(200);
+      expect(ms1.updateVi).toHaveBeenCalledTimes(1);
+
+      // Second subscriber on the same key — the merged set is still [1], so the
+      // valuesEqual branch must short-circuit and log "streamer keys unchanged".
+      const d2 = await streamer.stream(() => {}, [1]);
+      await vi.advanceTimersByTimeAsync(200);
+
+      expect(ms1.updateVi).toHaveBeenCalledTimes(1);
+      expect(debugSpy).toHaveBeenCalledWith("streamer keys unchanged", {
+        keys: [1],
+      });
+
+      d1();
+      d2();
+    });
+
+    it("should log an error when streamer.update rejects", async () => {
+      const ms1 = new MockStreamer([1], async () => {
+        await sleep.sleep(TimeSpan.milliseconds(10));
+        return { done: true, value: undefined };
+      });
+      const updateErr = new Error("update boom");
+      ms1.update = vi.fn(async () => {
+        throw updateErr;
+      });
+      const ins = new alamos.Instrumentation({
+        key: "test",
+        logger: new alamos.Logger(),
+      });
+      const errorSpy = vi.spyOn(ins.L, "error").mockImplementation(() => {});
+      // updateStreamer is fired-and-forgotten via void; absorb the resulting
+      // unhandled rejection so it doesn't fail the test.
+      const rejections: unknown[] = [];
+      const onRejection = (reason: unknown) => rejections.push(reason);
+      process.on("unhandledRejection", onRejection);
+
+      const streamer = new Streamer({
+        cache: new Cache({ channelRetriever: new MockRetriever() }),
+        openStreamer: createStreamOpener([ms1]),
+        instrumentation: ins,
+      });
+
+      try {
+        await streamer.stream(() => {}, [1]);
+        await vi.advanceTimersByTimeAsync(300);
+      } finally {
+        process.off("unhandledRejection", onRejection);
+      }
+
+      expect(errorSpy).toHaveBeenCalledWith("failed to update streamer", {
+        error: updateErr,
+      });
+      expect(rejections.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe("close path", () => {
+    it("should log an error when streamer.close throws and still mark the streamer closed", async () => {
+      const ms1 = new MockStreamer([1], async () => {
+        await sleep.sleep(TimeSpan.milliseconds(10));
+        return { done: true, value: undefined };
+      });
+      const closeErr = new Error("close boom");
+      ms1.closeVi.mockImplementation(() => {
+        throw closeErr;
+      });
+      const ins = new alamos.Instrumentation({
+        key: "test",
+        logger: new alamos.Logger(),
+      });
+      const errorSpy = vi.spyOn(ins.L, "error").mockImplementation(() => {});
+
+      let openCalls = 0;
+      const opener: framer.StreamOpener = async () => {
+        openCalls++;
+        return ms1;
+      };
+      const streamer = new Streamer({
+        cache: new Cache({ channelRetriever: new MockRetriever() }),
+        openStreamer: opener,
+        instrumentation: ins,
+      });
+
+      await streamer.stream(() => {}, [1]);
+      await vi.advanceTimersByTimeAsync(200);
+      expect(openCalls).toBe(1);
+
+      await streamer.close();
+
+      expect(errorSpy).toHaveBeenCalledWith("failed to close streamer", {
+        error: closeErr,
+      });
+      // close() should still flip this.closed even when the underlying
+      // streamer.close throws — subsequent stream() calls must be no-ops.
+      const disconnect = await streamer.stream(() => {}, [2]);
+      await vi.advanceTimersByTimeAsync(200);
+      expect(openCalls).toBe(1);
       disconnect();
     });
   });

--- a/pluto/src/telem/client/streamer.spec.ts
+++ b/pluto/src/telem/client/streamer.spec.ts
@@ -9,7 +9,7 @@
 
 import { type channel, Frame, type framer } from "@synnaxlabs/client";
 import { type MultiSeries, Series, sleep, TimeSpan } from "@synnaxlabs/x";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Cache } from "@/telem/client/cache/cache";
 import { MockRetriever } from "@/telem/client/reader.spec";
@@ -79,6 +79,13 @@ const createStreamOpener =
   };
 
 describe("Streamer", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
   describe("construction", () => {
     it("should correctly construct a new streamer that operates", async () => {
       const streamer = new Streamer({
@@ -114,9 +121,12 @@ describe("Streamer", () => {
 
       const responses: Map<channel.Key, MultiSeries>[] = [];
       const disconnect = await streamer.stream((d) => responses.push(d), [1]);
-      await expect.poll(() => responses.length > 5).toBe(true);
+      // Advance past the 100ms debounce plus enough 5ms read cycles to get well over 5
+      // responses.
+      await vi.advanceTimersByTimeAsync(200);
       disconnect();
 
+      expect(responses.length).toBeGreaterThan(5);
       // We should only ever get data for that particular channel.
       expect(responses.filter((r) => r.get(1)?.series.length === 0)).toHaveLength(
         responses.length - 1,
@@ -128,6 +138,52 @@ describe("Streamer", () => {
       // buffer we're allocating and subsequent calls just tell the handler to re-read
       // the buffer.
       expect(responses.filter((r) => r.get(1)?.series.length === 1)).toHaveLength(1);
+    });
+  });
+
+  describe("updateStreamer race", () => {
+    it("should not open two concurrent streamers when stream() is called twice during a slow openStreamer", async () => {
+      const ms1 = new MockStreamer([1], async () => {
+        await sleep.sleep(TimeSpan.milliseconds(20));
+        return { done: true, value: undefined };
+      });
+      const ms2 = new MockStreamer([1, 2], async () => {
+        await sleep.sleep(TimeSpan.milliseconds(20));
+        return { done: true, value: undefined };
+      });
+      const queue = [ms1, ms2];
+      let openCalls = 0;
+      const slowOpener: framer.StreamOpener = async () => {
+        openCalls++;
+        // Long enough that the next debounced updateStreamer fire happens while this
+        // call is still suspended.
+        await sleep.sleep(TimeSpan.milliseconds(300));
+        const next = queue.shift();
+        if (next == null) throw new Error("no streamers left");
+        return next;
+      };
+
+      const streamer = new Streamer({
+        cache: new Cache({ channelRetriever: new MockRetriever() }),
+        openStreamer: slowOpener,
+      });
+
+      // First subscription schedules debouncedUpdateStreamer at T+100ms.
+      const disconnect1 = await streamer.stream(() => {}, [1]);
+      // Advance to T=150 so updateStreamer #1 is mid-openStreamer (sleep ends at
+      // T=400).
+      await vi.advanceTimersByTimeAsync(150);
+      const disconnect2Promise = streamer.stream(() => {}, [2]);
+      // Advance enough for any racing opens (300ms each) and run loops to complete.
+      await vi.advanceTimersByTimeAsync(700);
+      const disconnect2 = await disconnect2Promise;
+
+      expect(openCalls).toBe(1);
+      // The orphaned second streamer's run loop should never have started.
+      expect(ms2.iteratorVi).not.toHaveBeenCalled();
+
+      disconnect1();
+      disconnect2();
     });
   });
 });

--- a/pluto/src/telem/client/streamer.spec.ts
+++ b/pluto/src/telem/client/streamer.spec.ts
@@ -337,8 +337,8 @@ describe("Streamer", () => {
         logger: new alamos.Logger(),
       });
       const errorSpy = vi.spyOn(ins.L, "error").mockImplementation(() => {});
-      // updateStreamer is fired-and-forgotten via void; absorb the resulting
-      // unhandled rejection so it doesn't fail the test.
+      // updateStreamer is fired-and-forgotten via the debounce, so a rethrow would
+      // surface as an unhandled rejection. The error must be logged and swallowed.
       const rejections: unknown[] = [];
       const onRejection = (reason: unknown) => rejections.push(reason);
       process.on("unhandledRejection", onRejection);
@@ -359,7 +359,76 @@ describe("Streamer", () => {
       expect(errorSpy).toHaveBeenCalledWith("failed to update streamer", {
         error: updateErr,
       });
-      expect(rejections.length).toBeGreaterThan(0);
+      expect(rejections).toHaveLength(0);
+    });
+  });
+
+  describe("liveness", () => {
+    it("should not block new subscriptions while a streamer teardown is stuck draining", async () => {
+      let reads = 0;
+      const stuck = new MockStreamer([1], async () => {
+        reads++;
+        if (reads === 1) {
+          await sleep.sleep(TimeSpan.milliseconds(5));
+          return {
+            done: false,
+            value: new Frame({ 1: new Series(new Float32Array([1])) }),
+          };
+        }
+        // Simulate a streamer whose read never returns (e.g. a HardenedStreamer stuck
+        // reconnecting): the run loop can never drain, so the teardown await hangs.
+        return await new Promise<IteratorResult<framer.Frame>>(() => {});
+      });
+      const streamer = new Streamer({
+        cache: new Cache({ channelRetriever: new MockRetriever() }),
+        openStreamer: createStreamOpener([stuck, new MockStreamer([2])]),
+        streamUpdateDelay: TimeSpan.milliseconds(50),
+      });
+
+      const disconnect1 = await streamer.stream(() => {}, [1]);
+      // Open the streamer and let the run loop read once, then block on the second read.
+      await vi.advanceTimersByTimeAsync(200);
+
+      // Last listener leaves: the no-keys teardown closes the streamer and awaits the
+      // stuck run loop, holding the connection lock indefinitely.
+      disconnect1();
+      await vi.advanceTimersByTimeAsync(200);
+
+      // A fresh subscription must still resolve even though the connection lock is held
+      // by the stuck teardown. Under a single shared lock this await would hang forever.
+      const disconnect2 = await streamer.stream(() => {}, [2]);
+      expect(disconnect2).toBeTypeOf("function");
+
+      disconnect2();
+    });
+
+    it("should not block a new subscription while a streamer is mid-open", async () => {
+      let opens = 0;
+      const slowOpener: framer.StreamOpener = async () => {
+        opens++;
+        await sleep.sleep(TimeSpan.milliseconds(300));
+        return new MockStreamer([1], async () => {
+          await sleep.sleep(TimeSpan.milliseconds(10));
+          return { done: true, value: undefined };
+        });
+      };
+      const streamer = new Streamer({
+        cache: new Cache({ channelRetriever: new MockRetriever() }),
+        openStreamer: slowOpener,
+      });
+
+      await streamer.stream(() => {}, [1]);
+      // Advance into the open's suspension window so updateStreamer holds the connection
+      // lock across the network round-trip.
+      await vi.advanceTimersByTimeAsync(150);
+      expect(opens).toBe(1);
+
+      // The open is still suspended (its 300ms sleep hasn't elapsed). A concurrent
+      // subscription must not wait on it. Under a single shared lock this would hang.
+      const disconnect = await streamer.stream(() => {}, [2]);
+      expect(disconnect).toBeTypeOf("function");
+
+      disconnect();
     });
   });
 

--- a/pluto/src/telem/client/streamer.ts
+++ b/pluto/src/telem/client/streamer.ts
@@ -50,9 +50,15 @@ export class Streamer {
     streamUpdateDelay: TimeSpan;
   };
 
+  // mu guards the listeners map and is held only for fast, synchronous work so that
+  // subscribing never blocks on network I/O.
   private readonly mu: Mutex = new Mutex();
+  // connMu serializes streamer open/update/close against each other so two concurrent
+  // updateStreamer calls can't open duplicate streamers. It is held across network I/O
+  // but is never acquired on the stream() path.
+  private readonly connMu: Mutex = new Mutex();
   private readonly listeners = new Map<StreamHandler, ListenerEntry>();
-  private readonly debouncedUpdateStreamer: () => void;
+  private readonly debouncedUpdateStreamer: ReturnType<typeof debounce>;
   private streamerRunLoop: Promise<void> | null = null;
   private streamer: framer.Streamer | null = null;
   private closed = false;
@@ -121,26 +127,34 @@ export class Streamer {
 
   private async updateStreamer(): Promise<void> {
     const { instrumentation: ins } = this.props;
-    await this.mu.runExclusive(async () => {
+    await this.connMu.runExclusive(async () => {
       if (this.closed) return;
-      try {
-        // Assemble the set of keys we need to stream.
-        const keys = new Set<channel.Key>();
-        this.listeners.forEach((v) => v.keys.forEach((k) => keys.add(k)));
 
+      // forEach is synchronous, so it cannot interleave with stream() /
+      // removeStreamHandler mutating the map. Snapshotting here without holding mu is
+      // safe, and any keys added after this point schedule their own updateStreamer.
+      const keys = new Set<channel.Key>();
+      this.listeners.forEach((v) => v.keys.forEach((k) => keys.add(k)));
+
+      try {
         // If we have no keys to stream, close the streamer to save network chatter.
+        // Clear state before closing so a throwing close() can't leave a dangling,
+        // forever-reconnecting streamer behind.
         if (keys.size === 0) {
-          ins.L.info("no keys to stream, closing streamer");
-          this.streamer?.close();
-          if (this.streamerRunLoop != null) await this.streamerRunLoop;
+          const prev = this.streamer;
+          const prevLoop = this.streamerRunLoop;
           this.streamer = null;
-          ins.L.info("streamer closed successfully");
+          this.streamerRunLoop = null;
+          prev?.close();
+          if (prevLoop != null) await prevLoop;
+          ins.L.info("streamer closed, no keys to stream");
           return;
         }
 
         const arrKeys = Array.from(keys);
         const valuesEqual =
-          compare.primitiveArrays(arrKeys, this.streamer?.keys ?? []) === compare.EQUAL;
+          compare.unorderedPrimitiveArrays(arrKeys, this.streamer?.keys ?? []) ===
+          compare.EQUAL;
         if (valuesEqual) {
           ins.L.debug("streamer keys unchanged", { keys: arrKeys });
           return;
@@ -160,8 +174,10 @@ export class Streamer {
 
         await this.streamer.update(arrKeys);
       } catch (e) {
+        // updateStreamer is invoked fire-and-forget via the debounce, so there is no
+        // caller to receive a thrown error. Log and swallow to avoid an unhandled
+        // rejection.
         ins.L.error("failed to update streamer", { error: e });
-        throw errors.fromUnknown(e);
       }
     });
   }
@@ -188,14 +204,19 @@ export class Streamer {
 
   async close(): Promise<void> {
     const { instrumentation: ins } = this.props;
-    await this.mu.runExclusive(async () => {
+    this.debouncedUpdateStreamer.cancel();
+    await this.connMu.runExclusive(async () => {
+      this.closed = true;
+      const prev = this.streamer;
+      const prevLoop = this.streamerRunLoop;
+      this.streamer = null;
+      this.streamerRunLoop = null;
       try {
-        this.streamer?.close();
-        if (this.streamerRunLoop != null) await this.streamerRunLoop;
+        prev?.close();
+        if (prevLoop != null) await prevLoop;
       } catch (e) {
         ins.L.error("failed to close streamer", { error: e });
       }
-      this.closed = true;
     });
   }
 }

--- a/pluto/src/telem/client/streamer.ts
+++ b/pluto/src/telem/client/streamer.ts
@@ -122,46 +122,48 @@ export class Streamer {
   private async updateStreamer(): Promise<void> {
     if (this.closed) return;
     const { instrumentation: ins } = this.props;
-    try {
-      // Assemble the set of keys we need to stream.
-      const keys = new Set<channel.Key>();
-      this.listeners.forEach((v) => v.keys.forEach((k) => keys.add(k)));
+    await this.mu.runExclusive(async () => {
+      try {
+        // Assemble the set of keys we need to stream.
+        const keys = new Set<channel.Key>();
+        this.listeners.forEach((v) => v.keys.forEach((k) => keys.add(k)));
 
-      // If we have no keys to stream, close the streamer to save network chatter.
-      if (keys.size === 0) {
-        ins.L.info("no keys to stream, closing streamer");
-        this.streamer?.close();
-        if (this.streamerRunLoop != null) await this.streamerRunLoop;
-        this.streamer = null;
-        ins.L.info("streamer closed successfully");
-        return;
+        // If we have no keys to stream, close the streamer to save network chatter.
+        if (keys.size === 0) {
+          ins.L.info("no keys to stream, closing streamer");
+          this.streamer?.close();
+          if (this.streamerRunLoop != null) await this.streamerRunLoop;
+          this.streamer = null;
+          ins.L.info("streamer closed successfully");
+          return;
+        }
+
+        const arrKeys = Array.from(keys);
+        const valuesEqual =
+          compare.primitiveArrays(arrKeys, this.streamer?.keys ?? []) === compare.EQUAL;
+        if (valuesEqual) {
+          ins.L.debug("streamer keys unchanged", { keys: arrKeys });
+          return;
+        }
+
+        // Update or create the streamer.
+        if (this.streamer == null) {
+          ins.L.info("creating new streamer", { keys: arrKeys });
+          this.streamer = await this.props.openStreamer({
+            channels: arrKeys,
+            throttleRate: THROTTLE_RATE,
+          });
+          this.streamerRunLoop = this.runStreamer(this.streamer);
+        }
+
+        ins.L.debug("updating streamer", { prev: this.streamer.keys, next: arrKeys });
+
+        await this.streamer.update(arrKeys);
+      } catch (e) {
+        ins.L.error("failed to update streamer", { error: e });
+        throw errors.fromUnknown(e);
       }
-
-      const arrKeys = Array.from(keys);
-      const valuesEqual =
-        compare.primitiveArrays(arrKeys, this.streamer?.keys ?? []) === compare.EQUAL;
-      if (valuesEqual) {
-        ins.L.debug("streamer keys unchanged", { keys: arrKeys });
-        return;
-      }
-
-      // Update or create the streamer.
-      if (this.streamer == null) {
-        ins.L.info("creating new streamer", { keys: arrKeys });
-        this.streamer = await this.props.openStreamer({
-          channels: arrKeys,
-          throttleRate: THROTTLE_RATE,
-        });
-        this.streamerRunLoop = this.runStreamer(this.streamer);
-      }
-
-      ins.L.debug("updating streamer", { prev: this.streamer.keys, next: arrKeys });
-
-      await this.streamer.update(arrKeys);
-    } catch (e) {
-      ins.L.error("failed to update streamer", { error: e });
-      throw errors.fromUnknown(e);
-    }
+    });
   }
 
   private async runStreamer(streamer: framer.Streamer): Promise<void> {

--- a/pluto/src/telem/client/streamer.ts
+++ b/pluto/src/telem/client/streamer.ts
@@ -120,9 +120,9 @@ export class Streamer {
   }
 
   private async updateStreamer(): Promise<void> {
-    if (this.closed) return;
     const { instrumentation: ins } = this.props;
     await this.mu.runExclusive(async () => {
+      if (this.closed) return;
       try {
         // Assemble the set of keys we need to stream.
         const keys = new Set<channel.Key>();
@@ -188,12 +188,14 @@ export class Streamer {
 
   async close(): Promise<void> {
     const { instrumentation: ins } = this.props;
-    try {
-      this.streamer?.close();
-      if (this.streamerRunLoop != null) await this.streamerRunLoop;
-    } catch (e) {
-      ins.L.error("failed to close streamer", { error: e });
-    }
-    this.closed = true;
+    await this.mu.runExclusive(async () => {
+      try {
+        this.streamer?.close();
+        if (this.streamerRunLoop != null) await this.streamerRunLoop;
+      } catch (e) {
+        ins.L.error("failed to close streamer", { error: e });
+      }
+      this.closed = true;
+    });
   }
 }


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

<!-- Edit the link below with the proper issue number and link -->

[SY-4328](https://linear.app/synnax/issue/SY-4328/fix-pluto-telem-client-streamer-race)

## Description

<!-- Write a description describing the changes. -->

Fix a race that occurred in the Pluto telem client streamer when two streamer calls were concurrently opened.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a race condition in the Pluto telem client `Streamer` where two concurrent `stream()` calls during a slow `openStreamer` could open two separate underlying streamers instead of one.

- **`updateStreamer()`**: The entire body (including the `if (this.closed)` guard) is now wrapped inside `this.mu.runExclusive()`, preventing a second debounced invocation from entering the streamer-creation path while the first is still awaiting `openStreamer`.
- **`close()`**: Now also wrapped in `this.mu.runExclusive()`, so it serializes with any in-flight `updateStreamer()` and properly observes and tears down a streamer that was assigned after `close()` was called.
- **Tests**: Four new targeted tests cover the race (duplicate open prevention, key propagation), the pre-debounce close guard, the mid-open close, and the post-close `stream()` no-op; the existing \"basic operation\" test is migrated to `vi.useFakeTimers()` for determinism.

<h3>Confidence Score: 4/5</h3>

Safe to merge: the race condition is correctly closed by serializing both `updateStreamer` and `close` through the same mutex, and four targeted tests verify the key scenarios.

The mutex wrapping of `updateStreamer` and `close` correctly prevents the concurrent double-open and the close-while-opening scenarios. `close()` holds the mutex while awaiting `streamerRunLoop`; `runStreamer` calls user-provided handlers during that window, and a handler re-entering `stream()` would silently become a no-op after `close()` releases the mutex. This is benign but undocumented.

The `close()` method in `streamer.ts` deserves a second look for the held-mutex-while-awaiting-run-loop pattern.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| pluto/src/telem/client/streamer.ts | Core fix: `updateStreamer` and `close` are now fully serialized via `this.mu`; `close()` holds the mutex while awaiting `streamerRunLoop`, which is correct but places an implicit constraint on StreamHandler callbacks. |
| pluto/src/telem/client/streamer.spec.ts | New tests cover the four key scenarios introduced by the fix; fake-timer migration improves determinism. One gap noted in previous thread: the race test does not assert that key 2 receives frames. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C1 as stream(key1)
    participant C2 as stream(key2)
    participant MU as Mutex (this.mu)
    participant US as updateStreamer
    participant CL as close()
    participant FS as framer.Streamer

    C1->>MU: runExclusive (add listener, schedule debounce)
    MU-->>C1: release

    Note over US: Debounce fires T+100ms
    US->>MU: runExclusive
    MU-->>US: acquired
    US->>FS: openStreamer() [awaits 300ms]

    C2->>MU: runExclusive [BLOCKED]

    FS-->>US: streamer returned
    US->>FS: this.streamer assigned, runStreamer started
    US->>FS: update([1])
    MU-->>US: release

    C2->>MU: acquired
    C2->>MU: add listener, schedule debounce
    MU-->>C2: release

    Note over US: Debounce fires T+100ms
    US->>MU: runExclusive
    MU-->>US: acquired
    US->>FS: update([1,2])
    MU-->>US: release

    CL->>MU: runExclusive
    MU-->>CL: acquired
    CL->>FS: streamer.close()
    CL->>US: await streamerRunLoop
    US-->>CL: run loop exits
    CL->>CL: "this.closed = true"
    MU-->>CL: release
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `pluto/src/telem/client/streamer.ts`, line 189-198 ([link](https://github.com/synnaxlabs/synnax/blob/5c51f12493e6ddcfed81f3dae73df439c2cbaad3/pluto/src/telem/client/streamer.ts#L189-L198)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **`close()` races with the mutex-protected `updateStreamer`**

   `close()` reads and mutates `this.streamer` / `this.closed` without acquiring `this.mu`, while `updateStreamer()` now holds the mutex for the full duration of `openStreamer()`. If `close()` is called while `openStreamer` is in-flight (i.e. `this.streamer` is still `null`), `this.streamer?.close()` becomes a no-op, `this.closed` is set to `true`, and `close()` returns. When `openStreamer` eventually resolves, `updateStreamer` assigns the new streamer and starts `runStreamer`—producing a loop that will never be stopped since `close()` already returned without observing that streamer. Wrapping `close()`'s body in `await this.mu.runExclusive(...)` (or at minimum the streamer-close and `this.closed = true` assignment) would ensure it sees the fully-settled streamer.
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["Fix pluto tests"](https://github.com/synnaxlabs/synnax/commit/e0db5a592f79bc35248cec0d25e93a068bcf35c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=35913068)</sub>

<!-- /greptile_comment -->