### PR TITLE
SY-4459: Show Connected Core and Page Details on Error Screens

### DIFF
--- a/console/src/app/vis/Toolbar.tsx
+++ b/console/src/app/vis/Toolbar.tsx
@@ -8,7 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { Errors, Icon } from "@synnaxlabs/pluto";
-import { type FC, type ReactElement } from "react";
+import { type FC, type ReactElement, useCallback } from "react";
 
 import { createSelectorLayout, useSelectorVisible } from "@/app/vis/Selector";
 import { type LayoutType } from "@/app/vis/types";
@@ -64,11 +64,20 @@ const NoVis = (): ReactElement => {
 
 const Content = (): ReactElement => {
   const layout = Session.Layout.useSelectActiveMosaicLayout();
+  const renderFallback = useCallback(
+    (props: Errors.FallbackProps) => (
+      <ErrorDiagnostics
+        page={layout == null ? undefined : { name: layout.name, key: layout.key }}
+        {...props}
+      />
+    ),
+    [layout],
+  );
   if (layout == null) return <NoVis />;
   const Toolbar = TOOLBARS[layout.type as LayoutType];
   if (Toolbar == null) return <NoVis />;
   return (
-    <Errors.SuspenseBoundary FallbackComponent={ErrorDiagnostics}>
+    <Errors.SuspenseBoundary FallbackComponent={renderFallback}>
       <Toolbar layoutKey={layout.key} />
     </Errors.SuspenseBoundary>
   );

--- a/console/src/app/vis/Toolbar.tsx
+++ b/console/src/app/vis/Toolbar.tsx
@@ -18,6 +18,7 @@ import { Log } from "@/feature/log";
 import { Schematic } from "@/feature/schematic";
 import { Table } from "@/feature/table";
 import { Empty } from "@/platform/empty";
+import { ErrorDiagnostics } from "@/platform/errors/ErrorDiagnostics";
 import { Layout } from "@/platform/layout";
 import { type Nav } from "@/platform/nav";
 import { Toolbar } from "@/platform/toolbar";
@@ -67,7 +68,7 @@ const Content = (): ReactElement => {
   const Toolbar = TOOLBARS[layout.type as LayoutType];
   if (Toolbar == null) return <NoVis />;
   return (
-    <Errors.SuspenseBoundary>
+    <Errors.SuspenseBoundary FallbackComponent={ErrorDiagnostics}>
       <Toolbar layoutKey={layout.key} />
     </Errors.SuspenseBoundary>
   );

--- a/console/src/app/vis/Toolbar.tsx
+++ b/console/src/app/vis/Toolbar.tsx
@@ -7,8 +7,8 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { Errors, Icon } from "@synnaxlabs/pluto";
-import { type FC, type ReactElement, useCallback } from "react";
+import { Icon } from "@synnaxlabs/pluto";
+import { type FC, type ReactElement } from "react";
 
 import { createSelectorLayout, useSelectorVisible } from "@/app/vis/Selector";
 import { type LayoutType } from "@/app/vis/types";
@@ -18,7 +18,7 @@ import { Log } from "@/feature/log";
 import { Schematic } from "@/feature/schematic";
 import { Table } from "@/feature/table";
 import { Empty } from "@/platform/empty";
-import { ErrorDiagnostics } from "@/platform/errors/ErrorDiagnostics";
+import { Errors } from "@/platform/errors";
 import { Layout } from "@/platform/layout";
 import { type Nav } from "@/platform/nav";
 import { Toolbar } from "@/platform/toolbar";
@@ -64,20 +64,11 @@ const NoVis = (): ReactElement => {
 
 const Content = (): ReactElement => {
   const layout = Session.Layout.useSelectActiveMosaicLayout();
-  const renderFallback = useCallback(
-    (props: Errors.FallbackProps) => (
-      <ErrorDiagnostics
-        page={layout == null ? undefined : { name: layout.name, key: layout.key }}
-        {...props}
-      />
-    ),
-    [layout],
-  );
   if (layout == null) return <NoVis />;
   const Toolbar = TOOLBARS[layout.type as LayoutType];
   if (Toolbar == null) return <NoVis />;
   return (
-    <Errors.SuspenseBoundary FallbackComponent={renderFallback}>
+    <Errors.SuspenseBoundary layoutKey={layout.key}>
       <Toolbar layoutKey={layout.key} />
     </Errors.SuspenseBoundary>
   );

--- a/console/src/platform/errors/Boundary.tsx
+++ b/console/src/platform/errors/Boundary.tsx
@@ -1,0 +1,37 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { Errors } from "@synnaxlabs/pluto";
+import { type PropsWithChildren, type ReactElement, useCallback } from "react";
+
+import { ErrorDiagnostics } from "@/platform/errors/ErrorDiagnostics";
+import { Session } from "@/session";
+
+export interface BoundaryProps extends PropsWithChildren {
+  /** When provided, crash diagnostics include the layout page's name and key. */
+  layoutKey?: string;
+}
+
+/** Error boundary that renders ErrorDiagnostics on a crash, annotating it with the
+ * connected Core and, when layoutKey is given, the page's name and key. */
+export const Boundary = ({ layoutKey, children }: BoundaryProps): ReactElement => {
+  const name = Session.Layout.useSelectName(layoutKey ?? "");
+  const renderFallback = useCallback(
+    (props: Errors.FallbackProps) => (
+      <ErrorDiagnostics
+        page={layoutKey == null ? undefined : { name, key: layoutKey }}
+        {...props}
+      />
+    ),
+    [name, layoutKey],
+  );
+  return (
+    <Errors.Boundary FallbackComponent={renderFallback}>{children}</Errors.Boundary>
+  );
+};

--- a/console/src/platform/errors/ErrorDiagnostics.spec.tsx
+++ b/console/src/platform/errors/ErrorDiagnostics.spec.tsx
@@ -67,7 +67,7 @@ describe("ErrorDiagnostics", () => {
     const store = await createTestStore();
     void act(() => store.dispatch(Session.Cluster.select("LOCAL")));
     await renderBoundary(store, <Throw error={new Error("boom")} />);
-    expect(messageText()).toBe("boom\nCore: Local @ localhost:9090");
+    expect(messageText()).toBe("boom\nCore: Local (localhost:9090)");
   });
 
   it("reports Core none when not connected to a Core", async () => {
@@ -102,7 +102,7 @@ describe("ErrorDiagnostics", () => {
     );
     const expected = [
       "Failed to retrieve schematic",
-      "Core: Local @ localhost:9090",
+      "Core: Local (localhost:9090)",
       '"fridge_schem" (l1)',
     ].join("\n");
     expect(messageText()).toBe(expected);

--- a/console/src/platform/errors/ErrorDiagnostics.spec.tsx
+++ b/console/src/platform/errors/ErrorDiagnostics.spec.tsx
@@ -1,0 +1,100 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { NotFoundError, status } from "@synnaxlabs/client";
+import { Errors } from "@synnaxlabs/pluto";
+import { act, type ReactElement } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { ErrorDiagnostics } from "@/platform/errors/ErrorDiagnostics";
+import { Layout } from "@/platform/layout";
+import { placeLayout } from "@/platform/layout/testutil";
+import { Session } from "@/session";
+import { createTestStore, renderWithConsole, type TestStore } from "@/testutil";
+
+// Errors.Fallback kicks off a source-map resolution effect; stub stacktrace-js at the
+// library boundary so it doesn't hit the network.
+vi.mock("stacktrace-js", () => ({
+  default: {
+    fromError: async () => {
+      throw new Error("no maps in test env");
+    },
+  },
+}));
+
+const Throw = ({ error }: { error: Error }): ReactElement => {
+  throw error;
+};
+
+const retrieveNotFoundError = (): Error =>
+  status.toError(
+    status.fromException(
+      new NotFoundError("schematic l1 not found"),
+      "Failed to retrieve schematic",
+    ),
+  );
+
+const messageText = (): string | null =>
+  document.querySelector(".pluto-error-fallback__message")?.textContent ?? null;
+
+describe("ErrorDiagnostics", () => {
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+  let warnSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleSpy.mockRestore();
+    warnSpy.mockRestore();
+  });
+
+  const renderBoundary = async (store: TestStore, child: ReactElement) =>
+    await renderWithConsole(
+      <Errors.Boundary FallbackComponent={ErrorDiagnostics}>{child}</Errors.Boundary>,
+      { store },
+    );
+
+  it("appends the connected Core to any error", async () => {
+    const store = await createTestStore();
+    void act(() => store.dispatch(Session.Cluster.select("LOCAL")));
+    await renderBoundary(store, <Throw error={new Error("boom")} />);
+    expect(messageText()).toBe("boom\nCore: Local @ localhost:9090");
+  });
+
+  it("reports Core none when not connected to a Core", async () => {
+    const store = await createTestStore();
+    await renderBoundary(store, <Throw error={new Error("boom")} />);
+    expect(messageText()).toBe("boom\nCore: none");
+  });
+
+  it("appends page type, name, and key for a layout page crash", async () => {
+    const store = await createTestStore();
+    placeLayout(store, "l1", { type: "schematic", name: "fridge_schem" });
+    void act(() => store.dispatch(Session.Cluster.select("LOCAL")));
+    const Renderer: Layout.Renderer = () => {
+      throw retrieveNotFoundError();
+    };
+    Renderer.displayName = "ThrowingRenderer";
+    await renderWithConsole(
+      <Layout.RendererProvider value={{ schematic: Renderer }}>
+        <Layout.Content layoutKey="l1" />
+      </Layout.RendererProvider>,
+      { store },
+    );
+    const expected = [
+      "Failed to retrieve schematic",
+      "Core: Local @ localhost:9090",
+      '"fridge_schem" (l1)',
+    ].join("\n");
+    expect(messageText()).toBe(expected);
+  });
+});

--- a/console/src/platform/errors/ErrorDiagnostics.spec.tsx
+++ b/console/src/platform/errors/ErrorDiagnostics.spec.tsx
@@ -81,9 +81,7 @@ describe("ErrorDiagnostics", () => {
     const error = new Error("boom");
     error.name = "NotFoundError";
     await renderBoundary(store, <Throw error={error} />);
-    const nameText = document.querySelector(
-      ".pluto-error-fallback__name",
-    )?.textContent;
+    const nameText = document.querySelector(".pluto-error-fallback__name")?.textContent;
     expect(nameText).toBe("NotFoundError");
     expect(messageText()).toBe("boom\nCore: none");
   });

--- a/console/src/platform/errors/ErrorDiagnostics.spec.tsx
+++ b/console/src/platform/errors/ErrorDiagnostics.spec.tsx
@@ -76,7 +76,19 @@ describe("ErrorDiagnostics", () => {
     expect(messageText()).toBe("boom\nCore: none");
   });
 
-  it("appends page type, name, and key for a layout page crash", async () => {
+  it("preserves the original error name in the fallback", async () => {
+    const store = await createTestStore();
+    const error = new Error("boom");
+    error.name = "NotFoundError";
+    await renderBoundary(store, <Throw error={error} />);
+    const nameText = document.querySelector(
+      ".pluto-error-fallback__name",
+    )?.textContent;
+    expect(nameText).toBe("NotFoundError");
+    expect(messageText()).toBe("boom\nCore: none");
+  });
+
+  it("appends page name and key for a layout page crash", async () => {
     const store = await createTestStore();
     placeLayout(store, "l1", { type: "schematic", name: "fridge_schem" });
     void act(() => store.dispatch(Session.Cluster.select("LOCAL")));
@@ -96,5 +108,19 @@ describe("ErrorDiagnostics", () => {
       '"fridge_schem" (l1)',
     ].join("\n");
     expect(messageText()).toBe(expected);
+  });
+
+  it("omits the name when a layout page has no name", async () => {
+    const store = await createTestStore();
+    const renderFallback = (props: Errors.FallbackProps): ReactElement => (
+      <ErrorDiagnostics page={{ key: "l1" }} {...props} />
+    );
+    await renderWithConsole(
+      <Errors.Boundary FallbackComponent={renderFallback}>
+        <Throw error={new Error("boom")} />
+      </Errors.Boundary>,
+      { store },
+    );
+    expect(messageText()).toBe("boom\nCore: none\n(l1)");
   });
 });

--- a/console/src/platform/errors/ErrorDiagnostics.tsx
+++ b/console/src/platform/errors/ErrorDiagnostics.tsx
@@ -1,0 +1,47 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { Errors } from "@synnaxlabs/pluto";
+import { type ReactElement } from "react";
+
+import { Session } from "@/session";
+
+export interface PageContext {
+  name?: string;
+  key: string;
+}
+
+export interface ErrorDiagnosticsProps extends Errors.FallbackProps {
+  page?: PageContext;
+}
+
+const pageLine = (page?: PageContext): string | null => {
+  if (page == null) return null;
+  const name = page.name != null ? `"${page.name}" ` : "";
+  return `${name}(${page.key})`;
+};
+
+// Annotates any caught error with the connected Core and, for layout pages, the page's
+// name and key, so a crash screenshot is triageable.
+export const ErrorDiagnostics = ({
+  page,
+  error,
+  ...rest
+}: ErrorDiagnosticsProps): ReactElement => {
+  const cluster = Session.Cluster.useSelectState();
+  const core =
+    cluster != null ? `${cluster.name} @ ${cluster.host}:${cluster.port}` : "none";
+  const message = [error.message, `Core: ${core}`, pageLine(page)]
+    .filter((line): line is string => line != null)
+    .join("\n");
+  const displayError = new Error(message, { cause: error.cause });
+  displayError.name = error.name;
+  displayError.stack = error.stack;
+  return <Errors.Fallback error={displayError} {...rest} />;
+};

--- a/console/src/platform/errors/ErrorDiagnostics.tsx
+++ b/console/src/platform/errors/ErrorDiagnostics.tsx
@@ -40,6 +40,7 @@ export const ErrorDiagnostics = ({
   const message = [error.message, `Core: ${core}`, pageLine(page)]
     .filter((line): line is string => line != null)
     .join("\n");
+  // Clone rather than mutate the caught error, preserving its name, stack, and cause.
   const displayError = new Error(message, { cause: error.cause });
   displayError.name = error.name;
   displayError.stack = error.stack;

--- a/console/src/platform/errors/ErrorDiagnostics.tsx
+++ b/console/src/platform/errors/ErrorDiagnostics.tsx
@@ -36,7 +36,7 @@ export const ErrorDiagnostics = ({
 }: ErrorDiagnosticsProps): ReactElement => {
   const cluster = Session.Cluster.useSelectState();
   const core =
-    cluster != null ? `${cluster.name} @ ${cluster.host}:${cluster.port}` : "none";
+    cluster != null ? `${cluster.name} (${cluster.host}:${cluster.port})` : "none";
   const message = [error.message, `Core: ${core}`, pageLine(page)]
     .filter((line): line is string => line != null)
     .join("\n");

--- a/console/src/platform/errors/SuspenseBoundary.tsx
+++ b/console/src/platform/errors/SuspenseBoundary.tsx
@@ -1,0 +1,36 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import {
+  type PropsWithChildren,
+  type ReactElement,
+  type ReactNode,
+  Suspense,
+} from "react";
+
+import { Boundary } from "@/platform/errors/Boundary";
+
+export interface SuspenseBoundaryProps extends PropsWithChildren {
+  /** When provided, crash diagnostics include the layout page's name and key. */
+  layoutKey?: string;
+  /** Rendered while children are suspended. Defaults to blank space. */
+  loading?: ReactNode;
+}
+
+/** Boundary + React Suspense in one component. On a crash it renders ErrorDiagnostics
+ * annotated with the connected Core and, when layoutKey is given, the page details. */
+export const SuspenseBoundary = ({
+  layoutKey,
+  loading,
+  children,
+}: SuspenseBoundaryProps): ReactElement => (
+  <Boundary layoutKey={layoutKey}>
+    <Suspense fallback={loading}>{children}</Suspense>
+  </Boundary>
+);

--- a/console/src/platform/errors/external.ts
+++ b/console/src/platform/errors/external.ts
@@ -7,4 +7,6 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-export * as Errors from "@/platform/errors/external";
+export * from "@/platform/errors/Boundary";
+export * from "@/platform/errors/Overlay";
+export * from "@/platform/errors/SuspenseBoundary";

--- a/console/src/platform/layout/Content.tsx
+++ b/console/src/platform/layout/Content.tsx
@@ -7,10 +7,9 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { Errors } from "@synnaxlabs/pluto";
 import { memo, type ReactElement, useCallback } from "react";
 
-import { ErrorDiagnostics } from "@/platform/errors/ErrorDiagnostics";
+import { Errors } from "@/platform/errors";
 import { useRenderer } from "@/platform/layout/context";
 import { useRemover } from "@/platform/layout/useRemover";
 import { Session } from "@/session";
@@ -31,7 +30,6 @@ export interface ContentProps {
 export const Content = memo(
   ({ layoutKey, forceHidden }: ContentProps): ReactElement => {
     const type = Session.Layout.useSelectType(layoutKey) ?? "";
-    const name = Session.Layout.useSelectName(layoutKey);
     const removeLayout = useRemover(layoutKey);
     const handleClose = useCallback(() => removeLayout(), [removeLayout]);
     const Renderer = useRenderer(type);
@@ -39,14 +37,8 @@ export const Content = memo(
     const isFocused = focused === layoutKey;
     let visible = focused == null || isFocused;
     if (forceHidden) visible = false;
-    const renderFallback = useCallback(
-      (props: Errors.FallbackProps) => (
-        <ErrorDiagnostics page={{ name, key: layoutKey }} {...props} />
-      ),
-      [name, layoutKey],
-    );
     return (
-      <Errors.SuspenseBoundary FallbackComponent={renderFallback}>
+      <Errors.SuspenseBoundary layoutKey={layoutKey}>
         <Renderer
           key={layoutKey}
           layoutKey={layoutKey}

--- a/console/src/platform/layout/Content.tsx
+++ b/console/src/platform/layout/Content.tsx
@@ -10,6 +10,7 @@
 import { Errors } from "@synnaxlabs/pluto";
 import { memo, type ReactElement, useCallback } from "react";
 
+import { ErrorDiagnostics } from "@/platform/errors/ErrorDiagnostics";
 import { useRenderer } from "@/platform/layout/context";
 import { useRemover } from "@/platform/layout/useRemover";
 import { Session } from "@/session";
@@ -30,6 +31,7 @@ export interface ContentProps {
 export const Content = memo(
   ({ layoutKey, forceHidden }: ContentProps): ReactElement => {
     const type = Session.Layout.useSelectType(layoutKey) ?? "";
+    const name = Session.Layout.useSelectName(layoutKey);
     const removeLayout = useRemover(layoutKey);
     const handleClose = useCallback(() => removeLayout(), [removeLayout]);
     const Renderer = useRenderer(type);
@@ -37,8 +39,14 @@ export const Content = memo(
     const isFocused = focused === layoutKey;
     let visible = focused == null || isFocused;
     if (forceHidden) visible = false;
+    const renderFallback = useCallback(
+      (props: Errors.FallbackProps) => (
+        <ErrorDiagnostics page={{ name, key: layoutKey }} {...props} />
+      ),
+      [name, layoutKey],
+    );
     return (
-      <Errors.SuspenseBoundary>
+      <Errors.SuspenseBoundary FallbackComponent={renderFallback}>
         <Renderer
           key={layoutKey}
           layoutKey={layoutKey}

--- a/console/src/platform/modals/Modal.tsx
+++ b/console/src/platform/modals/Modal.tsx
@@ -7,10 +7,10 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { Dialog, Errors } from "@synnaxlabs/pluto";
+import { Dialog } from "@synnaxlabs/pluto";
 import { memo, type ReactElement, useCallback } from "react";
 
-import { ErrorDiagnostics } from "@/platform/errors/ErrorDiagnostics";
+import { Errors } from "@/platform/errors";
 import { type Session } from "@/session";
 
 interface ModalProps extends Session.Modals.Entry {}
@@ -24,9 +24,7 @@ export const Modal = memo(({ dismiss, render }: ModalProps): ReactElement => {
       onVisibleChange={handleDismiss}
       background={0}
     >
-      <Errors.SuspenseBoundary FallbackComponent={ErrorDiagnostics}>
-        {render()}
-      </Errors.SuspenseBoundary>
+      <Errors.SuspenseBoundary>{render()}</Errors.SuspenseBoundary>
     </Dialog.Frame>
   );
 });

--- a/console/src/platform/modals/Modal.tsx
+++ b/console/src/platform/modals/Modal.tsx
@@ -10,6 +10,7 @@
 import { Dialog, Errors } from "@synnaxlabs/pluto";
 import { memo, type ReactElement, useCallback } from "react";
 
+import { ErrorDiagnostics } from "@/platform/errors/ErrorDiagnostics";
 import { type Session } from "@/session";
 
 interface ModalProps extends Session.Modals.Entry {}
@@ -23,7 +24,9 @@ export const Modal = memo(({ dismiss, render }: ModalProps): ReactElement => {
       onVisibleChange={handleDismiss}
       background={0}
     >
-      <Errors.SuspenseBoundary>{render()}</Errors.SuspenseBoundary>
+      <Errors.SuspenseBoundary FallbackComponent={ErrorDiagnostics}>
+        {render()}
+      </Errors.SuspenseBoundary>
     </Dialog.Frame>
   );
 });

--- a/console/src/platform/nav/Drawer.tsx
+++ b/console/src/platform/nav/Drawer.tsx
@@ -18,6 +18,7 @@ import {
 } from "react";
 
 import { CSS } from "@/platform/css";
+import { ErrorDiagnostics } from "@/platform/errors/ErrorDiagnostics";
 
 const X_THRESHOLD = { x: 36, y: 24 };
 const Y_THRESHOLD = xy.swap(X_THRESHOLD);
@@ -78,7 +79,9 @@ export const Drawer = ({
       borderColor={5}
       {...rest}
     >
-      <Errors.Boundary>{collapsed ? null : children}</Errors.Boundary>
+      <Errors.Boundary FallbackComponent={ErrorDiagnostics}>
+        {collapsed ? null : children}
+      </Errors.Boundary>
     </Nav.Drawer>
   );
 };

--- a/console/src/platform/nav/Drawer.tsx
+++ b/console/src/platform/nav/Drawer.tsx
@@ -9,7 +9,7 @@
 
 import "@/platform/nav/Nav.css";
 
-import { Eraser, Errors, Nav, type Resize } from "@synnaxlabs/pluto";
+import { Eraser, Nav, type Resize } from "@synnaxlabs/pluto";
 import { box, direction, type location, xy } from "@synnaxlabs/x";
 import {
   type MouseEvent as ReactMouseEvent,
@@ -18,7 +18,7 @@ import {
 } from "react";
 
 import { CSS } from "@/platform/css";
-import { ErrorDiagnostics } from "@/platform/errors/ErrorDiagnostics";
+import { Errors } from "@/platform/errors";
 
 const X_THRESHOLD = { x: 36, y: 24 };
 const Y_THRESHOLD = xy.swap(X_THRESHOLD);
@@ -79,9 +79,7 @@ export const Drawer = ({
       borderColor={5}
       {...rest}
     >
-      <Errors.Boundary FallbackComponent={ErrorDiagnostics}>
-        {collapsed ? null : children}
-      </Errors.Boundary>
+      <Errors.Boundary>{collapsed ? null : children}</Errors.Boundary>
     </Nav.Drawer>
   );
 };

--- a/pluto/src/errors/Fallback.css
+++ b/pluto/src/errors/Fallback.css
@@ -45,6 +45,10 @@
             width: 100%;
         }
 
+        .pluto-error-fallback__message {
+            white-space: pre-line;
+        }
+
         .pluto-error-fallback__stack-container {
             width: 100%;
             padding: 1rem;


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4459](https://linear.app/synnax/issue/SY-4459)

## Description

Console error screens now append the connected Core (`name @ host:port`) and, for layout pages, the page name and key to the error message. When a user sends a screenshot of a crash, you can immediately see which Core they're on and which page failed, making it triageable without follow-up questions. Applies to every in-app error boundary, not just page-retrieval failures.

<img width="798" height="168" alt="image" src="https://github.com/user-attachments/assets/88bea708-1da9-4f2e-b6fb-b6a54b09e6e8" />


## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds extra context to Console error screens. The main changes are:

- A new `ErrorDiagnostics` fallback with Core and page details.
- Updated layout, toolbar, modal, and drawer error boundaries.
- Tests for the new fallback message formatting.
- CSS support for multiline fallback messages.

<h3>Confidence Score: 5/5</h3>

The changed flow looks mergeable after a small diagnostics cleanup.

- The new fallback matches the existing Pluto boundary contract.
- The main layout crash path includes Core and page context.
- Toolbar crashes can still miss the page name and key.

console/src/app/vis/Toolbar.tsx

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| console/src/platform/errors/ErrorDiagnostics.tsx | Adds the diagnostics fallback and delegates rendering to Pluto's existing fallback. |
| console/src/platform/layout/Content.tsx | Passes layout page name and key into the diagnostics fallback for layout content crashes. |
| console/src/app/vis/Toolbar.tsx | Adds the diagnostics fallback for toolbar crashes, but omits the available page context. |
| console/src/platform/errors/ErrorDiagnostics.spec.tsx | Adds coverage for Core annotation, no-Core behavior, name preservation, and page context formatting. |
| pluto/src/errors/Fallback.css | Renders fallback messages with newline-aware whitespace. |

<sub>Reviews (1): Last reviewed commit: ["SY-4459: Add Test Coverage for Error Dia..."](https://github.com/synnaxlabs/synnax/commit/c939fc987f2b54ec2beb89a72965b884a54f5591) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=42605808)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/synnax/github/synnaxlabs/synnax/-/custom-context?memory=1f93b7ae-395e-4379-bb71-2f5a9a0f0287))

<!-- /greptile_comment -->