### PR TITLE
SY-4516: Fix flaky Arc tree Console test

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,10 @@ telemetry. Monorepo:
 - **Oracle** (`/oracle/`, Go) generates Go/TS/Python/C++/proto bindings from `.oracle`
   schemas in `/schemas/`. Never hand-edit generated code. See `oracle/CLAUDE.md`.
 
+Arc, Cesium, Aspen, Core, Console, Pluto, Freighter, Alamos, Gorp, Drift, Driver,
+Oracle, and X are proper nouns — capitalize them in prose (comments, docs, commit
+messages, PRs).
+
 ## Documentation
 
 Language and component rules auto-load from package-root `CLAUDE.md` stubs when you

--- a/console/src/feature/arc/tree.spec.ts
+++ b/console/src/feature/arc/tree.spec.ts
@@ -9,13 +9,12 @@
 
 import { arc as clientArc, group, ontology } from "@synnaxlabs/client";
 import { createTestClient } from "@synnaxlabs/client/testutil";
-import { type Status } from "@synnaxlabs/pluto";
 import { fireEvent } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { Arc } from "@/feature/arc";
 import { findTreeRow, renderOntologyTree } from "@/platform/tree/treeTestutil";
-import { CaptureStatuses, resolveFocusedTab, uniqueName } from "@/testutil";
+import { resolveFocusedTab, uniqueName } from "@/testutil";
 
 const client = createTestClient();
 
@@ -44,36 +43,6 @@ describe("arc/ontology", () => {
       const tab = await resolveFocusedTab(store, client);
       if (tab.variant !== "resource") throw new Error("expected a resource tab");
       expect(tab.resource.key).toBe(arc.key);
-    });
-
-    it("should open the tab without retrieving the arc", async () => {
-      const arc = await client.arcs.create({
-        name: uniqueName("arc"),
-        mode: "graph",
-        graph: { nodes: [], edges: [] },
-      });
-      const grp = await client.groups.create({
-        parent: ontology.ROOT_ID,
-        name: uniqueName("arcgrp"),
-      });
-      await client.ontology.addChildren(
-        group.ontologyID(grp.key),
-        clientArc.ontologyID(arc.key),
-      );
-      let statuses: Status.NotificationSpec[] = [];
-      const { store } = await renderOntologyTree({
-        client,
-        root: group.ontologyID(grp.key),
-        items: Arc.TREE_ITEMS,
-        extra: <CaptureStatuses onStatuses={(s) => (statuses = s)} />,
-      });
-      const row = await findTreeRow(arc.name);
-      await client.arcs.delete(arc.key);
-      fireEvent.doubleClick(row);
-      const tab = await resolveFocusedTab(store, client);
-      if (tab.variant !== "resource") throw new Error("expected a resource tab");
-      expect(tab.resource.key).toBe(arc.key);
-      expect(statuses).toEqual([]);
     });
   });
 });

--- a/console/src/platform/panel/useOpenResource.spec.tsx
+++ b/console/src/platform/panel/useOpenResource.spec.tsx
@@ -9,11 +9,15 @@
 
 import { ontology, table } from "@synnaxlabs/client";
 import { createTestClient } from "@synnaxlabs/client/testutil";
+import { type Status } from "@synnaxlabs/pluto";
+import { uuid } from "@synnaxlabs/x";
 import { act, renderHook } from "@testing-library/react";
+import { type PropsWithChildren, type ReactElement } from "react";
 import { describe, expect, it } from "vitest";
 
 import { Panel } from "@/platform/panel";
 import {
+  CaptureStatuses,
   createConsoleWrapper,
   resolveFocusedTab,
   selectTestProject,
@@ -35,5 +39,27 @@ describe("Panel.useOpenResource", () => {
     const tab = await resolveFocusedTab(store, client);
     if (tab.variant !== "resource") throw new Error("expected a resource tab");
     expect(tab.resource).toEqual(id);
+  });
+
+  it("opens the tab without retrieving the resource", async () => {
+    const { wrapper: Wrapper, store } = await createConsoleWrapper({ client });
+    await selectTestProject(store, client);
+    let statuses: Status.NotificationSpec[] = [];
+    const wrapper = ({ children }: PropsWithChildren): ReactElement => (
+      <Wrapper>
+        {children}
+        <CaptureStatuses onStatuses={(s) => (statuses = s)} />
+      </Wrapper>
+    );
+    const { result } = renderHook(() => Panel.useOpenResource(), { wrapper });
+    // The id references nothing on the cluster, so any retrieval fails loudly.
+    const id = table.ontologyID(uuid.create());
+    await act(async () => {
+      result.current(ontology.resourceZ.parse({ id, name: uniqueName("ghost") }));
+    });
+    const tab = await resolveFocusedTab(store, client);
+    if (tab.variant !== "resource") throw new Error("expected a resource tab");
+    expect(tab.resource).toEqual(id);
+    expect(statuses).toEqual([]);
   });
 });


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4516](https://linear.app/synnax/issue/SY-4516/fix-failing-console-test)

## Description

Fixes the Console test flaking on CI across PRs: `feature/arc/tree.spec > "should open the tab without retrieving the arc"` failing with "no tab focused".

The spec deleted the Arc from the cluster and then double-clicked its tree row. The tree's live subscription can process the delete and unmount the row before the click lands, so the click hits a detached node and no tab ever opens. Fast local runs win the race; CI runners lose it. Reproduced locally by yielding between the delete and the click. No ordering of delete-and-click is race-free — clicking first would let a regressed retrieval beat the delete instead.

The no-retrieval guard now lives at the layer that owns the behavior, in a deterministic form:

- `platform/panel/useOpenResource.spec.tsx`: new test opens a resource whose ontology ID references nothing on the cluster, so any reintroduced retrieval fails loudly (no tab / error status) with no live tree row to race against. Verified by mutation: temporarily adding a retrieve-then-open to `useOpenResource` fails exactly this test.
- `feature/arc/tree.spec.ts`: dropped the racy test; the remaining spec still covers the Arc wiring end to end (double-click opens a tab with the arc's key). The delete-then-click structure was a vestige of SY-4455, when Arc's onSelect really did retrieve and the test asserted the error path.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces a race-prone Arc tree test with deterministic coverage at the resource-opening hook layer.
- Removes the delete-and-double-click Arc tree test while retaining end-to-end Arc tab-opening coverage.
- Adds a hook test proving that a nonexistent resource can open directly without retrieval or error notifications.
- Renames both test files so their extensions match whether they contain JSX.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it changes only tests and preserves the intended behavioral coverage without the live-tree race.

The replacement test directly exercises resource tab opening with an absent cluster resource, while the remaining Arc tree test continues to verify Arc-specific selection wiring.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| console/src/feature/arc/tree.spec.ts | Removes the live-subscription race while preserving Arc tree selection and tab-opening coverage. |
| console/src/platform/panel/useOpenResource.spec.tsx | Adds deterministic no-retrieval coverage using an unpersisted ontology resource ID and status assertions. |

<sub>Reviews (1): Last reviewed commit: ["SY-4516: Fix flaky arc tree console test"](https://github.com/synnaxlabs/synnax/commit/fc64905006311bd5734d5839c4fb88774602c958) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47751335)</sub>

<!-- /greptile_comment -->