### PR TITLE
SY-4541: Bound websocket stream teardown so a silent client cannot hang Core shutdown

### DIFF
--- a/freighter/go/http/router.go
+++ b/freighter/go/http/router.go
@@ -40,11 +40,7 @@ type RouterConfig struct {
 	StreamWriteDeadline time.Duration
 }
 
-var (
-	_ config.Config[RouterConfig] = RouterConfig{}
-	// DefaultRouterConfig is the default configuration for a Router.
-	DefaultRouterConfig = RouterConfig{StreamWriteDeadline: 10 * time.Second}
-)
+var _ config.Config[RouterConfig] = RouterConfig{}
 
 // Validate implements config.Config.
 func (RouterConfig) Validate() error { return nil }
@@ -62,7 +58,10 @@ func (r RouterConfig) Override(other RouterConfig) RouterConfig {
 // returned Router will be bound to a fiber.App by calling Router.BindTo. Returns an
 // error if the merged config fails to validate.
 func NewRouter(configs ...RouterConfig) (*Router, error) {
-	cfg, err := config.New(DefaultRouterConfig, configs...)
+	cfg, err := config.New(
+		RouterConfig{StreamWriteDeadline: 10 * time.Second},
+		configs...,
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/freighter/go/http/router.go
+++ b/freighter/go/http/router.go
@@ -40,7 +40,11 @@ type RouterConfig struct {
 	StreamWriteDeadline time.Duration
 }
 
-var _ config.Config[RouterConfig] = RouterConfig{}
+var (
+	_ config.Config[RouterConfig] = RouterConfig{}
+	// DefaultRouterConfig is the default configuration for a Router.
+	DefaultRouterConfig = RouterConfig{StreamWriteDeadline: 10 * time.Second}
+)
 
 // Validate implements config.Config.
 func (RouterConfig) Validate() error { return nil }
@@ -58,7 +62,7 @@ func (r RouterConfig) Override(other RouterConfig) RouterConfig {
 // returned Router will be bound to a fiber.App by calling Router.BindTo. Returns an
 // error if the merged config fails to validate.
 func NewRouter(configs ...RouterConfig) (*Router, error) {
-	cfg, err := config.New(RouterConfig{}, configs...)
+	cfg, err := config.New(DefaultRouterConfig, configs...)
 	if err != nil {
 		return nil, err
 	}

--- a/freighter/go/http/stream.go
+++ b/freighter/go/http/stream.go
@@ -168,5 +168,12 @@ func (c *streamCore[I, O]) listenForContextCancellation() {
 		); err != nil && !errors.Is(err, websocket.ErrCloseSent) {
 			c.L.Error("error sending close message: %v \n", zap.Error(err))
 		}
+		// The close message only asks the peer to leave. Without a deadline, a peer
+		// that never answers blocks the reader, and with it the server's shutdown.
+		if err := c.conn.SetReadDeadline(
+			time.Now().Add(closeReadWriteDeadline),
+		); err != nil {
+			c.L.Error("error setting close read deadline", zap.Error(err))
+		}
 	}
 }

--- a/freighter/go/http/stream.go
+++ b/freighter/go/http/stream.go
@@ -164,7 +164,7 @@ func (c *streamCore[I, O]) listenForContextCancellation() {
 		if err := c.conn.WriteControl(
 			websocket.CloseMessage,
 			websocket.FormatCloseMessage(contextCancelledCloseCode, ""),
-			time.Now().Add(time.Second),
+			time.Now().Add(closeReadWriteDeadline),
 		); err != nil && !errors.Is(err, websocket.ErrCloseSent) {
 			c.L.Error("error sending close message: %v \n", zap.Error(err))
 		}

--- a/freighter/go/http/stream.go
+++ b/freighter/go/http/stream.go
@@ -168,8 +168,8 @@ func (c *streamCore[I, O]) listenForContextCancellation() {
 		); err != nil && !errors.Is(err, websocket.ErrCloseSent) {
 			c.L.Error("error sending close message: %v \n", zap.Error(err))
 		}
-		// The close message only asks the peer to leave. Without a deadline, a peer
-		// that never answers blocks the reader, and with it the server's shutdown.
+		// A peer that never answers the close message blocks the reader forever, and
+		// the server's shutdown with it.
 		if err := c.conn.SetReadDeadline(
 			time.Now().Add(closeReadWriteDeadline),
 		); err != nil {

--- a/freighter/go/http/stream_server.go
+++ b/freighter/go/http/stream_server.go
@@ -238,8 +238,7 @@ func (s *serverStream[RQ, RS]) close(err error) (closeErr error) {
 		return err
 	}
 
-	// Wait until the client acknowledges the closure. A silent peer trips the read
-	// deadline set above, which ends the wait as surely as an acknowledgement.
+	// Wait until the client acknowledges the closure.
 	for {
 		if _, err = s.receiveRaw(); err != nil {
 			if !ws.IsCloseError(err, ws.CloseNormalClosure, ws.CloseGoingAway) &&

--- a/freighter/go/http/stream_server.go
+++ b/freighter/go/http/stream_server.go
@@ -11,6 +11,7 @@ package http
 
 import (
 	"context"
+	"os"
 	"sync"
 	"syscall"
 	"time"
@@ -237,10 +238,12 @@ func (s *serverStream[RQ, RS]) close(err error) (closeErr error) {
 		return err
 	}
 
-	// Wait until the client acknowledges the closure.
+	// Wait until the client acknowledges the closure. A silent peer trips the read
+	// deadline set above, which ends the wait as surely as an acknowledgement.
 	for {
 		if _, err = s.receiveRaw(); err != nil {
-			if !ws.IsCloseError(err, ws.CloseNormalClosure, ws.CloseGoingAway) {
+			if !ws.IsCloseError(err, ws.CloseNormalClosure, ws.CloseGoingAway) &&
+				!errors.Is(err, os.ErrDeadlineExceeded) {
 				s.L.Error(
 					"expected normal closure, received error instead",
 					zap.Error(err),

--- a/freighter/go/http/stream_test.go
+++ b/freighter/go/http/stream_test.go
@@ -99,3 +99,52 @@ var _ = Describe("Stream", Ordered, Serial, func() {
 		})
 	})
 })
+
+var _ = Describe("Stream Shutdown", Serial, func() {
+	It("Should stop serving a stream whose peer never answers the close message", func(ctx SpecContext) {
+		ShouldNotLeakGoroutines()
+		addr := address.Newf("localhost:%d", MustSucceed(net.FindOpenPort()))
+		app := newFiberApp(fiber.Config{})
+		router := MustSucceed(fhttp.NewRouter(fhttp.RouterConfig{
+			StreamWriteDeadline: test.WriteDeadline,
+		}))
+		app.Get("/health", func(c fiber.Ctx) error {
+			return c.SendStatus(fiber.StatusOK)
+		})
+		server := fhttp.NewStreamServer[test.Request, test.Response](router, "/")
+		serving := make(chan struct{})
+		server.BindHandler(func(
+			_ context.Context,
+			stream freighter.ServerStream[test.Request, test.Response],
+		) error {
+			close(serving)
+			_, err := stream.Receive()
+			return err
+		})
+		router.BindTo(app)
+		go func() {
+			defer GinkgoRecover()
+			Expect(app.Listen(addr.PortString(), fiber.ListenConfig{
+				DisableStartupMessage: true,
+			})).To(Succeed())
+		}()
+		Eventually(func(g Gomega) {
+			g.Expect(pollHealth("http://" + addr.String() + "/health")).To(Succeed())
+		}).WithPolling(time.Millisecond).Should(Succeed())
+
+		// A raw peer that upgrades and then never reads. Control frames are only
+		// processed inside a read, so the close message goes unanswered.
+		headers := http.Header{}
+		headers.Set(fiber.HeaderContentType, "application/json")
+		conn, res := MustSucceed2((&ws.Dialer{}).DialContext(
+			ctx, "ws://"+addr.String()+"/", headers,
+		))
+		DeferCleanup(func() { Expect(conn.Close()).To(Succeed()) })
+		Expect(res.Body.Close()).To(Succeed())
+		Eventually(serving).Should(BeClosed())
+
+		shutdown := make(chan error, 1)
+		go func() { shutdown <- app.Shutdown() }()
+		Eventually(shutdown, 5*time.Second).Should(Receive(BeNil()))
+	})
+})

--- a/freighter/go/http/stream_test.go
+++ b/freighter/go/http/stream_test.go
@@ -27,9 +27,8 @@ import (
 	. "github.com/synnaxlabs/x/testutil"
 )
 
-// serveRouter binds the router to a fresh fiber app, serves it on an open port, and
-// returns once the app is answering requests. All stream servers must be registered
-// on the router first.
+// serveRouter serves the router on an open port, returning once the app is answering
+// requests. All servers must be registered on the router first.
 func serveRouter(router *fhttp.Router) (*fiber.App, address.Address) {
 	addr := address.Newf("localhost:%d", MustSucceed(net.FindOpenPort()))
 	app := newFiberApp(fiber.Config{})
@@ -106,39 +105,39 @@ var _ = Describe("Stream", Ordered, Serial, func() {
 			Expect(res.StatusCode).To(Equal(http.StatusUpgradeRequired))
 		})
 	})
-})
 
-var _ = Describe("Stream Shutdown", Serial, func() {
-	It("Should stop serving a stream whose peer never answers the close message", func(ctx SpecContext) {
-		ShouldNotLeakGoroutines()
-		router := MustSucceed(fhttp.NewRouter(fhttp.RouterConfig{
-			StreamWriteDeadline: test.WriteDeadline,
-		}))
-		server := fhttp.NewStreamServer[test.Request, test.Response](router, "/")
-		serving := make(chan struct{})
-		server.BindHandler(func(
-			_ context.Context,
-			stream freighter.ServerStream[test.Request, test.Response],
-		) error {
-			close(serving)
-			_, err := stream.Receive()
-			return err
+	Describe("Shutdown", func() {
+		// Serves its own app: shutting down the shared one would strand later specs.
+		It("should stop serving a stream whose peer never answers the close message", func(ctx SpecContext) {
+			router := MustSucceed(fhttp.NewRouter(fhttp.RouterConfig{
+				StreamWriteDeadline: test.WriteDeadline,
+			}))
+			ownServer := fhttp.NewStreamServer[test.Request, test.Response](router, "/")
+			serving := make(chan struct{})
+			ownServer.BindHandler(func(
+				_ context.Context,
+				stream freighter.ServerStream[test.Request, test.Response],
+			) error {
+				close(serving)
+				_, err := stream.Receive()
+				return err
+			})
+			ownApp, ownAddr := serveRouter(router)
+
+			// A raw peer that upgrades and then never reads. Control frames are only
+			// processed inside a read, so the close message goes unanswered.
+			headers := http.Header{}
+			headers.Set(fiber.HeaderContentType, "application/json")
+			conn, res := MustSucceed2((&ws.Dialer{}).DialContext(
+				ctx, "ws://"+ownAddr.String()+"/", headers,
+			))
+			DeferCleanup(func() { Expect(conn.Close()).To(Succeed()) })
+			Expect(res.Body.Close()).To(Succeed())
+			Eventually(serving).Should(BeClosed())
+
+			shutdown := make(chan error, 1)
+			go func() { shutdown <- ownApp.Shutdown() }()
+			Eventually(shutdown, 5*time.Second).Should(Receive(BeNil()))
 		})
-		app, addr := serveRouter(router)
-
-		// A raw peer that upgrades and then never reads. Control frames are only
-		// processed inside a read, so the close message goes unanswered.
-		headers := http.Header{}
-		headers.Set(fiber.HeaderContentType, "application/json")
-		conn, res := MustSucceed2((&ws.Dialer{}).DialContext(
-			ctx, "ws://"+addr.String()+"/", headers,
-		))
-		DeferCleanup(func() { Expect(conn.Close()).To(Succeed()) })
-		Expect(res.Body.Close()).To(Succeed())
-		Eventually(serving).Should(BeClosed())
-
-		shutdown := make(chan error, 1)
-		go func() { shutdown <- app.Shutdown() }()
-		Eventually(shutdown, 5*time.Second).Should(Receive(BeNil()))
 	})
 })

--- a/freighter/go/http/stream_test.go
+++ b/freighter/go/http/stream_test.go
@@ -27,6 +27,28 @@ import (
 	. "github.com/synnaxlabs/x/testutil"
 )
 
+// serveRouter binds the router to a fresh fiber app, serves it on an open port, and
+// returns once the app is answering requests. All stream servers must be registered
+// on the router first.
+func serveRouter(router *fhttp.Router) (*fiber.App, address.Address) {
+	addr := address.Newf("localhost:%d", MustSucceed(net.FindOpenPort()))
+	app := newFiberApp(fiber.Config{})
+	app.Get("/health", func(c fiber.Ctx) error {
+		return c.SendStatus(fiber.StatusOK)
+	})
+	router.BindTo(app)
+	go func() {
+		defer GinkgoRecover()
+		Expect(app.Listen(addr.PortString(), fiber.ListenConfig{
+			DisableStartupMessage: true,
+		})).To(Succeed())
+	}()
+	Eventually(func(g Gomega) {
+		g.Expect(pollHealth("http://" + addr.String() + "/health")).To(Succeed())
+	}).WithPolling(time.Millisecond).Should(Succeed())
+	return app, addr
+}
+
 var _ = Describe("Stream", Ordered, Serial, func() {
 	var (
 		server freighter.StreamServer[test.Request, test.Response]
@@ -37,28 +59,14 @@ var _ = Describe("Stream", Ordered, Serial, func() {
 
 	BeforeAll(func() {
 		ShouldNotLeakGoroutines()
-		addr = address.Newf("localhost:%d", MustSucceed(net.FindOpenPort()))
-		app = newFiberApp(fiber.Config{})
 		router := MustSucceed(fhttp.NewRouter(fhttp.RouterConfig{
 			StreamWriteDeadline: test.WriteDeadline,
 		}))
-		app.Get("/health", func(c fiber.Ctx) error {
-			return c.SendStatus(fiber.StatusOK)
-		})
 		server = fhttp.NewStreamServer[test.Request, test.Response](router, "/")
 		client = MustSucceed(fhttp.NewStreamClient[test.Request, test.Response](
 			fhttp.StreamClientConfig{Codec: json.Codec},
 		))
-		router.BindTo(app)
-		go func() {
-			defer GinkgoRecover()
-			Expect(app.Listen(addr.PortString(), fiber.ListenConfig{
-				DisableStartupMessage: true,
-			})).To(Succeed())
-		}()
-		Eventually(func(g Gomega) {
-			g.Expect(pollHealth("http://" + addr.String() + "/health")).To(Succeed())
-		}).WithPolling(1 * time.Millisecond).Should(Succeed())
+		app, addr = serveRouter(router)
 	})
 
 	AfterAll(func() { Expect(app.Shutdown()).To(Succeed()) })
@@ -103,14 +111,9 @@ var _ = Describe("Stream", Ordered, Serial, func() {
 var _ = Describe("Stream Shutdown", Serial, func() {
 	It("Should stop serving a stream whose peer never answers the close message", func(ctx SpecContext) {
 		ShouldNotLeakGoroutines()
-		addr := address.Newf("localhost:%d", MustSucceed(net.FindOpenPort()))
-		app := newFiberApp(fiber.Config{})
 		router := MustSucceed(fhttp.NewRouter(fhttp.RouterConfig{
 			StreamWriteDeadline: test.WriteDeadline,
 		}))
-		app.Get("/health", func(c fiber.Ctx) error {
-			return c.SendStatus(fiber.StatusOK)
-		})
 		server := fhttp.NewStreamServer[test.Request, test.Response](router, "/")
 		serving := make(chan struct{})
 		server.BindHandler(func(
@@ -121,16 +124,7 @@ var _ = Describe("Stream Shutdown", Serial, func() {
 			_, err := stream.Receive()
 			return err
 		})
-		router.BindTo(app)
-		go func() {
-			defer GinkgoRecover()
-			Expect(app.Listen(addr.PortString(), fiber.ListenConfig{
-				DisableStartupMessage: true,
-			})).To(Succeed())
-		}()
-		Eventually(func(g Gomega) {
-			g.Expect(pollHealth("http://" + addr.String() + "/health")).To(Succeed())
-		}).WithPolling(time.Millisecond).Should(Succeed())
+		app, addr := serveRouter(router)
 
 		// A raw peer that upgrades and then never reads. Control frames are only
 		// processed inside a read, so the close message goes unanswered.


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4541](https://linear.app/synnax/issue/SY-4541)

## Description

A Core with connected Consoles could receive `SIGINT`, log "Synnax is shutting down", and then never exit, leaving `kill -9` as the only way out.

When the server shuts down, Freighter's router cancels its stream context and waits for every websocket handler to return. Cancelling a stream only wrote a websocket close control message; it never closed the socket and never set a read deadline, and fasthttp clears all deadlines on a connection before hijacking it. So a peer that did not answer the close left the server's reader blocked forever, the post-shutdown drain never finished, and because `server.Close()` runs third in the reverse-ordered `MultiCloser`, the service, distribution, Aspen, and storage layers never began closing either.

The handler-initiated close path already solved this: it writes the close message, sets a 500ms read deadline, then waits for the acknowledgement. The shutdown path now does the same thing, so a silent peer costs a bounded wait rather than the entire teardown. No new synchronization is introduced: no extra goroutine, timer, or config, just a deadline on a socket that had none. The drain stays unbounded because every handler is now guaranteed to return.

Two smaller changes ride along:

- The close acknowledgement wait legitimately times out against a silent peer, so `os.ErrDeadlineExceeded` joins the expected-closure cases instead of logging at error level on every shutdown.
- `RouterConfig.StreamWriteDeadline` documented a ten second default that was never applied, leaving the deadline at zero for every caller except Core. A blocked write hangs teardown exactly like a blocked read, so the documented default is now real.

Verification, against a Core built from this branch:

- The scenario that previously hung indefinitely, a client holding a change stream with a blocked event loop, now shuts down in 604ms while the client stays wedged for a further 113 seconds.
- The healthy path, four clients with four streamers and four writers, shuts down in 0.14s, unchanged.
- The new spec drives a raw peer that upgrades and then never reads, so control frames are never processed. It fails by timeout without the fix and passes in 0.6s with it.

Related but deliberately out of scope: `SecureHTTPBranch.Stop` calls `fiber.App.Shutdown()`, which passes `context.Background()` to fasthttp and therefore waits without bound for non-hijacked connections. That path wants its own timeout and is not touched here.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR bounds websocket stream teardown by applying a read deadline after server cancellation and treats the resulting timeout as an expected close condition. It also activates the Router’s documented stream-write deadline default and adds coverage for a peer that never acknowledges shutdown.
- Adds a 500 ms read deadline to the server-cancellation close path.
- Suppresses expected deadline errors while waiting for close acknowledgement.
- Applies the documented ten-second default stream-write deadline.
- Adds an end-to-end shutdown test using a silent websocket peer.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the silent-peer shutdown path bounded and covered by an end-to-end test.

The cancellation listener now installs a finite read deadline that releases a blocked stream handler, while normal acknowledgement and configured write-deadline behavior remain intact.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| freighter/go/http/router.go | Applies the previously documented ten-second stream-write deadline through the Router’s default configuration. |
| freighter/go/http/stream.go | Bounds cancellation-driven websocket reads after sending the close control frame. |
| freighter/go/http/stream_server.go | Treats the deliberately induced close-read timeout as an expected shutdown outcome. |
| freighter/go/http/stream_test.go | Verifies that application shutdown completes when an upgraded websocket peer never processes the close frame. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant App as Fiber App
  participant Router
  participant Listener as Cancellation Listener
  participant Peer as Websocket Peer
  App->>Router: Post-shutdown hook
  Router->>Listener: Cancel stream context
  Listener->>Peer: Send close control frame
  Listener->>Listener: Set 500 ms read deadline
  alt Peer acknowledges
    Peer-->>Listener: Close acknowledgement
  else Peer remains silent
    Listener-->>Listener: Read deadline expires
  end
  Router->>Router: Stream handler exits
  Router-->>App: Drain completes
```

<sub>Reviews (1): Last reviewed commit: ["Bound websocket stream teardown with a r..."](https://github.com/synnaxlabs/synnax/commit/e5ebfe736454691fba97c8f6d790c3bc8b43448b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=49422501)</sub>

**Context used:**

- Knowledge Base — [Freighter Transport Library](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/freighter-transport.md)

<!-- /greptile_comment -->