### PR TITLE
SY-4370: Extract Haul and Color Session Slices from the Layout Slice

### DIFF
--- a/console/src/app/App.tsx
+++ b/console/src/app/App.tsx
@@ -12,20 +12,13 @@ import "@synnaxlabs/media/dist/media.css";
 import "@synnaxlabs/pluto/dist/pluto.css";
 
 import { Provider } from "@synnaxlabs/drift/react";
-import {
-  type Alamos,
-  type Color,
-  type Haul,
-  Pluto,
-  preventDefault,
-  type state,
-  type Triggers,
-  useInitializerRef,
-} from "@synnaxlabs/pluto";
-import { type ReactElement, useCallback, useEffect } from "react";
+import { useInitializerRef } from "@synnaxlabs/pluto";
+import { type ReactElement } from "react";
 
+import { Haul } from "@/app/haul";
 import { Imex } from "@/app/imex";
 import { Layout } from "@/app/layout";
+import { Pluto } from "@/app/pluto";
 import { Range } from "@/app/range";
 import { Task } from "@/app/task";
 import { Tree } from "@/app/tree";
@@ -36,77 +29,18 @@ import { Runtime } from "@/platform/runtime";
 import { Session } from "@/session";
 import WorkerURL from "@/worker?worker&url";
 
-const PREVENT_DEFAULT_TRIGGERS: Triggers.Trigger[] = [
-  ["Control", "P"],
-  ["Control", "Shift", "P"],
-  ["Control", "MouseLeft"],
-  ["Control", "W"],
-];
-
-const TRIGGERS_PROVIDER_PROPS: Triggers.ProviderProps = {
-  preventDefaultOn: PREVENT_DEFAULT_TRIGGERS,
-  preventDefaultOptions: { double: true },
-};
-
-const useHaulState: state.PureUse<Haul.DraggingState> = () => {
-  const hauled = Session.Layout.useSelectHauling();
-  const dispatch = Session.useDispatch();
-  const onHauledChange = useCallback(
-    (state: Haul.DraggingState) => dispatch(Session.Layout.setHauled(state)),
-    [dispatch],
-  );
-  return [hauled, onHauledChange];
-};
-
-const useColorContextState: state.PureUse<Color.ContextState> = () => {
-  const colorContext = Session.Layout.useSelectColorContext();
-  const dispatch = Session.useDispatch();
-  const onColorContextChange = useCallback(
-    (state: Color.ContextState) => dispatch(Session.Layout.setColorContext({ state })),
-    [dispatch],
-  );
-  return [colorContext, onColorContextChange];
-};
-
-const useBlockDefaultDropBehavior = (): void =>
-  useEffect(() => {
-    const doc = document.documentElement;
-    doc.addEventListener("dragover", preventDefault);
-    doc.addEventListener("drop", preventDefault);
-    return () => {
-      doc.removeEventListener("dragover", preventDefault);
-      doc.removeEventListener("drop", preventDefault);
-    };
-  }, []);
-
-const ALAMOS_PROPS: Alamos.ProviderProps = { level: "info" };
-
-const HAUL_PROPS: Haul.ProviderProps = { useState: useHaulState };
-const COLOR_PROPS: Color.ProviderProps = { useState: useColorContextState };
-
 const AppUnderContext = (): ReactElement => {
-  const cluster = Session.Cluster.useSelectState();
-  const themingProps = Session.Theme.useProviderProps();
-  useBlockDefaultDropBehavior();
+  Haul.useBlockDefaultDropBehavior();
   Runtime.useExternalLinkHandler();
 
   return (
-    <Pluto.Provider
-      workerEnabled
-      connParams={cluster ?? undefined}
-      workerURL={WorkerURL}
-      triggers={TRIGGERS_PROVIDER_PROPS}
-      haul={HAUL_PROPS}
-      color={COLOR_PROPS}
-      alamos={ALAMOS_PROPS}
-      theming={themingProps}
-    >
+    <Pluto.Context workerURL={WorkerURL}>
       <Vis.Canvas>
         <Session.Modals.Provider>
           <PlatformLayout.Window />
         </Session.Modals.Provider>
       </Vis.Canvas>
-    </Pluto.Provider>
+    </Pluto.Context>
   );
 };
 

--- a/console/src/app/App.tsx
+++ b/console/src/app/App.tsx
@@ -27,14 +27,14 @@ import { Errors } from "@/platform/errors";
 import { Layout as PlatformLayout } from "@/platform/layout";
 import { Runtime } from "@/platform/runtime";
 import { Session } from "@/session";
-import WorkerURL from "@/worker?worker&url";
+import workerURL from "@/worker?worker&url";
 
 const AppUnderContext = (): ReactElement => {
   Haul.useBlockDefaultDropBehavior();
   Runtime.useExternalLinkHandler();
 
   return (
-    <Pluto.Context workerURL={WorkerURL}>
+    <Pluto.Context workerURL={workerURL}>
       <Vis.Canvas>
         <Session.Modals.Provider>
           <PlatformLayout.Window />

--- a/console/src/app/haul/index.ts
+++ b/console/src/app/haul/index.ts
@@ -1,0 +1,10 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+export * as Haul from "@/app/haul/useBlockDefaultDropBehavior";

--- a/console/src/app/haul/useBlockDefaultDropBehavior.ts
+++ b/console/src/app/haul/useBlockDefaultDropBehavior.ts
@@ -1,0 +1,22 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { preventDefault } from "@synnaxlabs/pluto";
+import { useEffect } from "react";
+
+export const useBlockDefaultDropBehavior = (): void =>
+  useEffect(() => {
+    const doc = document.documentElement;
+    doc.addEventListener("dragover", preventDefault);
+    doc.addEventListener("drop", preventDefault);
+    return () => {
+      doc.removeEventListener("dragover", preventDefault);
+      doc.removeEventListener("drop", preventDefault);
+    };
+  }, []);

--- a/console/src/app/pluto/Context.tsx
+++ b/console/src/app/pluto/Context.tsx
@@ -1,0 +1,39 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { type Alamos, Pluto } from "@synnaxlabs/pluto";
+import { memo } from "react";
+
+import { Triggers } from "@/app/triggers";
+import { Session } from "@/session";
+
+export interface ContextProps extends Pick<
+  Pluto.ProviderProps,
+  "workerURL" | "children"
+> {}
+
+const ALAMOS_PROPS: Alamos.ProviderProps = { level: "info" };
+
+export const Context = memo((props: ContextProps) => {
+  const cluster = Session.Cluster.useSelectState();
+  const themingProps = Session.Theme.useProviderProps();
+  return (
+    <Pluto.Provider
+      workerEnabled
+      connParams={cluster}
+      triggers={Triggers.PROVIDER_PROPS}
+      haul={Session.Haul.PROVIDER_PROPS}
+      color={Session.Color.PROVIDER_PROPS}
+      alamos={ALAMOS_PROPS}
+      theming={themingProps}
+      {...props}
+    />
+  );
+});
+Context.displayName = "Pluto.Context";

--- a/console/src/app/pluto/index.ts
+++ b/console/src/app/pluto/index.ts
@@ -1,0 +1,10 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+export * as Pluto from "@/app/pluto/Context";

--- a/console/src/app/triggers/use.ts
+++ b/console/src/app/triggers/use.ts
@@ -16,6 +16,18 @@ import { Layout } from "@/platform/layout";
 import { Session } from "@/session";
 import { Modals } from "@/session/modals";
 
+const PREVENT_DEFAULT_ON: Triggers.Trigger[] = [
+  ["Control", "P"],
+  ["Control", "Shift", "P"],
+  ["Control", "MouseLeft"],
+  ["Control", "W"],
+];
+
+export const PROVIDER_PROPS: Triggers.ProviderProps = {
+  preventDefaultOn: PREVENT_DEFAULT_ON,
+  preventDefaultOptions: { double: true },
+};
+
 const CLOSE_WINDOW_TIMEOUT = TimeSpan.milliseconds(350);
 
 export const use = (): void => {

--- a/console/src/session/color/external.ts
+++ b/console/src/session/color/external.ts
@@ -1,0 +1,11 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+export * from "@/session/color/selectors";
+export * from "@/session/color/slice";

--- a/console/src/session/color/index.ts
+++ b/console/src/session/color/index.ts
@@ -1,0 +1,10 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+export * as Color from "@/session/color/external";

--- a/console/src/session/color/selectors.spec.tsx
+++ b/console/src/session/color/selectors.spec.tsx
@@ -56,21 +56,6 @@ describe("color selectors", () => {
     });
   });
 
-  describe("useGetContext", () => {
-    it("should read the current context on demand across dispatches", () => {
-      const store = createStore();
-      const { result } = renderHook(() => Color.useGetContext(), {
-        wrapper: createWrapper(store),
-      });
-      const get = result.current;
-      expect(get()).toEqual(PColor.ZERO_CONTEXT_STATE);
-      act(() => {
-        store.dispatch(Color.setContext(withFrequent));
-      });
-      expect(get()).toEqual(withFrequent);
-    });
-  });
-
   describe("PROVIDER_PROPS", () => {
     const renderProviderState = (store: ReturnType<typeof createStore>) =>
       renderHook(() => Color.PROVIDER_PROPS.useState?.(PColor.ZERO_CONTEXT_STATE), {

--- a/console/src/session/color/selectors.spec.tsx
+++ b/console/src/session/color/selectors.spec.tsx
@@ -1,0 +1,97 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { configureStore } from "@reduxjs/toolkit";
+import { Color as PColor } from "@synnaxlabs/pluto";
+import { act, renderHook } from "@testing-library/react";
+import { type FC, type PropsWithChildren, type ReactElement } from "react";
+import { Provider } from "react-redux";
+import { describe, expect, it } from "vitest";
+
+import { Color } from "@/session/color";
+
+const createStore = () =>
+  configureStore({ reducer: { [Color.SLICE_NAME]: Color.reducer } });
+
+const createWrapper = (
+  store: ReturnType<typeof createStore>,
+): FC<PropsWithChildren> => {
+  const Wrapper = ({ children }: PropsWithChildren): ReactElement => (
+    <Provider store={store}>{children}</Provider>
+  );
+  Wrapper.displayName = "Wrapper";
+  return Wrapper;
+};
+
+const withFrequent: PColor.ContextState = {
+  ...PColor.ZERO_CONTEXT_STATE,
+  frequent: { "#FF0000": { lastUsed: 1, count: 2, relevance: 3 } },
+};
+
+describe("color selectors", () => {
+  describe("useSelectContext", () => {
+    it("should return the zero context by default", () => {
+      const store = createStore();
+      const { result } = renderHook(() => Color.useSelectContext(), {
+        wrapper: createWrapper(store),
+      });
+      expect(result.current).toEqual(PColor.ZERO_CONTEXT_STATE);
+    });
+
+    it("should reflect a dispatched context change", () => {
+      const store = createStore();
+      const { result } = renderHook(() => Color.useSelectContext(), {
+        wrapper: createWrapper(store),
+      });
+      act(() => {
+        store.dispatch(Color.setContext(withFrequent));
+      });
+      expect(result.current).toEqual(withFrequent);
+    });
+  });
+
+  describe("useGetContext", () => {
+    it("should read the current context on demand across dispatches", () => {
+      const store = createStore();
+      const { result } = renderHook(() => Color.useGetContext(), {
+        wrapper: createWrapper(store),
+      });
+      const get = result.current;
+      expect(get()).toEqual(PColor.ZERO_CONTEXT_STATE);
+      act(() => {
+        store.dispatch(Color.setContext(withFrequent));
+      });
+      expect(get()).toEqual(withFrequent);
+    });
+  });
+
+  describe("PROVIDER_PROPS", () => {
+    const renderProviderState = (store: ReturnType<typeof createStore>) =>
+      renderHook(() => Color.PROVIDER_PROPS.useState?.(PColor.ZERO_CONTEXT_STATE), {
+        wrapper: createWrapper(store),
+      });
+
+    it("exposes a useState hook reflecting the color context", () => {
+      const store = createStore();
+      const { result } = renderProviderState(store);
+      expect(result.current?.[0]).toEqual(PColor.ZERO_CONTEXT_STATE);
+      act(() => {
+        store.dispatch(Color.setContext(withFrequent));
+      });
+      expect(result.current?.[0]).toEqual(withFrequent);
+    });
+
+    it("dispatches setContext when the setter is called", () => {
+      const store = createStore();
+      const { result } = renderProviderState(store);
+      act(() => result.current?.[1](withFrequent));
+      expect(store.getState()[Color.SLICE_NAME].context).toEqual(withFrequent);
+    });
+  });
+});

--- a/console/src/session/color/selectors.ts
+++ b/console/src/session/color/selectors.ts
@@ -10,7 +10,7 @@
 import { type Dispatch } from "@reduxjs/toolkit";
 import { Color, type state } from "@synnaxlabs/pluto";
 import { useCallback } from "react";
-import { useDispatch, useStore } from "react-redux";
+import { useDispatch } from "react-redux";
 
 import {
   type Action,
@@ -25,11 +25,6 @@ const selectContext = (state: StoreState): Color.ContextState =>
 
 export const useSelectContext = (): Color.ContextState =>
   Select.useMemo(selectContext, []);
-
-export const useGetContext = (): (() => Color.ContextState) => {
-  const store = useStore<StoreState>();
-  return useCallback(() => selectContext(store.getState()), [store]);
-};
 
 const useState: state.PureUse<Color.ContextState> = () => {
   const colorContext = useSelectContext();

--- a/console/src/session/color/selectors.ts
+++ b/console/src/session/color/selectors.ts
@@ -1,0 +1,44 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { type Dispatch } from "@reduxjs/toolkit";
+import { Color, type state } from "@synnaxlabs/pluto";
+import { useCallback } from "react";
+import { useDispatch, useStore } from "react-redux";
+
+import {
+  type Action,
+  setContext,
+  SLICE_NAME,
+  type StoreState,
+} from "@/session/color/slice";
+import { Select } from "@/session/select";
+
+const selectContext = (state: StoreState): Color.ContextState =>
+  Color.contextStateZ.parse(state[SLICE_NAME].context);
+
+export const useSelectContext = (): Color.ContextState =>
+  Select.useMemo(selectContext, []);
+
+export const useGetContext = (): (() => Color.ContextState) => {
+  const store = useStore<StoreState>();
+  return useCallback(() => selectContext(store.getState()), [store]);
+};
+
+const useState: state.PureUse<Color.ContextState> = () => {
+  const colorContext = useSelectContext();
+  const dispatch = useDispatch<Dispatch<Action>>();
+  const onColorContextChange = useCallback(
+    (state: Color.ContextState) => dispatch(setContext(state)),
+    [dispatch],
+  );
+  return [colorContext, onColorContextChange];
+};
+
+export const PROVIDER_PROPS: Color.ProviderProps = { useState };

--- a/console/src/session/color/slice.ts
+++ b/console/src/session/color/slice.ts
@@ -1,0 +1,41 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import { Color } from "@synnaxlabs/pluto";
+
+export const SLICE_NAME = "color";
+
+export interface SliceState {
+  // context is the color picker's shared context: recent colors and frequency
+  // data reused across pickers and windows.
+  context: Color.ContextState;
+}
+
+export interface StoreState {
+  [SLICE_NAME]: SliceState;
+}
+
+export const ZERO_SLICE_STATE: SliceState = { context: Color.ZERO_CONTEXT_STATE };
+
+const { actions, reducer } = createSlice({
+  name: SLICE_NAME,
+  initialState: ZERO_SLICE_STATE,
+  reducers: {
+    setContext: (state, { payload }: PayloadAction<Color.ContextState>) => {
+      state.context = payload;
+    },
+  },
+});
+
+export const { setContext } = actions;
+export { reducer };
+
+export type Action = ReturnType<(typeof actions)[keyof typeof actions]>;
+export type Payload = Action["payload"];

--- a/console/src/session/color/slice.ts
+++ b/console/src/session/color/slice.ts
@@ -13,8 +13,10 @@ import { Color } from "@synnaxlabs/pluto";
 export const SLICE_NAME = "color";
 
 export interface SliceState {
-  // context is the color picker's shared context: recent colors and frequency
-  // data reused across pickers and windows.
+  /**
+   * The color picker's shared context: recent colors and frequency data reused
+   * across pickers and windows.
+   */
   context: Color.ContextState;
 }
 

--- a/console/src/session/external.ts
+++ b/console/src/session/external.ts
@@ -9,7 +9,9 @@
 
 export * from "@/session/arc";
 export * from "@/session/cluster";
+export * from "@/session/color";
 export * from "@/session/docs";
+export * from "@/session/haul";
 export * from "@/session/layout";
 export * from "@/session/lineplot";
 export * from "@/session/log";

--- a/console/src/session/haul/external.ts
+++ b/console/src/session/haul/external.ts
@@ -1,0 +1,11 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+export * from "@/session/haul/selectors";
+export * from "@/session/haul/slice";

--- a/console/src/session/haul/index.ts
+++ b/console/src/session/haul/index.ts
@@ -1,0 +1,10 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+export * as Haul from "@/session/haul/external";

--- a/console/src/session/haul/selectors.spec.tsx
+++ b/console/src/session/haul/selectors.spec.tsx
@@ -1,0 +1,97 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { configureStore } from "@reduxjs/toolkit";
+import { type Haul as PHaul } from "@synnaxlabs/pluto";
+import { act, renderHook } from "@testing-library/react";
+import { type FC, type PropsWithChildren, type ReactElement } from "react";
+import { Provider } from "react-redux";
+import { describe, expect, it } from "vitest";
+
+import { Haul } from "@/session/haul";
+
+const createStore = () =>
+  configureStore({ reducer: { [Haul.SLICE_NAME]: Haul.reducer } });
+
+const createWrapper = (
+  store: ReturnType<typeof createStore>,
+): FC<PropsWithChildren> => {
+  const Wrapper = ({ children }: PropsWithChildren): ReactElement => (
+    <Provider store={store}>{children}</Provider>
+  );
+  Wrapper.displayName = "Wrapper";
+  return Wrapper;
+};
+
+const dragging: PHaul.DraggingState = {
+  source: { key: "src", type: "channel" },
+  items: [{ key: "a", type: "channel" }],
+};
+
+describe("haul selectors", () => {
+  describe("useSelectHauling", () => {
+    it("should return the zero dragging state by default", () => {
+      const store = createStore();
+      const { result } = renderHook(() => Haul.useSelectHauling(), {
+        wrapper: createWrapper(store),
+      });
+      expect(result.current).toEqual(Haul.ZERO_SLICE_STATE.state);
+    });
+
+    it("should reflect a dispatched haul", () => {
+      const store = createStore();
+      const { result } = renderHook(() => Haul.useSelectHauling(), {
+        wrapper: createWrapper(store),
+      });
+      act(() => {
+        store.dispatch(Haul.setHauled(dragging));
+      });
+      expect(result.current).toEqual(dragging);
+    });
+  });
+
+  describe("useGetHauling", () => {
+    it("should read the current dragging state on demand across dispatches", () => {
+      const store = createStore();
+      const { result } = renderHook(() => Haul.useGetHauling(), {
+        wrapper: createWrapper(store),
+      });
+      const get = result.current;
+      expect(get()).toEqual(Haul.ZERO_SLICE_STATE.state);
+      act(() => {
+        store.dispatch(Haul.setHauled(dragging));
+      });
+      expect(get()).toEqual(dragging);
+    });
+  });
+
+  describe("PROVIDER_PROPS", () => {
+    const renderProviderState = (store: ReturnType<typeof createStore>) =>
+      renderHook(() => Haul.PROVIDER_PROPS.useState?.(Haul.ZERO_SLICE_STATE.state), {
+        wrapper: createWrapper(store),
+      });
+
+    it("exposes a useState hook reflecting the dragging state", () => {
+      const store = createStore();
+      const { result } = renderProviderState(store);
+      expect(result.current?.[0]).toEqual(Haul.ZERO_SLICE_STATE.state);
+      act(() => {
+        store.dispatch(Haul.setHauled(dragging));
+      });
+      expect(result.current?.[0]).toEqual(dragging);
+    });
+
+    it("dispatches setHauled when the setter is called", () => {
+      const store = createStore();
+      const { result } = renderProviderState(store);
+      act(() => result.current?.[1](dragging));
+      expect(store.getState()[Haul.SLICE_NAME].state).toEqual(dragging);
+    });
+  });
+});

--- a/console/src/session/haul/selectors.spec.tsx
+++ b/console/src/session/haul/selectors.spec.tsx
@@ -56,21 +56,6 @@ describe("haul selectors", () => {
     });
   });
 
-  describe("useGetHauling", () => {
-    it("should read the current dragging state on demand across dispatches", () => {
-      const store = createStore();
-      const { result } = renderHook(() => Haul.useGetHauling(), {
-        wrapper: createWrapper(store),
-      });
-      const get = result.current;
-      expect(get()).toEqual(Haul.ZERO_SLICE_STATE.state);
-      act(() => {
-        store.dispatch(Haul.setHauled(dragging));
-      });
-      expect(get()).toEqual(dragging);
-    });
-  });
-
   describe("PROVIDER_PROPS", () => {
     const renderProviderState = (store: ReturnType<typeof createStore>) =>
       renderHook(() => Haul.PROVIDER_PROPS.useState?.(Haul.ZERO_SLICE_STATE.state), {

--- a/console/src/session/haul/selectors.ts
+++ b/console/src/session/haul/selectors.ts
@@ -10,7 +10,7 @@
 import { type Dispatch } from "@reduxjs/toolkit";
 import { type Haul, type state } from "@synnaxlabs/pluto";
 import { useCallback } from "react";
-import { useDispatch, useStore } from "react-redux";
+import { useDispatch } from "react-redux";
 
 import {
   type Action,
@@ -25,11 +25,6 @@ const selectHauling = (state: StoreState): Haul.DraggingState =>
 
 export const useSelectHauling = (): Haul.DraggingState =>
   Select.useMemo(selectHauling, []);
-
-export const useGetHauling = (): (() => Haul.DraggingState) => {
-  const store = useStore<StoreState>();
-  return useCallback(() => selectHauling(store.getState()), [store]);
-};
 
 const useState: state.PureUse<Haul.DraggingState> = () => {
   const hauled = useSelectHauling();

--- a/console/src/session/haul/selectors.ts
+++ b/console/src/session/haul/selectors.ts
@@ -1,0 +1,44 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { type Dispatch } from "@reduxjs/toolkit";
+import { type Haul, type state } from "@synnaxlabs/pluto";
+import { useCallback } from "react";
+import { useDispatch, useStore } from "react-redux";
+
+import {
+  type Action,
+  setHauled,
+  SLICE_NAME,
+  type StoreState,
+} from "@/session/haul/slice";
+import { Select } from "@/session/select";
+
+const selectHauling = (state: StoreState): Haul.DraggingState =>
+  state[SLICE_NAME].state;
+
+export const useSelectHauling = (): Haul.DraggingState =>
+  Select.useMemo(selectHauling, []);
+
+export const useGetHauling = (): (() => Haul.DraggingState) => {
+  const store = useStore<StoreState>();
+  return useCallback(() => selectHauling(store.getState()), [store]);
+};
+
+const useState: state.PureUse<Haul.DraggingState> = () => {
+  const hauled = useSelectHauling();
+  const dispatch = useDispatch<Dispatch<Action>>();
+  const onHauledChange = useCallback(
+    (state: Haul.DraggingState) => dispatch(setHauled(state)),
+    [dispatch],
+  );
+  return [hauled, onHauledChange];
+};
+
+export const PROVIDER_PROPS: Haul.ProviderProps = { useState };

--- a/console/src/session/haul/slice.ts
+++ b/console/src/session/haul/slice.ts
@@ -1,0 +1,47 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { createSlice, type PayloadAction } from "@reduxjs/toolkit";
+import { Haul } from "@synnaxlabs/pluto";
+
+export const SLICE_NAME = "haul";
+
+export interface SliceState {
+  // state is the drag-and-drop payload currently being hauled, mirrored into
+  // redux so drags synchronize across windows.
+  state: Haul.DraggingState;
+}
+
+export interface StoreState {
+  [SLICE_NAME]: SliceState;
+}
+
+export const ZERO_SLICE_STATE: SliceState = { state: Haul.ZERO_DRAGGING_STATE };
+
+const { actions, reducer } = createSlice({
+  name: SLICE_NAME,
+  initialState: ZERO_SLICE_STATE,
+  reducers: {
+    setHauled: (state, { payload }: PayloadAction<Haul.DraggingState>) => {
+      state.state = payload;
+    },
+  },
+});
+
+export const { setHauled } = actions;
+export { reducer };
+
+export type Action = ReturnType<(typeof actions)[keyof typeof actions]>;
+export type Payload = Action["payload"];
+
+// Drag state is transient; a persisted drag would resume a phantom haul on relaunch.
+export const PERSIST_EXCLUDE = <S extends StoreState>(state: S): S => ({
+  ...state,
+  [SLICE_NAME]: ZERO_SLICE_STATE,
+});

--- a/console/src/session/haul/slice.ts
+++ b/console/src/session/haul/slice.ts
@@ -13,8 +13,10 @@ import { Haul } from "@synnaxlabs/pluto";
 export const SLICE_NAME = "haul";
 
 export interface SliceState {
-  // state is the drag-and-drop payload currently being hauled, mirrored into
-  // redux so drags synchronize across windows.
+  /**
+   * The drag-and-drop payload currently being hauled, mirrored into redux so drags
+   * synchronize across windows.
+   */
   state: Haul.DraggingState;
 }
 
@@ -40,7 +42,7 @@ export { reducer };
 export type Action = ReturnType<(typeof actions)[keyof typeof actions]>;
 export type Payload = Action["payload"];
 
-// Drag state is transient; a persisted drag would resume a phantom haul on relaunch.
+/** Drag state is transient; a persisted drag would resume a phantom haul on relaunch. */
 export const PERSIST_EXCLUDE = <S extends StoreState>(state: S): S => ({
   ...state,
   [SLICE_NAME]: ZERO_SLICE_STATE,

--- a/console/src/session/layout/selectors.ts
+++ b/console/src/session/layout/selectors.ts
@@ -8,7 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { type Drift, selectWindow, selectWindowKey } from "@synnaxlabs/drift";
-import { Color, type Haul, type Mosaic } from "@synnaxlabs/pluto";
+import { type Mosaic } from "@synnaxlabs/pluto";
 import { useMemo, useSyncExternalStore } from "react";
 
 import {
@@ -199,17 +199,3 @@ export const selectActiveMosaicLayout = (
 
 export const useSelectActiveMosaicLayout = (): State | undefined =>
   Select.useMemo(selectActiveMosaicLayout, []);
-
-export const selectHauling = (state: StoreState): Haul.DraggingState =>
-  selectSliceState(state).hauling;
-
-export const useSelectHauling = (): Haul.DraggingState =>
-  Select.useMemo(selectHauling, []);
-
-export const selectColorContext = (state: StoreState): Color.ContextState => {
-  const rawContext = selectSliceState(state).colorContext;
-  return Color.contextStateZ.parse(rawContext);
-};
-
-export const useSelectColorContext = (): Color.ContextState =>
-  Select.useMemo(selectColorContext, []);

--- a/console/src/session/layout/slice.spec.ts
+++ b/console/src/session/layout/slice.spec.ts
@@ -9,7 +9,7 @@
 
 import { combineReducers, configureStore } from "@reduxjs/toolkit";
 import { Drift, MAIN_WINDOW } from "@synnaxlabs/drift";
-import { Color, type Haul, Mosaic } from "@synnaxlabs/pluto";
+import { Mosaic } from "@synnaxlabs/pluto";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { Layout } from "@/session/layout";
@@ -225,28 +225,6 @@ describe("Layout Slice", () => {
         (t) => t.tabKey === "plot-1",
       );
       expect(tab?.unsavedChanges).toBe(true);
-    });
-  });
-
-  describe("setHauled", () => {
-    it("should overwrite the hauling state", () => {
-      const haul: Haul.DraggingState = {
-        source: { key: "src", type: "drag" },
-        items: [{ key: "item-1", type: "drag" }],
-      };
-      store.dispatch(Layout.setHauled(haul));
-      expect(Layout.selectHauling(state())).toEqual(haul);
-    });
-  });
-
-  describe("setColorContext", () => {
-    it("should overwrite the color context", () => {
-      const ctx: Color.ContextState = {
-        ...Color.ZERO_CONTEXT_STATE,
-        frequent: { "#ff0000": { lastUsed: 1, count: 1, relevance: 1 } },
-      };
-      store.dispatch(Layout.setColorContext({ state: ctx }));
-      expect(Layout.selectColorContext(state())).toEqual(ctx);
     });
   });
 

--- a/console/src/session/layout/slice.ts
+++ b/console/src/session/layout/slice.ts
@@ -9,7 +9,7 @@
 
 import { createSlice, current, type PayloadAction } from "@reduxjs/toolkit";
 import { Drift, MAIN_WINDOW } from "@synnaxlabs/drift";
-import { Color, Haul, Mosaic, Tabs } from "@synnaxlabs/pluto";
+import { Mosaic, Tabs } from "@synnaxlabs/pluto";
 import { deep, type direction, id, location } from "@synnaxlabs/x";
 import { z } from "zod";
 
@@ -172,13 +172,11 @@ export const MAIN_LAYOUT: State = {
 export const sliceStateZ = z.object({
   version: z.literal(0).default(0),
   layouts: z.record(z.string(), stateZ).default({ [MAIN_LAYOUT_KEY]: MAIN_LAYOUT }),
-  hauling: Haul.draggingStateZ.default(Haul.ZERO_DRAGGING_STATE),
   mosaics: z
     .record(z.string(), mosaicStateZ)
     .default({ [MAIN_LAYOUT_KEY]: ZERO_MOSAIC_STATE }),
   altKeyToKey: z.record(z.string(), z.string()).default({}),
   keyToAltKey: z.record(z.string(), z.string()).default({}),
-  colorContext: Color.contextStateZ.default(Color.ZERO_CONTEXT_STATE),
 });
 export interface SliceState extends z.infer<typeof sliceStateZ> {}
 
@@ -198,10 +196,6 @@ export const SLICE_NAME = "layout";
 export interface StoreState {
   [SLICE_NAME]: SliceState;
 }
-
-export const PERSIST_EXCLUDE = ["hauling"].map(
-  (key) => `${SLICE_NAME}.${key}`,
-) as Array<deep.Key<StoreState>>;
 
 /** Signature for the placeLayout action. */
 export type PlacePayload = State;
@@ -255,8 +249,6 @@ interface SetUnsavedChangesPayload {
   unsavedChanges: boolean;
 }
 
-interface SetHaulingPayload extends Haul.DraggingState {}
-
 export interface SetProjectPayload {
   slice: SliceState;
 }
@@ -264,10 +256,6 @@ export interface SetProjectPayload {
 interface SetArgsPayload<T = unknown> {
   key: string;
   args: T;
-}
-
-export interface SetColorContextPayload {
-  state: Color.ContextState;
 }
 
 const purgeEmptyMosaics = (state: SliceState) => {
@@ -386,9 +374,6 @@ export const { actions, reducer } = createSlice({
       state.layouts[key] = layout;
       if (layout.type !== MOSAIC_WINDOW_TYPE) purgeEmptyMosaics(state);
     },
-    setHauled: (state, { payload }: PayloadAction<SetHaulingPayload>) => {
-      state.hauling = payload;
-    },
     remove: (state, { payload: { keys } }: PayloadAction<RemovePayload>) => {
       keys.forEach((contentKey) => {
         const layout = select(state, contentKey);
@@ -502,7 +487,6 @@ export const { actions, reducer } = createSlice({
           ...slice.layouts,
           main: MAIN_LAYOUT,
         },
-        hauling: s.hauling,
       });
       reconcileMosaicLayouts(next);
       return next;
@@ -513,7 +497,6 @@ export const { actions, reducer } = createSlice({
         ...layoutsToPreserve(state.layouts),
         main: MAIN_LAYOUT,
       },
-      hauling: state.hauling,
     }),
     setArgs: (state, { payload: { key, args } }: PayloadAction<SetArgsPayload>) => {
       const layout = select(state, key);
@@ -533,9 +516,6 @@ export const { actions, reducer } = createSlice({
       if (layout == null) return;
       const mosaic = state.mosaics[layout.windowKey];
       mosaic.focused = key;
-    },
-    setColorContext: (state, { payload }: PayloadAction<SetColorContextPayload>) => {
-      state.colorContext = payload.state;
     },
     setUnsavedChanges: (
       state,
@@ -566,9 +546,7 @@ export const {
   setAltKey,
   splitMosaicNode,
   rename,
-  setHauled,
   setProject,
-  setColorContext,
   clearProject,
   setUnsavedChanges,
 } = actions;

--- a/console/src/session/store.ts
+++ b/console/src/session/store.ts
@@ -21,7 +21,9 @@ import { useDispatch as baseUseDispatch, useStore as baseUseStore } from "react-
 
 import { Arc } from "@/session/arc";
 import { Cluster } from "@/session/cluster";
+import { Color } from "@/session/color";
 import { Docs } from "@/session/docs";
+import { Haul } from "@/session/haul";
 import { Layout } from "@/session/layout";
 import { LinePlot } from "@/session/lineplot";
 import { Log } from "@/session/log";
@@ -36,7 +38,7 @@ import { Table } from "@/session/table";
 import { Theme } from "@/session/theme";
 
 const PERSIST_EXCLUDE: Array<deep.Key<State> | ((func: State) => State)> = [
-  ...Layout.PERSIST_EXCLUDE,
+  Haul.PERSIST_EXCLUDE,
   ...Arc.PERSIST_EXCLUDE,
   ...LinePlot.PERSIST_EXCLUDE,
   ...Log.PERSIST_EXCLUDE,
@@ -47,8 +49,10 @@ const PERSIST_EXCLUDE: Array<deep.Key<State> | ((func: State) => State)> = [
 export const ZERO_STATE: State = {
   [Arc.SLICE_NAME]: Arc.ZERO_SLICE_STATE,
   [Cluster.SLICE_NAME]: Cluster.ZERO_SLICE_STATE,
+  [Color.SLICE_NAME]: Color.ZERO_SLICE_STATE,
   [Docs.SLICE_NAME]: Docs.ZERO_SLICE_STATE,
   [Drift.SLICE_NAME]: Drift.ZERO_SLICE_STATE,
+  [Haul.SLICE_NAME]: Haul.ZERO_SLICE_STATE,
   [Layout.SLICE_NAME]: Layout.ZERO_SLICE_STATE,
   [Nav.SLICE_NAME]: Nav.ZERO_SLICE_STATE,
   [Log.SLICE_NAME]: Log.ZERO_SLICE_STATE,
@@ -64,8 +68,10 @@ export const ZERO_STATE: State = {
 export const reducer = combineReducers({
   [Arc.SLICE_NAME]: Arc.reducer,
   [Cluster.SLICE_NAME]: Cluster.reducer,
+  [Color.SLICE_NAME]: Color.reducer,
   [Docs.SLICE_NAME]: Docs.reducer,
   [Drift.SLICE_NAME]: Drift.reducer,
+  [Haul.SLICE_NAME]: Haul.reducer,
   [Layout.SLICE_NAME]: Layout.reducer,
   [Nav.SLICE_NAME]: Nav.reducer,
   [Log.SLICE_NAME]: Log.reducer,
@@ -81,8 +87,10 @@ export const reducer = combineReducers({
 export interface State {
   [Arc.SLICE_NAME]: Arc.SliceState;
   [Cluster.SLICE_NAME]: Cluster.SliceState;
+  [Color.SLICE_NAME]: Color.SliceState;
   [Docs.SLICE_NAME]: Docs.SliceState;
   [Drift.SLICE_NAME]: Drift.SliceState;
+  [Haul.SLICE_NAME]: Haul.SliceState;
   [Layout.SLICE_NAME]: Layout.SliceState;
   [Log.SLICE_NAME]: Log.SliceState;
   [LinePlot.SLICE_NAME]: LinePlot.SliceState;
@@ -98,8 +106,10 @@ export interface State {
 export type Action =
   | Arc.Action
   | Cluster.Action
+  | Color.Action
   | Docs.Action
   | Drift.Action
+  | Haul.Action
   | Layout.Action
   | Log.Action
   | LinePlot.Action


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4370](https://linear.app/synnax/issue/SY-4370)

## Description

Extracts drag-and-drop (haul) and color-picker context state out of the monolithic layout slice into dedicated `session/haul` and `session/color` slices, and extracts the Pluto provider wiring out of `App.tsx` into `app/pluto` and `app/haul` modules.

- `session/haul` mirrors the active drag payload into redux so drags synchronize across windows; the whole slice is excluded from persistence so a relaunch never resumes a phantom haul.
- `session/color` holds the color picker's recent/frequent color context.
- The layout slice sheds `hauling`, `colorContext`, their reducers, and their selectors. Since zod strips unknown keys when parsing against the current slice schema, no new migration is needed (same approach as the nav-drawer extraction in v11). The `hauling: s.hauling` preservation lines in `setProject`/`clearProject` disappear entirely: drag state no longer needs protecting from project resets because it no longer lives in the slice being reset.
- `app/pluto/Context.tsx` wraps `Pluto.Provider` with the session-backed provider props, `app/haul` owns the default-drop-behavior blocker, and the triggers provider props move from `App.tsx` into `app/triggers`, leaving `App.tsx` as pure composition.

One behavioral note: persisted recent-color history resets once on upgrade, since the new color slice starts from zero state (consistent with the nav extraction precedent).

This mirrors work already staged on the SY-4370 panel branch chain; landing it on rc directly shrinks the downstream PRs to their actual subject matter.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR extracts haul (drag-and-drop) and color-picker context state from the monolithic layout slice into dedicated `session/haul` and `session/color` Redux slices, and moves Pluto provider wiring out of `App.tsx` into focused `app/pluto`, `app/haul`, and `app/triggers` modules.

- **`session/haul`** mirrors the active drag payload into Redux with a function-based `PERSIST_EXCLUDE` that zeroes the entire slice before serialization, preventing phantom drags on relaunch.
- **`session/color`** holds the color picker's recent/frequent color context and is intentionally persisted; the slice starts from zero state on first upgrade (consistent with the nav-drawer extraction precedent).
- The layout slice drops `hauling`, `colorContext`, their reducers, and selectors — zod schema stripping handles backward compatibility without a migration. Additionally, `Schematic.PERSIST_EXCLUDE` and `Table.PERSIST_EXCLUDE` are now included in the store's exclusion list, fixing a pre-existing omission.

<h3>Confidence Score: 5/5</h3>

Safe to merge — this is a well-scoped slice extraction with no behavioral regressions on the critical paths.

The refactoring correctly moves haul and color state out of the layout slice into isolated slices. The persistence mechanism change (function vs path strings) is valid per the store's type definition. The removed ?? undefined on connParams is benign because useSelectState returns Cluster | undefined, not null. The incidental additions of Schematic.PERSIST_EXCLUDE and Table.PERSIST_EXCLUDE fix a real pre-existing omission.

No files require special attention. All changed files are consistent and the test coverage for the new selectors is thorough.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| console/src/app/pluto/Context.tsx | New component wrapping Pluto.Provider with session-backed props; connParams passes cluster directly (safe since useSelectState returns Cluster | undefined, not null). |
| console/src/session/haul/slice.ts | New dedicated haul slice; PERSIST_EXCLUDE is a function that zeroes the entire slice before serialization — valid given the store's array type allows both forms. |
| console/src/session/color/slice.ts | New color context slice; intentionally has no PERSIST_EXCLUDE so recent-color history is persisted, resets once on upgrade as documented. |
| console/src/session/color/selectors.ts | selectContext runs Color.contextStateZ.parse on every invocation — intentional for backward-compat schema validation of persisted state. |
| console/src/session/store.ts | Adds Color and Haul to reducer, ZERO_STATE, State, and Action; also adds Schematic.PERSIST_EXCLUDE and Table.PERSIST_EXCLUDE that were previously missing. |
| console/src/session/layout/slice.ts | Drops hauling, colorContext fields and their reducers/selectors cleanly; zod schema stripping handles persisted state without a migration. |
| console/src/session/haul/selectors.spec.tsx | Good coverage of useSelectHauling, useGetHauling, and PROVIDER_PROPS.useState including state-dispatch round-trip tests. |
| console/src/session/color/selectors.spec.tsx | Mirrors haul test structure; good coverage of useSelectContext, useGetContext, and PROVIDER_PROPS integration. |
| console/src/app/App.tsx | Reduced to pure composition; provider wiring, hook definitions, and trigger constants cleanly delegated to dedicated modules. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph app["App Layer"]
        AppTsx["App.tsx\n(pure composition)"]
        PlutoCtx["app/pluto/Context.tsx\nPluto.Provider wrapper"]
        HaulApp["app/haul\nuseBlockDefaultDropBehavior"]
        TriggersApp["app/triggers\nPROVIDER_PROPS"]
    end
    subgraph session["Session Layer"]
        HaulSlice["session/haul/slice\nsetHauled, PERSIST_EXCLUDE fn"]
        HaulSel["session/haul/selectors\nuseSelectHauling, PROVIDER_PROPS"]
        ColorSlice["session/color/slice\nsetContext"]
        ColorSel["session/color/selectors\nuseSelectContext, PROVIDER_PROPS"]
        LayoutSlice["session/layout/slice\n(hauling + colorContext removed)"]
        Store["session/store\ncombined reducer + State"]
    end
    subgraph persist["Persistence"]
        PersistExclude["PERSIST_EXCLUDE"]
    end
    AppTsx --> PlutoCtx
    AppTsx --> HaulApp
    PlutoCtx --> HaulSel
    PlutoCtx --> ColorSel
    PlutoCtx --> TriggersApp
    HaulSel --> HaulSlice
    ColorSel --> ColorSlice
    HaulSlice --> Store
    ColorSlice --> Store
    LayoutSlice --> Store
    Store --> PersistExclude
    HaulSlice -. "zeros entire haul slice" .-> PersistExclude
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    subgraph app["App Layer"]
        AppTsx["App.tsx\n(pure composition)"]
        PlutoCtx["app/pluto/Context.tsx\nPluto.Provider wrapper"]
        HaulApp["app/haul\nuseBlockDefaultDropBehavior"]
        TriggersApp["app/triggers\nPROVIDER_PROPS"]
    end
    subgraph session["Session Layer"]
        HaulSlice["session/haul/slice\nsetHauled, PERSIST_EXCLUDE fn"]
        HaulSel["session/haul/selectors\nuseSelectHauling, PROVIDER_PROPS"]
        ColorSlice["session/color/slice\nsetContext"]
        ColorSel["session/color/selectors\nuseSelectContext, PROVIDER_PROPS"]
        LayoutSlice["session/layout/slice\n(hauling + colorContext removed)"]
        Store["session/store\ncombined reducer + State"]
    end
    subgraph persist["Persistence"]
        PersistExclude["PERSIST_EXCLUDE"]
    end
    AppTsx --> PlutoCtx
    AppTsx --> HaulApp
    PlutoCtx --> HaulSel
    PlutoCtx --> ColorSel
    PlutoCtx --> TriggersApp
    HaulSel --> HaulSlice
    ColorSel --> ColorSlice
    HaulSlice --> Store
    ColorSlice --> Store
    LayoutSlice --> Store
    Store --> PersistExclude
    HaulSlice -. "zeros entire haul slice" .-> PersistExclude
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Extract haul and color session slices an..."](https://github.com/synnaxlabs/synnax/commit/7166993f755afc721810a1db8b13d25656624c86) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=43717746)</sub>

<!-- /greptile_comment -->