### PR TITLE
SY-4505: Fix flaky Cesium streamer subscription update test

### DIFF
--- a/cesium/streamer_test.go
+++ b/cesium/streamer_test.go
@@ -106,8 +106,8 @@ var _ = Describe("Streamer Behavior", func() {
 					r.Inlet() <- cesium.StreamerRequest{Channels: []cesium.ChannelKey{key}}
 
 					// The subscription update is applied asynchronously, so writes
-					// racing ahead of it are dropped. Retry with increasing
-					// timestamps until a frame comes through.
+					// racing ahead of it are dropped. Retry with increasing timestamps
+					// until a frame comes through.
 					var res cesium.StreamerResponse
 					ts := telem.TimeStamp(10)
 					Eventually(func(g Gomega) {

--- a/cesium/streamer_test.go
+++ b/cesium/streamer_test.go
@@ -104,13 +104,20 @@ var _ = Describe("Streamer Behavior", func() {
 					r, o, closer := openStreamer(db, cesium.StreamerConfig{})
 
 					r.Inlet() <- cesium.StreamerRequest{Channels: []cesium.ChannelKey{key}}
-					MustSucceed(w.Write(telem.MultiFrame(
-						[]cesium.ChannelKey{key},
-						[]telem.Series{telem.NewSeriesSecondsTSV(10, 11)},
-					)))
 
+					// The subscription update is applied asynchronously, so writes
+					// racing ahead of it are dropped. Retry with increasing
+					// timestamps until a frame comes through.
 					var res cesium.StreamerResponse
-					Eventually(o.Outlet()).Should(Receive(&res))
+					ts := telem.TimeStamp(10)
+					Eventually(func(g Gomega) {
+						g.Expect(w.Write(telem.MultiFrame(
+							[]cesium.ChannelKey{key},
+							[]telem.Series{telem.NewSeriesSecondsTSV(ts)},
+						))).To(BeTrue())
+						ts++
+						g.Expect(o.Outlet()).To(Receive(&res))
+					}).Should(Succeed())
 					Expect(res.Frame.KeysSlice()).To(ContainElement(key))
 					Expect(closer.Close()).To(Succeed())
 					Expect(w.Close()).To(Succeed())


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4505](https://linear.app/synnax/issue/SY-4505)

## Description

Fixes the flaky cesium spec `Streamer Behavior > Happy Path > "Should deliver writes issued after a subscription update is sent"`.

The spec wrote a frame immediately after pushing a `StreamerRequest`, but the streamer applies subscription updates asynchronously: the request and relayed frames are drained by the same `select` loop, so a frame racing ahead of the update is filtered against the stale (empty) channel set and dropped. When that race was lost, the `Eventually` on the outlet timed out after 1s and the spec failed (roughly 1 in 3 full-suite runs locally).

The spec now retries the write inside an `Eventually` with strictly increasing timestamps (index channel) and polls the outlet each attempt, so a frame is guaranteed to come through once the subscription lands. Verified with 15 consecutive full-suite runs plus focused runs on both FS variants.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR stabilizes the Cesium streamer subscription update test. The main changes are:

- Retries writes while the asynchronous subscription update is pending.
- Uses increasing timestamps for each write attempt.
- Polls the outlet until a subscribed frame arrives.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge.

- No blocking issues found in the changed code.
- The retry matches the asynchronous subscription behavior and preserves the final response validation.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cesium/streamer_test.go | Replaces a race-prone one-shot write with polling retries that use increasing timestamps. |

<sub>Reviews (1): Last reviewed commit: ["update streamer test"](https://github.com/synnaxlabs/synnax/commit/752d69f44120beef6e5c6efaf29ab22483de0992) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46026103)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Rule used - When making changes to functionality, add correspo... ([source](https://app.greptile.com/synnax/-/custom-context?memory=8b39d83e-3d2b-4dd4-9e14-d0644d6bfe58))

**Learned From**
[synnaxlabs/synnax#1550](https://github.com/synnaxlabs/synnax/pull/1550)
- Rule used - Go 1.22+ supports ranging over integers with `for ... ([source](https://app.greptile.com/synnax/github/synnaxlabs/synnax/-/custom-context?memory=bb539076-079c-4421-9b0b-041087605f41))
- Context used - CLAUDE.md ([source](https://app.greptile.com/synnax/github/synnaxlabs/synnax/-/custom-context?memory=1f93b7ae-395e-4379-bb71-2f5a9a0f0287))
</details>

<!-- /greptile_comment -->