### PR TITLE
SY-4360: Task Config Provider Registry and Wire Composition

### DIFF
--- a/core/pkg/api/task/task.go
+++ b/core/pkg/api/task/task.go
@@ -147,6 +147,9 @@ func (s *Service) Retrieve(
 	if err != nil {
 		return res, err
 	}
+	if err = s.task.ResolveConfigs(ctx, nil, res.Tasks); err != nil {
+		return res, err
+	}
 
 	if req.IncludeStatus {
 		statuses := make([]task.Status, 0, len(res.Tasks))

--- a/core/pkg/service/task/config.go
+++ b/core/pkg/service/task/config.go
@@ -1,0 +1,156 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+package task
+
+import (
+	"context"
+	"sync"
+
+	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
+	"github.com/synnaxlabs/x/encoding/msgpack"
+	"github.com/synnaxlabs/x/errors"
+	"github.com/synnaxlabs/x/gorp"
+	"github.com/synnaxlabs/x/query"
+)
+
+// ConfigProvider stores strongly typed configurations for a set of task types. A
+// config service implements ConfigProvider and registers it via
+// Service.RegisterConfigProvider; the task writer then routes config storage for the
+// provider's task types through it instead of embedding the config on the task.
+// Internal tasks never dispatch to a provider.
+//
+// All methods receive the task writer's transaction, so a task and its config are
+// created, copied, or deleted atomically.
+type ConfigProvider interface {
+	// Types returns the exact task types this provider handles (e.g.
+	// "ni_analog_read"). Type strings must be unique across all registered providers.
+	Types() []string
+	// Create validates cfg and upserts the typed config record for the given task,
+	// returning the ontology ID of the config resource. Create must define the config
+	// resource within tx before returning, and must return the same ID for repeated
+	// calls with the same task key. It returns a validation error if cfg does not
+	// match the provider's schema for taskType.
+	Create(
+		ctx context.Context,
+		tx gorp.Tx,
+		task Key,
+		taskType string,
+		cfg msgpack.EncodedJSON,
+	) (ontology.ID, error)
+	// Load returns the wire representation of the config stored for the given task.
+	// It returns query.ErrNotFound if the provider has no record for the task.
+	Load(ctx context.Context, tx gorp.Tx, task Key) (msgpack.EncodedJSON, error)
+	// Copy duplicates the config of one task for another, returning the ontology ID
+	// of the new config resource. It returns query.ErrNotFound if the source task has
+	// no config record.
+	Copy(ctx context.Context, tx gorp.Tx, from, to Key) (ontology.ID, error)
+	// Delete removes the config record and its ontology resource for the given task.
+	// Deleting a task with no config record is a no-op.
+	Delete(ctx context.Context, tx gorp.Tx, task Key) error
+}
+
+// configProviders is the registry mapping exact task-type strings to providers.
+type configProviders struct {
+	mu sync.RWMutex
+	m  map[string]ConfigProvider
+}
+
+func (c *configProviders) register(p ConfigProvider) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	if c.m == nil {
+		c.m = make(map[string]ConfigProvider)
+	}
+	for _, t := range p.Types() {
+		if _, ok := c.m[t]; ok {
+			return errors.Newf(
+				"config provider already registered for task type %q",
+				t,
+			)
+		}
+	}
+	for _, t := range p.Types() {
+		c.m[t] = p
+	}
+	return nil
+}
+
+func (c *configProviders) get(taskType string) (ConfigProvider, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+	p, ok := c.m[taskType]
+	return p, ok
+}
+
+// RegisterConfigProvider registers a ConfigProvider for its task types. It returns an
+// error if another provider is already registered for one of the provider's types.
+// Registration must happen during startup, before the service begins handling writes.
+func (s *Service) RegisterConfigProvider(p ConfigProvider) error {
+	return s.configProviders.register(p)
+}
+
+// ResolveConfigs fills the Config field of each task from its registered config
+// provider. Tasks without a provider, internal tasks, and tasks whose provider has no
+// record yet keep their stored config untouched, so mixed states (configs not yet
+// migrated to a provider) resolve correctly.
+func (s *Service) ResolveConfigs(ctx context.Context, tx gorp.Tx, tasks []Task) error {
+	tx = gorp.OverrideTx(s.cfg.DB, tx)
+	for i := range tasks {
+		t := &tasks[i]
+		if t.Internal {
+			continue
+		}
+		p, ok := s.configProviders.get(t.Type)
+		if !ok {
+			continue
+		}
+		cfg, err := p.Load(ctx, tx, t.Key)
+		if errors.Is(err, query.ErrNotFound) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		t.Config = cfg
+	}
+	return nil
+}
+
+// ConfigDecoder decodes a wire-format config at a single schema version.
+type ConfigDecoder[T any] func(cfg msgpack.EncodedJSON) (T, error)
+
+// ErrNoConfigDecoders is returned by DecodeConfig when called with no decoders.
+var ErrNoConfigDecoders = errors.New("no config decoders provided")
+
+// DecodeConfig attempts each decoder in order and returns the first successful
+// result. Decoders should be ordered newest schema version first, with older versions
+// composing their migration into the decoder, so old-shaped wire input normalizes to
+// the current shape. If every decoder fails, the first decoder's error is returned,
+// since the current version produces the most relevant diagnostics.
+func DecodeConfig[T any](
+	cfg msgpack.EncodedJSON,
+	decoders ...ConfigDecoder[T],
+) (T, error) {
+	var firstErr error
+	for _, decode := range decoders {
+		v, err := decode(cfg)
+		if err == nil {
+			return v, nil
+		}
+		if firstErr == nil {
+			firstErr = err
+		}
+	}
+	var zero T
+	if firstErr == nil {
+		firstErr = ErrNoConfigDecoders
+	}
+	return zero, firstErr
+}

--- a/core/pkg/service/task/config_test.go
+++ b/core/pkg/service/task/config_test.go
@@ -1,0 +1,410 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+package task_test
+
+import (
+	"context"
+	"iter"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/synnaxlabs/synnax/pkg/distribution/group"
+	"github.com/synnaxlabs/synnax/pkg/distribution/mock"
+	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
+	"github.com/synnaxlabs/synnax/pkg/distribution/search"
+	"github.com/synnaxlabs/synnax/pkg/service/label"
+	"github.com/synnaxlabs/synnax/pkg/service/rack"
+	"github.com/synnaxlabs/synnax/pkg/service/status"
+	"github.com/synnaxlabs/synnax/pkg/service/task"
+	"github.com/synnaxlabs/x/encoding/msgpack"
+	"github.com/synnaxlabs/x/errors"
+	"github.com/synnaxlabs/x/gorp"
+	"github.com/synnaxlabs/x/kv/memkv"
+	"github.com/synnaxlabs/x/observe"
+	"github.com/synnaxlabs/x/query"
+	"github.com/synnaxlabs/x/telem"
+	. "github.com/synnaxlabs/x/testutil"
+	"github.com/synnaxlabs/x/zyn"
+)
+
+const fakeConfigType ontology.ResourceType = "task_config_fake"
+
+// fakeConfigOntologyService resolves the fake config resources the fake provider
+// defines, so ontology traversals over them succeed in tests.
+type fakeConfigOntologyService struct {
+	observe.Noop[iter.Seq[ontology.Change]]
+}
+
+var _ ontology.Service = (*fakeConfigOntologyService)(nil)
+
+func (f *fakeConfigOntologyService) Type() ontology.ResourceType { return fakeConfigType }
+
+func (f *fakeConfigOntologyService) Schema() zyn.Schema { return zyn.Object(nil) }
+
+func (f *fakeConfigOntologyService) RetrieveResource(
+	_ context.Context,
+	key string,
+	_ gorp.Tx,
+) (ontology.Resource, error) {
+	return ontology.Resource{
+		ID:   ontology.ID{Type: fakeConfigType, Key: key},
+		Name: key,
+	}, nil
+}
+
+type fakeProvider struct {
+	otg           *ontology.Ontology
+	types         []string
+	configs       map[task.Key]msgpack.EncodedJSON
+	createCalls   int
+	copyCalls     int
+	deleteCalls   int
+	lastCreateCfg msgpack.EncodedJSON
+}
+
+var _ task.ConfigProvider = (*fakeProvider)(nil)
+
+func newFakeProvider(otg *ontology.Ontology, types ...string) *fakeProvider {
+	return &fakeProvider{
+		otg:     otg,
+		types:   types,
+		configs: make(map[task.Key]msgpack.EncodedJSON),
+	}
+}
+
+func fakeConfigID(key task.Key) ontology.ID {
+	return ontology.ID{Type: fakeConfigType, Key: key.String()}
+}
+
+func (f *fakeProvider) Types() []string { return f.types }
+
+func (f *fakeProvider) Create(
+	ctx context.Context,
+	tx gorp.Tx,
+	key task.Key,
+	_ string,
+	cfg msgpack.EncodedJSON,
+) (ontology.ID, error) {
+	f.createCalls++
+	f.lastCreateCfg = cfg
+	f.configs[key] = cfg
+	id := fakeConfigID(key)
+	return id, f.otg.NewWriter(tx).DefineResource(ctx, id)
+}
+
+func (f *fakeProvider) Load(
+	_ context.Context,
+	_ gorp.Tx,
+	key task.Key,
+) (msgpack.EncodedJSON, error) {
+	cfg, ok := f.configs[key]
+	if !ok {
+		return nil, errors.Wrapf(query.ErrNotFound, "no config for task %v", key)
+	}
+	return cfg, nil
+}
+
+func (f *fakeProvider) Copy(
+	ctx context.Context,
+	tx gorp.Tx,
+	from, to task.Key,
+) (ontology.ID, error) {
+	f.copyCalls++
+	cfg, ok := f.configs[from]
+	if !ok {
+		return ontology.ID{}, errors.Wrapf(query.ErrNotFound, "no config for task %v", from)
+	}
+	f.configs[to] = cfg
+	id := fakeConfigID(to)
+	return id, f.otg.NewWriter(tx).DefineResource(ctx, id)
+}
+
+func (f *fakeProvider) Delete(ctx context.Context, tx gorp.Tx, key task.Key) error {
+	f.deleteCalls++
+	delete(f.configs, key)
+	return f.otg.NewWriter(tx).DeleteResource(ctx, fakeConfigID(key))
+}
+
+var _ = Describe("ConfigProvider", Ordered, func() {
+	var (
+		db       *gorp.DB
+		svc      *task.Service
+		otg      *ontology.Ontology
+		w        task.Writer
+		tx       gorp.Tx
+		testRack *rack.Rack
+		provider *fakeProvider
+	)
+	BeforeAll(func(ctx SpecContext) {
+		db = DeferClose(gorp.Wrap(memkv.New()))
+		otg = MustOpen(ontology.Open(ctx, ontology.Config{DB: db}))
+		searchIdx := MustOpen(search.Open())
+		g := MustOpen(group.OpenService(ctx, group.ServiceConfig{
+			DB:       db,
+			Ontology: otg,
+			Search:   searchIdx,
+		}))
+		labelSvc := MustOpen(label.OpenService(ctx, label.ServiceConfig{
+			DB:       db,
+			Ontology: otg,
+			Group:    g,
+			Search:   searchIdx,
+		}))
+		stat := MustOpen(status.OpenService(ctx, status.ServiceConfig{
+			Ontology: otg,
+			DB:       db,
+			Group:    g,
+			Label:    labelSvc,
+			Search:   searchIdx,
+		}))
+		rackService := MustOpen(rack.OpenService(ctx, rack.ServiceConfig{
+			DB:                  db,
+			Ontology:            otg,
+			Group:               g,
+			HostProvider:        mock.StaticHostKeyProvider(1),
+			Status:              stat,
+			HealthCheckInterval: 10 * telem.Millisecond,
+			Search:              searchIdx,
+		}))
+		svc = MustOpen(task.OpenService(ctx, task.ServiceConfig{
+			DB:       db,
+			Ontology: otg,
+			Group:    g,
+			Rack:     rackService,
+			Status:   stat,
+			Search:   searchIdx,
+		}))
+		otg.RegisterService(&fakeConfigOntologyService{})
+		provider = newFakeProvider(otg, "fake_typed", "fake_typed_2")
+		Expect(svc.RegisterConfigProvider(provider)).To(Succeed())
+		testRack = &rack.Rack{Name: "Config Test Rack"}
+		Expect(rackService.NewWriter(db).Create(ctx, testRack)).To(Succeed())
+	})
+	BeforeEach(func(ctx SpecContext) {
+		tx = db.OpenTx()
+		w = svc.NewWriter(tx)
+	})
+	AfterEach(func(ctx SpecContext) {
+		Expect(tx.Close()).To(Succeed())
+	})
+
+	Describe("RegisterConfigProvider", func() {
+		It("Should reject a provider for an already-claimed task type", func(ctx SpecContext) {
+			other := newFakeProvider(otg, "fake_typed")
+			Expect(svc.RegisterConfigProvider(other)).To(
+				MatchError(ContainSubstring("already registered")),
+			)
+		})
+	})
+
+	Describe("Create", func() {
+		It("Should route the config to the provider and link it to the task", func(ctx SpecContext) {
+			cfg := msgpack.EncodedJSON{"param": "value"}
+			t := task.Task{Key: task.NewKey(testRack.Key, 0), Type: "fake_typed", Name: "Typed", Config: cfg}
+			createCalls := provider.createCalls
+			Expect(w.Create(ctx, &t)).To(Succeed())
+			Expect(provider.createCalls).To(Equal(createCalls + 1))
+			Expect(provider.lastCreateCfg).To(Equal(cfg))
+			var children []ontology.Resource
+			Expect(otg.NewRetrieve().
+				WhereIDs(task.OntologyID(t.Key)).
+				TraverseTo(ontology.ChildrenTraverser).
+				Entries(&children).
+				Exec(ctx, tx)).To(Succeed())
+			Expect(children).To(HaveLen(1))
+			Expect(children[0].ID).To(Equal(fakeConfigID(t.Key)))
+		})
+
+		It("Should keep storing the config on the task while dual-writing", func(ctx SpecContext) {
+			cfg := msgpack.EncodedJSON{"param": "stored"}
+			t := task.Task{Key: task.NewKey(testRack.Key, 0), Type: "fake_typed", Name: "Stored", Config: cfg}
+			Expect(w.Create(ctx, &t)).To(Succeed())
+			var stored task.Task
+			Expect(svc.NewRetrieve().
+				Where(task.MatchKeys(t.Key)).
+				Entry(&stored).
+				Exec(ctx, tx)).To(Succeed())
+			Expect(stored.Config).To(Equal(cfg))
+		})
+
+		It("Should not dispatch internal tasks to the provider", func(ctx SpecContext) {
+			createCalls := provider.createCalls
+			t := task.Task{
+				Key:      task.NewKey(testRack.Key, 0),
+				Type:     "fake_typed",
+				Name:     "Internal",
+				Internal: true,
+				Config:   msgpack.EncodedJSON{"param": "internal"},
+			}
+			Expect(w.Create(ctx, &t)).To(Succeed())
+			Expect(provider.createCalls).To(Equal(createCalls))
+		})
+
+		It("Should leave task types without a provider on the fallback path", func(ctx SpecContext) {
+			createCalls := provider.createCalls
+			cfg := msgpack.EncodedJSON{"param": "fallback"}
+			t := task.Task{Key: task.NewKey(testRack.Key, 0), Type: "untyped", Name: "Fallback", Config: cfg}
+			Expect(w.Create(ctx, &t)).To(Succeed())
+			Expect(provider.createCalls).To(Equal(createCalls))
+			var stored task.Task
+			Expect(svc.NewRetrieve().
+				Where(task.MatchKeys(t.Key)).
+				Entry(&stored).
+				Exec(ctx, tx)).To(Succeed())
+			Expect(stored.Config).To(Equal(cfg))
+		})
+
+		It("Should hand the preserved config to the provider when updating a snapshot", func(ctx SpecContext) {
+			original := msgpack.EncodedJSON{"param": "original"}
+			t := task.Task{
+				Key:      task.NewKey(testRack.Key, 0),
+				Type:     "fake_typed",
+				Name:     "Snapshot",
+				Snapshot: true,
+				Config:   original,
+			}
+			Expect(w.Create(ctx, &t)).To(Succeed())
+			updated := t
+			updated.Config = msgpack.EncodedJSON{"param": "updated"}
+			Expect(w.Create(ctx, &updated)).To(Succeed())
+			Expect(provider.lastCreateCfg).To(Equal(original))
+		})
+	})
+
+	Describe("ResolveConfigs", func() {
+		It("Should fill configs from the provider", func(ctx SpecContext) {
+			cfg := msgpack.EncodedJSON{"param": "typed"}
+			t := task.Task{Key: task.NewKey(testRack.Key, 0), Type: "fake_typed", Name: "Resolve", Config: cfg}
+			Expect(w.Create(ctx, &t)).To(Succeed())
+			resolved := msgpack.EncodedJSON{"param": "resolved"}
+			provider.configs[t.Key] = resolved
+			tasks := []task.Task{{Key: t.Key, Type: t.Type}}
+			Expect(svc.ResolveConfigs(ctx, tx, tasks)).To(Succeed())
+			Expect(tasks[0].Config).To(Equal(resolved))
+		})
+
+		It("Should keep the stored config when the provider has no record", func(ctx SpecContext) {
+			cfg := msgpack.EncodedJSON{"param": "blob"}
+			tasks := []task.Task{{
+				Key:    task.NewKey(testRack.Key, 40),
+				Type:   "fake_typed",
+				Config: cfg,
+			}}
+			Expect(svc.ResolveConfigs(ctx, tx, tasks)).To(Succeed())
+			Expect(tasks[0].Config).To(Equal(cfg))
+		})
+
+		It("Should leave tasks without a provider untouched", func(ctx SpecContext) {
+			cfg := msgpack.EncodedJSON{"param": "untyped"}
+			tasks := []task.Task{{
+				Key:    task.NewKey(testRack.Key, 41),
+				Type:   "untyped",
+				Config: cfg,
+			}}
+			Expect(svc.ResolveConfigs(ctx, tx, tasks)).To(Succeed())
+			Expect(tasks[0].Config).To(Equal(cfg))
+		})
+
+		It("Should leave internal tasks untouched", func(ctx SpecContext) {
+			cfg := msgpack.EncodedJSON{"param": "internal"}
+			tasks := []task.Task{{
+				Key:      task.NewKey(testRack.Key, 42),
+				Type:     "fake_typed",
+				Internal: true,
+				Config:   cfg,
+			}}
+			Expect(svc.ResolveConfigs(ctx, tx, tasks)).To(Succeed())
+			Expect(tasks[0].Config).To(Equal(cfg))
+		})
+	})
+
+	Describe("Delete", func() {
+		It("Should delete the provider's config record with the task", func(ctx SpecContext) {
+			t := task.Task{
+				Key:    task.NewKey(testRack.Key, 0),
+				Type:   "fake_typed",
+				Name:   "Delete",
+				Config: msgpack.EncodedJSON{"param": "delete"},
+			}
+			Expect(w.Create(ctx, &t)).To(Succeed())
+			deleteCalls := provider.deleteCalls
+			Expect(w.Delete(ctx, t.Key, false)).To(Succeed())
+			Expect(provider.deleteCalls).To(Equal(deleteCalls + 1))
+			Expect(provider.configs).ToNot(HaveKey(t.Key))
+		})
+
+		It("Should not dispatch internal task deletion to the provider", func(ctx SpecContext) {
+			t := task.Task{
+				Key:      task.NewKey(testRack.Key, 0),
+				Type:     "fake_typed",
+				Name:     "Internal Delete",
+				Internal: true,
+			}
+			Expect(w.Create(ctx, &t)).To(Succeed())
+			deleteCalls := provider.deleteCalls
+			Expect(w.Delete(ctx, t.Key, true)).To(Succeed())
+			Expect(provider.deleteCalls).To(Equal(deleteCalls))
+		})
+
+		It("Should delete a task that does not exist without provider calls", func(ctx SpecContext) {
+			deleteCalls := provider.deleteCalls
+			Expect(w.Delete(ctx, task.NewKey(testRack.Key, 60000), false)).To(Succeed())
+			Expect(provider.deleteCalls).To(Equal(deleteCalls))
+		})
+	})
+
+	Describe("Copy", func() {
+		It("Should copy the provider's config record and link the new task", func(ctx SpecContext) {
+			cfg := msgpack.EncodedJSON{"param": "copy"}
+			t := task.Task{Key: task.NewKey(testRack.Key, 0), Type: "fake_typed", Name: "Source", Config: cfg}
+			Expect(w.Create(ctx, &t)).To(Succeed())
+			copied := MustSucceed(w.Copy(ctx, t.Key, "Copy", false))
+			Expect(provider.configs[copied.Key]).To(Equal(cfg))
+			var children []ontology.Resource
+			Expect(otg.NewRetrieve().
+				WhereIDs(task.OntologyID(copied.Key)).
+				TraverseTo(ontology.ChildrenTraverser).
+				Entries(&children).
+				Exec(ctx, tx)).To(Succeed())
+			Expect(children).To(HaveLen(1))
+			Expect(children[0].ID).To(Equal(fakeConfigID(copied.Key)))
+		})
+	})
+
+	Describe("DecodeConfig", func() {
+		type decoded struct{ Value string }
+		failing := func(msgpack.EncodedJSON) (decoded, error) {
+			return decoded{}, errors.New("current schema mismatch")
+		}
+		succeeding := func(cfg msgpack.EncodedJSON) (decoded, error) {
+			return decoded{Value: cfg["param"].(string)}, nil
+		}
+
+		It("Should return the first successful decode", func(ctx SpecContext) {
+			cfg := msgpack.EncodedJSON{"param": "v"}
+			Expect(task.DecodeConfig(cfg, succeeding, failing)).To(Equal(decoded{Value: "v"}))
+		})
+
+		It("Should fall back to older decoders", func(ctx SpecContext) {
+			cfg := msgpack.EncodedJSON{"param": "old"}
+			Expect(task.DecodeConfig(cfg, failing, succeeding)).To(Equal(decoded{Value: "old"}))
+		})
+
+		It("Should return the first decoder's error when all fail", func(ctx SpecContext) {
+			Expect(task.DecodeConfig(msgpack.EncodedJSON{}, failing, failing)).Error().
+				To(MatchError(ContainSubstring("current schema mismatch")))
+		})
+
+		It("Should error when no decoders are provided", func(ctx SpecContext) {
+			Expect(task.DecodeConfig[decoded](msgpack.EncodedJSON{})).Error().
+				To(MatchError(task.ErrNoConfigDecoders))
+		})
+	})
+})

--- a/core/pkg/service/task/service.go
+++ b/core/pkg/service/task/service.go
@@ -103,6 +103,7 @@ type Service struct {
 	group             group.Group
 	table             *gorp.Table[Key, Task]
 	commandChannelKey channel.Key
+	configProviders   configProviders
 }
 
 // Observe returns an observable that notifies callers of changes to task entries.
@@ -199,12 +200,13 @@ func (s *Service) Close() error { return s.closer.Close() }
 func (s *Service) NewWriter(tx gorp.Tx) Writer {
 	tx = gorp.OverrideTx(s.cfg.DB, tx)
 	return Writer{
-		tx:     tx,
-		otg:    s.cfg.Ontology.NewWriter(tx),
-		rack:   s.cfg.Rack.NewWriter(tx),
-		group:  s.group,
-		status: status.NewWriter[StatusDetails](s.cfg.Status, tx),
-		table:  s.table,
+		tx:        tx,
+		otg:       s.cfg.Ontology.NewWriter(tx),
+		rack:      s.cfg.Rack.NewWriter(tx),
+		group:     s.group,
+		status:    status.NewWriter[StatusDetails](s.cfg.Status, tx),
+		table:     s.table,
+		providers: &s.configProviders,
 	}
 }
 

--- a/core/pkg/service/task/writer.go
+++ b/core/pkg/service/task/writer.go
@@ -17,18 +17,21 @@ import (
 	"github.com/synnaxlabs/synnax/pkg/distribution/ontology"
 	"github.com/synnaxlabs/synnax/pkg/service/rack"
 	"github.com/synnaxlabs/synnax/pkg/service/status"
+	"github.com/synnaxlabs/x/errors"
 	"github.com/synnaxlabs/x/gorp"
+	"github.com/synnaxlabs/x/query"
 	xstatus "github.com/synnaxlabs/x/status"
 	"github.com/synnaxlabs/x/telem"
 )
 
 type Writer struct {
-	tx     gorp.Tx
-	otg    ontology.Writer
-	rack   rack.Writer
-	group  group.Group
-	status status.Writer[StatusDetails]
-	table  *gorp.Table[Key, Task]
+	tx        gorp.Tx
+	otg       ontology.Writer
+	rack      rack.Writer
+	group     group.Group
+	status    status.Writer[StatusDetails]
+	table     *gorp.Table[Key, Task]
+	providers *configProviders
 }
 
 func resolveStatus(t *Task, provided *status.Status[StatusDetails]) *status.Status[StatusDetails] {
@@ -60,11 +63,13 @@ func (w Writer) Create(ctx context.Context, t *Task) error {
 	}
 	providedStatus := (*status.Status[StatusDetails])(t.Status) // Preserve before clearing for gorp
 	t.Status = nil                                              // Status stored separately, not in gorp
+	cfg := t.Config
 	if err := w.table.NewCreate().
 		MergeExisting(func(_ gorp.Context, creating, existing Task) (Task, error) {
 			if existing.Snapshot {
 				creating.Config = existing.Config
 			}
+			cfg = creating.Config
 			return creating, nil
 		}).
 		Entry(t).
@@ -81,28 +86,62 @@ func (w Writer) Create(ctx context.Context, t *Task) error {
 	}
 	otgID := OntologyID(t.Key)
 	exists, err := w.otg.HasResource(ctx, otgID)
-	if err != nil || exists {
+	if err != nil {
 		return err
 	}
-	if err = w.otg.DefineResource(ctx, otgID); err != nil {
+	if !exists {
+		if err = w.otg.DefineResource(ctx, otgID); err != nil {
+			return err
+		}
+		if err = w.otg.DefineRelationship(
+			ctx,
+			w.group.OntologyID(),
+			ontology.RelationshipTypeParentOf,
+			otgID,
+		); err != nil {
+			return err
+		}
+	}
+	p, ok := w.providers.get(t.Type)
+	if !ok {
+		return nil
+	}
+	configID, err := p.Create(ctx, w.tx, t.Key, t.Type, cfg)
+	if err != nil {
 		return err
 	}
 	return w.otg.DefineRelationship(
 		ctx,
-		w.group.OntologyID(),
-		ontology.RelationshipTypeParentOf,
 		otgID,
+		ontology.RelationshipTypeParentOf,
+		configID,
 	)
 }
 
-// Delete deletes the task with the given key and its associated status.
+// Delete deletes the task with the given key, its associated status, and any config
+// record held by the task type's registered config provider.
 func (w Writer) Delete(ctx context.Context, key Key, allowInternal bool) error {
-	if err := w.table.NewDelete().
+	var t Task
+	err := w.table.NewRetrieve().
+		Where(gorp.MatchKeys[Key, Task](key)).
+		Entry(&t).
+		Exec(ctx, w.tx)
+	if err != nil && !errors.Is(err, query.ErrNotFound) {
+		return err
+	}
+	if err == nil && !t.Internal {
+		if p, ok := w.providers.get(t.Type); ok {
+			if err = p.Delete(ctx, w.tx, key); err != nil {
+				return err
+			}
+		}
+	}
+	if err = w.table.NewDelete().
 		Where(gorp.MatchKeys[Key, Task](key)).
 		Exec(ctx, w.tx); err != nil {
 		return err
 	}
-	if err := w.otg.DeleteResource(ctx, OntologyID(key)); err != nil {
+	if err = w.otg.DeleteResource(ctx, OntologyID(key)); err != nil {
 		return err
 	}
 	return w.status.Delete(ctx, OntologyID(key).String())
@@ -133,6 +172,25 @@ func (w Writer) Copy(
 		return Task{}, err
 	}
 	if err = w.otg.DefineResource(ctx, OntologyID(newKey)); err != nil {
+		return Task{}, err
+	}
+	if res.Internal {
+		return res, nil
+	}
+	p, ok := w.providers.get(res.Type)
+	if !ok {
+		return res, nil
+	}
+	configID, err := p.Copy(ctx, w.tx, key, newKey)
+	if err != nil {
+		return Task{}, err
+	}
+	if err = w.otg.DefineRelationship(
+		ctx,
+		OntologyID(newKey),
+		ontology.RelationshipTypeParentOf,
+		configID,
+	); err != nil {
 		return Task{}, err
 	}
 	return res, nil


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4360](https://linear.app/synnax/issue/SY-4360)

## Description

Phase 1 of the task/config split (RFC 0042, #2471): the type-agnostic machinery that
lets per-integration config services plug into the task service. Inert in production:
no providers are registered, so behavior is byte-identical to today.

- **`ConfigProvider` interface + registry** (`core/pkg/service/task/config.go`).
  Providers register exact task-type strings (mirroring imex's per-subtype importers);
  duplicate registration errors. All provider methods receive the task writer's
  `gorp.Tx`, so a task and its config are created, copied, or deleted in one
  transaction.
- **Writer dispatch.** `Create` routes the effective config (including the
  snapshot-preserved config on updates) to the matching provider and defines the
  `task -> parent -> config` ontology relationship. `Delete` and `Copy` route through
  the provider. Internal tasks and task types without a provider take the existing
  embedded-blob path unchanged. The blob keeps being written alongside the typed
  record (dual-write), per the RFC's downgrade-safe rollout.
- **Wire composition.** `task.Service.ResolveConfigs` fills `Task.Config` from the
  provider on the API retrieve path, falling back to the stored blob when the provider
  has no record, so mixed states (pre-bootstrap tasks) resolve correctly.
- **`DecodeConfig` helper.** The newest-first decode chain providers will use to
  normalize old-shaped wire input through the same versioned transforms as storage
  migration.

Covered by a fake-provider Ginkgo suite (registration conflicts, dispatch, internal
exclusion, fallback, snapshot preservation, delete/copy routing, resolution fallback,
decode chain). Task, driver, and rack suites pass.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces Phase 1 of the task/config split (RFC 0042): a `ConfigProvider` interface and registry that lets per-integration config services plug into the task service, with writer dispatch for Create/Delete/Copy and a `ResolveConfigs` read path that fills `Task.Config` from the provider, falling back to the stored blob for unregistered types and pre-bootstrap tasks. Because no providers are registered yet, runtime behavior is byte-identical to the current state.

- **`ConfigProvider` + registry** (`config.go`): thread-safe registration with duplicate-type detection; `ResolveConfigs` skips internal tasks, unknown types, and tasks whose provider returns `ErrNotFound`, correctly handling mixed migration states.
- **Writer dispatch** (`writer.go`): `Create` captures the snapshot-preserved config before gorp write and routes it to the provider; `Delete` pre-fetches the task to determine its type and internal flag before dispatching; `Copy` links the duplicated config resource to the new task's ontology node.
- **`DecodeConfig` helper** (`config.go`): generic newest-first decode chain returning the first success or the first (current-schema) error, with `ErrNoConfigDecoders` for the zero-decoder case; backed by a thorough Ginkgo suite.

<h3>Confidence Score: 4/5</h3>

Safe to merge as written — no providers are registered in production yet, so all new dispatch paths are unreachable and runtime behavior is unchanged.

The writer's Copy path has no fallback for query.ErrNotFound from p.Copy, unlike ResolveConfigs which explicitly handles pre-bootstrap tasks. Once providers go live in a later phase, copying an unbootstrapped source task will fail rather than silently falling back to the stored blob.

core/pkg/service/task/writer.go — specifically the Copy function's provider dispatch block.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| core/pkg/service/task/config.go | Introduces ConfigProvider interface, configProviders registry (with RWMutex for concurrent safety), ResolveConfigs with ErrNotFound fallback for mixed-state reads, and DecodeConfig generic helper. All logic is well-structured and properly handles edge cases. |
| core/pkg/service/task/writer.go | Wires provider dispatch into Create (with snapshot-preserved config capture), Delete (with pre-lookup and internal guard), and Copy (config duplication + ontology linking). Copy lacks the ErrNotFound fallback present in ResolveConfigs, which could surface failures for pre-bootstrap source tasks when providers go live. |
| core/pkg/service/task/config_test.go | Comprehensive Ginkgo suite covering registration conflicts, dispatch, internal exclusion, snapshot preservation, ErrNotFound fallback in ResolveConfigs, delete/copy routing, and DecodeConfig chain. No missing coverage for the tested paths. |
| core/pkg/service/task/service.go | Minimal diff: adds configProviders field to Service and passes &s.configProviders into NewWriter. Clean and correct. |
| core/pkg/api/task/task.go | Adds ResolveConfigs call after the retrieve query and before status augmentation, correctly using nil tx (falls back to DB). Single-line addition is correct and well-placed. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant API as api/task
    participant W as Writer
    participant T as gorp.Table
    participant P as ConfigProvider
    participant O as Ontology

    note over API,O: Create / Update path
    API->>W: Create(ctx, task)
    W->>T: NewCreate + MergeExisting (snapshot cfg preserved)
    T-->>W: merged task (cfg captured)
    W->>O: HasResource(taskID)
    alt first creation
        W->>O: DefineResource(taskID)
        W->>O: DefineRelationship(group → task)
    end
    alt "provider registered && not internal"
        W->>P: Create(ctx, tx, key, type, cfg)
        P-->>W: configID
        W->>O: DefineRelationship(task → config)
    end

    note over API,O: Retrieve path (ResolveConfigs)
    API->>W: Retrieve query
    W-->>API: []Task (with stored blobs)
    API->>P: ResolveConfigs(ctx, nil, tasks)
    loop each non-internal task with provider
        P->>P: Load(ctx, tx, key)
        alt found
            P-->>API: cfg (overrides stored blob)
        else ErrNotFound
            note over API: fallback: keep stored blob
        end
    end

    note over API,O: Delete path
    API->>W: Delete(ctx, key, allowInternal)
    W->>T: Retrieve(key) → task
    alt "task found && not internal && provider exists"
        W->>P: Delete(ctx, tx, key)
    end
    W->>T: Delete(key)
    W->>O: DeleteResource(taskID)

    note over API,O: Copy path
    API->>W: Copy(ctx, key, name, snapshot)
    W->>T: NewUpdate (clones entry with newKey)
    W->>O: DefineResource(newTaskID)
    alt "not internal && provider exists"
        W->>P: Copy(ctx, tx, from, to)
        P-->>W: configID
        W->>O: DefineRelationship(newTask → config)
    end
```

<sub>Reviews (1): Last reviewed commit: ["SY-4360: Task config provider registry a..."](https://github.com/synnaxlabs/synnax/commit/dc2c0ac54bd261f5f05d40c825381fa1f9eec1dd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36769473)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->