### PR TITLE
SY-4478: Fix Issue with sy_channel_set Marshaling

### DIFF
--- a/core/pkg/distribution/channel/ontology.go
+++ b/core/pkg/distribution/channel/ontology.go
@@ -56,8 +56,11 @@ var schema = zyn.Object(map[string]zyn.Schema{
 	"expression":  zyn.String(),
 })
 
-func ToPayload(c Channel) map[string]any {
-	return map[string]any{
+// ToPayload returns a map representation of the channel for use in ontology
+// resources and signal marshaling. The "operations" key is omitted when the
+// channel has no operations.
+func (c Channel) ToPayload() map[string]any {
+	p := map[string]any{
 		"key":         c.Key(),
 		"name":        c.Name,
 		"leaseholder": c.Leaseholder,
@@ -67,12 +70,15 @@ func ToPayload(c Channel) map[string]any {
 		"internal":    c.Internal,
 		"virtual":     c.Virtual,
 		"expression":  c.Expression,
-		"operations":  c.Operations,
 	}
+	if len(c.Operations) > 0 {
+		p["operations"] = c.Operations
+	}
+	return p
 }
 
 func newResource(c Channel) ontology.Resource {
-	return ontology.NewResource(schema, OntologyID(c.Key()), c.Name, ToPayload(c))
+	return ontology.NewResource(schema, OntologyID(c.Key()), c.Name, c.ToPayload())
 }
 
 var (

--- a/core/pkg/distribution/channel/ontology.go
+++ b/core/pkg/distribution/channel/ontology.go
@@ -56,9 +56,9 @@ var schema = zyn.Object(map[string]zyn.Schema{
 	"expression":  zyn.String(),
 })
 
-// ToPayload returns a map representation of the channel for use in ontology
-// resources and signal marshaling. The "operations" key is omitted when the
-// channel has no operations.
+// ToPayload returns a map representation of the channel for use in ontology resources
+// and signal marshaling. The "operations" key is omitted when the channel has no
+// operations.
 func (c Channel) ToPayload() map[string]any {
 	p := map[string]any{
 		"key":         c.Key(),

--- a/core/pkg/distribution/channel/ontology_test.go
+++ b/core/pkg/distribution/channel/ontology_test.go
@@ -38,6 +38,20 @@ var _ = Describe("Ontology", Ordered, func() {
 			Expect(ch.OntologyID()).To(Equal(channel.OntologyID(ch.Key())))
 		})
 	})
+	Describe("ToPayload", func() {
+		It("Should include operations when the channel has them", func() {
+			ch := channel.Channel{
+				Name:       "with_ops",
+				DataType:   telem.Float64T,
+				Operations: []channel.Operation{{Type: channel.OperationTypeAvg}},
+			}
+			Expect(ch.ToPayload()).To(HaveKeyWithValue("operations", ch.Operations))
+		})
+		It("Should omit the operations key when the channel has no operations", func() {
+			ch := channel.Channel{Name: "no_ops", DataType: telem.Float64T}
+			Expect(ch.ToPayload()).ToNot(HaveKey("operations"))
+		})
+	})
 	Describe("OpenNexter", func() {
 		It("Should correctly iterate over all channels", func(ctx SpecContext) {
 			Expect(node.Channel.Create(ctx, &channel.Channel{Name: "SG01", DataType: telem.Int64T, Virtual: true})).To(Succeed())

--- a/core/pkg/service/channel/channel.go
+++ b/core/pkg/service/channel/channel.go
@@ -47,7 +47,6 @@ var (
 	MatchVirtual                                = channel.MatchVirtual
 	MatchIsIndex                                = channel.MatchIsIndex
 	MatchInternal                               = channel.MatchInternal
-	ToPayload                                   = channel.ToPayload
 	MatchCalculated                             = channel.MatchCalculated
 	Not                                         = channel.Not
 	NewRandomName                               = channel.NewRandomName

--- a/core/pkg/service/channel/signals/signals.go
+++ b/core/pkg/service/channel/signals/signals.go
@@ -35,7 +35,7 @@ func Publish(
 			return unsafe.CastToBytes(k), nil
 		},
 		MarshalSet: func(c channel.Channel) ([]byte, error) {
-			v, err := json.Marshal(channel.ToPayload(c))
+			v, err := json.Marshal(c.ToPayload())
 			if err != nil {
 				return nil, err
 			}

--- a/core/pkg/service/channel/signals/signals_test.go
+++ b/core/pkg/service/channel/signals/signals_test.go
@@ -16,6 +16,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/samber/lo"
 	"github.com/synnaxlabs/synnax/pkg/service/channel"
 	"github.com/synnaxlabs/synnax/pkg/service/framer"
 	"github.com/synnaxlabs/x/confluence"
@@ -67,6 +68,26 @@ var _ = Describe("Signals", func() {
 			names[i] = p.Name
 		}
 		Expect(names).To(ContainElement(ch.Name))
+		requests.Close()
+		Eventually(responses.Outlet()).Should(BeClosed())
+		Expect(closeStreamer.Close()).To(Succeed())
+	})
+
+	It("Should not marshal zero-length operations to the set channel", func(ctx SpecContext) {
+		requests, responses, closeStreamer := openStreamer(ctx, "sy_channel_set")
+		ch := channel.Channel{
+			Name: channel.NewRandomName(), DataType: telem.TimeStampT, IsIndex: true,
+		}
+		Expect(channelSvc.Create(ctx, &ch)).To(Succeed())
+		var res framer.StreamerResponse
+		Eventually(responses.Outlet()).Should(Receive(&res))
+		payloads := MustSucceed(telem.UnmarshalJSONSeries[map[string]any](
+			res.Frame.SeriesAt(0),
+		))
+		payload := MustBeOk(lo.Find(payloads, func(p map[string]any) bool {
+			return p["name"] == ch.Name
+		}))
+		Expect(payload).ToNot(HaveKey("operations"))
 		requests.Close()
 		Eventually(responses.Outlet()).Should(BeClosed())
 		Expect(closeStreamer.Close()).To(Succeed())


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4478](https://linear.app/synnax/issue/SY-4478)

## Description

Channels without operations were marshaling an explicit `"operations": null` entry into `sy_channel_set` payloads and ontology resources. `ToPayload` is now a method on `Channel` and omits the `operations` key entirely when the channel has no operations, so consumers of the set channel no longer see a null operations field.

Also removes the now-unnecessary `ToPayload` function alias from the service-layer channel package — the method carries over through the `Channel` type alias.

Adds unit tests for the omit/include behavior of `ToPayload` and a channel signals test verifying that zero-length operations are not marshaled to `sy_channel_set`.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a marshaling bug where channels with no operations were emitting an explicit `"operations": null` field in `sy_channel_set` signal payloads and ontology resources. The fix converts `ToPayload` from a package-level function to a value-receiver method on `Channel` and conditionally skips the `"operations"` key when the slice is empty.

- `ontology.go`: `ToPayload` is now a method; `"operations"` is only inserted into the map when `len(c.Operations) > 0`, and `newResource` is updated accordingly.
- `channel.go` (service layer): the now-redundant `ToPayload` function alias is removed since the method is inherited through the `Channel` type alias.
- `signals.go` / `signals_test.go` / `ontology_test.go`: caller site updated to use method form; unit and integration tests added covering both the omit and include paths.

<h3>Confidence Score: 5/5</h3>

The change is small, targeted, and backward-compatible within the codebase; it adds coverage for both the fix and the happy path.

The refactor is mechanically straightforward — a function-to-method rename with a one-line conditional — and every call site has been updated. Both the unit tests in ontology_test.go and the integration test in signals_test.go directly exercise the omit/include paths. No pre-existing callers were left behind (verified via grep across the repository).

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| core/pkg/distribution/channel/ontology.go | Converts ToPayload from a package-level function to a value receiver method and conditionally omits the "operations" key when the slice is empty/nil, fixing the null-marshaling bug. |
| core/pkg/distribution/channel/ontology_test.go | Adds two unit tests for ToPayload: one verifying the "operations" key is included when operations are present, and one verifying it is omitted when there are none. |
| core/pkg/service/channel/channel.go | Removes the now-unnecessary ToPayload function alias since Channel is a type alias of distribution/channel.Channel and the method is inherited automatically. |
| core/pkg/service/channel/signals/signals.go | Updates MarshalSet callback to call the method form c.ToPayload() in place of the removed package-level function, no logic change. |
| core/pkg/service/channel/signals/signals_test.go | Adds an integration-level test that creates a channel with no operations, reads the sy_channel_set signal, and asserts the "operations" key is absent from the marshaled payload. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Service as channel.Service
    participant Signals as signals.Publish
    participant SetCh as sy_channel_set
    participant Consumer

    Service->>Signals: OnChange (channel created/updated)
    Signals->>Signals: MarshalSet(c channel.Channel)
    Note over Signals: c.ToPayload()<br/>omits "operations" key<br/>when len(c.Operations) == 0
    Signals->>SetCh: json.Marshal(payload) → telem.JSONT frame
    SetCh->>Consumer: streamed frame (no null "operations" field)

    Note over Service,Signals: ontology.newResource also calls<br/>c.ToPayload() — same omit behavior
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Service as channel.Service
    participant Signals as signals.Publish
    participant SetCh as sy_channel_set
    participant Consumer

    Service->>Signals: OnChange (channel created/updated)
    Signals->>Signals: MarshalSet(c channel.Channel)
    Note over Signals: c.ToPayload()<br/>omits "operations" key<br/>when len(c.Operations) == 0
    Signals->>SetCh: json.Marshal(payload) → telem.JSONT frame
    SetCh->>Consumer: streamed frame (no null "operations" field)

    Note over Service,Signals: ontology.newResource also calls<br/>c.ToPayload() — same omit behavior
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Format comment"](https://github.com/synnaxlabs/synnax/commit/66ba8c8679b2b59e886a8b1e0058c5614c2de733) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43407669)</sub>

<!-- /greptile_comment -->