### PR TITLE
SY-4558: Restore Arc token colors after the Monaco v36 theme id rename

### DIFF
--- a/pluto/src/code/Editor.spec.tsx
+++ b/pluto/src/code/Editor.spec.tsx
@@ -12,7 +12,7 @@ import { createRef } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Editor, type EditorHandle } from "@/code/Editor";
-import { type EditorExtension, type Language } from "@/code/language";
+import { BASE_THEMES, type EditorExtension, type Language } from "@/code/language";
 
 // Mock the Provider module — the real one pulls in the monaco-vscode-api runtime, whose
 // deep CSS imports cannot be evaluated under Node's ESM loader. We feed Editor a fake
@@ -401,8 +401,8 @@ describe("Editor", () => {
         theme: { semanticTokenColors: { dark: {}, light: {} } },
       } satisfies Language);
       renderEditor();
-      expect(monaco.editor.create.mock.calls[0][1].theme).toEqual("Default Light+");
-      expect(monaco.editor.setTheme).toHaveBeenCalledWith("Default Light+");
+      expect(monaco.editor.create.mock.calls[0][1].theme).toEqual(BASE_THEMES.light);
+      expect(monaco.editor.setTheme).toHaveBeenCalledWith(BASE_THEMES.light);
     });
   });
 

--- a/pluto/src/code/Editor.tsx
+++ b/pluto/src/code/Editor.tsx
@@ -23,7 +23,7 @@ import {
   useState,
 } from "react";
 
-import { type EditorExtension } from "@/code/language";
+import { BASE_THEMES, type EditorExtension } from "@/code/language";
 import { type Monaco, useLanguage, useMonaco } from "@/code/Provider";
 import { diff, utf16Offset } from "@/code/text";
 import { CSS } from "@/css";
@@ -154,7 +154,7 @@ interface UseProps {
 const useTheme = (hasCustomTheme: boolean) => {
   const theme = Theming.use();
   const prefersDark = theme.key.includes("Dark");
-  if (hasCustomTheme) return prefersDark ? "Default Dark+" : "Default Light+";
+  if (hasCustomTheme) return prefersDark ? BASE_THEMES.dark : BASE_THEMES.light;
   return prefersDark ? "vs-dark" : "vs";
 };
 

--- a/pluto/src/code/language.spec.ts
+++ b/pluto/src/code/language.spec.ts
@@ -1,0 +1,91 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { readFileSync } from "node:fs";
+import { createRequire } from "node:module";
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { BASE_THEMES, type Language, registerLanguage } from "@/code/language";
+
+const { registerExtensionMock, registerFileURLMock, updateMock } = vi.hoisted(() => ({
+  registerExtensionMock: vi.fn(),
+  registerFileURLMock: vi.fn(),
+  updateMock: vi.fn(),
+}));
+vi.mock("@codingame/monaco-vscode-api/extensions", () => ({
+  registerExtension: registerExtensionMock,
+  ExtensionHostKind: { LocalProcess: 1 },
+}));
+vi.mock("@codingame/monaco-vscode-extension-api", () => ({
+  workspace: { getConfiguration: () => ({ update: updateMock }) },
+  ConfigurationTarget: { Global: 1 },
+}));
+
+interface ThemeManifest {
+  contributes: { themes: { id: string }[] };
+}
+
+const readThemeManifest = (): ThemeManifest => {
+  const path = createRequire(import.meta.url).resolve(
+    "@codingame/monaco-vscode-theme-defaults-default-extension/resources/package.json",
+  );
+  return JSON.parse(readFileSync(path, "utf-8")) as ThemeManifest;
+};
+
+const LANGUAGE: Language = {
+  name: "arc",
+  configuration: "{}",
+  grammar: { scopeName: "source.arc", raw: "{}" },
+  theme: {
+    semanticTokenColors: { dark: { keyword: "#fff" }, light: { keyword: "#000" } },
+    textMateRules: {
+      dark: [{ scope: "keyword.arc", settings: { foreground: "#fff" } }],
+      light: [{ scope: "keyword.arc", settings: { foreground: "#000" } }],
+    },
+  },
+};
+
+describe("language", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    registerExtensionMock.mockReturnValue({ registerFileUrl: registerFileURLMock });
+  });
+
+  describe("BASE_THEMES", () => {
+    // VS Code renamed these ids (dropping a "Default " prefix) in the upgrade to
+    // monaco-vscode-api v36. Nothing failed loudly: the base theme still resolved
+    // through a compatibility shim, but the token color customizations are matched
+    // literally against the theme's settings id, so every language color was dropped.
+    it("should name themes the installed VS Code theme extension contributes", () => {
+      const ids = readThemeManifest().contributes.themes.map(({ id }) => id);
+      Object.values(BASE_THEMES).forEach((theme) => expect(ids).toContain(theme));
+    });
+  });
+
+  describe("registerLanguage", () => {
+    it("should scope the token colors to the base themes the editor selects", async () => {
+      await registerLanguage(LANGUAGE);
+      const scopes = updateMock.mock.calls.map(([, value]) => Object.keys(value));
+      expect(scopes).toEqual([
+        [`[${BASE_THEMES.dark}]`, `[${BASE_THEMES.light}]`],
+        [`[${BASE_THEMES.dark}]`, `[${BASE_THEMES.light}]`],
+      ]);
+    });
+
+    it("should register the grammar and configuration files", async () => {
+      await registerLanguage(LANGUAGE);
+      const paths = registerFileURLMock.mock.calls.map(([path]) => path);
+      expect(paths).toEqual([
+        "./arc.tmLanguage.json",
+        "./arc.language-configuration.json",
+      ]);
+    });
+  });
+});

--- a/pluto/src/code/language.ts
+++ b/pluto/src/code/language.ts
@@ -39,6 +39,11 @@ export interface LanguageTheme {
   };
 }
 
+/** BASE_THEMES are the settings ids of the VS Code themes that a language with a theme
+ * builds on. VS Code renames these between releases, and a stale id silently drops every
+ * token color, so `language.spec.ts` pins them against the installed theme extension. */
+export const BASE_THEMES = { dark: "Dark+", light: "Light+" } as const;
+
 /** Language is the declarative contribution a consumer passes to Code.Provider. It is
  * plain data plus an optional language-server opener: the provider owns every Monaco
  * interaction, so contributors never import monaco themselves. */
@@ -55,8 +60,8 @@ export interface Language {
   /** grammar is the TextMate grammar: its top-level scope name and the raw
    * tmLanguage.json contents. */
   grammar: { scopeName: string; raw: string };
-  /** theme colors the language's tokens. Languages with a theme use VS Code's
-   * Default Dark+/Light+ base themes; languages without one fall back to vs-dark/vs. */
+  /** theme colors the language's tokens. Languages with a theme use the VS Code base
+   * themes in BASE_THEMES; languages without one fall back to vs-dark/vs. */
   theme?: LanguageTheme;
   /** editorExtensions are applied to every editor opened for this language unless the
    * editor overrides them via its own `extensions` prop. */
@@ -76,8 +81,8 @@ const applyTheme = async (theme: LanguageTheme): Promise<void> => {
       await config.update(
         "semanticTokenColorCustomizations",
         {
-          "[Default Dark+]": { rules: theme.semanticTokenColors.dark },
-          "[Default Light+]": { rules: theme.semanticTokenColors.light },
+          [`[${BASE_THEMES.dark}]`]: { rules: theme.semanticTokenColors.dark },
+          [`[${BASE_THEMES.light}]`]: { rules: theme.semanticTokenColors.light },
         },
         vscode.ConfigurationTarget.Global,
       );
@@ -85,8 +90,8 @@ const applyTheme = async (theme: LanguageTheme): Promise<void> => {
       await config.update(
         "tokenColorCustomizations",
         {
-          "[Default Dark+]": { textMateRules: theme.textMateRules.dark },
-          "[Default Light+]": { textMateRules: theme.textMateRules.light },
+          [`[${BASE_THEMES.dark}]`]: { textMateRules: theme.textMateRules.dark },
+          [`[${BASE_THEMES.light}]`]: { textMateRules: theme.textMateRules.light },
         },
         vscode.ConfigurationTarget.Global,
       );


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4558](https://linear.app/synnax/issue/SY-4558/restore-arc-token-colors-after-the-monaco-v36-theme-id-rename)

## Description

The Arc editor lost all of its syntax coloring after the upgrade to `@codingame/monaco-vscode-*` v36 (#2661). The upgrade pulled in a VS Code base that renamed the default theme settings ids: `Default Dark+` and `Default Light+` became `Dark+` and `Light+`.

Nothing failed loudly, because VS Code's compatibility shim covers half the path. `migrateThemeSettingsId` runs when reading the `workbench.colorTheme` setting and inside `findThemeBySettingsId`, so `monaco.editor.setTheme("Default Dark+")` still resolved and the base theme kept working. The token color customizations take a different path: `colorThemeData.isThemeScopeMatch` compares the `[Default Dark+]` bracket key literally against the theme's settings id, which is now `Dark+`. No match means every Arc semantic token color and TextMate rule was dropped, leaving a plain Dark+/Light+ editor with no Arc coloring at all.

The two ids were previously spelled out at two call sites, `Editor.tsx` choosing the theme and `language.ts` keying the customizations, which is what let them break in lockstep without any signal. They now come from one `BASE_THEMES` constant, and the customization scope keys are built from it, so the pair cannot drift.

The regression test is the point of the change. `Editor.spec.tsx` already had a theme test, but it asserts against a fake monaco, so it passed happily through this break and would pass through the next rename. The new `language.spec.ts` reads the installed theme extension's own manifest and asserts our ids are among the themes it contributes. Reverting the ids fails it:

```
× should name themes the installed VS Code theme extension contributes
AssertionError: expected [ 'Light 2026', 'Dark 2026', …(8) ] to include 'Default Dark+'
```

The next `@codingame` bump that renames a theme now fails at test time instead of shipping a colorless editor. The older `Editor.spec.tsx` assertion was updated to reference `BASE_THEMES` rather than a hardcoded string, so it no longer reads as coverage it does not provide.

### Not included

A second, independent problem is out of scope here and still open. In the packaged Console, both Monaco workers 404. Pluto's `base: "/pluto/"` bakes absolute `/pluto/assets/...` worker URLs into its dist, and the Console app serves nothing under `/pluto/`, so the requests fall through to the SPA index and fail to parse as modules:

```
Could not create web worker(s). Falling back to loading web worker code in main thread
SyntaxError: Unexpected token '<'
```

That message is stale VS Code wording; there is no main-thread fallback in this version, so TextMate tokenization does not run in production regardless of theming. The fix is a build-layout decision (drop `base` for the lib build, or have the Console serve `pluto/dist/assets`) and is tracked separately.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR restores Arc syntax colors by centralizing the current VS Code base-theme identifiers and using them for both Monaco theme selection and scoped token customizations.
- Adds `BASE_THEMES` as the shared source of `Dark+` and `Light+` identifiers.
- Updates editor selection and semantic/TextMate customization scopes to use the shared identifiers.
- Adds a regression test that checks the identifiers against the installed theme extension manifest and expands language-registration coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the restored theme identifiers consistently shared across editor selection, customization scopes, and regression coverage.

The changed runtime paths use the identifiers contributed by the installed VS Code theme extension, and the added tests guard both identifier compatibility and configuration scoping without introducing a supported build or initialization failure.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pluto/src/code/language.ts | Centralizes the renamed base-theme identifiers and consistently applies them to semantic-token and TextMate customization scopes. |
| pluto/src/code/Editor.tsx | Selects the centralized base-theme identifier whenever the active language supplies custom token colors. |
| pluto/src/code/language.spec.ts | Adds focused coverage for installed theme identifiers, customization scopes, and language resource registration. |
| pluto/src/code/Editor.spec.tsx | Updates the editor theme assertion to reference the same shared identifiers used by production code. |

<sub>Reviews (1): Last reviewed commit: ["Pin the Monaco base theme ids to the ins..."](https://github.com/synnaxlabs/synnax/commit/858c009cd47157a243d15e9c4054261b60c9bf33) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51369855)</sub>

<!-- /greptile_comment -->