### PR TITLE
SY-4362: Fix Log Lifecycle Integration Test Notification Interception

### DIFF
--- a/integration/console/log.py
+++ b/integration/console/log.py
@@ -37,7 +37,13 @@ class Log(ConsolePage):
             self.set_channel(channel_name)
 
     def clear_channels(self) -> None:
-        """Remove all currently selected channels from the log."""
+        """Remove all currently selected channels from the log.
+
+        The remove buttons sit at the right edge of the bottom toolbar, directly
+        under the notification stack, so an open notification (e.g. a recurring
+        driver failure status) intercepts the click. Silence notifications
+        before each attempt and retry once on interception.
+        """
         self.layout.show_visualization_toolbar()
         toolbar = self.page.locator(".console-log-toolbar")
         while True:
@@ -46,7 +52,12 @@ class Log(ConsolePage):
             )
             if remove_btns.count() == 0:
                 break
-            remove_btns.first.click()
+            self.layout.notifications.close_all()
+            try:
+                remove_btns.first.click(timeout=5000)
+            except PlaywrightTimeoutError:
+                self.layout.notifications.close_all()
+                remove_btns.first.click()
 
     def set_channel(self, channel_name: str) -> None:
         """Add a channel to the log via the 'Add a channel...' row."""

--- a/integration/console/log.py
+++ b/integration/console/log.py
@@ -57,7 +57,7 @@ class Log(ConsolePage):
                 remove_btns.first.click(timeout=5000)
             except PlaywrightTimeoutError:
                 self.layout.notifications.close_all()
-                remove_btns.first.click()
+                remove_btns.first.click(timeout=5000)
 
     def set_channel(self, channel_name: str) -> None:
         """Add a channel to the log via the 'Add a channel...' row."""


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4362](https://linear.app/synnax/issue/SY-4362)

## Description

`console/log/log_lifecycle` fails consistently on `rc` (both Ubuntu and Windows, including retries) since `test_timestamp_channel_streaming` was added in SY-4345. The failing step is `log.clear_channels()`: the channel-row remove button renders at the far right edge of the bottom visualization toolbar, directly under the console notification stack (`bottom: 3rem; right: 3rem; z-index: 20`). In CI, two notifications occupy that spot for the whole test: a persistent core/client version-mismatch warning and an OPC UA "Failed to reach server" critical status that the driver scan task re-raises every ~10s (a device left over from `task_lifecycle` keeps failing to connect after the simulator shuts down). Playwright retries the click for the full 15s timeout and is intercepted every time.

`clear_channels` now silences notifications before each remove-button click and retries once on interception. Silencing adds the status key to the aggregator's silenced set, so the recurring OPC UA status cannot re-appear mid-loop, unlike a plain dismissal that would race with the next re-raise. This matches the existing `notifications.close_all()` pattern used by the arc and channels clients.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes a flaky CI integration test by silencing the notification stack before each remove-button click in `clear_channels()`, with a single retry on interception. This prevents recurring OPC UA and version-mismatch notifications from overlapping the toolbar button in CI.

- `clear_channels()` now calls `notifications.close_all()` before each click attempt and catches `PlaywrightTimeoutError` to silence and retry once, matching the pattern used in arc/channels clients.
- The `PlaywrightTimeoutError` import is already present in the module from prior use.

<h3>Confidence Score: 4/5</h3>

The change is safe to merge — it only affects the integration test helper for clearing log channels and cannot affect production code.

The fix is straightforward and well-motivated. The only notable rough edge is that the retry click omits an explicit timeout, so a second consecutive interception would leave the test hanging for the default 30 s before surfacing an error, instead of the 5 s used on the first attempt.

integration/console/log.py — specifically the timeout on the retry click in clear_channels().

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| integration/console/log.py | Adds notification-silencing + retry logic around the remove-button click in clear_channels() to fix CI interception; second retry uses default Playwright timeout (30 s) instead of the 5 s used on the first attempt. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[clear_channels called] --> B[show_visualization_toolbar]
    B --> C{remove_btns.count == 0?}
    C -- yes --> D[break / return]
    C -- no --> E[notifications.close_all]
    E --> F[remove_btns.first.click timeout=5s]
    F -- success --> C
    F -- PlaywrightTimeoutError --> G[notifications.close_all again]
    G --> H[remove_btns.first.click default timeout ~30s]
    H -- success --> C
    H -- PlaywrightTimeoutError --> I[exception propagates up]
```

<sub>Reviews (1): Last reviewed commit: ["SY-4362: Silence notifications before cl..."](https://github.com/synnaxlabs/synnax/commit/19caf02a0f53ce9258ecf90ed7f3d5ab7f1f6a57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36802031)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->