### PR TITLE
SY-4519: Prune Already-Published Distributions Before Python Publish

### DIFF
--- a/.github/workflows/deploy.py.yaml
+++ b/.github/workflows/deploy.py.yaml
@@ -52,5 +52,13 @@ jobs:
         working-directory: client/py
         run: uv build
 
+      - name: Prune already-published distributions
+        run: python scripts/prune_published.py
+
       - name: Publish
-        run: uv publish --check-url https://pypi.org/simple/
+        run: |
+          if compgen -G "dist/*.whl" > /dev/null || compgen -G "dist/*.tar.gz" > /dev/null; then
+            uv publish --check-url https://pypi.org/simple/
+          else
+            echo "All distributions already published; nothing to upload."
+          fi

--- a/.github/workflows/test.scripts.yaml
+++ b/.github/workflows/test.scripts.yaml
@@ -1,0 +1,29 @@
+name: Test - Scripts
+
+on:
+  pull_request:
+    paths:
+      - .github/workflows/test.scripts.yaml
+      - scripts/**
+  push:
+    branches:
+      - main
+      - rc
+    paths:
+      - .github/workflows/test.scripts.yaml
+      - scripts/**
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Repository
+        uses: actions/checkout@v6
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v8.1.0
+
+      - name: Run Tests
+        run: uvx pytest scripts

--- a/scripts/prune_published.py
+++ b/scripts/prune_published.py
@@ -37,11 +37,18 @@ def parse_name_version(filename: str) -> tuple[str, str]:
     name component never contains a hyphen and splitting on ``-`` is safe.
     """
     if filename.endswith(".whl"):
-        name, version = filename.split("-")[:2]
+        parts = filename.removesuffix(".whl").split("-")
+        if len(parts) not in (5, 6):
+            raise ValueError(f"malformed wheel file name: {filename}")
+        name, version = parts[:2]
     elif filename.endswith(".tar.gz"):
-        name, version = filename.removesuffix(".tar.gz").rsplit("-", 1)
+        name, _, version = filename.removesuffix(".tar.gz").rpartition("-")
+        if not name:
+            raise ValueError(f"malformed sdist file name: {filename}")
     else:
         raise ValueError(f"unrecognized distribution file: {filename}")
+    if not version[:1].isdigit():
+        raise ValueError(f"unable to parse version from file name: {filename}")
     return re.sub(r"[-_.]+", "-", name).lower(), version
 
 

--- a/scripts/prune_published.py
+++ b/scripts/prune_published.py
@@ -1,13 +1,11 @@
-#!/usr/bin/env python3
-
-# Copyright 2026 Synnax Labs, Inc.
+#  Copyright 2026 Synnax Labs, Inc.
 #
-# Use of this software is governed by the Business Source License included in the file
-# licenses/BSL.txt.
+#  Use of this software is governed by the Business Source License included in the file
+#  licenses/BSL.txt.
 #
-# As of the Change Date specified in that file, in accordance with the Business Source
-# License, use of this software will be governed by the Apache License, Version 2.0,
-# included in the file licenses/APL.txt.
+#  As of the Change Date specified in that file, in accordance with the Business Source
+#  License, use of this software will be governed by the Apache License, Version 2.0,
+#  included in the file licenses/APL.txt.
 
 """Removes distribution files from dist/ that already exist on PyPI.
 

--- a/scripts/prune_published.py
+++ b/scripts/prune_published.py
@@ -30,7 +30,12 @@ from pathlib import Path
 
 def parse_name_version(filename: str) -> tuple[str, str]:
     """Extracts the PEP 503 normalized project name and version from a wheel or
-    sdist file name."""
+    sdist file name.
+
+    Wheel (PEP 427) and sdist (PEP 625) file names escape the project name by
+    replacing runs of ``-_.`` with ``_`` (e.g. synnax-x -> synnax_x), so the
+    name component never contains a hyphen and splitting on ``-`` is safe.
+    """
     if filename.endswith(".whl"):
         name, version = filename.split("-")[:2]
     elif filename.endswith(".tar.gz"):

--- a/scripts/prune_published.py
+++ b/scripts/prune_published.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+
+# Copyright 2026 Synnax Labs, Inc.
+#
+# Use of this software is governed by the Business Source License included in the file
+# licenses/BSL.txt.
+#
+# As of the Change Date specified in that file, in accordance with the Business Source
+# License, use of this software will be governed by the Apache License, Version 2.0,
+# included in the file licenses/APL.txt.
+
+"""Removes distribution files from dist/ that already exist on PyPI.
+
+PyPI file names are immutable: once a file is published it can never be uploaded
+again, and rebuilding an unchanged package does not reproduce the published bytes
+across time (a build backend upgrade alone rewrites the wheel's WHEEL file), so
+uv's hash-based `--check-url` skipping fails for unchanged packages. Pruning by
+published file name limits `uv publish` to genuinely new files. Run by the deploy
+pipeline between `uv build` and `uv publish` (see SY-4519).
+
+Usage: prune_published.py [dist-dir]
+"""
+
+import json
+import re
+import sys
+import urllib.error
+import urllib.request
+from functools import cache
+from pathlib import Path
+
+
+def parse_name_version(filename: str) -> tuple[str, str]:
+    """Extracts the PEP 503 normalized project name and version from a wheel or
+    sdist file name."""
+    if filename.endswith(".whl"):
+        name, version = filename.split("-")[:2]
+    elif filename.endswith(".tar.gz"):
+        name, version = filename.removesuffix(".tar.gz").rsplit("-", 1)
+    else:
+        raise ValueError(f"unrecognized distribution file: {filename}")
+    return re.sub(r"[-_.]+", "-", name).lower(), version
+
+
+@cache
+def published_files(name: str, version: str) -> frozenset[str]:
+    """Returns the file names already published on PyPI for the given release, or
+    an empty set if the release does not exist."""
+    url = f"https://pypi.org/pypi/{name}/{version}/json"
+    try:
+        with urllib.request.urlopen(url) as resp:
+            release = json.load(resp)
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return frozenset()
+        raise
+    return frozenset(f["filename"] for f in release["urls"])
+
+
+def main() -> None:
+    dist_dir = (
+        Path(sys.argv[1])
+        if len(sys.argv) > 1
+        else Path(__file__).resolve().parent.parent / "dist"
+    )
+    if not dist_dir.is_dir():
+        sys.exit(f"❌ distribution directory not found: {dist_dir}")
+    dists = [p for p in dist_dir.iterdir() if p.name.endswith((".whl", ".tar.gz"))]
+    for file in sorted(dists):
+        name, version = parse_name_version(file.name)
+        if file.name in published_files(name, version):
+            print(f"↷ {file.name} already on PyPI, pruning")
+            file.unlink()
+        else:
+            print(f"→ {file.name} will be published")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/test_prune_published.py
+++ b/scripts/test_prune_published.py
@@ -1,0 +1,157 @@
+#  Copyright 2026 Synnax Labs, Inc.
+#
+#  Use of this software is governed by the Business Source License included in the file
+#  licenses/BSL.txt.
+#
+#  As of the Change Date specified in that file, in accordance with the Business Source
+#  License, use of this software will be governed by the Apache License, Version 2.0,
+#  included in the file licenses/APL.txt.
+
+import io
+import json
+import sys
+import urllib.error
+from pathlib import Path
+
+import pytest
+
+import prune_published
+
+
+@pytest.fixture(autouse=True)
+def clear_published_files_cache() -> None:
+    prune_published.published_files.cache_clear()
+
+
+class TestParseNameVersion:
+    """Tests for wheel and sdist file name parsing."""
+
+    @pytest.mark.parametrize(
+        ("filename", "name", "version"),
+        [
+            ("alamos-0.56.0-py3-none-any.whl", "alamos", "0.56.0"),
+            ("synnax_x-0.56.0-py3-none-any.whl", "synnax-x", "0.56.0"),
+            ("synnax_freighter-0.56.0-py3-none-any.whl", "synnax-freighter", "0.56.0"),
+            ("Some_Pkg-1.0-1-py3-none-any.whl", "some-pkg", "1.0"),
+            ("alamos-0.56.0.tar.gz", "alamos", "0.56.0"),
+            ("synnax_freighter-0.56.0.tar.gz", "synnax-freighter", "0.56.0"),
+            ("synnax-0.56.1.tar.gz", "synnax", "0.56.1"),
+        ],
+    )
+    def test_should_parse_normalized_name_and_version(
+        self, filename: str, name: str, version: str
+    ) -> None:
+        """Should extract the PEP 503 normalized name and the version."""
+        assert prune_published.parse_name_version(filename) == (name, version)
+
+    @pytest.mark.parametrize(
+        "filename",
+        [
+            ".gitignore",
+            "notes.txt",
+            "foo-py3-none-any.whl",
+            "synnax-x-0.56.0-py3-none-any.whl",
+            "foo.tar.gz",
+        ],
+    )
+    def test_should_reject_malformed_file_names(self, filename: str) -> None:
+        """Should raise instead of querying a nonexistent release."""
+        with pytest.raises(ValueError):
+            prune_published.parse_name_version(filename)
+
+
+class TestPublishedFiles:
+    """Tests for the PyPI release lookup."""
+
+    def test_should_return_file_names_for_existing_release(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Should collect the file names published for the release."""
+        body = json.dumps(
+            {"urls": [{"filename": "alamos-0.56.0-py3-none-any.whl"}]}
+        ).encode()
+        monkeypatch.setattr(
+            prune_published.urllib.request, "urlopen", lambda url: io.BytesIO(body)
+        )
+        assert prune_published.published_files("alamos", "0.56.0") == frozenset(
+            {"alamos-0.56.0-py3-none-any.whl"}
+        )
+
+    def test_should_return_empty_set_for_missing_release(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Should treat a 404 as an unpublished release."""
+
+        def raise_not_found(url: str) -> io.BytesIO:
+            raise urllib.error.HTTPError(url, 404, "Not Found", None, None)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(prune_published.urllib.request, "urlopen", raise_not_found)
+        assert prune_published.published_files("alamos", "9.9.9") == frozenset()
+
+    def test_should_propagate_other_http_errors(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Should not swallow non-404 failures."""
+
+        def raise_server_error(url: str) -> io.BytesIO:
+            raise urllib.error.HTTPError(url, 503, "Unavailable", None, None)  # type: ignore[arg-type]
+
+        monkeypatch.setattr(
+            prune_published.urllib.request, "urlopen", raise_server_error
+        )
+        with pytest.raises(urllib.error.HTTPError):
+            prune_published.published_files("alamos", "0.56.0")
+
+
+class TestMain:
+    """Tests for the pruning entry point."""
+
+    def test_should_prune_published_and_keep_new_files(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Should delete already-published files and keep unpublished ones."""
+        (tmp_path / "alamos-0.56.0-py3-none-any.whl").touch()
+        (tmp_path / "alamos-0.56.0.tar.gz").touch()
+        (tmp_path / "synnax-0.56.1-py3-none-any.whl").touch()
+        (tmp_path / ".gitignore").touch()
+        published = {
+            ("alamos", "0.56.0"): frozenset(
+                {"alamos-0.56.0-py3-none-any.whl", "alamos-0.56.0.tar.gz"}
+            )
+        }
+        monkeypatch.setattr(
+            prune_published,
+            "published_files",
+            lambda name, version: published.get((name, version), frozenset()),
+        )
+        monkeypatch.setattr(sys, "argv", ["prune_published.py", str(tmp_path)])
+        prune_published.main()
+        assert sorted(p.name for p in tmp_path.iterdir()) == [
+            ".gitignore",
+            "synnax-0.56.1-py3-none-any.whl",
+        ]
+
+    def test_should_keep_missing_file_of_partially_published_release(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Should retry the sdist when only the wheel made it to PyPI."""
+        (tmp_path / "alamos-0.56.0-py3-none-any.whl").touch()
+        (tmp_path / "alamos-0.56.0.tar.gz").touch()
+        monkeypatch.setattr(
+            prune_published,
+            "published_files",
+            lambda name, version: frozenset({"alamos-0.56.0-py3-none-any.whl"}),
+        )
+        monkeypatch.setattr(sys, "argv", ["prune_published.py", str(tmp_path)])
+        prune_published.main()
+        assert [p.name for p in tmp_path.iterdir()] == ["alamos-0.56.0.tar.gz"]
+
+    def test_should_exit_when_dist_directory_is_missing(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Should fail loudly when the dist directory does not exist."""
+        monkeypatch.setattr(
+            sys, "argv", ["prune_published.py", str(tmp_path / "nonexistent")]
+        )
+        with pytest.raises(SystemExit):
+            prune_published.main()


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4519](https://linear.app/synnax/issue/SY-4519)

## Description

Follow-up to #2638, whose `--check-url`-only approach failed on the next deploy ([run](https://github.com/synnaxlabs/synnax/actions/runs/30373674859/job/90323744892)) with:

```
error: Local file and index file do not match for alamos-0.56.0-py3-none-any.whl.
```

Root cause: `--check-url` skips a duplicate only when the local file is **byte-identical** to the published one, and rebuilds of unchanged packages are not reproducible across time. Diffing the published `alamos-0.56.0` wheel against a fresh build shows exactly one difference — `Generator: hatchling 1.29.0` vs `1.31.0` in the `WHEEL` file — which changes the hash. Any build-backend upgrade breaks hash equality for every package that wasn't version-bumped.

Since PyPI file names are immutable regardless of contents, the correct skip criterion is the **file name**, not the hash:

- New `scripts/prune_published.py` runs between `uv build` and `uv publish`: it queries the PyPI JSON API for each built distribution and deletes files whose exact names are already published, leaving only genuinely new files to upload. Checking per file (rather than per version) lets a partially uploaded release retry its missing files.
- The publish step skips cleanly when everything was pruned (e.g. a `uv.lock`-only change with no version bumps), and keeps `--check-url` as a guard against concurrent runs racing on the same upload.

Verified locally: built all four packages plus the currently unpublished `synnax` 0.56.1 into a dist directory and ran the script — it pruned the six already-published 0.56.0 files and kept `synnax-0.56.1` (both wheel and sdist).

Once merged, the workflow re-triggers and should finally publish `synnax` 0.56.1.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds release-safe Python distribution pruning and automated coverage.
- Queries PyPI by normalized package name and version, removing only distribution filenames already published.
- Validates wheel and sdist filename parsing, including escaped project names and malformed inputs.
- Skips publishing when all built artifacts were pruned while retaining `--check-url` for concurrent-upload protection.
- Adds script-focused pytest coverage and a dedicated GitHub Actions workflow.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| scripts/prune_published.py | Adds validated distribution filename parsing, cached PyPI release lookups, and exact-filename pruning before publication. |
| scripts/test_prune_published.py | Covers normalized names, wheel build tags, malformed artifacts, PyPI responses, partial releases, pruning, and missing directories. |
| .github/workflows/deploy.py.yaml | Inserts pruning after all builds and conditionally publishes only when distribution artifacts remain. |
| .github/workflows/test.scripts.yaml | Adds path-filtered CI execution for tests under scripts. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant CI as Python Deploy Workflow
    participant Build as uv build
    participant Prune as prune_published.py
    participant PyPI as PyPI JSON API
    participant Publish as uv publish
    CI->>Build: Build four Python packages
    Build-->>Prune: Write wheel and sdist artifacts to dist/
    loop Each distribution
        Prune->>PyPI: Query package/version metadata
        PyPI-->>Prune: Return published filenames
        alt Exact filename already exists
            Prune->>Prune: Delete local artifact
        else Filename is unpublished
            Prune->>Prune: Retain local artifact
        end
    end
    alt Artifacts remain
        CI->>Publish: Publish with --check-url
    else Everything was pruned
        CI->>CI: Skip publication cleanly
    end
```

<sub>Reviews (3): Last reviewed commit: ["SY-4519: Validate Distribution File Name..."](https://github.com/synnaxlabs/synnax/commit/64bf5105aa8535f87b887447f892033d0aecd24b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=47987182)</sub>

<!-- /greptile_comment -->