### PR TITLE
SY-4508: Reuse Arc tabs in user docs

### DIFF
--- a/docs/site/src/pages/reference/control/arc/concepts/channels-and-series.mdx
+++ b/docs/site/src/pages/reference/control/arc/concepts/channels-and-series.mdx
@@ -55,7 +55,7 @@ statements) or an **imperative context** (inside a function body).
 
 <Fragment slot="flow">
 
-In flow statements, channels are **event-driven data** sources:
+In flow statements, channels are **event-driven data sources**:
 
 ```arc
 sensor -> controller{} -> actuator

--- a/docs/site/src/pages/reference/control/arc/concepts/channels-and-series.mdx
+++ b/docs/site/src/pages/reference/control/arc/concepts/channels-and-series.mdx
@@ -11,6 +11,7 @@ nextURL: "/reference/control/arc/concepts/stateful-variables"
 ---
 
 import { Divider, Note } from "@synnaxlabs/pluto";
+import { Arc } from "@/components";
 import { mdxOverrides } from "@/components/mdxOverrides";
 
 export const components = mdxOverrides;
@@ -50,38 +51,37 @@ channels in the Console's resources panel before writing code.
 Channels behave differently depending on whether you're in a **reactive context** (flow
 statements) or an **imperative context** (inside a function body).
 
-### Reactive Context
+<Arc.Tabs client:load>
 
-In flow statements, channels are event-driven data sources:
+<Fragment slot="flow">
+
+In flow statements, channels are **event-driven data** sources:
 
 ```arc
-sensor -> filter{threshold=50.0} -> controller{} -> actuator
+sensor -> controller{} -> actuator
 ```
 
-When new data arrives on `sensor`, the entire pipeline executes. The runtime tracks
-which data has been processed using watermarks, so only new data triggers execution.
+When new data arrives on `sensor`, the entire pipeline executes.
 
-You can also bind a channel, or an expression over channels, to a name. The resulting
-[variable](/reference/control/arc/reference/variables) tracks the channel and updates as
-new data arrives.
+</Fragment>
 
-### Imperative Context
+<Fragment slot="function">
 
 Inside function bodies, channel reads are **non-blocking snapshots**:
 
 ```arc
-func controller{setpoint chan f64, output chan f64} (pressure f64) f64 {
-    target := setpoint // Read latest value (non-blocking)
-    error := pressure - target
-    if error > 10 {
-        output = error // Write to channel
-    }
+func controller{setpoint chan f64} (pressure f64) f64 {
+    error := pressure - setpoint // Read latest value (non-blocking)
     return error
 }
 ```
 
-The line `target := setpoint` returns immediately with the most recent value written to
-the `setpoint` channel. If nothing has been written yet, it returns zero.
+</Fragment>
+
+</Arc.Tabs>
+
+You can also bind a channel, or an expression over channels, to a
+[variable](/reference/control/arc/reference/variables) that updates as new data arrives.
 
 | Aspect        | Reactive (`->`)     | Imperative (function body)    |
 | ------------- | ------------------- | ----------------------------- |
@@ -108,26 +108,35 @@ This lets you write reusable functions that work with different channels.
 
 ## Writing to Channels
 
-Inside functions, use assignment syntax to write to channels:
+Write to a channel by making it the final target of a flow statement, or with assignment
+syntax inside a function.
+
+<Arc.Tabs client:load>
+
+<Fragment slot="flow">
 
 ```arc
-func control{valve chan u8} (pressure f64) {
-    if pressure > 500 {
-        valve = 1
-    } else {
-        valve = 0
-    }
+stage control {
+    sensor -> scale{factor=2.0} -> output_channel
 }
 ```
 
-Writes are queued until the end of the execution cycle. Multiple writes to the same
-channel in a single cycle result in the last value being sent.
+</Fragment>
 
-In flow statements, you can write directly to channels as the final target:
+<Fragment slot="function">
 
 ```arc
-sensor -> scale{factor=2.0} -> output_channel
+func control{valve chan u8} (pressure f64) {
+    if pressure > 500 { valve = 1 }
+}
 ```
+
+</Fragment>
+
+</Arc.Tabs>
+
+Writes are queued until the end of the execution cycle. Multiple writes to the same
+channel in a single cycle result in the last value being sent.
 
 <Divider.Divider x />
 

--- a/docs/site/src/pages/reference/control/arc/reference/functions.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/functions.mdx
@@ -11,6 +11,7 @@ nextURL: "/reference/control/arc/reference/statements"
 ---
 
 import { Divider, Note } from "@synnaxlabs/pluto";
+import { Arc } from "@/components";
 import { mdxOverrides } from "@/components/mdxOverrides";
 
 export const components = mdxOverrides;
@@ -154,29 +155,34 @@ sensor -> split{} -> {
 
 ## Calling Functions
 
-Arc has two calling conventions depending on context.
+Arc has two calling conventions depending on context: parentheses inside function
+bodies, and braces to instantiate a function in a flow statement.
 
-### In Function Bodies
+<Arc.Tabs client:load>
 
-Inside function bodies, call functions with parentheses:
+<Fragment slot="flow">
 
 ```arc
-func outer(x f64) f64 {
-    y := inner(x) // function call
-    z := clamp(y, 0.0, 100.0)
-    return z
+stage main {
+    // sensor value feeds the trigger
+    sensor -> filter{threshold=50.0} -> output
 }
 ```
 
-### In Flows
+</Fragment>
 
-In flow statements, instantiate functions with braces:
+<Fragment slot="function">
 
 ```arc
-sensor -> filter{threshold=50.0} -> output
+func outer(x f64) f64 {
+    y := inner(x, 0.0, 100.0) // function call
+    return y
+}
 ```
 
-The incoming sensor value feeds the function's trigger.
+</Fragment>
+
+</Arc.Tabs>
 
 <Divider.Divider x />
 

--- a/docs/site/src/pages/reference/control/arc/reference/standard-library/ranges.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/standard-library/ranges.mdx
@@ -9,6 +9,7 @@ nextURL: "/reference/control/arc/reference/standard-library/status"
 ---
 
 import { Note, Icon, Text } from "@synnaxlabs/pluto";
+import { Arc } from "@/components";
 import Details from "@/components/details/Details.astro";
 import { mdxOverrides } from "@/components/mdxOverrides";
 
@@ -35,13 +36,29 @@ shown as "In Progress"), and outputs the new range key.
 
 </Details>
 
-```arc
-ranges.create{name="Terminal Count", color="#3bc454"} -> key_ch
+<Arc.Tabs client:load>
 
+<Fragment slot="flow">
+
+```arc
+sequence ranges_create {
+  ranges.create{name="Terminal Count", color="#3bc454"} -> range_key
+}
+```
+
+</Fragment>
+
+<Fragment slot="function">
+
+```arc
 func ranges_create() {
   range_key := ranges.create("Terminal Count", parent_key, "#3bc454")
 }
 ```
+
+</Fragment>
+
+</Arc.Tabs>
 
 ## `end`
 
@@ -59,10 +76,26 @@ range key.
 
 </Details>
 
-```arc
-trigger -> ranges.end{key=range_key}
+<Arc.Tabs client:load>
 
+<Fragment slot="flow">
+
+```arc
+sequence ranges_end {
+  trigger -> ranges.end{key=range_key}
+}
+```
+
+</Fragment>
+
+<Fragment slot="function">
+
+```arc
 func ranges_end() {
     ranges.end(range_key)
 }
 ```
+
+</Fragment>
+
+</Arc.Tabs>

--- a/docs/site/src/pages/reference/control/arc/reference/standard-library/status.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/standard-library/status.mdx
@@ -9,6 +9,7 @@ nextURL: "/reference/control/arc/reference/standard-library/time"
 ---
 
 import { Note, Icon, Text } from "@synnaxlabs/pluto";
+import { Arc } from "@/components";
 import Details from "@/components/details/Details.astro";
 import { mdxOverrides } from "@/components/mdxOverrides";
 
@@ -40,18 +41,34 @@ addressing it by name or by key, and outputs the resolved status key.
 
 </Details>
 
-```arc
-trigger -> status.set{
-    key_or_name = "ox_alarm",
-    variant = "error",
-    message = "Overpressure detected"
-}
+<Arc.Tabs client:load>
 
-func raise_alarm() {
-    alarm_key = status.set(
-      "ox_alarm",
-      "Overpressure detected",
-      "error"
-    )
+<Fragment slot="flow">
+
+```arc
+stage main {
+  trigger -> status.set{
+    key_or_name = "ox_alarm",
+    message = "Overpressure detected",
+    variant = "error",
+  } -> status_key
 }
 ```
+
+</Fragment>
+
+<Fragment slot="function">
+
+```arc
+func raise_alarm() {
+  status_key = status.set(
+    "ox_alarm",
+    "Overpressure detected",
+    "error"
+  )
+}
+```
+
+</Fragment>
+
+</Arc.Tabs>

--- a/docs/site/src/pages/reference/control/arc/reference/standard-library/time.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/standard-library/time.mdx
@@ -10,6 +10,7 @@ nextURL: "/reference/control/arc/reference/errors"
 ---
 
 import { Divider, Icon, Text } from "@synnaxlabs/pluto";
+import { Arc } from "@/components";
 import Details from "@/components/details/Details.astro";
 import { mdxOverrides } from "@/components/mdxOverrides";
 
@@ -52,13 +53,29 @@ function call, so it can be wired into a chain or called inside a `func`.
 
 </Details>
 
-```arc
-trigger -> time.now{} -> current_time
+<Arc.Tabs client:load>
 
+<Fragment slot="flow">
+
+```arc
+stage stamp {
+  trigger -> time.now{} -> current_time
+}
+```
+
+</Fragment>
+
+<Fragment slot="function">
+
+```arc
 func stamp() {
     current_time = time.now()
 }
 ```
+
+</Fragment>
+
+</Arc.Tabs>
 
 <Divider.Divider x />
 


### PR DESCRIPTION
## Linear Issue

[SY-4508](https://linear.app/synnax/issue/SY-4508)

## Description

Followup to SY-4293. Converts the remaining flow/func example pairs to the `Arc.Tabs` component across channels, functions, ranges, status, and time.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR is a follow-up to SY-4293, converting the remaining flow/function example pairs in the Arc documentation to use the shared `Arc.Tabs` component. All five changed files follow the same mechanical pattern: import `Arc` from `@/components`, wrap paired code blocks in `<Arc.Tabs client:load>` with `<Fragment slot="flow">` and `<Fragment slot="function">`, and adjust surrounding prose where needed.

- **Channels & Series** (`channels-and-series.mdx`): Both the "Reactive/Imperative Context" and "Writing to Channels" sections are tabified; the variable-binding sentence is lifted outside the tabs, and the `else` branch in the write example is intentionally trimmed for height parity.
- **Functions** (`functions.mdx`): The "Calling Functions" sub-sections are merged into a single tabbed block with updated lead prose.
- **Standard Library** (`ranges.mdx`, `status.mdx`, `time.mdx`): Each stdlib entry's paired examples are wrapped in `Arc.Tabs`, with flow snippets now shown inside named `sequence`/`stage` wrapper blocks for clarity.

<h3>Confidence Score: 5/5</h3>

Documentation-only changes with no runtime code; safe to merge.

All five files apply the same well-established Arc.Tabs migration pattern introduced in SY-4293. The import is added correctly, client:load directives are present on every instance, and no content is dropped without a deliberate reason (previously discussed in review threads). No logic, API calls, or data paths are affected.

**Files Needing Attention:** No files require special attention.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/site/src/pages/reference/control/arc/concepts/channels-and-series.mdx | Two sections tabified with Arc.Tabs; reactive/imperative context and write examples are simplified and wrapped correctly. Import added, client:load directive applied consistently. |
| docs/site/src/pages/reference/control/arc/reference/functions.mdx | Calling-conventions section converted to Arc.Tabs with updated prose; flow snippet wrapped in named stage block. No logic issues. |
| docs/site/src/pages/reference/control/arc/reference/standard-library/ranges.mdx | Both create and end entries tabified with Arc.Tabs; flow snippets wrapped in sequence blocks with consistent naming. No issues. |
| docs/site/src/pages/reference/control/arc/reference/standard-library/status.mdx | status.set entry tabified; flow snippet placed inside a named stage block with reordered named arguments. Function example indentation normalized. |
| docs/site/src/pages/reference/control/arc/reference/standard-library/time.mdx | time.now entry tabified with Arc.Tabs; flow snippet wrapped in a named stage block. No issues. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Paired code blocks\nflow + function] --> B[Wrap in Arc.Tabs client:load]
    B --> C[Fragment slot=flow]
    B --> D[Fragment slot=function]
    C --> E[Flow snippet\nwrapped in stage/sequence block]
    D --> F[Function snippet\nwith parenthesis call syntax]
    E --> G[Rendered tab UI]
    F --> G
```

<sub>Reviews (2): Last reviewed commit: ["fix styling"](https://github.com/synnaxlabs/synnax/commit/05478798fcef9005e20b38484da939b8c5e0523b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47172554)</sub>

<!-- /greptile_comment -->