### PR TITLE
SY-4489: Add Boolean Icon to Boolean Channel

### DIFF
--- a/pluto/src/telem/resolveDataTypeIcon.spec.ts
+++ b/pluto/src/telem/resolveDataTypeIcon.spec.ts
@@ -14,6 +14,10 @@ import { Icon } from "@/icon";
 import { resolveDataTypeIcon } from "@/telem/resolveDataTypeIcon";
 
 describe("resolveDataTypeIcon", () => {
+  it("should return the Boolean icon for BOOLEAN data type", () => {
+    expect(resolveDataTypeIcon(DataType.BOOLEAN)).toBe(Icon.Boolean);
+  });
+
   it("should return the JSON icon for JSON data type", () => {
     expect(resolveDataTypeIcon(DataType.JSON)).toBe(Icon.JSON);
   });

--- a/pluto/src/telem/resolveDataTypeIcon.ts
+++ b/pluto/src/telem/resolveDataTypeIcon.ts
@@ -12,6 +12,7 @@ import { DataType } from "@synnaxlabs/x";
 import { Icon } from "@/icon";
 
 export const resolveDataTypeIcon = (d: DataType): Icon.FC | undefined => {
+  if (d.equals(DataType.BOOLEAN)) return Icon.Boolean;
   if (d.equals(DataType.JSON)) return Icon.JSON;
   if (d.equals(DataType.BYTES)) return Icon.Binary;
   if (d.isInteger) return Icon.Binary;

--- a/x/ts/src/telem/telem.ts
+++ b/x/ts/src/telem/telem.ts
@@ -2113,12 +2113,12 @@ export class DataType
     DataType.INT64,
     DataType.FLOAT32,
     DataType.FLOAT64,
+    DataType.BOOLEAN,
     DataType.TIMESTAMP,
     DataType.UUID,
     DataType.STRING,
     DataType.JSON,
     DataType.BYTES,
-    DataType.BOOLEAN,
   ];
 
   private static readonly SHORT_STRINGS = new Map<string, string>([
@@ -2132,12 +2132,12 @@ export class DataType
     [DataType.INT64.toString(), "i64"],
     [DataType.FLOAT32.toString(), "f32"],
     [DataType.FLOAT64.toString(), "f64"],
+    [DataType.BOOLEAN.toString(), "bool"],
     [DataType.TIMESTAMP.toString(), "ts"],
     [DataType.UUID.toString(), "uuid"],
     [DataType.STRING.toString(), "str"],
     [DataType.JSON.toString(), "json"],
     [DataType.BYTES.toString(), "bytes"],
-    [DataType.BOOLEAN.toString(), "bool"],
   ]);
 
   static readonly BIG_INT_TYPES = [DataType.INT64, DataType.UINT64, DataType.TIMESTAMP];


### PR DESCRIPTION
Add a Boolean icon to the data type selector so `bool` channels are visually
distinct from numeric types.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a dedicated Boolean icon mapping so `bool` channels are visually distinct in data-type selectors and channel displays.
- Maps `DataType.BOOLEAN` to `Icon.Boolean`.
- Adds a focused unit test for the Boolean mapping.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The Boolean icon is valid and exported through the expected namespace, existing callers can render it, and the exact-match branch does not conflict with other data-type classifications.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pluto/src/telem/resolveDataTypeIcon.ts | Correctly adds an exact Boolean data-type mapping to the existing icon resolver. |
| pluto/src/telem/resolveDataTypeIcon.spec.ts | Adds focused coverage asserting that Boolean resolves to the dedicated icon. |

<sub>Reviews (1): Last reviewed commit: ["SY-4489: Add boolean icon to boolean cha..."](https://github.com/synnaxlabs/synnax/commit/01de562c7143a0bc218d90c30324184107351ab8) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=50115252)</sub>

<!-- /greptile_comment -->