### PR TITLE
SY-4463: Verify Warm Bazel Cache on 200GB Windows Bots (do not merge)

### DIFF
--- a/.github/workflows/test.integration.yaml
+++ b/.github/workflows/test.integration.yaml
@@ -7,6 +7,8 @@
 # License, use of this software will be governed by the Apache License, Version 2.0,
 # included in the file licenses/APL.txt.
 
+# CI trigger to verify SY-4463 warm Bazel cache on the 200GB Windows bots (revert before merge).
+
 name: Test - Integration
 
 run-name:


### PR DESCRIPTION
## Purpose

Throwaway PR to trigger the **Test - Integration** suite on rc, which builds the Windows
driver on the build bots. Verifies that after the 160 -> 200 GB disk resize, the Clean step
in `CleanBuildCaches.ps1` now logs `keeping caches warm (no clean)` instead of firing
`bazel clean` every build.

**Do not merge** - the one-line comment in `test.integration.yaml` is only here to trip the
path filter. Close after the Windows build's Clean step is confirmed.

Related: SY-4463 (Keep the Bazel Cache Warm on Windows).

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a temporary CI trigger comment for the Windows cache check.

- Marks the SY-4463 warm Bazel-cache verification.
- Leaves the integration workflow behavior unchanged.

<h3>Confidence Score: 5/5</h3>

This looks safe to merge, though the PR description says to close it rather than merge it.

- No blocking issues found in the changed code.
- The only change is a YAML comment, so workflow behavior is unchanged.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| .github/workflows/test.integration.yaml | Adds a temporary YAML comment without changing workflow configuration or execution. |

<sub>Reviews (1): Last reviewed commit: ["Trigger integration test to verify warm ..."](https://github.com/synnaxlabs/synnax/commit/d5a244385713bb22473304530ef549e03d6427dc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=46069529)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://app.greptile.com/synnax/github/synnaxlabs/synnax/-/custom-context?memory=1f93b7ae-395e-4379-bb71-2f5a9a0f0287))

<!-- /greptile_comment -->