### PR TITLE
SY-4421: Fix Saving a Local Range Failing with Validation Errors

### DIFF
--- a/console/src/range/Create.tsx
+++ b/console/src/range/Create.tsx
@@ -87,18 +87,17 @@ export const Create: Layout.Renderer = (props) => {
 
   const saveLocal = useCallback(() => {
     if (!form.validate()) return;
-    const value = form.value();
-    if (value.key == null) return;
+    const { name, key, timeRange } = form.value();
+    if (key == null) return;
     dispatch(
       add({
         ranges: [
           {
             persisted: false,
-            ...value,
-            key: value.key ?? "",
+            name,
+            key,
             variant: "static",
-            timeRange: new TimeRange(value.timeRange.start, value.timeRange.end)
-              .numeric,
+            timeRange: new TimeRange(timeRange.start, timeRange.end).numeric,
           },
         ],
       }),

--- a/console/src/range/Toolbar.tsx
+++ b/console/src/range/Toolbar.tsx
@@ -121,7 +121,11 @@ export const useRename = () => {
 const listItem = Component.renderProp((props: BaseList.ItemProps<string>) => {
   const { itemKey } = props;
   const entry = useSelect(itemKey);
-  const labels = Ranger.useLabels(itemKey)?.data ?? [];
+  const isLocal = entry != null && !entry.persisted;
+  const labels =
+    Ranger.useLabels(itemKey, {
+      beforeRetrieve: useCallback(() => (isLocal ? [] : true), [isLocal]),
+    })?.data ?? [];
   const onRename = useRename();
   const hasUpdatePermission = Access.useUpdateGranted(ranger.ontologyID(itemKey));
   if (entry == null || entry.variant === "dynamic") return null;

--- a/pluto/src/label/queries.ts
+++ b/pluto/src/label/queries.ts
@@ -64,7 +64,7 @@ export const matchRelationship = (rel: ontology.Relationship, id: ontology.ID) =
     type: label.LABELED_BY_ONTOLOGY_RELATIONSHIP_TYPE,
   });
 
-type LabelsOfQuery = {
+export type LabelsOfQuery = {
   id: ontology.ID;
 };
 

--- a/pluto/src/ranger/queries.ts
+++ b/pluto/src/ranger/queries.ts
@@ -637,8 +637,12 @@ export const useForm = Flux.createForm<FormQuery, typeof formSchema, FluxSubStor
 
 export const useLabels = (
   key: ranger.Key,
+  opts?: Omit<
+    Flux.UseDirectRetrieveParams<Label.LabelsOfQuery, label.Label[]>,
+    "query"
+  >,
 ): Flux.UseDirectRetrieveReturn<label.Label[]> =>
-  Label.useRetrieveLabelsOf({ id: ranger.ontologyID(key) });
+  Label.useRetrieveLabelsOf({ id: ranger.ontologyID(key) }, opts);
 
 export type ListQuery = Omit<ranger.RetrieveRequest, "names">;
 


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4421](https://linear.app/synnax/issue/SY-4421)

## Description

Local ranges were broken in the Console: creating one locally threw a "Failed to retrieve labels" error, and saving it to Synnax failed validation so it never persisted.

This traced back to the range schema standardization in [SY-4352](https://linear.app/synnax/issue/SY-4352), which made the no-parent case reject `parent: ""` (`expected object, received string`). Two console paths still fed local ranges into Synnax with the old shape:

- **Save to Synnax failed validation** — `Create.tsx`'s `saveLocal` spread the entire form value (which carries `parent: ""` and `labels: []`) into the redux-stored local range. When that range was later persisted via `usePersist → client.ranges.create`, the baked-in `parent: ""` failed the new schema.
- **"Failed to retrieve labels"** — the Ranges toolbar called `useLabels` for every listed range, including local (non-persisted) ones whose UUID doesn't exist in Synnax, so label retrieval 404'd.

### Changes

- `console/src/range/Create.tsx` — `saveLocal` now stores only the real `StaticRange` fields (`name`, `key`, `persisted`, `variant`, `timeRange`), matching `afterSave`. No `parent`/`labels` leak into the local range. (The form's own `save()` path already converted `parent` correctly, so persisted ranges were unaffected.)
- `console/src/range/Toolbar.tsx` — the list item short-circuits label retrieval with `[]` for local ranges via `beforeRetrieve`; once a range becomes persisted, normal retrieval resumes.
- `pluto/src/ranger/queries.ts` — `useLabels` now accepts and forwards optional retrieve options.
- `pluto/src/label/queries.ts` — exported `LabelsOfQuery` to type those options.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

## Test plan

- `console/range/range_lifecycle` integration test (failing since 6/18 with "Range None not found") now passes on the first attempt; it exercises *Create local range → Save to Synnax*.
- `range/range_explorer` and `range/range_details` also pass (Core + embedded Console, no driver).
- `pnpm format`, `lint`, and `check-types` are clean for `console` and `pluto`.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixes two bugs introduced during range schema standardization (SY-4352): local ranges failing on save due to `parent: ""`/`labels: []` leaking into the redux store, and the Ranges toolbar 404-ing on label retrieval for non-persisted ranges.

- **`Create.tsx`**: `saveLocal` now destructures only `name`, `key`, and `timeRange` from the form value, matching `afterSave`, so no stale `parent` or `labels` fields are dispatched to the store.
- **`Toolbar.tsx`**: list items gate `useLabels` behind `beforeRetrieve`, short-circuiting the network call for local ranges until they are persisted.
- **`pluto/src/ranger/queries.ts` / `pluto/src/label/queries.ts`**: `useLabels` now accepts and forwards optional retrieve params; `LabelsOfQuery` is exported to type them.

<h3>Confidence Score: 4/5</h3>

Safe to merge — both bug fixes are narrowly scoped and traced end-to-end in the integration test suite described in the PR.

The core fixes in Create.tsx and the pluto query layer are clean and well-reasoned. The one rough edge is in Toolbar.tsx: returning [] from beforeRetrieve is treated as false by the framework's loose-equality guard ([] == false in JS), so the state is never explicitly seeded with an empty array — it just stays undefined and ?.data ?? [] papers over it. This works correctly today, but the mechanism is subtly different from the expressed intent, and would misbehave if a list item ever held stale label data before becoming local.

console/src/range/Toolbar.tsx — the beforeRetrieve callback semantics warrant a second look.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| console/src/range/Create.tsx | Narrows saveLocal to only dispatch the real StaticRange fields (name, key, variant, timeRange, persisted), eliminating the parent: "" and labels: [] fields that were leaking into the redux store and causing schema validation errors on persist. |
| console/src/range/Toolbar.tsx | Adds beforeRetrieve guard to skip label retrieval for non-persisted (local) ranges; the returned [] is loose-equal to false in JS so it silently skips the fetch rather than seeding state with an empty array, though the observable behavior is correct for the current usage. |
| pluto/src/label/queries.ts | Exports LabelsOfQuery type so callers can reference it when typing the optional retrieve options forwarded to useRetrieveLabelsOf. |
| pluto/src/ranger/queries.ts | Threads optional opts (everything except query) through useLabels to Label.useRetrieveLabelsOf, enabling callers to pass beforeRetrieve and other retrieve options. |

</details>

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant CreateModal as Create.tsx
    participant Redux as Redux Store
    participant Toolbar as Toolbar.tsx
    participant Synnax

    User->>CreateModal: Click "Save Locally"
    CreateModal->>CreateModal: "Destructure {name, key, timeRange} only"
    CreateModal->>Redux: "dispatch add({persisted:false, name, key, variant, timeRange})"
    Redux-->>Toolbar: "Entry appears (persisted=false)"
    Toolbar->>Toolbar: "isLocal = true"
    Toolbar->>Toolbar: beforeRetrieve → skip fetch
    Note over Toolbar: labels shown as []

    User->>CreateModal: Click "Save to Synnax"
    CreateModal->>Synnax: client.ranges.create (no parent/"" leak)
    Synnax-->>Redux: "store.ranges.set (persisted=true)"
    Redux-->>Toolbar: "entry.persisted = true"
    Toolbar->>Toolbar: "isLocal = false"
    Toolbar->>Synnax: useLabels fetch (beforeRetrieve → true)
    Synnax-->>Toolbar: label.Label[]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant CreateModal as Create.tsx
    participant Redux as Redux Store
    participant Toolbar as Toolbar.tsx
    participant Synnax

    User->>CreateModal: Click "Save Locally"
    CreateModal->>CreateModal: "Destructure {name, key, timeRange} only"
    CreateModal->>Redux: "dispatch add({persisted:false, name, key, variant, timeRange})"
    Redux-->>Toolbar: "Entry appears (persisted=false)"
    Toolbar->>Toolbar: "isLocal = true"
    Toolbar->>Toolbar: beforeRetrieve → skip fetch
    Note over Toolbar: labels shown as []

    User->>CreateModal: Click "Save to Synnax"
    CreateModal->>Synnax: client.ranges.create (no parent/"" leak)
    Synnax-->>Redux: "store.ranges.set (persisted=true)"
    Redux-->>Toolbar: "entry.persisted = true"
    Toolbar->>Toolbar: "isLocal = false"
    Toolbar->>Synnax: useLabels fetch (beforeRetrieve → true)
    Synnax-->>Toolbar: label.Label[]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["SY-4421: Fix saving local ranges failing..."](https://github.com/synnaxlabs/synnax/commit/699a5d18ec89c4a44c352dac14128522c5024734) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39321976)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->