### PR TITLE
SY-4408: Generate list and dict types for array aliases and maps in Oracle Python output

### DIFF
--- a/oracle/plugin/py/types/types.go
+++ b/oracle/plugin/py/types/types.go
@@ -341,9 +341,11 @@ func typeDefBaseToPython(typeRef resolution.TypeRef, currentNamespace string, ta
 	if resolution.IsPrimitive(typeRef.Name) {
 		return primitiveToPython(typeRef.Name, data)
 	}
-	// Handle Array type
+	// Handle Array type. Collection elements are resolved via typeToPython, which
+	// handles every form (struct, enum, alias, union); typeDefBaseToPython only
+	// special-cases distinct bases and would yield Any for a struct element.
 	if typeRef.Name == "Array" && len(typeRef.TypeArgs) > 0 {
-		elemType := typeDefBaseToPython(typeRef.TypeArgs[0], currentNamespace, table, data)
+		elemType := typeToPython(typeRef.TypeArgs[0], table, data)
 		// Fixed-size array -> tuple type
 		if typeRef.ArraySize != nil {
 			data.imports.addTyping("Tuple")
@@ -353,7 +355,13 @@ func typeDefBaseToPython(typeRef resolution.TypeRef, currentNamespace string, ta
 			}
 			return fmt.Sprintf("Tuple[%s]", strings.Join(elements, ", "))
 		}
-		return elemType
+		return fmt.Sprintf("list[%s]", elemType)
+	}
+	// Handle Map type
+	if typeRef.Name == "Map" && len(typeRef.TypeArgs) >= 2 {
+		keyType := typeToPython(typeRef.TypeArgs[0], table, data)
+		valueType := typeToPython(typeRef.TypeArgs[1], table, data)
+		return fmt.Sprintf("dict[%s, %s]", keyType, valueType)
 	}
 	// Try to resolve another typedef
 	resolved, ok := typeRef.Resolve(table)
@@ -1140,7 +1148,10 @@ func typeToPython(
 		return primitiveToPython(typeRef.Name, data)
 	}
 
-	// Handle Array type
+	// Handle Array type. The bare element type is returned (not list[...]); field
+	// processing wraps array-typed fields in list[...] itself off the element type,
+	// so wrapping here would double-wrap. Alias contexts that need list[...] use
+	// typeDefBaseToPython / typeRefToPythonAlias instead.
 	if typeRef.Name == "Array" && len(typeRef.TypeArgs) > 0 {
 		elemType := typeToPython(typeRef.TypeArgs[0], table, data)
 		// Fixed-size array -> tuple type
@@ -1153,6 +1164,13 @@ func typeToPython(
 			return fmt.Sprintf("Tuple[%s]", strings.Join(elements, ", "))
 		}
 		return elemType
+	}
+
+	// Handle Map type
+	if typeRef.Name == "Map" && len(typeRef.TypeArgs) >= 2 {
+		keyType := typeToPython(typeRef.TypeArgs[0], table, data)
+		valueType := typeToPython(typeRef.TypeArgs[1], table, data)
+		return fmt.Sprintf("dict[%s, %s]", keyType, valueType)
 	}
 
 	// Try to resolve the type
@@ -1243,6 +1261,19 @@ func typeRefToPythonAlias(
 	table *resolution.Table,
 	data *templateData,
 ) string {
+	// Array and map alias targets (e.g. Nodes = Node[], Authorities = map<...>) are
+	// builtin generics that do not resolve to a struct, so handle them here rather
+	// than falling through to the scalar/struct path below.
+	if typeRef.Name == "Array" && len(typeRef.TypeArgs) > 0 && typeRef.ArraySize == nil {
+		return fmt.Sprintf("list[%s]", typeToPython(typeRef.TypeArgs[0], table, data))
+	}
+	if typeRef.Name == "Map" && len(typeRef.TypeArgs) >= 2 {
+		return fmt.Sprintf(
+			"dict[%s, %s]",
+			typeToPython(typeRef.TypeArgs[0], table, data),
+			typeToPython(typeRef.TypeArgs[1], table, data),
+		)
+	}
 	resolved, ok := typeRef.Resolve(table)
 	if !ok {
 		return typeToPython(typeRef, table, data)

--- a/oracle/plugin/py/types/types_test.go
+++ b/oracle/plugin/py/types/types_test.go
@@ -1818,3 +1818,97 @@ var _ = Describe("Python Union Field & Variant Coverage", func() {
 		ExpectContent(resp, "types_gen.py").ToContain("scales: Annotated[list[Scale], BeforeValidator(lists.none_to_empty)] = Field(default_factory=list)")
 	})
 })
+
+var _ = Describe("Collection type aliases and maps", func() {
+	It("Should render a top-level array alias as list[Elem]", func(ctx SpecContext) {
+		loader := NewMockFileLoader()
+		typesPlugin := types.New(types.DefaultOptions())
+		source := `
+			@py output "out"
+
+			Node struct {
+				key string
+			}
+
+			Nodes Node[]
+		`
+		resp := MustGenerate(ctx, source, "graph", loader, typesPlugin)
+		ExpectContent(resp, "types_gen.py").ToContain("Nodes: TypeAlias = list[Node]")
+	})
+
+	It("Should render a map field as dict[K, V]", func(ctx SpecContext) {
+		loader := NewMockFileLoader()
+		typesPlugin := types.New(types.DefaultOptions())
+		source := `
+			@py output "out"
+
+			Authorities struct {
+				channels map<uint32, uint8>
+			}
+		`
+		resp := MustGenerate(ctx, source, "ir", loader, typesPlugin)
+		ExpectContent(resp, "types_gen.py").ToContain("channels: dict[int, int]")
+	})
+
+	It("Should render a map<string, record> field as dict[str, dict[str, Any]]", func(ctx SpecContext) {
+		loader := NewMockFileLoader()
+		typesPlugin := types.New(types.DefaultOptions())
+		source := `
+			@py output "out"
+
+			Graph struct {
+				configs map<string, record>
+			}
+		`
+		resp := MustGenerate(ctx, source, "graph", loader, typesPlugin)
+		ExpectContent(resp, "types_gen.py").ToContain("configs: dict[str, dict[str, Any]]")
+	})
+
+	It("Should render a struct-valued map field as dict[str, Struct]", func(ctx SpecContext) {
+		loader := NewMockFileLoader()
+		typesPlugin := types.New(types.DefaultOptions())
+		source := `
+			@py output "out"
+
+			Node struct {
+				key string
+			}
+
+			Graph struct {
+				nodes map<string, Node>
+			}
+		`
+		resp := MustGenerate(ctx, source, "graph", loader, typesPlugin)
+		ExpectContent(resp, "types_gen.py").ToContain("nodes: dict[str, Node]")
+	})
+
+	It("Should render an explicit array alias (= Elem[]) as list[Elem]", func(ctx SpecContext) {
+		loader := NewMockFileLoader()
+		typesPlugin := types.New(types.DefaultOptions())
+		source := `
+			@py output "out"
+
+			Node struct {
+				key string
+			}
+
+			Nodes = Node[]
+		`
+		resp := MustGenerate(ctx, source, "graph", loader, typesPlugin)
+		content := MustContentOf(resp, "types_gen.py")
+		Expect(content).To(ContainSubstring("Nodes: TypeAlias = list[Node]"))
+		Expect(content).NotTo(ContainSubstring("Nodes: TypeAlias = Any"))
+	})
+
+	It("Should render an explicit map alias (= map<K,V>) as dict[K, V]", func(ctx SpecContext) {
+		loader := NewMockFileLoader()
+		typesPlugin := types.New(types.DefaultOptions())
+		source := `
+			@py output "out"
+
+			Authorities = map<uint32, uint8>
+		`
+		resp := MustGenerate(ctx, source, "ir", loader, typesPlugin)
+		ExpectContent(resp, "types_gen.py").ToContain("Authorities: TypeAlias = dict[int, int]")
+	})
+})


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4408](https://linear.app/synnax/issue/SY-4408)

## Description

The Oracle Python type generator (`oracle/plugin/py/types`) rendered two schema constructs as untyped `Any`:

- **Top-level array aliases** (`Nodes Node[]`, `Edges Edge[]`) collapsed to `Any` (or dropped the list, yielding the bare element).
- **Map types** (`map<string, record>`, `map<uint32, uint8>`) had no handler and fell through to `Any`.

Array *fields* and inline arrays already generated correctly; only the alias/typedef and map paths were affected. These constructs were never exercised by an existing `@py output` schema, so no generated output changes today — the fix is needed by the Arc Python client migration (separate PR), which is the first Python schema to use array aliases and maps.

Changes, all in `oracle/plugin/py/types/types.go`:

- `typeDefBaseToPython` (distinct-form aliases): dynamic arrays now render `list[X]` (was the bare element); added a `map<K,V>` branch → `dict[K,V]`. Collection elements resolve through `typeToPython`, which handles every form and avoids the `Any` fallback the distinct-form resolver gives for struct elements.
- `typeToPython` (shared with field rendering): added a `map<K,V>` branch → `dict[K,V]`. The array branch intentionally still returns the bare element, because field processing wraps the outermost array in `list[...]` itself.
- `typeRefToPythonAlias` (explicit `=` aliases): array and map alias targets render `list[X]` / `dict[K,V]` rather than falling through to the struct/scalar path.

Added regression tests in `types_test.go` covering: top-level array alias → `list[Node]`, `map<uint32,uint8>` field → `dict[int, int]`, `map<string, record>` → `dict[str, dict[str, Any]]`, struct-valued map field → `dict[str, Node]`, and the explicit `= Elem[]` / `= map<K,V>` alias forms.

Note: nested collections inside type arguments (`map<K, V[]>`, `T[][]`) remain unsupported, but that is a parser/grammar limitation (the array modifier is not carried on map type arguments and `T[][]` fails analysis), not a code-generator issue, and no schema uses it.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the Oracle Python type generator to emit correct types for two previously-unhandled schema constructs: top-level array aliases now render as `list[X]` instead of the bare element, and `map<K,V>` types (in fields, distinct-form aliases, and explicit `=` aliases) now render as `dict[K, V]` instead of `Any`. Changes are confined to three resolver functions in `types.go`, with six new regression tests.

- `typeDefBaseToPython` and `typeRefToPythonAlias` now handle `Array` (dynamic) and `Map` builtin generics before falling through to the struct/scalar path; element types are resolved via `typeToPython` to avoid the `Any` fallback the distinct-form path gives for struct elements.
- `typeToPython` gains a `Map` branch returning `dict[K, V]`; the Array branch deliberately still returns the bare element because field processing wraps it in `list[...]` itself.
- Required map fields in structs are missing the null-to-empty coercion (`BeforeValidator(dicts.none_to_empty)`) and `default_factory=dict` that required array fields and `record` fields already receive, so any schema using a required non-optional `map<K,V>` field will fail Pydantic validation on a `null` or absent payload.

<h3>Confidence Score: 3/5</h3>

Safe to merge for existing schemas (no current output changes), but the generated code for required map fields will fail Pydantic validation on null or absent payloads once real schemas start using map types.

The three resolver fixes are correct and the tests cover the main alias/field/map combinations. However, required map<K,V> fields in structs will not get the null-to-empty coercion or default_factory treatment that array and record fields already have, so every consumer of the first schema to use a required map field will see unexpected Pydantic ValidationErrors at runtime.

oracle/plugin/py/types/types.go — the field-processing block around lines 722–743 needs a Map branch analogous to the existing IsArray and isRecord branches

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| oracle/plugin/py/types/types.go | Adds list[X] / dict[K,V] rendering for array aliases and map types in three resolver paths; required map fields are missing the null-to-empty coercion and default_factory treatment that array and record fields receive |
| oracle/plugin/py/types/types_test.go | Adds six regression tests covering top-level array alias, explicit = alias, map field, map alias, struct-valued map, and map<string,record>; none of the map-field tests assert null-coercion/default_factory behavior |

</details>



<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Field or Alias TypeRef] --> B{Context?}
    B -->|Distinct-form alias| C[typeDefBaseToPython]
    B -->|Explicit = alias| D[typeRefToPythonAlias]
    B -->|Struct field| E[typeToPython via processField]

    C --> C1{typeRef.Name?}
    C1 -->|Primitive| C2[primitiveToPython]
    C1 -->|Array, dynamic| C3["list[typeToPython(elem)]"]
    C1 -->|Array, fixed| C4["Tuple[elem x N]"]
    C1 -->|Map NEW| C5["dict[typeToPython(K), typeToPython(V)]"]
    C1 -->|Other| C6{Resolve}
    C6 -->|DistinctForm| C7[TypeName]
    C6 -->|Fail| C8[Any]

    D --> D1{typeRef.Name?}
    D1 -->|Array dynamic NEW| D2["list[typeToPython(elem)]"]
    D1 -->|Map NEW| D3["dict[typeToPython(K), typeToPython(V)]"]
    D1 -->|Other| D4{Resolve}
    D4 -->|StructForm| D5[StructName or generic]
    D4 -->|Fail| D6[typeToPython]

    E --> F{field.Type.Name?}
    F -->|Array| G["IsArray=true → list[typeToPython(elem)]"]
    G --> G1["+ BeforeValidator(lists.none_to_empty) + default_factory=list"]
    F -->|record| H["typeToPython → dict[str,Any]"]
    H --> H1["+ BeforeValidator(dicts.none_to_empty) + default_factory=dict"]
    F -->|Map NEW| I["typeToPython → dict[K,V]"]
    I --> I2["⚠️ No null coercion, no default_factory"]
    F -->|Primitive/Struct/Enum| J[typeToPython result]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Field or Alias TypeRef] --> B{Context?}
    B -->|Distinct-form alias| C[typeDefBaseToPython]
    B -->|Explicit = alias| D[typeRefToPythonAlias]
    B -->|Struct field| E[typeToPython via processField]

    C --> C1{typeRef.Name?}
    C1 -->|Primitive| C2[primitiveToPython]
    C1 -->|Array, dynamic| C3["list[typeToPython(elem)]"]
    C1 -->|Array, fixed| C4["Tuple[elem x N]"]
    C1 -->|Map NEW| C5["dict[typeToPython(K), typeToPython(V)]"]
    C1 -->|Other| C6{Resolve}
    C6 -->|DistinctForm| C7[TypeName]
    C6 -->|Fail| C8[Any]

    D --> D1{typeRef.Name?}
    D1 -->|Array dynamic NEW| D2["list[typeToPython(elem)]"]
    D1 -->|Map NEW| D3["dict[typeToPython(K), typeToPython(V)]"]
    D1 -->|Other| D4{Resolve}
    D4 -->|StructForm| D5[StructName or generic]
    D4 -->|Fail| D6[typeToPython]

    E --> F{field.Type.Name?}
    F -->|Array| G["IsArray=true → list[typeToPython(elem)]"]
    G --> G1["+ BeforeValidator(lists.none_to_empty) + default_factory=list"]
    F -->|record| H["typeToPython → dict[str,Any]"]
    H --> H1["+ BeforeValidator(dicts.none_to_empty) + default_factory=dict"]
    F -->|Map NEW| I["typeToPython → dict[K,V]"]
    I --> I2["⚠️ No null coercion, no default_factory"]
    F -->|Primitive/Struct/Enum| J[typeToPython result]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `oracle/plugin/py/types/types.go`, line 722-743 ([link](https://github.com/synnaxlabs/synnax/blob/d9e0f78a86b5e59d2e38e8c8e741f69bf6bf6194/oracle/plugin/py/types/types.go#L722-L743)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=9" align="top"></a> **Map fields missing null-coercion and default_factory**

   Required array fields get `BeforeValidator(lists.none_to_empty)` and `default_factory=list` (lines 738–740), and `record` fields get the `dicts` equivalent (lines 741–743), so they gracefully handle a `null` or absent payload. Map fields (`field.Type.Name == "Map"`) match neither branch — `fd.IsArray` is false and `isRecord` is false — so the generated output for a required `map<K,V>` field is bare `dict[K, V]` with no validator and no default. Any Pydantic model that deserializes a payload where the map key is absent or `null` will raise a `ValidationError` instead of receiving `{}`.

</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (1): Last reviewed commit: ["SY-4408: Generate list and dict types fo..."](https://github.com/synnaxlabs/synnax/commit/d9e0f78a86b5e59d2e38e8c8e741f69bf6bf6194) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=38836508)</sub>

<!-- /greptile_comment -->