### PR TITLE
SY-4284: Allow Arrow Keys to Move Individual Schematic Symbols

### DIFF
--- a/pluto/src/vis/diagram/Diagram.tsx
+++ b/pluto/src/vis/diagram/Diagram.tsx
@@ -88,6 +88,7 @@ const EDITABLE_PROPS: ReactFlowProps = {
   nodesDraggable: true,
   nodesConnectable: true,
   elementsSelectable: true,
+  nodesFocusable: true,
   zoomOnDoubleClick: false,
   nodeClickDistance: 5,
   reconnectRadius: 15,


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4284](https://linear.app/synnax/issue/SY-4284)

## Description

Previously, arrow keys would only nudge schematic objects after a lasso/box-selection. After a plain single click, arrow keys did nothing, even though the symbol was clearly selected.

The root cause was that schematic nodes were not keyboard-focusable in edit mode. React Flow only moves a node with the arrow keys while that node's DOM element holds keyboard focus. The `EDITABLE_PROPS` / `NOT_EDITABLE_PROPS` split disabled `nodesFocusable` for view mode but never re-enabled it for edit mode, so once a diagram had been rendered non-editable, its nodes stayed non-focusable (the React Flow store retains the last explicit value when the prop becomes `undefined`). Lasso selection still worked because React Flow focuses its own selection rectangle, which carries an independent key handler.

This change re-enables `nodesFocusable` in `EDITABLE_PROPS`, restoring the intended symmetry where every interaction `NOT_EDITABLE_PROPS` disables, `EDITABLE_PROPS` re-enables. With nodes focusable again, a single click focuses the symbol and the arrow keys nudge it (hold Shift for a larger step), matching the existing box-selection behavior.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.