### PR TITLE
SY-4463: Keep the Bazel Cache Warm on Windows

### DIFF
--- a/.github/workflows/build.synnax.yaml
+++ b/.github/workflows/build.synnax.yaml
@@ -687,7 +687,7 @@ jobs:
       - name: Clean Build Caches (Windows)
         if: always() && matrix.os == 'windows-build-bot'
         shell: powershell
-        run: integration/scripts/CleanBuildCaches.ps1 -MinFreeGB 40
+        run: integration/scripts/CleanBuildCaches.ps1 -MinFreeGB 35
 
   docker:
     name: Build Docker Image

--- a/.github/workflows/build.synnax.yaml
+++ b/.github/workflows/build.synnax.yaml
@@ -687,7 +687,7 @@ jobs:
       - name: Clean Build Caches (Windows)
         if: always() && matrix.os == 'windows-build-bot'
         shell: powershell
-        run: integration/scripts/CleanBuildCaches.ps1 -MinFreeGB 25
+        run: integration/scripts/CleanBuildCaches.ps1 -MinFreeGB 40
 
   docker:
     name: Build Docker Image

--- a/integration/scripts/CleanBuildCaches.ps1
+++ b/integration/scripts/CleanBuildCaches.ps1
@@ -61,10 +61,12 @@ if (Test-EnoughSpace) {
     Write-Output "Free space ${freeMB}MB >= target ${minFreeMB}MB - keeping caches warm (no clean)."
     Write-Output ""
     $diskAfter = Get-DiskUsedMB
+    $diskFreed = $diskBefore - $diskAfter
     Write-Output "=== Summary ==="
     Write-Output "  Cache freed:  0MB"
     Write-Output "  Disk before:  ${diskBefore}MB"
     Write-Output "  Disk after:   ${diskAfter}MB"
+    Write-Output "  Disk freed:   ${diskFreed}MB"
     Write-DiskSummary
     return
 }

--- a/integration/scripts/CleanBuildCaches.ps1
+++ b/integration/scripts/CleanBuildCaches.ps1
@@ -14,10 +14,10 @@
 # - Otherwise: `bazel clean` first (largest consumer), then oldest Go/binary files
 #   until MinFreeGB is available.
 #
-# Usage: CleanBuildCaches.ps1 [-MinFreeGB 40]
+# Usage: CleanBuildCaches.ps1 [-MinFreeGB 35]
 
 param(
-    [int]$MinFreeGB = 40
+    [int]$MinFreeGB = 35
 )
 
 # Best-effort cleanup — must never fail the build

--- a/integration/scripts/CleanBuildCaches.ps1
+++ b/integration/scripts/CleanBuildCaches.ps1
@@ -8,13 +8,16 @@
 # included in the file licenses/APL.txt.
 
 # Cleans build caches on self-hosted Windows runners to prevent unbounded disk growth.
-# - Bazel: always runs `bazel clean` (unconditional - remote cache serves next build)
-# - Go/binaries: deletes oldest files first until MinFreeGB of disk space is available
+# Runs only under disk pressure so the Bazel output tree stays warm and builds stay
+# incremental:
+# - If free space >= MinFreeGB, nothing is cleaned.
+# - Otherwise: `bazel clean` first (largest consumer), then oldest Go/binary files
+#   until MinFreeGB is available.
 #
-# Usage: CleanBuildCaches.ps1 [-MinFreeGB 25]
+# Usage: CleanBuildCaches.ps1 [-MinFreeGB 40]
 
 param(
-    [int]$MinFreeGB = 25
+    [int]$MinFreeGB = 40
 )
 
 # Best-effort cleanup — must never fail the build
@@ -53,7 +56,20 @@ Write-Output "=== Build Cache Cleanup (target: ${MinFreeGB}GB free) ==="
 Write-Output "  Current free space: ${freeMB}MB (target: ${minFreeMB}MB)"
 Write-Output ""
 
-# --- Bazel clean (unconditional) ---
+# --- Above threshold: Keep Bazel cache warm ---
+if (Test-EnoughSpace) {
+    Write-Output "Free space ${freeMB}MB >= target ${minFreeMB}MB - keeping caches warm (no clean)."
+    Write-Output ""
+    $diskAfter = Get-DiskUsedMB
+    Write-Output "=== Summary ==="
+    Write-Output "  Cache freed:  0MB"
+    Write-Output "  Disk before:  ${diskBefore}MB"
+    Write-Output "  Disk after:   ${diskAfter}MB"
+    Write-DiskSummary
+    return
+}
+
+# --- Below threshold: Bazel is the largest consumer, so clean it first ---
 Write-Output "Bazel clean:"
 $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
 $bazelBase = $null


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4463](https://linear.app/synnax/issue/SY-4463)

## Description

The post-build cleanup ran `bazel clean` on every Windows build, wiping the Bazel cache each time. Every build then started cold: recompiling third-party deps, re-fetching external repos, and re-checking every action against the remote cache.

The cleanup now only runs when the disk is low on space. Above the threshold the cache is left warm, so builds are incremental. Below it, the same cleanup as before runs, so disk usage stays bounded.

## Testing

Ran the updated script and workflow directly on a build runner:

- Ran the cleanup with plenty of free disk and confirmed it takes the new path: logs "keeping caches warm", skips the clean, and deletes nothing.
- Ran a driver build, then the cleanup, then another build. The second build reused the cache and finished in seconds instead of a ~35 min cold rebuild, confirming the cache survives the cleanup step.
- Forced the low-disk path and confirmed it still cleans, so disk stays bounded.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR changes the Windows build cache cleanup script from unconditionally running `bazel clean` on every post-build invocation to only cleaning when disk space is below a threshold (now 35 GB, up from 25 GB). When there's enough free space the script returns immediately, leaving the Bazel output tree intact so subsequent builds are incremental rather than cold.

- **`CleanBuildCaches.ps1`**: Adds an early-return fast path (`Test-EnoughSpace`) before any cleanup runs. When free space meets the target the script logs a summary and exits; below the threshold the existing Bazel-clean-then-Go-cache-purge logic still executes.
- **`build.synnax.yaml`**: Updates the `-MinFreeGB` argument from 25 to 35 to match the new default in the script.

<h3>Confidence Score: 5/5</h3>

Safe to merge — the change is additive (a new early-return guard) and leaves all existing cleanup paths untouched.

The new warm-cache path is a straightforward conditional early-return. The threshold bump from 25 GB to 35 GB is consistent between the workflow call and the script default. The existing Bazel-clean and Go-cache-purge paths are structurally unchanged, and the summary output across all three exit paths is consistent.

No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| integration/scripts/CleanBuildCaches.ps1 | Adds conditional early-exit when free space meets the 35 GB target, keeping the Bazel output tree warm; the existing cleanup paths for low-disk scenarios are unchanged and correct. |
| .github/workflows/build.synnax.yaml | Single-line threshold bump from 25 to 35 GB to match the updated script default; no other workflow logic changed. |

<h3>Flowchart</h3>

<a href="#gh-light-mode-only">

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A([CleanBuildCaches.ps1 starts]) --> B[Capture diskBefore, freeMB]
    B --> C{Test-EnoughSpace\nfree >= MinFreeGB?}
    C -- Yes\nnew warm-cache path --> D[Log: keeping caches warm]
    D --> E[Print summary\nCache freed: 0MB]
    E --> F([return — Bazel cache intact])

    C -- No\nexisting cleanup path --> G[bazel clean]
    G --> H{Test-EnoughSpace\nafter bazel clean?}
    H -- Yes --> I[Print summary\nCache freed: freedBazel]
    I --> J([return])
    H -- No --> K[Delete oldest Go/binary\ncache files until target met]
    K --> L{Target met?}
    L -- No --> M[Log WARNING: caches exhausted]
    M --> N[Print final summary]
    L -- Yes --> N
    N --> O([return])
```

</a>
<a href="#gh-dark-mode-only">

```mermaid
%%{init: {'theme': 'base', 'themeVariables': {"darkMode": true, "background": "#0d1117", "primaryColor": "#21262d", "primaryTextColor": "#e6edf3", "primaryBorderColor": "#8b949e", "lineColor": "#8b949e", "textColor": "#e6edf3", "edgeLabelBackground": "#161b22", "actorBkg": "#21262d", "actorBorder": "#8b949e", "actorTextColor": "#e6edf3", "actorLineColor": "#8b949e", "signalColor": "#8b949e", "signalTextColor": "#e6edf3", "noteBkgColor": "#373320", "noteBorderColor": "#d4a72c", "noteTextColor": "#f0e6c0", "labelBoxBkgColor": "#21262d", "labelBoxBorderColor": "#8b949e", "labelTextColor": "#e6edf3", "loopTextColor": "#e6edf3", "activationBkgColor": "#30363d", "activationBorderColor": "#8b949e"}}}%%
flowchart TD
    A([CleanBuildCaches.ps1 starts]) --> B[Capture diskBefore, freeMB]
    B --> C{Test-EnoughSpace\nfree >= MinFreeGB?}
    C -- Yes\nnew warm-cache path --> D[Log: keeping caches warm]
    D --> E[Print summary\nCache freed: 0MB]
    E --> F([return — Bazel cache intact])

    C -- No\nexisting cleanup path --> G[bazel clean]
    G --> H{Test-EnoughSpace\nafter bazel clean?}
    H -- Yes --> I[Print summary\nCache freed: freedBazel]
    I --> J([return])
    H -- No --> K[Delete oldest Go/binary\ncache files until target met]
    K --> L{Target met?}
    L -- No --> M[Log WARNING: caches exhausted]
    M --> N[Print final summary]
    L -- Yes --> N
    N --> O([return])
```

</a>

<sub>Reviews (2): Last reviewed commit: ["SY-4463: Add write-output line"](https://github.com/synnaxlabs/synnax/commit/d8b78abc7e815579f70d85447c88e656a703f981) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=44365458)</sub>

<!-- /greptile_comment -->