### PR TITLE
SY-4204: Upgrade GitHub Actions

### DIFF
--- a/.github/actions/test-python/action.yaml
+++ b/.github/actions/test-python/action.yaml
@@ -45,7 +45,7 @@ runs:
         exit 1
 
     - name: Install uv
-      uses: astral-sh/setup-uv@v8.1.0
+      uses: astral-sh/setup-uv@v8.2.0
 
     - name: Set up Python
       uses: actions/setup-python@v6
@@ -84,7 +84,7 @@ runs:
 
     - name: Upload coverage
       if: inputs.coverage == 'true'
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@v7
       with:
         fail_ci_if_error: true
         flags: ${{ inputs.coverage_flag }}

--- a/.github/actions/test-typescript/action.yaml
+++ b/.github/actions/test-typescript/action.yaml
@@ -73,7 +73,7 @@ runs:
 
     - name: Upload coverage
       if: inputs.test == 'true'
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@v7
       with:
         fail_ci_if_error: true
         flags: ${{ inputs.coverage_flag }}

--- a/.github/workflows/build.docker.yaml
+++ b/.github/workflows/build.docker.yaml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4

--- a/.github/workflows/build.synnax.yaml
+++ b/.github/workflows/build.synnax.yaml
@@ -121,7 +121,7 @@ jobs:
       GO_BUILD_TAGS: ${{ steps.go-tags.outputs.GO_BUILD_TAGS }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Get Version
         id: version
@@ -217,7 +217,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Update Submodules
         run: git submodule update --init --recursive
@@ -692,7 +692,7 @@ jobs:
       packages: write
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Update Submodules
         run: git submodule update --init --recursive
@@ -799,7 +799,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Import Apple Developer Certificate
         if: startsWith(matrix.os, 'macos') && inputs.sign_binaries

--- a/.github/workflows/check.oracle.yaml
+++ b/.github/workflows/check.oracle.yaml
@@ -68,7 +68,7 @@ jobs:
     # job to the required-checks list in branch protection.
     continue-on-error: true
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       # The full formatter chain runs during the `generated` gate, so we
       # need every formatter the chain dispatches: gofmt (Go),
@@ -99,7 +99,7 @@ jobs:
           python-version-file: pyproject.toml
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
 

--- a/.github/workflows/deploy.docs.yaml
+++ b/.github/workflows/deploy.docs.yaml
@@ -30,7 +30,7 @@ jobs:
       DOCS_ALGOLIA_WRITE_API_KEY: ${{ secrets.DOCS_ALGOLIA_WRITE_API_KEY }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/deploy.py.yaml
+++ b/.github/workflows/deploy.py.yaml
@@ -23,10 +23,10 @@ jobs:
       UV_PUBLISH_TOKEN: ${{ secrets.PYPI_TOKEN }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.2.0
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/deploy.synnax.yaml
+++ b/.github/workflows/deploy.synnax.yaml
@@ -85,7 +85,7 @@ jobs:
       VERSION: ${{ steps.version.outputs.VERSION }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Get version
         id: version
@@ -109,7 +109,7 @@ jobs:
       CONSOLE_VERSION: ${{ steps.console-version.outputs.VERSION }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Get Console Version
         id: console-version
@@ -195,7 +195,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Download Core Binary
         uses: actions/download-artifact@v8
@@ -248,7 +248,7 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Create Driver Install Script for NI Linux Real-Time
         run: |
@@ -278,7 +278,7 @@ jobs:
       VERSION: ${{ needs.create-release.outputs.CONSOLE_VERSION }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Get Console Version
         id: console-version

--- a/.github/workflows/deploy.ts.yaml
+++ b/.github/workflows/deploy.ts.yaml
@@ -27,7 +27,7 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v6

--- a/.github/workflows/fuzz.go.yaml
+++ b/.github/workflows/fuzz.go.yaml
@@ -22,7 +22,7 @@ jobs:
             artifact: arc-go
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Go
         uses: actions/setup-go@v6

--- a/.github/workflows/lint.buildifier.yaml
+++ b/.github/workflows/lint.buildifier.yaml
@@ -35,7 +35,7 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - uses: actions/setup-go@v6
         with:

--- a/.github/workflows/lint.integration.yaml
+++ b/.github/workflows/lint.integration.yaml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Lint
         uses: ./.github/actions/test-python

--- a/.github/workflows/test.alamos.py.yaml
+++ b/.github/workflows/test.alamos.py.yaml
@@ -46,7 +46,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Test Python
         uses: ./.github/actions/test-python

--- a/.github/workflows/test.alamos.ts.yaml
+++ b/.github/workflows/test.alamos.ts.yaml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Test TypeScript
         uses: ./.github/actions/test-typescript

--- a/.github/workflows/test.arc.yaml
+++ b/.github/workflows/test.arc.yaml
@@ -58,7 +58,7 @@ jobs:
     needs: [server]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Force Quit Existing Synnax Processes
         continue-on-error: true
@@ -139,7 +139,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Update Submodules
         run: git submodule update --init --recursive

--- a/.github/workflows/test.client.yaml
+++ b/.github/workflows/test.client.yaml
@@ -98,7 +98,7 @@ jobs:
       ts: ${{ steps.filter.outputs.ts }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Diff Changes
         uses: dorny/paths-filter@v4
@@ -183,7 +183,7 @@ jobs:
           - 9090:9090
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.19.0
@@ -233,7 +233,7 @@ jobs:
           - 9090:9090
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Test Python
         uses: ./.github/actions/test-python
@@ -268,7 +268,7 @@ jobs:
           - 9090:9090
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Test TypeScript
         uses: ./.github/actions/test-typescript

--- a/.github/workflows/test.console.yaml
+++ b/.github/workflows/test.console.yaml
@@ -92,7 +92,7 @@ jobs:
           - 9090:9090
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Test TypeScript
         uses: ./.github/actions/test-typescript

--- a/.github/workflows/test.copyright.yaml
+++ b/.github/workflows/test.copyright.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Check Copyright Headers
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Check Copyright Headers
         run: ./scripts/check_copyrights.sh

--- a/.github/workflows/test.docs.yaml
+++ b/.github/workflows/test.docs.yaml
@@ -53,7 +53,7 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Test TypeScript
         uses: ./.github/actions/test-typescript

--- a/.github/workflows/test.drift.yaml
+++ b/.github/workflows/test.drift.yaml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Test TypeScript
         uses: ./.github/actions/test-typescript

--- a/.github/workflows/test.driver.yaml
+++ b/.github/workflows/test.driver.yaml
@@ -70,7 +70,7 @@ jobs:
     needs: server
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Force Quit Existing Synnax Processes
         continue-on-error: true

--- a/.github/workflows/test.format.yaml
+++ b/.github/workflows/test.format.yaml
@@ -13,7 +13,7 @@ jobs:
     name: Check Formatting
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
       - uses: pnpm/action-setup@v6
       - uses: actions/setup-node@v6
         with:

--- a/.github/workflows/test.freighter.cpp.yaml
+++ b/.github/workflows/test.freighter.cpp.yaml
@@ -59,7 +59,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.19.0

--- a/.github/workflows/test.freighter.yaml
+++ b/.github/workflows/test.freighter.yaml
@@ -66,7 +66,7 @@ jobs:
       ts: ${{ steps.filter.outputs.ts }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Diff Changes
         uses: dorny/paths-filter@v4
@@ -131,7 +131,7 @@ jobs:
           - 8080:8080
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Test Python
         uses: ./.github/actions/test-python
@@ -160,7 +160,7 @@ jobs:
           - 8080:8080
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Test TypeScript
         uses: ./.github/actions/test-typescript

--- a/.github/workflows/test.go.yaml
+++ b/.github/workflows/test.go.yaml
@@ -46,7 +46,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up Go
         uses: actions/setup-go@v6
@@ -88,7 +88,7 @@ jobs:
         working-directory: ${{ inputs.directory }}
 
       - name: Upload coverage
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@v7
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.integration.worker.yaml
+++ b/.github/workflows/test.integration.worker.yaml
@@ -33,7 +33,7 @@ jobs:
       matrix: ${{ fromJSON(inputs.test_matrix) }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Force Quit Existing Synnax Processes (Windows)
         if: runner.os == 'Windows'
@@ -64,7 +64,7 @@ jobs:
         run: git submodule update --init --recursive
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.2.0
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/test.integration.yaml
+++ b/.github/workflows/test.integration.yaml
@@ -99,7 +99,7 @@ jobs:
         steps.test-matrix.outputs.TEST_MATRIX }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Get Version
         id: version

--- a/.github/workflows/test.media.yaml
+++ b/.github/workflows/test.media.yaml
@@ -41,7 +41,7 @@ jobs:
       TURBO_TEAM: ${{ vars.TURBO_TEAM }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Lint TypeScript
         uses: ./.github/actions/test-typescript

--- a/.github/workflows/test.migration.clients.yaml
+++ b/.github/workflows/test.migration.clients.yaml
@@ -62,7 +62,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Start Core on main
         id: start_main
@@ -81,12 +81,12 @@ jobs:
           echo "Synnax failed to start" && exit 1
 
       - name: Checkout main
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: main
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.2.0
 
       - name: Set up Python
         uses: actions/setup-python@v6
@@ -111,7 +111,7 @@ jobs:
           docker rm synnax-main
 
       - name: Checkout current branch
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Login to Github Container registry
         uses: docker/login-action@v4

--- a/.github/workflows/test.migration.yaml
+++ b/.github/workflows/test.migration.yaml
@@ -40,7 +40,7 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Reference Run ID
         run: echo "Reference run ID:${{ inputs.ref_run_id }}"
@@ -70,7 +70,7 @@ jobs:
         run: integration/scripts/download_artifacts.sh
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v8.1.0
+        uses: astral-sh/setup-uv@v8.2.0
 
       - name: Set up Python
         uses: actions/setup-python@v6

--- a/.github/workflows/test.pluto.yaml
+++ b/.github/workflows/test.pluto.yaml
@@ -85,7 +85,7 @@ jobs:
           - 9090:9090
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Test TypeScript
         uses: ./.github/actions/test-typescript

--- a/.github/workflows/test.protobuf.yaml
+++ b/.github/workflows/test.protobuf.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Buf CI
         uses: bufbuild/buf-action@v1

--- a/.github/workflows/test.soem.yaml
+++ b/.github/workflows/test.soem.yaml
@@ -24,7 +24,7 @@ jobs:
     runs-on: macos-build-bot
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Update Submodules
         run: git submodule update --init --recursive

--- a/.github/workflows/test.updates.yaml
+++ b/.github/workflows/test.updates.yaml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Check Versions
         run: scripts/check_versions.sh

--- a/.github/workflows/test.x.cpp.yaml
+++ b/.github/workflows/test.x.cpp.yaml
@@ -55,7 +55,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Setup Bazel
         uses: bazel-contrib/setup-bazel@0.19.0

--- a/.github/workflows/test.x.py.yaml
+++ b/.github/workflows/test.x.py.yaml
@@ -46,7 +46,7 @@ jobs:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Test Python
         uses: ./.github/actions/test-python

--- a/.github/workflows/test.x.ts.yaml
+++ b/.github/workflows/test.x.ts.yaml
@@ -58,7 +58,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Test TypeScript
         uses: ./.github/actions/test-typescript


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4204](https://linear.app/synnax/issue/SY-4204)

## Description

Upgrades the pinned versions of third-party GitHub Actions used across the CI/CD
workflows to their latest major releases:

- `actions/checkout` → `v7`
- `codecov/codecov-action` → `v7`
- `astral-sh/setup-uv` → `v8.2.0`

This keeps our CI tooling current and on supported action versions. The change is
limited to `.github/` workflow and composite-action definitions; there are no source
or behavioral changes.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR upgrades three pinned GitHub Actions versions across all 37 workflow and composite-action files in `.github/`: `actions/checkout` v6→v7, `codecov/codecov-action` v6→v7, and `astral-sh/setup-uv` v8.1.0→v8.2.0. The changes are purely mechanical version bumps with no source or behavioral changes.

- **`actions/checkout@v7`** introduces a breaking change that blocks fork PR checkout in `pull_request_target` / `workflow_run` workflows by default; a grep of all workflow triggers confirms none of this repo's workflows use those event types, so the breaking change is irrelevant here.
- **`codecov/codecov-action@v7`** bumps the Codecov Wrapper submodule to fetch its PGP verification key from the `codecovsecops` Keybase account — a security improvement with no API changes.
- **`astral-sh/setup-uv@v8.2.0`** is a purely additive minor release adding two new optional inputs (`quiet`, `download-from-astral-mirror`); no existing workflow uses them so there are no compatibility concerns.

<h3>Confidence Score: 5/5</h3>

All 37 files contain purely mechanical version-tag bumps to three well-known GitHub Actions; no source code or workflow logic was altered.

The only notable change requiring scrutiny was the actions/checkout v7 security-focused breaking change around fork PR checkout in pull_request_target and workflow_run workflows. A full grep of all workflow triggers confirmed none of this repo's workflows use those event types, so the breaking change has no effect. The other two bumps (codecov v7, setup-uv v8.2.0) are non-breaking. All version references are consistent across the entire .github/ tree with no stale or missed instances.

No files require special attention. The changes are consistent and complete across all 37 workflow files.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/actions/test-python/action.yaml | Bumps astral-sh/setup-uv v8.1.0→v8.2.0 and codecov/codecov-action v6→v7; both are non-breaking upgrades. |
| .github/actions/test-typescript/action.yaml | Bumps codecov/codecov-action v6→v7; straightforward upgrade with no API changes. |
| .github/workflows/build.synnax.yaml | Four checkout steps updated from v6 to v7; workflow uses pull_request/push triggers only, so v7's fork-safety breaking change does not apply. |
| .github/workflows/test.migration.clients.yaml | Three checkout steps (including one with ref: main) and one setup-uv step updated; all upgrades are compatible with existing usage. |
| .github/workflows/test.go.yaml | Bumps actions/checkout v6→v7 and codecov/codecov-action v6→v7; no compatibility concerns. |
| .github/workflows/deploy.synnax.yaml | Five checkout steps updated from v6 to v7; deployment workflow uses non-fork-PR triggers. |

</details>

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[37 workflow / composite-action files] --> B{Action being upgraded}
    B --> C["actions/checkout\nv6 → v7"]
    B --> D["codecov/codecov-action\nv6 → v7"]
    B --> E["astral-sh/setup-uv\nv8.1.0 → v8.2.0"]

    C --> C1["Breaking change: blocks fork PR checkout\nin pull_request_target / workflow_run"]
    C1 --> C2{"Repo uses those\ntriggers?"}
    C2 -- No --> C3["✅ Safe — no impact"]

    D --> D1["PGP key now fetched from\ncodecovsecops Keybase"]
    D1 --> D2["✅ Safe — security improvement"]

    E --> E1["Adds optional quiet &\ndownload-from-astral-mirror inputs"]
    E1 --> E2["✅ Safe — additive only"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[37 workflow / composite-action files] --> B{Action being upgraded}
    B --> C["actions/checkout\nv6 → v7"]
    B --> D["codecov/codecov-action\nv6 → v7"]
    B --> E["astral-sh/setup-uv\nv8.1.0 → v8.2.0"]

    C --> C1["Breaking change: blocks fork PR checkout\nin pull_request_target / workflow_run"]
    C1 --> C2{"Repo uses those\ntriggers?"}
    C2 -- No --> C3["✅ Safe — no impact"]

    D --> D1["PGP key now fetched from\ncodecovsecops Keybase"]
    D1 --> D2["✅ Safe — security improvement"]

    E --> E1["Adds optional quiet &\ndownload-from-astral-mirror inputs"]
    E1 --> E2["✅ Safe — additive only"]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Update GitHub actions"](https://github.com/synnaxlabs/synnax/commit/64b7f9f5c0d46f66d89468b7b8c240f2f110b0fd) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39173602)</sub>

<!-- /greptile_comment -->