### PR TITLE
Fix Calculated-Channel Status Retrieval Passing the Wrong Details Schema

### DIFF
--- a/pluto/src/channel/queries.ts
+++ b/pluto/src/channel/queries.ts
@@ -122,11 +122,10 @@ const retrieveSingle = async ({
   }
   if (isCalculated(ch.payload))
     try {
-      const st = await Status.retrieveSingle<typeof channel.statusZ>({
+      const st = await Status.retrieveSingle({
         store,
         client,
         query: { key: channel.statusKey(key) },
-        detailsSchema: channel.statusZ,
       });
       ch = client.channels.sugar({ ...ch.payload, status: st });
     } catch (e) {


### PR DESCRIPTION
## Description

`Channel.useRetrieve` passed `channel.statusZ` (a full status schema) as the `detailsSchema` when retrieving a calculated channel's status, so the wire response parse demanded `variant` and `message` fields inside `details` and rejected any real status payload. The failure only surfaced when the status was not already in the flux cache (the cached path skips the wire parse), which made `channel/queries.spec.ts`'s calculated-channel status test look flaky rather than broken: it failed roughly half of full-file runs under load.

`channel.statusZ` carries no details schema, so the retrieve should not constrain `details` at all. With the fix, the previously flaky spec passes 5/5 consecutive full-file runs against a live server.

The existing "should retrieve a calculated channel with its error status" spec covers both the cached and wire paths once the parse is correct, so no new test is added.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a bug in `Channel.useRetrieve` where `channel.statusZ` (the full status schema, including `variant`, `message`, `time`, etc.) was incorrectly passed as the `detailsSchema` argument to `Status.retrieveSingle`. Since `detailsSchema` is applied as the schema for the nested `details` sub-field of a status, passing the full status schema there caused the wire-response parse to demand fields like `variant` and `message` inside `details`, which always fails for real payloads. The cache path bypassed the parse, making the bug appear intermittent.

- Removes the incorrect `detailsSchema: channel.statusZ` argument and its associated type parameter from the `Status.retrieveSingle` call, leaving details unconstrained (matching the correct `z.ZodNever` default).
- The existing "should retrieve a calculated channel with its error status" spec now reliably passes on the wire path with this correction.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change removes a single incorrectly-passed argument that caused the wire-path parse to always fail, with no other logic altered.

The diff is a two-line removal in one file: the wrong detailsSchema argument and its now-redundant generic type parameter are dropped. The root cause is clearly described, the existing integration spec directly exercises the fixed code path, and there are no cascading changes or new failure modes introduced.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pluto/src/channel/queries.ts | Removes the incorrectly-typed `detailsSchema: channel.statusZ` parameter (and its generic type argument) from the `Status.retrieveSingle` call for calculated channels — a targeted, correct one-liner bug fix. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant Hook as Channel.useRetrieve
    participant RetrieveSingle as retrieveSingle
    participant StatusCache as Flux Status Cache
    participant StatusRetrieve as Status.retrieveSingle
    participant Wire as Server (wire)

    Hook->>RetrieveSingle: "{ key }"
    RetrieveSingle->>StatusCache: get(statusKey)
    alt cache hit
        StatusCache-->>RetrieveSingle: status (no parse)
    else cache miss
        StatusCache-->>RetrieveSingle: null
        RetrieveSingle->>StatusRetrieve: "{ store, client, query } (no detailsSchema — FIXED)"
        StatusRetrieve->>Wire: retrieve status
        Wire-->>StatusRetrieve: "{ variant, message, details: {channel: key}, ... }"
        Note over StatusRetrieve: Parse with statusZ(), details unconstrained
        StatusRetrieve-->>RetrieveSingle: status.Status
    end
    RetrieveSingle-->>Hook: channel with status
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant Hook as Channel.useRetrieve
    participant RetrieveSingle as retrieveSingle
    participant StatusCache as Flux Status Cache
    participant StatusRetrieve as Status.retrieveSingle
    participant Wire as Server (wire)

    Hook->>RetrieveSingle: "{ key }"
    RetrieveSingle->>StatusCache: get(statusKey)
    alt cache hit
        StatusCache-->>RetrieveSingle: status (no parse)
    else cache miss
        StatusCache-->>RetrieveSingle: null
        RetrieveSingle->>StatusRetrieve: "{ store, client, query } (no detailsSchema — FIXED)"
        StatusRetrieve->>Wire: retrieve status
        Wire-->>StatusRetrieve: "{ variant, message, details: {channel: key}, ... }"
        Note over StatusRetrieve: Parse with statusZ(), details unconstrained
        StatusRetrieve-->>RetrieveSingle: status.Status
    end
    RetrieveSingle-->>Hook: channel with status
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Fix calculated-channel status retrieval ..."](https://github.com/synnaxlabs/synnax/commit/471a884a10663623eeb013de195054309280a081) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43664003)</sub>

<!-- /greptile_comment -->