### PR TITLE
SY-4383: Stop Oracle-Generated Code From Importing the Distribution Layer

### DIFF
--- a/core/pkg/api/channel/pb/translator.gen.go
+++ b/core/pkg/api/channel/pb/translator.gen.go
@@ -13,9 +13,9 @@ package pb
 
 import (
 	"github.com/synnaxlabs/synnax/pkg/api/channel"
-	"github.com/synnaxlabs/synnax/pkg/distribution/node"
 	servicechannel "github.com/synnaxlabs/synnax/pkg/service/channel"
 	channelpb "github.com/synnaxlabs/synnax/pkg/service/channel/pb"
+	"github.com/synnaxlabs/synnax/pkg/service/node"
 	"github.com/synnaxlabs/synnax/pkg/service/status"
 	statuspb "github.com/synnaxlabs/synnax/pkg/service/status/pb"
 	controlpb "github.com/synnaxlabs/x/control/pb"

--- a/core/pkg/api/channel/types.gen.go
+++ b/core/pkg/api/channel/types.gen.go
@@ -12,8 +12,8 @@
 package channel
 
 import (
-	"github.com/synnaxlabs/synnax/pkg/distribution/node"
 	servicechannel "github.com/synnaxlabs/synnax/pkg/service/channel"
+	"github.com/synnaxlabs/synnax/pkg/service/node"
 	"github.com/synnaxlabs/synnax/pkg/service/status"
 	"github.com/synnaxlabs/x/control"
 	"github.com/synnaxlabs/x/telem"

--- a/core/pkg/service/channel/codec.gen.go
+++ b/core/pkg/service/channel/codec.gen.go
@@ -12,7 +12,7 @@
 package channel
 
 import (
-	"github.com/synnaxlabs/synnax/pkg/distribution/node"
+	"github.com/synnaxlabs/synnax/pkg/service/node"
 	"github.com/synnaxlabs/x/control"
 	"github.com/synnaxlabs/x/encoding/orc"
 	"github.com/synnaxlabs/x/telem"

--- a/core/pkg/service/channel/codec_gen_test.go
+++ b/core/pkg/service/channel/codec_gen_test.go
@@ -19,8 +19,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/synnaxlabs/x/encoding/orc"
 
-	"github.com/synnaxlabs/synnax/pkg/distribution/node"
 	"github.com/synnaxlabs/synnax/pkg/service/channel"
+	"github.com/synnaxlabs/synnax/pkg/service/node"
 	"github.com/synnaxlabs/x/control"
 	"github.com/synnaxlabs/x/telem"
 )

--- a/core/pkg/service/channel/pb/translator.gen.go
+++ b/core/pkg/service/channel/pb/translator.gen.go
@@ -12,8 +12,8 @@
 package pb
 
 import (
-	"github.com/synnaxlabs/synnax/pkg/distribution/node"
 	"github.com/synnaxlabs/synnax/pkg/service/channel"
+	"github.com/synnaxlabs/synnax/pkg/service/node"
 	controlpb "github.com/synnaxlabs/x/control/pb"
 	"github.com/synnaxlabs/x/errors"
 	"github.com/synnaxlabs/x/telem"

--- a/core/pkg/service/channel/retrieve.gen.go
+++ b/core/pkg/service/channel/retrieve.gen.go
@@ -14,7 +14,7 @@ package channel
 import (
 	"context"
 	"github.com/samber/lo"
-	"github.com/synnaxlabs/synnax/pkg/distribution/node"
+	"github.com/synnaxlabs/synnax/pkg/service/node"
 	"github.com/synnaxlabs/synnax/pkg/service/ontology"
 	"github.com/synnaxlabs/synnax/pkg/service/search"
 	"github.com/synnaxlabs/x/gorp"

--- a/core/pkg/service/channel/types.gen.go
+++ b/core/pkg/service/channel/types.gen.go
@@ -12,7 +12,7 @@
 package channel
 
 import (
-	"github.com/synnaxlabs/synnax/pkg/distribution/node"
+	"github.com/synnaxlabs/synnax/pkg/service/node"
 	"github.com/synnaxlabs/x/control"
 	"github.com/synnaxlabs/x/telem"
 	"github.com/synnaxlabs/x/validate"

--- a/schemas/synnax/cluster.oracle
+++ b/schemas/synnax/cluster.oracle
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-@go output  "core/pkg/distribution/node"
+@go output  "core/pkg/service/node"
 @py output  "client/py/synnax/cluster"
 @ts output  "client/ts/src/cluster"
 @cpp output "client/cpp/cluster"


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4383](https://linear.app/synnax/issue/SY-4383/make-sure-minimal-things-in-service-layer-import-from-distribution)

## Description

Oracle's `@go output` for the node schema (`schemas/synnax/cluster.oracle`) pointed at `core/pkg/distribution/node`, so generated channel code in the service and api layers imported the distribution layer directly. This repoints the output at `core/pkg/service/node` and regenerates, so the service layer's generated bindings (channel types, codec, retrieve, protobuf translators) now import node from the service layer instead of reaching below it.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes an architectural layering violation where Oracle-generated code in the service and API layers was importing directly from `pkg/distribution/node`. The oracle schema's `@go output` directive is repointed from `core/pkg/distribution/node` to `core/pkg/service/node`, and all seven affected generated files are regenerated to import through the service-layer re-export package instead.

- The `service/node` package exposes type aliases (`Key`, `Node`, `Cluster`, etc.) that forward to `distribution/node` unchanged — so this is a pure import-path correction with no behavioral change.
- All generated files (`types.gen.go`, `codec.gen.go`, `retrieve.gen.go`, and both `pb/translator.gen.go` files plus the test) consistently use only `node.Key`, which is correctly re-exported by `service/node`.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all changes are mechanical import-path corrections in generated files with no behavioral impact.

The `service/node` package uses Go type aliases, so every type consumed by the generated files (`node.Key`, etc.) is structurally identical to its `distribution/node` counterpart. The oracle schema change is a one-line redirect, and all seven regenerated files use only symbols that `service/node` correctly re-exports. No logic was altered.

No files require special attention. The `service/node/node.go` re-export layer covers all symbols used by the generated code.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| schemas/synnax/cluster.oracle | Root change: `@go output` directive updated from `core/pkg/distribution/node` to `core/pkg/service/node`, driving all downstream regeneration. |
| core/pkg/service/channel/types.gen.go | Import changed from `distribution/node` to `service/node`; uses only `node.Key`, which is correctly re-exported. |
| core/pkg/service/channel/codec.gen.go | Import changed; uses `node.Key` for Leaseholder decoding — fully covered by service/node re-export. |
| core/pkg/service/channel/retrieve.gen.go | Import changed; `MatchLeaseholders` accepts `...node.Key` — type is available in service/node. |
| core/pkg/service/channel/pb/translator.gen.go | Import changed; `node.Key` used in `ChannelFromPB` — correctly re-exported by service/node. |
| core/pkg/api/channel/types.gen.go | Import changed from distribution/node to service/node; `node.Key` used for the Leaseholder API field. |
| core/pkg/api/channel/pb/translator.gen.go | Import changed; `node.Key` cast in `ChannelFromPB` is valid with service/node's type alias. |
| core/pkg/service/channel/codec_gen_test.go | Test import updated to service/node in lock-step with codec.gen.go; no test logic changes. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A["schemas/synnax/cluster.oracle\n(@go output)"] -->|"Before: core/pkg/distribution/node"| B["pkg/distribution/node\n(aspen wrappers)"]
    A -->|"After: core/pkg/service/node"| C["pkg/service/node\n(re-exports distribution/node types)"]
    C --> B

    D["pkg/service/channel/*.gen.go\n(types, codec, retrieve)"] -->|"Now imports"| C
    E["pkg/service/channel/pb/translator.gen.go"] -->|"Now imports"| C
    F["pkg/api/channel/types.gen.go"] -->|"Now imports"| C
    G["pkg/api/channel/pb/translator.gen.go"] -->|"Now imports"| C

    style B fill:#f9a,stroke:#c66
    style C fill:#9f9,stroke:#393
    style A fill:#99f,stroke:#339
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A["schemas/synnax/cluster.oracle\n(@go output)"] -->|"Before: core/pkg/distribution/node"| B["pkg/distribution/node\n(aspen wrappers)"]
    A -->|"After: core/pkg/service/node"| C["pkg/service/node\n(re-exports distribution/node types)"]
    C --> B

    D["pkg/service/channel/*.gen.go\n(types, codec, retrieve)"] -->|"Now imports"| C
    E["pkg/service/channel/pb/translator.gen.go"] -->|"Now imports"| C
    F["pkg/api/channel/types.gen.go"] -->|"Now imports"| C
    G["pkg/api/channel/pb/translator.gen.go"] -->|"Now imports"| C

    style B fill:#f9a,stroke:#c66
    style C fill:#9f9,stroke:#393
    style A fill:#99f,stroke:#339
```

</a>

<sub>Reviews (1): Last reviewed commit: ["Make sure Oracle doesn&#39;t use distributio..."](https://github.com/synnaxlabs/synnax/commit/dc6c54ab8e2bda814187243043f2fe005db7ae10) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44263530)</sub>

<!-- /greptile_comment -->