### PR TITLE
Fix undefined analyzer.New in calculation_analyzer_test

### DIFF
--- a/core/pkg/service/channel/calculation_analyzer_test.go
+++ b/core/pkg/service/channel/calculation_analyzer_test.go
@@ -73,7 +73,7 @@ var _ = Describe("Analyze", func() {
 			r := StaticResolver{
 				{Name: "ox-pt-1", Kind: symbol.KindChannel, Type: types.Chan(types.F32()), ID: 10},
 			}
-			a := analyzer.New(r, parser.Config{AllowDashedNames: true})
+			a := channel.NewCalculationAnalyzer(r, parser.Config{AllowDashedNames: true})
 			ch := channel.Channel{Name: "calc", Expression: "return ox-pt-1 * 2.0"}
 			res := MustSucceed(a.Analyze(ctx, ch))
 			Expect(res.ChanDataType).To(Equal(telem.Float32T))


### PR DESCRIPTION
## Description

The dashed-names test in `calculation_analyzer_test.go` calls `analyzer.New(...)`, but the `analyzer` package is not imported, which breaks the build (`Test - Core` is red on `rc`). This swaps it for the `channel.NewCalculationAnalyzer` constructor, which already accepts a variadic `parser.Config`. No behavior change to the test itself.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a build-breaking test in `calculation_analyzer_test.go` where the `dashed-names` test case called `analyzer.New(...)` but the `analyzer` package was never imported. The fix replaces the undefined call with `channel.NewCalculationAnalyzer(...)`, which is already used in every other test case in the file and accepts the same variadic `parser.Config` argument.

- Replaces `analyzer.New(r, parser.Config{AllowDashedNames: true})` with `channel.NewCalculationAnalyzer(r, parser.Config{AllowDashedNames: true})` on line 76 — the only changed line.
- The fix is mechanically identical in behavior since `channel.NewCalculationAnalyzer` has signature `(arc.SymbolResolver, ...parser.Config)` and is what all other tests in the file use.

<h3>Confidence Score: 5/5</h3>

Safe to merge — one-line correction that restores a failing build with no logic change.

The change swaps an undefined symbol for the correct constructor already used in every other test case in the same file. The constructor signature is compatible, the test logic is unchanged, and no other code paths are affected.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| core/pkg/service/channel/calculation_analyzer_test.go | Single-line build fix: replaces undefined `analyzer.New(...)` call with the correct `channel.NewCalculationAnalyzer(...)` constructor already used throughout the rest of the file; no behavioral change. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["dashed-names test\n(before)"] --> B["analyzer.New(r, parser.Config{AllowDashedNames: true})"]
    B --> C["❌ Build failure\n(analyzer package not imported)"]

    D["dashed-names test\n(after)"] --> E["channel.NewCalculationAnalyzer(r, parser.Config{AllowDashedNames: true})"]
    E --> F["✅ Build passes\n(channel package already imported)"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["dashed-names test\n(before)"] --> B["analyzer.New(r, parser.Config{AllowDashedNames: true})"]
    B --> C["❌ Build failure\n(analyzer package not imported)"]

    D["dashed-names test\n(after)"] --> E["channel.NewCalculationAnalyzer(r, parser.Config{AllowDashedNames: true})"]
    E --> F["✅ Build passes\n(channel package already imported)"]
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Fix undefined analyzer.New in calculatio..."](https://github.com/synnaxlabs/synnax/commit/17281a206011498ea344d66bffd0e8a505ad2640) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=40992232)</sub>

<!-- /greptile_comment -->