### PR TITLE
SY-4510: Fix flaky Cesium streamer channel validation test

### DIFF
--- a/cesium/streamer_test.go
+++ b/cesium/streamer_test.go
@@ -294,10 +294,19 @@ var _ = Describe("Streamer Behavior", func() {
 					r.Inlet() <- cesium.StreamerRequest{
 						Channels: []cesium.ChannelKey{key, GenerateChannelKey()},
 					}
-					MustSucceed(w.Write(telem.UnaryFrame(key, telem.NewSeriesSecondsTSV(10, 11))))
 
+					// The subscription update is applied asynchronously, so writes
+					// racing ahead of it are dropped. Retry with increasing timestamps
+					// until a frame comes through.
 					var res cesium.StreamerResponse
-					Eventually(o.Outlet()).Should(Receive(&res))
+					ts := telem.TimeStamp(10)
+					Eventually(func(g Gomega) {
+						g.Expect(w.Write(
+							telem.UnaryFrame(key, telem.NewSeriesSecondsTSV(ts)),
+						)).To(BeTrue())
+						ts++
+						g.Expect(o.Outlet()).To(Receive(&res))
+					}).Should(Succeed())
 					Expect(res.Frame.KeysSlice()).To(ConsistOf(key))
 					Expect(closer.Close()).To(Succeed())
 					Expect(w.Close()).To(Succeed())


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4510](https://linear.app/synnax/issue/SY-4510/fix-flakey-cesium-test)

## Description

The `Channel Validation > "Should allow subscription updates for channels that do not exist"` spec sent a subscription update into the streamer's inlet and then wrote a single frame. The streamer applies subscription updates asynchronously in the same select loop that filters relayed frames, so when the write won the race the frame was dropped and the `Eventually` timed out — the same race SY-4505 (#2616) fixed in the sibling spec, which missed this second occurrence.

Applies the same fix: retry the write with increasing timestamps until a frame is delivered. Verified with 25 focused `--race` repeats and 52 consecutive full-suite `ginkgo --race --until-it-fails` attempts (the unfixed test failed on attempt 1).

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a flaky race condition in `cesium/streamer_test.go` by applying the same retry-on-write pattern that was introduced for a sibling spec in #2616 but was missed in this second test case.

- **Race fix**: the `"Should allow subscription updates for channels that do not exist"` spec previously sent a subscription update and then performed a single write; because the update is processed asynchronously, the write could race ahead and be dropped. The fix wraps the write + receive check inside an `Eventually` closure that retries with an incrementing timestamp until a frame is delivered.
- **Pattern consistency**: the new code is structurally identical to the sibling fix at line 113, using `telem.TimeStamp` increment across retries and Gomega's `g.Expect` for inner assertions.

<h3>Confidence Score: 5/5</h3>

Safe to merge — single test-only change with no production code touched.

The change is confined to one test spec and directly mirrors an already-proven pattern from the sibling fix. The telem.TimeStamp type is compatible with NewSeriesSecondsTSV's variadic parameter, the ts++ placement correctly ensures each retry uses a fresh timestamp, and the outlet check only validates the key — so latent frames from earlier retries cannot cause a false failure.

**Files Needing Attention:** No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cesium/streamer_test.go | Replaces a single write+receive sequence with an Eventually retry loop (incrementing ts) to eliminate a race between the async subscription update and the write; mirrors the identical pattern from the sibling test fix in #2616. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Test
    participant Streamer
    participant Writer
    participant Outlet

    Test->>Streamer: "StreamerRequest{Channels: [key, nonExistentKey]}"
    Note over Streamer: subscription update applied<br/>asynchronously in select loop

    loop Eventually (retry with ts++)
        Test->>Writer: w.Write(UnaryFrame(key, NewSeriesSecondsTSV(ts)))
        Writer-->>Test: true (accepted)
        Test->>Test: ts++
        alt subscription update already applied
            Streamer->>Outlet: relay frame
            Test->>Outlet: "Receive(&res) ✓ → Succeed"
        else write raced ahead of subscription update
            Note over Streamer: frame dropped (not subscribed yet)
            Test->>Outlet: "Receive(&res) ✗ → retry"
        end
    end

    Test->>Test: Expect(res.Frame.KeysSlice()).To(ConsistOf(key))
```

<sub>Reviews (1): Last reviewed commit: ["SY-4510: Fix flaky Cesium streamer chann..."](https://github.com/synnaxlabs/synnax/commit/9504ef1257bf6fe9ed89466e1a513afae60cd16e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47148046)</sub>

<!-- /greptile_comment -->