### PR TITLE
SY-4428: Move imex HTTP routes under /api/v1/imex

### DIFF
--- a/.vscode/synnax.code-workspace
+++ b/.vscode/synnax.code-workspace
@@ -165,6 +165,7 @@
       "Gomega",
       "Gorpify",
       "immer",
+      "imex",
       "Ingester",
       "Ingesters",
       "JSONT",

--- a/core/pkg/transport/http/http.go
+++ b/core/pkg/transport/http/http.go
@@ -202,7 +202,7 @@ func Bind(layer *api.Layer, router *http.Router, ch *distchannel.Service) {
 		ViewDelete:   http.NewUnaryServer[view.DeleteRequest, types.Nil](router, "/api/v1/view/delete"),
 
 		// IMPORT/EXPORT
-		ImExImport: http.NewUnaryServer[imex.ImportRequest, imex.ImportResponse](router, "/api/v1/import", http.WithRequestDecoders(json.Codec)),
-		ImExExport: http.NewUnaryServer[imex.ExportRequest, imex.ExportResponse](router, "/api/v1/export", http.WithResponseEncoders(json.Codec)),
+		ImExImport: http.NewUnaryServer[imex.ImportRequest, imex.ImportResponse](router, "/api/v1/imex/import", http.WithRequestDecoders(json.Codec)),
+		ImExExport: http.NewUnaryServer[imex.ExportRequest, imex.ExportResponse](router, "/api/v1/imex/export", http.WithResponseEncoders(json.Codec)),
 	})
 }


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4428](https://linear.app/synnax/issue/SY-4428/move-imex-http-routes-under-apiv1imex-and-add-imex-spelling-entry)

## Description

Splits the server-side route change out of the Python imex client PR ([SY-4130](https://linear.app/synnax/issue/SY-4130/add-python-client-support-for-server-side-import-and-export)) so that CI does not have to rebuild the Core on every push to that PR.

- `core/pkg/transport/http/http.go` — move the import/export routes from `/api/v1/import` and `/api/v1/export` to `/api/v1/imex/import` and `/api/v1/imex/export`.
- `.vscode/synnax.code-workspace` — add `imex` to the spell-check dictionary.

No client currently consumes these routes, so the change is self-contained and safe to land ahead of the Python (SY-4130) and TypeScript (SY-4129) client PRs.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves the server-side import/export HTTP endpoints from `/api/v1/import` and `/api/v1/export` to `/api/v1/imex/import` and `/api/v1/imex/export`, grouping them under a shared `/imex` prefix. It also adds "imex" to the VS Code spell-check dictionary.

- The route rename in `core/pkg/transport/http/http.go` is a two-line change; a codebase-wide search confirms no existing client code references the old paths, so there are no broken consumers.
- The workspace dictionary entry in `.vscode/synnax.code-workspace` prevents false spell-check warnings on the new path segment.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the route rename is self-contained and no existing client code references the old paths.

A codebase-wide search finds zero references to the old /api/v1/import and /api/v1/export paths, confirming the PR author's claim that no client consumes them yet. The change is a two-line string substitution with no logic alterations, and the accompanying dictionary entry is cosmetic.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| core/pkg/transport/http/http.go | Two route strings updated from /api/v1/{import,export} to /api/v1/imex/{import,export}; no other changes and no existing consumers of the old paths found in the repo. |
| .vscode/synnax.code-workspace | Adds "imex" to the cSpell custom word list to suppress spell-check warnings; no functional impact. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Client
    participant Router as HTTP Router

    Note over Client,Router: Before this PR
    Client->>Router: POST /api/v1/import
    Router-->>Client: ImportResponse

    Client->>Router: POST /api/v1/export
    Router-->>Client: ExportResponse

    Note over Client,Router: After this PR
    Client->>Router: POST /api/v1/imex/import
    Router-->>Client: ImportResponse

    Client->>Router: POST /api/v1/imex/export
    Router-->>Client: ExportResponse
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Client
    participant Router as HTTP Router

    Note over Client,Router: Before this PR
    Client->>Router: POST /api/v1/import
    Router-->>Client: ImportResponse

    Client->>Router: POST /api/v1/export
    Router-->>Client: ExportResponse

    Note over Client,Router: After this PR
    Client->>Router: POST /api/v1/imex/import
    Router-->>Client: ImportResponse

    Client->>Router: POST /api/v1/imex/export
    Router-->>Client: ExportResponse
```

</a>

<sub>Reviews (1): Last reviewed commit: ["SY-4428: Move imex HTTP routes under /ap..."](https://github.com/synnaxlabs/synnax/commit/bec9fd96056b1162391a56429a1c6bc32dee22fe) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=39621456)</sub>

<!-- /greptile_comment -->