### PR TITLE
SY-4455: Fix Search Palette Opening Resources Twice per Click

### DIFF
--- a/console/src/feature/search/List.spec.tsx
+++ b/console/src/feature/search/List.spec.tsx
@@ -9,12 +9,14 @@
 
 import { DataType } from "@synnaxlabs/client";
 import { createTestClient } from "@synnaxlabs/client/testutil";
+import { Icon } from "@synnaxlabs/pluto";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { type ReactElement, useState } from "react";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 
 import { Channel } from "@/feature/channel";
 import { Search } from "@/feature/search";
+import { Search as PlatformSearch } from "@/platform/search";
 import { createConsoleWrapper, stubGeometry, uniqueName } from "@/testutil";
 
 stubGeometry();
@@ -23,11 +25,15 @@ const client = createTestClient();
 
 const PLACEHOLDER = <>Search</>;
 
-const Harness = (): ReactElement => {
+const Harness = ({
+  items = Channel.SEARCH_LIST_ITEMS,
+}: {
+  items?: PlatformSearch.ListItems;
+}): ReactElement => {
   const [value, setValue] = useState("");
   return (
     <Search.List
-      items={Channel.SEARCH_LIST_ITEMS}
+      items={items}
       value={value}
       inputPlaceholder={PLACEHOLDER}
       onChange={setValue}
@@ -35,9 +41,9 @@ const Harness = (): ReactElement => {
   );
 };
 
-const renderSearch = async (): Promise<void> => {
+const renderSearch = async (items?: PlatformSearch.ListItems): Promise<void> => {
   const { wrapper } = await createConsoleWrapper({ client });
-  render(<Harness />, { wrapper });
+  render(<Harness items={items} />, { wrapper });
 };
 
 const searchInput = (): HTMLInputElement => {
@@ -64,5 +70,27 @@ describe("Search.List", () => {
     await renderSearch();
     fireEvent.change(searchInput(), { target: { value: ch.name } });
     await waitFor(() => expect(screen.getByText(ch.name)).toBeTruthy());
+  });
+
+  it("fires a search item's onSelect exactly once per mouse click", async () => {
+    const ch = await client.channels.create({
+      name: uniqueName("ch"),
+      dataType: DataType.FLOAT32,
+      virtual: true,
+    });
+    const onSelect = vi.fn();
+    const TestItem = PlatformSearch.createListItem({
+      icon: <Icon.Channel />,
+      useOnSelect: () => onSelect,
+    });
+    await renderSearch({ channel: TestItem });
+    fireEvent.change(searchInput(), { target: { value: ch.name } });
+    await waitFor(() => expect(screen.getByText(ch.name)).toBeTruthy());
+    // A real mouse click carries detail 1. Selection re-dispatches a synthetic
+    // click (detail 0) on the item, which is the only click allowed to fire
+    // onSelect; the item must not also fire it for the original click.
+    fireEvent.click(screen.getByText(ch.name), { detail: 1 });
+    await waitFor(() => expect(onSelect).toHaveBeenCalledTimes(1));
+    expect(onSelect.mock.calls[0][0].name).toEqual(ch.name);
   });
 });

--- a/console/src/platform/search/ListItem.tsx
+++ b/console/src/platform/search/ListItem.tsx
@@ -25,7 +25,7 @@ export const BaseListItem = ({ icon, onSelect, ...rest }: BaseListItemProps) => 
   const { name } = item;
   const handleSelect = useCallback(() => onSelect(item), [onSelect, item]);
   return (
-    <Palette.ListItem {...rest} onClick={handleSelect}>
+    <Palette.ListItem {...rest} onSelect={handleSelect}>
       <Text.Text weight={450} gap="medium">
         {icon}
         {name}


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4455](https://linear.app/synnax/issue/SY-4455)

## Description

Selecting a resource in the search palette opened it twice: two identical tabs and two server-side visualizations per click. `BaseListItem` passed its open handler to `Palette.ListItem` as `onClick`, and the `{...rest}` spread let that override the palette's detail-gated click handler. A real mouse click (detail 1) then fired the open handler directly, while the selection machinery re-dispatched its synthetic click (detail 0) and fired it a second time.

The fix passes the handler as `onSelect`, which `Palette.ListItem` invokes only for the synthetic click, restoring exactly one open per pick. This is what broke the `channel_lifecycle` integration test on every PR based on rc since #2572 merged (the tab-close wait found the surviving twin tab and timed out). Unit tests missed it because jsdom's `element.click()` carries detail 0; the new regression spec dispatches a click with detail 1 the way a real browser does and asserts the handler fires exactly once.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a double-open bug in the search palette where selecting a resource opened it twice — once via the direct `onClick` and again via the palette's synthetic re-dispatch mechanism. The root cause was that `BaseListItem` passed its open handler as `onClick`, which `{...rest}` spread onto `Select.ListItem` inside `Palette.ListItem`, overriding the detail-gated guard that is supposed to prevent double-fires.

- **`ListItem.tsx`**: Passes the handler as `onSelect` instead of `onClick`; `Palette.ListItem` destructures `onSelect` before spreading `...rest`, so the guard in `handleClick` (which only fires when `e.detail === 0`) now functions correctly.
- **`List.spec.tsx`**: Adds a regression test that fires a `detail: 1` click to simulate a real mouse event and asserts `onSelect` is called exactly once, validating both the direct-click path (must not fire) and the subsequent synthetic click path (must fire once).

<h3>Confidence Score: 5/5</h3>

A targeted, well-understood one-line fix with a new regression test that directly reproduces the original failure mode. No new state, APIs, or side-effects introduced.

The change is minimal: swapping `onClick` for `onSelect` on a single component props pass-through. The mechanism is fully traced through `Palette.ListItem`'s destructuring and `{...rest}` spread, the fix is correct, and the regression test fires a real-browser-style click (detail: 1) to confirm the guard holds end-to-end.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| console/src/platform/search/ListItem.tsx | One-line fix: changes `onClick={handleSelect}` to `onSelect={handleSelect}` on Palette.ListItem, preventing the open handler from being included in `{...rest}` and overriding Palette.ListItem's detail-gated click guard. |
| console/src/feature/search/List.spec.tsx | Adds a regression test that dispatches a real mouse click (detail: 1) to verify onSelect fires exactly once, closing the gap left by jsdom's synthetic element.click() (detail: 0) that previously masked the double-fire bug. |

<h3>Sequence Diagram</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
sequenceDiagram
    participant User
    participant SelectListItem as Select.ListItem
    participant PaletteListItem as Palette.ListItem (handleClick)
    participant SelectFrame as Select.Frame (BaseList.handleSelect)
    participant BaseListItem as BaseListItem (handleSelect)

    Note over User,BaseListItem: Before fix
    User->>SelectListItem: click (detail: 1)
    SelectListItem->>BaseListItem: onClick fires (handleSelect)
    BaseListItem->>BaseListItem: onSelect(item) FIRST fire
    SelectListItem->>SelectFrame: onChange(key)
    SelectFrame->>SelectListItem: element.click() synthetic (detail: 0)
    SelectListItem->>BaseListItem: onClick fires (handleSelect)
    BaseListItem->>BaseListItem: onSelect(item) SECOND fire

    Note over User,BaseListItem: After fix
    User->>SelectListItem: click (detail: 1)
    SelectListItem->>PaletteListItem: "handleClick detail=1, no-op"
    SelectListItem->>SelectFrame: onChange(key)
    SelectFrame->>SelectListItem: element.click() synthetic (detail: 0)
    SelectListItem->>PaletteListItem: "handleClick detail=0, calls onSelect"
    PaletteListItem->>BaseListItem: handleSelect() called
    BaseListItem->>BaseListItem: onSelect(item) exactly ONCE
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
sequenceDiagram
    participant User
    participant SelectListItem as Select.ListItem
    participant PaletteListItem as Palette.ListItem (handleClick)
    participant SelectFrame as Select.Frame (BaseList.handleSelect)
    participant BaseListItem as BaseListItem (handleSelect)

    Note over User,BaseListItem: Before fix
    User->>SelectListItem: click (detail: 1)
    SelectListItem->>BaseListItem: onClick fires (handleSelect)
    BaseListItem->>BaseListItem: onSelect(item) FIRST fire
    SelectListItem->>SelectFrame: onChange(key)
    SelectFrame->>SelectListItem: element.click() synthetic (detail: 0)
    SelectListItem->>BaseListItem: onClick fires (handleSelect)
    BaseListItem->>BaseListItem: onSelect(item) SECOND fire

    Note over User,BaseListItem: After fix
    User->>SelectListItem: click (detail: 1)
    SelectListItem->>PaletteListItem: "handleClick detail=1, no-op"
    SelectListItem->>SelectFrame: onChange(key)
    SelectFrame->>SelectListItem: element.click() synthetic (detail: 0)
    SelectListItem->>PaletteListItem: "handleClick detail=0, calls onSelect"
    PaletteListItem->>BaseListItem: handleSelect() called
    BaseListItem->>BaseListItem: onSelect(item) exactly ONCE
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Fix search palette opening resources twi..."](https://github.com/synnaxlabs/synnax/commit/965e2b38eabc794387683bf8b8601812bbd9f883) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43687516)</sub>

<!-- /greptile_comment -->