### PR TITLE
SY-4073: Add integration claude.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,6 +7,8 @@ this repository.
 
 - **Architecture**: See @docs/claude/architecture.md for system design and data flows
 - **Testing**: See @docs/claude/testing.md for cross-language testing guide
+- **Integration tests**: See @docs/claude/integration-test.md for writing integration
+  tests (especially Arc reactive-runtime gotchas)
 - **TypeScript**: See @docs/claude/toolchains/typescript.md for TS/JS development
 - **Go**: See @docs/claude/toolchains/go.md for Go development
 - **Python**: See @docs/claude/toolchains/python.md for Python development

--- a/docs/claude/integration-test.md
+++ b/docs/claude/integration-test.md
@@ -1,0 +1,97 @@
+# Writing Integration Tests
+
+This guide covers how to write integration tests well, with a focus on Arc tests where
+the runtime's reactive semantics make naive tests flaky or silently wrong. For running
+tests via the test conductor and reading debug bundles, see @docs/claude/testing.md.
+
+## Where Tests Live
+
+- Test cases are Python files under `integration/tests/<area>/` (e.g.
+  `integration/tests/arc/`).
+- Each case is registered in `integration/tests/<area>_tests.json` as
+  `"<area>/<file_stem>"` (e.g. `"arc/variables"`).
+- The conductor maps the case name to the file by stem and auto-discovers the single
+  concrete `TestCase` subclass in it. The class name does not need to match the file.
+
+## Structure Conventions
+
+Model new Arc tests on the existing ones, which are the source of truth for both API and
+style:
+
+- `inline_bodies.py` for inline `stage {}` / `sequence {}` bodies, nesting, and sibling
+  sequences.
+- `stl_string.py` and `stl_math.py` for the shared-trigger pattern and `@dataclass` case
+  lists.
+- `stage_routing.py` and `thermal_monitor.py` for sequence/stage transitions.
+
+Headless Arc tests extend `ArcCase` (`tests.arc.arc`), drive the program through the
+Python client, and must define `arc_source`, `arc_name_prefix`, `start_cmd_channel`, and
+`subscribe_channels`. Conventions that keep a broad test readable:
+
+- Break the Arc source into clearly labeled sections with a single-line divider, not a
+  multi-line block:
+
+  ```
+  // ──────────────────────────── value variables ────────────────────────────
+  ```
+
+  Keep the label short and descriptive. Do not number sections (`Group A`, etc.).
+
+- Group output channel names into per-section lists and concatenate them into one
+  `OUTPUTS`. Set `subscribe_channels = OUTPUTS` (only the channels you assert on).
+- Create channels in typed buckets and build them with `create_virtual_channels`.
+- Give each section its own `_verify_*` method, called in order from
+  `verify_sequence_execution`.
+- Use a `@dataclass` case list plus a loop when the same assertion repeats over varying
+  inputs, the same way the stl tests do.
+
+## Triggers: Shared Start by Default
+
+The base class fires `start_cmd_channel` once when it loads the program. Make that the
+default activation for everything: point every sequence's entry at it.
+
+```
+vars_start => a_main
+vars_start => b_main
+vars_start => c_main
+```
+
+All sequences then activate concurrently off one trigger, and each `_verify_*` method
+only drives its own inputs. Only introduce a separate trigger channel when a section
+genuinely needs independent activation, for example when one source would otherwise fan
+out into two conflicting transitions, or when a flow must stay gated until a later step.
+
+## Arc Runtime Semantics (the traps)
+
+These are the behaviors that make Arc integration tests fail in non-obvious ways.
+
+- **Stage flows run concurrently.** Every flow in a stage executes asynchronously each
+  cycle. Do not rely on the order of lines within a stage for a value to be ready.
+- **No same-tick read-after-write.** A flow cannot observe a variable that was written
+  on the same tick. Latch a value on one tick, then read it on a later tick.
+- **Stage entry ignores pre-activation writes.** A channel value written before its
+  stage is active is dropped. Write a stage's inputs only after the stage is active.
+  Emit a readiness marker on entry (`1 -> a_ready`) and `wait_for_eq("a_ready", 1)`
+  before driving that stage.
+- **First truthy transition wins.** When several `=>` transitions in a stage can be
+  truthy in the same cycle, the first in line order fires. Keep transitions mutually
+  exclusive, or split them across stages so each assertion is unambiguous.
+
+## No Timing Hacks
+
+- Do not call `time.now()` in the Arc program unless the timing itself is what the test
+  verifies. It makes results nondeterministic.
+- Never use `sy.sleep` or `time.sleep` in a test. Use the bounded polling helpers
+  (`wait_for_eq`, `wait_for_gt`, `wait_for_ge`, etc.), which fail fast with a clear
+  message instead of hanging.
+- Do not assert a value written on the same tick as a transition that leaves the stage;
+  that is a race. Assert the definite downstream effect instead.
+
+## Test Vectoring
+
+- Derive the matrix of cases from proven behavior (the feature's own unit tests), not
+  from assumptions about how the runtime should behave.
+- Give each vector its own input (but prefer the shared start trigger where possible)
+  and output so a failure points at exactly one line rather than a shared channel.
+- Cover the axes that matter for the feature: scope, source kind, sink kind, and data
+  type.


### PR DESCRIPTION
Add integration claude.md

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Claude guidance for integration tests.

- Adds a new `docs/claude/integration-test.md` guide.
- Documents Arc integration test structure and runtime traps.
- Links the guide from the top-level `CLAUDE.md` index.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge after a small documentation fix.

- The changes are documentation-only.
- The guide mostly matches the existing Arc test framework.
- One sentence can mislead authors into adding extra discoverable test classes.

docs/claude/integration-test.md

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CLAUDE.md | Adds an index link to the new integration test guide. |
| docs/claude/integration-test.md | Adds integration and Arc test guidance, with one misleading statement about test class discovery. |

<sub>Reviews (1): Last reviewed commit: ["SY-4073: Add integratin--test.md"](https://github.com/synnaxlabs/synnax/commit/915a68db9f303429f6194adae6b076ea93965196) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=41277200)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/synnax/github/synnaxlabs/synnax/-/custom-context?memory=1f93b7ae-395e-4379-bb71-2f5a9a0f0287))

<!-- /greptile_comment -->