### PR TITLE
SY-4473: Fix Core Download URL 404 During Release

### DIFF
--- a/.github/workflows/deploy.synnax.yaml
+++ b/.github/workflows/deploy.synnax.yaml
@@ -151,8 +151,9 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 tag_name: synnaxTag,
+                target_commitish: context.sha,
                 name: 'Synnax v${{ needs.setup.outputs.VERSION }}',
-                draft: false,
+                draft: true,
                 prerelease: false
               });
             }
@@ -275,6 +276,24 @@ jobs:
       - name: Upload Install Script
         run: |
           gh release upload --clobber synnax-v${{ needs.setup.outputs.VERSION }} install-driver-nilinuxrt.sh
+
+  publish-core-release:
+    name: Publish Core Release
+    runs-on: ubuntu-latest
+    needs: [setup, build, windows-installer, ni-install-script]
+    if: github.event_name == 'push'
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v7
+
+      - name: Publish Release
+        run: |
+          gh release edit synnax-v${{ needs.setup.outputs.VERSION }} \
+            --draft=false --repo ${{ github.repository }}
 
   publish-console-update:
     name: Publish Console Auto-Update

--- a/.github/workflows/deploy.synnax.yaml
+++ b/.github/workflows/deploy.synnax.yaml
@@ -287,9 +287,6 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - name: Checkout Repository
-        uses: actions/checkout@v7
-
       - name: Publish Release
         run: |
           gh release edit synnax-v${{ needs.setup.outputs.VERSION }} \

--- a/docs/site/src/util/fetchVersion.ts
+++ b/docs/site/src/util/fetchVersion.ts
@@ -7,8 +7,29 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-const VERSION =
-  "https://raw.githubusercontent.com/synnaxlabs/synnax/main/core/pkg/version/VERSION";
+const RELEASES = "https://api.github.com/repos/synnaxlabs/synnax/releases?per_page=30";
 
-export const fetchVersion = async (): Promise<string> =>
-  await (await fetch(VERSION)).text();
+interface Release {
+  tag_name: string;
+  draft: boolean;
+}
+
+const STABLE = /^synnax-v(\d+\.\d+\.\d+)$/;
+
+const resolveVersion = async (): Promise<string> => {
+  const releases = (await (await fetch(RELEASES)).json()) as Release[];
+  for (const { tag_name, draft } of releases) {
+    const match = STABLE.exec(tag_name);
+    if (!draft && match != null) return match[1];
+  }
+  throw new Error("no published Synnax release found");
+};
+
+// Memoized to one API call per build; the components below render across many pages.
+let cached: Promise<string> | null = null;
+
+// Skips draft releases, so buttons never point at a build that isn't published yet.
+export const fetchVersion = async (): Promise<string> => {
+  cached ??= resolveVersion();
+  return await cached;
+};


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4473](https://linear.app/synnax/issue/SY-4473)

## Description

The Core and driver download links on the docs site read their version from `core/pkg/version/VERSION`, which is bumped on `main` before the release build finishes uploading assets. This left links pointing at a `synnax-vX.Y.Z` release whose installer did not exist yet, producing a 404 during the release window. The Console avoids this because its button reads a spec file written only after publish.

This makes "the latest release" mean "a fully-published release". The `synnax-v*` release is now created as a draft, assets upload to the draft, and a new `publish-core-release` job publishes it only after `build`, `windows-installer`, and `ni-install-script` succeed. On the docs side, `fetchVersion` reads the newest published (non-draft) `synnax-v*` release from the GitHub releases API, skipping drafts and `-rc` tags.

Failure modes are safe: an unpublished release keeps the previous working link, and an upload failure surfaces as a red CI run rather than a user-facing 404.

## Testing

The release path only runs on push to `main`/`rc`, so it was validated out of band. A throwaway hidden draft release confirmed the mechanics end to end: uploading assets to a draft works, the git tag is created only on publish (at the correct commit), and the download URL returns 200 only after publish. The release was then deleted. The `fetchVersion` selection logic was covered by a local test confirming it picks the newest published release and skips drafts and `-rc` tags.

## Basic Readiness

- [x] I have performed a self-review of my code.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a release-window 404 by making the `synnax-v*` GitHub release a draft until all assets are fully uploaded, then publishing it atomically via a new `publish-core-release` gating job. The docs site's `fetchVersion` utility is updated to query the GitHub Releases API and return only the newest non-draft, non-rc `synnax-v*` release instead of reading the raw VERSION file that is bumped before assets exist.

- **Workflow change**: `create-release` now creates the synnax release with `draft: true` and `target_commitish` set; a new `publish-core-release` job (gated on `build`, `windows-installer`, and `ni-install-script`) calls `gh release edit --draft=false` to atomically expose the release only after all uploads succeed.
- **`fetchVersion` change**: Replaces the static raw-file URL with a paginated GitHub Releases API call, filtered by the `synnax-v(\\d+\\.\\d+\\.\\d+)` pattern and `draft: false`, with module-level memoization to keep it to one API call per docs build.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the draft-gate approach correctly prevents publishing until all asset uploads succeed, and the docs API call degrades safely to a build error rather than a broken download link.

Both changes are narrow and well-scoped. The workflow gating relies on GitHub Actions' implicit success() guard, which is preserved because publish-core-release uses no status-check function in its if expression. The fetchVersion rewrite is correct in its filtering logic; the two suggestions are hardening improvements, not present defects.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/deploy.synnax.yaml | Release creation switched to draft mode with a new publish-core-release gate job that only publishes after all asset-upload jobs succeed; logic is correct and the implicit success() guard is intact. |
| docs/site/src/util/fetchVersion.ts | Replaced static VERSION file URL with a GitHub Releases API call that skips drafts and rc tags; memoized correctly, but lacks response.ok check and uses a fixed per_page=30 that could miss the latest stable release if the repo accumulates many total releases. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant CI as GitHub Actions
    participant GH as GitHub Releases API
    participant Docs as Docs Build (fetchVersion)

    CI->>GH: "createRelease(draft=true, target_commitish=sha)"
    Note over GH: synnax-vX.Y.Z exists as DRAFT
    CI->>GH: upload assets (build, windows-installer, ni-install-script)
    Note over CI: publish-core-release waits for all uploads
    CI->>GH: "gh release edit --draft=false"
    Note over GH: synnax-vX.Y.Z is now PUBLISHED

    Docs->>GH: "GET /releases?per_page=30"
    GH-->>Docs: [...releases]
    Note over Docs: filter: !draft && /^synnax-v(\d+\.\d+\.\d+)$/
    Docs-->>Docs: return first match (newest published stable)
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant CI as GitHub Actions
    participant GH as GitHub Releases API
    participant Docs as Docs Build (fetchVersion)

    CI->>GH: "createRelease(draft=true, target_commitish=sha)"
    Note over GH: synnax-vX.Y.Z exists as DRAFT
    CI->>GH: upload assets (build, windows-installer, ni-install-script)
    Note over CI: publish-core-release waits for all uploads
    CI->>GH: "gh release edit --draft=false"
    Note over GH: synnax-vX.Y.Z is now PUBLISHED

    Docs->>GH: "GET /releases?per_page=30"
    GH-->>Docs: [...releases]
    Note over Docs: filter: !draft && /^synnax-v(\d+\.\d+\.\d+)$/
    Docs-->>Docs: return first match (newest published stable)
```

</a>

<sub>Reviews (2): Last reviewed commit: ["SY-4473: Removed uneeded step"](https://github.com/synnaxlabs/synnax/commit/f0342b8ab91ceea24dd5e3a3f1ca0f61fefcfa24) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43089932)</sub>

<!-- /greptile_comment -->