### PR TITLE
SY-4440: Fix Flaky range_lifecycle Integration Test

### DIFF
--- a/integration/console/ranges.py
+++ b/integration/console/ranges.py
@@ -121,7 +121,7 @@ class RangesClient:
             name: Name of the range to search for and open.
         """
         self.layout.search_palette(name)
-        name_input = self.layout.page.locator("input[placeholder='Name']").first
+        name_input = self.layout.page.locator("input[placeholder='Name']:visible").first
         name_input.wait_for(state="visible", timeout=5000)
         expect(name_input).to_have_value(name, timeout=5000)
 
@@ -368,12 +368,32 @@ class RangesClient:
         self.layout.close_tab(name)
 
     def open_overview_from_explorer(self, name: str) -> None:
-        """Open the range overview/details page from explorer."""
+        """Open the range overview/details page from the explorer.
+
+        Clicking an explorer row places the range's overview layout, which opens
+        a new overview tab or focuses an existing one. When an overview tab for
+        the range is already open, the row click does not reliably switch the
+        active tab to it (the explorer tab can stay focused), leaving the
+        overview's Name field hidden. Focus an already-open tab directly when
+        present, fall back to the row click otherwise, and retry until the
+        overview for this range is showing.
+        """
+        if self.is_overview_showing(name):
+            return
         item = self.get_explorer_item(name)
         item.wait_for(state="visible", timeout=5000)
-        # A single click on the explorer row opens the overview; a second click
-        # re-toggles it shut, so click once and wait for the Name field.
-        item.click()
+        for attempt in range(3):
+            tab = self.layout.get_tab(name)
+            if tab.count() > 0:
+                tab.click()
+            else:
+                item.click()
+            try:
+                self.wait_for_overview(name)
+                return
+            except PlaywrightTimeoutError:
+                if attempt == 2:
+                    raise
 
     def navigate_to_parent(self, parent_name: str) -> None:
         """Navigate to parent range from current range overview.
@@ -388,7 +408,7 @@ class RangesClient:
 
     def wait_for_overview(self, name: str) -> None:
         """Wait for the range overview to show a specific range."""
-        name_input = self.layout.page.locator("input[placeholder='Name']").first
+        name_input = self.layout.page.locator("input[placeholder='Name']:visible").first
         name_input.wait_for(state="visible", timeout=5000)
         expect(name_input).to_have_value(name, timeout=5000)
 
@@ -401,7 +421,7 @@ class RangesClient:
         Returns:
             True if the overview shows the range name in the header.
         """
-        header = self.layout.page.locator("input[placeholder='Name']").first
+        header = self.layout.page.locator("input[placeholder='Name']:visible").first
         if not header.is_visible():
             return False
         return header.input_value() == name
@@ -562,7 +582,7 @@ class RangesClient:
         Args:
             new_name: The new name for the range.
         """
-        name_input = self.layout.page.locator("input[placeholder='Name']").first
+        name_input = self.layout.page.locator("input[placeholder='Name']:visible").first
         name_input.wait_for(state="visible", timeout=5000)
         name_input.click()
         name_input.fill(new_name)


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4440](https://linear.app/synnax/issue/SY-4440)

## Description

The `console/range/range_lifecycle` integration test was failing intermittently (~75% of runs), always at `test_remove_label_in_overview` where `wait_for_overview` timed out waiting for the overview's `Name` field to become visible.

**Root cause:** `RangesClient.open_overview_from_explorer` opened the overview by clicking the range's row in the Range Explorer, which dispatches a layout placement. When an overview tab for that range was already open, the placement did not reliably switch the active tab to it — the Explorer tab stayed focused, so the overview's `Name` input never became visible. A Playwright trace showed three identical `open_overview_from_explorer` calls where the same selector resolved in ~2 ms twice and then hung for the full 5 s timeout the third time. This was compounded by a latent fragility: the mosaic keeps inactive overview tabs mounted-but-hidden, so multiple `input[placeholder='Name']` elements coexist and `.first` could resolve to a hidden one.

**Fix** (`integration/console/ranges.py`):
- `open_overview_from_explorer` now focuses an already-open overview tab directly when present, falls back to the explorer-row click otherwise, and retries until the overview for the range is showing.
- Scoped the overview `Name`-input lookups to the visible tab (`:visible`) so they no longer match the hidden, still-mounted `Name` inputs of other open overview tabs.

**Validation:** before the fix the test failed 3/3 consecutive runs; after the fix it passed 8/8 consecutive runs under the same (orphan-polluted) server state. The sibling tests `range_details` and `range_explorer`, which share these helpers, also pass.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a flaky `range_lifecycle` integration test (`test_remove_label_in_overview`) that was failing ~75% of runs because clicking an explorer row to open an already-open overview tab did not reliably switch the active tab, leaving the overview's `Name` input hidden.

- `open_overview_from_explorer` now adds an early-return when the overview is already showing, then retries up to three times: it clicks an existing tab directly when one is present, or falls back to the explorer-row click, waiting for the overview to become active after each attempt.
- All four `input[placeholder='Name']` locators are tightened with the `:visible` pseudo-class so they no longer match the hidden, still-mounted `Name` inputs of other open overview tabs in the mosaic.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is scoped entirely to a test helper in the integration test layer and does not affect production code.

The fix is minimal and well-targeted: it addresses a concrete Playwright timing issue that was reproducible and validated, changes only one file, and the retry logic includes proper exception propagation on the final attempt. The `:visible` narrowing is strictly safer than the previous unscoped `.first` selectors. No regressions are introduced in the sibling test suites that share these helpers.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| integration/console/ranges.py | Fixes flaky overview-tab focus issue: adds `:visible` scoping to all `Name` input lookups, adds early-return guard, and adds a 3-attempt retry loop that prefers direct tab click over explorer-row click when a tab already exists. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[open_overview_from_explorer] --> B{is_overview_showing?}
    B -->|Yes| C[return early]
    B -->|No| D[get_explorer_item and wait visible]
    D --> E[for attempt in 0..2]
    E --> F{get_tab exists?}
    F -->|tab found| G[tab.click]
    F -->|no tab| H[item.click]
    G --> I[wait_for_overview 5s]
    H --> I
    I -->|success| J[return]
    I -->|TimeoutError| K{attempt == 2?}
    K -->|Yes| L[re-raise]
    K -->|No| E
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A[open_overview_from_explorer] --> B{is_overview_showing?}
    B -->|Yes| C[return early]
    B -->|No| D[get_explorer_item and wait visible]
    D --> E[for attempt in 0..2]
    E --> F{get_tab exists?}
    F -->|tab found| G[tab.click]
    F -->|no tab| H[item.click]
    G --> I[wait_for_overview 5s]
    H --> I
    I -->|success| J[return]
    I -->|TimeoutError| K{attempt == 2?}
    K -->|Yes| L[re-raise]
    K -->|No| E
```

</a>

<sub>Reviews (1): Last reviewed commit: ["SY-4440: Fix flaky range\_lifecycle integ..."](https://github.com/synnaxlabs/synnax/commit/b292e8ad072854a8459e65588c3156ee9f952c14) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40671794)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->