### PR TITLE
[oracle] Parse sentinel-defaulted fields into the zero value in C++

### DIFF
--- a/client/cpp/arc/json.gen.h
+++ b/client/cpp/arc/json.gen.h
@@ -37,7 +37,7 @@ inline x::json::json StatusDetails::to_json() const {
 
 inline Arc Arc::parse(x::json::Parser parser) {
     return Arc{
-        .key = parser.field<Key>("key"),
+        .key = parser.field<Key>("key", Key{}),
         .name = parser.field<std::string>("name"),
         .mode = parser.field<std::string>("mode"),
         .graph = parser.field<::arc::graph::Graph>("graph"),

--- a/client/cpp/label/json.gen.h
+++ b/client/cpp/label/json.gen.h
@@ -21,7 +21,7 @@ namespace synnax::label {
 
 inline Label Label::parse(x::json::Parser parser) {
     return Label{
-        .key = parser.field<Key>("key"),
+        .key = parser.field<Key>("key", Key{}),
         .name = parser.field<std::string>("name"),
         .color = parser.field<::x::color::Color>("color"),
     };

--- a/client/cpp/status/json.gen.h
+++ b/client/cpp/status/json.gen.h
@@ -25,12 +25,12 @@ namespace synnax::status {
 template<typename Details>
 Status<Details> Status<Details>::parse(x::json::Parser parser) {
     return Status<Details>{
-        .key = parser.field<std::string>("key"),
+        .key = parser.field<std::string>("key", ""),
         .name = parser.field<std::string>("name", ""),
         .variant = parser.field<std::string>("variant"),
         .message = parser.field<std::string>("message"),
         .description = parser.field<std::string>("description", ""),
-        .time = parser.field<::x::telem::TimeStamp>("time"),
+        .time = parser.field<::x::telem::TimeStamp>("time", ::x::telem::TimeStamp{}),
         .details = parser.field<Details>("details"),
         .labels = parser.field<std::optional<std::vector<::synnax::label::Label>>>(
             "labels"

--- a/client/cpp/view/json.gen.h
+++ b/client/cpp/view/json.gen.h
@@ -20,7 +20,7 @@ namespace synnax::view {
 
 inline View View::parse(x::json::Parser parser) {
     return View{
-        .key = parser.field<Key>("key"),
+        .key = parser.field<Key>("key", Key{}),
         .name = parser.field<std::string>("name"),
         .type = parser.field<std::string>("type"),
         .query = parser.field<x::json::json::object_t>("query"),

--- a/oracle/plugin/cpp/json/json.go
+++ b/oracle/plugin/cpp/json/json.go
@@ -792,7 +792,7 @@ func (p *Plugin) parseExprForField(
 		}
 		if hasDefault {
 			defaultVal := jsonDefaultLiteral(field, data.table)
-			if defaultVal == "" && field.Optional {
+			if defaultVal == "" {
 				defaultVal = defaultValueForPrimitive(typeRef.Name)
 			}
 			if defaultVal != "" {
@@ -837,6 +837,13 @@ func (p *Plugin) parseExprForField(
 				cppType,
 				jsonName,
 				defaultVal,
+			)
+		} else if isSentinelDefault(field, data.table) {
+			return fmt.Sprintf(
+				`parser.field<%s>("%s", %s{})`,
+				cppType,
+				jsonName,
+				cppType,
 			)
 		}
 	}
@@ -1090,8 +1097,8 @@ func (p *Plugin) toJSONExprForField(
 
 // hasRenderableDefault reports whether the field declares a default the parse
 // expression can honor. Struct and array defaults count (their branches render
-// them); identifier defaults count only when they resolve to an enum variant or
-// boolean literal, so sentinels like create do not relax a required field.
+// them); identifier defaults count when they resolve to an enum variant or
+// boolean literal, and sentinels fall back to the type's zero value.
 func hasRenderableDefault(field resolution.Field, table *resolution.Table) bool {
 	if field.Default == nil {
 		return false
@@ -1099,7 +1106,16 @@ func hasRenderableDefault(field resolution.Field, table *resolution.Table) bool 
 	if field.Default.Kind != resolution.ValueKindIdent {
 		return true
 	}
-	return jsonDefaultLiteral(field, table) != ""
+	return jsonDefaultLiteral(field, table) != "" || isSentinelDefault(field, table)
+}
+
+// isSentinelDefault reports whether the field defaults to a sentinel the producer
+// resolves, such as create or now. The value cannot be rendered as a C++ literal,
+// and a decoder must not require a field whose producer assigns it.
+func isSentinelDefault(field resolution.Field, table *resolution.Table) bool {
+	return field.Default != nil &&
+		field.Default.Kind == resolution.ValueKindIdent &&
+		jsonDefaultLiteral(field, table) == ""
 }
 
 // jsonDefaultLiteral renders a field's schema default as a C++ literal usable as

--- a/oracle/plugin/cpp/json/json_test.go
+++ b/oracle/plugin/cpp/json/json_test.go
@@ -1304,22 +1304,31 @@ var _ = Describe("C++ JSON Union Generation", func() {
 		},
 	)
 
-	It("Should keep fields with sentinel defaults required", func(ctx SpecContext) {
-		source := `
+	It(
+		"Should parse fields with sentinel defaults into the zero value",
+		func(ctx SpecContext) {
+			source := `
 			@cpp output "out"
 
+			Key = uuid
+
 			Status struct {
-				key  string = create
-				name string = ""
+				key    string = create
+				record uuid = create
+				parent Key = create
+				name   string = ""
 			}
 		`
-		resp := MustGenerate(ctx, source, "config", loader, jsonPlugin)
-		ExpectContent(resp, "json.gen.h").
-			ToContain(
-				`.key = parser.field<std::string>("key"),`,
-				`.name = parser.field<std::string>("name", ""),`,
-			)
-	})
+			resp := MustGenerate(ctx, source, "config", loader, jsonPlugin)
+			ExpectContent(resp, "json.gen.h").
+				ToContain(
+					`.key = parser.field<std::string>("key", ""),`,
+					`.record = parser.field<x::uuid::UUID>("record", x::uuid::UUID{}),`,
+					`.parent = parser.field<Key>("parent", Key{}),`,
+					`.name = parser.field<std::string>("name", ""),`,
+				)
+		},
+	)
 })
 
 var _ = Describe("C++ JSON Union Array Fields", func() {


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4299](https://linear.app/synnax/issue/SY-4299)

## Description

A field that defaults to a sentinel (`create`, `now`) is assigned by the producer,
so a decoder must not require it. TypeScript already generates
`z.uuid().default(uuid.create)` for these fields and Go leaves the zero value for
the writer to fill, but the C++ JSON generator deliberately kept them required.

Task configs make this reachable: every stored config record carries a
`create`-defaulted `key`, and `driver/common/read_task.h` parses every read task
through the generated `BaseReadConfig::parse`, so a config written without a key
fails to configure for every integration.

The C++ parse expression now falls back to the type's zero value for a sentinel
default. Regenerated output on `rc` is four lines across `arc`, `label`, `status`,
and `view`.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates the C++ JSON generator so omitted producer-assigned sentinel fields parse into their type's zero value and regenerates all affected client headers.

- Adds zero-value fallbacks for unresolved sentinel defaults in generated C++ parsers.
- Regenerates Arc, Label, Status, and View JSON parsing output.
- Adds generator coverage for string, UUID, and aliased UUID sentinel fields.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking concern that the new sentinel predicate can mask unsupported or misspelled identifier defaults.

The intended create and now defaults generate valid zero-value parser expressions and all affected checked-in headers were regenerated, but sentinel recognition is broader than the documented producer-assigned cases.

**Files Needing Attention:** oracle/plugin/cpp/json/json.go

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| oracle/plugin/cpp/json/json.go | Implements sentinel-default zero-value parsing, but the new predicate also classifies arbitrary unresolved identifier defaults as sentinels. |
| oracle/plugin/cpp/json/json_test.go | Updates generator coverage to assert zero-value fallbacks for sentinel-defaulted strings, UUIDs, and UUID aliases. |
| client/cpp/arc/json.gen.h | Regenerates Arc key parsing to use a nil UUID fallback when the key is omitted. |
| client/cpp/label/json.gen.h | Regenerates Label key parsing to use a nil UUID fallback when the key is omitted. |
| client/cpp/status/json.gen.h | Regenerates Status key and timestamp parsing with empty-string and zero-timestamp fallbacks. |
| client/cpp/view/json.gen.h | Regenerates View key parsing to use a nil UUID fallback when the key is omitted. |

<sub>Reviews (1): Last reviewed commit: ["Parse sentinel-defaulted fields into the..."](https://github.com/synnaxlabs/synnax/commit/cf0b4ef793d4c36ec168a572134ed43e06378a7d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51450531)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Oracle Codegen](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/oracle-codegen.md)
- Knowledge Base — [Client SDKs](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/client-sdks.md)

<!-- /greptile_comment -->