### PR TITLE
SY-4420: Treat Non-Empty String Outputs as Truthy in the Go Arc Runtime

### DIFF
--- a/arc/cpp/runtime/state/state_test.cpp
+++ b/arc/cpp/runtime/state/state_test.cpp
@@ -870,6 +870,44 @@ TEST(StateTest, IsSeriesTruthy_Int64Series) {
     EXPECT_TRUE(Node::is_series_truthy(non_zero_series));
 }
 
+/// @brief Test that is_series_truthy treats a non-empty string as truthy
+TEST(StateTest, IsSeriesTruthy_StringSeries) {
+    x::telem::Series empty_string(std::string(""));
+    EXPECT_FALSE(Node::is_series_truthy(empty_string));
+
+    x::telem::Series non_empty_string(std::string("ox_alarm"));
+    EXPECT_TRUE(Node::is_series_truthy(non_empty_string));
+}
+
+/// @brief Test that a real node's string output drives is_output_truthy
+TEST(StateTest, IsOutputTruthy_StringOutput) {
+    arc::types::Param output_param;
+    output_param.name = "output";
+    output_param.type = arc::types::Type{.kind = arc::types::Kind::String};
+
+    arc::ir::Node producer;
+    producer.key = "producer";
+    producer.type = "producer";
+    producer.outputs.push_back(output_param);
+
+    arc::ir::Function fn;
+    fn.key = "test";
+
+    arc::ir::IR ir;
+    ir.nodes.push_back(producer);
+    ir.functions.push_back(fn);
+
+    Config cfg{.ir = ir, .channels = {}};
+    State s(cfg, arc::runtime::errors::noop_handler);
+    auto node = ASSERT_NIL_P(s.node("producer"));
+
+    *node.output(0) = x::telem::Series(std::string("ox_alarm"));
+    EXPECT_TRUE(node.is_output_truthy(0));
+
+    *node.output(0) = x::telem::Series(std::string(""));
+    EXPECT_FALSE(node.is_output_truthy(0));
+}
+
 TEST(StateTest, SetAuthority_BufferAndFlush) {
     State s = create_minimal_state();
     s.set_authority(42, 200);

--- a/arc/go/runtime/node/state.go
+++ b/arc/go/runtime/node/state.go
@@ -302,6 +302,8 @@ func isSeriesTruthy(s telem.Series) bool {
 		return telem.ValueAt[uint8](s, -1) != 0
 	case telem.TimeStampT:
 		return telem.ValueAt[telem.TimeStamp](s, -1) != 0
+	case telem.StringT:
+		return len(s.At(-1)) > 0
 	default:
 		return false
 	}

--- a/arc/go/runtime/node/state_test.go
+++ b/arc/go/runtime/node/state_test.go
@@ -1368,6 +1368,26 @@ var _ = Describe("ProgramState", func() {
 				*n.Output(0) = telem.NewSeriesV[telem.TimeStamp](telem.Now())
 				Expect(n.IsOutputTruthy(0)).To(BeTrue())
 			})
+
+			It("Should treat a non-empty string as truthy and an empty string as falsy", func(ctx SpecContext) {
+				g := graph.Graph{
+					Nodes: []graph.Node{{Key: "test", Type: "test"}},
+					Functions: []graph.Function{{
+						Key: "test",
+						Outputs: types.Params{
+							{Name: outputParam, Type: types.String()},
+						},
+					}},
+				}
+				prog, diagnostics := graph.Analyze(ctx, g, nil)
+				Expect(diagnostics.Ok()).To(BeTrue())
+				s := node.New(prog)
+				n := s.Node("test")
+				*n.Output(0) = telem.NewSeriesV[string]("")
+				Expect(n.IsOutputTruthy(0)).To(BeFalse())
+				*n.Output(0) = telem.NewSeriesV[string]("ox_alarm")
+				Expect(n.IsOutputTruthy(0)).To(BeTrue())
+			})
 		})
 	})
 

--- a/arc/go/sequence_test.go
+++ b/arc/go/sequence_test.go
@@ -123,6 +123,32 @@ var _ = Describe("Sequence", func() {
 			Expect(lastU8(out, 103)).To(Equal(uint8(1)))
 		})
 
+		It("Advances past steps whose terminal node outputs a string", func(ctx SpecContext) {
+			resolver := channelSymbols(map[string]channelDef{
+				"start_cmd": {types.U8(), 100},
+				"done":      {types.U8(), 101},
+			})
+			h := newRuntimeHarness(ctx, `
+				func make_key() str {
+				    return "ox_alarm"
+				}
+				sequence main {
+				    make_key{}
+				    make_key{}
+				    make_key{}
+				    1 -> done
+				}
+				start_cmd => main`, resolver,
+				channels.Digest{Key: 100, DataType: telem.Uint8T},
+				channels.Digest{Key: 101, DataType: telem.Uint8T},
+			)
+			defer h.Close(ctx)
+
+			trigger(h, ctx, 100)
+			out, _ := h.Flush()
+			Expect(lastU8(out, 101)).To(Equal(uint8(1)))
+		})
+
 		It("Blocks at a bare expression gate until truthy", func(ctx SpecContext) {
 			resolver := channelSymbols(map[string]channelDef{
 				"start_cmd": {types.U8(), 100},

--- a/core/pkg/service/arc/status/set_test.go
+++ b/core/pkg/service/arc/status/set_test.go
@@ -291,6 +291,17 @@ var _ = Describe("setNode.Next", func() {
 		Expect(outTime.Len()).To(Equal(int64(1)))
 	})
 
+	It("Should report a truthy output on success so a sequence step advances", func(ctx SpecContext) {
+		name := "next_truthy_" + uuid.NewString()
+		ok, _ := build(ctx, name, "msg", "info")
+		ok.Next(nodeCtx(ctx))
+		Expect(ok.IsOutputTruthy(0)).To(BeTrue())
+
+		failed, _ := build(ctx, "", "msg", "info")
+		failed.Next(nodeCtx(ctx))
+		Expect(failed.IsOutputTruthy(0)).To(BeFalse())
+	})
+
 	It("Should update an existing row by name (single match)", func(ctx SpecContext) {
 		name := "next_single_" + uuid.NewString()
 		existingKey := uuid.NewString()

--- a/core/pkg/service/arc/task/task_test.go
+++ b/core/pkg/service/arc/task/task_test.go
@@ -510,6 +510,63 @@ var _ = Describe("Task", Ordered, func() {
 
 	})
 
+	Describe("Sequence with consecutive status.set steps", func() {
+		It("Should advance through every status.set step", func(ctx SpecContext) {
+			trig := createVirtualCh(ctx, "seq_status_trig", telem.Uint8T)
+			base := "seq_status_" + uuid.NewString()[:8]
+			prog := arc.Text{Raw: fmt.Sprintf(`
+				import status
+
+				sequence main {
+				    status.set{key_or_name="%[1]s_a", message="m", variant="info"},
+				    status.set{key_or_name="%[1]s_b", message="m", variant="error"},
+				    status.set{key_or_name="%[1]s_c", message="m", variant="warning"},
+				    status.set{key_or_name="%[1]s_d", message="m", variant="loading"},
+				}
+
+				%[2]s => main
+			`, base, trig.Name)}
+
+			svcTask := task.Task{
+				Key:    task.NewKey(rack.NewKey(1, 1), 7),
+				Name:   "test-status-sequence",
+				Type:   arctask.Type,
+				Config: configToMap(arctask.Config{ArcKey: uuid.New()}),
+			}
+			t := MustSucceed(newTextFactory(ctx, prog).ConfigureTask(ctx, svcTask))
+			Expect(t.Exec(ctx, task.Command{Type: "start"})).To(Succeed())
+			defer func() { Expect(t.Stop()).To(Succeed()) }()
+
+			time.Sleep(20 * time.Millisecond)
+			w := MustSucceed(dist.Framer.OpenWriter(ctx, framer.WriterConfig{
+				Keys:  []channel.Key{trig.Key()},
+				Start: telem.Now(),
+			}))
+			Expect(w.Write(frame.NewUnary(trig.Key(), telem.NewSeriesV[uint8](1)))).To(BeTrue())
+			Expect(w.Close()).To(Succeed())
+
+			byName := func(name string) status.Status[svcarc.StatusDetails] {
+				var stat status.Status[svcarc.StatusDetails]
+				Expect(status.NewRetrieve[svcarc.StatusDetails](statusSvc).
+					Where(status.Match(func(_ gorp.Context, _ status.Retrieve[svcarc.StatusDetails], s *status.Status[svcarc.StatusDetails]) (bool, error) {
+						return s.Name == name, nil
+					})).Entry(&stat).Exec(ctx, nil)).To(Succeed())
+				return stat
+			}
+
+			Eventually(func(g Gomega) {
+				g.Expect(status.NewRetrieve[svcarc.StatusDetails](statusSvc).
+					Where(status.Match(func(_ gorp.Context, _ status.Retrieve[svcarc.StatusDetails], s *status.Status[svcarc.StatusDetails]) (bool, error) {
+						return s.Name == base+"_d", nil
+					})).Entry(&status.Status[svcarc.StatusDetails]{}).Exec(ctx, nil)).To(Succeed())
+			}).Should(Succeed())
+
+			Expect(byName(base + "_b").Variant).To(BeEquivalentTo("error"))
+			Expect(byName(base + "_c").Variant).To(BeEquivalentTo("warning"))
+			Expect(byName(base + "_d").Variant).To(BeEquivalentTo("loading"))
+		})
+	})
+
 	Describe("Status Reporting", func() {
 		It("Should set a task-level warning when status.set matches multiple statuses by name", func(ctx SpecContext) {
 			ch := &channel.Channel{Name: "report_trigger", Virtual: true, DataType: telem.Float32T}

--- a/integration/tests/arc/stl_status.py
+++ b/integration/tests/arc/stl_status.py
@@ -16,12 +16,29 @@ from tests.arc.arc import ArcCase
 TRIG_SET = "trig_status_set"
 TRIG_DUP_FUNC = "trig_dup_func"
 TRIG_DUP_FLOW = "trig_dup_flow"
+TRIG_SEQ = "trig_status_seq"
 DUP_FUNC_KEY = "dup_func_key"
+SEQ_DONE = "seq_status_done"
 
 DUP_NAME = "duplicate_status_name"
 DUP_KEYS = ("44440001", "44440002")
 DUP_VARIANT = "info"
 DUP_MESSAGE = "some message"
+
+# Each consecutive status.set step in status_seq must set its own row. SEQ_ROWS
+# is (name, key); SEQ_EXPECTED maps name to the (variant, message) it sets.
+SEQ_ROWS = [
+    ("status_seq_a", "33330001"),
+    ("status_seq_b", "33330002"),
+    ("status_seq_c", "33330003"),
+    ("status_seq_d", "33330004"),
+]
+SEQ_EXPECTED = {
+    "status_seq_a": ("info", "seq step a"),
+    "status_seq_b": ("warning", "seq step b"),
+    "status_seq_c": ("error", "seq step c"),
+    "status_seq_d": ("loading", "seq step d"),
+}
 
 ARC_STL_STATUS_SOURCE = """
 import status
@@ -51,6 +68,15 @@ func set_duplicate() {
 }
 trig_dup_func -> set_duplicate{}
 trig_dup_flow -> status.set{"duplicate_status_name", "some message", "info"}
+
+sequence status_seq {
+    status.set{"status_seq_a", "seq step a", "info"},
+    status.set{"status_seq_b", "seq step b", "warning"},
+    status.set{"status_seq_c", "seq step c", "error"},
+    status.set{"status_seq_d", "seq step d", "loading"},
+    1 -> seq_status_done
+}
+trig_status_seq => status_seq
 """
 
 
@@ -112,14 +138,16 @@ class StlStatus(ArcCase):
     arc_source = ARC_STL_STATUS_SOURCE
     arc_name_prefix = "ArcStlStatus"
     start_cmd_channel = "start_stl_status_cmd"
-    subscribe_channels = KEY_CHANNELS + [DUP_FUNC_KEY]
+    subscribe_channels = KEY_CHANNELS + [DUP_FUNC_KEY, SEQ_DONE]
     collect_notifications = True
 
     def setup(self) -> None:
         create_virtual_channel(self.client, TRIG_SET, sy.DataType.UINT8)
         create_virtual_channel(self.client, TRIG_DUP_FUNC, sy.DataType.UINT8)
         create_virtual_channel(self.client, TRIG_DUP_FLOW, sy.DataType.UINT8)
+        create_virtual_channel(self.client, TRIG_SEQ, sy.DataType.UINT8)
         create_virtual_channel(self.client, DUP_FUNC_KEY, sy.DataType.STRING)
+        create_virtual_channel(self.client, SEQ_DONE, sy.DataType.UINT8)
         for ch in KEY_CHANNELS:
             create_virtual_channel(self.client, ch, sy.DataType.STRING)
         for c in CASES:
@@ -140,11 +168,21 @@ class StlStatus(ArcCase):
                     message="initialized",
                 )
             )
+        for name, key in SEQ_ROWS:
+            self.client.statuses.set(
+                sy.Status(
+                    key=key,
+                    name=name,
+                    variant="disabled",
+                    message="initialized",
+                )
+            )
         super().setup()
 
     def teardown(self) -> None:
-        for c in CASES:
-            keys = [s.key for s in self._rows(c.name)]
+        names = [c.name for c in CASES] + [name for name, _ in SEQ_ROWS]
+        for name in names:
+            keys = [s.key for s in self._rows(name)]
             if keys:
                 self.client.statuses.delete(keys)
         super().teardown()
@@ -157,6 +195,7 @@ class StlStatus(ArcCase):
     def verify_sequence_execution(self) -> None:
         self._verify_set()
         self._verify_warn_on_duplicate()
+        self._verify_sequence_steps()
 
     def _verify_set(self) -> None:
         self.log("Firing set trigger: every case upserts its predefined row")
@@ -192,3 +231,18 @@ class StlStatus(ArcCase):
                 f"second match {DUP_KEYS[1]} should be unchanged, "
                 f"got ({second.variant!r}, {second.message!r})"
             )
+
+    def _verify_sequence_steps(self) -> None:
+        self.log("Firing sequence trigger: every status.set step must set its row")
+        self.writer.write(TRIG_SEQ, 1)
+        self.wait_for_eq(SEQ_DONE, 1)
+        for name, (variant, message) in SEQ_EXPECTED.items():
+            rows = self._rows(name)
+            if len(rows) != 1:
+                self.fail(f"{name}: expected 1 row after sequence, got {len(rows)}")
+            row = rows[0]
+            if (row.variant, row.message) != (variant, message):
+                self.fail(
+                    f"{name}: expected step to set ({variant!r}, {message!r}), "
+                    f"got ({row.variant!r}, {row.message!r})"
+                )


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4420](https://linear.app/synnax/issue/SY-4420/treat-non-empty-string-outputs-as-truthy-in-the-go-arc-runtime)

## Description

Go's `isSeriesTruthy` returns false for all string outputs (default case), while the C++ runtime treats a non-empty string as truthy. Because a sequence step only advances when its terminal node's output is truthy, any sequence step whose node returns a string (e.g. `status.set`) stalls the sequence after the first such step.

The following was broken (only the first status was being set):

```go
import (
    status
    time
)
sequence main {
    status.set{"My Status", "My Message", "info"},
    time.wait{1s},
    status.set{"My error", "My Message", "error"},
    time.wait{1s},
    status.set{"My warning", "My Message", "warning"},
    time.wait{1s},
    status.set{"My Status", "My Message", "loading"},
}

1 => main
```

Fix: add the missing string case to `isSeriesTruthy` (non-empty string is truthy, `""` is falsy) to bring the Go runtime to parity with C++.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a Go/C++ parity bug in the Arc runtime's `isSeriesTruthy` function by adding a `StringT` case that treats a non-empty string as truthy (and an empty string as falsy), matching the existing C++ behavior. Without this fix, sequence steps whose terminal node returns a string (e.g. `status.set`) would never advance past the first step because the function fell through to the `default: return false` branch.

- **Core fix** (`arc/go/runtime/node/state.go`): adds `case telem.StringT: return len(s.At(-1)) > 0` to the switch in `isSeriesTruthy`, guarded by the pre-existing `s.Len() == 0` early-return.
- **Tests at every level**: unit tests in Go (`state_test.go`) and C++ (`state_test.cpp`), a sequence-level integration test (`sequence_test.go`), a `status.set`-specific node test (`set_test.go`), a full task-level scenario (`task_test.go`), and an end-to-end Python integration test (`stl_status.py`).

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is a single-case addition to a well-guarded switch, fully covered by new tests at every level.

The fix is minimal: one new case in isSeriesTruthy. The pre-existing s.Len() == 0 guard means s.At(-1) can never be called on an empty series, ruling out a panic. New tests span unit, integration, and end-to-end layers. The C++ parity tests confirm the intended semantics were already correct on that side. No existing tests were modified or removed.

No files require special attention — all changes are additive and well-tested.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| arc/go/runtime/node/state.go | Adds the missing StringT case to isSeriesTruthy; the existing s.Len() == 0 guard ensures s.At(-1) is only called on a non-empty series, so no panic risk. |
| arc/go/runtime/node/state_test.go | New unit test covers both the empty-string (falsy) and non-empty-string (truthy) paths through the updated isSeriesTruthy. |
| arc/cpp/runtime/state/state_test.cpp | Documents the existing C++ is_series_truthy string behavior with two new tests, confirming Go parity. |
| arc/go/sequence_test.go | End-to-end sequence test verifies that multiple consecutive string-returning steps all advance correctly. |
| core/pkg/service/arc/status/set_test.go | New test asserts that status.set reports a truthy output when it succeeds and a falsy output when it fails (empty name), covering the real-world use case from the bug report. |
| core/pkg/service/arc/task/task_test.go | Integration test drives a real task with four consecutive status.set steps and asserts all four rows are updated, reproducing the exact bug from the issue. |
| integration/tests/arc/stl_status.py | Adds a Python integration scenario that fires a sequence trigger and asserts all four status rows reach their expected variant/message values. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Sequence step executes terminal node] --> B{Node output series empty?}
    B -- Yes --> C[isSeriesTruthy → false\nstep does NOT advance]
    B -- No --> D{DataType?}
    D -- Float/Int/Uint/Timestamp --> E[last value != 0?]
    D -- StringT\nnew case --> F["len(s.At(-1)) > 0?"]
    D -- default\nold behaviour --> G[return false\nstep stalls forever]
    E -- true --> H[isSeriesTruthy → true\nsequence advances]
    E -- false --> C
    F -- non-empty string --> H
    F -- empty string --> C
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[Sequence step executes terminal node] --> B{Node output series empty?}
    B -- Yes --> C[isSeriesTruthy → false\nstep does NOT advance]
    B -- No --> D{DataType?}
    D -- Float/Int/Uint/Timestamp --> E[last value != 0?]
    D -- StringT\nnew case --> F["len(s.At(-1)) > 0?"]
    D -- default\nold behaviour --> G[return false\nstep stalls forever]
    E -- true --> H[isSeriesTruthy → true\nsequence advances]
    E -- false --> C
    F -- non-empty string --> H
    F -- empty string --> C
```

</a>

<sub>Reviews (1): Last reviewed commit: ["SY-4420: Treat non-empty string outputs ..."](https://github.com/synnaxlabs/synnax/commit/c23639750a4eaaddb22d1f1dd2bc4998249ec9cf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39172623)</sub>

<!-- /greptile_comment -->