### PR TITLE
SY-4353: Fix Log State Sync Spamming

### DIFF
--- a/integration/console/log.py
+++ b/integration/console/log.py
@@ -68,6 +68,54 @@ class Log(ConsolePage):
                 return True
         return False
 
+    def copy_visible_entries(self) -> str:
+        """Drag-select the log and copy the selection via the context menu.
+
+        Log entries are drawn on a canvas, so they are not countable as DOM
+        nodes. A mouse drag (not the Ctrl+A trigger) sets the selection, and the
+        context-menu Copy item writes it through ``navigator.clipboard.write``
+        (the async clipboard API). Both avoid the focus-dependent native copy
+        event and the active-tab trigger gate, so the round-trip is reliable in
+        headless runs. Returns "" if the copy could not be performed.
+        """
+        self.layout.get_tab(self.page_name).click()
+        if not self.pane_locator:
+            return ""
+        bbox = self.pane_locator.bounding_box()
+        if bbox is None:
+            return ""
+        x = bbox["x"] + 40
+        self.page.mouse.move(x, bbox["y"] + 10)
+        self.page.mouse.down()
+        self.page.mouse.move(x, bbox["y"] + bbox["height"] - 10, steps=5)
+        self.page.mouse.up()
+        self.pane_locator.click(button="right", position={"x": 40, "y": 10})
+        menu = self.page.locator(".pluto-menu-context").first
+        try:
+            menu.wait_for(state="visible", timeout=3000)
+            menu.locator(".pluto-menu-item").filter(has_text="Copy").first.click(
+                timeout=2000
+            )
+        except PlaywrightTimeoutError:
+            self.page.keyboard.press("Escape")
+            return ""
+        return self.layout.read_clipboard()
+
+    def wait_for_copied_entries(self, retries: int = 20) -> list[str]:
+        """Poll the drag-select + context-menu copy until it yields entries.
+
+        Returns the non-empty copied lines (one per rendered entry), or an empty
+        list if nothing was copied within the retry budget.
+        """
+        lines: list[str] = []
+        for _ in range(retries):
+            text = self.copy_visible_entries()
+            lines = [ln for ln in text.split("\n") if ln.strip()]
+            if lines:
+                return lines
+            self.page.wait_for_timeout(250)
+        return lines
+
     def is_empty(self) -> bool:
         """Check if the log shows any empty state message."""
         if not self.pane_locator:

--- a/integration/console/log.py
+++ b/integration/console/log.py
@@ -68,41 +68,6 @@ class Log(ConsolePage):
                 return True
         return False
 
-    def copy_all_entries(self) -> str:
-        """Select all rendered log entries and copy them to the clipboard.
-
-        Log entries are drawn on a canvas, so they are not countable as DOM
-        elements. Select-all (Ctrl+A) followed by copy (Ctrl+C) round-trips the
-        rendered entries through the clipboard, which is the only fidelity-true
-        proxy for what the user actually sees.
-
-        Returns:
-            The copied entry text (one entry per line).
-        """
-        self.layout.get_tab(self.page_name).click()
-        assert self.pane_locator is not None, "Log pane should be visible"
-        self.pane_locator.click(position={"x": 40, "y": 200})
-        self.page.keyboard.press("Control+a")
-        self.page.keyboard.press("Control+c")
-        return self.layout.read_clipboard()
-
-    def entry_count(self) -> int:
-        """Return the number of rendered log entries via select-all + copy."""
-        text = self.copy_all_entries()
-        return len([line for line in text.split("\n") if line != ""])
-
-    def wait_for_entry_count(self, expected: int, retries: int = 20) -> int:
-        """Poll until at least ``expected`` entries are rendered, returning the
-        final observed count (which may be less than ``expected`` on timeout).
-        """
-        count = 0
-        for _ in range(retries):
-            count = self.entry_count()
-            if count >= expected:
-                return count
-            self.page.wait_for_timeout(250)
-        return count
-
     def is_empty(self) -> bool:
         """Check if the log shows any empty state message."""
         if not self.pane_locator:

--- a/integration/tests/console/log/log_lifecycle.py
+++ b/integration/tests/console/log/log_lifecycle.py
@@ -170,9 +170,7 @@ class LogLifecycle(ConsoleCase):
         assert log.wait_until_streaming(), (
             "Log should stream entries from a timestamp channel"
         )
-        assert log.wait_for_entry_count(1) >= 1, (
-            "Log should render entries from a timestamp channel"
-        )
+        assert not log.is_empty(), "Log should render entries from a timestamp channel"
 
     def test_virtual_channel_streaming(self, log: Log) -> None:
         """Test that log streams data from a virtual channel and that log data

--- a/integration/tests/console/log/log_lifecycle.py
+++ b/integration/tests/console/log/log_lifecycle.py
@@ -7,6 +7,8 @@
 #  License, use of this software will be governed by the Apache License, Version 2.0,
 #  included in the file licenses/APL.txt.
 
+import re
+
 from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 import synnax as sy
@@ -170,7 +172,16 @@ class LogLifecycle(ConsoleCase):
         assert log.wait_until_streaming(), (
             "Log should stream entries from a timestamp channel"
         )
-        assert not log.is_empty(), "Log should render entries from a timestamp channel"
+        entries = log.wait_for_copied_entries()
+        assert len(entries) >= 1, "Log should render entries from a timestamp channel"
+        # Each entry's value must render as a formatted date (e.g. "Jun 9
+        # 15:59:52.809"), not the raw i64 nanosecond value. This is the bigint
+        # formatting path whose regression previously froze the log.
+        formatted_value = re.compile(r"[A-Z][a-z]{2} \d{1,2} \d{2}:\d{2}:\d{2}")
+        assert all(
+            self.idx_name in entry and formatted_value.search(entry)
+            for entry in entries
+        ), f"Log should render formatted timestamp values, got {entries!r}"
 
     def test_virtual_channel_streaming(self, log: Log) -> None:
         """Test that log streams data from a virtual channel and that log data

--- a/pluto/src/log/Base.spec.tsx
+++ b/pluto/src/log/Base.spec.tsx
@@ -64,7 +64,6 @@ const DEFAULT_STATE = {
   selectedText: "",
   selectedLines: [],
   computedLineHeight: 16,
-  entryCount: 0,
 };
 
 const setupAether = (overrides: Record<string, unknown> = {}) => {
@@ -103,7 +102,7 @@ describe("log/Base", () => {
     });
 
     it("should render the live button when not empty", () => {
-      setupAether({ empty: false, entryCount: 10 });
+      setupAether({ empty: false });
       const { container } = renderLog();
       const liveButton = container.querySelector(".pluto-log__live");
       expect(liveButton).not.toBeNull();
@@ -281,7 +280,6 @@ describe("log/Base", () => {
     const PRIMED_STATE = {
       ...DEFAULT_STATE,
       empty: false,
-      entryCount: 10,
       selectionStart: 2,
       selectionEnd: 7,
       selectedText: "primed",
@@ -308,33 +306,33 @@ describe("log/Base", () => {
     };
 
     const isSelectAll = (r: Record<string, unknown>) =>
-      r.selectionStart === 0 && r.selectionEnd === 9;
+      r.selectionStart === 0 && r.selectionEnd === Number.MAX_SAFE_INTEGER;
     const isClearSelection = (r: Record<string, unknown>) =>
       r.selectionStart === -1 && r.selectionEnd === -1 && r.selectedText === "";
 
     it("should fire setState selecting all entries on Ctrl+A when enableTriggers is true", () => {
-      const { setState } = setupAether({ empty: false, entryCount: 10 });
+      const { setState } = setupAether({ empty: false });
       renderLog({ enableTriggers: true });
       fireCtrlA();
       expect(findUpdaterResult(setState, isSelectAll)).toBeDefined();
     });
 
     it("should not fire setState on Ctrl+A when enableTriggers returns false", () => {
-      const { setState } = setupAether({ empty: false, entryCount: 10 });
+      const { setState } = setupAether({ empty: false });
       renderLog({ enableTriggers: () => false });
       fireCtrlA();
       expect(findUpdaterResult(setState, isSelectAll)).toBeUndefined();
     });
 
     it("should fire setState selecting all on Ctrl+A when enableTriggers is undefined", () => {
-      const { setState } = setupAether({ empty: false, entryCount: 10 });
+      const { setState } = setupAether({ empty: false });
       renderLog();
       fireCtrlA();
       expect(findUpdaterResult(setState, isSelectAll)).toBeDefined();
     });
 
     it("should clear selection on Escape when enableTriggers is true", () => {
-      const { setState } = setupAether({ empty: false, entryCount: 10 });
+      const { setState } = setupAether({ empty: false });
       renderLog({ enableTriggers: true });
       fireEvent.keyDown(document.body, { code: "Escape" });
       fireEvent.keyUp(document.body, { code: "Escape" });
@@ -342,7 +340,7 @@ describe("log/Base", () => {
     });
 
     it("should not clear selection on Escape when enableTriggers returns false", () => {
-      const { setState } = setupAether({ empty: false, entryCount: 10 });
+      const { setState } = setupAether({ empty: false });
       renderLog({ enableTriggers: () => false });
       fireEvent.keyDown(document.body, { code: "Escape" });
       fireEvent.keyUp(document.body, { code: "Escape" });

--- a/pluto/src/log/Base.tsx
+++ b/pluto/src/log/Base.tsx
@@ -25,6 +25,11 @@ import { Canvas } from "@/vis/canvas";
 
 const COPY_TRIGGER: Triggers.Trigger = ["Control", "C"];
 
+// Select-all sends "to end" rather than a concrete index so the entry count never
+// has to be synced from the worker on every batch. The worker holds entries.length
+// and its slice/clamp logic resolves this to the true last entry at render time.
+const SELECT_ALL_END = Number.MAX_SAFE_INTEGER;
+
 type Mode = "selectAll" | "clearSelection" | "togglePause" | "default";
 
 const TRIGGER_CONFIG: Triggers.ModeConfig<Mode> = {
@@ -83,7 +88,6 @@ export const Base = ({
     region,
     visibleStart,
     computedLineHeight,
-    entryCount,
   } = state;
 
   const resizeRef = Canvas.useRegion(
@@ -171,14 +175,9 @@ export const Base = ({
         if (enableTriggers === false) return;
         if (typeof enableTriggers === "function" && !enableTriggers()) return;
         const mode = Triggers.determineMode(TRIGGER_CONFIG, triggers);
-        if (mode === "selectAll") {
-          if (entryCount === 0) return;
-          setState((s) => ({
-            ...s,
-            selectionStart: 0,
-            selectionEnd: entryCount - 1,
-          }));
-        } else if (mode === "clearSelection")
+        if (mode === "selectAll")
+          setState((s) => ({ ...s, selectionStart: 0, selectionEnd: SELECT_ALL_END }));
+        else if (mode === "clearSelection")
           setState((s) => ({
             ...s,
             selectionStart: -1,
@@ -188,7 +187,7 @@ export const Base = ({
         else if (mode === "togglePause")
           setState((s) => ({ ...s, scrolling: !s.scrolling }));
       },
-      [entryCount, setState, enableTriggers],
+      [setState, enableTriggers],
     ),
   });
 

--- a/pluto/src/log/aether/Log.spec.ts
+++ b/pluto/src/log/aether/Log.spec.ts
@@ -283,7 +283,6 @@ describe("log/aether/Log", () => {
       expect(parsed.selectedText).toBe("");
       expect(parsed.selectedLines).toEqual([]);
       expect(parsed.computedLineHeight).toBe(0);
-      expect(parsed.entryCount).toBe(0);
     });
 
     it("should provide defaults for channel-related fields", () => {
@@ -326,16 +325,16 @@ describe("log/aether/Log", () => {
     });
   });
 
-  describe("entryCount tracking", () => {
-    it("should set entryCount when entries arrive", () => {
+  describe("empty tracking", () => {
+    it("should set empty to false when entries arrive", () => {
       const entries = Array.from({ length: 7 }, (_, i) => makeEntry(i));
       const { log } = setupWithContext(entries);
-      expect(log.state.entryCount).toBe(7);
+      expect(log.state.empty).toBe(false);
     });
 
-    it("should keep entryCount at 0 when no entries", () => {
+    it("should keep empty true when no entries", () => {
       const { log } = setupWithContext([]);
-      expect(log.state.entryCount).toBe(0);
+      expect(log.state.empty).toBe(true);
     });
   });
 
@@ -954,6 +953,16 @@ describe("log/aether/Log", () => {
       // selectedLines should contain entries 2 through 5 inclusive
       expect(log.state.selectedLines).toHaveLength(4);
       expect(log.state.selectedText).toContain("\n");
+    });
+
+    it("should clamp a select-to-end sentinel to all entries", () => {
+      const entries = Array.from({ length: 10 }, (_, i) => makeEntry(i));
+      const { log } = setupWithContext(entries, REGION_500, {
+        selectionStart: 0,
+        selectionEnd: Number.MAX_SAFE_INTEGER,
+      });
+      log.render();
+      expect(log.state.selectedLines).toHaveLength(10);
     });
 
     it("should handle reversed selection (end < start)", () => {

--- a/pluto/src/log/aether/Log.ts
+++ b/pluto/src/log/aether/Log.ts
@@ -60,7 +60,6 @@ export const logStateZ = log.logZ
       .array(z.object({ text: z.string(), color: z.string() }))
       .default([]),
     computedLineHeight: z.number().default(0),
-    entryCount: z.number().default(0),
   });
 
 const SCROLLBAR_RENDER_THRESHOLD = 0.98;
@@ -256,13 +255,8 @@ export class Log extends aether.Leaf<typeof logStateZ, InternalState> {
 
   private checkEmpty(): void {
     const actuallyEmpty = this.entries.length === 0;
-    const countChanged = this.entries.length !== this.state.entryCount;
-    if (actuallyEmpty === this.state.empty && !countChanged) return;
-    this.setState((s) => ({
-      ...s,
-      empty: actuallyEmpty,
-      entryCount: this.entries.length,
-    }));
+    if (actuallyEmpty === this.state.empty) return;
+    this.setState((s) => ({ ...s, empty: actuallyEmpty }));
   }
 
   afterDelete(): void {


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4353](https://linear.app/synnax/issue/SY-4353)

## Description

The log's aether worker carried `entryCount` in its synced state solely so the main-thread select-all (`Ctrl+A`) could compute `selectionEnd`. `checkEmpty()` refreshed `entryCount` on **every stream batch**, and since each worker `setState` is a full-state worker→main message (`aether.ts`), this re-rendered the React `Base` component once per batch — defeating the purpose of worker-thread rendering.

This moves the clamp to the worker, which already holds `entries.length`:

- Select-all now sends a "to end" sentinel (`Number.MAX_SAFE_INTEGER`); the worker's existing `slice`/`Math.min` logic resolves it against the real entry count at render time.
- `entryCount` is removed from synced state. `checkEmpty()` now syncs only the `empty` boolean, which flips a couple of times per session instead of on every batch.

The select-all selection now follows the live tail (new entries are included), which is the more correct behavior for a streaming log.

### Integration test

The `log_lifecycle` timestamp regression check previously read the canvas by simulating `Ctrl+A` → native `copy` event → clipboard. That chain depends on window focus and the active-tab trigger gate, so it passed headed but consistently failed headless.

It now reads content reliably by **drag-selecting** the log (mouse events, not the trigger) and copying via the **context-menu Copy** item, which uses `navigator.clipboard.write` (the async clipboard API). The assertion verifies the index channel's value renders as a formatted date (e.g. `Jun 9 15:59:52.809`) rather than a raw i64 nanosecond value — directly exercising the bigint→date formatting path the regression broke. Verified passing across repeated headless runs.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.