### PR TITLE
SY-4445: Rename Arc Graph Configs Wire Field to Inputs

### DIFF
--- a/arc/cpp/graph/json.gen.h
+++ b/arc/cpp/graph/json.gen.h
@@ -56,10 +56,10 @@ inline Graph Graph::parse(x::json::Parser parser) {
         .functions = parser.field<::arc::ir::Functions>("functions"),
         .edges = parser.field<Edges>("edges"),
         .nodes = parser.field<Nodes>("nodes"),
-        .configs = parser
-                       .field<std::unordered_map<std::string, x::json::json::object_t>>(
-                           "configs"
-                       ),
+        .inputs = parser
+                      .field<std::unordered_map<std::string, x::json::json::object_t>>(
+                          "inputs"
+                      ),
     };
 }
 
@@ -68,7 +68,7 @@ inline x::json::json Graph::to_json() const {
     j["functions"] = this->functions.to_json();
     j["edges"] = this->edges.to_json();
     j["nodes"] = this->nodes.to_json();
-    j["configs"] = this->configs;
+    j["inputs"] = this->inputs;
     return j;
 }
 

--- a/arc/cpp/graph/proto.gen.h
+++ b/arc/cpp/graph/proto.gen.h
@@ -102,10 +102,10 @@ inline std::pair<::arc::graph::pb::Graph, x::errors::Error> Graph::to_proto() co
         if (err) return {{}, err};
         *pb.add_nodes() = v;
     }
-    for (const auto &[k, v]: this->configs) {
+    for (const auto &[k, v]: this->inputs) {
         auto [pb_v, err] = x::json::to_struct(v);
         if (err) return {{}, err};
-        (*pb.mutable_configs())[k] = pb_v;
+        (*pb.mutable_inputs())[k] = pb_v;
     }
     return {pb, x::errors::NIL};
 }
@@ -122,10 +122,10 @@ Graph::from_proto(const ::arc::graph::pb::Graph &pb) {
         return {{}, err};
     if (auto err = x::pb::from_proto_repeated<Node>(cpp.nodes, pb.nodes()))
         return {{}, err};
-    for (const auto &[k, v]: pb.configs()) {
+    for (const auto &[k, v]: pb.inputs()) {
         auto [cpp_v, err] = x::json::from_struct(v);
         if (err) return {{}, err};
-        cpp.configs[k] = cpp_v;
+        cpp.inputs[k] = cpp_v;
     }
     return {cpp, x::errors::NIL};
 }

--- a/arc/cpp/graph/types.gen.h
+++ b/arc/cpp/graph/types.gen.h
@@ -30,8 +30,8 @@ struct Edge;
 struct Graph;
 
 /// @brief Node is a visual node in the Arc graph editor representing a function
-/// instantiation with position data. The function type and configuration parameter
-/// values are stored in the graph's configs map, keyed by the node key.
+/// instantiation with position data. The function type and input parameter values are
+/// stored in the graph's inputs map, keyed by the node key.
 struct Node {
     /// @brief key is the unique identifier for this node instance.
     std::string key;
@@ -180,12 +180,11 @@ struct Graph {
     Edges edges = {};
     /// @brief nodes contains visual nodes with canvas positions.
     Nodes nodes = {};
-    /// @brief configs contains per-node configuration keyed by node key. Each value is
-    /// a
-    /// JSON object holding the node's function type under "type" plus its configuration
-    /// parameter values. The wire format stores it as an opaque record; the client
-    /// types it per function.
-    std::unordered_map<std::string, x::json::json::object_t> configs = {};
+    /// @brief inputs contains per-node inputs keyed by node key. Each value is a JSON
+    /// object holding the node's function type under "type" plus its input parameter
+    /// values. The wire format stores it as an opaque record; the client types it per
+    /// function.
+    std::unordered_map<std::string, x::json::json::object_t> inputs = {};
 
     static Graph parse(x::json::Parser parser);
     [[nodiscard]] x::json::json to_json() const;

--- a/arc/go/graph/analyze.go
+++ b/arc/go/graph/analyze.go
@@ -116,8 +116,8 @@ func Analyze(
 	freshFuncTypes := make(map[string]types.Type)
 	irNodes := make(ir.Nodes, len(g.Nodes))
 	for i, n := range g.Nodes {
-		cfg := g.Inputs[n.Key]
-		rawType, ok := cfg["type"]
+		inputs := g.Inputs[n.Key]
+		rawType, ok := inputs["type"]
 		if !ok {
 			aCtx.Diagnostics.Add(diagnostics.Errorf(
 				nil,
@@ -152,7 +152,7 @@ func Analyze(
 		}
 		// Param values come from the node's entry in the graph inputs map.
 		for j, param := range freshType.Inputs {
-			paramValue, ok := cfg[param.Name]
+			paramValue, ok := inputs[param.Name]
 			if !ok {
 				continue
 			}

--- a/arc/go/graph/analyze.go
+++ b/arc/go/graph/analyze.go
@@ -116,7 +116,7 @@ func Analyze(
 	freshFuncTypes := make(map[string]types.Type)
 	irNodes := make(ir.Nodes, len(g.Nodes))
 	for i, n := range g.Nodes {
-		cfg := g.Configs[n.Key]
+		cfg := g.Inputs[n.Key]
 		rawType, ok := cfg["type"]
 		if !ok {
 			aCtx.Diagnostics.Add(diagnostics.Errorf(
@@ -150,7 +150,7 @@ func Analyze(
 			Inputs:   freshType.Inputs,
 			Outputs:  freshType.Outputs,
 		}
-		// Param values come from the node's entry in the graph configs map.
+		// Param values come from the node's entry in the graph inputs map.
 		for j, param := range freshType.Inputs {
 			paramValue, ok := cfg[param.Name]
 			if !ok {

--- a/arc/go/graph/codec.gen.go
+++ b/arc/go/graph/codec.gen.go
@@ -80,10 +80,10 @@ func (g Graph) EncodeOrc(w *orc.Writer) error {
 			}
 		}
 	}
-	w.Bool(g.Configs != nil)
-	if g.Configs != nil {
-		w.Uint32(uint32(len(g.Configs)))
-		for key, val := range g.Configs {
+	w.Bool(g.Inputs != nil)
+	if g.Inputs != nil {
+		w.Uint32(uint32(len(g.Inputs)))
+		for key, val := range g.Inputs {
 			w.String(key)
 			{
 				b, err := json.Marshal(val)
@@ -162,7 +162,7 @@ func (g *Graph) DecodeOrc(r *orc.Reader) error {
 			if err != nil {
 				return err
 			}
-			g.Configs = make(map[string]msgpack.EncodedJSON, n)
+			g.Inputs = make(map[string]msgpack.EncodedJSON, n)
 			for range n {
 				var key string
 				var val msgpack.EncodedJSON
@@ -178,7 +178,7 @@ func (g *Graph) DecodeOrc(r *orc.Reader) error {
 						return err
 					}
 				}
-				g.Configs[key] = val
+				g.Inputs[key] = val
 			}
 		}
 	}

--- a/arc/go/graph/codec_gen_test.go
+++ b/arc/go/graph/codec_gen_test.go
@@ -124,20 +124,20 @@ var _ = Describe("Codec", func() {
 						Key: "test_40",
 					},
 				},
-				Nodes:   []graph.Node{{Key: "test_42", Position: spatial.XY{X: 44.5, Y: 45.5}}},
-				Configs: map[string]msgpack.EncodedJSON{"test_46": {"key_46": "value_46"}},
+				Nodes:  []graph.Node{{Key: "test_42", Position: spatial.XY{X: 44.5, Y: 45.5}}},
+				Inputs: map[string]msgpack.EncodedJSON{"test_46": {"key_46": "value_46"}},
 			}),
 			Entry("zero values", graph.Graph{
 				Functions: nil,
 				Edges:     nil,
 				Nodes:     nil,
-				Configs:   nil,
+				Inputs:    nil,
 			}),
 			Entry("empty collections", graph.Graph{
 				Functions: []ir.Function{},
 				Edges:     []graph.Edge{},
 				Nodes:     []graph.Node{},
-				Configs:   map[string]msgpack.EncodedJSON{},
+				Inputs:    map[string]msgpack.EncodedJSON{},
 			}),
 		)
 	})
@@ -240,8 +240,8 @@ func BenchmarkEncodeDecodeGraph(b *testing.B) {
 				Key: "test_40",
 			},
 		},
-		Nodes:   []graph.Node{{Key: "test_42", Position: spatial.XY{X: 44.5, Y: 45.5}}},
-		Configs: map[string]msgpack.EncodedJSON{"test_46": {"key_46": "value_46"}},
+		Nodes:  []graph.Node{{Key: "test_42", Position: spatial.XY{X: 44.5, Y: 45.5}}},
+		Inputs: map[string]msgpack.EncodedJSON{"test_46": {"key_46": "value_46"}},
 	}
 	w := orc.NewWriter(0)
 	r := orc.NewReader(nil)
@@ -394,8 +394,8 @@ func FuzzDecodeGraph(f *testing.F) {
 					Key: "test_40",
 				},
 			},
-			Nodes:   []graph.Node{{Key: "test_42", Position: spatial.XY{X: 44.5, Y: 45.5}}},
-			Configs: map[string]msgpack.EncodedJSON{"test_46": {"key_46": "value_46"}},
+			Nodes:  []graph.Node{{Key: "test_42", Position: spatial.XY{X: 44.5, Y: 45.5}}},
+			Inputs: map[string]msgpack.EncodedJSON{"test_46": {"key_46": "value_46"}},
 		}
 		w := orc.NewWriter(0)
 		if err := seed.EncodeOrc(w); err != nil {
@@ -408,7 +408,7 @@ func FuzzDecodeGraph(f *testing.F) {
 			Functions: nil,
 			Edges:     nil,
 			Nodes:     nil,
-			Configs:   nil,
+			Inputs:    nil,
 		}
 		w := orc.NewWriter(0)
 		if err := seed.EncodeOrc(w); err != nil {
@@ -421,7 +421,7 @@ func FuzzDecodeGraph(f *testing.F) {
 			Functions: []ir.Function{},
 			Edges:     []graph.Edge{},
 			Nodes:     []graph.Node{},
-			Configs:   map[string]msgpack.EncodedJSON{},
+			Inputs:    map[string]msgpack.EncodedJSON{},
 		}
 		w := orc.NewWriter(0)
 		if err := seed.EncodeOrc(w); err != nil {

--- a/arc/go/graph/graph_test.go
+++ b/arc/go/graph/graph_test.go
@@ -28,14 +28,14 @@ import (
 )
 
 // nodeSpec describes a graph node together with its function type and configuration
-// parameter values, which now live in the graph's Configs map rather than on the node.
+// parameter values, which now live in the graph's Inputs map rather than on the node.
 type nodeSpec struct {
 	key string
 	typ string
 	cfg map[string]any
 }
 
-// buildNodes converts node specs into the graph's Nodes slice plus the Configs map,
+// buildNodes converts node specs into the graph's Nodes slice plus the Inputs map,
 // keying each config by node key and storing the function type under "type".
 func buildNodes(specs ...nodeSpec) (graph.Nodes, map[string]msgpack.EncodedJSON) {
 	nodes := make(graph.Nodes, len(specs))
@@ -153,7 +153,7 @@ var _ = Describe("Graph", func() {
 					},
 				},
 				Nodes:   nodes,
-				Configs: configs,
+				Inputs: configs,
 				Edges: graph.Edges{
 					{Edge: ir.Edge{
 						Source: arc.Handle{Node: "first", Param: ir.DefaultOutputParam},
@@ -211,7 +211,7 @@ var _ = Describe("Graph", func() {
 						},
 					},
 					Nodes:   nodes,
-					Configs: configs,
+					Inputs: configs,
 					Edges: graph.Edges{
 						{Edge: ir.Edge{
 							Source: ir.Handle{Node: "source1", Param: ir.DefaultOutputParam},
@@ -276,7 +276,7 @@ var _ = Describe("Graph", func() {
 						},
 					},
 					Nodes:   nodes,
-					Configs: configs,
+					Inputs: configs,
 					Edges: graph.Edges{
 						{Edge: ir.Edge{
 							Source: ir.Handle{Node: "int_source1", Param: ir.DefaultOutputParam},
@@ -343,7 +343,7 @@ var _ = Describe("Graph", func() {
 						},
 					},
 					Nodes:   nodes,
-					Configs: configs,
+					Inputs: configs,
 					Edges: graph.Edges{
 						{Edge: ir.Edge{
 							Source: ir.Handle{Node: "src1", Param: ir.DefaultOutputParam},
@@ -410,7 +410,7 @@ var _ = Describe("Graph", func() {
 						},
 					},
 					Nodes:   nodes,
-					Configs: configs,
+					Inputs: configs,
 					Edges: graph.Edges{
 						{Edge: ir.Edge{
 							Source: ir.Handle{Node: "float_src", Param: ir.DefaultOutputParam},
@@ -454,7 +454,7 @@ var _ = Describe("Graph", func() {
 						},
 					},
 					Nodes:   nodes,
-					Configs: configs,
+					Inputs: configs,
 					Edges: graph.Edges{
 						{Edge: ir.Edge{
 							Source: ir.Handle{Node: "str_src", Param: ir.DefaultOutputParam},
@@ -490,7 +490,7 @@ var _ = Describe("Graph", func() {
 						},
 					},
 					Nodes:   nodes,
-					Configs: configs,
+					Inputs: configs,
 					Edges: graph.Edges{
 						{Edge: ir.Edge{
 							Source: ir.Handle{Node: "src", Param: ir.DefaultOutputParam},
@@ -525,7 +525,7 @@ var _ = Describe("Graph", func() {
 						},
 					},
 					Nodes:   nodes,
-					Configs: configs,
+					Inputs: configs,
 					Edges: graph.Edges{
 						{Edge: ir.Edge{
 							Source: ir.Handle{Node: "src", Param: ir.DefaultOutputParam},
@@ -560,7 +560,7 @@ var _ = Describe("Graph", func() {
 						},
 					},
 					Nodes:   nodes,
-					Configs: configs,
+					Inputs: configs,
 					Edges: graph.Edges{
 						{Edge: ir.Edge{
 							Source: ir.Handle{Node: "str_src", Param: ir.DefaultOutputParam},
@@ -598,7 +598,7 @@ var _ = Describe("Graph", func() {
 				)
 				g := arc.Graph{
 					Nodes:   nodes,
-					Configs: configs,
+					Inputs: configs,
 					Edges: graph.Edges{
 						{Edge: ir.Edge{
 							Source: arc.Handle{Node: "on", Param: ir.DefaultOutputParam},
@@ -691,7 +691,7 @@ var _ = Describe("Graph", func() {
 				graphWithFunctions := graph.Graph{
 					Functions: functions,
 					Nodes:     g.Nodes,
-					Configs:   g.Configs,
+					Inputs:   g.Inputs,
 					Edges:     g.Edges,
 				}
 
@@ -723,8 +723,8 @@ var _ = Describe("Graph", func() {
 				Expect(inter.Edges).To(HaveLen(4))
 
 				// Verify configuration was parsed correctly
-				Expect(parsed.Configs["constant"]).To(HaveKeyWithValue("value", 10))
-				Expect(parsed.Configs["stable_for"]).To(HaveKeyWithValue("duration", int(telem.Millisecond)))
+				Expect(parsed.Inputs["constant"]).To(HaveKeyWithValue("value", 10))
+				Expect(parsed.Inputs["stable_for"]).To(HaveKeyWithValue("duration", int(telem.Millisecond)))
 
 				// Verify polymorphic node instances have concrete resolved types
 				// func definitions stay polymorphic, but each node instance gets concrete types
@@ -774,7 +774,7 @@ var _ = Describe("Graph", func() {
 					},
 				},
 				Nodes:   nodes,
-				Configs: configs,
+				Inputs: configs,
 			}
 			resolver := []symbol.Symbol{{
 				Name: "f64_sensor",
@@ -808,7 +808,7 @@ var _ = Describe("Graph", func() {
 					},
 				},
 				Nodes:   nodes,
-				Configs: configs,
+				Inputs: configs,
 			}
 			resolver := []symbol.Symbol{{
 				Name: "f64_sensor",
@@ -830,7 +830,7 @@ var _ = Describe("Graph", func() {
 			)
 			g := arc.Graph{
 				Nodes:   nodes,
-				Configs: configs,
+				Inputs: configs,
 			}
 			resolver := []symbol.Symbol{{
 				Name: "f64_sensor",
@@ -866,7 +866,7 @@ var _ = Describe("Graph", func() {
 							},
 						},
 						Nodes:   nodes,
-						Configs: configs,
+						Inputs: configs,
 						Edges: graph.Edges{
 							{Edge: ir.Edge{
 								Source: ir.Handle{Node: "src", Param: ir.DefaultOutputParam},
@@ -906,7 +906,7 @@ var _ = Describe("Graph", func() {
 							},
 						},
 						Nodes:   nodes,
-						Configs: configs,
+						Inputs: configs,
 						Edges: graph.Edges{
 							{Edge: ir.Edge{
 								Source: ir.Handle{Node: "src1", Param: ir.DefaultOutputParam},
@@ -939,7 +939,7 @@ var _ = Describe("Graph", func() {
 							},
 						},
 						Nodes:   nodes,
-						Configs: configs,
+						Inputs: configs,
 						Edges:   graph.Edges{},
 					}
 					g = MustSucceed(graph.Parse(g))
@@ -972,7 +972,7 @@ var _ = Describe("Graph", func() {
 							},
 						},
 						Nodes:   nodes,
-						Configs: configs,
+						Inputs: configs,
 						Edges: graph.Edges{
 							{Edge: ir.Edge{
 								Source: ir.Handle{Node: "src1", Param: ir.DefaultOutputParam},
@@ -1008,7 +1008,7 @@ var _ = Describe("Graph", func() {
 							},
 						},
 						Nodes:   nodes,
-						Configs: configs,
+						Inputs: configs,
 						Edges: graph.Edges{
 							{Edge: ir.Edge{
 								Source: ir.Handle{Node: "src1", Param: ir.DefaultOutputParam},
@@ -1050,7 +1050,7 @@ var _ = Describe("Graph", func() {
 						},
 					},
 					Nodes:   nodes,
-					Configs: configs,
+					Inputs: configs,
 					Edges: graph.Edges{
 						{Edge: ir.Edge{
 							Source: ir.Handle{Node: "src1", Param: ir.DefaultOutputParam},
@@ -1090,7 +1090,7 @@ var _ = Describe("Graph", func() {
 						},
 					},
 					Nodes:   nodes,
-					Configs: configs,
+					Inputs: configs,
 					Edges: graph.Edges{
 						{Edge: ir.Edge{
 							Source: ir.Handle{Node: "src", Param: ir.DefaultOutputParam},
@@ -1114,7 +1114,7 @@ var _ = Describe("Graph", func() {
 				func(ctx SpecContext, cfg msgpack.EncodedJSON, expected string) {
 					g := graph.Graph{
 						Nodes:   graph.Nodes{{Key: "n1"}},
-						Configs: map[string]msgpack.EncodedJSON{"n1": cfg},
+						Inputs: map[string]msgpack.EncodedJSON{"n1": cfg},
 					}
 					g = MustSucceed(graph.Parse(g))
 					_, diagnostics := graph.Analyze(ctx, g, NewGraphRoot(nil))
@@ -1154,7 +1154,7 @@ var _ = Describe("Graph", func() {
 					},
 				},
 				Nodes:   nodes,
-				Configs: configs,
+				Inputs: configs,
 				Edges: graph.Edges{
 					{Edge: ir.Edge{
 						Source: ir.Handle{Node: "on", Param: ir.DefaultOutputParam},
@@ -1194,7 +1194,7 @@ var _ = Describe("Graph", func() {
 					},
 				},
 				Nodes:   nodes,
-				Configs: configs,
+				Inputs: configs,
 				Edges: graph.Edges{
 					{Edge: ir.Edge{
 						Source: ir.Handle{Node: "on", Param: ir.DefaultOutputParam},
@@ -1235,7 +1235,7 @@ var _ = Describe("Graph", func() {
 					},
 				},
 				Nodes:   nodes,
-				Configs: configs,
+				Inputs: configs,
 				Edges: graph.Edges{
 					{Edge: ir.Edge{
 						Source: ir.Handle{Node: "on", Param: ir.DefaultOutputParam},

--- a/arc/go/graph/graph_test.go
+++ b/arc/go/graph/graph_test.go
@@ -152,7 +152,7 @@ var _ = Describe("Graph", func() {
 						},
 					},
 				},
-				Nodes:   nodes,
+				Nodes:  nodes,
 				Inputs: configs,
 				Edges: graph.Edges{
 					{Edge: ir.Edge{
@@ -210,7 +210,7 @@ var _ = Describe("Graph", func() {
 							},
 						},
 					},
-					Nodes:   nodes,
+					Nodes:  nodes,
 					Inputs: configs,
 					Edges: graph.Edges{
 						{Edge: ir.Edge{
@@ -275,7 +275,7 @@ var _ = Describe("Graph", func() {
 							},
 						},
 					},
-					Nodes:   nodes,
+					Nodes:  nodes,
 					Inputs: configs,
 					Edges: graph.Edges{
 						{Edge: ir.Edge{
@@ -342,7 +342,7 @@ var _ = Describe("Graph", func() {
 							},
 						},
 					},
-					Nodes:   nodes,
+					Nodes:  nodes,
 					Inputs: configs,
 					Edges: graph.Edges{
 						{Edge: ir.Edge{
@@ -409,7 +409,7 @@ var _ = Describe("Graph", func() {
 							},
 						},
 					},
-					Nodes:   nodes,
+					Nodes:  nodes,
 					Inputs: configs,
 					Edges: graph.Edges{
 						{Edge: ir.Edge{
@@ -453,7 +453,7 @@ var _ = Describe("Graph", func() {
 							},
 						},
 					},
-					Nodes:   nodes,
+					Nodes:  nodes,
 					Inputs: configs,
 					Edges: graph.Edges{
 						{Edge: ir.Edge{
@@ -489,7 +489,7 @@ var _ = Describe("Graph", func() {
 							},
 						},
 					},
-					Nodes:   nodes,
+					Nodes:  nodes,
 					Inputs: configs,
 					Edges: graph.Edges{
 						{Edge: ir.Edge{
@@ -524,7 +524,7 @@ var _ = Describe("Graph", func() {
 							},
 						},
 					},
-					Nodes:   nodes,
+					Nodes:  nodes,
 					Inputs: configs,
 					Edges: graph.Edges{
 						{Edge: ir.Edge{
@@ -559,7 +559,7 @@ var _ = Describe("Graph", func() {
 							},
 						},
 					},
-					Nodes:   nodes,
+					Nodes:  nodes,
 					Inputs: configs,
 					Edges: graph.Edges{
 						{Edge: ir.Edge{
@@ -597,7 +597,7 @@ var _ = Describe("Graph", func() {
 					}},
 				)
 				g := arc.Graph{
-					Nodes:   nodes,
+					Nodes:  nodes,
 					Inputs: configs,
 					Edges: graph.Edges{
 						{Edge: ir.Edge{
@@ -691,7 +691,7 @@ var _ = Describe("Graph", func() {
 				graphWithFunctions := graph.Graph{
 					Functions: functions,
 					Nodes:     g.Nodes,
-					Inputs:   g.Inputs,
+					Inputs:    g.Inputs,
 					Edges:     g.Edges,
 				}
 
@@ -773,7 +773,7 @@ var _ = Describe("Graph", func() {
 						},
 					},
 				},
-				Nodes:   nodes,
+				Nodes:  nodes,
 				Inputs: configs,
 			}
 			resolver := []symbol.Symbol{{
@@ -807,7 +807,7 @@ var _ = Describe("Graph", func() {
 						},
 					},
 				},
-				Nodes:   nodes,
+				Nodes:  nodes,
 				Inputs: configs,
 			}
 			resolver := []symbol.Symbol{{
@@ -829,7 +829,7 @@ var _ = Describe("Graph", func() {
 				}},
 			)
 			g := arc.Graph{
-				Nodes:   nodes,
+				Nodes:  nodes,
 				Inputs: configs,
 			}
 			resolver := []symbol.Symbol{{
@@ -865,7 +865,7 @@ var _ = Describe("Graph", func() {
 								},
 							},
 						},
-						Nodes:   nodes,
+						Nodes:  nodes,
 						Inputs: configs,
 						Edges: graph.Edges{
 							{Edge: ir.Edge{
@@ -905,7 +905,7 @@ var _ = Describe("Graph", func() {
 								},
 							},
 						},
-						Nodes:   nodes,
+						Nodes:  nodes,
 						Inputs: configs,
 						Edges: graph.Edges{
 							{Edge: ir.Edge{
@@ -938,9 +938,9 @@ var _ = Describe("Graph", func() {
 								},
 							},
 						},
-						Nodes:   nodes,
+						Nodes:  nodes,
 						Inputs: configs,
-						Edges:   graph.Edges{},
+						Edges:  graph.Edges{},
 					}
 					g = MustSucceed(graph.Parse(g))
 					inter, diagnostics := graph.Analyze(ctx, g, NewGraphRoot(nil))
@@ -971,7 +971,7 @@ var _ = Describe("Graph", func() {
 								},
 							},
 						},
-						Nodes:   nodes,
+						Nodes:  nodes,
 						Inputs: configs,
 						Edges: graph.Edges{
 							{Edge: ir.Edge{
@@ -1007,7 +1007,7 @@ var _ = Describe("Graph", func() {
 								},
 							},
 						},
-						Nodes:   nodes,
+						Nodes:  nodes,
 						Inputs: configs,
 						Edges: graph.Edges{
 							{Edge: ir.Edge{
@@ -1049,7 +1049,7 @@ var _ = Describe("Graph", func() {
 							},
 						},
 					},
-					Nodes:   nodes,
+					Nodes:  nodes,
 					Inputs: configs,
 					Edges: graph.Edges{
 						{Edge: ir.Edge{
@@ -1089,7 +1089,7 @@ var _ = Describe("Graph", func() {
 							},
 						},
 					},
-					Nodes:   nodes,
+					Nodes:  nodes,
 					Inputs: configs,
 					Edges: graph.Edges{
 						{Edge: ir.Edge{
@@ -1113,7 +1113,7 @@ var _ = Describe("Graph", func() {
 			DescribeTable("Should report a clear diagnostic instead of failing to resolve an empty type",
 				func(ctx SpecContext, cfg msgpack.EncodedJSON, expected string) {
 					g := graph.Graph{
-						Nodes:   graph.Nodes{{Key: "n1"}},
+						Nodes:  graph.Nodes{{Key: "n1"}},
 						Inputs: map[string]msgpack.EncodedJSON{"n1": cfg},
 					}
 					g = MustSucceed(graph.Parse(g))
@@ -1153,7 +1153,7 @@ var _ = Describe("Graph", func() {
 						},
 					},
 				},
-				Nodes:   nodes,
+				Nodes:  nodes,
 				Inputs: configs,
 				Edges: graph.Edges{
 					{Edge: ir.Edge{
@@ -1193,7 +1193,7 @@ var _ = Describe("Graph", func() {
 						},
 					},
 				},
-				Nodes:   nodes,
+				Nodes:  nodes,
 				Inputs: configs,
 				Edges: graph.Edges{
 					{Edge: ir.Edge{
@@ -1234,7 +1234,7 @@ var _ = Describe("Graph", func() {
 						},
 					},
 				},
-				Nodes:   nodes,
+				Nodes:  nodes,
 				Inputs: configs,
 				Edges: graph.Edges{
 					{Edge: ir.Edge{

--- a/arc/go/graph/migrations/v56/migrate_auto.gen.go
+++ b/arc/go/graph/migrations/v56/migrate_auto.gen.go
@@ -43,20 +43,20 @@ func AutoMigrateGraph(ctx context.Context, old Graph) (graph.Graph, error) {
 			return graph.Graph{}, err
 		}
 	}
-	configs := make(map[string]msgpack.EncodedJSON, len(old.Nodes))
+	inputs := make(map[string]msgpack.EncodedJSON, len(old.Nodes))
 	for _, v := range old.Nodes {
 		cfg := msgpack.EncodedJSON{}
 		for k, val := range v.Config {
 			cfg[k] = val
 		}
 		cfg["type"] = v.Type
-		configs[v.Key] = cfg
+		inputs[v.Key] = cfg
 	}
 	return graph.Graph{
 		Functions: functions,
 		Edges:     edges,
 		Nodes:     nodes,
-		Inputs:    configs,
+		Inputs:    inputs,
 	}, nil
 }
 

--- a/arc/go/graph/migrations/v56/migrate_auto.gen.go
+++ b/arc/go/graph/migrations/v56/migrate_auto.gen.go
@@ -56,7 +56,7 @@ func AutoMigrateGraph(ctx context.Context, old Graph) (graph.Graph, error) {
 		Functions: functions,
 		Edges:     edges,
 		Nodes:     nodes,
-		Configs:   configs,
+		Inputs:    configs,
 	}, nil
 }
 

--- a/arc/go/graph/msgpack.go
+++ b/arc/go/graph/msgpack.go
@@ -72,8 +72,8 @@ func (g *Graph) DecodeMsgpack(dec *msgpack.Decoder) error {
 		g.Nodes = legacy.Nodes
 	}
 	// Legacy graphs stored the function type and config inline on each node with
-	// no configs map; lift them into Configs keyed by node key.
-	if g.Configs == nil {
+	// no inputs map; lift them into Inputs keyed by node key.
+	if g.Inputs == nil {
 		var legacy struct {
 			Nodes []struct {
 				Key    string               `msgpack:"key"`
@@ -85,12 +85,12 @@ func (g *Graph) DecodeMsgpack(dec *msgpack.Decoder) error {
 			return err
 		}
 		if len(legacy.Nodes) > 0 {
-			g.Configs = make(map[string]xmsgpack.EncodedJSON, len(legacy.Nodes))
+			g.Inputs = make(map[string]xmsgpack.EncodedJSON, len(legacy.Nodes))
 			for _, ln := range legacy.Nodes {
 				cfg := xmsgpack.EncodedJSON{}
 				maps.Copy(cfg, ln.Config)
 				cfg["type"] = ln.Type
-				g.Configs[ln.Key] = cfg
+				g.Inputs[ln.Key] = cfg
 			}
 		}
 	}

--- a/arc/go/graph/msgpack.go
+++ b/arc/go/graph/msgpack.go
@@ -87,10 +87,10 @@ func (g *Graph) DecodeMsgpack(dec *msgpack.Decoder) error {
 		if len(legacy.Nodes) > 0 {
 			g.Inputs = make(map[string]xmsgpack.EncodedJSON, len(legacy.Nodes))
 			for _, ln := range legacy.Nodes {
-				cfg := xmsgpack.EncodedJSON{}
-				maps.Copy(cfg, ln.Config)
-				cfg["type"] = ln.Type
-				g.Inputs[ln.Key] = cfg
+				inputs := xmsgpack.EncodedJSON{}
+				maps.Copy(inputs, ln.Config)
+				inputs["type"] = ln.Type
+				g.Inputs[ln.Key] = inputs
 			}
 		}
 	}

--- a/arc/go/graph/msgpack_test.go
+++ b/arc/go/graph/msgpack_test.go
@@ -71,7 +71,7 @@ var _ = Describe("DecodeMsgpack", func() {
 			Expect(decoded.Edges).To(HaveLen(1))
 		})
 
-		It("Should lift legacy inline node type and config into the configs map", func() {
+		It("Should lift legacy inline node type and config into the inputs map", func() {
 			legacy := struct {
 				Nodes []struct {
 					Key      string               `msgpack:"key"`
@@ -94,11 +94,11 @@ var _ = Describe("DecodeMsgpack", func() {
 			var decoded graph.Graph
 			Expect(msgpack.Unmarshal(data, &decoded)).To(Succeed())
 			Expect(decoded.Nodes).To(HaveLen(2))
-			Expect(decoded.Configs["n1"]).To(SatisfyAll(
+			Expect(decoded.Inputs["n1"]).To(SatisfyAll(
 				HaveKeyWithValue("type", "on"),
 				HaveKeyWithValue("channel", int8(12)),
 			))
-			Expect(decoded.Configs["n2"]).To(HaveKeyWithValue("type", "printer"))
+			Expect(decoded.Inputs["n2"]).To(HaveKeyWithValue("type", "printer"))
 		})
 	})
 })

--- a/arc/go/graph/pb/graph.pb.go
+++ b/arc/go/graph/pb/graph.pb.go
@@ -36,8 +36,8 @@ const (
 )
 
 // Node is a visual node in the Arc graph editor representing a function instantiation
-// with position data. The function type and configuration parameter values are stored
-// in the graph's configs map, keyed by the node key.
+// with position data. The function type and input parameter values are stored in the
+// graph's inputs map, keyed by the node key.
 type Node struct {
 	state protoimpl.MessageState `protogen:"open.v1"`
 	// key is the unique identifier for this node instance.
@@ -177,11 +177,10 @@ type Graph struct {
 	Edges []*Edge `protobuf:"bytes,2,rep,name=edges,proto3" json:"edges,omitempty"`
 	// nodes contains visual nodes with canvas positions.
 	Nodes []*Node `protobuf:"bytes,3,rep,name=nodes,proto3" json:"nodes,omitempty"`
-	// configs contains per-node configuration keyed by node key. Each value is a JSON
-	// object holding the node's function type under "type" plus its configuration parameter
-	// values. The wire format stores it as an opaque record; the client types it per
-	// function.
-	Configs       map[string]*structpb.Struct `protobuf:"bytes,4,rep,name=configs,proto3" json:"configs,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
+	// inputs contains per-node inputs keyed by node key. Each value is a JSON object
+	// holding the node's function type under "type" plus its input parameter values. The
+	// wire format stores it as an opaque record; the client types it per function.
+	Inputs        map[string]*structpb.Struct `protobuf:"bytes,4,rep,name=inputs,proto3" json:"inputs,omitempty" protobuf_key:"bytes,1,opt,name=key" protobuf_val:"bytes,2,opt,name=value"`
 	unknownFields protoimpl.UnknownFields
 	sizeCache     protoimpl.SizeCache
 }
@@ -237,9 +236,9 @@ func (x *Graph) GetNodes() []*Node {
 	return nil
 }
 
-func (x *Graph) GetConfigs() map[string]*structpb.Struct {
+func (x *Graph) GetInputs() map[string]*structpb.Struct {
 	if x != nil {
-		return x.Configs
+		return x.Inputs
 	}
 	return nil
 }
@@ -256,13 +255,13 @@ const file_arc_go_graph_pb_graph_proto_rawDesc = "" +
 	"\x06source\x18\x01 \x01(\v2\x11.arc.ir.pb.HandleR\x06source\x12)\n" +
 	"\x06target\x18\x02 \x01(\v2\x11.arc.ir.pb.HandleR\x06target\x12'\n" +
 	"\x04kind\x18\x03 \x01(\x0e2\x13.arc.ir.pb.EdgeKindR\x04kind\x12\x10\n" +
-	"\x03key\x18\x04 \x01(\tR\x03key\"\x9f\x02\n" +
+	"\x03key\x18\x04 \x01(\tR\x03key\"\x9b\x02\n" +
 	"\x05Graph\x121\n" +
 	"\tfunctions\x18\x01 \x03(\v2\x13.arc.ir.pb.FunctionR\tfunctions\x12(\n" +
 	"\x05edges\x18\x02 \x03(\v2\x12.arc.graph.pb.EdgeR\x05edges\x12(\n" +
-	"\x05nodes\x18\x03 \x03(\v2\x12.arc.graph.pb.NodeR\x05nodes\x12:\n" +
-	"\aconfigs\x18\x04 \x03(\v2 .arc.graph.pb.Graph.ConfigsEntryR\aconfigs\x1aS\n" +
-	"\fConfigsEntry\x12\x10\n" +
+	"\x05nodes\x18\x03 \x03(\v2\x12.arc.graph.pb.NodeR\x05nodes\x127\n" +
+	"\x06inputs\x18\x04 \x03(\v2\x1f.arc.graph.pb.Graph.InputsEntryR\x06inputs\x1aR\n" +
+	"\vInputsEntry\x12\x10\n" +
 	"\x03key\x18\x01 \x01(\tR\x03key\x12-\n" +
 	"\x05value\x18\x02 \x01(\v2\x17.google.protobuf.StructR\x05value:\x028\x01B\x94\x01\n" +
 	"\x10com.arc.graph.pbB\n" +
@@ -285,7 +284,7 @@ var file_arc_go_graph_pb_graph_proto_goTypes = []any{
 	(*Node)(nil),            // 0: arc.graph.pb.Node
 	(*Edge)(nil),            // 1: arc.graph.pb.Edge
 	(*Graph)(nil),           // 2: arc.graph.pb.Graph
-	nil,                     // 3: arc.graph.pb.Graph.ConfigsEntry
+	nil,                     // 3: arc.graph.pb.Graph.InputsEntry
 	(*pb.XY)(nil),           // 4: x.spatial.pb.XY
 	(*pb1.Handle)(nil),      // 5: arc.ir.pb.Handle
 	(pb1.EdgeKind)(0),       // 6: arc.ir.pb.EdgeKind
@@ -300,8 +299,8 @@ var file_arc_go_graph_pb_graph_proto_depIdxs = []int32{
 	7, // 4: arc.graph.pb.Graph.functions:type_name -> arc.ir.pb.Function
 	1, // 5: arc.graph.pb.Graph.edges:type_name -> arc.graph.pb.Edge
 	0, // 6: arc.graph.pb.Graph.nodes:type_name -> arc.graph.pb.Node
-	3, // 7: arc.graph.pb.Graph.configs:type_name -> arc.graph.pb.Graph.ConfigsEntry
-	8, // 8: arc.graph.pb.Graph.ConfigsEntry.value:type_name -> google.protobuf.Struct
+	3, // 7: arc.graph.pb.Graph.inputs:type_name -> arc.graph.pb.Graph.InputsEntry
+	8, // 8: arc.graph.pb.Graph.InputsEntry.value:type_name -> google.protobuf.Struct
 	9, // [9:9] is the sub-list for method output_type
 	9, // [9:9] is the sub-list for method input_type
 	9, // [9:9] is the sub-list for extension type_name

--- a/arc/go/graph/pb/graph.proto
+++ b/arc/go/graph/pb/graph.proto
@@ -20,8 +20,8 @@ import "x/go/spatial/pb/spatial.proto";
 option go_package = "github.com/synnaxlabs/arc/graph/pb";
 
 // Node is a visual node in the Arc graph editor representing a function instantiation
-// with position data. The function type and configuration parameter values are stored
-// in the graph's configs map, keyed by the node key.
+// with position data. The function type and input parameter values are stored in the
+// graph's inputs map, keyed by the node key.
 message Node {
   // key is the unique identifier for this node instance.
   string key = 1;
@@ -52,9 +52,8 @@ message Graph {
   repeated Edge edges = 2;
   // nodes contains visual nodes with canvas positions.
   repeated Node nodes = 3;
-  // configs contains per-node configuration keyed by node key. Each value is a JSON
-  // object holding the node's function type under "type" plus its configuration parameter
-  // values. The wire format stores it as an opaque record; the client types it per
-  // function.
-  map<string, google.protobuf.Struct> configs = 4;
+  // inputs contains per-node inputs keyed by node key. Each value is a JSON object
+  // holding the node's function type under "type" plus its input parameter values. The
+  // wire format stores it as an opaque record; the client types it per function.
+  map<string, google.protobuf.Struct> inputs = 4;
 }

--- a/arc/go/graph/pb/translator.gen.go
+++ b/arc/go/graph/pb/translator.gen.go
@@ -164,14 +164,14 @@ func GraphToPB(r graph.Graph) (*Graph, error) {
 		Edges:     edgesVal,
 		Nodes:     nodesVal,
 	}
-	if r.Configs != nil {
-		pb.Configs = make(map[string]*structpb.Struct, len(r.Configs))
-		for k, v := range r.Configs {
+	if r.Inputs != nil {
+		pb.Inputs = make(map[string]*structpb.Struct, len(r.Inputs))
+		for k, v := range r.Inputs {
 			converted, err := structpb.NewStruct(v)
 			if err != nil {
 				return nil, err
 			}
-			pb.Configs[k] = converted
+			pb.Inputs[k] = converted
 		}
 	}
 	return pb, nil
@@ -196,10 +196,10 @@ func GraphFromPB(pb *Graph) (graph.Graph, error) {
 	if err != nil {
 		return graph.Graph{}, err
 	}
-	if pb.Configs != nil {
-		r.Configs = make(map[string]msgpack.EncodedJSON, len(pb.Configs))
-		for k, v := range pb.Configs {
-			r.Configs[k] = msgpack.EncodedJSON(v.AsMap())
+	if pb.Inputs != nil {
+		r.Inputs = make(map[string]msgpack.EncodedJSON, len(pb.Inputs))
+		for k, v := range pb.Inputs {
+			r.Inputs[k] = msgpack.EncodedJSON(v.AsMap())
 		}
 	}
 	return r, nil

--- a/arc/go/graph/types.gen.go
+++ b/arc/go/graph/types.gen.go
@@ -24,8 +24,8 @@ type Nodes []Node
 type Edges []Edge
 
 // Node is a visual node in the Arc graph editor representing a function instantiation
-// with position data. The function type and configuration parameter values are stored
-// in the graph's configs map, keyed by the node key.
+// with position data. The function type and input parameter values are stored in the
+// graph's inputs map, keyed by the node key.
 type Node struct {
 	// Key is the unique identifier for this node instance.
 	Key string `json:"key" msgpack:"key"`
@@ -51,9 +51,8 @@ type Graph struct {
 	Edges Edges `json:"edges,omitzero" msgpack:"edges,omitzero"`
 	// Nodes contains visual nodes with canvas positions.
 	Nodes Nodes `json:"nodes,omitzero" msgpack:"nodes,omitzero"`
-	// Configs contains per-node configuration keyed by node key. Each value is a JSON
-	// object holding the node's function type under "type" plus its configuration parameter
-	// values. The wire format stores it as an opaque record; the client types it per
-	// function.
-	Configs map[string]msgpack.EncodedJSON `json:"configs,omitzero" msgpack:"configs,omitzero"`
+	// Inputs contains per-node inputs keyed by node key. Each value is a JSON object
+	// holding the node's function type under "type" plus its input parameter values. The
+	// wire format stores it as an opaque record; the client types it per function.
+	Inputs map[string]msgpack.EncodedJSON `json:"inputs,omitzero" msgpack:"inputs,omitzero"`
 }

--- a/arc/go/runtime/node/bench_test.go
+++ b/arc/go/runtime/node/bench_test.go
@@ -29,7 +29,7 @@ func BenchmarkRefreshInputsSingleInput(b *testing.B) {
 			{Key: "source"},
 			{Key: "target"},
 		},
-		Configs: map[string]msgpack.EncodedJSON{
+		Inputs: map[string]msgpack.EncodedJSON{
 			"source": {"type": "source"},
 			"target": {"type": "target"},
 		},

--- a/arc/go/runtime/node/node_test.go
+++ b/arc/go/runtime/node/node_test.go
@@ -55,7 +55,7 @@ func (m *mockFactory) ModuleName() string { return m.moduleName }
 func newTestConfig(ctx context.Context, nodeType string) node.Config {
 	g := graph.Graph{
 		Nodes:     []graph.Node{{Key: "n1"}},
-		Inputs:   map[string]msgpack.EncodedJSON{"n1": {"type": nodeType}},
+		Inputs:    map[string]msgpack.EncodedJSON{"n1": {"type": nodeType}},
 		Functions: []graph.Function{{Key: nodeType}},
 	}
 	analyzed, _ := graph.Analyze(ctx, g, symbol.NewRoot(nil, nil))
@@ -183,7 +183,7 @@ var _ = Describe("Node", func() {
 				irNode = ir.Node{Key: "test", Type: "constant"}
 				g      = graph.Graph{
 					Nodes:     []graph.Node{{Key: "test"}},
-					Inputs:   map[string]msgpack.EncodedJSON{"test": {"type": "constant"}},
+					Inputs:    map[string]msgpack.EncodedJSON{"test": {"type": "constant"}},
 					Functions: []graph.Function{{Key: "constant"}},
 				}
 				analyzed, _ = graph.Analyze(ctx, g, nil)

--- a/arc/go/runtime/node/node_test.go
+++ b/arc/go/runtime/node/node_test.go
@@ -55,7 +55,7 @@ func (m *mockFactory) ModuleName() string { return m.moduleName }
 func newTestConfig(ctx context.Context, nodeType string) node.Config {
 	g := graph.Graph{
 		Nodes:     []graph.Node{{Key: "n1"}},
-		Configs:   map[string]msgpack.EncodedJSON{"n1": {"type": nodeType}},
+		Inputs:   map[string]msgpack.EncodedJSON{"n1": {"type": nodeType}},
 		Functions: []graph.Function{{Key: nodeType}},
 	}
 	analyzed, _ := graph.Analyze(ctx, g, symbol.NewRoot(nil, nil))
@@ -183,7 +183,7 @@ var _ = Describe("Node", func() {
 				irNode = ir.Node{Key: "test", Type: "constant"}
 				g      = graph.Graph{
 					Nodes:     []graph.Node{{Key: "test"}},
-					Configs:   map[string]msgpack.EncodedJSON{"test": {"type": "constant"}},
+					Inputs:   map[string]msgpack.EncodedJSON{"test": {"type": "constant"}},
 					Functions: []graph.Function{{Key: "constant"}},
 				}
 				analyzed, _ = graph.Analyze(ctx, g, nil)

--- a/arc/go/runtime/node/state_test.go
+++ b/arc/go/runtime/node/state_test.go
@@ -1288,7 +1288,7 @@ var _ = Describe("ProgramState", func() {
 		Describe("isSeriesTruthy helper", func() {
 			It("Should return false for empty series", func(ctx SpecContext) {
 				g := graph.Graph{
-					Nodes:   []graph.Node{{Key: "test"}},
+					Nodes:  []graph.Node{{Key: "test"}},
 					Inputs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
 					Functions: []graph.Function{{
 						Key: "test",
@@ -1308,7 +1308,7 @@ var _ = Describe("ProgramState", func() {
 
 			It("Should return false for series with last element 0 (float64)", func(ctx SpecContext) {
 				g := graph.Graph{
-					Nodes:   []graph.Node{{Key: "test"}},
+					Nodes:  []graph.Node{{Key: "test"}},
 					Inputs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
 					Functions: []graph.Function{{
 						Key: "test",
@@ -1327,7 +1327,7 @@ var _ = Describe("ProgramState", func() {
 
 			It("Should return true for series with last element non-zero (float64)", func(ctx SpecContext) {
 				g := graph.Graph{
-					Nodes:   []graph.Node{{Key: "test"}},
+					Nodes:  []graph.Node{{Key: "test"}},
 					Inputs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
 					Functions: []graph.Function{{
 						Key: "test",
@@ -1346,7 +1346,7 @@ var _ = Describe("ProgramState", func() {
 
 			It("Should return false for series with last element 0 (uint8)", func(ctx SpecContext) {
 				g := graph.Graph{
-					Nodes:   []graph.Node{{Key: "test"}},
+					Nodes:  []graph.Node{{Key: "test"}},
 					Inputs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
 					Functions: []graph.Function{{
 						Key: "test",
@@ -1365,7 +1365,7 @@ var _ = Describe("ProgramState", func() {
 
 			It("Should return true for series with last element non-zero (uint8)", func(ctx SpecContext) {
 				g := graph.Graph{
-					Nodes:   []graph.Node{{Key: "test"}},
+					Nodes:  []graph.Node{{Key: "test"}},
 					Inputs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
 					Functions: []graph.Function{{
 						Key: "test",
@@ -1384,7 +1384,7 @@ var _ = Describe("ProgramState", func() {
 
 			It("Should return false for series with last element 0 (int32)", func(ctx SpecContext) {
 				g := graph.Graph{
-					Nodes:   []graph.Node{{Key: "test"}},
+					Nodes:  []graph.Node{{Key: "test"}},
 					Inputs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
 					Functions: []graph.Function{{
 						Key: "test",
@@ -1403,7 +1403,7 @@ var _ = Describe("ProgramState", func() {
 
 			It("Should return true for series with last element non-zero (int32)", func(ctx SpecContext) {
 				g := graph.Graph{
-					Nodes:   []graph.Node{{Key: "test"}},
+					Nodes:  []graph.Node{{Key: "test"}},
 					Inputs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
 					Functions: []graph.Function{{
 						Key: "test",
@@ -1422,7 +1422,7 @@ var _ = Describe("ProgramState", func() {
 
 			It("Should return false for out-of-range output ordinal", func(ctx SpecContext) {
 				g := graph.Graph{
-					Nodes:   []graph.Node{{Key: "test"}},
+					Nodes:  []graph.Node{{Key: "test"}},
 					Inputs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
 					Functions: []graph.Function{{
 						Key: "test",
@@ -1442,7 +1442,7 @@ var _ = Describe("ProgramState", func() {
 
 			It("Should check the last element only", func(ctx SpecContext) {
 				g := graph.Graph{
-					Nodes:   []graph.Node{{Key: "test"}},
+					Nodes:  []graph.Node{{Key: "test"}},
 					Inputs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
 					Functions: []graph.Function{{
 						Key: "test",
@@ -1465,7 +1465,7 @@ var _ = Describe("ProgramState", func() {
 
 			It("Should handle timestamp type", func(ctx SpecContext) {
 				g := graph.Graph{
-					Nodes:   []graph.Node{{Key: "test"}},
+					Nodes:  []graph.Node{{Key: "test"}},
 					Inputs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
 					Functions: []graph.Function{{
 						Key: "test",
@@ -1486,7 +1486,7 @@ var _ = Describe("ProgramState", func() {
 
 			It("Should treat a non-empty string as truthy and an empty string as falsy", func(ctx SpecContext) {
 				g := graph.Graph{
-					Nodes:   []graph.Node{{Key: "test"}},
+					Nodes:  []graph.Node{{Key: "test"}},
 					Inputs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
 					Functions: []graph.Function{{
 						Key: "test",
@@ -1510,7 +1510,7 @@ var _ = Describe("ProgramState", func() {
 	Describe("ResolveInput", func() {
 		buildNode := func(ctx SpecContext) *node.State {
 			g := graph.Graph{
-				Nodes:   []graph.Node{{Key: "n"}},
+				Nodes:  []graph.Node{{Key: "n"}},
 				Inputs: map[string]msgpack.EncodedJSON{"n": {"type": "n"}},
 				Functions: []graph.Function{{
 					Key: "n",

--- a/arc/go/runtime/node/state_test.go
+++ b/arc/go/runtime/node/state_test.go
@@ -31,7 +31,7 @@ var _ = Describe("ProgramState", func() {
 					{Key: "in3"},
 					{Key: "target"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"in1":    {"type": "in1"},
 					"in2":    {"type": "in2"},
 					"in3":    {"type": "in3"},
@@ -107,7 +107,7 @@ var _ = Describe("ProgramState", func() {
 		It("Should correctly align outputs of one node with inputs of another", func(ctx SpecContext) {
 			g := graph.Graph{
 				Nodes: graph.Nodes{{Key: "first"}, {Key: "second"}},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"first":  {"type": "first"},
 					"second": {"type": "second"},
 				},
@@ -165,7 +165,7 @@ var _ = Describe("ProgramState", func() {
 					{Key: "src"},
 					{Key: "dest"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"src":  {"type": "src"},
 					"dest": {"type": "dest"},
 				},
@@ -206,7 +206,7 @@ var _ = Describe("ProgramState", func() {
 					{Key: "producer"},
 					{Key: "consumer"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"producer": {"type": "producer"},
 					"consumer": {"type": "consumer"},
 				},
@@ -256,7 +256,7 @@ var _ = Describe("ProgramState", func() {
 					{Key: "b"},
 					{Key: "target"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"a":      {"type": "a"},
 					"b":      {"type": "b"},
 					"target": {"type": "target"},
@@ -316,7 +316,7 @@ var _ = Describe("ProgramState", func() {
 					{Key: "late"},
 					{Key: "target"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"early":  {"type": "early"},
 					"late":   {"type": "late"},
 					"target": {"type": "target"},
@@ -366,7 +366,7 @@ var _ = Describe("ProgramState", func() {
 					{Key: "source"},
 					{Key: "sink"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"source": {"type": "source"},
 					"sink":   {"type": "sink"},
 				},
@@ -419,7 +419,7 @@ var _ = Describe("ProgramState", func() {
 					{Key: "b"},
 					{Key: "target"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"a":      {"type": "a"},
 					"b":      {"type": "b"},
 					"target": {"type": "target"},
@@ -473,7 +473,7 @@ var _ = Describe("ProgramState", func() {
 					{Key: "src"},
 					{Key: "dst"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"src": {"type": "src"},
 					"dst": {"type": "dst"},
 				},
@@ -530,7 +530,7 @@ var _ = Describe("ProgramState", func() {
 						{Key: "rhs"},
 						{Key: "op"},
 					},
-					Configs: map[string]msgpack.EncodedJSON{
+					Inputs: map[string]msgpack.EncodedJSON{
 						"lhs": {"type": "lhs"},
 						"rhs": {"type": "rhs"},
 						"op":  {"type": "op"},
@@ -588,7 +588,7 @@ var _ = Describe("ProgramState", func() {
 						{Key: "b"},
 						{Key: "compute"},
 					},
-					Configs: map[string]msgpack.EncodedJSON{
+					Inputs: map[string]msgpack.EncodedJSON{
 						"a":       {"type": "a"},
 						"b":       {"type": "b"},
 						"compute": {"type": "compute"},
@@ -647,7 +647,7 @@ var _ = Describe("ProgramState", func() {
 						{Key: "late"},
 						{Key: "target"},
 					},
-					Configs: map[string]msgpack.EncodedJSON{
+					Inputs: map[string]msgpack.EncodedJSON{
 						"early":  {"type": "early"},
 						"late":   {"type": "late"},
 						"target": {"type": "target"},
@@ -711,7 +711,7 @@ var _ = Describe("ProgramState", func() {
 						{Key: "y"},
 						{Key: "processor"},
 					},
-					Configs: map[string]msgpack.EncodedJSON{
+					Inputs: map[string]msgpack.EncodedJSON{
 						"x":         {"type": "x"},
 						"y":         {"type": "y"},
 						"processor": {"type": "processor"},
@@ -781,7 +781,7 @@ var _ = Describe("ProgramState", func() {
 						{Key: "c"},
 						{Key: "combiner"},
 					},
-					Configs: map[string]msgpack.EncodedJSON{
+					Inputs: map[string]msgpack.EncodedJSON{
 						"a":        {"type": "a"},
 						"b":        {"type": "b"},
 						"c":        {"type": "c"},
@@ -847,7 +847,7 @@ var _ = Describe("ProgramState", func() {
 					{Key: "source"},
 					{Key: "processor"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"source":    {"type": "source"},
 					"processor": {"type": "processor"},
 				},
@@ -891,7 +891,7 @@ var _ = Describe("ProgramState", func() {
 					{Key: "source"},
 					{Key: "windowed"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"source":   {"type": "source"},
 					"windowed": {"type": "windowed"},
 				},
@@ -944,7 +944,7 @@ var _ = Describe("ProgramState", func() {
 					{Key: "multiplier_source"},
 					{Key: "processor"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"data_source":       {"type": "data_source"},
 					"multiplier_source": {"type": "multiplier_source"},
 					"processor":         {"type": "processor"},
@@ -1000,7 +1000,7 @@ var _ = Describe("ProgramState", func() {
 					{Key: "input"},
 					{Key: "calculator"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"input":      {"type": "input"},
 					"calculator": {"type": "calculator"},
 				},
@@ -1057,7 +1057,7 @@ var _ = Describe("ProgramState", func() {
 					{Key: "src2"},
 					{Key: "combiner"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"src1":     {"type": "src1"},
 					"src2":     {"type": "src2"},
 					"combiner": {"type": "combiner"},
@@ -1115,7 +1115,7 @@ var _ = Describe("ProgramState", func() {
 					{Key: "data"},
 					{Key: "processor"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"data":      {"type": "data"},
 					"processor": {"type": "processor"},
 				},
@@ -1163,7 +1163,7 @@ var _ = Describe("ProgramState", func() {
 					{Key: "source"},
 					{Key: "processor"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"source":    {"type": "source"},
 					"processor": {"type": "processor"},
 				},
@@ -1226,7 +1226,7 @@ var _ = Describe("ProgramState", func() {
 					{Key: "input"},
 					{Key: "adder"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"input": {"type": "input"},
 					"adder": {"type": "adder"},
 				},
@@ -1266,7 +1266,7 @@ var _ = Describe("ProgramState", func() {
 				Nodes: []graph.Node{
 					{Key: "generator"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"generator": {"type": "generator"},
 				},
 				Edges: graph.Edges{},
@@ -1289,7 +1289,7 @@ var _ = Describe("ProgramState", func() {
 			It("Should return false for empty series", func(ctx SpecContext) {
 				g := graph.Graph{
 					Nodes:   []graph.Node{{Key: "test"}},
-					Configs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
+					Inputs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
 					Functions: []graph.Function{{
 						Key: "test",
 						Outputs: types.Params{
@@ -1309,7 +1309,7 @@ var _ = Describe("ProgramState", func() {
 			It("Should return false for series with last element 0 (float64)", func(ctx SpecContext) {
 				g := graph.Graph{
 					Nodes:   []graph.Node{{Key: "test"}},
-					Configs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
+					Inputs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
 					Functions: []graph.Function{{
 						Key: "test",
 						Outputs: types.Params{
@@ -1328,7 +1328,7 @@ var _ = Describe("ProgramState", func() {
 			It("Should return true for series with last element non-zero (float64)", func(ctx SpecContext) {
 				g := graph.Graph{
 					Nodes:   []graph.Node{{Key: "test"}},
-					Configs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
+					Inputs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
 					Functions: []graph.Function{{
 						Key: "test",
 						Outputs: types.Params{
@@ -1347,7 +1347,7 @@ var _ = Describe("ProgramState", func() {
 			It("Should return false for series with last element 0 (uint8)", func(ctx SpecContext) {
 				g := graph.Graph{
 					Nodes:   []graph.Node{{Key: "test"}},
-					Configs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
+					Inputs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
 					Functions: []graph.Function{{
 						Key: "test",
 						Outputs: types.Params{
@@ -1366,7 +1366,7 @@ var _ = Describe("ProgramState", func() {
 			It("Should return true for series with last element non-zero (uint8)", func(ctx SpecContext) {
 				g := graph.Graph{
 					Nodes:   []graph.Node{{Key: "test"}},
-					Configs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
+					Inputs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
 					Functions: []graph.Function{{
 						Key: "test",
 						Outputs: types.Params{
@@ -1385,7 +1385,7 @@ var _ = Describe("ProgramState", func() {
 			It("Should return false for series with last element 0 (int32)", func(ctx SpecContext) {
 				g := graph.Graph{
 					Nodes:   []graph.Node{{Key: "test"}},
-					Configs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
+					Inputs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
 					Functions: []graph.Function{{
 						Key: "test",
 						Outputs: types.Params{
@@ -1404,7 +1404,7 @@ var _ = Describe("ProgramState", func() {
 			It("Should return true for series with last element non-zero (int32)", func(ctx SpecContext) {
 				g := graph.Graph{
 					Nodes:   []graph.Node{{Key: "test"}},
-					Configs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
+					Inputs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
 					Functions: []graph.Function{{
 						Key: "test",
 						Outputs: types.Params{
@@ -1423,7 +1423,7 @@ var _ = Describe("ProgramState", func() {
 			It("Should return false for out-of-range output ordinal", func(ctx SpecContext) {
 				g := graph.Graph{
 					Nodes:   []graph.Node{{Key: "test"}},
-					Configs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
+					Inputs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
 					Functions: []graph.Function{{
 						Key: "test",
 						Outputs: types.Params{
@@ -1443,7 +1443,7 @@ var _ = Describe("ProgramState", func() {
 			It("Should check the last element only", func(ctx SpecContext) {
 				g := graph.Graph{
 					Nodes:   []graph.Node{{Key: "test"}},
-					Configs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
+					Inputs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
 					Functions: []graph.Function{{
 						Key: "test",
 						Outputs: types.Params{
@@ -1466,7 +1466,7 @@ var _ = Describe("ProgramState", func() {
 			It("Should handle timestamp type", func(ctx SpecContext) {
 				g := graph.Graph{
 					Nodes:   []graph.Node{{Key: "test"}},
-					Configs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
+					Inputs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
 					Functions: []graph.Function{{
 						Key: "test",
 						Outputs: types.Params{
@@ -1487,7 +1487,7 @@ var _ = Describe("ProgramState", func() {
 			It("Should treat a non-empty string as truthy and an empty string as falsy", func(ctx SpecContext) {
 				g := graph.Graph{
 					Nodes:   []graph.Node{{Key: "test"}},
-					Configs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
+					Inputs: map[string]msgpack.EncodedJSON{"test": {"type": "test"}},
 					Functions: []graph.Function{{
 						Key: "test",
 						Outputs: types.Params{
@@ -1511,7 +1511,7 @@ var _ = Describe("ProgramState", func() {
 		buildNode := func(ctx SpecContext) *node.State {
 			g := graph.Graph{
 				Nodes:   []graph.Node{{Key: "n"}},
-				Configs: map[string]msgpack.EncodedJSON{"n": {"type": "n"}},
+				Inputs: map[string]msgpack.EncodedJSON{"n": {"type": "n"}},
 				Functions: []graph.Function{{
 					Key: "n",
 					Inputs: types.Params{
@@ -1546,7 +1546,7 @@ var _ = Describe("ProgramState", func() {
 					{Key: "src"},
 					{Key: "target"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"src":    {"type": "src"},
 					"target": {"type": "target"},
 				},

--- a/arc/go/stl/channels/channels_test.go
+++ b/arc/go/stl/channels/channels_test.go
@@ -146,7 +146,7 @@ var _ = Describe("Channel", func() {
 					{Key: "producer"},
 					{Key: "writer"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"test":     {"type": "on"},
 					"producer": {"type": "producer"},
 					"writer":   {"type": "write"},
@@ -267,7 +267,7 @@ var _ = Describe("Channel", func() {
 		BeforeEach(func(ctx SpecContext) {
 			g := graph.Graph{
 				Nodes: []graph.Node{{Key: "source"}},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"source": {"type": "on"},
 				},
 				Functions: []graph.Function{{
@@ -516,7 +516,7 @@ var _ = Describe("Channel", func() {
 			It("Should skip data when alignment mismatch", func(ctx SpecContext) {
 				g2 := graph.Graph{
 					Nodes: []graph.Node{{Key: "misaligned"}},
-					Configs: map[string]msgpack.EncodedJSON{
+					Inputs: map[string]msgpack.EncodedJSON{
 						"misaligned": {"type": "on"},
 					},
 					Functions: []graph.Function{{
@@ -565,7 +565,7 @@ var _ = Describe("Channel", func() {
 					{Key: "upstream"},
 					{Key: "sink"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"upstream": {"type": "producer"},
 					"sink":     {"type": "write"},
 				},
@@ -702,7 +702,7 @@ var _ = Describe("Channel", func() {
 						{Key: "read"},
 						{Key: "write"},
 					},
-					Configs: map[string]msgpack.EncodedJSON{
+					Inputs: map[string]msgpack.EncodedJSON{
 						"read":  {"type": "on"},
 						"write": {"type": "write"},
 					},
@@ -768,7 +768,7 @@ var _ = Describe("Channel", func() {
 						{Key: "write1"},
 						{Key: "write2"},
 					},
-					Configs: map[string]msgpack.EncodedJSON{
+					Inputs: map[string]msgpack.EncodedJSON{
 						"read1":  {"type": "on"},
 						"read2":  {"type": "on2"},
 						"write1": {"type": "write"},

--- a/arc/go/stl/constant/constant_test.go
+++ b/arc/go/stl/constant/constant_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Constant", func() {
 			factory = constant.NewHost()
 			g := graph.Graph{
 				Nodes: []graph.Node{{Key: "const"}},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"const": {"type": "constant"},
 				},
 				Functions: []graph.Function{{
@@ -123,7 +123,7 @@ var _ = Describe("Constant", func() {
 			factory = constant.NewHost()
 			g := graph.Graph{
 				Nodes: []graph.Node{{Key: "const"}},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"const": {"type": "constant"},
 				},
 				Functions: []graph.Function{{
@@ -226,7 +226,7 @@ var _ = Describe("Constant", func() {
 					{Key: "const"},
 					{Key: "sink"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"const": {"type": "constant"},
 					"sink":  {"type": "sink"},
 				},

--- a/arc/go/stl/control/control_test.go
+++ b/arc/go/stl/control/control_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Control", func() {
 		It("Should create factory with state", func(ctx SpecContext) {
 			g := graph.Graph{
 				Nodes:     []graph.Node{{Key: "set_auth"}},
-				Inputs:   map[string]msgpack.EncodedJSON{"set_auth": {"type": "set_authority"}},
+				Inputs:    map[string]msgpack.EncodedJSON{"set_auth": {"type": "set_authority"}},
 				Functions: []graph.Function{{Key: "set_authority"}},
 			}
 			inter, diagnostics := graph.Analyze(ctx, g, NewGraphRoot(nil))
@@ -52,7 +52,7 @@ var _ = Describe("Control", func() {
 		BeforeEach(func(ctx SpecContext) {
 			g := graph.Graph{
 				Nodes:     []graph.Node{{Key: "set_auth"}},
-				Inputs:   map[string]msgpack.EncodedJSON{"set_auth": {"type": "set_authority"}},
+				Inputs:    map[string]msgpack.EncodedJSON{"set_auth": {"type": "set_authority"}},
 				Functions: []graph.Function{{Key: "set_authority"}},
 			}
 			analyzed, diagnostics := graph.Analyze(ctx, g, NewGraphRoot(nil))
@@ -168,7 +168,7 @@ var _ = Describe("Control", func() {
 		BeforeEach(func(ctx SpecContext) {
 			g := graph.Graph{
 				Nodes:     []graph.Node{{Key: "set_auth"}},
-				Inputs:   map[string]msgpack.EncodedJSON{"set_auth": {"type": "set_authority"}},
+				Inputs:    map[string]msgpack.EncodedJSON{"set_auth": {"type": "set_authority"}},
 				Functions: []graph.Function{{Key: "set_authority"}},
 			}
 			analyzed, diagnostics := graph.Analyze(ctx, g, NewGraphRoot(nil))
@@ -267,7 +267,7 @@ var _ = Describe("Control", func() {
 		BeforeEach(func(ctx SpecContext) {
 			g := graph.Graph{
 				Nodes:     []graph.Node{{Key: "set_auth"}},
-				Inputs:   map[string]msgpack.EncodedJSON{"set_auth": {"type": "set_authority"}},
+				Inputs:    map[string]msgpack.EncodedJSON{"set_auth": {"type": "set_authority"}},
 				Functions: []graph.Function{{Key: "set_authority"}},
 			}
 			analyzed, diagnostics := graph.Analyze(ctx, g, NewGraphRoot(nil))
@@ -328,7 +328,7 @@ var _ = Describe("Control", func() {
 		It("Should always return false", func(ctx SpecContext) {
 			g := graph.Graph{
 				Nodes:     []graph.Node{{Key: "set_auth"}},
-				Inputs:   map[string]msgpack.EncodedJSON{"set_auth": {"type": "set_authority"}},
+				Inputs:    map[string]msgpack.EncodedJSON{"set_auth": {"type": "set_authority"}},
 				Functions: []graph.Function{{Key: "set_authority"}},
 			}
 			analyzed, diagnostics := graph.Analyze(ctx, g, NewGraphRoot(nil))

--- a/arc/go/stl/control/control_test.go
+++ b/arc/go/stl/control/control_test.go
@@ -32,7 +32,7 @@ var _ = Describe("Control", func() {
 		It("Should create factory with state", func(ctx SpecContext) {
 			g := graph.Graph{
 				Nodes:     []graph.Node{{Key: "set_auth"}},
-				Configs:   map[string]msgpack.EncodedJSON{"set_auth": {"type": "set_authority"}},
+				Inputs:   map[string]msgpack.EncodedJSON{"set_auth": {"type": "set_authority"}},
 				Functions: []graph.Function{{Key: "set_authority"}},
 			}
 			inter, diagnostics := graph.Analyze(ctx, g, NewGraphRoot(nil))
@@ -52,7 +52,7 @@ var _ = Describe("Control", func() {
 		BeforeEach(func(ctx SpecContext) {
 			g := graph.Graph{
 				Nodes:     []graph.Node{{Key: "set_auth"}},
-				Configs:   map[string]msgpack.EncodedJSON{"set_auth": {"type": "set_authority"}},
+				Inputs:   map[string]msgpack.EncodedJSON{"set_auth": {"type": "set_authority"}},
 				Functions: []graph.Function{{Key: "set_authority"}},
 			}
 			analyzed, diagnostics := graph.Analyze(ctx, g, NewGraphRoot(nil))
@@ -168,7 +168,7 @@ var _ = Describe("Control", func() {
 		BeforeEach(func(ctx SpecContext) {
 			g := graph.Graph{
 				Nodes:     []graph.Node{{Key: "set_auth"}},
-				Configs:   map[string]msgpack.EncodedJSON{"set_auth": {"type": "set_authority"}},
+				Inputs:   map[string]msgpack.EncodedJSON{"set_auth": {"type": "set_authority"}},
 				Functions: []graph.Function{{Key: "set_authority"}},
 			}
 			analyzed, diagnostics := graph.Analyze(ctx, g, NewGraphRoot(nil))
@@ -267,7 +267,7 @@ var _ = Describe("Control", func() {
 		BeforeEach(func(ctx SpecContext) {
 			g := graph.Graph{
 				Nodes:     []graph.Node{{Key: "set_auth"}},
-				Configs:   map[string]msgpack.EncodedJSON{"set_auth": {"type": "set_authority"}},
+				Inputs:   map[string]msgpack.EncodedJSON{"set_auth": {"type": "set_authority"}},
 				Functions: []graph.Function{{Key: "set_authority"}},
 			}
 			analyzed, diagnostics := graph.Analyze(ctx, g, NewGraphRoot(nil))
@@ -328,7 +328,7 @@ var _ = Describe("Control", func() {
 		It("Should always return false", func(ctx SpecContext) {
 			g := graph.Graph{
 				Nodes:     []graph.Node{{Key: "set_auth"}},
-				Configs:   map[string]msgpack.EncodedJSON{"set_auth": {"type": "set_authority"}},
+				Inputs:   map[string]msgpack.EncodedJSON{"set_auth": {"type": "set_authority"}},
 				Functions: []graph.Function{{Key: "set_authority"}},
 			}
 			analyzed, diagnostics := graph.Analyze(ctx, g, NewGraphRoot(nil))

--- a/arc/go/stl/math/math_test.go
+++ b/arc/go/stl/math/math_test.go
@@ -35,7 +35,7 @@ func makeMathGraph(nodeType string, dt types.Type) graph.Graph {
 			{Key: "input"},
 			{Key: "math"},
 		},
-		Configs: map[string]msgpack.EncodedJSON{
+		Inputs: map[string]msgpack.EncodedJSON{
 			"input": {"type": "input"},
 			"math":  {"type": nodeType},
 		},
@@ -57,7 +57,7 @@ func makeMathGraphWithReset(nodeType string, dt types.Type) graph.Graph {
 			{Key: "reset_signal"},
 			{Key: "math"},
 		},
-		Configs: map[string]msgpack.EncodedJSON{
+		Inputs: map[string]msgpack.EncodedJSON{
 			"input":        {"type": "input"},
 			"reset_signal": {"type": "reset_signal"},
 			"math":         {"type": nodeType},
@@ -701,7 +701,7 @@ var _ = Describe("Derivative", func() {
 				{Key: "input"},
 				{Key: "deriv"},
 			},
-			Configs: map[string]msgpack.EncodedJSON{
+			Inputs: map[string]msgpack.EncodedJSON{
 				"input": {"type": "input"},
 				"deriv": {"type": "derivative"},
 			},

--- a/arc/go/stl/op/op_test.go
+++ b/arc/go/stl/op/op_test.go
@@ -33,7 +33,7 @@ var _ = Describe("OP", func() {
 				{Key: "rhs"},
 				{Key: "op"},
 			},
-			Configs: map[string]msgpack.EncodedJSON{
+			Inputs: map[string]msgpack.EncodedJSON{
 				"lhs": {"type": "lhs"},
 				"rhs": {"type": "rhs"},
 				"op":  {"type": t},
@@ -119,7 +119,7 @@ var _ = Describe("OP", func() {
 				{Key: "input"},
 				{Key: "op"},
 			},
-			Configs: map[string]msgpack.EncodedJSON{
+			Inputs: map[string]msgpack.EncodedJSON{
 				"input": {"type": "input"},
 				"op":    {"type": t},
 			},
@@ -166,7 +166,7 @@ var _ = Describe("OP", func() {
 					{Key: "rhs"},
 					{Key: "op"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"lhs": {"type": "lhs"},
 					"rhs": {"type": "rhs"},
 					"op":  {"type": "ge"},
@@ -222,7 +222,7 @@ var _ = Describe("OP", func() {
 					{Key: "rhs"},
 					{Key: "op"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"lhs": {"type": "lhs"},
 					"rhs": {"type": "rhs"},
 					"op":  {"type": "eq"},
@@ -279,7 +279,7 @@ var _ = Describe("OP", func() {
 					{Key: "rhs"},
 					{Key: "op"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"lhs": {"type": "lhs"},
 					"rhs": {"type": "rhs"},
 					"op":  {"type": "or"},
@@ -336,7 +336,7 @@ var _ = Describe("OP", func() {
 					{Key: "rhs"},
 					{Key: "op"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"lhs": {"type": "lhs"},
 					"rhs": {"type": "rhs"},
 					"op":  {"type": "and"},
@@ -393,7 +393,7 @@ var _ = Describe("OP", func() {
 					{Key: "rhs"},
 					{Key: "op"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"lhs": {"type": "lhs"},
 					"rhs": {"type": "rhs"},
 					"op":  {"type": "or"},
@@ -449,7 +449,7 @@ var _ = Describe("OP", func() {
 					{Key: "rhs"},
 					{Key: "op"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"lhs": {"type": "lhs"},
 					"rhs": {"type": "rhs"},
 					"op":  {"type": "and"},

--- a/arc/go/stl/selector/selector_test.go
+++ b/arc/go/stl/selector/selector_test.go
@@ -43,7 +43,7 @@ var _ = Describe("Select", func() {
 					{Key: "source"},
 					{Key: "select"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"source": {"type": "source"},
 					"select": {"type": "select"},
 				},
@@ -103,7 +103,7 @@ var _ = Describe("Select", func() {
 					{Key: "source"},
 					{Key: "select"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"source": {"type": "source"},
 					"select": {"type": "select"},
 				},
@@ -392,7 +392,7 @@ var _ = Describe("Select", func() {
 					{Key: "source"},
 					{Key: "select"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"source": {"type": "source"},
 					"select": {"type": "select"},
 				},
@@ -440,7 +440,7 @@ var _ = Describe("Select", func() {
 					{Key: "source"},
 					{Key: "select"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"source": {"type": "source"},
 					"select": {"type": "select"},
 				},

--- a/arc/go/stl/stable/stable_test.go
+++ b/arc/go/stl/stable/stable_test.go
@@ -53,7 +53,7 @@ var _ = Describe("StableFor", func() {
 				{Key: "source"},
 				{Key: "stable"},
 			},
-			Configs: map[string]msgpack.EncodedJSON{
+			Inputs: map[string]msgpack.EncodedJSON{
 				"source": {"type": "source"},
 				"stable": {"type": "stable_for"},
 			},
@@ -401,7 +401,7 @@ var _ = Describe("StableFor", func() {
 					{Key: "source"},
 					{Key: "stable"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"source": {"type": "source"},
 					"stable": {
 						"type":     "stable_for",

--- a/arc/go/stl/time/time_test.go
+++ b/arc/go/stl/time/time_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Time", func() {
 			changedOutputs = nil
 			g := graph.Graph{
 				Nodes: []graph.Node{{Key: "interval_1"}},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"interval_1": {"type": "interval", "period": int64(telem.Second)},
 				},
 				Functions: []graph.Function{{
@@ -331,7 +331,7 @@ var _ = Describe("Time", func() {
 			changedOutputs = nil
 			g := graph.Graph{
 				Nodes: []graph.Node{{Key: "wait_1"}},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"wait_1": {"type": "wait", "duration": int64(telem.Second)},
 				},
 				Functions: []graph.Function{{
@@ -873,7 +873,7 @@ var _ = Describe("Time", func() {
 					{Key: "interval_1"},
 					{Key: "interval_2"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"interval_1": {"type": "interval", "period": int64(100 * telem.Millisecond)},
 					"interval_2": {"type": "interval", "period": int64(150 * telem.Millisecond)},
 				},
@@ -984,7 +984,7 @@ var _ = Describe("Time", func() {
 			changedOutputs = nil
 			g := graph.Graph{
 				Nodes: []graph.Node{{Key: "interval_1"}},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"interval_1": {"type": "interval", "period": int64(100 * telem.Millisecond)},
 				},
 				Functions: []graph.Function{{
@@ -1176,7 +1176,7 @@ var _ = Describe("Time", func() {
 			It("Should fire early within tolerance", func(ctx SpecContext) {
 				g := graph.Graph{
 					Nodes: []graph.Node{{Key: "wait_1"}},
-					Configs: map[string]msgpack.EncodedJSON{
+					Inputs: map[string]msgpack.EncodedJSON{
 						"wait_1": {"type": "wait", "duration": int64(100 * telem.Millisecond)},
 					},
 					Functions: []graph.Function{{
@@ -1247,7 +1247,7 @@ var _ = Describe("Time", func() {
 				factory = MustSucceed(time.NewHost(ctx, nil))
 				g := graph.Graph{
 					Nodes: []graph.Node{{Key: "interval_1"}},
-					Configs: map[string]msgpack.EncodedJSON{
+					Inputs: map[string]msgpack.EncodedJSON{
 						"interval_1": {"type": "interval", "period": int64(telem.Second)},
 					},
 					Functions: []graph.Function{{
@@ -1333,7 +1333,7 @@ var _ = Describe("Time", func() {
 				factory = MustSucceed(time.NewHost(ctx, nil))
 				g := graph.Graph{
 					Nodes: []graph.Node{{Key: "wait_1"}},
-					Configs: map[string]msgpack.EncodedJSON{
+					Inputs: map[string]msgpack.EncodedJSON{
 						"wait_1": {"type": "wait", "duration": int64(telem.Second)},
 					},
 					Functions: []graph.Function{{
@@ -1474,7 +1474,7 @@ var _ = Describe("Time", func() {
 			changedOutputs = nil
 			g := graph.Graph{
 				Nodes: []graph.Node{{Key: "now_1"}},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"now_1": {"type": "now"},
 				},
 				Functions: []graph.Function{{

--- a/arc/go/stl/wasm/bench_test.go
+++ b/arc/go/stl/wasm/bench_test.go
@@ -91,7 +91,7 @@ func BenchmarkWASMNodeSimpleArithmetic(b *testing.B) {
 			{Key: "b"},
 			{Key: "affine"},
 		},
-		Configs: map[string]msgpack.EncodedJSON{
+		Inputs: map[string]msgpack.EncodedJSON{
 			"x":      {"type": "x"},
 			"a":      {"type": "a"},
 			"b":      {"type": "b"},
@@ -257,7 +257,7 @@ func BenchmarkWASMNodeZeroAlloc(b *testing.B) {
 			{Key: "b"},
 			{Key: "affine"},
 		},
-		Configs: map[string]msgpack.EncodedJSON{
+		Inputs: map[string]msgpack.EncodedJSON{
 			"x":      {"type": "x"},
 			"a":      {"type": "a"},
 			"b":      {"type": "b"},

--- a/arc/go/stl/wasm/wasm_test.go
+++ b/arc/go/stl/wasm/wasm_test.go
@@ -248,7 +248,7 @@ func singleFunctionGraph(key string, outType types.Type, body string) arc.Graph 
 			Body:    ir.Body{Raw: body},
 		}},
 		Nodes:   []graph.Node{{Key: key}},
-		Configs: map[string]msgpack.EncodedJSON{key: {"type": key}},
+		Inputs: map[string]msgpack.EncodedJSON{key: {"type": key}},
 	}
 }
 
@@ -287,7 +287,7 @@ func binaryOpGraph(
 			{Key: rhsKey},
 			{Key: opKey},
 		},
-		Configs: map[string]msgpack.EncodedJSON{
+		Inputs: map[string]msgpack.EncodedJSON{
 			lhsKey: {"type": lhsKey},
 			rhsKey: {"type": rhsKey},
 			opKey:  {"type": opKey},
@@ -374,7 +374,7 @@ var _ = Describe("WASM", func() {
 					{Key: "b", Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.I64()}}, Body: ir.Body{Raw: `{ return 1 }`}},
 				},
 				Nodes: []graph.Node{{Key: "a"}, {Key: "b"}, {Key: "math_ops"}},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"a":        {"type": "a"},
 					"b":        {"type": "b"},
 					"math_ops": {"type": "math_ops"},
@@ -452,7 +452,7 @@ var _ = Describe("WASM", func() {
 					{Key: "c1"},
 					{Key: "c2"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"c1": {"type": "counter1"},
 					"c2": {"type": "counter2"},
 				},
@@ -498,7 +498,7 @@ var _ = Describe("WASM", func() {
 					{Key: "counter_a"},
 					{Key: "counter_b"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"counter_a": {"type": "counter"},
 					"counter_b": {"type": "counter"},
 				},
@@ -552,7 +552,7 @@ var _ = Describe("WASM", func() {
 					{Key: "x", Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.I64()}}, Body: ir.Body{Raw: `{ return 1 }`}},
 				},
 				Nodes: []graph.Node{{Key: "x"}, {Key: "add"}},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"x":   {"type": "x"},
 					"add": {"type": "add"},
 				},
@@ -580,7 +580,7 @@ var _ = Describe("WASM", func() {
 					{Key: "a", Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.I32()}}, Body: ir.Body{Raw: `{ return 1 }`}},
 				},
 				Nodes: []graph.Node{{Key: "a"}, {Key: "compute"}},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"a":       {"type": "a"},
 					"compute": {"type": "compute"},
 				},
@@ -608,7 +608,7 @@ var _ = Describe("WASM", func() {
 					{Key: "value", Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.F64()}}, Body: ir.Body{Raw: `{ return 1.0 }`}},
 				},
 				Nodes: []graph.Node{{Key: "value"}, {Key: "scale"}},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"value": {"type": "value"},
 					"scale": {"type": "scale"},
 				},
@@ -650,7 +650,7 @@ var _ = Describe("WASM", func() {
 					{Key: "value", Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.F64()}}, Body: ir.Body{Raw: `{ return 1.0 }`}},
 				},
 				Nodes: []graph.Node{{Key: "value"}, {Key: "scale"}},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"value": {"type": "value"},
 					"scale": {"type": "scale"},
 				},
@@ -732,7 +732,7 @@ trigger_ch -> emit_period{period=1s}
 					{Key: "b", Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.I64()}}, Body: ir.Body{Raw: `{ return 1 }`}},
 				},
 				Nodes: []graph.Node{{Key: "a"}, {Key: "b"}, {Key: "math_ops"}},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"a":        {"type": "a"},
 					"b":        {"type": "b"},
 					"math_ops": {"type": "math_ops"},
@@ -1218,7 +1218,7 @@ trigger_ch -> emit_period{period=1s}
 					{Key: "val_src"},
 					{Key: "neg_c"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"val_src": {"type": "val_src"},
 					"neg_c":   {"type": "neg_c"},
 				},
@@ -1254,7 +1254,7 @@ trigger_ch -> emit_period{period=1s}
 					{Key: "val_src"},
 					{Key: "neg_cf"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"val_src": {"type": "val_src"},
 					"neg_cf":  {"type": "neg_cf"},
 				},
@@ -1293,7 +1293,7 @@ trigger_ch -> emit_period{period=1s}
 					{Key: "source"},
 					{Key: "str_len"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"source":  {"type": "source"},
 					"str_len": {"type": "str_len"},
 				},
@@ -1338,7 +1338,7 @@ trigger_ch -> emit_period{period=1s}
 					{Key: "source"},
 					{Key: "qstr_len"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"source":   {"type": "source"},
 					"qstr_len": {"type": "qstr_len"},
 				},
@@ -1392,7 +1392,7 @@ trigger_ch -> emit_period{period=1s}
 					{Key: "src_b"},
 					{Key: "qstr_concat"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"src_a":       {"type": "src_a"},
 					"src_b":       {"type": "src_b"},
 					"qstr_concat": {"type": "qstr_concat"},
@@ -1454,7 +1454,7 @@ trigger_ch -> emit_period{period=1s}
 					{Key: "source"},
 					{Key: "labeler"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"source":  {"type": "source"},
 					"labeler": {"type": "labeler"},
 				},
@@ -1505,7 +1505,7 @@ trigger_ch -> emit_period{period=1s}
 					{Key: "source"},
 					{Key: "tagger"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"source": {"type": "source"},
 					"tagger": {"type": "tagger"},
 				},
@@ -1550,7 +1550,7 @@ trigger_ch -> emit_period{period=1s}
 					{Key: "source"},
 					{Key: "stringify"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"source":    {"type": "source"},
 					"stringify": {"type": "stringify"},
 				},
@@ -1601,7 +1601,7 @@ trigger_ch -> emit_period{period=1s}
 					{Key: "source"},
 					{Key: "labeler"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"source":  {"type": "source"},
 					"labeler": {"type": "labeler"},
 				},
@@ -1706,7 +1706,7 @@ trigger_ch -> emit_period{period=1s}
 					{Key: "input_source"},
 					{Key: "add_config"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"input_source": {"type": "input_source"},
 					"add_config":   {"type": "add_config", "x": int64(10)},
 				},
@@ -1747,7 +1747,7 @@ trigger_ch -> emit_period{period=1s}
 					{Key: "input_source"},
 					{Key: "multi_config"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"input_source": {"type": "input_source"},
 					"multi_config": {"type": "multi_config", "a": int32(5), "b": int32(10)},
 				},
@@ -1787,7 +1787,7 @@ trigger_ch -> emit_period{period=1s}
 					{Key: "input_source"},
 					{Key: "scale_config"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"input_source": {"type": "input_source"},
 					"scale_config": {"type": "scale_config", "factor": 2.5},
 				},
@@ -1827,7 +1827,7 @@ trigger_ch -> emit_period{period=1s}
 					{Key: "input_source"},
 					{Key: "offset_func"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"input_source": {"type": "input_source"},
 					"offset_func":  {"type": "offset_func", "offset": int64(-50)},
 				},
@@ -1868,7 +1868,7 @@ trigger_ch -> emit_period{period=1s}
 					{Key: "input_source"},
 					{Key: "scale_neg"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"input_source": {"type": "input_source"},
 					"scale_neg":    {"type": "scale_neg", "factor": -3.0},
 				},
@@ -2223,7 +2223,7 @@ trigger_ch -> emit_period{period=1s}
 					{Key: "trigger_source"},
 					{Key: "void_func"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"trigger_source": {"type": "trigger_source"},
 					"void_func":      {"type": "void_func"},
 				},
@@ -2267,7 +2267,7 @@ trigger_ch -> emit_period{period=1s}
 					{Key: "trigger_source"},
 					{Key: "void_with_state"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"trigger_source":  {"type": "trigger_source"},
 					"void_with_state": {"type": "void_with_state"},
 				},
@@ -2387,7 +2387,7 @@ trigger_ch -> emit_period{period=1s}
 				Nodes: []graph.Node{
 					{Key: "increment_counter"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"increment_counter": {"type": "increment_counter", "counter": uint32(100)},
 				},
 				Edges: graph.Edges{},
@@ -2444,7 +2444,7 @@ trigger_ch -> emit_period{period=1s}
 					{Key: "input_source"},
 					{Key: "count_rising"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"input_source": {"type": "input_source"},
 					"count_rising": {"type": "count_rising", "counter": uint32(100)},
 				},
@@ -2537,7 +2537,7 @@ trigger_ch -> emit_period{period=1s}
 				Nodes: []graph.Node{
 					{Key: "combine_sensors"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"combine_sensors": {
 						"type":     "combine_sensors",
 						"temp":     uint32(100),
@@ -2599,7 +2599,7 @@ trigger_ch -> emit_period{period=1s}
 				Nodes: []graph.Node{
 					{Key: "multi_op"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"multi_op": {
 						"type":    "multi_op",
 						"a":       uint32(200),
@@ -2665,7 +2665,7 @@ trigger_ch -> emit_period{period=1s}
 				Nodes: []graph.Node{
 					{Key: "square_value"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"square_value": {
 						"type":    "square_value",
 						"value":   uint32(300),
@@ -2749,7 +2749,7 @@ trigger_ch -> emit_period{period=1s}
 					{Key: "value_source"},
 					{Key: "tolerance_check"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"value_source": {"type": "value_source"},
 					"tolerance_check": {
 						"type":            "tolerance_check",
@@ -3273,7 +3273,7 @@ input_ch -> count_local{} -> sink_ch
 					Body:    ir.Body{Raw: `{}`},
 				}},
 				Nodes: []graph.Node{{Key: "log_fn"}},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"log_fn": {"type": "log_fn", "msg": "hello"},
 				},
 			}

--- a/arc/go/stl/wasm/wasm_test.go
+++ b/arc/go/stl/wasm/wasm_test.go
@@ -247,7 +247,7 @@ func singleFunctionGraph(key string, outType types.Type, body string) arc.Graph 
 			Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: outType}},
 			Body:    ir.Body{Raw: body},
 		}},
-		Nodes:   []graph.Node{{Key: key}},
+		Nodes:  []graph.Node{{Key: key}},
 		Inputs: map[string]msgpack.EncodedJSON{key: {"type": key}},
 	}
 }

--- a/client/py/synnax/arc/graph/types_gen.py
+++ b/client/py/synnax/arc/graph/types_gen.py
@@ -21,8 +21,8 @@ from x import spatial
 
 class Node(BaseModel):
     """Is a visual node in the Arc graph editor representing a function
-    instantiation with position data. The function type and configuration
-    parameter values are stored in the graph's configs map, keyed by the
+    instantiation with position data. The function type and input
+    parameter values are stored in the graph's inputs map, keyed by the
     node key.
 
     Attributes:
@@ -59,13 +59,13 @@ class Graph(BaseModel):
         functions: Contains function definitions available in this graph.
         edges: Contains dataflow connections between node parameters.
         nodes: Contains visual nodes with canvas positions.
-        configs: Contains per-node configuration keyed by node key. Each value is a
-            JSON object holding the node's function type under "type" plus its
-            configuration parameter values. The wire format stores it as an
-            opaque record; the client types it per function.
+        inputs: Contains per-node inputs keyed by node key. Each value is a JSON
+            object holding the node's function type under "type" plus its input
+            parameter values. The wire format stores it as an opaque record; the
+            client types it per function.
     """
 
     functions: ir.Functions = Field(default_factory=list)
     edges: Edges = Field(default_factory=list)
     nodes: Nodes = Field(default_factory=list)
-    configs: dict[str, dict[str, Any]] = Field(default_factory=dict)
+    inputs: dict[str, dict[str, Any]] = Field(default_factory=dict)

--- a/client/ts/src/arc/actions.gen.ts
+++ b/client/ts/src/arc/actions.gen.ts
@@ -27,8 +27,8 @@ export type RenamePayload = z.infer<typeof renamePayloadZ>;
 /**
  * SetNode inserts the node if no node with the same key exists, otherwise
  * replaces the existing node in place. Operates only on the node's
- * position; the node's function type and config are set separately
- * via SetNodeConfig.
+ * position; the node's function type and inputs are set separately
+ * via SetNodeInputs.
  */
 export const setNodePayloadZ = z.object({
   node: graph.nodeZ,
@@ -45,20 +45,20 @@ export const setNodePositionPayloadZ = z.object({
 export type SetNodePositionPayload = z.infer<typeof setNodePositionPayloadZ>;
 
 /**
- * SetNodeConfig merges the given config into the entry for the given key in the
+ * SetNodeInputs merges the given inputs into the entry for the given key in the
  * graph inputs map. Top-level fields present in the payload overwrite
  * existing fields; fields absent from the payload are preserved. The
  * node's function type is held under "type".
  */
-export const setNodeConfigPayloadZ = z.object({
+export const setNodeInputsPayloadZ = z.object({
   key: z.string(),
-  config: caseconv.preserveCase(record.unknownZ().default(() => ({}))),
+  inputs: caseconv.preserveCase(record.unknownZ().default(() => ({}))),
 });
 
-export type SetNodeConfigPayload = z.infer<typeof setNodeConfigPayloadZ>;
+export type SetNodeInputsPayload = z.infer<typeof setNodeInputsPayloadZ>;
 
 /**
- * RemoveNode removes the node with the given key along with its config entry and
+ * RemoveNode removes the node with the given key along with its inputs entry and
  * any edges connected to it.
  */
 export const removeNodePayloadZ = z.object({
@@ -143,8 +143,8 @@ export const actionZ = z.discriminatedUnion("type", [
     setNodePosition: setNodePositionPayloadZ,
   }),
   z.object({
-    type: z.literal("set_node_config"),
-    setNodeConfig: setNodeConfigPayloadZ,
+    type: z.literal("set_node_inputs"),
+    setNodeInputs: setNodeInputsPayloadZ,
   }),
   z.object({ type: z.literal("remove_node"), removeNode: removeNodePayloadZ }),
   z.object({ type: z.literal("add_edge"), addEdge: addEdgePayloadZ }),
@@ -174,11 +174,11 @@ export const setNodePosition = (
   setNodePosition: setNodePositionPayloadZ.parse(payload),
 });
 
-export const setNodeConfig = (
-  payload: z.input<typeof setNodeConfigPayloadZ>,
+export const setNodeInputs = (
+  payload: z.input<typeof setNodeInputsPayloadZ>,
 ): Action => ({
-  type: "set_node_config",
-  setNodeConfig: setNodeConfigPayloadZ.parse(payload),
+  type: "set_node_inputs",
+  setNodeInputs: setNodeInputsPayloadZ.parse(payload),
 });
 
 export const removeNode = (payload: z.input<typeof removeNodePayloadZ>): Action => ({
@@ -229,7 +229,7 @@ export interface Handlers {
     state: Draft<Arc>,
     payload: SetNodePositionPayload,
   ) => HandlerResult;
-  setNodeConfig: (state: Draft<Arc>, payload: SetNodeConfigPayload) => HandlerResult;
+  setNodeInputs: (state: Draft<Arc>, payload: SetNodeInputsPayload) => HandlerResult;
   removeNode: (state: Draft<Arc>, payload: RemoveNodePayload) => HandlerResult;
   addEdge: (state: Draft<Arc>, payload: AddEdgePayload) => HandlerResult;
   removeEdge: (state: Draft<Arc>, payload: RemoveEdgePayload) => HandlerResult;
@@ -248,8 +248,8 @@ export const createReduceAll = (handlers: Handlers) =>
         return handlers.setNode(state, action.setNode);
       case "set_node_position":
         return handlers.setNodePosition(state, action.setNodePosition);
-      case "set_node_config":
-        return handlers.setNodeConfig(state, action.setNodeConfig);
+      case "set_node_inputs":
+        return handlers.setNodeInputs(state, action.setNodeInputs);
       case "remove_node":
         return handlers.removeNode(state, action.removeNode);
       case "add_edge":

--- a/client/ts/src/arc/actions.gen.ts
+++ b/client/ts/src/arc/actions.gen.ts
@@ -46,7 +46,7 @@ export type SetNodePositionPayload = z.infer<typeof setNodePositionPayloadZ>;
 
 /**
  * SetNodeConfig merges the given config into the entry for the given key in the
- * graph configs map. Top-level fields present in the payload overwrite
+ * graph inputs map. Top-level fields present in the payload overwrite
  * existing fields; fields absent from the payload are preserved. The
  * node's function type is held under "type".
  */

--- a/client/ts/src/arc/actions.spec.ts
+++ b/client/ts/src/arc/actions.spec.ts
@@ -90,7 +90,7 @@ describe("arc reducer", () => {
     });
   });
 
-  describe("setNodeConfig", () => {
+  describe("setNodeInputs", () => {
     it("should overwrite fields present in both the existing and payload configs", () => {
       const state = empty({
         nodes: [node("n1", 0, 0)],
@@ -98,7 +98,7 @@ describe("arc reducer", () => {
       });
       const out = apply(
         state,
-        arc.setNodeConfig({ key: "n1", config: cfg("constant", { value: 2 }) }),
+        arc.setNodeInputs({ key: "n1", inputs: cfg("constant", { value: 2 }) }),
       );
       expect(out.graph.inputs.n1).toEqual(cfg("constant", { value: 2 }));
     });
@@ -107,11 +107,11 @@ describe("arc reducer", () => {
         nodes: [node("n1", 0, 0)],
         inputs: { n1: cfg("constant", { value: 1 }) },
       });
-      const out = apply(state, arc.setNodeConfig({ key: "n1", config: { value: 2 } }));
+      const out = apply(state, arc.setNodeInputs({ key: "n1", inputs: { value: 2 } }));
       expect(out.graph.inputs.n1).toEqual(cfg("constant", { value: 2 }));
     });
     it("should write the config even when no entry exists yet", () => {
-      const out = apply(empty(), arc.setNodeConfig({ key: "n1", config: cfg("add") }));
+      const out = apply(empty(), arc.setNodeInputs({ key: "n1", inputs: cfg("add") }));
       expect(out.graph.inputs.n1).toEqual(cfg("add"));
     });
   });
@@ -371,9 +371,9 @@ describe("arc reducer", () => {
       const out = apply(
         empty(),
         arc.setNode({ node: node("src", 0, 0) }),
-        arc.setNodeConfig({ key: "src", config: cfg("on", { channel: 1 }) }),
+        arc.setNodeInputs({ key: "src", inputs: cfg("on", { channel: 1 }) }),
         arc.setNode({ node: node("sink", 200, 0) }),
-        arc.setNodeConfig({ key: "sink", config: cfg("write", { channel: 2 }) }),
+        arc.setNodeInputs({ key: "sink", inputs: cfg("write", { channel: 2 }) }),
         arc.addEdge({
           edge: {
             key: "srcsink",
@@ -413,7 +413,7 @@ describe("arc reducer inverses", () => {
   };
 
   // Node removal cascades to its config and connected edges; the inverse
-  // re-inserts the node via setNode (which appends) plus setNodeConfig and
+  // re-inserts the node via setNode (which appends) plus setNodeInputs and
   // addEdge. Slice order is not preserved, so compare nodes by key.
   const expectGraphRoundTrip = (state: arc.Arc, actions: arc.Action[]) => {
     const { next, inverse } = arc.reduceAll(state, actions);
@@ -465,14 +465,14 @@ describe("arc reducer inverses", () => {
     });
   });
 
-  describe("setNodeConfig", () => {
+  describe("setNodeInputs", () => {
     it("should invert by restoring the prior config", () => {
       expectGraphRoundTrip(
         empty({
           nodes: [node("n1", 0, 0)],
           inputs: { n1: cfg("constant", { value: 1 }) },
         }),
-        [arc.setNodeConfig({ key: "n1", config: cfg("constant", { value: 2 }) })],
+        [arc.setNodeInputs({ key: "n1", inputs: cfg("constant", { value: 2 }) })],
       );
     });
   });
@@ -541,7 +541,7 @@ describe("arc reducer inverses", () => {
       expect(
         arc.isUndoable(arc.setNodePosition({ key: "n1", position: { x: 0, y: 0 } })),
       ).toBe(true);
-      expect(arc.isUndoable(arc.setNodeConfig({ key: "n1", config: cfg("add") }))).toBe(
+      expect(arc.isUndoable(arc.setNodeInputs({ key: "n1", inputs: cfg("add") }))).toBe(
         true,
       );
       expect(arc.isUndoable(arc.removeNode({ key: "n1" }))).toBe(true);

--- a/client/ts/src/arc/actions.spec.ts
+++ b/client/ts/src/arc/actions.spec.ts
@@ -94,25 +94,25 @@ describe("arc reducer", () => {
     it("should overwrite fields present in both the existing and payload configs", () => {
       const state = empty({
         nodes: [node("n1", 0, 0)],
-        configs: { n1: cfg("constant", { value: 1 }) },
+        inputs: { n1: cfg("constant", { value: 1 }) },
       });
       const out = apply(
         state,
         arc.setNodeConfig({ key: "n1", config: cfg("constant", { value: 2 }) }),
       );
-      expect(out.graph.configs.n1).toEqual(cfg("constant", { value: 2 }));
+      expect(out.graph.inputs.n1).toEqual(cfg("constant", { value: 2 }));
     });
     it("should merge the config into the existing entry, preserving absent fields", () => {
       const state = empty({
         nodes: [node("n1", 0, 0)],
-        configs: { n1: cfg("constant", { value: 1 }) },
+        inputs: { n1: cfg("constant", { value: 1 }) },
       });
       const out = apply(state, arc.setNodeConfig({ key: "n1", config: { value: 2 } }));
-      expect(out.graph.configs.n1).toEqual(cfg("constant", { value: 2 }));
+      expect(out.graph.inputs.n1).toEqual(cfg("constant", { value: 2 }));
     });
     it("should write the config even when no entry exists yet", () => {
       const out = apply(empty(), arc.setNodeConfig({ key: "n1", config: cfg("add") }));
-      expect(out.graph.configs.n1).toEqual(cfg("add"));
+      expect(out.graph.inputs.n1).toEqual(cfg("add"));
     });
   });
 
@@ -134,12 +134,12 @@ describe("arc reducer", () => {
             kind: arc.ir.EdgeKind.continuous,
           },
         ],
-        configs: { n2: cfg("add") },
+        inputs: { n2: cfg("add") },
       });
       const out = apply(state, arc.removeNode({ key: "n2" }));
       expect(out.graph.nodes).toEqual([node("n1", 0, 0), node("n3", 2, 2)]);
       expect(out.graph.edges).toEqual([]);
-      expect(out.graph.configs.n2).toBeUndefined();
+      expect(out.graph.inputs.n2).toBeUndefined();
     });
     it("should keep unrelated edges intact", () => {
       const state = empty({
@@ -385,7 +385,7 @@ describe("arc reducer", () => {
       );
       expect(out.graph.nodes).toHaveLength(2);
       expect(out.graph.edges).toHaveLength(1);
-      expect(out.graph.configs.src).toEqual(cfg("on", { channel: 1 }));
+      expect(out.graph.inputs.src).toEqual(cfg("on", { channel: 1 }));
     });
     it("should leave state untouched when given an empty action list", () => {
       const state = empty({ nodes: [node("n1", 0, 0)] });
@@ -422,7 +422,7 @@ describe("arc reducer inverses", () => {
       Object.fromEntries(ns.map((n) => [n.key, n]));
     expect(byKey(restored.graph.nodes)).toEqual(byKey(state.graph.nodes));
     expect(restored.graph.edges).toEqual(state.graph.edges);
-    expect(restored.graph.configs).toEqual(state.graph.configs);
+    expect(restored.graph.inputs).toEqual(state.graph.inputs);
   };
 
   describe("rename", () => {
@@ -470,7 +470,7 @@ describe("arc reducer inverses", () => {
       expectGraphRoundTrip(
         empty({
           nodes: [node("n1", 0, 0)],
-          configs: { n1: cfg("constant", { value: 1 }) },
+          inputs: { n1: cfg("constant", { value: 1 }) },
         }),
         [arc.setNodeConfig({ key: "n1", config: cfg("constant", { value: 2 }) })],
       );
@@ -490,7 +490,7 @@ describe("arc reducer inverses", () => {
               kind: arc.ir.EdgeKind.continuous,
             },
           ],
-          configs: { n1: cfg("on", { channel: 1 }) },
+          inputs: { n1: cfg("on", { channel: 1 }) },
         }),
         [arc.removeNode({ key: "n1" })],
       );

--- a/client/ts/src/arc/actions.ts
+++ b/client/ts/src/arc/actions.ts
@@ -69,16 +69,16 @@ const handlers: Handlers = {
   // fields. A future ReplaceNodeConfig action can close the gap by enabling
   // wholesale replacement.
   setNodeConfig: (state, payload) => {
-    const existingRaw = state.graph.configs[payload.key];
+    const existingRaw = state.graph.inputs[payload.key];
     if (existingRaw == null) {
-      state.graph.configs[payload.key] = payload.config;
+      state.graph.inputs[payload.key] = payload.config;
       return { inverse: [], targets: [payload.key] };
     }
     const existing = actions.snapshotDraft(existingRaw);
     const restoreFields: record.Unknown = {};
     for (const k of Object.keys(payload.config))
       if (existing[k] !== undefined) restoreFields[k] = existing[k];
-    state.graph.configs[payload.key] = { ...existing, ...payload.config };
+    state.graph.inputs[payload.key] = { ...existing, ...payload.config };
     if (Object.keys(restoreFields).length === 0)
       return { inverse: [], targets: [payload.key] };
     return {
@@ -90,12 +90,12 @@ const handlers: Handlers = {
     const idx = state.graph.nodes.findIndex((n) => n.key === payload.key);
     if (idx === -1) return actions.NO_OP_RESULT;
     const oldNode = actions.snapshotDraft(state.graph.nodes[idx]);
-    const oldConfig = actions.snapshotDraft(state.graph.configs[payload.key]);
+    const oldConfig = actions.snapshotDraft(state.graph.inputs[payload.key]);
     const removedEdges = state.graph.edges
       .filter((e) => e.source.node === payload.key || e.target.node === payload.key)
       .map((e) => actions.snapshotDraft(e));
     state.graph.nodes.splice(idx, 1);
-    delete state.graph.configs[payload.key];
+    delete state.graph.inputs[payload.key];
     state.graph.edges = state.graph.edges.filter(
       (e) => e.source.node !== payload.key && e.target.node !== payload.key,
     );

--- a/client/ts/src/arc/actions.ts
+++ b/client/ts/src/arc/actions.ts
@@ -20,7 +20,7 @@ import {
   removeNode,
   rename,
   setNode,
-  setNodeConfig,
+  setNodeInputs,
   setNodePosition,
 } from "@/arc/actions.gen";
 import { type ir } from "@/arc/ir";
@@ -62,27 +62,27 @@ const handlers: Handlers = {
       targets: [payload.key],
     };
   },
-  // The inverse of SetNodeConfig is imperfect for keys the action newly
-  // introduces: SetNodeConfig only merges, so it cannot remove keys that did
+  // The inverse of SetNodeInputs is imperfect for keys the action newly
+  // introduces: SetNodeInputs only merges, so it cannot remove keys that did
   // not previously exist. The inverse here restores values for keys that DID
   // exist before the merge; keys added by the action remain on undo as phantom
-  // fields. A future ReplaceNodeConfig action can close the gap by enabling
+  // fields. A future ReplaceNodeInputs action can close the gap by enabling
   // wholesale replacement.
-  setNodeConfig: (state, payload) => {
+  setNodeInputs: (state, payload) => {
     const existingRaw = state.graph.inputs[payload.key];
     if (existingRaw == null) {
-      state.graph.inputs[payload.key] = payload.config;
+      state.graph.inputs[payload.key] = payload.inputs;
       return { inverse: [], targets: [payload.key] };
     }
     const existing = actions.snapshotDraft(existingRaw);
     const restoreFields: record.Unknown = {};
-    for (const k of Object.keys(payload.config))
+    for (const k of Object.keys(payload.inputs))
       if (existing[k] !== undefined) restoreFields[k] = existing[k];
-    state.graph.inputs[payload.key] = { ...existing, ...payload.config };
+    state.graph.inputs[payload.key] = { ...existing, ...payload.inputs };
     if (Object.keys(restoreFields).length === 0)
       return { inverse: [], targets: [payload.key] };
     return {
-      inverse: [setNodeConfig({ key: payload.key, config: restoreFields })],
+      inverse: [setNodeInputs({ key: payload.key, inputs: restoreFields })],
       targets: [payload.key],
     };
   },
@@ -90,7 +90,7 @@ const handlers: Handlers = {
     const idx = state.graph.nodes.findIndex((n) => n.key === payload.key);
     if (idx === -1) return actions.NO_OP_RESULT;
     const oldNode = actions.snapshotDraft(state.graph.nodes[idx]);
-    const oldConfig = actions.snapshotDraft(state.graph.inputs[payload.key]);
+    const oldInputs = actions.snapshotDraft(state.graph.inputs[payload.key]);
     const removedEdges = state.graph.edges
       .filter((e) => e.source.node === payload.key || e.target.node === payload.key)
       .map((e) => actions.snapshotDraft(e));
@@ -100,8 +100,8 @@ const handlers: Handlers = {
       (e) => e.source.node !== payload.key && e.target.node !== payload.key,
     );
     const inverse: Action[] = [setNode({ node: oldNode })];
-    if (oldConfig != null)
-      inverse.push(setNodeConfig({ key: payload.key, config: oldConfig }));
+    if (oldInputs != null)
+      inverse.push(setNodeInputs({ key: payload.key, inputs: oldInputs }));
     inverse.push(...removedEdges.map((e) => addEdge({ edge: e })));
     return { inverse, targets: [payload.key] };
   },

--- a/client/ts/src/arc/graph/types.gen.ts
+++ b/client/ts/src/arc/graph/types.gen.ts
@@ -16,8 +16,8 @@ import { ir } from "@/arc/ir";
 
 /**
  * Node is a visual node in the Arc graph editor representing a function
- * instantiation with position data. The function type and configuration
- * parameter values are stored in the graph's configs map, keyed by the
+ * instantiation with position data. The function type and input
+ * parameter values are stored in the graph's inputs map, keyed by the
  * node key.
  */
 export const nodeZ = z.object({
@@ -51,12 +51,12 @@ export const graphZ = z.object({
   /** nodes contains visual nodes with canvas positions. */
   nodes: nodesZ.default([]),
   /**
-   * configs contains per-node configuration keyed by node key. Each value is a
-   * JSON object holding the node's function type under "type" plus its
-   * configuration parameter values. The wire format stores it as an
-   * opaque record; the client types it per function.
+   * inputs contains per-node inputs keyed by node key. Each value is a JSON
+   * object holding the node's function type under "type" plus its input
+   * parameter values. The wire format stores it as an opaque record; the
+   * client types it per function.
    */
-  configs: caseconv.preserveCase(
+  inputs: caseconv.preserveCase(
     z.record(z.string(), record.unknownZ()).default(() => ({})),
   ),
 });

--- a/console/src/feature/arc/editor/toolbar/graph/Properties.tsx
+++ b/console/src/feature/arc/editor/toolbar/graph/Properties.tsx
@@ -51,7 +51,7 @@ const IndividualConfig = ({ nodeKey }: IndividualConfigProps): ReactElement | nu
     sync: true,
     onChange: useCallback(
       ({ values: config }: Form.OnChangeArgs<typeof Arc.Graph.Node.configZ>) =>
-        dispatch(arc.setNodeConfig({ key: nodeKey, config: deep.copy(config) })),
+        dispatch(arc.setNodeInputs({ key: nodeKey, inputs: deep.copy(config) })),
       [dispatch, nodeKey],
     ),
   });

--- a/console/src/feature/arc/import.spec.ts
+++ b/console/src/feature/arc/import.spec.ts
@@ -82,7 +82,7 @@ describe("arc import", () => {
           },
         }),
       );
-      expect(migrated.pendingUpload?.graph.configs.n1).toEqual({
+      expect(migrated.pendingUpload?.graph.inputs.n1).toEqual({
         type: "status.set",
         key_or_name: "alarm",
         variant: "warning",
@@ -92,7 +92,7 @@ describe("arc import", () => {
 
     it("should default missing legacy fields when rewriting set_status", () => {
       const migrated = Arc.anyStateZ.parse(v1State({ n1: { key: "set_status" } }));
-      expect(migrated.pendingUpload?.graph.configs.n1).toEqual({
+      expect(migrated.pendingUpload?.graph.inputs.n1).toEqual({
         type: "status.set",
         key_or_name: "",
         variant: "success",
@@ -104,7 +104,7 @@ describe("arc import", () => {
       const migrated = Arc.anyStateZ.parse(
         v1State({ n1: { key: "channel.read", channel: 42 } }),
       );
-      expect(migrated.pendingUpload?.graph.configs.n1).toEqual({
+      expect(migrated.pendingUpload?.graph.inputs.n1).toEqual({
         type: "channel.read",
         channel: 42,
       });
@@ -119,7 +119,7 @@ describe("arc import", () => {
       );
       expect(result.name).toBe("Imported Arc");
       expect(result.mode).toBe("graph");
-      expect(result.graph?.configs?.n1).toEqual({ type: "channel.read", channel: 42 });
+      expect(result.graph?.inputs?.n1).toEqual({ type: "channel.read", channel: 42 });
       expect(result.text?.raw).toBe("x = 1");
     });
 

--- a/console/src/feature/arc/import.ts
+++ b/console/src/feature/arc/import.ts
@@ -209,7 +209,7 @@ const v2StateMigration = migrate.createMigration<V1State, V2State>({
 });
 
 // buildPendingGraph converts a legacy v2 redux graph into a flux graph document, lifting
-// each node's inline props (with the function type under "key") into the configs map
+// each node's inline props (with the function type under "key") into the inputs map
 // (under "type"), keyed by node key.
 const buildPendingGraph = (state: V2State): arc.graph.Graph => ({
   nodes: state.graph.nodes.map((n) => ({ key: n.key, position: n.position })),
@@ -219,7 +219,7 @@ const buildPendingGraph = (state: V2State): arc.graph.Graph => ({
     target: e.target,
     kind: arc.ir.EdgeKind.continuous,
   })),
-  configs: Object.fromEntries(
+  inputs: Object.fromEntries(
     Object.entries(state.graph.props).map(([k, { key, ...rest }]) => [
       k,
       { ...rest, type: key },

--- a/core/pkg/service/arc/actions.gen.go
+++ b/core/pkg/service/arc/actions.gen.go
@@ -53,7 +53,7 @@ type SetNodePositionPayload struct {
 }
 
 // SetNodeConfigPayload merges the given config into the entry for the given key in the
-// graph configs map. Top-level fields present in the payload overwrite existing fields;
+// graph inputs map. Top-level fields present in the payload overwrite existing fields;
 // fields absent from the payload are preserved. The node's function type is held under
 // "type".
 type SetNodeConfigPayload struct {

--- a/core/pkg/service/arc/actions.gen.go
+++ b/core/pkg/service/arc/actions.gen.go
@@ -24,7 +24,7 @@ const (
 	ActionTypeRename          = "rename"
 	ActionTypeSetNode         = "set_node"
 	ActionTypeSetNodePosition = "set_node_position"
-	ActionTypeSetNodeConfig   = "set_node_config"
+	ActionTypeSetNodeInputs   = "set_node_inputs"
 	ActionTypeRemoveNode      = "remove_node"
 	ActionTypeAddEdge         = "add_edge"
 	ActionTypeRemoveEdge      = "remove_edge"
@@ -41,7 +41,7 @@ type RenamePayload struct {
 
 // SetNodePayload inserts the node if no node with the same key exists, otherwise
 // replaces the existing node in place. Operates only on the node's position; the node's
-// function type and config are set separately via SetNodeConfig.
+// function type and inputs are set separately via SetNodeInputs.
 type SetNodePayload struct {
 	Node graph.Node `json:"node" msgpack:"node"`
 }
@@ -52,16 +52,16 @@ type SetNodePositionPayload struct {
 	Position spatial.XY `json:"position" msgpack:"position"`
 }
 
-// SetNodeConfigPayload merges the given config into the entry for the given key in the
+// SetNodeInputsPayload merges the given inputs into the entry for the given key in the
 // graph inputs map. Top-level fields present in the payload overwrite existing fields;
 // fields absent from the payload are preserved. The node's function type is held under
 // "type".
-type SetNodeConfigPayload struct {
+type SetNodeInputsPayload struct {
 	Key    string              `json:"key" msgpack:"key"`
-	Config msgpack.EncodedJSON `json:"config" msgpack:"config"`
+	Inputs msgpack.EncodedJSON `json:"inputs" msgpack:"inputs"`
 }
 
-// RemoveNodePayload removes the node with the given key along with its config entry and
+// RemoveNodePayload removes the node with the given key along with its inputs entry and
 // any edges connected to it.
 type RemoveNodePayload struct {
 	Key string `json:"key" msgpack:"key"`
@@ -120,7 +120,7 @@ type Action struct {
 	Rename          *RenamePayload          `json:"rename,omitempty" msgpack:"rename,omitempty"`
 	SetNode         *SetNodePayload         `json:"set_node,omitempty" msgpack:"set_node,omitempty"`
 	SetNodePosition *SetNodePositionPayload `json:"set_node_position,omitempty" msgpack:"set_node_position,omitempty"`
-	SetNodeConfig   *SetNodeConfigPayload   `json:"set_node_config,omitempty" msgpack:"set_node_config,omitempty"`
+	SetNodeInputs   *SetNodeInputsPayload   `json:"set_node_inputs,omitempty" msgpack:"set_node_inputs,omitempty"`
 	RemoveNode      *RemoveNodePayload      `json:"remove_node,omitempty" msgpack:"remove_node,omitempty"`
 	AddEdge         *AddEdgePayload         `json:"add_edge,omitempty" msgpack:"add_edge,omitempty"`
 	RemoveEdge      *RemoveEdgePayload      `json:"remove_edge,omitempty" msgpack:"remove_edge,omitempty"`
@@ -154,11 +154,11 @@ func Reduce(state Arc, actions ...Action) (Arc, error) {
 				return state, union.MissingPayload(a.Type)
 			}
 			state, err = a.SetNodePosition.Handle(state)
-		case ActionTypeSetNodeConfig:
-			if a.SetNodeConfig == nil {
+		case ActionTypeSetNodeInputs:
+			if a.SetNodeInputs == nil {
 				return state, union.MissingPayload(a.Type)
 			}
-			state, err = a.SetNodeConfig.Handle(state)
+			state, err = a.SetNodeInputs.Handle(state)
 		case ActionTypeRemoveNode:
 			if a.RemoveNode == nil {
 				return state, union.MissingPayload(a.Type)
@@ -219,9 +219,9 @@ func NewSetNodePositionAction(p SetNodePositionPayload) Action {
 	return Action{Type: ActionTypeSetNodePosition, SetNodePosition: &p}
 }
 
-// NewSetNodeConfigAction wraps a SetNodeConfigPayload in an Action envelope.
-func NewSetNodeConfigAction(p SetNodeConfigPayload) Action {
-	return Action{Type: ActionTypeSetNodeConfig, SetNodeConfig: &p}
+// NewSetNodeInputsAction wraps a SetNodeInputsPayload in an Action envelope.
+func NewSetNodeInputsAction(p SetNodeInputsPayload) Action {
+	return Action{Type: ActionTypeSetNodeInputs, SetNodeInputs: &p}
 }
 
 // NewRemoveNodeAction wraps a RemoveNodePayload in an Action envelope.

--- a/core/pkg/service/arc/actions.go
+++ b/core/pkg/service/arc/actions.go
@@ -52,21 +52,21 @@ func (p SetNodePositionPayload) Handle(state Arc) (Arc, error) {
 	return state, nil
 }
 
-// Handle merges the payload config into the inputs entry for the given key in
+// Handle merges the payload inputs into the entry for the given key in
 // the graph inputs map. Top-level fields present in the payload overwrite
 // existing fields; fields absent from the payload are preserved.
-func (p SetNodeConfigPayload) Handle(state Arc) (Arc, error) {
+func (p SetNodeInputsPayload) Handle(state Arc) (Arc, error) {
 	if state.Graph.Inputs == nil {
 		state.Graph.Inputs = make(map[string]msgpack.EncodedJSON)
 	}
 	if existing := state.Graph.Inputs[p.Key]; existing != nil {
-		merged := make(msgpack.EncodedJSON, len(existing)+len(p.Config))
+		merged := make(msgpack.EncodedJSON, len(existing)+len(p.Inputs))
 		maps.Copy(merged, existing)
-		maps.Copy(merged, p.Config)
+		maps.Copy(merged, p.Inputs)
 		state.Graph.Inputs[p.Key] = merged
 		return state, nil
 	}
-	state.Graph.Inputs[p.Key] = p.Config
+	state.Graph.Inputs[p.Key] = p.Inputs
 	return state, nil
 }
 

--- a/core/pkg/service/arc/actions.go
+++ b/core/pkg/service/arc/actions.go
@@ -52,21 +52,21 @@ func (p SetNodePositionPayload) Handle(state Arc) (Arc, error) {
 	return state, nil
 }
 
-// Handle merges the payload config into the configs entry for the given key in
-// the graph configs map. Top-level fields present in the payload overwrite
+// Handle merges the payload config into the inputs entry for the given key in
+// the graph inputs map. Top-level fields present in the payload overwrite
 // existing fields; fields absent from the payload are preserved.
 func (p SetNodeConfigPayload) Handle(state Arc) (Arc, error) {
-	if state.Graph.Configs == nil {
-		state.Graph.Configs = make(map[string]msgpack.EncodedJSON)
+	if state.Graph.Inputs == nil {
+		state.Graph.Inputs = make(map[string]msgpack.EncodedJSON)
 	}
-	if existing := state.Graph.Configs[p.Key]; existing != nil {
+	if existing := state.Graph.Inputs[p.Key]; existing != nil {
 		merged := make(msgpack.EncodedJSON, len(existing)+len(p.Config))
 		maps.Copy(merged, existing)
 		maps.Copy(merged, p.Config)
-		state.Graph.Configs[p.Key] = merged
+		state.Graph.Inputs[p.Key] = merged
 		return state, nil
 	}
-	state.Graph.Configs[p.Key] = p.Config
+	state.Graph.Inputs[p.Key] = p.Config
 	return state, nil
 }
 
@@ -79,7 +79,7 @@ func (p RemoveNodePayload) Handle(state Arc) (Arc, error) {
 			break
 		}
 	}
-	delete(state.Graph.Configs, p.Key)
+	delete(state.Graph.Inputs, p.Key)
 	kept := make(graph.Edges, 0, len(state.Graph.Edges))
 	for _, e := range state.Graph.Edges {
 		if e.Source.Node == p.Key || e.Target.Node == p.Key {

--- a/core/pkg/service/arc/actions_test.go
+++ b/core/pkg/service/arc/actions_test.go
@@ -95,21 +95,21 @@ var _ = Describe("Reducer", func() {
 	Describe("SetNodeConfig", func() {
 		It("Should merge the configuration into the existing entry", func() {
 			state := withGraph(graph.Nodes{gnode("n1", 0, 0)}, nil)
-			state.Graph.Configs = map[string]msgpack.EncodedJSON{"n1": {"gain": 1}}
+			state.Graph.Inputs = map[string]msgpack.EncodedJSON{"n1": {"gain": 1}}
 			out := MustSucceed(arc.Reduce(state, arc.NewSetNodeConfigAction(arc.SetNodeConfigPayload{
 				Key:    "n1",
 				Config: msgpack.EncodedJSON{"offset": 2},
 			})))
-			Expect(out.Graph.Configs["n1"]).To(Equal(msgpack.EncodedJSON{"gain": 1, "offset": 2}))
+			Expect(out.Graph.Inputs["n1"]).To(Equal(msgpack.EncodedJSON{"gain": 1, "offset": 2}))
 		})
 		It("Should overwrite fields present in both the existing and payload configs", func() {
 			state := withGraph(graph.Nodes{gnode("n1", 0, 0)}, nil)
-			state.Graph.Configs = map[string]msgpack.EncodedJSON{"n1": {"gain": 1}}
+			state.Graph.Inputs = map[string]msgpack.EncodedJSON{"n1": {"gain": 1}}
 			out := MustSucceed(arc.Reduce(state, arc.NewSetNodeConfigAction(arc.SetNodeConfigPayload{
 				Key:    "n1",
 				Config: msgpack.EncodedJSON{"gain": 5},
 			})))
-			Expect(out.Graph.Configs["n1"]).To(Equal(msgpack.EncodedJSON{"gain": 5}))
+			Expect(out.Graph.Inputs["n1"]).To(Equal(msgpack.EncodedJSON{"gain": 5}))
 		})
 		It("Should write the configuration even when no node has the key", func() {
 			state := withGraph(graph.Nodes{gnode("n1", 0, 0)}, nil)
@@ -117,7 +117,7 @@ var _ = Describe("Reducer", func() {
 				Key:    "ghost",
 				Config: msgpack.EncodedJSON{"offset": 2},
 			})))
-			Expect(out.Graph.Configs["ghost"]).To(Equal(msgpack.EncodedJSON{"offset": 2}))
+			Expect(out.Graph.Inputs["ghost"]).To(Equal(msgpack.EncodedJSON{"offset": 2}))
 		})
 	})
 
@@ -127,7 +127,7 @@ var _ = Describe("Reducer", func() {
 				graph.Nodes{gnode("n1", 0, 0), gnode("n2", 1, 1), gnode("n3", 2, 2)},
 				graph.Edges{gedge("e1", "n1", "out", "n2", "in"), gedge("e2", "n2", "out", "n3", "in")},
 			)
-			state.Graph.Configs = map[string]msgpack.EncodedJSON{
+			state.Graph.Inputs = map[string]msgpack.EncodedJSON{
 				"n2": {"type": "stage"},
 				"n3": {"type": "stage"},
 			}
@@ -136,8 +136,8 @@ var _ = Describe("Reducer", func() {
 			})))
 			Expect(out.Graph.Nodes).To(Equal(graph.Nodes{gnode("n1", 0, 0), gnode("n3", 2, 2)}))
 			Expect(out.Graph.Edges).To(BeEmpty())
-			Expect(out.Graph.Configs).ToNot(HaveKey("n2"))
-			Expect(out.Graph.Configs).To(HaveKey("n3"))
+			Expect(out.Graph.Inputs).ToNot(HaveKey("n2"))
+			Expect(out.Graph.Inputs).To(HaveKey("n3"))
 		})
 		It("Should keep unrelated edges intact", func() {
 			state := withGraph(

--- a/core/pkg/service/arc/actions_test.go
+++ b/core/pkg/service/arc/actions_test.go
@@ -92,30 +92,30 @@ var _ = Describe("Reducer", func() {
 		})
 	})
 
-	Describe("SetNodeConfig", func() {
+	Describe("SetNodeInputs", func() {
 		It("Should merge the configuration into the existing entry", func() {
 			state := withGraph(graph.Nodes{gnode("n1", 0, 0)}, nil)
 			state.Graph.Inputs = map[string]msgpack.EncodedJSON{"n1": {"gain": 1}}
-			out := MustSucceed(arc.Reduce(state, arc.NewSetNodeConfigAction(arc.SetNodeConfigPayload{
+			out := MustSucceed(arc.Reduce(state, arc.NewSetNodeInputsAction(arc.SetNodeInputsPayload{
 				Key:    "n1",
-				Config: msgpack.EncodedJSON{"offset": 2},
+				Inputs: msgpack.EncodedJSON{"offset": 2},
 			})))
 			Expect(out.Graph.Inputs["n1"]).To(Equal(msgpack.EncodedJSON{"gain": 1, "offset": 2}))
 		})
 		It("Should overwrite fields present in both the existing and payload configs", func() {
 			state := withGraph(graph.Nodes{gnode("n1", 0, 0)}, nil)
 			state.Graph.Inputs = map[string]msgpack.EncodedJSON{"n1": {"gain": 1}}
-			out := MustSucceed(arc.Reduce(state, arc.NewSetNodeConfigAction(arc.SetNodeConfigPayload{
+			out := MustSucceed(arc.Reduce(state, arc.NewSetNodeInputsAction(arc.SetNodeInputsPayload{
 				Key:    "n1",
-				Config: msgpack.EncodedJSON{"gain": 5},
+				Inputs: msgpack.EncodedJSON{"gain": 5},
 			})))
 			Expect(out.Graph.Inputs["n1"]).To(Equal(msgpack.EncodedJSON{"gain": 5}))
 		})
 		It("Should write the configuration even when no node has the key", func() {
 			state := withGraph(graph.Nodes{gnode("n1", 0, 0)}, nil)
-			out := MustSucceed(arc.Reduce(state, arc.NewSetNodeConfigAction(arc.SetNodeConfigPayload{
+			out := MustSucceed(arc.Reduce(state, arc.NewSetNodeInputsAction(arc.SetNodeInputsPayload{
 				Key:    "ghost",
-				Config: msgpack.EncodedJSON{"offset": 2},
+				Inputs: msgpack.EncodedJSON{"offset": 2},
 			})))
 			Expect(out.Graph.Inputs["ghost"]).To(Equal(msgpack.EncodedJSON{"offset": 2}))
 		})
@@ -265,7 +265,7 @@ var _ = Describe("Reducer", func() {
 			Entry("rename", arc.ActionTypeRename),
 			Entry("set_node", arc.ActionTypeSetNode),
 			Entry("set_node_position", arc.ActionTypeSetNodePosition),
-			Entry("set_node_config", arc.ActionTypeSetNodeConfig),
+			Entry("set_node_inputs", arc.ActionTypeSetNodeInputs),
 			Entry("remove_node", arc.ActionTypeRemoveNode),
 			Entry("add_edge", arc.ActionTypeAddEdge),
 			Entry("remove_edge", arc.ActionTypeRemoveEdge),

--- a/core/pkg/service/arc/codec_gen_test.go
+++ b/core/pkg/service/arc/codec_gen_test.go
@@ -81,8 +81,8 @@ var _ = Describe("Codec", func() {
 							Key: "test_28",
 						},
 					},
-					Nodes:   []graph.Node{{Key: "test_30", Position: spatial.XY{X: 32.5, Y: 33.5}}},
-					Configs: map[string]msgpack.EncodedJSON{"test_34": {"key_34": "value_34"}},
+					Nodes:  []graph.Node{{Key: "test_30", Position: spatial.XY{X: 32.5, Y: 33.5}}},
+					Inputs: map[string]msgpack.EncodedJSON{"test_34": {"key_34": "value_34"}},
 				},
 				Text: text.Text{
 					Doc: text.Document{
@@ -106,7 +106,7 @@ var _ = Describe("Codec", func() {
 					Functions: nil,
 					Edges:     nil,
 					Nodes:     nil,
-					Configs:   nil,
+					Inputs:    nil,
 				},
 				Text: text.Text{Doc: text.Document{Inserts: nil, Deletes: nil}},
 			}),
@@ -169,8 +169,8 @@ func BenchmarkEncodeDecodeArc(b *testing.B) {
 					Key: "test_28",
 				},
 			},
-			Nodes:   []graph.Node{{Key: "test_30", Position: spatial.XY{X: 32.5, Y: 33.5}}},
-			Configs: map[string]msgpack.EncodedJSON{"test_34": {"key_34": "value_34"}},
+			Nodes:  []graph.Node{{Key: "test_30", Position: spatial.XY{X: 32.5, Y: 33.5}}},
+			Inputs: map[string]msgpack.EncodedJSON{"test_34": {"key_34": "value_34"}},
 		},
 		Text: text.Text{
 			Doc: text.Document{
@@ -259,8 +259,8 @@ func FuzzDecodeArc(f *testing.F) {
 						Key: "test_28",
 					},
 				},
-				Nodes:   []graph.Node{{Key: "test_30", Position: spatial.XY{X: 32.5, Y: 33.5}}},
-				Configs: map[string]msgpack.EncodedJSON{"test_34": {"key_34": "value_34"}},
+				Nodes:  []graph.Node{{Key: "test_30", Position: spatial.XY{X: 32.5, Y: 33.5}}},
+				Inputs: map[string]msgpack.EncodedJSON{"test_34": {"key_34": "value_34"}},
 			},
 			Text: text.Text{
 				Doc: text.Document{
@@ -291,7 +291,7 @@ func FuzzDecodeArc(f *testing.F) {
 				Functions: nil,
 				Edges:     nil,
 				Nodes:     nil,
-				Configs:   nil,
+				Inputs:    nil,
 			},
 			Text: text.Text{Doc: text.Document{Inserts: nil, Deletes: nil}},
 		}

--- a/core/pkg/service/arc/migrations/v54/migrate_test.go
+++ b/core/pkg/service/arc/migrations/v54/migrate_test.go
@@ -141,7 +141,7 @@ var _ = Describe("v54 -> current Arc migration", func() {
 		Expect(got.Graph.Nodes).To(HaveLen(2))
 
 		_ = MustBeOk(got.Graph.Nodes.Find("alarm"))
-		alarmCfg := got.Graph.Configs["alarm"]
+		alarmCfg := got.Graph.Inputs["alarm"]
 		Expect(alarmCfg["type"]).To(Equal("status.set"))
 		Expect(alarmCfg["key_or_name"]).To(Equal("ox_alarm"))
 		Expect(alarmCfg["variant"]).To(Equal("error"))
@@ -150,7 +150,7 @@ var _ = Describe("v54 -> current Arc migration", func() {
 		Expect(alarmCfg).ToNot(HaveKey("description"))
 
 		_ = MustBeOk(got.Graph.Nodes.Find("scale"))
-		scaleCfg := got.Graph.Configs["scale"]
+		scaleCfg := got.Graph.Inputs["scale"]
 		Expect(scaleCfg["type"]).To(Equal("scale"))
 		Expect(scaleCfg["factor"]).To(Equal("2"))
 	})
@@ -183,7 +183,7 @@ var _ = Describe("v54 -> current Arc migration", func() {
 			Where(gorp.MatchKeys[arc.Key, arc.Arc](seed.Key)).
 			Entry(&got).Exec(ctx, db)).To(Succeed())
 		_ = MustBeOk(got.Graph.Nodes.Find("alarm"))
-		alarmCfg := got.Graph.Configs["alarm"]
+		alarmCfg := got.Graph.Inputs["alarm"]
 		Expect(alarmCfg["type"]).To(Equal("status.set"))
 		Expect(alarmCfg["key_or_name"]).To(Equal(""))
 		Expect(alarmCfg["variant"]).To(Equal("success"))

--- a/core/pkg/service/arc/service_test.go
+++ b/core/pkg/service/arc/service_test.go
@@ -78,7 +78,7 @@ var _ = Describe("CompileProgram", func() {
 				Nodes: []graph.Node{
 					{Key: "src"},
 				},
-				Configs: map[string]msgpack.EncodedJSON{
+				Inputs: map[string]msgpack.EncodedJSON{
 					"src": {"type": "source"},
 				},
 				Edges: graph.Edges{

--- a/core/pkg/service/arc/task/task_test.go
+++ b/core/pkg/service/arc/task/task_test.go
@@ -46,14 +46,14 @@ import (
 )
 
 // graphNodeSpec describes a graph node along with its function type and configuration
-// parameter values, which live in the graph's Configs map keyed by node key.
+// parameter values, which live in the graph's Inputs map keyed by node key.
 type graphNodeSpec struct {
 	key string
 	typ string
 	cfg map[string]any
 }
 
-// buildGraphNodes converts node specs into the graph's Nodes slice and Configs map,
+// buildGraphNodes converts node specs into the graph's Nodes slice and Inputs map,
 // storing each node's function type under the "type" key in its config entry.
 func buildGraphNodes(specs ...graphNodeSpec) (graph.Nodes, map[string]msgpack.EncodedJSON) {
 	nodes := make(graph.Nodes, len(specs))
@@ -169,7 +169,7 @@ var _ = Describe("Task", Ordered, func() {
 		nodes, configs := buildGraphNodes(
 			graphNodeSpec{key: "on", typ: "on", cfg: map[string]any{"channel": chKey}},
 		)
-		return graph.Graph{Nodes: nodes, Configs: configs}
+		return graph.Graph{Nodes: nodes, Inputs: configs}
 	}
 
 	createVirtualCh := func(ctx context.Context, prefix string, dataType telem.DataType) *channel.Channel {
@@ -528,7 +528,7 @@ var _ = Describe("Task", Ordered, func() {
 			badNodes, badConfigs := buildGraphNodes(
 				graphNodeSpec{key: "bad", typ: "nonexistent_type"},
 			)
-			badNodeGraph := graph.Graph{Nodes: badNodes, Configs: badConfigs}
+			badNodeGraph := graph.Graph{Nodes: badNodes, Inputs: badConfigs}
 			svcTask := task.Task{
 				Key:    task.NewKey(rack.NewKey(1, 1), 1),
 				Name:   "test-bad-node",
@@ -560,7 +560,7 @@ var _ = Describe("Task", Ordered, func() {
 			)
 			alarmGraph := graph.Graph{
 				Nodes:   alarmNodes,
-				Configs: alarmConfigs,
+				Inputs: alarmConfigs,
 				Edges: graph.Edges{
 					{Edge: ir.Edge{
 						Source: graph.Handle{Node: "on", Param: ir.DefaultOutputParam},
@@ -697,7 +697,7 @@ var _ = Describe("Task", Ordered, func() {
 			)
 			reportGraph := graph.Graph{
 				Nodes:   reportNodes,
-				Configs: reportConfigs,
+				Inputs: reportConfigs,
 				Edges: graph.Edges{
 					{Edge: ir.Edge{
 						Source: graph.Handle{Node: "on", Param: ir.DefaultOutputParam},

--- a/core/pkg/service/arc/task/task_test.go
+++ b/core/pkg/service/arc/task/task_test.go
@@ -559,7 +559,7 @@ var _ = Describe("Task", Ordered, func() {
 				}},
 			)
 			alarmGraph := graph.Graph{
-				Nodes:   alarmNodes,
+				Nodes:  alarmNodes,
 				Inputs: alarmConfigs,
 				Edges: graph.Edges{
 					{Edge: ir.Edge{
@@ -696,7 +696,7 @@ var _ = Describe("Task", Ordered, func() {
 				}},
 			)
 			reportGraph := graph.Graph{
-				Nodes:   reportNodes,
+				Nodes:  reportNodes,
 				Inputs: reportConfigs,
 				Edges: graph.Edges{
 					{Edge: ir.Edge{

--- a/core/pkg/service/channel/calculation/compiler/compile.go
+++ b/core/pkg/service/channel/calculation/compiler/compile.go
@@ -117,7 +117,7 @@ func Compile(ctx context.Context, cfgs ...Config) (Module, error) {
 				Body:    calcFn.Body,
 			},
 		},
-		Configs: map[string]xmsgpack.EncodedJSON{},
+		Inputs: map[string]xmsgpack.EncodedJSON{},
 	}
 	addNode := func(key, typ string, config xmsgpack.EncodedJSON) {
 		g.Nodes = append(g.Nodes, graph.Node{Key: key})
@@ -125,7 +125,7 @@ func Compile(ctx context.Context, cfgs ...Config) (Module, error) {
 			config = xmsgpack.EncodedJSON{}
 		}
 		config["type"] = typ
-		g.Configs[key] = config
+		g.Inputs[key] = config
 	}
 	addNode(calculationKey, calculationKey, nil)
 	addNode(writeKey, writeKey, xmsgpack.EncodedJSON{"channel": cfg.Channel.Key()})

--- a/core/pkg/service/channel/calculation/compiler/compile.go
+++ b/core/pkg/service/channel/calculation/compiler/compile.go
@@ -119,13 +119,13 @@ func Compile(ctx context.Context, cfgs ...Config) (Module, error) {
 		},
 		Inputs: map[string]xmsgpack.EncodedJSON{},
 	}
-	addNode := func(key, typ string, config xmsgpack.EncodedJSON) {
+	addNode := func(key, typ string, inputs xmsgpack.EncodedJSON) {
 		g.Nodes = append(g.Nodes, graph.Node{Key: key})
-		if config == nil {
-			config = xmsgpack.EncodedJSON{}
+		if inputs == nil {
+			inputs = xmsgpack.EncodedJSON{}
 		}
-		config["type"] = typ
-		g.Inputs[key] = config
+		inputs["type"] = typ
+		g.Inputs[key] = inputs
 	}
 	addNode(calculationKey, calculationKey, nil)
 	addNode(writeKey, writeKey, xmsgpack.EncodedJSON{"channel": cfg.Channel.Key()})

--- a/pluto/src/arc/graph/Diagram.tsx
+++ b/pluto/src/arc/graph/Diagram.tsx
@@ -70,7 +70,7 @@ const NodeRenderer = ({
   const dispatch = useSingleDispatch();
   const handleChange = useCallback(
     (config: Partial<record.Unknown>) =>
-      dispatch(arc.setNodeConfig({ key: nodeKey, config })),
+      dispatch(arc.setNodeInputs({ key: nodeKey, inputs: config })),
     [nodeKey, dispatch],
   );
   if (config == null) return null;

--- a/pluto/src/arc/graph/clipboard.spec.tsx
+++ b/pluto/src/arc/graph/clipboard.spec.tsx
@@ -47,7 +47,7 @@ const createGraphArc = async (): Promise<arc.Arc> =>
           kind: arc.ir.EdgeKind.continuous,
         },
       ],
-      configs: { [N1]: { type: "constant" }, [N2]: { type: "log" } },
+      inputs: { [N1]: { type: "constant" }, [N2]: { type: "log" } },
       functions: [],
     },
     text: { raw: "" },

--- a/pluto/src/arc/graph/clipboard.ts
+++ b/pluto/src/arc/graph/clipboard.ts
@@ -46,7 +46,8 @@ export const useClipboard = ({
       const actions: arc.Action[] = [];
       for (const { node, config } of nodes) {
         actions.push(arc.setNode({ node }));
-        if (config != null) actions.push(arc.setNodeConfig({ key: node.key, config }));
+        if (config != null)
+          actions.push(arc.setNodeInputs({ key: node.key, inputs: config }));
       }
       for (const { edge } of edges)
         actions.push(arc.addEdge({ edge: { ...edge, key: uuid.create() } }));

--- a/pluto/src/arc/graph/clipboard.ts
+++ b/pluto/src/arc/graph/clipboard.ts
@@ -38,9 +38,9 @@ export const useClipboard = ({
       const a = store.arcs.get(key);
       if (a == null) return null;
       const {
-        graph: { nodes, edges, configs },
+        graph: { nodes, edges, inputs },
       } = a;
-      return { nodes, edges, configs };
+      return { nodes, edges, configs: inputs };
     },
     apply: ({ nodes, edges, newKeys }) => {
       const actions: arc.Action[] = [];

--- a/pluto/src/arc/queries.spec.tsx
+++ b/pluto/src/arc/queries.spec.tsx
@@ -51,7 +51,7 @@ describe("Arc queries", () => {
             kind: arc.ir.EdgeKind.continuous,
           },
         ],
-        configs: {
+        inputs: {
           n1: { type: "constant", value: 0 },
           n2: { type: "constant", value: 1 },
         },
@@ -688,7 +688,7 @@ describe("Arc queries", () => {
       expect(formData.graph).toEqual({
         nodes: [],
         edges: [],
-        configs: {},
+        inputs: {},
         functions: [],
       });
       expect(formData.text).toEqual({

--- a/pluto/src/arc/queries.spec.tsx
+++ b/pluto/src/arc/queries.spec.tsx
@@ -1062,7 +1062,7 @@ describe("Arc queries", () => {
       await act(async () => {
         await result.current.dispatch.dispatchAsync({
           key: isolated.key,
-          actions: [arc.setNodeConfig({ key: "n1", config: { value: 99 } })],
+          actions: [arc.setNodeInputs({ key: "n1", inputs: { value: 99 } })],
         });
       });
       expect(result.current.nodes).toBe(initial);
@@ -1177,7 +1177,7 @@ describe("Arc queries", () => {
       await act(async () => {
         await result.current.dispatch.dispatchAsync({
           key: isolated.key,
-          actions: [arc.setNodeConfig({ key: "n2", config: { value: 42 } })],
+          actions: [arc.setNodeInputs({ key: "n2", inputs: { value: 42 } })],
         });
       });
       expect(result.current.config).toBe(initial);
@@ -1196,7 +1196,7 @@ describe("Arc queries", () => {
       await act(async () => {
         await result.current.dispatch.dispatchAsync({
           key: isolated.key,
-          actions: [arc.setNodeConfig({ key: "n1", config: { value: 42 } })],
+          actions: [arc.setNodeInputs({ key: "n1", inputs: { value: 42 } })],
         });
       });
       await waitFor(() => {
@@ -1286,7 +1286,7 @@ describe("Arc queries", () => {
           key: isolated.key,
           actions: [
             arc.setNode({ node: { key: "n3", position: { x: 5, y: 5 } } }),
-            arc.setNodeConfig({ key: "n3", config: { type: "constant", value: 7 } }),
+            arc.setNodeInputs({ key: "n3", inputs: { type: "constant", value: 7 } }),
           ],
         });
       });

--- a/pluto/src/arc/queries.ts
+++ b/pluto/src/arc/queries.ts
@@ -168,7 +168,7 @@ export const useSelectNodeConfig = Scope.bindHook(
   Flux.createSelector<FluxSubStore, SelectNodePropsArgs, Node.Config>({
     subscribe: (store, { key }, notify) => store.arcs.onSet(notify, key),
     select: (store, { key, nodeKey }) =>
-      requireArc(store, key).graph.configs[nodeKey] as Node.Config,
+      requireArc(store, key).graph.inputs[nodeKey] as Node.Config,
   }),
 );
 

--- a/pluto/src/arc/queries.ts
+++ b/pluto/src/arc/queries.ts
@@ -221,9 +221,9 @@ export const useAddNode = (keyOverride?: arc.Key) => {
           arc.setNode({
             node: { key: nodeKey, position: xy.construct(position ?? xy.ZERO) },
           }),
-          arc.setNodeConfig({
+          arc.setNodeInputs({
             key: nodeKey,
-            config: spec.defaultConfig(theme) as record.Unknown,
+            inputs: spec.defaultConfig(theme) as record.Unknown,
           }),
         ],
       });

--- a/schemas/arc/graph.oracle
+++ b/schemas/arc/graph.oracle
@@ -26,8 +26,8 @@ Node struct {
 
     @doc value """
         is a visual node in the Arc graph editor representing a function
-        instantiation with position data. The function type and configuration
-        parameter values are stored in the graph's configs map, keyed by the
+        instantiation with position data. The function type and input
+        parameter values are stored in the graph's inputs map, keyed by the
         node key.
     """
 }
@@ -62,12 +62,12 @@ Graph struct {
     nodes     Nodes = [] {
         @doc value "contains visual nodes with canvas positions."
     }
-    configs   map<string, record> = {} {
+    inputs    map<string, record> = {} {
         @doc value        """
-            contains per-node configuration keyed by node key. Each value is a
-            JSON object holding the node's function type under "type" plus its
-            configuration parameter values. The wire format stores it as an
-            opaque record; the client types it per function.
+            contains per-node inputs keyed by node key. Each value is a JSON
+            object holding the node's function type under "type" plus its input
+            parameter values. The wire format stores it as an opaque record; the
+            client types it per function.
         """
         @ts preserve_case
     }

--- a/schemas/synnax/arc.oracle
+++ b/schemas/synnax/arc.oracle
@@ -92,8 +92,8 @@ Arc struct {
         @doc value """
             inserts the node if no node with the same key exists, otherwise
             replaces the existing node in place. Operates only on the node's
-            position; the node's function type and config are set separately
-            via SetNodeConfig.
+            position; the node's function type and inputs are set separately
+            via SetNodeInputs.
         """
     }
 
@@ -104,14 +104,14 @@ Arc struct {
         @doc value "moves a graph node to a new canvas position."
     }
 
-    action SetNodeConfig {
+    action SetNodeInputs {
         key    string
-        config record {
+        inputs record {
             @ts preserve_case
         }
 
         @doc value """
-            merges the given config into the entry for the given key in the
+            merges the given inputs into the entry for the given key in the
             graph inputs map. Top-level fields present in the payload overwrite
             existing fields; fields absent from the payload are preserved. The
             node's function type is held under "type".
@@ -122,7 +122,7 @@ Arc struct {
         key string
 
         @doc value """
-            removes the node with the given key along with its config entry and
+            removes the node with the given key along with its inputs entry and
             any edges connected to it.
         """
     }

--- a/schemas/synnax/arc.oracle
+++ b/schemas/synnax/arc.oracle
@@ -112,7 +112,7 @@ Arc struct {
 
         @doc value """
             merges the given config into the entry for the given key in the
-            graph configs map. Top-level fields present in the payload overwrite
+            graph inputs map. Top-level fields present in the payload overwrite
             existing fields; fields absent from the payload are preserved. The
             node's function type is held under "type".
         """


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4445](https://linear.app/synnax/issue/SY-4445)

## Description

Renames the Arc graph's per-node map field from `configs` to `inputs` in `schemas/arc/graph.oracle`, regenerating Go, TypeScript, Python, and C++ and updating all hand-written consumers. This completes the RFC 0039 config to inputs unification in the graph editor.

No data migration is required: the `configs` map is a v57-only structure (from SY-4391, not yet on `main`), so it never ships under the `configs` name.

Note:

`migrations/v56/migrate_auto.gen.go` was hand-edited (`Configs` to `Inputs` on its return line) as a stopgap, since `oracle migrate` currently fails analyzing the frozen v56 snapshot (a pre-existing `unresolved type` bug, tracked separately). It regenerates identically once that is fixed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR completes the RFC 0039 rename of the Arc graph's per-node map field from `configs` to `inputs` across all layers of the stack: the oracle schema, generated Go/TypeScript/Python/C++ bindings, protobuf definitions, and every hand-written consumer. No wire-format breaking changes occur — the protobuf field number (4) is preserved, the oracle binary codec is positional, and the msgpack struct tag is updated consistently.

- The `configs` → `inputs` rename flows through the oracle schema, all generated files, and every hand-written consumer (Go actions, TypeScript actions + clipboard adapter, Python types, C++ headers, import migration, compiler).
- `clipboard.ts` intentionally maps the arc graph's `inputs` field to the generic `Diagram.Snapshot.configs` field, bridging the renamed domain type to the unchanged generic diagram interface — this is correct and tested.
- The `migrations/v56/migrate_auto.gen.go` hand-edit (acknowledged in the PR description as a stopgap) correctly renames the local variable from `configs` to `inputs` as well, addressing the cognitive-friction issue from a previous review.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a purely mechanical rename with no behavioral changes, no wire-format breakage, and the field being renamed never shipped to main under the old name.

The rename is thorough and consistent across all 48 files: the oracle schema, every generated binding (Go, TypeScript, Python, C++), the protobuf definition (field number 4 preserved for wire compatibility), the binary codec (positional, unaffected by name), the msgpack codec (safe because the field is v57-only), and every hand-written consumer. The clipboard adapter's intentional inputs → configs bridging to the generic diagram interface is correct and covered by integration tests. No issues were found.

No files require special attention. The hand-edited migration stopgap in arc/go/graph/migrations/v56/migrate_auto.gen.go is acknowledged in the PR description and will regenerate correctly once the upstream oracle bug is fixed.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| schemas/arc/graph.oracle | Source of truth for the rename: `configs` field renamed to `inputs` in the Graph struct with matching doc updates. |
| arc/go/graph/pb/graph.proto | Protobuf field renamed from `configs` to `inputs` while preserving field number 4, maintaining wire compatibility. |
| arc/go/graph/msgpack.go | Legacy-decode path correctly updated to populate `Inputs` instead of `Configs`; msgpack struct tag change is safe as this field is v57-only. |
| pluto/src/arc/graph/clipboard.ts | Correctly bridges arc domain `inputs` to the generic `Diagram.Snapshot.configs` field; intentional adapter mapping, not a missed rename. |
| arc/go/graph/migrations/v56/migrate_auto.gen.go | Hand-edited stopgap: local variable and struct field assignment both renamed from `configs`/`Configs` to `inputs`/`Inputs`, fixing the stale-variable issue noted in the previous review. |
| core/pkg/service/arc/actions.go | All `Configs` map accesses (nil-init, merge, delete) correctly updated to `Inputs`. |
| client/ts/src/arc/actions.ts | TypeScript action handlers updated to use `graph.inputs` for all read/write/delete operations. |
| core/pkg/service/channel/calculation/compiler/compile.go | Compile function updated to initialize `Inputs` instead of `Configs` when constructing a graph for compilation. |
| console/src/layered/service/arc/imex/import.ts | Import migration's `buildPendingGraph` helper correctly uses `inputs` instead of `configs` in the returned graph object. |


<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    schema["schemas/arc/graph.oracle\nconfigs → inputs"]
    schema --> go_types["arc/go/graph/types.gen.go\nGraph.Inputs"]
    schema --> ts_types["client/ts/src/arc/graph/types.gen.ts\ngraph.inputs"]
    schema --> py_types["client/py/synnax/arc/graph/types_gen.py\ninputs"]
    schema --> cpp_types["arc/cpp/graph/types.gen.h\ninputs"]
    schema --> proto["arc/go/graph/pb/graph.proto\nfield 4: inputs (number preserved)"]
    go_types --> msgpack["arc/go/graph/msgpack.go\nlegacy decode → Inputs"]
    go_types --> codec["arc/go/graph/codec.gen.go\nEncodeOrc/DecodeOrc → Inputs"]
    go_types --> pb_trans["arc/go/graph/pb/translator.gen.go\nGraphToPB/GraphFromPB → Inputs"]
    go_types --> actions_go["core/pkg/service/arc/actions.go\nSetNodeConfig, RemoveNode → Inputs"]
    go_types --> analyze["arc/go/graph/analyze.go\ng.Inputs[n.Key]"]
    go_types --> compile["core/.../compiler/compile.go\ng.Inputs[key]"]
    go_types --> migrate["arc/go/graph/migrations/v56/migrate_auto.gen.go\nreturns Inputs (hand-edited stopgap)"]
    ts_types --> actions_ts["client/ts/src/arc/actions.ts\ngraph.inputs[key]"]
    ts_types --> queries["pluto/src/arc/queries.ts\ngraph.inputs[nodeKey]"]
    ts_types --> clipboard["pluto/src/arc/graph/clipboard.ts\ngraph.inputs → Snapshot.configs bridge"]
    ts_types --> imex["console/.../imex/import.ts\nbuildPendingGraph → inputs"]
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    schema["schemas/arc/graph.oracle\nconfigs → inputs"]
    schema --> go_types["arc/go/graph/types.gen.go\nGraph.Inputs"]
    schema --> ts_types["client/ts/src/arc/graph/types.gen.ts\ngraph.inputs"]
    schema --> py_types["client/py/synnax/arc/graph/types_gen.py\ninputs"]
    schema --> cpp_types["arc/cpp/graph/types.gen.h\ninputs"]
    schema --> proto["arc/go/graph/pb/graph.proto\nfield 4: inputs (number preserved)"]
    go_types --> msgpack["arc/go/graph/msgpack.go\nlegacy decode → Inputs"]
    go_types --> codec["arc/go/graph/codec.gen.go\nEncodeOrc/DecodeOrc → Inputs"]
    go_types --> pb_trans["arc/go/graph/pb/translator.gen.go\nGraphToPB/GraphFromPB → Inputs"]
    go_types --> actions_go["core/pkg/service/arc/actions.go\nSetNodeConfig, RemoveNode → Inputs"]
    go_types --> analyze["arc/go/graph/analyze.go\ng.Inputs[n.Key]"]
    go_types --> compile["core/.../compiler/compile.go\ng.Inputs[key]"]
    go_types --> migrate["arc/go/graph/migrations/v56/migrate_auto.gen.go\nreturns Inputs (hand-edited stopgap)"]
    ts_types --> actions_ts["client/ts/src/arc/actions.ts\ngraph.inputs[key]"]
    ts_types --> queries["pluto/src/arc/queries.ts\ngraph.inputs[nodeKey]"]
    ts_types --> clipboard["pluto/src/arc/graph/clipboard.ts\ngraph.inputs → Snapshot.configs bridge"]
    ts_types --> imex["console/.../imex/import.ts\nbuildPendingGraph → inputs"]
```

</a>

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `arc/go/graph/migrations/v56/migrate_auto.gen.go`, line 46-59 ([link](https://github.com/synnaxlabs/synnax/blob/59657ea236e7d8d64ce27bf28ef5871c2b928376/arc/go/graph/migrations/v56/migrate_auto.gen.go#L46-L59)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=9" align="top"></a> **Local variable `configs` is misleadingly named after the old field**

   The local variable is still called `configs` (line 46) but it is now assigned to `graph.Graph.Inputs`. The PR description acknowledges this file was hand-edited as a stopgap, but the stale local name adds cognitive friction when reading the migration alongside the renamed type. It will not regenerate correctly until the `unresolved type` bug in `oracle migrate` is fixed.

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!
</details>

<!-- /greptile_failed_comments -->

<sub>Reviews (2): Last reviewed commit: ["nitfix"](https://github.com/synnaxlabs/synnax/commit/7cdcb576d62065c6baa574c3753ac7291367b6c0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41178624)</sub>

<!-- /greptile_comment -->