### PR TITLE
SY-4413: Rename Arc Stdlib Module Config Structs to Inputs

### DIFF
--- a/arc/cpp/stl/math/math.h
+++ b/arc/cpp/stl/math/math.h
@@ -46,19 +46,19 @@ struct WindowInputs {
 
     static std::pair<WindowInputs, x::errors::Error>
     create(const types::Params &params) {
-        WindowInputs cfg;
+        WindowInputs inputs;
         for (size_t i = 0; i < params.size(); i++) {
             const auto &p = params[i];
             if (p.name == "duration") {
                 auto sv = types::to_sample_value(p.value, p.type);
                 if (sv.has_value())
-                    cfg.duration = x::telem::TimeSpan(x::telem::cast<int64_t>(*sv));
+                    inputs.duration = x::telem::TimeSpan(x::telem::cast<int64_t>(*sv));
             } else if (p.name == "count") {
                 auto sv = types::to_sample_value(p.value, p.type);
-                if (sv.has_value()) cfg.count = x::telem::cast<int64_t>(*sv);
+                if (sv.has_value()) inputs.count = x::telem::cast<int64_t>(*sv);
             }
         }
-        return {cfg, x::errors::NIL};
+        return {inputs, x::errors::NIL};
     }
 };
 
@@ -72,7 +72,7 @@ private:
     runtime::state::Node state;
     types::Kind kind;
     Op op;
-    WindowInputs cfg;
+    WindowInputs inputs;
     int64_t sample_count = 0;
     x::telem::TimeStamp start_time{0};
     x::telem::TimeStamp last_reset_time{0};
@@ -84,14 +84,14 @@ public:
         runtime::state::Node &&state,
         types::Kind kind,
         Op op,
-        WindowInputs cfg,
+        WindowInputs inputs,
         size_t input_idx,
         std::optional<size_t> reset_idx
     ):
         state(std::move(state)),
         kind(kind),
         op(op),
-        cfg(std::move(cfg)),
+        inputs(std::move(inputs)),
         input_idx(input_idx),
         reset_idx(reset_idx) {}
 
@@ -117,16 +117,16 @@ public:
                 );
         }
 
-        if (this->cfg.duration > x::telem::TimeSpan(0) && input_time->size() > 0) {
+        if (this->inputs.duration > x::telem::TimeSpan(0) && input_time->size() > 0) {
             auto current_time = x::telem::TimeStamp(input_time->at<int64_t>(-1));
             if (x::telem::TimeSpan(current_time - this->start_time) >=
-                this->cfg.duration) {
+                this->inputs.duration) {
                 should_reset = true;
                 this->start_time = current_time;
             }
         }
 
-        if (this->cfg.count > 0 && this->sample_count >= this->cfg.count)
+        if (this->inputs.count > 0 && this->sample_count >= this->inputs.count)
             should_reset = true;
 
         if (should_reset) {
@@ -659,7 +659,7 @@ public:
             };
         }
 
-        auto [window_cfg, err] = WindowInputs::create(cfg.node.inputs);
+        auto [inputs, err] = WindowInputs::create(cfg.node.inputs);
         if (err) return {nullptr, err};
 
         Aggregator::Op op;
@@ -691,7 +691,7 @@ public:
                 std::move(cfg.state),
                 kind,
                 op,
-                window_cfg,
+                inputs,
                 input_idx,
                 reset_idx
             ),

--- a/arc/cpp/stl/math/math.h
+++ b/arc/cpp/stl/math/math.h
@@ -40,13 +40,13 @@ T int_pow(T base, T exp) {
     return result;
 }
 
-struct WindowConfig {
+struct WindowInputs {
     x::telem::TimeSpan duration{0};
     int64_t count = 0;
 
-    static std::pair<WindowConfig, x::errors::Error>
+    static std::pair<WindowInputs, x::errors::Error>
     create(const types::Params &params) {
-        WindowConfig cfg;
+        WindowInputs cfg;
         for (size_t i = 0; i < params.size(); i++) {
             const auto &p = params[i];
             if (p.name == "duration") {
@@ -72,7 +72,7 @@ private:
     runtime::state::Node state;
     types::Kind kind;
     Op op;
-    WindowConfig cfg;
+    WindowInputs cfg;
     int64_t sample_count = 0;
     x::telem::TimeStamp start_time{0};
     x::telem::TimeStamp last_reset_time{0};
@@ -84,7 +84,7 @@ public:
         runtime::state::Node &&state,
         types::Kind kind,
         Op op,
-        WindowConfig cfg,
+        WindowInputs cfg,
         size_t input_idx,
         std::optional<size_t> reset_idx
     ):
@@ -659,7 +659,7 @@ public:
             };
         }
 
-        auto [window_cfg, err] = WindowConfig::create(cfg.node.inputs);
+        auto [window_cfg, err] = WindowInputs::create(cfg.node.inputs);
         if (err) return {nullptr, err};
 
         Aggregator::Op op;

--- a/arc/cpp/stl/math/math_test.cpp
+++ b/arc/cpp/stl/math/math_test.cpp
@@ -290,7 +290,7 @@ TEST(MathAvgTest, WeightedAverageWithUnequalBatchSizes) {
     EXPECT_NEAR(checker.output(0)->at<double>(0), 23.333, 0.01);
 }
 
-TEST(MathAvgTest, ResetsWithCountConfig) {
+TEST(MathAvgTest, ResetsWithCountInput) {
     types::Param count_param;
     count_param.name = "count";
     count_param.type = types::Type{.kind = types::Kind::I64};
@@ -319,7 +319,7 @@ TEST(MathAvgTest, ResetsWithCountConfig) {
     EXPECT_DOUBLE_EQ(checker2.output(0)->at<double>(0), 50.0);
 }
 
-TEST(MathAvgTest, ResetsWithDurationConfig) {
+TEST(MathAvgTest, ResetsWithDurationInput) {
     types::Param duration_param;
     duration_param.name = "duration";
     duration_param.type = types::Type{.kind = types::Kind::I64};
@@ -419,7 +419,7 @@ TEST(MathMinTest, MaintainsMinAcrossBatches) {
     EXPECT_EQ(checker.output(0)->at<int32_t>(0), 30);
 }
 
-TEST(MathMinTest, ResetsWithDurationConfig) {
+TEST(MathMinTest, ResetsWithDurationInput) {
     types::Param duration_param;
     duration_param.name = "duration";
     duration_param.type = types::Type{.kind = types::Kind::I64};
@@ -454,7 +454,7 @@ TEST(MathMinTest, ResetsWithDurationConfig) {
     EXPECT_EQ(checker2.output(0)->at<int32_t>(0), 40);
 }
 
-TEST(MathMinTest, ResetsWithCountConfig) {
+TEST(MathMinTest, ResetsWithCountInput) {
     types::Param count_param;
     count_param.name = "count";
     count_param.type = types::Type{.kind = types::Kind::I64};
@@ -575,7 +575,7 @@ TEST(MathMaxTest, MaintainsMaxAcrossBatches) {
     EXPECT_DOUBLE_EQ(checker.output(0)->at<double>(0), 50.0);
 }
 
-TEST(MathMaxTest, ResetsWithDurationConfig) {
+TEST(MathMaxTest, ResetsWithDurationInput) {
     types::Param duration_param;
     duration_param.name = "duration";
     duration_param.type = types::Type{.kind = types::Kind::I64};
@@ -604,7 +604,7 @@ TEST(MathMaxTest, ResetsWithDurationConfig) {
     EXPECT_DOUBLE_EQ(checker2.output(0)->at<double>(0), 15.0);
 }
 
-TEST(MathMaxTest, ResetsWithCountConfig) {
+TEST(MathMaxTest, ResetsWithCountInput) {
     types::Param count_param;
     count_param.name = "count";
     count_param.type = types::Type{.kind = types::Kind::I64};

--- a/arc/cpp/stl/stable/stable.h
+++ b/arc/cpp/stl/stable/stable.h
@@ -24,10 +24,10 @@
 
 namespace arc::stl::stable {
 
-struct StableForConfig {
+struct StableForInputs {
     x::telem::TimeSpan duration;
 
-    static std::pair<StableForConfig, x::errors::Error>
+    static std::pair<StableForInputs, x::errors::Error>
     create(const types::Params &params) {
         const auto &param = params["duration"];
         auto sv = types::to_sample_value(param.value, param.type);
@@ -54,7 +54,7 @@ struct StableForConfig {
 /// function, matching the Go runtime behavior.
 class StableFor : public runtime::node::Node {
     runtime::state::Node state;
-    StableForConfig cfg;
+    StableForInputs cfg;
     size_t input_idx;
     x::telem::MonoClock clock;
     std::optional<uint8_t> value;
@@ -63,7 +63,7 @@ class StableFor : public runtime::node::Node {
 
 public:
     explicit StableFor(
-        const StableForConfig &cfg,
+        const StableForInputs &cfg,
         runtime::state::Node &&state,
         size_t input_idx,
         x::telem::NowFunc now = nullptr
@@ -129,7 +129,7 @@ public:
     std::pair<std::unique_ptr<runtime::node::Node>, x::errors::Error>
     create(runtime::node::Config &&cfg) override {
         if (!this->handles(cfg.node.type)) return {nullptr, x::errors::NOT_FOUND};
-        auto [node_cfg, err] = StableForConfig::create(cfg.node.inputs);
+        auto [node_cfg, err] = StableForInputs::create(cfg.node.inputs);
         if (err) return {nullptr, err};
         auto [input_idx, in_err] = cfg.node.resolve_input(ir::default_input_param);
         if (in_err) return {nullptr, in_err};

--- a/arc/cpp/stl/stable/stable.h
+++ b/arc/cpp/stl/stable/stable.h
@@ -54,7 +54,7 @@ struct StableForInputs {
 /// function, matching the Go runtime behavior.
 class StableFor : public runtime::node::Node {
     runtime::state::Node state;
-    StableForInputs cfg;
+    StableForInputs inputs;
     size_t input_idx;
     x::telem::MonoClock clock;
     std::optional<uint8_t> value;
@@ -63,13 +63,13 @@ class StableFor : public runtime::node::Node {
 
 public:
     explicit StableFor(
-        const StableForInputs &cfg,
+        const StableForInputs &inputs,
         runtime::state::Node &&state,
         size_t input_idx,
         x::telem::NowFunc now = nullptr
     ):
         state(std::move(state)),
-        cfg(cfg),
+        inputs(inputs),
         input_idx(input_idx),
         clock(std::move(now)) {}
 
@@ -94,7 +94,7 @@ public:
         const auto current_value = *this->value;
         const auto current_time = this->clock.now();
         if (x::telem::TimeSpan(current_time - this->last_changed) >=
-            this->cfg.duration) {
+            this->inputs.duration) {
             if (!this->last_sent.has_value() || *this->last_sent != current_value) {
                 const auto &o = this->state.output(0);
                 const auto &o_time = this->state.output_time(0);
@@ -129,12 +129,12 @@ public:
     std::pair<std::unique_ptr<runtime::node::Node>, x::errors::Error>
     create(runtime::node::Config &&cfg) override {
         if (!this->handles(cfg.node.type)) return {nullptr, x::errors::NOT_FOUND};
-        auto [node_cfg, err] = StableForInputs::create(cfg.node.inputs);
+        auto [inputs, err] = StableForInputs::create(cfg.node.inputs);
         if (err) return {nullptr, err};
         auto [input_idx, in_err] = cfg.node.resolve_input(ir::default_input_param);
         if (in_err) return {nullptr, in_err};
         return {
-            std::make_unique<StableFor>(node_cfg, std::move(cfg.state), input_idx),
+            std::make_unique<StableFor>(inputs, std::move(cfg.state), input_idx),
             x::errors::NIL
         };
     }

--- a/arc/cpp/stl/stable/stable_test.cpp
+++ b/arc/cpp/stl/stable/stable_test.cpp
@@ -113,25 +113,25 @@ x::telem::NowFunc make_now(x::telem::TimeStamp &current_time) {
 }
 }
 
-TEST(StableForConfigTest, CreatesConfigFromValidParams) {
+TEST(StableForInputsTest, CreatesInputsFromValidParams) {
     types::Param duration_param;
     duration_param.name = "duration";
     duration_param.type = types::Type{.kind = types::Kind::I64};
     duration_param.value = x::telem::SECOND.nanoseconds();
     types::Params params;
     params.push_back(duration_param);
-    const auto cfg = ASSERT_NIL_P(StableForConfig::create(params));
+    const auto cfg = ASSERT_NIL_P(StableForInputs::create(params));
     EXPECT_EQ(cfg.duration, x::telem::SECOND);
 }
 
-TEST(StableForConfigTest, ReturnsErrorForNullDuration) {
+TEST(StableForInputsTest, ReturnsErrorForNullDuration) {
     types::Param duration_param;
     duration_param.name = "duration";
     duration_param.type = types::Type{.kind = types::Kind::I64};
     duration_param.value = nullptr;
     types::Params params;
     params.push_back(duration_param);
-    ASSERT_OCCURRED_AS_P(StableForConfig::create(params), x::errors::VALIDATION);
+    ASSERT_OCCURRED_AS_P(StableForInputs::create(params), x::errors::VALIDATION);
 }
 
 TEST(StableForModuleTest, ReturnsNotFoundForWrongType) {
@@ -162,7 +162,7 @@ TEST(StableForTest, DoesNotEmitBeforeDuration) {
     TestSetup setup(x::telem::SECOND.nanoseconds());
     x::telem::TimeStamp current_time(0);
     StableFor node(
-        ASSERT_NIL_P(StableForConfig::create(setup.ir.nodes[1].inputs)),
+        ASSERT_NIL_P(StableForInputs::create(setup.ir.nodes[1].inputs)),
         setup.make_stable_node(),
         0,
         make_now(current_time)
@@ -189,7 +189,7 @@ TEST(StableForTest, EmitsWhenStableForDuration) {
     TestSetup setup(x::telem::SECOND.nanoseconds());
     x::telem::TimeStamp current_time(0);
     StableFor node(
-        ASSERT_NIL_P(StableForConfig::create(setup.ir.nodes[1].inputs)),
+        ASSERT_NIL_P(StableForInputs::create(setup.ir.nodes[1].inputs)),
         setup.make_stable_node(),
         0,
         make_now(current_time)
@@ -226,7 +226,7 @@ TEST(StableForTest, ResetsTimerOnValueChange) {
     TestSetup setup(x::telem::SECOND.nanoseconds());
     x::telem::TimeStamp current_time(0);
     StableFor node(
-        ASSERT_NIL_P(StableForConfig::create(setup.ir.nodes[1].inputs)),
+        ASSERT_NIL_P(StableForInputs::create(setup.ir.nodes[1].inputs)),
         setup.make_stable_node(),
         0,
         make_now(current_time)
@@ -268,7 +268,7 @@ TEST(StableForTest, DoesNotEmitSameValueTwice) {
     TestSetup setup(x::telem::SECOND.nanoseconds());
     x::telem::TimeStamp current_time(0);
     StableFor node(
-        ASSERT_NIL_P(StableForConfig::create(setup.ir.nodes[1].inputs)),
+        ASSERT_NIL_P(StableForInputs::create(setup.ir.nodes[1].inputs)),
         setup.make_stable_node(),
         0,
         make_now(current_time)
@@ -297,7 +297,7 @@ TEST(StableForTest, EmitsDifferentValueAfterStablePeriod) {
     TestSetup setup(x::telem::SECOND.nanoseconds());
     x::telem::TimeStamp current_time(0);
     StableFor node(
-        ASSERT_NIL_P(StableForConfig::create(setup.ir.nodes[1].inputs)),
+        ASSERT_NIL_P(StableForInputs::create(setup.ir.nodes[1].inputs)),
         setup.make_stable_node(),
         0,
         make_now(current_time)
@@ -335,7 +335,7 @@ TEST(StableForTest, HandlesMultipleValuesInSingleInput) {
     TestSetup setup(x::telem::SECOND.nanoseconds());
     x::telem::TimeStamp current_time(0);
     StableFor node(
-        ASSERT_NIL_P(StableForConfig::create(setup.ir.nodes[1].inputs)),
+        ASSERT_NIL_P(StableForInputs::create(setup.ir.nodes[1].inputs)),
         setup.make_stable_node(),
         0,
         make_now(current_time)
@@ -365,7 +365,7 @@ TEST(StableForTest, ResetClearsState) {
     TestSetup setup(x::telem::SECOND.nanoseconds());
     x::telem::TimeStamp current_time(0);
     StableFor node(
-        ASSERT_NIL_P(StableForConfig::create(setup.ir.nodes[1].inputs)),
+        ASSERT_NIL_P(StableForInputs::create(setup.ir.nodes[1].inputs)),
         setup.make_stable_node(),
         0,
         make_now(current_time)
@@ -392,7 +392,7 @@ TEST(StableForTest, HandlesEmptyInput) {
     TestSetup setup(x::telem::SECOND.nanoseconds());
     x::telem::TimeStamp current_time(x::telem::SECOND.nanoseconds());
     StableFor node(
-        ASSERT_NIL_P(StableForConfig::create(setup.ir.nodes[1].inputs)),
+        ASSERT_NIL_P(StableForInputs::create(setup.ir.nodes[1].inputs)),
         setup.make_stable_node(),
         0,
         make_now(current_time)
@@ -410,7 +410,7 @@ TEST(StableForTest, IsOutputTruthyDelegatesToState) {
     TestSetup setup(x::telem::SECOND.nanoseconds());
     x::telem::TimeStamp current_time(0);
     StableFor node(
-        ASSERT_NIL_P(StableForConfig::create(setup.ir.nodes[1].inputs)),
+        ASSERT_NIL_P(StableForInputs::create(setup.ir.nodes[1].inputs)),
         setup.make_stable_node(),
         0,
         make_now(current_time)
@@ -434,7 +434,7 @@ TEST(StableForTest, HandlesSameValueRepeatedInInput) {
     TestSetup setup(x::telem::SECOND.nanoseconds());
     x::telem::TimeStamp current_time(0);
     StableFor node(
-        ASSERT_NIL_P(StableForConfig::create(setup.ir.nodes[1].inputs)),
+        ASSERT_NIL_P(StableForInputs::create(setup.ir.nodes[1].inputs)),
         setup.make_stable_node(),
         0,
         make_now(current_time)
@@ -463,7 +463,7 @@ TEST(StableForTest, ResetAllowsSameValueToEmitAgain) {
     TestSetup setup(x::telem::SECOND.nanoseconds());
     x::telem::TimeStamp current_time(0);
     StableFor node(
-        ASSERT_NIL_P(StableForConfig::create(setup.ir.nodes[1].inputs)),
+        ASSERT_NIL_P(StableForInputs::create(setup.ir.nodes[1].inputs)),
         setup.make_stable_node(),
         0,
         make_now(current_time)

--- a/arc/cpp/stl/stable/stable_test.cpp
+++ b/arc/cpp/stl/stable/stable_test.cpp
@@ -120,8 +120,8 @@ TEST(StableForInputsTest, CreatesInputsFromValidParams) {
     duration_param.value = x::telem::SECOND.nanoseconds();
     types::Params params;
     params.push_back(duration_param);
-    const auto cfg = ASSERT_NIL_P(StableForInputs::create(params));
-    EXPECT_EQ(cfg.duration, x::telem::SECOND);
+    const auto inputs = ASSERT_NIL_P(StableForInputs::create(params));
+    EXPECT_EQ(inputs.duration, x::telem::SECOND);
 }
 
 TEST(StableForInputsTest, ReturnsErrorForNullDuration) {

--- a/arc/cpp/stl/time/time.h
+++ b/arc/cpp/stl/time/time.h
@@ -71,27 +71,29 @@ struct IntervalInputs {
 
 class Interval : public runtime::node::Node {
     runtime::state::Node state;
-    IntervalInputs cfg;
+    IntervalInputs inputs;
     x::telem::TimeSpan last_fired;
 
 public:
-    explicit Interval(const IntervalInputs &cfg, runtime::state::Node &&state):
-        state(std::move(state)), cfg(cfg), last_fired(-1 * this->cfg.interval) {}
+    explicit Interval(const IntervalInputs &inputs, runtime::state::Node &&state):
+        state(std::move(state)),
+        inputs(inputs),
+        last_fired(-1 * this->inputs.interval) {}
 
     x::errors::Error next(runtime::node::Context &ctx) override {
         if (ctx.reason != runtime::node::RunReason::TimerTick) {
             ctx.mark_self_changed();
-            ctx.set_deadline(this->last_fired + this->cfg.interval);
+            ctx.set_deadline(this->last_fired + this->inputs.interval);
             return x::errors::NIL;
         }
-        if (ctx.elapsed - this->last_fired < this->cfg.interval - ctx.tolerance) {
+        if (ctx.elapsed - this->last_fired < this->inputs.interval - ctx.tolerance) {
             ctx.mark_self_changed();
-            ctx.set_deadline(this->last_fired + this->cfg.interval);
+            ctx.set_deadline(this->last_fired + this->inputs.interval);
             return x::errors::NIL;
         }
         this->last_fired = ctx.elapsed;
         ctx.mark_self_changed();
-        ctx.set_deadline(this->last_fired + this->cfg.interval);
+        ctx.set_deadline(this->last_fired + this->inputs.interval);
         const auto &o = this->state.output(0);
         const auto &o_time = this->state.output_time(0);
         o->resize(1);
@@ -102,7 +104,7 @@ public:
         return x::errors::NIL;
     }
 
-    void reset() override { last_fired = -1 * cfg.interval; }
+    void reset() override { last_fired = -1 * inputs.interval; }
 
     [[nodiscard]] bool is_output_truthy(size_t output_idx) const override {
         return state.is_output_truthy(output_idx);
@@ -133,23 +135,23 @@ struct WaitInputs {
 /// @brief One-shot timer that fires once after a specified duration.
 class Wait : public runtime::node::Node {
     runtime::state::Node state;
-    WaitInputs cfg;
+    WaitInputs inputs;
     x::telem::TimeSpan start_time = x::telem::TimeSpan(-1);
     bool fired = false;
 
 public:
-    explicit Wait(const WaitInputs &cfg, runtime::state::Node &&state):
-        state(std::move(state)), cfg(cfg) {}
+    explicit Wait(const WaitInputs &inputs, runtime::state::Node &&state):
+        state(std::move(state)), inputs(inputs) {}
 
     x::errors::Error next(runtime::node::Context &ctx) override {
         if (this->fired) return x::errors::NIL;
         if (this->start_time.nanoseconds() < 0) this->start_time = ctx.elapsed;
-        ctx.set_deadline(this->start_time + this->cfg.duration);
+        ctx.set_deadline(this->start_time + this->inputs.duration);
         if (ctx.reason != runtime::node::RunReason::TimerTick) {
             ctx.mark_self_changed();
             return x::errors::NIL;
         }
-        if (ctx.elapsed - this->start_time < this->cfg.duration - ctx.tolerance) {
+        if (ctx.elapsed - this->start_time < this->inputs.duration - ctx.tolerance) {
             ctx.mark_self_changed();
             return x::errors::NIL;
         }
@@ -228,28 +230,28 @@ public:
     std::pair<std::unique_ptr<runtime::node::Node>, x::errors::Error>
     create(runtime::node::Config &&cfg) override {
         if (cfg.node.type == "interval") {
-            auto [node_cfg, err] = IntervalInputs::create(cfg.node.inputs);
+            auto [inputs, err] = IntervalInputs::create(cfg.node.inputs);
             if (err) return {nullptr, err};
-            this->update_base_interval(node_cfg.interval);
+            this->update_base_interval(inputs.interval);
             return {
-                std::make_unique<Interval>(node_cfg, std::move(cfg.state)),
+                std::make_unique<Interval>(inputs, std::move(cfg.state)),
                 x::errors::NIL
             };
         }
         if (cfg.node.type == "wait") {
-            auto [node_cfg, err] = WaitInputs::create(cfg.node.inputs);
+            auto [inputs, err] = WaitInputs::create(cfg.node.inputs);
             if (err) return {nullptr, err};
-            this->update_base_interval(node_cfg.duration);
+            this->update_base_interval(inputs.duration);
             return {
-                std::make_unique<Wait>(node_cfg, std::move(cfg.state)),
+                std::make_unique<Wait>(inputs, std::move(cfg.state)),
                 x::errors::NIL
             };
         }
         if (cfg.node.type == "now") {
-            auto [node_cfg, err] = NowInputs::create(cfg.node.inputs);
+            auto [inputs, err] = NowInputs::create(cfg.node.inputs);
             if (err) return {nullptr, err};
             return {
-                std::make_unique<Now>(node_cfg, std::move(cfg.state), &this->clock),
+                std::make_unique<Now>(inputs, std::move(cfg.state), &this->clock),
                 x::errors::NIL
             };
         }

--- a/arc/cpp/stl/time/time.h
+++ b/arc/cpp/stl/time/time.h
@@ -47,10 +47,10 @@ inline x::telem::TimeSpan calculate_tolerance(
     }
 }
 
-struct IntervalConfig {
+struct IntervalInputs {
     x::telem::TimeSpan interval;
 
-    static std::pair<IntervalConfig, x::errors::Error>
+    static std::pair<IntervalInputs, x::errors::Error>
     create(const types::Params &params) {
         const auto &param = params["period"];
         auto sv = types::to_sample_value(param.value, param.type);
@@ -71,11 +71,11 @@ struct IntervalConfig {
 
 class Interval : public runtime::node::Node {
     runtime::state::Node state;
-    IntervalConfig cfg;
+    IntervalInputs cfg;
     x::telem::TimeSpan last_fired;
 
 public:
-    explicit Interval(const IntervalConfig &cfg, runtime::state::Node &&state):
+    explicit Interval(const IntervalInputs &cfg, runtime::state::Node &&state):
         state(std::move(state)), cfg(cfg), last_fired(-1 * this->cfg.interval) {}
 
     x::errors::Error next(runtime::node::Context &ctx) override {
@@ -109,10 +109,10 @@ public:
     }
 };
 
-struct WaitConfig {
+struct WaitInputs {
     x::telem::TimeSpan duration;
 
-    static std::pair<WaitConfig, x::errors::Error> create(const types::Params &params) {
+    static std::pair<WaitInputs, x::errors::Error> create(const types::Params &params) {
         const auto &param = params["duration"];
         auto sv = types::to_sample_value(param.value, param.type);
         if (!sv.has_value())
@@ -133,12 +133,12 @@ struct WaitConfig {
 /// @brief One-shot timer that fires once after a specified duration.
 class Wait : public runtime::node::Node {
     runtime::state::Node state;
-    WaitConfig cfg;
+    WaitInputs cfg;
     x::telem::TimeSpan start_time = x::telem::TimeSpan(-1);
     bool fired = false;
 
 public:
-    explicit Wait(const WaitConfig &cfg, runtime::state::Node &&state):
+    explicit Wait(const WaitInputs &cfg, runtime::state::Node &&state):
         state(std::move(state)), cfg(cfg) {}
 
     x::errors::Error next(runtime::node::Context &ctx) override {
@@ -174,9 +174,9 @@ public:
     }
 };
 
-struct NowConfig {
-    static std::pair<NowConfig, x::errors::Error> create(const types::Params &) {
-        return {NowConfig{}, x::errors::NIL};
+struct NowInputs {
+    static std::pair<NowInputs, x::errors::Error> create(const types::Params &) {
+        return {NowInputs{}, x::errors::NIL};
     }
 };
 
@@ -187,7 +187,7 @@ class Now : public runtime::node::Node {
 
 public:
     explicit Now(
-        const NowConfig &,
+        const NowInputs &,
         runtime::state::Node &&state,
         x::telem::MonoClock *clock
     ):
@@ -228,7 +228,7 @@ public:
     std::pair<std::unique_ptr<runtime::node::Node>, x::errors::Error>
     create(runtime::node::Config &&cfg) override {
         if (cfg.node.type == "interval") {
-            auto [node_cfg, err] = IntervalConfig::create(cfg.node.inputs);
+            auto [node_cfg, err] = IntervalInputs::create(cfg.node.inputs);
             if (err) return {nullptr, err};
             this->update_base_interval(node_cfg.interval);
             return {
@@ -237,7 +237,7 @@ public:
             };
         }
         if (cfg.node.type == "wait") {
-            auto [node_cfg, err] = WaitConfig::create(cfg.node.inputs);
+            auto [node_cfg, err] = WaitInputs::create(cfg.node.inputs);
             if (err) return {nullptr, err};
             this->update_base_interval(node_cfg.duration);
             return {
@@ -246,7 +246,7 @@ public:
             };
         }
         if (cfg.node.type == "now") {
-            auto [node_cfg, err] = NowConfig::create(cfg.node.inputs);
+            auto [node_cfg, err] = NowInputs::create(cfg.node.inputs);
             if (err) return {nullptr, err};
             return {
                 std::make_unique<Now>(node_cfg, std::move(cfg.state), &this->clock),

--- a/arc/cpp/stl/time/time_test.cpp
+++ b/arc/cpp/stl/time/time_test.cpp
@@ -75,46 +75,46 @@ private:
     }
 };
 
-TEST(IntervalConfigTest, CreatesConfigFromValidParams) {
+TEST(IntervalInputsTest, CreatesInputsFromValidParams) {
     types::Param period_param;
     period_param.name = "period";
     period_param.type = types::Type{.kind = types::Kind::I64};
     period_param.value = x::telem::SECOND.nanoseconds();
     types::Params params;
     params.push_back(period_param);
-    const auto cfg = ASSERT_NIL_P(IntervalConfig::create(params));
+    const auto cfg = ASSERT_NIL_P(IntervalInputs::create(params));
     EXPECT_EQ(cfg.interval, x::telem::SECOND);
 }
 
-TEST(IntervalConfigTest, ReturnsErrorForNullPeriod) {
+TEST(IntervalInputsTest, ReturnsErrorForNullPeriod) {
     types::Param period_param;
     period_param.name = "period";
     period_param.type = types::Type{.kind = types::Kind::I64};
     period_param.value = nullptr;
     types::Params params;
     params.push_back(period_param);
-    ASSERT_OCCURRED_AS_P(IntervalConfig::create(params), x::errors::VALIDATION);
+    ASSERT_OCCURRED_AS_P(IntervalInputs::create(params), x::errors::VALIDATION);
 }
 
-TEST(WaitConfigTest, CreatesConfigFromValidParams) {
+TEST(WaitInputsTest, CreatesInputsFromValidParams) {
     types::Param duration_param;
     duration_param.name = "duration";
     duration_param.type = types::Type{.kind = types::Kind::I64};
     duration_param.value = x::telem::SECOND.nanoseconds();
     types::Params params;
     params.push_back(duration_param);
-    const auto cfg = ASSERT_NIL_P(WaitConfig::create(params));
+    const auto cfg = ASSERT_NIL_P(WaitInputs::create(params));
     EXPECT_EQ(cfg.duration, x::telem::SECOND);
 }
 
-TEST(WaitConfigTest, ReturnsErrorForNullDuration) {
+TEST(WaitInputsTest, ReturnsErrorForNullDuration) {
     types::Param duration_param;
     duration_param.name = "duration";
     duration_param.type = types::Type{.kind = types::Kind::I64};
     duration_param.value = nullptr;
     types::Params params;
     params.push_back(duration_param);
-    ASSERT_OCCURRED_AS_P(WaitConfig::create(params), x::errors::VALIDATION);
+    ASSERT_OCCURRED_AS_P(WaitInputs::create(params), x::errors::VALIDATION);
 }
 
 /// @brief Test that module returns NOT_FOUND for non-time node types.
@@ -200,7 +200,7 @@ TEST(TimeModuleTest, BaseIntervalComputesGCDAcrossNodes) {
 /// @brief Test that Interval does not fire again before next interval elapses.
 TEST(IntervalTest, DoesNotFireBeforeNextIntervalElapses) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(IntervalConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
     Interval node(cfg, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
@@ -219,7 +219,7 @@ TEST(IntervalTest, DoesNotFireBeforeNextIntervalElapses) {
 /// @brief Test that Interval fires when the interval is reached.
 TEST(IntervalTest, FiresWhenIntervalReached) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(IntervalConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
     Interval node(cfg, setup.make_node());
 
     auto ctx = make_context(x::telem::SECOND);
@@ -234,7 +234,7 @@ TEST(IntervalTest, FiresWhenIntervalReached) {
 /// @brief Test that Interval fires repeatedly at each interval.
 TEST(IntervalTest, FiresRepeatedly) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(IntervalConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
     Interval node(cfg, setup.make_node());
 
     auto ctx1 = make_context(x::telem::SECOND);
@@ -256,7 +256,7 @@ TEST(IntervalTest, FiresRepeatedly) {
 /// @brief Test that Interval sets the timestamp to elapsed time when firing.
 TEST(IntervalTest, SetsTimestampOnFire) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(IntervalConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
     Interval node(cfg, setup.make_node());
 
     auto ctx = make_context(x::telem::SECOND * 5);
@@ -271,7 +271,7 @@ TEST(IntervalTest, SetsTimestampOnFire) {
 /// @brief Test that Interval calls mark_changed when firing.
 TEST(IntervalTest, CallsMarkChangedOnFire) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(IntervalConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
     Interval node(cfg, setup.make_node());
 
     std::vector<size_t> marked;
@@ -286,7 +286,7 @@ TEST(IntervalTest, CallsMarkChangedOnFire) {
 /// @brief Test that Interval does not call mark_changed when not firing.
 TEST(IntervalTest, DoesNotCallMarkChangedWhenNotFiring) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(IntervalConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
     Interval node(cfg, setup.make_node());
 
     auto ctx1 = make_context(x::telem::SECOND);
@@ -303,7 +303,7 @@ TEST(IntervalTest, DoesNotCallMarkChangedWhenNotFiring) {
 /// @brief Test that Interval is_output_truthy delegates to state.
 TEST(IntervalTest, IsOutputTruthyDelegatesToState) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(IntervalConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
     Interval node(cfg, setup.make_node());
 
     auto ctx = make_context(x::telem::SECOND);
@@ -315,7 +315,7 @@ TEST(IntervalTest, IsOutputTruthyDelegatesToState) {
 /// @brief Test that Interval is_output_truthy returns false before firing.
 TEST(IntervalTest, IsOutputTruthyFalseBeforeFiring) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(IntervalConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
     Interval node(cfg, setup.make_node());
 
     EXPECT_FALSE(node.is_output_truthy(0));
@@ -324,7 +324,7 @@ TEST(IntervalTest, IsOutputTruthyFalseBeforeFiring) {
 /// @brief Test that Interval is_output_truthy returns false for unknown param.
 TEST(IntervalTest, IsOutputTruthyFalseForUnknownParam) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(IntervalConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
     Interval node(cfg, setup.make_node());
 
     auto ctx = make_context(x::telem::SECOND);
@@ -336,7 +336,7 @@ TEST(IntervalTest, IsOutputTruthyFalseForUnknownParam) {
 /// @brief Test that Interval reset allows it to fire immediately again.
 TEST(IntervalTest, ResetAllowsImmediateFiring) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(IntervalConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
     Interval node(cfg, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
@@ -360,7 +360,7 @@ TEST(IntervalTest, ResetAllowsImmediateFiring) {
 
 TEST(IntervalTest, OnlyFiresOnTimerTick) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(IntervalConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
     Interval node(cfg, setup.make_node());
 
     bool changed_called = false;
@@ -392,7 +392,7 @@ TEST(IntervalTest, OnlyFiresOnTimerTick) {
 /// @brief Test that Wait does not fire before the duration elapses.
 TEST(WaitTest, DoesNotFireBeforeDurationElapses) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
     Wait node(cfg, setup.make_node());
 
     auto ctx = make_context(x::telem::MILLISECOND * 500);
@@ -406,7 +406,7 @@ TEST(WaitTest, DoesNotFireBeforeDurationElapses) {
 /// @brief Test that Wait fires once after the duration elapses.
 TEST(WaitTest, FiresOnceAfterDuration) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
     Wait node(cfg, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
@@ -425,7 +425,7 @@ TEST(WaitTest, FiresOnceAfterDuration) {
 /// @brief Test that Wait does not fire again after the first fire.
 TEST(WaitTest, DoesNotFireAgain) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
     Wait node(cfg, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
@@ -448,7 +448,7 @@ TEST(WaitTest, DoesNotFireAgain) {
 /// @brief Test that Wait reset allows it to fire again.
 TEST(WaitTest, ResetAllowsFiringAgain) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
     Wait node(cfg, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
@@ -476,7 +476,7 @@ TEST(WaitTest, ResetAllowsFiringAgain) {
 
 TEST(WaitTest, OnlyFiresOnTimerTick) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
     Wait node(cfg, setup.make_node());
 
     bool changed_called = false;
@@ -510,7 +510,7 @@ TEST(WaitTest, OnlyFiresOnTimerTick) {
 /// @brief Test that Wait measures duration from first next() call, not construction.
 TEST(WaitTest, MeasuresDurationFromFirstNextCall) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
     Wait node(cfg, setup.make_node());
 
     auto ctx1 = make_context(x::telem::SECOND * 10);
@@ -531,7 +531,7 @@ TEST(WaitTest, MeasuresDurationFromFirstNextCall) {
 /// TimerTick, not when the stage was activated via channel input.
 TEST(WaitTest, StartsTimingFromChannelInputThatActivatesStage) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
     Wait node(cfg, setup.make_node());
 
     auto ctx1 = make_context(
@@ -556,7 +556,7 @@ TEST(WaitTest, StartsTimingFromChannelInputThatActivatesStage) {
 /// next TimerTick, effectively doubling the wait duration.
 TEST(WaitTest, StartsTimingFromChannelInputAfterReset) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
     Wait node(cfg, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
@@ -589,7 +589,7 @@ TEST(WaitTest, StartsTimingFromChannelInputAfterReset) {
 /// @brief Test that Wait calls mark_self_changed when active but not yet fired.
 TEST(WaitTest, CallsMarkSelfChangedWhenActiveButNotFired) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
     Wait node(cfg, setup.make_node());
 
     int self_changed_calls = 0;
@@ -626,7 +626,7 @@ TEST(WaitTest, CallsMarkSelfChangedWhenActiveButNotFired) {
 /// non-tick cycles without being starved.
 TEST(WaitTest, CallsMarkSelfChangedOnChannelInputToSurvive) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
     Wait node(cfg, setup.make_node());
 
     int self_changed_calls = 0;
@@ -666,7 +666,7 @@ TEST(WaitTest, CallsMarkSelfChangedOnChannelInputToSurvive) {
 /// @brief Test that Wait sets the timestamp to elapsed time when firing.
 TEST(WaitTest, SetsTimestampOnFire) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
     Wait node(cfg, setup.make_node());
 
     auto ctx1 = make_context(x::telem::SECOND * 2);
@@ -684,7 +684,7 @@ TEST(WaitTest, SetsTimestampOnFire) {
 /// @brief Test that Wait calls mark_changed when firing.
 TEST(WaitTest, CallsMarkChangedOnFire) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
     Wait node(cfg, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
@@ -702,7 +702,7 @@ TEST(WaitTest, CallsMarkChangedOnFire) {
 /// @brief Test that Wait does not call mark_changed when not firing.
 TEST(WaitTest, DoesNotCallMarkChangedWhenNotFiring) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
     Wait node(cfg, setup.make_node());
 
     int call_count = 0;
@@ -716,7 +716,7 @@ TEST(WaitTest, DoesNotCallMarkChangedWhenNotFiring) {
 /// @brief Test that Wait is_output_truthy delegates to state.
 TEST(WaitTest, IsOutputTruthyDelegatesToState) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
     Wait node(cfg, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
@@ -731,7 +731,7 @@ TEST(WaitTest, IsOutputTruthyDelegatesToState) {
 /// @brief Test that Wait reset restarts timing from zero.
 TEST(WaitTest, ResetRestartsTimingFromZero) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
     Wait node(cfg, setup.make_node());
 
     auto ctx1 = make_context(x::telem::SECOND * 5);
@@ -818,7 +818,7 @@ TEST(CalculateToleranceTest, HalfIntervalMinimum) {
 /// @brief Test that Interval fires within tolerance.
 TEST(IntervalToleranceTest, FiresWithinTolerance) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(IntervalConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
     Interval node(cfg, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
@@ -839,7 +839,7 @@ TEST(IntervalToleranceTest, FiresWithinTolerance) {
 /// @brief Test that Interval does not fire too early even with tolerance.
 TEST(IntervalToleranceTest, DoesNotFireTooEarly) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(IntervalConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
     Interval node(cfg, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
@@ -857,7 +857,7 @@ TEST(IntervalToleranceTest, DoesNotFireTooEarly) {
 /// @brief Test that Wait fires within tolerance.
 TEST(WaitToleranceTest, FiresWithinTolerance) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
     Wait node(cfg, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
@@ -878,7 +878,7 @@ TEST(WaitToleranceTest, FiresWithinTolerance) {
 /// @brief Test that Wait does not fire too early even with tolerance.
 TEST(WaitToleranceTest, DoesNotFireTooEarly) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
     Wait node(cfg, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
@@ -896,7 +896,7 @@ TEST(WaitToleranceTest, DoesNotFireTooEarly) {
 /// @brief Test that Interval fires correctly with zero tolerance (original behavior).
 TEST(IntervalToleranceTest, ZeroToleranceRequiresExactTime) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(IntervalConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
     Interval node(cfg, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
@@ -921,7 +921,7 @@ TEST(IntervalToleranceTest, ZeroToleranceRequiresExactTime) {
 /// @brief Test that Wait fires correctly with zero tolerance (original behavior).
 TEST(WaitToleranceTest, ZeroToleranceRequiresExactTime) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
     Wait node(cfg, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0), x::telem::TimeSpan(0));
@@ -964,7 +964,7 @@ TEST(CalculateToleranceTest, AutoMode) {
 TEST(IntervalDeadlineTest, SetsDeadlineToLastFiredPlusPeriod) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
     const auto cfg = ASSERT_NIL_P(
-        time::IntervalConfig::create(setup.ir.nodes[0].inputs)
+        time::IntervalInputs::create(setup.ir.nodes[0].inputs)
     );
     time::Interval node(cfg, setup.make_node());
 
@@ -978,7 +978,7 @@ TEST(IntervalDeadlineTest, SetsDeadlineToLastFiredPlusPeriod) {
 TEST(IntervalDeadlineTest, SetsDeadlineOnNonTimerTick) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
     const auto cfg = ASSERT_NIL_P(
-        time::IntervalConfig::create(setup.ir.nodes[0].inputs)
+        time::IntervalInputs::create(setup.ir.nodes[0].inputs)
     );
     time::Interval node(cfg, setup.make_node());
 
@@ -999,7 +999,7 @@ TEST(IntervalDeadlineTest, SetsDeadlineOnNonTimerTick) {
 TEST(IntervalDeadlineTest, SetsDeadlineAfterFiring) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
     const auto cfg = ASSERT_NIL_P(
-        time::IntervalConfig::create(setup.ir.nodes[0].inputs)
+        time::IntervalInputs::create(setup.ir.nodes[0].inputs)
     );
     time::Interval node(cfg, setup.make_node());
 
@@ -1015,7 +1015,7 @@ TEST(IntervalDeadlineTest, SetsDeadlineAfterFiring) {
 
 TEST(WaitDeadlineTest, SetsDeadlineToStartTimePlusDuration) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(time::WaitConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(time::WaitInputs::create(setup.ir.nodes[0].inputs));
     time::Wait node(cfg, setup.make_node());
 
     x::telem::TimeSpan reported_deadline(-1);
@@ -1027,7 +1027,7 @@ TEST(WaitDeadlineTest, SetsDeadlineToStartTimePlusDuration) {
 
 TEST(WaitDeadlineTest, SetsDeadlineOnChannelInput) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(time::WaitConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(time::WaitInputs::create(setup.ir.nodes[0].inputs));
     time::Wait node(cfg, setup.make_node());
 
     x::telem::TimeSpan reported_deadline(-1);
@@ -1043,7 +1043,7 @@ TEST(WaitDeadlineTest, SetsDeadlineOnChannelInput) {
 
 TEST(WaitDeadlineTest, DoesNotSetDeadlineAfterFiring) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(time::WaitConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(time::WaitInputs::create(setup.ir.nodes[0].inputs));
     time::Wait node(cfg, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
@@ -1061,7 +1061,7 @@ TEST(WaitDeadlineTest, DoesNotSetDeadlineAfterFiring) {
 
 TEST(WaitDeadlineTest, SetsCorrectDeadlineAfterReset) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(time::WaitConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(time::WaitInputs::create(setup.ir.nodes[0].inputs));
     time::Wait node(cfg, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
@@ -1117,7 +1117,7 @@ private:
 /// @brief Now node outputs a valid wall-clock timestamp.
 TEST(NowTest, OutputsWallClockTimestamp) {
     NowTestSetup setup;
-    const auto cfg = ASSERT_NIL_P(time::NowConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(time::NowInputs::create(setup.ir.nodes[0].inputs));
     time::Now node(cfg, setup.make_node(), &setup.clock);
 
     const auto before = x::telem::TimeStamp::now().nanoseconds();
@@ -1139,7 +1139,7 @@ TEST(NowTest, OutputsWallClockTimestamp) {
 /// @brief Now node fires on any RunReason (not just TimerTick).
 TEST(NowTest, FiresOnChannelInput) {
     NowTestSetup setup;
-    const auto cfg = ASSERT_NIL_P(time::NowConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(time::NowInputs::create(setup.ir.nodes[0].inputs));
     time::Now node(cfg, setup.make_node(), &setup.clock);
 
     bool changed = false;
@@ -1160,7 +1160,7 @@ TEST(NowTest, FiresOnChannelInput) {
 /// @brief Now node output and output_time contain the same timestamp.
 TEST(NowTest, OutputAndOutputTimeMatch) {
     NowTestSetup setup;
-    const auto cfg = ASSERT_NIL_P(time::NowConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(time::NowInputs::create(setup.ir.nodes[0].inputs));
     time::Now node(cfg, setup.make_node(), &setup.clock);
 
     auto ctx = make_context(x::telem::SECOND);
@@ -1177,7 +1177,7 @@ TEST(NowTest, OutputAndOutputTimeMatch) {
 /// @brief Now node works correctly after reset.
 TEST(NowTest, WorksAfterReset) {
     NowTestSetup setup;
-    const auto cfg = ASSERT_NIL_P(time::NowConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(time::NowInputs::create(setup.ir.nodes[0].inputs));
     time::Now node(cfg, setup.make_node(), &setup.clock);
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
@@ -1199,7 +1199,7 @@ TEST(NowTest, WorksAfterReset) {
 /// @brief Now node is_output_truthy returns false for unknown param.
 TEST(NowTest, IsOutputTruthyFalseForUnknownParam) {
     NowTestSetup setup;
-    const auto cfg = ASSERT_NIL_P(time::NowConfig::create(setup.ir.nodes[0].inputs));
+    const auto cfg = ASSERT_NIL_P(time::NowInputs::create(setup.ir.nodes[0].inputs));
     time::Now node(cfg, setup.make_node(), &setup.clock);
     EXPECT_FALSE(node.is_output_truthy(999));
 }

--- a/arc/cpp/stl/time/time_test.cpp
+++ b/arc/cpp/stl/time/time_test.cpp
@@ -82,8 +82,8 @@ TEST(IntervalInputsTest, CreatesInputsFromValidParams) {
     period_param.value = x::telem::SECOND.nanoseconds();
     types::Params params;
     params.push_back(period_param);
-    const auto cfg = ASSERT_NIL_P(IntervalInputs::create(params));
-    EXPECT_EQ(cfg.interval, x::telem::SECOND);
+    const auto inputs = ASSERT_NIL_P(IntervalInputs::create(params));
+    EXPECT_EQ(inputs.interval, x::telem::SECOND);
 }
 
 TEST(IntervalInputsTest, ReturnsErrorForNullPeriod) {
@@ -103,8 +103,8 @@ TEST(WaitInputsTest, CreatesInputsFromValidParams) {
     duration_param.value = x::telem::SECOND.nanoseconds();
     types::Params params;
     params.push_back(duration_param);
-    const auto cfg = ASSERT_NIL_P(WaitInputs::create(params));
-    EXPECT_EQ(cfg.duration, x::telem::SECOND);
+    const auto inputs = ASSERT_NIL_P(WaitInputs::create(params));
+    EXPECT_EQ(inputs.duration, x::telem::SECOND);
 }
 
 TEST(WaitInputsTest, ReturnsErrorForNullDuration) {
@@ -200,8 +200,8 @@ TEST(TimeModuleTest, BaseIntervalComputesGCDAcrossNodes) {
 /// @brief Test that Interval does not fire again before next interval elapses.
 TEST(IntervalTest, DoesNotFireBeforeNextIntervalElapses) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
-    Interval node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
+    Interval node(inputs, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
     ASSERT_NIL(node.next(ctx1));
@@ -219,8 +219,8 @@ TEST(IntervalTest, DoesNotFireBeforeNextIntervalElapses) {
 /// @brief Test that Interval fires when the interval is reached.
 TEST(IntervalTest, FiresWhenIntervalReached) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
-    Interval node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
+    Interval node(inputs, setup.make_node());
 
     auto ctx = make_context(x::telem::SECOND);
     ASSERT_NIL(node.next(ctx));
@@ -234,8 +234,8 @@ TEST(IntervalTest, FiresWhenIntervalReached) {
 /// @brief Test that Interval fires repeatedly at each interval.
 TEST(IntervalTest, FiresRepeatedly) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
-    Interval node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
+    Interval node(inputs, setup.make_node());
 
     auto ctx1 = make_context(x::telem::SECOND);
     ASSERT_NIL(node.next(ctx1));
@@ -256,8 +256,8 @@ TEST(IntervalTest, FiresRepeatedly) {
 /// @brief Test that Interval sets the timestamp to elapsed time when firing.
 TEST(IntervalTest, SetsTimestampOnFire) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
-    Interval node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
+    Interval node(inputs, setup.make_node());
 
     auto ctx = make_context(x::telem::SECOND * 5);
     ASSERT_NIL(node.next(ctx));
@@ -271,8 +271,8 @@ TEST(IntervalTest, SetsTimestampOnFire) {
 /// @brief Test that Interval calls mark_changed when firing.
 TEST(IntervalTest, CallsMarkChangedOnFire) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
-    Interval node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
+    Interval node(inputs, setup.make_node());
 
     std::vector<size_t> marked;
     auto ctx = make_context(x::telem::SECOND);
@@ -286,8 +286,8 @@ TEST(IntervalTest, CallsMarkChangedOnFire) {
 /// @brief Test that Interval does not call mark_changed when not firing.
 TEST(IntervalTest, DoesNotCallMarkChangedWhenNotFiring) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
-    Interval node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
+    Interval node(inputs, setup.make_node());
 
     auto ctx1 = make_context(x::telem::SECOND);
     node.next(ctx1);
@@ -303,8 +303,8 @@ TEST(IntervalTest, DoesNotCallMarkChangedWhenNotFiring) {
 /// @brief Test that Interval is_output_truthy delegates to state.
 TEST(IntervalTest, IsOutputTruthyDelegatesToState) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
-    Interval node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
+    Interval node(inputs, setup.make_node());
 
     auto ctx = make_context(x::telem::SECOND);
     node.next(ctx);
@@ -315,8 +315,8 @@ TEST(IntervalTest, IsOutputTruthyDelegatesToState) {
 /// @brief Test that Interval is_output_truthy returns false before firing.
 TEST(IntervalTest, IsOutputTruthyFalseBeforeFiring) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
-    Interval node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
+    Interval node(inputs, setup.make_node());
 
     EXPECT_FALSE(node.is_output_truthy(0));
 }
@@ -324,8 +324,8 @@ TEST(IntervalTest, IsOutputTruthyFalseBeforeFiring) {
 /// @brief Test that Interval is_output_truthy returns false for unknown param.
 TEST(IntervalTest, IsOutputTruthyFalseForUnknownParam) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
-    Interval node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
+    Interval node(inputs, setup.make_node());
 
     auto ctx = make_context(x::telem::SECOND);
     node.next(ctx);
@@ -336,8 +336,8 @@ TEST(IntervalTest, IsOutputTruthyFalseForUnknownParam) {
 /// @brief Test that Interval reset allows it to fire immediately again.
 TEST(IntervalTest, ResetAllowsImmediateFiring) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
-    Interval node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
+    Interval node(inputs, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
     node.next(ctx1);
@@ -360,8 +360,8 @@ TEST(IntervalTest, ResetAllowsImmediateFiring) {
 
 TEST(IntervalTest, OnlyFiresOnTimerTick) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
-    Interval node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
+    Interval node(inputs, setup.make_node());
 
     bool changed_called = false;
     runtime::node::Context ctx;
@@ -392,8 +392,8 @@ TEST(IntervalTest, OnlyFiresOnTimerTick) {
 /// @brief Test that Wait does not fire before the duration elapses.
 TEST(WaitTest, DoesNotFireBeforeDurationElapses) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
-    Wait node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
+    Wait node(inputs, setup.make_node());
 
     auto ctx = make_context(x::telem::MILLISECOND * 500);
     ASSERT_NIL(node.next(ctx));
@@ -406,8 +406,8 @@ TEST(WaitTest, DoesNotFireBeforeDurationElapses) {
 /// @brief Test that Wait fires once after the duration elapses.
 TEST(WaitTest, FiresOnceAfterDuration) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
-    Wait node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
+    Wait node(inputs, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
     ASSERT_NIL(node.next(ctx1));
@@ -425,8 +425,8 @@ TEST(WaitTest, FiresOnceAfterDuration) {
 /// @brief Test that Wait does not fire again after the first fire.
 TEST(WaitTest, DoesNotFireAgain) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
-    Wait node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
+    Wait node(inputs, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
     node.next(ctx1);
@@ -448,8 +448,8 @@ TEST(WaitTest, DoesNotFireAgain) {
 /// @brief Test that Wait reset allows it to fire again.
 TEST(WaitTest, ResetAllowsFiringAgain) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
-    Wait node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
+    Wait node(inputs, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
     node.next(ctx1);
@@ -476,8 +476,8 @@ TEST(WaitTest, ResetAllowsFiringAgain) {
 
 TEST(WaitTest, OnlyFiresOnTimerTick) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
-    Wait node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
+    Wait node(inputs, setup.make_node());
 
     bool changed_called = false;
     runtime::node::Context ctx;
@@ -510,8 +510,8 @@ TEST(WaitTest, OnlyFiresOnTimerTick) {
 /// @brief Test that Wait measures duration from first next() call, not construction.
 TEST(WaitTest, MeasuresDurationFromFirstNextCall) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
-    Wait node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
+    Wait node(inputs, setup.make_node());
 
     auto ctx1 = make_context(x::telem::SECOND * 10);
     node.next(ctx1);
@@ -531,8 +531,8 @@ TEST(WaitTest, MeasuresDurationFromFirstNextCall) {
 /// TimerTick, not when the stage was activated via channel input.
 TEST(WaitTest, StartsTimingFromChannelInputThatActivatesStage) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
-    Wait node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
+    Wait node(inputs, setup.make_node());
 
     auto ctx1 = make_context(
         x::telem::SECOND * 5,
@@ -556,8 +556,8 @@ TEST(WaitTest, StartsTimingFromChannelInputThatActivatesStage) {
 /// next TimerTick, effectively doubling the wait duration.
 TEST(WaitTest, StartsTimingFromChannelInputAfterReset) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
-    Wait node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
+    Wait node(inputs, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
     node.next(ctx1);
@@ -589,8 +589,8 @@ TEST(WaitTest, StartsTimingFromChannelInputAfterReset) {
 /// @brief Test that Wait calls mark_self_changed when active but not yet fired.
 TEST(WaitTest, CallsMarkSelfChangedWhenActiveButNotFired) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
-    Wait node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
+    Wait node(inputs, setup.make_node());
 
     int self_changed_calls = 0;
     bool changed_called = false;
@@ -626,8 +626,8 @@ TEST(WaitTest, CallsMarkSelfChangedWhenActiveButNotFired) {
 /// non-tick cycles without being starved.
 TEST(WaitTest, CallsMarkSelfChangedOnChannelInputToSurvive) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
-    Wait node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
+    Wait node(inputs, setup.make_node());
 
     int self_changed_calls = 0;
     bool changed_called = false;
@@ -666,8 +666,8 @@ TEST(WaitTest, CallsMarkSelfChangedOnChannelInputToSurvive) {
 /// @brief Test that Wait sets the timestamp to elapsed time when firing.
 TEST(WaitTest, SetsTimestampOnFire) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
-    Wait node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
+    Wait node(inputs, setup.make_node());
 
     auto ctx1 = make_context(x::telem::SECOND * 2);
     node.next(ctx1);
@@ -684,8 +684,8 @@ TEST(WaitTest, SetsTimestampOnFire) {
 /// @brief Test that Wait calls mark_changed when firing.
 TEST(WaitTest, CallsMarkChangedOnFire) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
-    Wait node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
+    Wait node(inputs, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
     node.next(ctx1);
@@ -702,8 +702,8 @@ TEST(WaitTest, CallsMarkChangedOnFire) {
 /// @brief Test that Wait does not call mark_changed when not firing.
 TEST(WaitTest, DoesNotCallMarkChangedWhenNotFiring) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
-    Wait node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
+    Wait node(inputs, setup.make_node());
 
     int call_count = 0;
     auto ctx = make_context(x::telem::MILLISECOND * 100);
@@ -716,8 +716,8 @@ TEST(WaitTest, DoesNotCallMarkChangedWhenNotFiring) {
 /// @brief Test that Wait is_output_truthy delegates to state.
 TEST(WaitTest, IsOutputTruthyDelegatesToState) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
-    Wait node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
+    Wait node(inputs, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
     node.next(ctx1);
@@ -731,8 +731,8 @@ TEST(WaitTest, IsOutputTruthyDelegatesToState) {
 /// @brief Test that Wait reset restarts timing from zero.
 TEST(WaitTest, ResetRestartsTimingFromZero) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
-    Wait node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
+    Wait node(inputs, setup.make_node());
 
     auto ctx1 = make_context(x::telem::SECOND * 5);
     node.next(ctx1);
@@ -818,8 +818,8 @@ TEST(CalculateToleranceTest, HalfIntervalMinimum) {
 /// @brief Test that Interval fires within tolerance.
 TEST(IntervalToleranceTest, FiresWithinTolerance) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
-    Interval node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
+    Interval node(inputs, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
     ASSERT_NIL(node.next(ctx1));
@@ -839,8 +839,8 @@ TEST(IntervalToleranceTest, FiresWithinTolerance) {
 /// @brief Test that Interval does not fire too early even with tolerance.
 TEST(IntervalToleranceTest, DoesNotFireTooEarly) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
-    Interval node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
+    Interval node(inputs, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
     ASSERT_NIL(node.next(ctx1));
@@ -857,8 +857,8 @@ TEST(IntervalToleranceTest, DoesNotFireTooEarly) {
 /// @brief Test that Wait fires within tolerance.
 TEST(WaitToleranceTest, FiresWithinTolerance) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
-    Wait node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
+    Wait node(inputs, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
     ASSERT_NIL(node.next(ctx1));
@@ -878,8 +878,8 @@ TEST(WaitToleranceTest, FiresWithinTolerance) {
 /// @brief Test that Wait does not fire too early even with tolerance.
 TEST(WaitToleranceTest, DoesNotFireTooEarly) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
-    Wait node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
+    Wait node(inputs, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
     ASSERT_NIL(node.next(ctx1));
@@ -896,8 +896,8 @@ TEST(WaitToleranceTest, DoesNotFireTooEarly) {
 /// @brief Test that Interval fires correctly with zero tolerance (original behavior).
 TEST(IntervalToleranceTest, ZeroToleranceRequiresExactTime) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
-    Interval node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(IntervalInputs::create(setup.ir.nodes[0].inputs));
+    Interval node(inputs, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
     ASSERT_NIL(node.next(ctx1));
@@ -921,8 +921,8 @@ TEST(IntervalToleranceTest, ZeroToleranceRequiresExactTime) {
 /// @brief Test that Wait fires correctly with zero tolerance (original behavior).
 TEST(WaitToleranceTest, ZeroToleranceRequiresExactTime) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
-    Wait node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(WaitInputs::create(setup.ir.nodes[0].inputs));
+    Wait node(inputs, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0), x::telem::TimeSpan(0));
     ASSERT_NIL(node.next(ctx1));
@@ -963,10 +963,10 @@ TEST(CalculateToleranceTest, AutoMode) {
 
 TEST(IntervalDeadlineTest, SetsDeadlineToLastFiredPlusPeriod) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(
+    const auto inputs = ASSERT_NIL_P(
         time::IntervalInputs::create(setup.ir.nodes[0].inputs)
     );
-    time::Interval node(cfg, setup.make_node());
+    time::Interval node(inputs, setup.make_node());
 
     x::telem::TimeSpan reported_deadline(-1);
     auto ctx = make_context(x::telem::TimeSpan(0));
@@ -977,10 +977,10 @@ TEST(IntervalDeadlineTest, SetsDeadlineToLastFiredPlusPeriod) {
 
 TEST(IntervalDeadlineTest, SetsDeadlineOnNonTimerTick) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(
+    const auto inputs = ASSERT_NIL_P(
         time::IntervalInputs::create(setup.ir.nodes[0].inputs)
     );
-    time::Interval node(cfg, setup.make_node());
+    time::Interval node(inputs, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
     ASSERT_NIL(node.next(ctx1));
@@ -998,10 +998,10 @@ TEST(IntervalDeadlineTest, SetsDeadlineOnNonTimerTick) {
 
 TEST(IntervalDeadlineTest, SetsDeadlineAfterFiring) {
     TestSetup setup("interval", "period", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(
+    const auto inputs = ASSERT_NIL_P(
         time::IntervalInputs::create(setup.ir.nodes[0].inputs)
     );
-    time::Interval node(cfg, setup.make_node());
+    time::Interval node(inputs, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
     ASSERT_NIL(node.next(ctx1));
@@ -1015,8 +1015,10 @@ TEST(IntervalDeadlineTest, SetsDeadlineAfterFiring) {
 
 TEST(WaitDeadlineTest, SetsDeadlineToStartTimePlusDuration) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(time::WaitInputs::create(setup.ir.nodes[0].inputs));
-    time::Wait node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(
+        time::WaitInputs::create(setup.ir.nodes[0].inputs)
+    );
+    time::Wait node(inputs, setup.make_node());
 
     x::telem::TimeSpan reported_deadline(-1);
     auto ctx = make_context(x::telem::SECOND * 5);
@@ -1027,8 +1029,10 @@ TEST(WaitDeadlineTest, SetsDeadlineToStartTimePlusDuration) {
 
 TEST(WaitDeadlineTest, SetsDeadlineOnChannelInput) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(time::WaitInputs::create(setup.ir.nodes[0].inputs));
-    time::Wait node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(
+        time::WaitInputs::create(setup.ir.nodes[0].inputs)
+    );
+    time::Wait node(inputs, setup.make_node());
 
     x::telem::TimeSpan reported_deadline(-1);
     auto ctx = make_context(
@@ -1043,8 +1047,10 @@ TEST(WaitDeadlineTest, SetsDeadlineOnChannelInput) {
 
 TEST(WaitDeadlineTest, DoesNotSetDeadlineAfterFiring) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(time::WaitInputs::create(setup.ir.nodes[0].inputs));
-    time::Wait node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(
+        time::WaitInputs::create(setup.ir.nodes[0].inputs)
+    );
+    time::Wait node(inputs, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
     ASSERT_NIL(node.next(ctx1));
@@ -1061,8 +1067,10 @@ TEST(WaitDeadlineTest, DoesNotSetDeadlineAfterFiring) {
 
 TEST(WaitDeadlineTest, SetsCorrectDeadlineAfterReset) {
     TestSetup setup("wait", "duration", x::telem::SECOND.nanoseconds());
-    const auto cfg = ASSERT_NIL_P(time::WaitInputs::create(setup.ir.nodes[0].inputs));
-    time::Wait node(cfg, setup.make_node());
+    const auto inputs = ASSERT_NIL_P(
+        time::WaitInputs::create(setup.ir.nodes[0].inputs)
+    );
+    time::Wait node(inputs, setup.make_node());
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
     ASSERT_NIL(node.next(ctx1));
@@ -1117,8 +1125,8 @@ private:
 /// @brief Now node outputs a valid wall-clock timestamp.
 TEST(NowTest, OutputsWallClockTimestamp) {
     NowTestSetup setup;
-    const auto cfg = ASSERT_NIL_P(time::NowInputs::create(setup.ir.nodes[0].inputs));
-    time::Now node(cfg, setup.make_node(), &setup.clock);
+    const auto inputs = ASSERT_NIL_P(time::NowInputs::create(setup.ir.nodes[0].inputs));
+    time::Now node(inputs, setup.make_node(), &setup.clock);
 
     const auto before = x::telem::TimeStamp::now().nanoseconds();
     auto ctx = make_context(x::telem::SECOND * 5);
@@ -1139,8 +1147,8 @@ TEST(NowTest, OutputsWallClockTimestamp) {
 /// @brief Now node fires on any RunReason (not just TimerTick).
 TEST(NowTest, FiresOnChannelInput) {
     NowTestSetup setup;
-    const auto cfg = ASSERT_NIL_P(time::NowInputs::create(setup.ir.nodes[0].inputs));
-    time::Now node(cfg, setup.make_node(), &setup.clock);
+    const auto inputs = ASSERT_NIL_P(time::NowInputs::create(setup.ir.nodes[0].inputs));
+    time::Now node(inputs, setup.make_node(), &setup.clock);
 
     bool changed = false;
     auto ctx = make_context(
@@ -1160,8 +1168,8 @@ TEST(NowTest, FiresOnChannelInput) {
 /// @brief Now node output and output_time contain the same timestamp.
 TEST(NowTest, OutputAndOutputTimeMatch) {
     NowTestSetup setup;
-    const auto cfg = ASSERT_NIL_P(time::NowInputs::create(setup.ir.nodes[0].inputs));
-    time::Now node(cfg, setup.make_node(), &setup.clock);
+    const auto inputs = ASSERT_NIL_P(time::NowInputs::create(setup.ir.nodes[0].inputs));
+    time::Now node(inputs, setup.make_node(), &setup.clock);
 
     auto ctx = make_context(x::telem::SECOND);
     ASSERT_NIL(node.next(ctx));
@@ -1177,8 +1185,8 @@ TEST(NowTest, OutputAndOutputTimeMatch) {
 /// @brief Now node works correctly after reset.
 TEST(NowTest, WorksAfterReset) {
     NowTestSetup setup;
-    const auto cfg = ASSERT_NIL_P(time::NowInputs::create(setup.ir.nodes[0].inputs));
-    time::Now node(cfg, setup.make_node(), &setup.clock);
+    const auto inputs = ASSERT_NIL_P(time::NowInputs::create(setup.ir.nodes[0].inputs));
+    time::Now node(inputs, setup.make_node(), &setup.clock);
 
     auto ctx1 = make_context(x::telem::TimeSpan(0));
     ASSERT_NIL(node.next(ctx1));
@@ -1199,8 +1207,8 @@ TEST(NowTest, WorksAfterReset) {
 /// @brief Now node is_output_truthy returns false for unknown param.
 TEST(NowTest, IsOutputTruthyFalseForUnknownParam) {
     NowTestSetup setup;
-    const auto cfg = ASSERT_NIL_P(time::NowInputs::create(setup.ir.nodes[0].inputs));
-    time::Now node(cfg, setup.make_node(), &setup.clock);
+    const auto inputs = ASSERT_NIL_P(time::NowInputs::create(setup.ir.nodes[0].inputs));
+    time::Now node(inputs, setup.make_node(), &setup.clock);
     EXPECT_FALSE(node.is_output_truthy(999));
 }
 

--- a/arc/go/stl/channels/channels.go
+++ b/arc/go/stl/channels/channels.go
@@ -120,7 +120,7 @@ func (h *Host) Create(_ context.Context, cfg node.Config) (node.Node, error) {
 	if !isSource && !isSink {
 		return nil, query.ErrNotFound
 	}
-	var nodeCfg config
+	var nodeCfg inputs
 	if err := schema.Parse(cfg.Node.Inputs.ValueMap(), &nodeCfg); err != nil {
 		return nil, err
 	}
@@ -142,7 +142,7 @@ var schema = zyn.Object(map[string]zyn.Schema{
 	"channel": zyn.Uint32().Coerce(),
 })
 
-type config struct {
+type inputs struct {
 	Channel uint32 `json:"channel"`
 }
 

--- a/arc/go/stl/channels/channels.go
+++ b/arc/go/stl/channels/channels.go
@@ -120,14 +120,14 @@ func (h *Host) Create(_ context.Context, cfg node.Config) (node.Node, error) {
 	if !isSource && !isSink {
 		return nil, query.ErrNotFound
 	}
-	var nodeCfg inputs
-	if err := schema.Parse(cfg.Node.Inputs.ValueMap(), &nodeCfg); err != nil {
+	var inputs nodeInputs
+	if err := schema.Parse(cfg.Node.Inputs.ValueMap(), &inputs); err != nil {
 		return nil, err
 	}
 	if isSource {
 		return &source{
 			State: cfg.State,
-			key:   nodeCfg.Channel,
+			key:   inputs.Channel,
 			state: h.state,
 		}, nil
 	}
@@ -135,14 +135,14 @@ func (h *Host) Create(_ context.Context, cfg node.Config) (node.Node, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &sink{State: cfg.State, state: h.state, key: nodeCfg.Channel, inputIdx: inputIdx}, nil
+	return &sink{State: cfg.State, state: h.state, key: inputs.Channel, inputIdx: inputIdx}, nil
 }
 
 var schema = zyn.Object(map[string]zyn.Schema{
 	"channel": zyn.Uint32().Coerce(),
 })
 
-type inputs struct {
+type nodeInputs struct {
 	Channel uint32 `json:"channel"`
 }
 

--- a/arc/go/stl/control/control.go
+++ b/arc/go/stl/control/control.go
@@ -90,7 +90,7 @@ func (h *Host) Create(_ context.Context, cfg node.Config) (node.Node, error) {
 	if cfg.Node.Type != symbolName {
 		return nil, query.ErrNotFound
 	}
-	var nodeCfg nodeConfig
+	var nodeCfg nodeInputs
 	if err := schema.Parse(cfg.Node.Inputs.ValueMap(), &nodeCfg); err != nil {
 		return nil, errors.Wrap(err, "control.set_authority config")
 	}
@@ -110,7 +110,7 @@ var schema = zyn.Object(map[string]zyn.Schema{
 	"channel": zyn.Number().Uint32(),
 })
 
-type nodeConfig struct {
+type nodeInputs struct {
 	Value   uint8  `json:"value"`
 	Channel uint32 `json:"channel"`
 }

--- a/arc/go/stl/control/control.go
+++ b/arc/go/stl/control/control.go
@@ -90,17 +90,17 @@ func (h *Host) Create(_ context.Context, cfg node.Config) (node.Node, error) {
 	if cfg.Node.Type != symbolName {
 		return nil, query.ErrNotFound
 	}
-	var nodeCfg nodeInputs
-	if err := schema.Parse(cfg.Node.Inputs.ValueMap(), &nodeCfg); err != nil {
-		return nil, errors.Wrap(err, "control.set_authority config")
+	var inputs nodeInputs
+	if err := schema.Parse(cfg.Node.Inputs.ValueMap(), &inputs); err != nil {
+		return nil, errors.Wrap(err, "control.set_authority inputs")
 	}
 	var channelKey *uint32
-	if nodeCfg.Channel != 0 {
-		channelKey = &nodeCfg.Channel
+	if inputs.Channel != 0 {
+		channelKey = &inputs.Channel
 	}
 	return &setAuthority{
 		auth:       h.auth,
-		authority:  nodeCfg.Value,
+		authority:  inputs.Value,
 		channelKey: channelKey,
 	}, nil
 }

--- a/arc/go/stl/math/math.go
+++ b/arc/go/stl/math/math.go
@@ -245,8 +245,8 @@ func (h *Host) Create(_ context.Context, nodeCfg node.Config) (node.Node, error)
 			telem.NewSeriesV[telem.TimeStamp](1),
 		)
 	}
-	var cfg WindowInputs
-	if err := windowInputsSchema.Parse(nodeCfg.Node.Inputs.ValueMap(), &cfg); err != nil {
+	var inputs WindowInputs
+	if err := windowInputsSchema.Parse(nodeCfg.Node.Inputs.ValueMap(), &inputs); err != nil {
 		return nil, err
 	}
 	return &avgNode{
@@ -255,7 +255,7 @@ func (h *Host) Create(_ context.Context, nodeCfg node.Config) (node.Node, error)
 		resetIdx:    resetIdx,
 		process:     reductionFn,
 		sampleCount: 0,
-		cfg:         cfg,
+		inputs:      inputs,
 	}, nil
 }
 
@@ -272,7 +272,7 @@ var windowInputsSchema = zyn.Object(map[string]zyn.Schema{
 type avgNode struct {
 	*node.State
 	process       reductionFn
-	cfg           WindowInputs
+	inputs        WindowInputs
 	inputIdx      int
 	resetIdx      int
 	sampleCount   int64
@@ -316,15 +316,15 @@ func (r *avgNode) Next(ctx node.Context) {
 		}
 	}
 
-	if r.cfg.Duration > 0 && inputTime.Len() > 0 {
+	if r.inputs.Duration > 0 && inputTime.Len() > 0 {
 		currentTime := telem.ValueAt[telem.TimeStamp](inputTime, -1)
-		if telem.TimeSpan(currentTime-r.startTime) >= r.cfg.Duration {
+		if telem.TimeSpan(currentTime-r.startTime) >= r.inputs.Duration {
 			shouldReset = true
 			r.startTime = currentTime
 		}
 	}
 
-	if r.cfg.Count > 0 && r.sampleCount >= r.cfg.Count {
+	if r.inputs.Count > 0 && r.sampleCount >= r.inputs.Count {
 		shouldReset = true
 	}
 

--- a/arc/go/stl/math/math.go
+++ b/arc/go/stl/math/math.go
@@ -29,9 +29,9 @@ import (
 
 const (
 	avgSymbolName        = "avg"
-	countConfigParam     = "count"
+	countInputParam     = "count"
 	derivativeSymbolName = "derivative"
-	durationConfigParam  = "duration"
+	durationInputParam  = "duration"
 	maxSymbolName        = "max"
 	minSymbolName        = "min"
 	powSymbolName        = "pow"
@@ -61,8 +61,8 @@ func createBaseSymbol(name string, doc doc.Doc) *symbol.Symbol {
 		Type: types.Function(types.FunctionProperties{
 			Inputs: types.Params{
 				{Name: ir.DefaultInputParam, Type: types.Variable("T", &numConstraint)},
-				{Name: durationConfigParam, Type: types.TimeSpan(), Value: telem.TimeSpanZero},
-				{Name: countConfigParam, Type: types.I64(), Value: 0},
+				{Name: durationInputParam, Type: types.TimeSpan(), Value: telem.TimeSpanZero},
+				{Name: countInputParam, Type: types.I64(), Value: 0},
 				{Name: resetInputParam, Type: types.U8(), Value: 0},
 			},
 			Outputs: types.Params{
@@ -245,8 +245,8 @@ func (h *Host) Create(_ context.Context, nodeCfg node.Config) (node.Node, error)
 			telem.NewSeriesV[telem.TimeStamp](1),
 		)
 	}
-	var cfg WindowConfig
-	if err := windowConfigSchema.Parse(nodeCfg.Node.Inputs.ValueMap(), &cfg); err != nil {
+	var cfg WindowInputs
+	if err := windowInputsSchema.Parse(nodeCfg.Node.Inputs.ValueMap(), &cfg); err != nil {
 		return nil, err
 	}
 	return &avgNode{
@@ -259,20 +259,20 @@ func (h *Host) Create(_ context.Context, nodeCfg node.Config) (node.Node, error)
 	}, nil
 }
 
-type WindowConfig struct {
+type WindowInputs struct {
 	Duration telem.TimeSpan `json:"duration" msgpack:"duration"`
 	Count    int64          `json:"count" msgpack:"count"`
 }
 
-var windowConfigSchema = zyn.Object(map[string]zyn.Schema{
-	durationConfigParam: zyn.Int64().Optional().Coerce(),
-	countConfigParam:    zyn.Int64().Optional().Coerce(),
+var windowInputsSchema = zyn.Object(map[string]zyn.Schema{
+	durationInputParam: zyn.Int64().Optional().Coerce(),
+	countInputParam:    zyn.Int64().Optional().Coerce(),
 })
 
 type avgNode struct {
 	*node.State
 	process       reductionFn
-	cfg           WindowConfig
+	cfg           WindowInputs
 	inputIdx      int
 	resetIdx      int
 	sampleCount   int64

--- a/arc/go/stl/math/math.go
+++ b/arc/go/stl/math/math.go
@@ -29,9 +29,9 @@ import (
 
 const (
 	avgSymbolName        = "avg"
-	countInputParam     = "count"
+	countInputParam      = "count"
 	derivativeSymbolName = "derivative"
-	durationInputParam  = "duration"
+	durationInputParam   = "duration"
 	maxSymbolName        = "max"
 	minSymbolName        = "min"
 	powSymbolName        = "pow"

--- a/arc/go/stl/stable/stable.go
+++ b/arc/go/stl/stable/stable.go
@@ -98,8 +98,8 @@ func (h *Host) Create(_ context.Context, cfg node.Config) (node.Node, error) {
 	if cfg.Node.Type != bareSymbolName && cfg.Node.Type != qualifiedMemberName {
 		return nil, query.ErrNotFound
 	}
-	var cfgVals inputs
-	if err := inputsSchema.Parse(cfg.Node.Inputs.ValueMap(), &cfgVals); err != nil {
+	var inputs nodeInputs
+	if err := inputsSchema.Parse(cfg.Node.Inputs.ValueMap(), &inputs); err != nil {
 		return nil, err
 	}
 	inputIdx, err := cfg.State.ResolveInput(ir.DefaultInputParam)
@@ -109,12 +109,12 @@ func (h *Host) Create(_ context.Context, cfg node.Config) (node.Node, error) {
 	return &forNode{
 		State:    cfg.State,
 		inputIdx: inputIdx,
-		duration: cfgVals.Duration,
+		duration: inputs.Duration,
 		now:      h.now,
 	}, nil
 }
 
-type inputs struct {
+type nodeInputs struct {
 	Duration telem.TimeSpan
 }
 

--- a/arc/go/stl/stable/stable.go
+++ b/arc/go/stl/stable/stable.go
@@ -98,8 +98,8 @@ func (h *Host) Create(_ context.Context, cfg node.Config) (node.Node, error) {
 	if cfg.Node.Type != bareSymbolName && cfg.Node.Type != qualifiedMemberName {
 		return nil, query.ErrNotFound
 	}
-	var cfgVals config
-	if err := configSchema.Parse(cfg.Node.Inputs.ValueMap(), &cfgVals); err != nil {
+	var cfgVals inputs
+	if err := inputsSchema.Parse(cfg.Node.Inputs.ValueMap(), &cfgVals); err != nil {
 		return nil, err
 	}
 	inputIdx, err := cfg.State.ResolveInput(ir.DefaultInputParam)
@@ -114,11 +114,11 @@ func (h *Host) Create(_ context.Context, cfg node.Config) (node.Node, error) {
 	}, nil
 }
 
-type config struct {
+type inputs struct {
 	Duration telem.TimeSpan
 }
 
-var configSchema = zyn.Object(map[string]zyn.Schema{
+var inputsSchema = zyn.Object(map[string]zyn.Schema{
 	"duration": zyn.Int64().Coerce(),
 })
 

--- a/arc/go/stl/time/time.go
+++ b/arc/go/stl/time/time.go
@@ -26,12 +26,12 @@ import (
 )
 
 const (
-	intervalSymbolName  = "interval"
-	waitSymbolName      = "wait"
-	nowSymbolName       = "now"
+	intervalSymbolName = "interval"
+	waitSymbolName     = "wait"
+	nowSymbolName      = "now"
 	periodInputParam   = "period"
 	durationInputParam = "duration"
-	name                = "time"
+	name               = "time"
 )
 
 // MinTolerance is the minimum tolerance for timing comparisons,

--- a/arc/go/stl/time/time.go
+++ b/arc/go/stl/time/time.go
@@ -29,8 +29,8 @@ const (
 	intervalSymbolName  = "interval"
 	waitSymbolName      = "wait"
 	nowSymbolName       = "now"
-	periodConfigParam   = "period"
-	durationConfigParam = "duration"
+	periodInputParam   = "period"
+	durationInputParam = "duration"
 	name                = "time"
 )
 
@@ -72,7 +72,7 @@ func NewSymbols() []*symbol.Symbol {
 		Exec: symbol.ExecFlow,
 		Type: types.Function(types.FunctionProperties{
 			Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.U8()}},
-			Inputs:  types.Params{{Name: periodConfigParam, Type: types.TimeSpan()}},
+			Inputs:  types.Params{{Name: periodInputParam, Type: types.TimeSpan()}},
 		}),
 		Trigger: symbol.TriggerOnly,
 		Doc:     intervalDoc,
@@ -83,7 +83,7 @@ func NewSymbols() []*symbol.Symbol {
 		Exec: symbol.ExecFlow,
 		Type: types.Function(types.FunctionProperties{
 			Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.U8()}},
-			Inputs:  types.Params{{Name: durationConfigParam, Type: types.TimeSpan()}},
+			Inputs:  types.Params{{Name: durationInputParam, Type: types.TimeSpan()}},
 		}),
 		Trigger: symbol.TriggerOnly,
 		Doc:     waitDoc,
@@ -143,7 +143,7 @@ func NewHost(ctx context.Context, rt wazero.Runtime) (*Host, error) {
 func (h *Host) Create(_ context.Context, cfg node.Config) (node.Node, error) {
 	switch cfg.Node.Type {
 	case intervalSymbolName:
-		periodParam, ok := cfg.Node.Inputs.Get(periodConfigParam)
+		periodParam, ok := cfg.Node.Inputs.Get(periodInputParam)
 		if !ok {
 			return nil, query.ErrNotFound
 		}
@@ -159,7 +159,7 @@ func (h *Host) Create(_ context.Context, cfg node.Config) (node.Node, error) {
 		}, nil
 
 	case waitSymbolName:
-		durationParam, ok := cfg.Node.Inputs.Get(durationConfigParam)
+		durationParam, ok := cfg.Node.Inputs.Get(durationInputParam)
 		if !ok {
 			return nil, query.ErrNotFound
 		}


### PR DESCRIPTION
## Linear Issue

[SY-4413](https://linear.app/synnax/issue/SY-4413)

## Description

Completes the config to inputs terminology sweep (RFC 0039) in the Arc stdlib runtime modules, which the unification left behind. Renames the config-named input structs, their schemas, and param-name constants to the `Inputs` form across both runtimes:

- Go: `WindowConfig`/`windowConfigSchema` (math), `nodeConfig` (control), `config`/`configSchema` (stable), `config` (channels), and the `durationConfigParam`/`countConfigParam`/`periodConfigParam` constants (math, time).
- C++: `WindowConfig` (math), `StableForConfig` (stable), `IntervalConfig`/`WaitConfig`/`NowConfig` (time), plus their tests.

Internal identifiers only. The `zyn` schemas and `Node.Inputs.ValueMap()` calls are behavior identical, so there is no wire-format, migration, or user-facing change. Go stl suites pass (math, time, control, stable, channels).

## Follow-ups

This is one of several independent sibling sweeps finishing the config to inputs terminology tail (RFC 0039 Appendix A). Each lands as its own PR:

- [SY-4388](https://linear.app/synnax/issue/SY-4388): remove the `symbol.KindConfig` enum (internal, no migration).
- [SY-4389](https://linear.app/synnax/issue/SY-4389): rename the ANTLR grammar `config` productions (done last).
- [SY-4445](https://linear.app/synnax/issue/SY-4445): rename the graph `configs` wire field to `inputs` (wire-format change with its own codec migration; deliberately not bundled here).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes a terminology sweep (RFC 0039) renaming "Config" input structs to "Inputs" across the Arc stdlib runtime modules in both Go and C++. All changes are pure identifier renames with no behavioral, schema, or wire-format modifications.

- **Go**: Renames `WindowConfig`/`windowConfigSchema`, `config`/`configSchema`, `nodeConfig`, and the `durationConfigParam`/`countConfigParam`/`periodConfigParam` constants to their `*Inputs` / `*InputParam` equivalents across `math.go`, `stable.go`, `channels.go`, `control.go`, and `time.go`.
- **C++**: Renames `WindowConfig`, `StableForConfig`, `IntervalConfig`, `WaitConfig`, and `NowConfig` structs to `*Inputs` in `math.h`, `stable.h`, and `time.h`, with corresponding test-name updates in all three `_test.cpp` files.
- All `zyn` schema keys, parameter string values, and node type strings are untouched, preserving wire-format compatibility.

<h3>Confidence Score: 5/5</h3>

Pure identifier rename with no behavioral, schema, or wire-format changes; all call sites updated and verified to have no external references.

Every renamed identifier was verified to have no references outside the changed files. The zyn schema keys, parameter string values, and node type strings are all untouched, so runtime behavior is identical. Tests were updated in lock-step with the production code.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| arc/go/stl/math/math.go | Renames WindowConfig→WindowInputs, windowConfigSchema→windowInputsSchema, countConfigParam→countInputParam, durationConfigParam→durationInputParam; all usages within the file are updated consistently. |
| arc/go/stl/time/time.go | Renames periodConfigParam→periodInputParam and durationConfigParam→durationInputParam constants; all call sites updated; string values unchanged. |
| arc/go/stl/control/control.go | Renames unexported nodeConfig→nodeInputs; single declaration and single usage both updated correctly. |
| arc/go/stl/channels/channels.go | Renames unexported config→inputs; declaration and usage in Create() both updated correctly. |
| arc/go/stl/stable/stable.go | Renames unexported config→inputs and configSchema→inputsSchema; all usages updated consistently. |
| arc/cpp/stl/math/math.h | Renames WindowConfig→WindowInputs across struct definition, static factory, field declaration, and constructor parameter; all five sites updated. |
| arc/cpp/stl/stable/stable.h | Renames StableForConfig→StableForInputs across struct definition, factory, field, and constructor parameter; all sites updated. |
| arc/cpp/stl/time/time.h | Renames IntervalConfig, WaitConfig, NowConfig to their Inputs equivalents across all struct definitions, factories, fields, and constructor parameters. |
| arc/cpp/stl/math/math_test.cpp | Updates six test names from *Config to *Input and all WindowConfig::create calls to WindowInputs::create. |
| arc/cpp/stl/stable/stable_test.cpp | Renames StableForConfigTest suite to StableForInputsTest and updates all StableForConfig::create calls to StableForInputs::create across nine test cases. |
| arc/cpp/stl/time/time_test.cpp | Renames IntervalConfigTest, WaitConfigTest suites and updates ~30 IntervalConfig/WaitConfig/NowConfig::create calls to their Inputs equivalents throughout the file. |

<h3>Class Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
classDiagram
    note "Go stdlib renames"
    class WindowInputs["WindowInputs (was WindowConfig)"] {
        +Duration TimeSpan
        +Count int64
    }
    class nodeInputs["nodeInputs (was nodeConfig) — control"] {
        +Value uint8
        +Channel uint32
    }
    class inputs_channels["inputs (was config) — channels"] {
        +Channel uint32
    }
    class inputs_stable["inputs (was config) — stable"] {
        +Duration TimeSpan
    }
    note "C++ stdlib renames"
    class WindowInputs_cpp["WindowInputs (was WindowConfig) — C++"] {
        +duration TimeSpan
        +count int64
        +create(params) pair
    }
    class StableForInputs["StableForInputs (was StableForConfig)"] {
        +duration TimeSpan
        +create(params) pair
    }
    class IntervalInputs["IntervalInputs (was IntervalConfig)"] {
        +interval TimeSpan
        +create(params) pair
    }
    class WaitInputs["WaitInputs (was WaitConfig)"] {
        +duration TimeSpan
        +create(params) pair
    }
    class NowInputs["NowInputs (was NowConfig)"] {
        +create(params) pair
    }
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
classDiagram
    note "Go stdlib renames"
    class WindowInputs["WindowInputs (was WindowConfig)"] {
        +Duration TimeSpan
        +Count int64
    }
    class nodeInputs["nodeInputs (was nodeConfig) — control"] {
        +Value uint8
        +Channel uint32
    }
    class inputs_channels["inputs (was config) — channels"] {
        +Channel uint32
    }
    class inputs_stable["inputs (was config) — stable"] {
        +Duration TimeSpan
    }
    note "C++ stdlib renames"
    class WindowInputs_cpp["WindowInputs (was WindowConfig) — C++"] {
        +duration TimeSpan
        +count int64
        +create(params) pair
    }
    class StableForInputs["StableForInputs (was StableForConfig)"] {
        +duration TimeSpan
        +create(params) pair
    }
    class IntervalInputs["IntervalInputs (was IntervalConfig)"] {
        +interval TimeSpan
        +create(params) pair
    }
    class WaitInputs["WaitInputs (was WaitConfig)"] {
        +duration TimeSpan
        +create(params) pair
    }
    class NowInputs["NowInputs (was NowConfig)"] {
        +create(params) pair
    }
```

</a>

<sub>Reviews (2): Last reviewed commit: ["SY-4413: Fix gofmt alignment in math/tim..."](https://github.com/synnaxlabs/synnax/commit/ca44ead2820fb1ac5137dc39904b5bf51459fbc6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41138300)</sub>

<!-- /greptile_comment -->