### PR TITLE
SY-4297: Arc Params Refactor (Part 4) - Downstream Consumers

### DIFF
--- a/arc/go/analyzer/expression/expression.go
+++ b/arc/go/analyzer/expression/expression.go
@@ -459,10 +459,11 @@ func analyzePrimary(ctx context.Context[parser.IPrimaryExpressionContext]) {
 		}
 		// Track channel reads for:
 		// 1. Direct channel symbols (KindChannel)
-		// 2. Config params with channel type (they are the source)
+		// 2. Params with channel type (they are the source)
 		// 3. Variables with channel type that have a SourceID
 		shouldTrackRead := resolved.Kind == symbol.KindChannel ||
-			(resolved.Type.Kind == basetypes.KindChan && resolved.Kind == symbol.KindConfig) ||
+			(resolved.Type.Kind == basetypes.KindChan &&
+				(resolved.Kind == symbol.KindConfig || resolved.Kind == symbol.KindInput)) ||
 			(resolved.Type.Kind == basetypes.KindChan && resolved.SourceID != nil)
 		if shouldTrackRead {
 			fn, fnErr := ctx.Scope.ClosestAncestorOfKind(symbol.KindFunction)

--- a/arc/go/compiler/compiler.go
+++ b/arc/go/compiler/compiler.go
@@ -32,7 +32,6 @@ package compiler
 
 import (
 	"context"
-	"slices"
 	"strings"
 
 	"github.com/antlr4-go/antlr/v4"
@@ -102,7 +101,7 @@ func Compile(ctx context.Context, program ir.IR, opts ...Option) (Output, error)
 			compiled = append(compiled, cf)
 			continue
 		}
-		params := slices.Concat(i.Config, i.Inputs)
+		params := i.Inputs
 		var returnType types.Type
 		defaultOutput, hasDefaultOutput := i.Outputs.Get(ir.DefaultOutputParam)
 		hasNamedOutputs := len(i.Outputs) > 1 || (len(i.Outputs) == 1 && !hasDefaultOutput)

--- a/arc/go/compiler/statement/variable.go
+++ b/arc/go/compiler/statement/variable.go
@@ -64,7 +64,7 @@ func compileLocalVariable(ctx context.Context[parser.ILocalVariableContext]) err
 		if rhsScope, kind := resolveChannelSource(ctx, ctx.AST.Expression()); kind != channelSourceNone {
 			switch kind {
 			case channelSourceLocal:
-				// Config params and variables have WASM locals holding the channel key
+				// Params and variables have WASM locals holding the channel key
 				ctx.Writer.WriteLocalGet(rhsScope.ID)
 			case channelSourceGlobal:
 				// Global channels don't have locals - their ID IS the channel key
@@ -95,7 +95,7 @@ type channelSourceKind int
 
 const (
 	channelSourceNone   channelSourceKind = iota // Not a channel source
-	channelSourceLocal                           // Config param or variable with chan type (has WASM local)
+	channelSourceLocal                           // Param or variable with chan type (has WASM local)
 	channelSourceGlobal                          // Global channel (ID is the channel key)
 )
 

--- a/arc/go/compiler/statement/variable.go
+++ b/arc/go/compiler/statement/variable.go
@@ -117,9 +117,11 @@ func resolveChannelSource(
 	if scope.Kind == symbol.KindChannel {
 		return scope, channelSourceGlobal
 	}
-	// Config param or variable with channel type - has a WASM local holding the key
+	// Param or variable with channel type - has a WASM local holding the key
 	if scope.Type.Kind == types.KindChan &&
-		(scope.Kind == symbol.KindConfig || scope.Kind == symbol.KindVariable) {
+		(scope.Kind == symbol.KindConfig ||
+			scope.Kind == symbol.KindInput ||
+			scope.Kind == symbol.KindVariable) {
 		return scope, channelSourceLocal
 	}
 	return nil, channelSourceNone

--- a/arc/go/graph/analyze.go
+++ b/arc/go/graph/analyze.go
@@ -78,10 +78,6 @@ func Analyze(
 			aCtx.Diagnostics.Add(diagnostics.Error(err, fn.Body.AST))
 			return ir.IR{}, aCtx.Diagnostics
 		}
-		if err = bindParams(aCtx, funcScope, fn.Config, symbol.KindConfig); err != nil {
-			aCtx.Diagnostics.Add(diagnostics.Error(err, fn.Body.AST))
-			return ir.IR{}, aCtx.Diagnostics
-		}
 		if err = bindParams(aCtx, funcScope, fn.Inputs, symbol.KindInput); err != nil {
 			aCtx.Diagnostics.Add(diagnostics.Error(err, fn.Body.AST))
 			return ir.IR{}, aCtx.Diagnostics
@@ -130,31 +126,31 @@ func Analyze(
 			Key:      n.Key,
 			Type:     n.Type,
 			Channels: fnSym.Channels.Copy(),
-			Config:   freshType.Config,
 			Inputs:   freshType.Inputs,
 			Outputs:  freshType.Outputs,
 		}
-		// Process provided config values
-		for j, configParam := range freshType.Config {
-			configValue, ok := n.Config[configParam.Name]
+		// n.Config is the editor-supplied value map (a generated graph field),
+		// not the removed type-level Config.
+		for j, param := range freshType.Inputs {
+			paramValue, ok := n.Config[param.Name]
 			if !ok {
 				continue
 			}
-			if configParam.Type.Kind == types.KindChan {
+			if param.Type.Kind == types.KindChan {
 				var k uint32
-				if err = zyn.Uint32().Coerce().Parse(configValue, &k); err != nil {
+				if err = zyn.Uint32().Coerce().Parse(paramValue, &k); err != nil {
 					return ir.IR{}, aCtx.Diagnostics
 				}
 				channelSym, err := aCtx.Scope.Resolve(aCtx, strconv.Itoa(int(k)))
 				if err == nil && channelSym.Type.Kind == types.KindChan {
-					if err := configParam.Type.ChanDirection.CheckCompatibility(channelSym.Type.ChanDirection); err != nil {
+					if err := param.Type.ChanDirection.CheckCompatibility(channelSym.Type.ChanDirection); err != nil {
 						aCtx.Diagnostics.Add(diagnostics.Error(err, nil))
 						return ir.IR{}, aCtx.Diagnostics
 					}
 					if err = atypes.Check(
 						aCtx.Constraints,
 						channelSym.Type,
-						configParam.Type,
+						param.Type,
 						nil,
 						"",
 					); err != nil {
@@ -164,28 +160,15 @@ func Analyze(
 					symbol.ResolveConfigChannel(
 						&node.Channels,
 						fnSym,
-						configParam.Name,
+						param.Name,
 						k,
 						channelSym.Name,
 					)
 				}
 			}
-			node.Config[j].Value = configValue
+			node.Inputs[j].Value = paramValue
 		}
 		irNodes[i] = node
-
-		// Validate all required config parameters are provided
-		for _, configParam := range freshType.Config {
-			if configParam.Value == nil {
-				aCtx.Diagnostics.Add(diagnostics.Errorf(
-					nil,
-					"node '%s' (%s) missing required config parameter '%s'",
-					n.Key,
-					n.Type,
-					configParam.Name,
-				))
-			}
-		}
 	}
 
 	// Step 5: Check Types Across Edges, Unify, and Apply Substitutions
@@ -245,8 +228,8 @@ func Analyze(
 	return out, aCtx.Diagnostics
 }
 
-// bindParams adds function parameters to the symbol scope with the specified kind.
-// Used internally to bind Config, Input, and Output parameters during function
+// bindParams adds function parameters to the symbol scope with the specified
+// kind. Used internally to bind input and output parameters during function
 // registration.
 func bindParams(
 	ctx context.Context,

--- a/arc/go/ir/function.go
+++ b/arc/go/ir/function.go
@@ -19,7 +19,6 @@ import (
 // Type returns the type signature of f.
 func (f Function) Type() types.Type {
 	return types.Function(types.FunctionProperties{
-		Config:  f.Config,
 		Inputs:  f.Inputs,
 		Outputs: f.Outputs,
 	})
@@ -47,26 +46,16 @@ func (f Function) stringWithPrefix(prefix string) string {
 	b.WriteString(f.Key)
 	b.WriteString("\n")
 
-	hasConfig := len(f.Config) > 0
 	hasInputs := len(f.Inputs) > 0
 	hasOutputs := len(f.Outputs) > 0
 
 	// Channels
-	isLast := !hasConfig && !hasInputs && !hasOutputs
+	isLast := !hasInputs && !hasOutputs
 	b.WriteString(prefix)
 	b.WriteString(TreePrefix(isLast))
 	b.WriteString("channels: ")
 	b.WriteString(formatChannels(f.Channels))
 	b.WriteString("\n")
-
-	if hasConfig {
-		isLast = !hasInputs && !hasOutputs
-		b.WriteString(prefix)
-		b.WriteString(TreePrefix(isLast))
-		b.WriteString("config: ")
-		b.WriteString(formatParams(f.Config))
-		b.WriteString("\n")
-	}
 
 	if hasInputs {
 		isLast = !hasOutputs

--- a/arc/go/ir/node.go
+++ b/arc/go/ir/node.go
@@ -35,25 +35,15 @@ func (n Node) stringWithPrefix(prefix string) string {
 	var b strings.Builder
 	_, _ = fmt.Fprintf(&b, "%s (type: %s)\n", n.Key, n.Type)
 
-	hasConfig := len(n.Config) > 0
 	hasInputs := len(n.Inputs) > 0
 	hasOutputs := len(n.Outputs) > 0
 
-	isLast := !hasConfig && !hasInputs && !hasOutputs
+	isLast := !hasInputs && !hasOutputs
 	b.WriteString(prefix)
 	b.WriteString(TreePrefix(isLast))
 	b.WriteString("channels: ")
 	b.WriteString(formatChannels(n.Channels))
 	b.WriteString("\n")
-
-	if hasConfig {
-		isLast = !hasInputs && !hasOutputs
-		b.WriteString(prefix)
-		b.WriteString(TreePrefix(isLast))
-		b.WriteString("config: ")
-		b.WriteString(formatParams(n.Config))
-		b.WriteString("\n")
-	}
 
 	if hasInputs {
 		isLast = !hasOutputs

--- a/arc/go/text/analyze.go
+++ b/arc/go/text/analyze.go
@@ -260,13 +260,6 @@ type flowNodeResult struct {
 	inlineScope *ir.Scope
 }
 
-func firstInputParam(inputs types.Params) string {
-	if len(inputs) > 0 {
-		return inputs[0].Name
-	}
-	return ir.DefaultInputParam
-}
-
 func firstOutputParam(outputs types.Params) string {
 	if len(outputs) > 0 {
 		return outputs[0].Name
@@ -459,7 +452,7 @@ func buildChannelReadNode(name string, sym *symbol.Symbol, kg *keyGenerator) (no
 		Key:      nodeKey,
 		Type:     "on",
 		Channels: types.NewChannels(),
-		Config:   types.Params{{Name: "channel", Type: sym.Type, Value: chKey}},
+		Inputs:   types.Params{{Name: "channel", Type: sym.Type, Value: chKey}},
 		Outputs:  types.Params{{Name: ir.DefaultOutputParam, Type: sym.Type.Unwrap()}},
 	}
 	n.Channels.Read[chKey] = sym.Name
@@ -473,9 +466,11 @@ func buildChannelWriteNode(name string, sym *symbol.Symbol, kg *keyGenerator) (n
 		Key:      nodeKey,
 		Type:     "write",
 		Channels: types.NewChannels(),
-		Config:   types.Params{{Name: "channel", Type: sym.Type, Value: chKey}},
-		Inputs:   types.Params{{Name: ir.DefaultInputParam, Type: sym.Type.Unwrap()}},
-		Outputs:  types.Params{{Name: ir.DefaultOutputParam, Type: types.U8()}},
+		Inputs: types.Params{
+			{Name: "channel", Type: sym.Type, Value: chKey},
+			{Name: ir.DefaultInputParam, Type: sym.Type.Unwrap()},
+		},
+		Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.U8()}},
 	}
 	n.Channels.Write[chKey] = sym.Name
 	return newNodeResult(n, ir.DefaultInputParam, ir.DefaultOutputParam), true
@@ -491,7 +486,7 @@ func buildGlobalConstantNode(
 		Key:      key,
 		Type:     "constant",
 		Channels: types.NewChannels(),
-		Config:   types.Params{{Name: "value", Type: sym.Type, Value: sym.DefaultValue}},
+		Inputs:   types.Params{{Name: "value", Type: sym.Type, Value: sym.DefaultValue}},
 		Outputs:  types.Params{{Name: ir.DefaultOutputParam, Type: sym.Type}},
 	}
 	return newNodeResult(n, ir.DefaultInputParam, ir.DefaultOutputParam), true
@@ -566,21 +561,19 @@ func analyzeFunctionNode(
 		Key:      key,
 		Type:     nodeType,
 		Channels: sym.Channels.Copy(),
-		Config:   slices.Clone(freshType.Config),
+		Inputs:   slices.Clone(freshType.Inputs),
 		Outputs:  slices.Clone(freshType.Outputs),
 	}
-	// STL ExecBoth inputs mirror config; in flow form the upstream is a
-	// trigger, so omit Inputs. User-defined funcs (AST != nil) keep them.
-	upstreamIsTrigger := sym.Exec == symbol.ExecBoth && sym.AST == nil
-	if !upstreamIsTrigger {
-		n.Inputs = slices.Clone(freshType.Inputs)
-	}
 	var ok bool
-	n.Config, ok = extractConfigValues(acontext.Child(ctx, ctx.AST.ConfigValues()), n.Config, n, sym)
+	n.Inputs, ok = extractConfigValues(acontext.Child(ctx, ctx.AST.ConfigValues()), n.Inputs, n, sym)
 	if !ok {
 		return nodeResult{}, false
 	}
-	return newNodeResult(n, firstInputParam(n.Inputs), firstOutputParam(n.Outputs)), true
+	inputParam := ir.DefaultInputParam
+	if sym.Trigger.Target != "" {
+		inputParam = sym.Trigger.Target
+	}
+	return newNodeResult(n, inputParam, firstOutputParam(n.Outputs)), true
 }
 
 // tryAnalyzeFmtStrLiteral handles the format-string-with-placeholders case by
@@ -625,7 +618,6 @@ func tryAnalyzeFmtStrLiteral(
 		Key:      synthKey,
 		Body:     ir.Body{Raw: body},
 		Inputs:   types.Params{},
-		Config:   types.Params{},
 		Outputs:  types.Params{{Name: ir.DefaultOutputParam, Type: outputType}},
 		Channels: sym.Channels.Copy(),
 	})
@@ -667,7 +659,7 @@ func analyzeExpression(
 			Key:      key,
 			Type:     "constant",
 			Channels: types.NewChannels(),
-			Config:   types.Params{{Name: "value", Type: outputType, Value: parsedValue.Value}},
+			Inputs:   types.Params{{Name: "value", Type: outputType, Value: parsedValue.Value}},
 			Outputs:  types.Params{{Name: ir.DefaultOutputParam, Type: outputType}},
 		}
 		return newNodeResult(n, ir.DefaultInputParam, ir.DefaultOutputParam), true
@@ -736,7 +728,6 @@ func Analyze(
 		i.Functions = append(i.Functions, ir.Function{
 			Key:      c.Name,
 			Body:     ir.Body{Raw: bodyAst.GetText(), AST: bodyAst},
-			Config:   c.Type.Config,
 			Inputs:   c.Type.Inputs,
 			Outputs:  c.Type.Outputs,
 			Channels: c.Channels,

--- a/docs/tech/rfc/0039-260513-arc-function-call-unification.md
+++ b/docs/tech/rfc/0039-260513-arc-function-call-unification.md
@@ -1037,3 +1037,31 @@ it lands.
 
 Open question for that phase: what the rules rename to (e.g. `braceBlock` / `parenBlock`
 by surface form). Not just find-and-replace.
+
+### Part 4 - `symbol.KindConfig` should be deprecated
+
+Distinct from both the type-level `Config` collapse (this RFC) and the grammar `config`
+rename (above): the symbol-table scope `Kind` still carries a `KindConfig` / `KindInput`
+split. Plan §Phase 3 deliberately kept it ("the symbol `Kind` distinction stays via the
+block the param came from"). Since this RFC's intent is that "config" is no longer a
+load-bearing concept, the scope `Kind` should follow.
+
+Part 4 narrowed it without removing it: the graph analyzer now binds all params
+`KindInput`, and `KindInput` absorbed `KindConfig`'s channel behavior at the two sites
+where they diverged (`compiler/statement/variable.go` channel-source resolution and
+`analyzer/expression/expression.go` channel-read tracking). The remaining producer is
+`addConfigToScope` (text path, `analyzer/function/function.go`), which still emits
+`KindConfig` for brace-block params; every `KindConfig` reader therefore has to match
+both kinds for now.
+
+Full removal: flip `addConfigToScope` to `KindInput`, delete the `KindConfig` enum value
+and its `kind_string.go` entry, and collapse the readers. Most are already trivial: the
+`KindConfig` cases in `compiler/expression/identifier.go` and the write path of
+`compiler/statement/variable.go` are byte-identical to their `KindInput` neighbors, and
+`analyzer/statement/statement.go` only special-cases `KindChannel`; the LSP sites
+(`lsp/semantic.go`, `lsp/hover.go`) are cosmetic.
+
+Do it after the tree is green (post-Part 9), same reasoning as the grammar rename: a
+mechanical `Kind` collapse on a compiling tree lets the compiler and tests catch every
+missed reader, whereas mid-stack on the broken-by-design tree there is no safety net.
+Independent of the grammar rename; neither blocks the other.


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4297](https://linear.app/synnax/issue/SY-4297)

## Description

Part 4 of the Arc Function-Call Unification stack ([RFC 0039](docs/tech/rfc/0039-260513-arc-function-call-unification.md)). Stacked on **Part 3 (#2448)**; the schema/codegen that removed the `Config` field landed in **Part 1 (#2421)**.

This is the downstream-consumer conversion (RFC §6.3-6.4). Part 3 collapsed the analyzer and passed its design gate; this part propagates the unified `Inputs` list into the remaining readers so the producers of IR all speak one parameter list.

**Unified Inputs in the consumers.** `compiler/compiler.go` replaces `slices.Concat(Config, Inputs)` with `Inputs`; `ir/function.go` and `ir/node.go` drop `Config` from `Type()` and the tree render; `text/analyze.go` and `graph/analyze.go` fold every `Config:` field into `Inputs:` across their node and function builders (the channel-write builder merges its old two-field shape into one `Inputs` list, config-first).

**Trigger-driven edge target.** In `text/analyze.go` the `upstreamIsTrigger` heuristic and `firstInputParam` are replaced by a direct `sym.Trigger` consult, mirroring Part 3's `consultTrigger`: `TriggerOnly` targets the default activation handle, `TriggerInput(name)` targets the named param. `graph/analyze.go` drops its local required-param check, now covered by the edge-aware check already in `ResolveNodeTypes`.

**Begin deprecating `symbol.KindConfig`.** Per the unification intent that "config" is no longer load-bearing, the graph analyzer now binds all params as `KindInput`, and `KindInput` absorbs `KindConfig`'s channel behavior in `compiler/statement/variable.go` and `analyzer/expression/expression.go`. Full removal of the enum is deferred to a post-Part-9 follow-up logged in RFC Appendix A.

### Reviewer notes

- **Does not compile yet, by design.** The `ir` and `graph` msgpack legacy decoders still read `.Config` and are left for the Part 8 codec migration (a correct merge needs the symbol-aware mirror dedup only that phase has); first green build is Part 9. CI red is expected; review on the diff. `gofmt` passes on the changed files.
- **No tests in this part.** The fixture sweep and new tests are Part 7. One follow-on: the graph "missing required config parameter" message becomes "missing required input" now that `ResolveNodeTypes` owns the check.
- **Plan vs. code (non-issue).** Three plan paths were stale: `runtime/node/state.go` already iterates `Inputs` (no-op), `compiler/expression/compiler.go` was already clean, and `text/analyze.go` had five synthetic `Config:` node/function literals the plan never listed (all folded).

## Basic Readiness

- [x] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Part 4 of the Arc function-call unification stack propagates the unified `Inputs` list through all remaining downstream consumers, completing the collapse of the `Config` type-level field into `Inputs` across the compiler, IR renderers, graph analyzer, and text analyzer.

- **Compiler & IR** (`compiler.go`, `ir/function.go`, `ir/node.go`): `slices.Concat(Config, Inputs)` → plain `Inputs`; `Config` dropped from `Type()` and the tree-render methods.
- **Analyzers** (`graph/analyze.go`, `text/analyze.go`): all node/function builders fold former `Config:` fields into `Inputs:`; the graph analyzer removes `bindParams(KindConfig)` and delegates required-param checking to `ResolveNodeTypes`/`resolve.go`; the text analyzer replaces the `upstreamIsTrigger`/`firstInputParam` heuristic with a direct `sym.Trigger.Target` consult.
- **KindConfig narrowing** (`compiler/statement/variable.go`, `analyzer/expression/expression.go`): `KindInput` absorbs `KindConfig`'s channel-source and channel-read tracking behavior; full `KindConfig` enum removal is deferred to post-Part-9 and documented in the RFC appendix.

<h3>Confidence Score: 5/5</h3>

The changes are a well-scoped mechanical migration across 8 files, each following the same straightforward pattern of replacing Config with Inputs. No new runtime paths are opened, the intentional non-compiling state is limited to the legacy codec decoders, and all edge-case invariants (required-param validation, trigger-target routing, channel-source resolution) have been verified to remain correct under the new structure.

Every change in this PR is a direct consequence of the schema change landed in Part 1. The substitution of Inputs for Config is applied consistently across all consumer sites, the KindConfig narrowing extends existing conditions rather than rewriting logic, and the Trigger-driven edge target correctly mirrors Part 3's consultTrigger approach. No issues were found that would affect correctness of the generated IR or runtime behavior.

No files require special attention. The acknowledged non-compiling state in the msgpack legacy decoders is out of scope for this part and expected until Part 8.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| arc/go/compiler/compiler.go | Drops slices.Concat(Config, Inputs) in favor of plain Inputs; removes the slices import. Mechanical and correct. |
| arc/go/compiler/statement/variable.go | Extends resolveChannelSource and related comments to cover KindInput alongside KindConfig; stale 'Config param' comments in the diff have been updated to 'Param'. Unchanged portions remain accurate for the current transition state. |
| arc/go/analyzer/expression/expression.go | Adds KindInput to the shouldTrackRead channel-read condition alongside KindConfig. Logical parity with the variable.go extension; correct. |
| arc/go/graph/analyze.go | Removes bindParams call for KindConfig and the old required-param validation loop; iterates freshType.Inputs to populate node values from the editor-supplied n.Config map. The missing-required-input check is delegated to ResolveNodeTypes/resolve.go as discussed in PR thread. |
| arc/go/ir/function.go | Drops Config from the Type() FunctionProperties and from the stringWithPrefix tree renderer. Clean removal. |
| arc/go/ir/node.go | Mirrors function.go: drops Config from the node tree renderer. hasConfig variable and its conditional block are cleanly removed. |
| arc/go/text/analyze.go | Folds Config fields into Inputs across all node builders; replaces firstInputParam heuristic with sym.Trigger.Target lookup; removes upstreamIsTrigger Inputs-omission for ExecBoth STL functions. All changes follow RFC §6.3 intent. |
| docs/tech/rfc/0039-260513-arc-function-call-unification.md | Appends Part 4 appendix entry documenting the KindConfig deprecation plan: what was narrowed now, what remains, and the post-Part-9 removal sequence. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Symbol / Type Definition\nConfig + Inputs] -->|Part 1: schema removed Config| B[Unified Inputs]

    B --> C[text/analyze.go\nbuildChannelReadNode\nbuildChannelWriteNode\nbuildGlobalConstantNode\nanalyzeExpression\nanalyzeFunctionNode]
    B --> D[graph/analyze.go\nbindParams KindConfig removed\nn.Config map → Inputs lookup]
    B --> E[ir/function.go + ir/node.go\nType removes Config\nstringWithPrefix removes config branch]
    B --> F[compiler/compiler.go\nslices.Concat removed\nparams = i.Inputs]

    C -->|extractConfigValues now\nreceives unified Inputs| G[ir.Node.Inputs]
    D -->|ResolveNodeTypes owns\nrequired-param check| G
    E --> G
    F --> G

    G -->|KindInput absorbs KindConfig\nchannel behavior| H[analyzer/expression/expression.go\ncompiler/statement/variable.go]

    style B fill:#d4edda,stroke:#28a745
    style G fill:#d4edda,stroke:#28a745
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `arc/go/compiler/statement/variable.go`, line 96-100 ([link](https://github.com/synnaxlabs/synnax/blob/ad1ede8b069736f1e2556adcc50f22af173ac4f9/arc/go/compiler/statement/variable.go#L96-L100)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Two comments in the unchanged portion of this file still reference only "Config param" after the PR extends the branch to cover `KindInput` as well. The constant comment at the top of the const block and the case comment in `compileLocalVariable` both need updating for consistency with the inline comment that was already fixed in `resolveChannelSource`.

   

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

2. `arc/go/compiler/statement/variable.go`, line 66-68 ([link](https://github.com/synnaxlabs/synnax/blob/ad1ede8b069736f1e2556adcc50f22af173ac4f9/arc/go/compiler/statement/variable.go#L66-L68)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> Stale comment: says "Config params and variables" but `resolveChannelSource` now also returns `channelSourceLocal` for `KindInput` symbols. Should read "Params and variables have WASM locals holding the channel key".
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["SY-4297: Arc Params Refactor (Part 4) - ..."](https://github.com/synnaxlabs/synnax/commit/f99f474f1a8e4243cd67d056858a11b1b2875db3) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36314566)</sub>

<!-- /greptile_comment -->