### PR TITLE
SY-4339: Aether-Level Channel Metadata Queries

### DIFF
--- a/pluto/src/channel/aether/index.ts
+++ b/pluto/src/channel/aether/index.ts
@@ -1,0 +1,10 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+export * as channel from "@/channel/aether/queries";

--- a/pluto/src/channel/aether/queries.ts
+++ b/pluto/src/channel/aether/queries.ts
@@ -1,0 +1,66 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { channel, type Synnax } from "@synnaxlabs/client";
+import { deep } from "@synnaxlabs/x";
+
+import { type flux } from "@/flux/aether";
+
+export const FLUX_STORE_KEY = "channels";
+
+export interface FluxStore extends flux.UnaryStore<channel.Key, channel.Channel> {}
+
+export interface FluxSubStore extends flux.Store {
+  [FLUX_STORE_KEY]: FluxStore;
+}
+
+const SET_CHANNEL_LISTENER: flux.ChannelListener<
+  FluxSubStore,
+  typeof channel.payloadZ
+> = {
+  channel: channel.SET_CHANNEL_NAME,
+  schema: channel.payloadZ,
+  onChange: async ({ store, changed, client }) =>
+    store.channels.set(client.channels.sugar(changed)),
+};
+
+const DELETE_CHANNEL_LISTENER: flux.ChannelListener<FluxSubStore, typeof channel.keyZ> =
+  {
+    channel: channel.DELETE_CHANNEL_NAME,
+    schema: channel.keyZ,
+    onChange: ({ store, changed }) => store.channels.delete(changed),
+  };
+
+export const FLUX_STORE_CONFIG: flux.UnaryStoreConfig<
+  FluxSubStore,
+  channel.Key,
+  channel.Channel
+> = {
+  equal: (a, b) => deep.equal(a.payload, b.payload),
+  listeners: [SET_CHANNEL_LISTENER, DELETE_CHANNEL_LISTENER],
+};
+
+/**
+ * Resolves the channel with the given key, returning it from the store if cached and
+ * otherwise retrieving it from the cluster and populating the store. Subsequent calls
+ * for the same key, on any consumer sharing the store, are served from cache.
+ *
+ * @throws QueryError if the channel does not exist.
+ */
+export const retrieveCached = async (
+  client: Synnax,
+  store: FluxSubStore,
+  key: channel.Key,
+): Promise<channel.Channel> => {
+  const cached = store.channels.get(key);
+  if (cached != null) return cached;
+  const ch = await client.channels.retrieve(key);
+  store.channels.set(ch.key, ch);
+  return ch;
+};

--- a/pluto/src/channel/queries.ts
+++ b/pluto/src/channel/queries.ts
@@ -16,9 +16,10 @@ import {
   ontology,
   ranger,
 } from "@synnaxlabs/client";
-import { array, deep, errors, type optional, primitive, TimeSpan } from "@synnaxlabs/x";
+import { array, errors, type optional, primitive, TimeSpan } from "@synnaxlabs/x";
 import { z } from "zod";
 
+import { type channel as aetherChannel } from "@/channel/aether";
 import { Flux } from "@/flux";
 import { type Group } from "@/group";
 import { Ontology } from "@/ontology";
@@ -26,44 +27,21 @@ import { type Ranger } from "@/ranger";
 import { state } from "@/state";
 import { Status } from "@/status";
 
-export const FLUX_STORE_KEY = "channels";
+export {
+  FLUX_STORE_CONFIG,
+  FLUX_STORE_KEY,
+  type FluxStore,
+} from "@/channel/aether/queries";
+
 const RESOURCE_NAME = "channel";
 const PLURAL_RESOURCE_NAME = "channels";
 
-export interface FluxStore extends Flux.UnaryStore<channel.Key, channel.Channel> {}
-
 interface FluxSubStore extends Status.FluxSubStore {
-  [FLUX_STORE_KEY]: FluxStore;
+  [aetherChannel.FLUX_STORE_KEY]: aetherChannel.FluxStore;
   [Ranger.RANGE_ALIASES_FLUX_STORE_KEY]: Ranger.AliasFluxStore;
   [Ontology.RESOURCES_FLUX_STORE_KEY]: Ontology.ResourceFluxStore;
   [Group.FLUX_STORE_KEY]: Group.FluxStore;
 }
-
-const SET_CHANNEL_LISTENER: Flux.ChannelListener<
-  FluxSubStore,
-  typeof channel.payloadZ
-> = {
-  channel: channel.SET_CHANNEL_NAME,
-  schema: channel.payloadZ,
-  onChange: async ({ store, changed, client }) =>
-    store.channels.set(client.channels.sugar(changed)),
-};
-
-const DELETE_CHANNEL_LISTENER: Flux.ChannelListener<FluxSubStore, typeof channel.keyZ> =
-  {
-    channel: channel.DELETE_CHANNEL_NAME,
-    schema: channel.keyZ,
-    onChange: ({ store, changed }) => store.channels.delete(changed),
-  };
-
-export const FLUX_STORE_CONFIG: Flux.UnaryStoreConfig<
-  FluxSubStore,
-  channel.Key,
-  channel.Channel
-> = {
-  equal: (a, b) => deep.equal(a.payload, b.payload),
-  listeners: [SET_CHANNEL_LISTENER, DELETE_CHANNEL_LISTENER],
-};
 
 export const formSchema = channel.newZ
   .required({ expression: true })

--- a/pluto/src/pluto/aether/pluto.ts
+++ b/pluto/src/pluto/aether/pluto.ts
@@ -12,6 +12,7 @@ import { Instrumentation, Logger, logThresholdFilter } from "@synnaxlabs/alamos"
 import { access } from "@/access/aether";
 import { aether } from "@/aether/aether";
 import { alamos } from "@/alamos/aether";
+import { channel } from "@/channel/aether";
 import { flux } from "@/flux/aether";
 import { lineplot } from "@/lineplot/aether";
 import { range } from "@/lineplot/range/aether";
@@ -42,12 +43,14 @@ import { toggle } from "@/vis/toggle/aether";
 import { value } from "@/vis/value/aether";
 
 const STORE_CONFIG: flux.StoreConfig<{
+  [channel.FLUX_STORE_KEY]: channel.FluxStore;
   [ranger.FLUX_STORE_KEY]: ranger.FluxStore;
   [ontology.RELATIONSHIPS_FLUX_STORE_KEY]: ontology.RelationshipFluxStore;
   [ontology.RESOURCES_FLUX_STORE_KEY]: ontology.ResourceFluxStore;
   [access.policy.FLUX_STORE_KEY]: access.policy.FluxStore;
   [access.role.FLUX_STORE_KEY]: access.role.FluxStore;
 }> = {
+  [channel.FLUX_STORE_KEY]: channel.FLUX_STORE_CONFIG,
   [ranger.FLUX_STORE_KEY]: ranger.FLUX_STORE_CONFIG,
   [ontology.RELATIONSHIPS_FLUX_STORE_KEY]: ontology.RELATIONSHIP_FLUX_STORE_CONFIG,
   [ontology.RESOURCES_FLUX_STORE_KEY]: ontology.RESOURCE_FLUX_STORE_CONFIG,

--- a/pluto/src/telem/control/aether/controller.ts
+++ b/pluto/src/telem/control/aether/controller.ts
@@ -31,7 +31,9 @@ import { z } from "zod";
 
 import { aether } from "@/aether/aether";
 import { alamos } from "@/alamos/aether";
+import { channel as aetherChannel } from "@/channel/aether";
 import { type theming } from "@/ether";
+import { flux } from "@/flux/aether";
 import { status } from "@/status/aether";
 import { synnax } from "@/synnax/aether";
 import { telem } from "@/telem/aether";
@@ -55,6 +57,7 @@ export const controllerMethodsZ = {
 
 interface InternalState {
   client: Synnax | null;
+  store: aetherChannel.FluxSubStore;
   instrumentation: Instrumentation;
   stateProv: StateProvider;
   addStatus: status.Adder;
@@ -101,6 +104,7 @@ export class Controller
     i.stateProv = nextStateProv;
     i.telemCtx = telem.useChildContext(ctx, this, i.telemCtx);
     i.client = nextClient;
+    i.store = flux.useStore<aetherChannel.FluxSubStore>(ctx, this.key);
   }
 
   afterDelete(): void {
@@ -309,7 +313,8 @@ export class SetChannelValue
 
   async needsControlOf(client: Synnax): Promise<channel.Key[]> {
     if (this.props.channel === 0) return [];
-    const chan = await client.channels.retrieve(this.props.channel);
+    const { store } = this.controller.internal;
+    const chan = await aetherChannel.retrieveCached(client, store, this.props.channel);
     const keys = [chan.key];
     if (chan.index !== 0) keys.push(chan.index);
     return keys;
@@ -360,7 +365,8 @@ export class AcquireChannelControl
   }
 
   async needsControlOf(client: Synnax): Promise<channel.Key[]> {
-    const chan = await client.channels.retrieve(this.props.channel);
+    const { store } = this.controller.internal;
+    const chan = await aetherChannel.retrieveCached(client, store, this.props.channel);
     const keys = [chan.key];
     if (chan.index !== 0) keys.push(chan.index);
     return keys;
@@ -369,9 +375,9 @@ export class AcquireChannelControl
   set(acquire: boolean): void {
     this.runAsync(async () => {
       const { controller } = this;
-      const { client } = controller.internal;
+      const { client, store } = controller.internal;
       if (client == null) return;
-      const ch = await client.channels.retrieve(this.props.channel);
+      const ch = await aetherChannel.retrieveCached(client, store, this.props.channel);
       const keys = [ch.key];
       if (ch.index !== 0) keys.push(ch.index);
       if (!acquire) await this.controller.releaseAuthority(keys);


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4339](https://linear.app/synnax/issue/SY-4339)

## Description

Channel metadata on the aether (worker) thread was resolved through ad-hoc paths that bypassed the Flux framework entirely. In particular, the control path (`telem/control/aether/controller.ts`) resolved channels via raw `client.channels.retrieve`, with no caching, no coalescing, and no reactivity — every control acquisition re-fetched channel metadata cold and went stale on rename/re-index. The Flux channel store, meanwhile, was never registered on the worker thread at all.

This PR brings channel metadata onto the Flux store on the aether thread and migrates the control path to it as the first consumer:

- Extracts the channel Flux store config into a React-free `channel/aether/queries.ts` (mirroring the `ranger/aether` split) so it can be imported into the worker bundle without pulling in React. `channel/queries.ts` re-exports the moved symbols, leaving the React-thread `Channel.*` surface and `Pluto.tsx` untouched.
- Adds a cache-first `retrieveCached` helper that resolves a channel from the store, falling back to the cluster on a miss and populating the store so subsequent reads (on any worker consumer sharing the store) are served from cache.
- Registers the channel store in the aether `STORE_CONFIG`, so the worker now self-syncs channel metadata via the `sy_channel_set` / `sy_channel_delete` streaming listeners.
- Migrates all three control retrieval sites (`SetChannelValue.needsControlOf`, `AcquireChannelControl.needsControlOf` and `.set`) to `retrieveCached`.

Scope is deliberately limited to aether-thread channel **metadata** resolution. Telemetry/data reads, sample streaming, and main-thread call sites are out of scope. The telem source and log source metadata reads (and folding the `DebouncedBatchRetriever` in as the store's fetcher to preserve request coalescing) are follow-ups.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts the channel Flux-store config into a React-free `channel/aether/queries.ts` module, registers the channel store on the aether worker's `STORE_CONFIG`, and migrates all three control-path channel-retrieve sites in `controller.ts` from raw `client.channels.retrieve` to a new `retrieveCached` helper that serves hits from the worker-local store and falls back to the cluster on a miss.

- `channel/aether/queries.ts` is a new, React-free file containing `FLUX_STORE_KEY`, `FluxStore`, `FLUX_STORE_CONFIG`, the `sy_channel_set`/`sy_channel_delete` streaming listeners, and the `retrieveCached` cache-first lookup helper; `channel/queries.ts` re-exports these symbols to keep the main-thread surface unchanged.
- `pluto/aether/pluto.ts` adds the channel store to the worker `STORE_CONFIG`, enabling self-syncing channel metadata on the aether thread via the existing streaming listener infrastructure.
- `controller.ts` stores a scoped `aetherChannel.FluxSubStore` in `InternalState` (populated in `afterUpdate`) and threads it through to all three `retrieveCached` call sites in `SetChannelValue` and `AcquireChannelControl`.

<h3>Confidence Score: 4/5</h3>

Safe to merge; the changes are a clean extraction and wiring of existing channel-store logic onto the aether thread with no behavioral regressions on the main thread.

The refactoring is straightforward: logic moved verbatim from channel/queries.ts to channel/aether/queries.ts, the store is correctly registered in STORE_CONFIG, and the three retrieval sites in controller.ts are migrated consistently. The only notable gap is that AcquireChannelControl.needsControlOf lacks the zero-key guard that SetChannelValue.needsControlOf has. No automated tests cover the new retrieveCached path or the store registration.

pluto/src/telem/control/aether/controller.ts — verify the zero-key guard inconsistency in AcquireChannelControl.needsControlOf; pluto/src/channel/aether/queries.ts — new file with no tests for retrieveCached.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| pluto/src/channel/aether/queries.ts | New file: extracts FLUX_STORE_KEY, FluxStore, FLUX_STORE_CONFIG, SET/DELETE listeners, and the new retrieveCached helper from the main-thread queries.ts into a React-free aether module. Logic is correct; the equal callback ignores the key parameter (see comment). |
| pluto/src/channel/aether/index.ts | Thin barrel export for the new aether/queries module; no issues. |
| pluto/src/channel/queries.ts | Re-exports FLUX_STORE_CONFIG, FLUX_STORE_KEY, and FluxStore from aether/queries while replacing the local FluxSubStore to use the aether symbols; backward-compatible surface left intact. |
| pluto/src/pluto/aether/pluto.ts | Adds channel.FLUX_STORE_KEY and channel.FLUX_STORE_CONFIG to the aether STORE_CONFIG so the worker self-syncs channel metadata via sy_channel_set / sy_channel_delete streaming events. |
| pluto/src/telem/control/aether/controller.ts | Adds store: aetherChannel.FluxSubStore to InternalState and migrates all three channel-retrieve sites to retrieveCached; AcquireChannelControl.needsControlOf is missing the zero-key guard present in SetChannelValue. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant C as Controller (afterUpdate)
    participant S as FluxStore (channels)
    participant R as retrieveCached
    participant CL as Synnax Client

    C->>S: flux.useStore(ctx, this.key)
    Note over C,S: store scoped to Controller key

    rect rgb(200, 230, 255)
        Note over R,CL: Cache-first retrieval
        R->>S: store.channels.get(key)
        alt cache hit
            S-->>R: channel.Channel
        else cache miss
            S-->>R: undefined
            R->>CL: client.channels.retrieve(key)
            CL-->>R: channel.Channel
            R->>S: store.channels.set(ch.key, ch)
        end
        R-->>C: channel.Channel
    end

    rect rgb(200, 255, 200)
        Note over S,CL: Streaming updates (sy_channel_set)
        CL--)S: SET_CHANNEL_LISTENER.onChange
        S->>S: store.channels.set(sugar(payload))
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `pluto/src/telem/control/aether/controller.ts`, line 367-373 ([link](https://github.com/synnaxlabs/synnax/blob/36a8784caf8d0ee602047e08094bc21bbf813218/pluto/src/telem/control/aether/controller.ts#L367-L373)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Missing zero-key guard in `AcquireChannelControl.needsControlOf`**

   `SetChannelValue.needsControlOf` guards against `channel === 0` (line 315) and returns early, but `AcquireChannelControl.needsControlOf` does not. If `this.props.channel` is 0, the call hits `retrieveCached` → cache miss → `client.channels.retrieve(0)` → a QueryError is thrown and propagates as an unhandled rejection in the `create`/`deleteTelem` code paths where `void this.updateNeedsControlOf()` discards the promise. All three retrieval sites are being migrated here, making this the natural opportunity to align the guard.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["SY-4339: Register channel Flux store on ..."](https://github.com/synnaxlabs/synnax/commit/36a8784caf8d0ee602047e08094bc21bbf813218) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36104571)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->