### PR TITLE
Docs: update Python formatting docs to Ruff

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,9 +62,10 @@ cd <module> && go build ./...  # Build module
 
 ```bash
 cd client/py
-uv sync        # Install dependencies
-uv run pytest  # Run tests
-uv run black . # Format code
+uv sync                 # Install dependencies
+uv run pytest           # Run tests
+uv run ruff format .    # Format code
+uv run ruff check --fix # Lint and sort imports
 ```
 
 ### C++ Development
@@ -85,7 +86,7 @@ bazel build //driver/cmd:driver # Build driver binary
 ## Universal Code Style
 
 - **Line length**: 88 characters across all languages
-- **Formatters**: Prettier (TS), Black (Python), gofmt (Go), clang-format (C++)
+- **Formatters**: Prettier (TS), Ruff (Python), gofmt (Go), clang-format (C++)
 - **Testing**: BDD style with language-specific frameworks
 - **Imports**: Absolute imports preferred in TypeScript
 - **Comments**: Only add comments when they provide non-obvious context. Never add

--- a/docs/claude/toolchains/python.md
+++ b/docs/claude/toolchains/python.md
@@ -50,7 +50,7 @@ requires-python = ">=3.12,<4"
 dependencies = ["alamos", "synnax-freighter", "pydantic>=2.12.5", "numpy>=2.3.5"]
 
 [dependency-groups]
-dev = ["ruff>=0.15.18", "mypy>=2.1.0", "pytest>=9.0.2"]
+dev = ["ruff>=0.15.18,<1", "mypy>=2.1.0,<3", "pytest>=9.1.1,<10"]
 
 [build-system]
 requires = ["hatchling"]

--- a/docs/claude/toolchains/python.md
+++ b/docs/claude/toolchains/python.md
@@ -50,7 +50,7 @@ requires-python = ">=3.12,<4"
 dependencies = ["alamos", "synnax-freighter", "pydantic>=2.12.5", "numpy>=2.3.5"]
 
 [dependency-groups]
-dev = ["black>=25.12.0", "isort>=7.0.0", "mypy>=1.19.0", "pytest>=9.0.2"]
+dev = ["ruff>=0.15.18", "mypy>=2.1.0", "pytest>=9.0.2"]
 
 [build-system]
 requires = ["hatchling"]
@@ -59,17 +59,12 @@ build-backend = "hatchling.build"
 
 ## Code Style
 
-### Black (Formatter)
+### Ruff (Formatter + Linter)
 
-- 88 character line length
-- Automatically formats code
-- Run: `uv run black .`
-
-### isort (Import Sorter)
-
-- Configured with `profile = "black"` for compatibility
-- Automatically organizes imports
-- Run: `uv run isort .`
+- 88 character line length, target `py312`
+- Formats code and sorts imports (pyflakes + isort rules via `select = ["F", "I"]`)
+- Run: `uv run ruff format .` to format, `uv run ruff check --fix` to lint and sort
+  imports
 
 ### mypy (Type Checker)
 


### PR DESCRIPTION
Updates `CLAUDE.md` and the Python toolchain doc to reflect that `client/py` and `integration/` use `ruff` (formatter + linter) and `mypy`. The old `black`/`isort` references were stale. Verified against the `pyproject.toml` configs and the `test-python` CI action.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the Python formatting docs to use Ruff. The main changes are:

- Replaces Black and isort commands with Ruff commands in `CLAUDE.md`.
- Updates the Python toolchain dependency example with current Ruff, mypy, and pytest bounds.
- Documents Ruff formatting, linting, import sorting, and Python target settings.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| CLAUDE.md | Updates the common Python commands and formatter list from Black to Ruff. |
| docs/claude/toolchains/python.md | Updates the Python toolchain example and code-style section for Ruff, mypy, and pytest. |

<sub>Reviews (2): Last reviewed commit: ["docs: align Python dev dependency bounds..."](https://github.com/synnaxlabs/synnax/commit/7ecfaf3cea764fa3ecccea2e577750ede80541a7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42588671)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/synnax/github/synnaxlabs/synnax/-/custom-context?memory=1f93b7ae-395e-4379-bb71-2f5a9a0f0287))

<!-- /greptile_comment -->