### PR TITLE
SY-4363: Consolidate Ontology Writer Resource and Relationship Methods

### DIFF
--- a/core/pkg/distribution/channel/lease_proxy.go
+++ b/core/pkg/distribution/channel/lease_proxy.go
@@ -502,17 +502,17 @@ func (s *Service) maybeSetResources(
 		return OntologyID(ch.Key()), !ch.Internal
 	})
 	w := s.cfg.Ontology.NewWriter(txn)
-	if err := w.DefineManyResources(ctx, externalIDs); err != nil {
+	if err := w.DefineResource(ctx, externalIDs...); err != nil {
 		return err
 	}
 	if opts.CreateWithoutGroupRelationship {
 		return nil
 	}
-	return w.DefineFromOneToManyRelationships(
+	return w.DefineRelationship(
 		ctx,
 		group.OntologyID(s.group.Key),
 		ontology.RelationshipTypeParentOf,
-		externalIDs,
+		externalIDs...,
 	)
 }
 
@@ -619,7 +619,7 @@ func (s *Service) maybeDeleteResources(
 	}
 	ids := lo.Map(keys, func(k Key, _ int) ontology.ID { return OntologyID(k) })
 	w := s.cfg.Ontology.NewWriter(tx)
-	return w.DeleteManyResources(ctx, ids)
+	return w.DeleteResource(ctx, ids...)
 }
 
 func (s *Service) deleteRemote(ctx context.Context, target node.Key, keys Keys) error {

--- a/core/pkg/distribution/ontology/ontology.go
+++ b/core/pkg/distribution/ontology/ontology.go
@@ -57,13 +57,12 @@ type Ontology struct {
 	relIndexes           relationshipIndexes
 }
 
-// relationshipIndexes bundles the secondary indexes registered on the
-// relationship table. relByTo answers "given an ID, which relationships
-// point at it" in O(1), which is the lookup that ParentsTraverser would
-// otherwise serve via a full pebble scan. relByFrom is the symmetric
-// from-keyed index used by ChildrenTraverser; it duplicates work that the
-// from-prefix scan already does cheaply, but having both directions in the
-// index lets the traverse dispatcher pick the index uniformly without
+// relationshipIndexes bundles the secondary indexes registered on the relationship
+// table. relByTo answers "given an ID, which relationships point at it" in O(1), which
+// is the lookup that ParentsTraverser would otherwise serve via a full pebble scan.
+// relByFrom is the symmetric from-keyed index used by ChildrenTraverser; it duplicates
+// work that the from-prefix scan already does cheaply, but having both directions in
+// the index lets the traverse dispatcher pick the index uniformly without
 // special-casing direction.
 type relationshipIndexes struct {
 	byTo   *gorp.LookupIndex[string, Relationship, ID]
@@ -72,11 +71,11 @@ type relationshipIndexes struct {
 
 func newRelationshipIndexes() relationshipIndexes {
 	return relationshipIndexes{
-		byTo: gorp.NewLookupIndex[string, Relationship, ID](
+		byTo: gorp.NewLookupIndex(
 			"relationship_by_to",
 			func(r *Relationship) ID { return r.To },
 		),
-		byFrom: gorp.NewLookupIndex[string, Relationship, ID](
+		byFrom: gorp.NewLookupIndex(
 			"relationship_by_from",
 			func(r *Relationship) ID { return r.From },
 		),
@@ -92,10 +91,7 @@ type Config struct {
 	alamos.Instrumentation
 }
 
-var (
-	_             config.Config[Config] = Config{}
-	DefaultConfig                       = Config{}
-)
+var _ config.Config[Config] = Config{}
 
 // Validate implements config.Config.
 func (c Config) Validate() error {
@@ -114,7 +110,7 @@ func (c Config) Override(other Config) Config {
 // Open opens the ontology using the given configuration. If the RootID resource does
 // not exist, it will be created.
 func Open(ctx context.Context, configs ...Config) (o *Ontology, err error) {
-	cfg, err := config.New(DefaultConfig, configs...)
+	cfg, err := config.New(Config{}, configs...)
 	if err != nil {
 		return nil, err
 	}
@@ -159,31 +155,24 @@ func Open(ctx context.Context, configs ...Config) (o *Ontology, err error) {
 
 // Writer defines and deletes resources within the ontology.
 type Writer interface {
-	// DefineResource defines a new resource with the given ID. If the resource already
-	// exists, DefineResource does nothing.
-	DefineResource(context.Context, ID) error
+	// DefineResource defines one or more new resources with the given IDs. If any of
+	// the resources already exist, DefineResource does nothing for those. Returns nil
+	// if no IDs are provided.
+	DefineResource(context.Context, ...ID) error
 	// HasResource returns true if the resource with the given ID exists.
 	HasResource(context.Context, ID) (bool, error)
-	// DefineManyResources defines multiple resources with the given IDs. If any of the
-	// resources already exist, DefineManyResources does nothing.
-	DefineManyResources(context.Context, []ID) error
-	// DeleteResource deletes the resource with the given ID along with all of its
-	// incoming and outgoing relationships.  If the resource does not exist,
-	// DeleteResource does nothing.
-	DeleteResource(context.Context, ID) error
-	// DeleteManyResources deletes multiple resources with the given IDs along with all
-	// of their incoming and outgoing relationships. If any of the resources do not
-	// exist, DeleteManyResources does nothing.
-	DeleteManyResources(context.Context, []ID) error
+	// DeleteResource deletes one or more resources with the given IDs along with all of
+	// their incoming and outgoing relationships. If any of the resources do not exist,
+	// DeleteResource does nothing for those. Returns nil if no IDs are provided.
+	DeleteResource(context.Context, ...ID) error
 	HasRelationship(ctx context.Context, from ID, t RelationshipType, to ID) (bool, error)
-	// DefineRelationship defines a directional relationship of type t between the
-	// resources with the given keys. If the relationship already exists,
-	// DefineRelationship does nothing.
-	DefineRelationship(ctx context.Context, from ID, t RelationshipType, to ID) error
-	// DefineFromOneToManyRelationships defines a directional relationship of type t
-	// from the resource with the given ID to multiple resources. If any of the
-	// relationships already exist, DefineFromOneToManyRelationships does nothing.
-	DefineFromOneToManyRelationships(ctx context.Context, from ID, t RelationshipType, to []ID) error
+	// DefineRelationship defines a directional relationship of type t from the resource
+	// with the given from ID to one or more to IDs. Already-existing relationships are
+	// silently skipped. Returns graph.ErrCyclicDependency if any of the new
+	// relationships would create a cycle (including the case where the
+	// reverse-direction relationship already exists). Returns nil if no to IDs are
+	// provided.
+	DefineRelationship(ctx context.Context, from ID, t RelationshipType, to ...ID) error
 	// DeleteRelationship deletes the relationship with the given keys and type. If the
 	// relationship does not exist, DeleteRelationship does nothing.
 	DeleteRelationship(ctx context.Context, from ID, t RelationshipType, to ID) error
@@ -191,12 +180,12 @@ type Writer interface {
 	// types from the resource with the given ID. If the resource does not exist, or if
 	// it has no outgoing relationships of the given types,
 	// DeleteOutgoingRelationshipsOfTypes does nothing.
-	DeleteOutgoingRelationshipsOfType(ctx context.Context, from ID, relationshipType RelationshipType) error
+	DeleteOutgoingRelationshipsOfType(context.Context, ID, RelationshipType) error
 	// DeleteIncomingRelationshipsOfType deletes all incoming relationships of the given
 	// types to the resource with the given ID. If the resource does not exist, or if it
 	// has no incoming relationships of the given types,
 	// DeleteIncomingRelationshipsOfTypes does nothing.
-	DeleteIncomingRelationshipsOfType(ctx context.Context, to ID, relationshipType RelationshipType) error
+	DeleteIncomingRelationshipsOfType(context.Context, ID, RelationshipType) error
 	// NewRetrieve opens a new Retrieve query that provides a view of pending operations
 	// merged with the underlying database. If the Writer is executing directly against
 	// the underlying database, the Retrieve query behaves exactly as if calling

--- a/core/pkg/distribution/ontology/writer_dag.go
+++ b/core/pkg/distribution/ontology/writer_dag.go
@@ -84,6 +84,7 @@ func (d dagWriter) DefineRelationship(
 	if len(to) == 0 {
 		return nil
 	}
+	to = lo.Uniq(to)
 	if err := d.validateResourcesExist(ctx, from); err != nil {
 		return err
 	}

--- a/core/pkg/distribution/ontology/writer_dag.go
+++ b/core/pkg/distribution/ontology/writer_dag.go
@@ -109,21 +109,33 @@ func (d dagWriter) DefineRelationship(ctx context.Context, from ID, t Relationsh
 
 // DefineFromOneToManyRelationships implements the Writer interface.
 func (d dagWriter) DefineFromOneToManyRelationships(ctx context.Context, from ID, t RelationshipType, to []ID) error {
-	rels := lo.Map(to, func(id ID, _ int) Relationship { return Relationship{From: from, To: id, Type: t} })
 	if err := d.validateResourcesExist(ctx, from); err != nil {
 		return err
 	}
 	if err := d.validateResourcesExist(ctx, to...); err != nil {
 		return err
 	}
-	for _, rel := range rels {
-		descendants, err := d.retrieveDescendants(ctx, rel.To)
+	rels := make([]Relationship, 0, len(to))
+	for _, id := range to {
+		rel := Relationship{From: from, To: id, Type: t}
+		exists, err := d.checkRelationshipExists(ctx, rel)
 		if err != nil {
 			return err
 		}
-		if _, exists := descendants[from]; exists {
+		if exists {
+			continue
+		}
+		descendants, err := d.retrieveDescendants(ctx, id)
+		if err != nil {
+			return err
+		}
+		if _, cyclic := descendants[from]; cyclic {
 			return graph.ErrCyclicDependency
 		}
+		rels = append(rels, rel)
+	}
+	if len(rels) == 0 {
+		return nil
 	}
 	return d.relationshipTable.NewCreate().Entries(&rels).Exec(ctx, d.tx)
 }

--- a/core/pkg/distribution/ontology/writer_dag.go
+++ b/core/pkg/distribution/ontology/writer_dag.go
@@ -32,16 +32,10 @@ type dagWriter struct {
 var _ Writer = dagWriter{}
 
 // DefineResource implements the Writer interface.
-func (d dagWriter) DefineResource(ctx context.Context, tk ID) error {
-	if err := tk.Validate(); err != nil {
-		return err
+func (d dagWriter) DefineResource(ctx context.Context, ids ...ID) error {
+	if len(ids) == 0 {
+		return nil
 	}
-	return d.resourceTable.NewCreate().
-		Entry(&Resource{ID: tk}).
-		Exec(ctx, d.tx)
-}
-
-func (d dagWriter) DefineManyResources(ctx context.Context, ids []ID) error {
 	for _, id := range ids {
 		if err := id.Validate(); err != nil {
 			return err
@@ -49,18 +43,23 @@ func (d dagWriter) DefineManyResources(ctx context.Context, ids []ID) error {
 	}
 	resources := lo.Map(ids, func(id ID, _ int) Resource { return Resource{ID: id} })
 	return d.resourceTable.NewCreate().Entries(&resources).Exec(ctx, d.tx)
-
 }
 
 // DeleteResource implements the Writer interface.
-func (d dagWriter) DeleteResource(ctx context.Context, id ID) error {
-	if err := d.deleteIncomingRelationships(ctx, id); err != nil {
-		return err
+func (d dagWriter) DeleteResource(ctx context.Context, ids ...ID) error {
+	if len(ids) == 0 {
+		return nil
 	}
-	if err := d.deleteOutgoingRelationships(ctx, id); err != nil {
-		return err
+	for _, id := range ids {
+		if err := d.deleteIncomingRelationships(ctx, id); err != nil {
+			return err
+		}
+		if err := d.deleteOutgoingRelationships(ctx, id); err != nil {
+			return err
+		}
 	}
-	return d.resourceTable.NewDelete().Where(gorp.MatchKeys[string, Resource](id.String())).Exec(ctx, d.tx)
+	return d.resourceTable.NewDelete().
+		Where(gorp.MatchKeys[string, Resource](IDsToKeys(ids)...)).Exec(ctx, d.tx)
 }
 
 func (d dagWriter) HasResource(ctx context.Context, id ID) (bool, error) {
@@ -75,40 +74,16 @@ func (d dagWriter) HasRelationship(ctx context.Context, from ID, t RelationshipT
 	})
 }
 
-func (d dagWriter) DeleteManyResources(ctx context.Context, ids []ID) error {
-	for _, id := range ids {
-		if err := d.deleteIncomingRelationships(ctx, id); err != nil {
-			return err
-		}
-		if err := d.deleteOutgoingRelationships(ctx, id); err != nil {
-			return err
-		}
-	}
-	return d.resourceTable.NewDelete().Where(gorp.MatchKeys[string, Resource](IDsToKeys(ids)...)).Exec(ctx, d.tx)
-}
-
 // DefineRelationship implements the Writer interface.
-func (d dagWriter) DefineRelationship(ctx context.Context, from ID, t RelationshipType, to ID) error {
-	rel := Relationship{From: from, To: to, Type: t}
-	exists, err := d.checkRelationshipExists(ctx, rel)
-	if err != nil || exists {
-		return err
+func (d dagWriter) DefineRelationship(
+	ctx context.Context,
+	from ID,
+	t RelationshipType,
+	to ...ID,
+) error {
+	if len(to) == 0 {
+		return nil
 	}
-	if err := d.validateResourcesExist(ctx, from, to); err != nil {
-		return err
-	}
-	descendants, err := d.retrieveDescendants(ctx, to)
-	if err != nil {
-		return err
-	}
-	if _, exists := descendants[from]; exists {
-		return graph.ErrCyclicDependency
-	}
-	return d.relationshipTable.NewCreate().Entry(&rel).Exec(ctx, d.tx)
-}
-
-// DefineFromOneToManyRelationships implements the Writer interface.
-func (d dagWriter) DefineFromOneToManyRelationships(ctx context.Context, from ID, t RelationshipType, to []ID) error {
 	if err := d.validateResourcesExist(ctx, from); err != nil {
 		return err
 	}

--- a/core/pkg/distribution/ontology/writer_test.go
+++ b/core/pkg/distribution/ontology/writer_test.go
@@ -153,6 +153,60 @@ var _ = Describe("Writer", func() {
 					[]ontology.ID{idOne},
 				)).Error().To(MatchError(graph.ErrCyclicDependency))
 			})
+			It("Should return an error if one of the targets creates a transitive cycle", func(ctx SpecContext) {
+				idThree := newSampleType("baz")
+				Expect(w.DefineResource(ctx, idThree)).To(Succeed())
+				Expect(w.DefineRelationship(ctx, idOne, ontology.RelationshipTypeParentOf, idTwo)).To(Succeed())
+				Expect(w.DefineRelationship(ctx, idTwo, ontology.RelationshipTypeParentOf, idThree)).To(Succeed())
+				Expect(w.DefineFromOneToManyRelationships(
+					ctx,
+					idThree,
+					ontology.RelationshipTypeParentOf,
+					[]ontology.ID{idOne},
+				)).Error().To(MatchError(graph.ErrCyclicDependency))
+			})
+			It("Should be idempotent when called twice with the same arguments", func(ctx SpecContext) {
+				Expect(w.DefineFromOneToManyRelationships(
+					ctx,
+					idOne,
+					ontology.RelationshipTypeParentOf,
+					[]ontology.ID{idTwo},
+				)).To(Succeed())
+				Expect(w.DefineFromOneToManyRelationships(
+					ctx,
+					idOne,
+					ontology.RelationshipTypeParentOf,
+					[]ontology.ID{idTwo},
+				)).To(Succeed())
+				var res []ontology.Resource
+				Expect(w.NewRetrieve().
+					WhereIDs(idOne).
+					TraverseTo(ontology.ChildrenTraverser).
+					Entries(&res).
+					Exec(ctx, tx)).To(Succeed())
+				Expect(res).To(HaveLen(1))
+				Expect(res[0].ID).To(Equal(idTwo))
+			})
+			It("Should skip already-existing relationships and create only the new ones", func(ctx SpecContext) {
+				idThree := newSampleType("baz")
+				Expect(w.DefineResource(ctx, idThree)).To(Succeed())
+				Expect(w.DefineRelationship(ctx, idOne, ontology.RelationshipTypeParentOf, idTwo)).To(Succeed())
+				Expect(w.DefineFromOneToManyRelationships(
+					ctx,
+					idOne,
+					ontology.RelationshipTypeParentOf,
+					[]ontology.ID{idTwo, idThree},
+				)).To(Succeed())
+				var res []ontology.Resource
+				Expect(w.NewRetrieve().
+					WhereIDs(idOne).
+					TraverseTo(ontology.ChildrenTraverser).
+					Entries(&res).
+					Exec(ctx, tx)).To(Succeed())
+				Expect(res).To(HaveLen(2))
+				gotIDs := []ontology.ID{res[0].ID, res[1].ID}
+				Expect(gotIDs).To(ConsistOf(idTwo, idThree))
+			})
 		})
 		Describe("Deleting a Relationship", func() {
 			It("Should delete a relationship by its ID", func(ctx SpecContext) {

--- a/core/pkg/distribution/ontology/writer_test.go
+++ b/core/pkg/distribution/ontology/writer_test.go
@@ -38,7 +38,7 @@ var _ = Describe("Writer", func() {
 		})
 		It("Should define many resources by their names", func(ctx SpecContext) {
 			ids := []ontology.ID{id, newSampleType("bar")}
-			Expect(w.DefineManyResources(ctx, ids)).To(Succeed())
+			Expect(w.DefineResource(ctx, ids...)).To(Succeed())
 			Expect(w.NewRetrieve().WhereIDs(ids...).Exec(ctx, tx)).To(Succeed())
 		})
 		Describe("Deleting a Resource", func() {
@@ -121,11 +121,11 @@ var _ = Describe("Writer", func() {
 		})
 		Describe("Defining a Relationship to Many Resources", func() {
 			It("Should define a relationship to many resources by their IDs", func(ctx SpecContext) {
-				Expect(w.DefineFromOneToManyRelationships(
+				Expect(w.DefineRelationship(
 					ctx,
 					idOne,
 					ontology.RelationshipTypeParentOf,
-					[]ontology.ID{idTwo},
+					idTwo,
 				)).To(Succeed())
 				var res []ontology.Resource
 				Expect(w.NewRetrieve().
@@ -137,20 +137,20 @@ var _ = Describe("Writer", func() {
 				Expect(res[0].ID).To(Equal(idTwo))
 			})
 			It("Should return an error if any of the resources are not defined", func(ctx SpecContext) {
-				Expect(w.DefineFromOneToManyRelationships(
+				Expect(w.DefineRelationship(
 					ctx,
 					idOne,
 					ontology.RelationshipTypeParentOf,
-					[]ontology.ID{newSampleType("42")},
+					newSampleType("42"),
 				)).To(MatchError(query.ErrNotFound))
 			})
 			It("Should return an error if a cyclic relationship is created", func(ctx SpecContext) {
 				Expect(w.DefineRelationship(ctx, idOne, ontology.RelationshipTypeParentOf, idTwo)).To(Succeed())
-				Expect(w.DefineFromOneToManyRelationships(
+				Expect(w.DefineRelationship(
 					ctx,
 					idTwo,
 					ontology.RelationshipTypeParentOf,
-					[]ontology.ID{idOne},
+					idOne,
 				)).Error().To(MatchError(graph.ErrCyclicDependency))
 			})
 			It("Should return an error if one of the targets creates a transitive cycle", func(ctx SpecContext) {
@@ -158,25 +158,25 @@ var _ = Describe("Writer", func() {
 				Expect(w.DefineResource(ctx, idThree)).To(Succeed())
 				Expect(w.DefineRelationship(ctx, idOne, ontology.RelationshipTypeParentOf, idTwo)).To(Succeed())
 				Expect(w.DefineRelationship(ctx, idTwo, ontology.RelationshipTypeParentOf, idThree)).To(Succeed())
-				Expect(w.DefineFromOneToManyRelationships(
+				Expect(w.DefineRelationship(
 					ctx,
 					idThree,
 					ontology.RelationshipTypeParentOf,
-					[]ontology.ID{idOne},
+					idOne,
 				)).Error().To(MatchError(graph.ErrCyclicDependency))
 			})
 			It("Should be idempotent when called twice with the same arguments", func(ctx SpecContext) {
-				Expect(w.DefineFromOneToManyRelationships(
+				Expect(w.DefineRelationship(
 					ctx,
 					idOne,
 					ontology.RelationshipTypeParentOf,
-					[]ontology.ID{idTwo},
+					idTwo,
 				)).To(Succeed())
-				Expect(w.DefineFromOneToManyRelationships(
+				Expect(w.DefineRelationship(
 					ctx,
 					idOne,
 					ontology.RelationshipTypeParentOf,
-					[]ontology.ID{idTwo},
+					idTwo,
 				)).To(Succeed())
 				var res []ontology.Resource
 				Expect(w.NewRetrieve().
@@ -191,11 +191,11 @@ var _ = Describe("Writer", func() {
 				idThree := newSampleType("baz")
 				Expect(w.DefineResource(ctx, idThree)).To(Succeed())
 				Expect(w.DefineRelationship(ctx, idOne, ontology.RelationshipTypeParentOf, idTwo)).To(Succeed())
-				Expect(w.DefineFromOneToManyRelationships(
+				Expect(w.DefineRelationship(
 					ctx,
 					idOne,
 					ontology.RelationshipTypeParentOf,
-					[]ontology.ID{idTwo, idThree},
+					idTwo, idThree,
 				)).To(Succeed())
 				var res []ontology.Resource
 				Expect(w.NewRetrieve().

--- a/core/pkg/service/label/writer.go
+++ b/core/pkg/service/label/writer.go
@@ -53,7 +53,7 @@ func (w Writer) Delete(ctx context.Context, keys ...Key) error {
 	if err := w.table.NewDelete().Where(gorp.MatchKeys[Key, Label](keys...)).Exec(ctx, w.tx); err != nil {
 		return err
 	}
-	return w.otg.DeleteManyResources(ctx, OntologyIDs(keys))
+	return w.otg.DeleteResource(ctx, OntologyIDs(keys)...)
 }
 
 // Label assigns a set of labels to the target resource. If the target resource already

--- a/core/pkg/service/ranger/migrations/v0/migrate.go
+++ b/core/pkg/service/ranger/migrations/v0/migrate.go
@@ -163,13 +163,13 @@ func Migration(cfg MigrationConfig) migrate.Migration {
 				if err = otgWriter.DefineResource(ctx, OntologyID(newParentRange.Key)); err != nil {
 					return err
 				}
-				if err = otgWriter.DefineFromOneToManyRelationships(
+				if err = otgWriter.DefineRelationship(
 					ctx,
 					OntologyID(newParentRange.Key),
 					ontology.RelationshipTypeParentOf,
 					lo.Map(childRanges, func(r ontology.Resource, _ int) ontology.ID {
 						return r.ID
-					}),
+					})...,
 				); err != nil {
 					return err
 				}

--- a/core/pkg/service/task/service.go
+++ b/core/pkg/service/task/service.go
@@ -21,7 +21,7 @@ import (
 	"github.com/synnaxlabs/synnax/pkg/distribution/signals"
 	"github.com/synnaxlabs/synnax/pkg/service/rack"
 	"github.com/synnaxlabs/synnax/pkg/service/status"
-	"github.com/synnaxlabs/synnax/pkg/service/task/migrations/v0"
+	v0 "github.com/synnaxlabs/synnax/pkg/service/task/migrations/v0"
 	v54 "github.com/synnaxlabs/synnax/pkg/service/task/migrations/v54"
 	"github.com/synnaxlabs/x/config"
 	"github.com/synnaxlabs/x/gorp"
@@ -119,16 +119,13 @@ func OpenService(ctx context.Context, configs ...ServiceConfig) (s *Service, err
 	cleanup, ok := service.NewOpener(ctx, &s.closer)
 	defer func() { err = cleanup(err) }()
 	v0Mig := v0.Migration(v0.MigrationConfig{Status: cfg.Status})
-	if s.table, err = gorp.OpenTable[Key, Task](ctx, gorp.TableConfig[Key, Task]{
+	if s.table, err = gorp.OpenTable(ctx, gorp.TableConfig[Key, Task]{
 		DB: cfg.DB,
 		Migrations: []migrate.Migration{
 			v0Mig,
 			gorp.CodecMigration[v54.Key, v54.Task]("msgpack_to_orc", v0Mig.Key()),
 			migrate.WithAddedDeps(
-				gorp.NewEntryMigration[v54.Key, Key, v54.Task, Task](
-					"v54_drop_status",
-					MigrateTask,
-				),
+				gorp.NewEntryMigration("v54_drop_status", MigrateTask),
 				"msgpack_to_orc",
 			),
 		},
@@ -167,7 +164,7 @@ func OpenService(ctx context.Context, configs ...ServiceConfig) (s *Service, err
 	if sig, err = signals.PublishFromGorp(
 		ctx,
 		cfg.Signals,
-		signals.GorpPublisherConfigPureNumeric[Key, Task](s.table.Observe(), telem.Uint64T),
+		signals.GorpPublisherConfigPureNumeric(s.table.Observe(), telem.Uint64T),
 	); !ok(err, sig) {
 		return nil, err
 	}
@@ -189,7 +186,7 @@ func (s *Service) cleanupInternalOntologyResources(ctx context.Context) {
 	for _, t := range tasks {
 		ids = append(ids, OntologyID(t.Key))
 	}
-	if err := s.cfg.Ontology.NewWriter(nil).DeleteManyResources(ctx, ids); err != nil {
+	if err := s.cfg.Ontology.NewWriter(nil).DeleteResource(ctx, ids...); err != nil {
 		s.cfg.L.Warn("unable to delete internal task resources", zap.Error(err))
 	}
 }

--- a/core/pkg/service/user/root_test.go
+++ b/core/pkg/service/user/root_test.go
@@ -131,8 +131,8 @@ func purgeUsersAndAuth(ctx context.Context) {
 		if err := gorp.WrapWriter[user.Key, user.User](tx).Delete(ctx, keys...); err != nil {
 			return err
 		}
-		if err := otg.NewWriter(tx).DeleteManyResources(
-			ctx, user.OntologyIDsFromKeys(keys),
+		if err := otg.NewWriter(tx).DeleteResource(
+			ctx, user.OntologyIDsFromKeys(keys)...,
 		); err != nil {
 			return err
 		}

--- a/core/pkg/service/user/writer.go
+++ b/core/pkg/service/user/writer.go
@@ -116,5 +116,5 @@ func (w Writer) Delete(ctx context.Context, keys ...Key) error {
 		}).Exec(ctx, w.tx); err != nil {
 		return err
 	}
-	return w.otg.DeleteManyResources(ctx, OntologyIDsFromKeys(keys))
+	return w.otg.DeleteResource(ctx, OntologyIDsFromKeys(keys)...)
 }


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4363](https://linear.app/synnax/issue/SY-4363)

## Description

Consolidates the singular and plural ontology `Writer` methods into single variadic entry points:

- `DefineResource(ctx, ID)` + `DefineManyResources(ctx, []ID)` → `DefineResource(ctx, ...ID)`
- `DeleteResource(ctx, ID)` + `DeleteManyResources(ctx, []ID)` → `DeleteResource(ctx, ...ID)`
- `DefineRelationship(ctx, from, t, ID)` + `DefineFromOneToManyRelationships(ctx, from, t, []ID)` → `DefineRelationship(ctx, from, t, ...ID)`

The plural relationship method previously had a looser contract than its singular counterpart — no idempotent skip on already-existing relationships, and no reverse-direction cycle check. As a pre-requisite to consolidation, `DefineFromOneToManyRelationships` was tightened to match `DefineRelationship`'s behavior per-element so that the unified variadic method has one well-defined contract regardless of arity. Tests were added for idempotency, partial skip (existing + new), and transitive cycles caught through the descendants traversal.

All singular call sites (the vast majority) pass through unchanged under the new variadic signatures. The handful of slice-passing call sites in `label`, `user`, `task`, `channel/lease_proxy`, and `ranger/migrations/v0` were updated to spread with `...`.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR consolidates the `ontology.Writer` interface by merging three pairs of singular/plural methods into single variadic entry points (`DefineResource`, `DeleteResource`, `DefineRelationship`). As a prerequisite, the old plural `DefineFromOneToManyRelationships` was tightened to match the single-target contract — adding per-element idempotent skip and reverse-direction cycle detection — so the unified variadic form has one well-defined invariant regardless of arity.

- **`writer_dag.go`**: Three method pairs collapsed into three variadic methods; `lo.Uniq` deduplication added before the loop in `DefineRelationship`; batch resource/relationship writes preserved for the multi-element path.
- **`ontology.go`**: `Writer` interface updated to variadic signatures; `DefaultConfig` zero-value alias removed; type parameters elided where Go can infer them.
- **Call sites** across `label`, `user`, `task`, `channel/lease_proxy`, and `ranger/migrations/v0`: updated to spread-syntax (`ids...`) with no logic changes; new tests cover idempotency, partial-skip, and transitive cycle detection.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the consolidation is a pure API surface reduction with no behavioral regressions on existing call sites.

The variadic unification is mechanically straightforward: single-element callers are unaffected by the signature change, and multi-element callers now benefit from the tighter cycle-detection contract. The new per-element existence check order (resource validation before relationship check) is a net improvement in correctness. Tests cover idempotency, partial-skip, and transitive cycles. No data-loss or ordering hazards were found in the implementation.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| core/pkg/distribution/ontology/writer_dag.go | Core consolidation: DefineResource, DeleteResource, and DefineRelationship unified into variadic forms; the new DefineRelationship tightens the old many-to-many path to include per-element idempotent skip and reverse-direction cycle detection, matching the old single-target contract. |
| core/pkg/distribution/ontology/ontology.go | Writer interface updated to reflect unified variadic signatures; DefaultConfig variable removed in favour of Config{} inline; type-parameter elision on gorp.NewLookupIndex now uses Go inference. |
| core/pkg/distribution/ontology/writer_test.go | Tests updated to new API; four new cases added covering idempotency, partial-skip (existing + new), and transitive cycle detection; BeforeEach/tx rollback pattern ensures no cross-test state leakage. |
| core/pkg/distribution/channel/lease_proxy.go | Call sites updated from DefineManyResources/DefineFromOneToManyRelationships/DeleteManyResources to spread-syntax variadic forms; no logic changes. |
| core/pkg/service/ranger/migrations/v0/migrate.go | DefineFromOneToManyRelationships replaced with DefineRelationship spread; inline lo.Map spread is idiomatic and correct. |
| core/pkg/service/task/service.go | DeleteManyResources updated to DeleteResource spread; minor type-inference cleanup on gorp.OpenTable and signals.GorpPublisherConfigPureNumeric. |
| core/pkg/service/user/writer.go | DeleteManyResources updated to DeleteResource spread; no logic change. |
| core/pkg/service/user/root_test.go | Test helper updated from DeleteManyResources to DeleteResource spread; no logic change. |
| core/pkg/service/label/writer.go | One call site updated to DeleteResource spread; no logic change. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["DefineRelationship(ctx, from, t, to ...ID)"]
    A --> B{len == 0}
    B -- yes --> Z[return nil]
    B -- no --> C[lo.Uniq]
    C --> D[validateResourcesExist from]
    D --> E[validateResourcesExist to...]
    E --> F[for each id in to]
    F --> G[checkRelationshipExists]
    G --> H{reverse exists}
    H -- yes --> ERR1[ErrCyclicDependency]
    H -- no --> I{forward exists}
    I -- yes --> SKIP[skip continue]
    SKIP --> F
    I -- no --> J[retrieveDescendants id]
    J --> K{from in descendants}
    K -- yes --> ERR2[ErrCyclicDependency]
    K -- no --> L[append to batch]
    L --> F
    F -- done --> M{batch empty}
    M -- yes --> Z
    M -- no --> N[Entries.Exec batch write]
```

<sub>Reviews (2): Last reviewed commit: ["Address Greptile comment"](https://github.com/synnaxlabs/synnax/commit/ac8be6c7620dc2229b5c0db370d64c22f308dca8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=36834254)</sub>

<!-- /greptile_comment -->