### PR TITLE
[docs]: Highlight Arc primitive conversion functions

### DIFF
--- a/arc/ts/src/grammar/arc.tmLanguage.json
+++ b/arc/ts/src/grammar/arc.tmLanguage.json
@@ -168,6 +168,10 @@
     "types": {
       "patterns": [
         {
+          "name": "support.function.builtin.arc",
+          "match": "\\b(i8|i16|i32|i64|u8|u16|u32|u64|f32|f64|str)\\b(?=\\s*\\()"
+        },
+        {
           "name": "support.type.primitive.arc",
           "match": "\\b(i8|i16|i32|i64|u8|u16|u32|u64|f32|f64|str)\\b"
         },


### PR DESCRIPTION
Adds a grammar rule so primitive conversion functions (`str()`, `i32()`, `f32()`, `f64()`, etc.) render in the function accent color instead of the default color, matching how they already look for other builtins like `len()`. Only kicks in when a primitive name is called as a function, so type annotations like `x f64` are unchanged. Coloring only, no compiler or runtime impact.

Note that in the live editor this is overridden by the semantic tokens from core, so it mainly affects static highlighting like the docs.

[Example in docs](<https://docs-dgdtvuikr-synnax.vercel.app/reference/control/arc/reference/types#type-casting>)

<img src="https://github.com/user-attachments/assets/a3ec3074-ebf3-4288-8520-92f3bcb8355d " alt="image" width="720" data-linear-height="212" />

<img src="https://github.com/user-attachments/assets/473d3519-c301-48fd-a03d-43debe00ffec " alt="image" width="720" data-linear-height="216" />

### Greptile Summary

This PR adds a single TextMate grammar rule to `arc.tmLanguage.json` so that primitive type names (`i8`, `i16`, … `f64`, `str`) are highlighted in the function accent color when used as conversion functions (i.e., followed by `(`), matching how existing builtins like `len` and `now` are already colored.

* Adds a `support.function.builtin.arc` pattern inside the `types` repository, placed before the existing `support.type.primitive.arc` fallback, using a lookahead `(?=\s*\()` so type annotations like `x f64` are unaffected.
* Scoping-only change with no compiler or runtime impact; the new rule is overridden by semantic tokens in the live editor and only affects static highlighting (e.g., docs).

### Confidence Score: 5/5

This is a safe, self-contained syntax highlighting change with no logic, compiler, or runtime impact.

The change adds one correctly ordered TextMate grammar rule. The lookahead `(?=\s*\()` is well-formed, the rule is placed before the fallback primitive-type rule, and the `#types` repository is already included ahead of `#functions` in the top-level pattern list, so precedence is correct in all contexts. No behavioral changes outside of static syntax coloring.

No files require special attention.

### Important Files Changed

<!-- linear:table-colwidths:400,400 -->
| Filename | Overview |
| -- | -- |
| arc/ts/src/grammar/arc.tmLanguage.json | Adds a new TextMate grammar rule that matches primitive type names (i8–u64, f32, f64, str) followed by `(` and scopes them as `support.function.builtin.arc` instead of `support.type.primitive.arc`; rule is correctly ordered before the fallback type pattern and the top-level `#types` repository is already included before `#functions`, so precedence is correct. |

### Flowchart

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["Token: primitive name (e.g. i32, f64, str)"] --> B{"Followed by '(' ?"}
    B -- Yes --> C["New rule matched\nsupport.function.builtin.arc\n(function accent color)"]
    B -- No --> D["Existing rule matched\nsupport.type.primitive.arc\n(type color — unchanged)"]
    C --> E["Displayed in docs / static highlighting\nas a builtin function"]
    D --> F["Displayed as a type annotation\n(e.g. 'x f64' unchanged)"]
    G["Live editor"] -- "Semantic tokens from core override grammar" --> E
```

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["Token: primitive name (e.g. i32, f64, str)"] --> B{"Followed by '(' ?"}
    B -- Yes --> C["New rule matched\nsupport.function.builtin.arc\n(function accent color)"]
    B -- No --> D["Existing rule matched\nsupport.type.primitive.arc\n(type color — unchanged)"]
    C --> E["Displayed in docs / static highlighting\nas a builtin function"]
    D --> F["Displayed as a type annotation\n(e.g. 'x f64' unchanged)"]
    G["Live editor"] -- "Semantic tokens from core override grammar" --> E
```

Reviews (1): Last reviewed commit: ["Add accent color primitive conversion fu..."](<https://github.com/synnaxlabs/synnax/commit/21b1d850104c75d0fecb6e3d99bcffed92c237f3>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=44227162>)