### PR TITLE
SY-4535: Add a name to the node metrics writer

### DIFF
--- a/core/pkg/service/metrics/metrics_test.go
+++ b/core/pkg/service/metrics/metrics_test.go
@@ -11,6 +11,7 @@ package metrics_test
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -341,6 +342,46 @@ var _ = Describe("Metrics", func() {
 			Expect(parentsAfterReopen).To(HaveLen(1))
 			Expect(parentsAfterReopen[0].ID).To(Equal(metricsGroup.OntologyID()))
 
+			Expect(svc.Close()).To(Succeed())
+		})
+	})
+	Describe("Writer Control Subject", func() {
+		It("Should name the writer after the host node", func(ctx SpecContext) {
+			svc := MustSucceed(metrics.OpenService(ctx, metrics.ServiceConfig{
+				Channel:            channelSvc,
+				Group:              groupSvc,
+				Ontology:           otg,
+				Framer:             framerSvc,
+				HostProvider:       dist.Cluster,
+				DB:                 dist.DB,
+				Storage:            dist.Storage,
+				CollectionInterval: 100 * time.Millisecond,
+			}))
+			var controlCh channel.Channel
+			Expect(channelSvc.NewRetrieve().
+				Where(channel.MatchNames(fmt.Sprintf(
+					"sy_node_%v_control", dist.Cluster.HostKey(),
+				))).
+				Entry(&controlCh).
+				Exec(ctx, nil),
+			).To(Succeed())
+			streamer := MustSucceed(framerSvc.NewStreamer(ctx, framer.StreamerConfig{
+				Keys: []channel.Key{controlCh.Key()},
+			}))
+			sCtx := signal.Wrap(ctx)
+			requests, responses := confluence.Attach(streamer, 2)
+			streamer.Flow(sCtx, confluence.CloseOutputInletsOnExit())
+			var res framer.StreamerResponse
+			Eventually(responses.Outlet()).Should(Receive(&res))
+			var state string
+			for _, s := range res.Frame.Entries() {
+				state += string(s.Data)
+			}
+			Expect(state).To(ContainSubstring(fmt.Sprintf(
+				"Node %v Metrics Writer", dist.Cluster.HostKey(),
+			)))
+			requests.Close()
+			Eventually(responses.Outlet()).Should(BeClosed())
 			Expect(svc.Close()).To(Succeed())
 		})
 	})

--- a/core/pkg/service/metrics/metrics_test.go
+++ b/core/pkg/service/metrics/metrics_test.go
@@ -16,6 +16,7 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	"github.com/synnaxlabs/cesium"
 	"github.com/synnaxlabs/synnax/pkg/distribution/framer/frame"
 	"github.com/synnaxlabs/synnax/pkg/service/channel"
 	"github.com/synnaxlabs/synnax/pkg/service/framer"
@@ -347,7 +348,7 @@ var _ = Describe("Metrics", func() {
 	})
 	Describe("Writer Control Subject", func() {
 		It("Should name the writer after the host node", func(ctx SpecContext) {
-			svc := MustSucceed(metrics.OpenService(ctx, metrics.ServiceConfig{
+			MustOpen(metrics.OpenService(ctx, metrics.ServiceConfig{
 				Channel:            channelSvc,
 				Group:              groupSvc,
 				Ontology:           otg,
@@ -371,18 +372,22 @@ var _ = Describe("Metrics", func() {
 			sCtx := signal.Wrap(ctx)
 			requests, responses := confluence.Attach(streamer, 2)
 			streamer.Flow(sCtx, confluence.CloseOutputInletsOnExit())
+			DeferCleanup(func() {
+				requests.Close()
+				Eventually(responses.Outlet()).Should(BeClosed())
+			})
 			var res framer.StreamerResponse
 			Eventually(responses.Outlet()).Should(Receive(&res))
-			var state string
-			for _, s := range res.Frame.Entries() {
-				state += string(s.Data)
+			update := MustSucceed(cesium.DecodeControlUpdate(res.Frame.SeriesAt(0)))
+			holders := make([]string, 0, len(update.Transfers))
+			for _, t := range update.Transfers {
+				if t.To != nil {
+					holders = append(holders, t.To.Subject.Name)
+				}
 			}
-			Expect(state).To(ContainSubstring(fmt.Sprintf(
+			Expect(holders).To(ContainElement(fmt.Sprintf(
 				"Node %v Metrics Writer", dist.Cluster.HostKey(),
 			)))
-			requests.Close()
-			Eventually(responses.Outlet()).Should(BeClosed())
-			Expect(svc.Close()).To(Succeed())
 		})
 	})
 	Describe("Metric Collection", func() {

--- a/core/pkg/service/metrics/service.go
+++ b/core/pkg/service/metrics/service.go
@@ -27,6 +27,7 @@ import (
 	"github.com/synnaxlabs/x/config"
 	"github.com/synnaxlabs/x/confluence"
 	"github.com/synnaxlabs/x/confluence/plumber"
+	"github.com/synnaxlabs/x/control"
 	"github.com/synnaxlabs/x/gorp"
 	"github.com/synnaxlabs/x/override"
 	"github.com/synnaxlabs/x/signal"
@@ -236,6 +237,9 @@ func OpenService(ctx context.Context, cfgs ...ServiceConfig) (*Service, error) {
 	w, err := cfg.Framer.NewStreamWriter(
 		ctx,
 		framer.WriterConfig{
+			ControlSubject: control.Subject{
+				Name: fmt.Sprintf("Node %v Metrics Writer", cfg.HostProvider.HostKey()),
+			},
 			Keys:                     channel.KeysFromChannels(metricsChannels),
 			AutoIndex:                new(true),
 			AutoIndexPersistInterval: telem.Second * 30,


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4535](https://linear.app/synnax/issue/SY-4535)

## Description

The metrics service opened its frame writer with the default control subject: a
random UUID key and no name. Anything surfacing control state for the node metrics
channels (the `sy_node_N_control` channel, control legends) showed an anonymous
UUID instead of a recognizable owner.

The writer now sets a human-readable control subject name, `Node N Metrics Writer`,
derived from the host key. The subject key keeps its generated UUID default so two
service instances (as exercised by the channel-reuse test) never collide inside a
control region.

Also adds a test that streams the node control channel and asserts the writer's
subject name appears in the control state snapshot.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR gives each node metrics writer a human-readable control subject name while preserving its generated unique key.
- Names the writer `Node N Metrics Writer` using the host node key.
- Adds coverage that streams the node control channel and verifies the name in its control-state snapshot.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The configured subject name overlays the writer defaults without replacing the generated unique key, and the added test exercises the resulting control-state representation.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| core/pkg/service/metrics/service.go | Adds the host-derived control subject name while the writer configuration retains its generated UUID key. |
| core/pkg/service/metrics/metrics_test.go | Adds an integration-style assertion that the metrics writer name appears in streamed control state. |

<sub>Reviews (1): Last reviewed commit: ["Add a control subject name to the node m..."](https://github.com/synnaxlabs/synnax/commit/924799a8ebc6519bc6f5bd59d26fdecfcd1a48fa) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=48901304)</sub>

<!-- /greptile_comment -->