### PR TITLE
SY-4559: Stop trusting cached answers when the change stream is off

### DIFF
--- a/client/py/synnax/__init__.py
+++ b/client/py/synnax/__init__.py
@@ -27,6 +27,7 @@ from synnax.channel import Channel
 from synnax.control import Controller
 from synnax.device import Device
 from synnax.exceptions import (
+    AccessDenied,
     AuthError,
     ConfigurationError,
     ControlError,
@@ -108,6 +109,7 @@ __all__ = [
     "Alignment",
     "Arc",
     "AUTO_SPAN",
+    "AccessDenied",
     "AuthError",
     "Authority",
     "Controller",

--- a/client/py/synnax/exceptions.py
+++ b/client/py/synnax/exceptions.py
@@ -64,6 +64,12 @@ class ExpiredToken(AuthError):
     TYPE = AuthError.TYPE + ".expired_token"
 
 
+class AccessDenied(AuthError):
+    """Raised when a user does not have permission to perform an action."""
+
+    TYPE = AuthError.TYPE + ".access_denied"
+
+
 class UnexpectedError(Exception):
     """Raised when an unexpected error occurs."""
 
@@ -125,6 +131,8 @@ def _decode(encoded: freighter.ExceptionPayload) -> Exception | None:
     if encoded.type.startswith(AuthError.TYPE):
         if encoded.type.startswith(InvalidCredentials.TYPE):
             return InvalidCredentials(encoded.data)
+        if encoded.type.startswith(AccessDenied.TYPE):
+            return AccessDenied(encoded.data)
         return AuthError(encoded.data)
 
     if encoded.type.startswith(UnexpectedError.TYPE):

--- a/client/py/tests/test_access.py
+++ b/client/py/tests/test_access.py
@@ -213,5 +213,5 @@ class TestAccessAuthClient:
             password="pwd2",
         )
 
-        with pytest.raises(sy.AuthError):
+        with pytest.raises(sy.AccessDenied):
             client2.users.create(username=str(uuid.uuid4()), password="pwd3")

--- a/client/ts/src/access/policy/access.spec.ts
+++ b/client/ts/src/access/policy/access.spec.ts
@@ -11,7 +11,7 @@ import { id } from "@synnaxlabs/x";
 import { beforeAll, describe, expect, it, vi } from "vitest";
 
 import { policy } from "@/access/policy";
-import { AuthError, NotFoundError } from "@/errors";
+import { AccessDeniedError, NotFoundError } from "@/errors";
 import { query } from "@/query";
 import {
   createTestClient,
@@ -64,7 +64,7 @@ describe("policy", () => {
       });
       await expect(
         userClient.access.policies.retrieve(randomPolicy.key),
-      ).rejects.toThrow(AuthError);
+      ).rejects.toSatisfy(AccessDeniedError.matches);
     });
 
     it("should allow the caller to retrieve policies with the correct policy", async () => {
@@ -111,7 +111,7 @@ describe("policy", () => {
           objects: [],
           actions: ["retrieve"],
         }),
-      ).rejects.toThrow(AuthError);
+      ).rejects.toSatisfy(AccessDeniedError.matches);
     });
 
     it("should allow the caller to delete policies with the correct policy", async () => {
@@ -143,9 +143,9 @@ describe("policy", () => {
         objects: [],
         actions: ["retrieve"],
       });
-      await expect(userClient.access.policies.delete(randomPolicy.key)).rejects.toThrow(
-        AuthError,
-      );
+      await expect(
+        userClient.access.policies.delete(randomPolicy.key),
+      ).rejects.toSatisfy(AccessDeniedError.matches);
     });
   });
 });

--- a/client/ts/src/arc/access.spec.ts
+++ b/client/ts/src/arc/access.spec.ts
@@ -10,7 +10,7 @@
 import { describe, expect, it } from "vitest";
 
 import { arc } from "@/arc";
-import { AuthError, NotFoundError } from "@/errors";
+import { AccessDeniedError, NotFoundError } from "@/errors";
 import { createTestClient, createTestClientWithPolicy } from "@/testutil";
 
 const client = createTestClient();
@@ -28,7 +28,9 @@ describe("arc", () => {
         mode: "text",
       };
       const randomArc = await client.arcs.create(a);
-      await expect(userClient.arcs.retrieve(randomArc.key)).rejects.toThrow(AuthError);
+      await expect(userClient.arcs.retrieve(randomArc.key)).rejects.toSatisfy(
+        AccessDeniedError.matches,
+      );
     });
 
     it("should allow the caller to retrieve arcs with the correct policy", async () => {
@@ -69,7 +71,7 @@ describe("arc", () => {
           name: "test",
           mode: "text",
         }),
-      ).rejects.toThrow(AuthError);
+      ).rejects.toSatisfy(AccessDeniedError.matches);
     });
 
     it("should allow the caller to delete arcs with the correct policy", async () => {
@@ -98,7 +100,9 @@ describe("arc", () => {
         name: "test",
         mode: "text",
       });
-      await expect(userClient.arcs.delete(randomArc.key)).rejects.toThrow(AuthError);
+      await expect(userClient.arcs.delete(randomArc.key)).rejects.toSatisfy(
+        AccessDeniedError.matches,
+      );
     });
   });
 });

--- a/client/ts/src/arc/arc.spec.ts
+++ b/client/ts/src/arc/arc.spec.ts
@@ -11,7 +11,7 @@ import { crdt, id, uuid } from "@synnaxlabs/x";
 import { describe, expect, it, vi } from "vitest";
 
 import { arc } from "@/arc";
-import { AuthError } from "@/errors";
+import { AccessDeniedError } from "@/errors";
 import { query } from "@/query";
 import { status } from "@/status";
 import { task } from "@/task";
@@ -184,7 +184,7 @@ describe("arc", () => {
           key: created.key,
           rack: rackB.key,
         }),
-      ).rejects.toThrow(AuthError);
+      ).rejects.toSatisfy(AccessDeniedError.matches);
       const surviving = await client.tasks.retrieve(tsk.key);
       expect(surviving.key).toEqual(tsk.key);
     });

--- a/client/ts/src/channel/access.spec.ts
+++ b/client/ts/src/channel/access.spec.ts
@@ -11,7 +11,7 @@ import { DataType, id } from "@synnaxlabs/x";
 import { describe, expect, it } from "vitest";
 
 import { channel } from "@/channel";
-import { AuthError, NotFoundError } from "@/errors";
+import { AccessDeniedError, NotFoundError } from "@/errors";
 import { createTestClient, createTestClientWithPolicy } from "@/testutil";
 
 const client = createTestClient();
@@ -29,8 +29,8 @@ describe("channel", () => {
         dataType: DataType.FLOAT32,
         virtual: true,
       });
-      await expect(userClient.channels.retrieve(randomChannel.key)).rejects.toThrow(
-        AuthError,
+      await expect(userClient.channels.retrieve(randomChannel.key)).rejects.toSatisfy(
+        AccessDeniedError.matches,
       );
     });
 
@@ -76,7 +76,7 @@ describe("channel", () => {
           dataType: DataType.FLOAT32,
           virtual: true,
         }),
-      ).rejects.toThrow(AuthError);
+      ).rejects.toSatisfy(AccessDeniedError.matches);
     });
 
     it("should allow the caller to delete channels with the correct policy", async () => {
@@ -107,8 +107,8 @@ describe("channel", () => {
         dataType: DataType.FLOAT32,
         virtual: true,
       });
-      await expect(userClient.channels.delete(randomChannel.key)).rejects.toThrow(
-        AuthError,
+      await expect(userClient.channels.delete(randomChannel.key)).rejects.toSatisfy(
+        AccessDeniedError.matches,
       );
     });
   });

--- a/client/ts/src/client.spec.ts
+++ b/client/ts/src/client.spec.ts
@@ -12,7 +12,12 @@ import { describe, expect, it } from "vitest";
 
 import { type connection } from "@/connection";
 import { AuthError, DisconnectedError } from "@/errors";
-import { createTestClient, TEST_CLIENT_PARAMS } from "@/testutil";
+import { label } from "@/label";
+import {
+  createTestClient,
+  createTestClientWithPolicy,
+  TEST_CLIENT_PARAMS,
+} from "@/testutil";
 
 const reasonOf = (status: connection.Status): connection.Reason | undefined =>
   status.variant === "error" ? status.details.reason : undefined;
@@ -83,6 +88,32 @@ describe("connect", () => {
     await client.connect();
     client.close();
     expect(client.connection.status.variant).toEqual("disabled");
+  });
+});
+
+describe("denied change stream", () => {
+  it("should connect with a warning when the user cannot stream changes", async () => {
+    const root = createTestClient();
+    const restricted = await createTestClientWithPolicy(root, {
+      name: "test",
+      objects: [label.ontologyID("")],
+      actions: ["retrieve"],
+    });
+    const status = await restricted.connect();
+    expect(status.variant).toEqual("warning");
+    expect(status.details.streamDenied).toBe(true);
+    expect(status.details.authenticated).toBe(true);
+    expect(status.description).not.toEqual("");
+    // the reads the user is allowed to make still work
+    const created = await root.labels.create({
+      name: "denied-stream",
+      color: "#000000",
+    });
+    await expect(restricted.labels.retrieve(created.key)).resolves.toMatchObject({
+      key: created.key,
+    });
+    restricted.close();
+    root.close();
   });
 });
 

--- a/client/ts/src/client.ts
+++ b/client/ts/src/client.ts
@@ -10,6 +10,7 @@
 import {
   breaker,
   type CrudeTimeSpan,
+  errors,
   TimeSpan,
   TimeStamp,
   url,
@@ -25,7 +26,7 @@ import { channel } from "@/channel";
 import { connection } from "@/connection";
 import { control } from "@/control";
 import { device } from "@/device";
-import { errorsMiddleware } from "@/errors";
+import { AccessDeniedError, errorsMiddleware } from "@/errors";
 import { framer } from "@/framer";
 import { group } from "@/group";
 import { imex } from "@/imex";
@@ -155,7 +156,7 @@ export default class Synnax extends framer.Client {
     super({ stream: transport.stream, unary: transport.unary, retriever: chRetriever });
     const cache = new query.Cache({
       openStreamer: parsedParams.cache
-        ? async (channels, { onOpen, onReopen }) => {
+        ? async (channels, { onOpen, onReopen, onDead }) => {
             const hardened = await framer.HardenedStreamer.open(
               (config) => this.openStreamer(config),
               channels,
@@ -167,12 +168,26 @@ export default class Synnax extends framer.Client {
                 onReopen?.();
               },
               (error) => this.conn.notify({ type: "stream.drop", error }),
-            );
+            ).catch((error: unknown) => {
+              if (AccessDeniedError.matches(error))
+                this.conn.notify({
+                  type: "stream.denied",
+                  error: errors.fromUnknown(error),
+                });
+              throw error;
+            });
             // Reads start when the ObservableStreamer is constructed below,
             // so onOpen fires strictly before any frame or reconnect.
             onOpen?.();
             this.conn.notify({ type: "stream.live" });
-            return new framer.ObservableStreamer(hardened);
+            return new framer.ObservableStreamer(hardened, undefined, (error) => {
+              this.conn.notify(
+                AccessDeniedError.matches(error)
+                  ? { type: "stream.denied", error }
+                  : { type: "stream.drop", error },
+              );
+              onDead?.(error);
+            });
           }
         : null,
       onError: parsedParams.onInternalError,
@@ -295,8 +310,9 @@ export default class Synnax extends framer.Client {
   }
 
   /**
-   * Awaits the connection's first success. Idempotent: resolves immediately
-   * when already connected.
+   * Awaits the connection becoming usable: success, or warning when the cluster
+   * refuses live updates. Idempotent: resolves immediately when already
+   * connected.
    * @throws {AuthError} on a definitive credential rejection.
    * @throws {DisconnectedError} when the cluster cannot be reached after the
    * configured retry budget, or when the client is closed while waiting.

--- a/client/ts/src/client.ts
+++ b/client/ts/src/client.ts
@@ -168,12 +168,10 @@ export default class Synnax extends framer.Client {
                 onReopen?.();
               },
               (error) => this.conn.notify({ type: "stream.drop", error }),
-            ).catch((error: unknown) => {
+            ).catch((exc: unknown) => {
+              const error = errors.fromUnknown(exc);
               if (AccessDeniedError.matches(error))
-                this.conn.notify({
-                  type: "stream.denied",
-                  error: errors.fromUnknown(error),
-                });
+                this.conn.notify({ type: "stream.denied", error });
               throw error;
             });
             // Reads start when the ObservableStreamer is constructed below,

--- a/client/ts/src/connection/client.ts
+++ b/client/ts/src/connection/client.ts
@@ -111,8 +111,9 @@ export type Mode = "checking" | "heartbeat" | "idle";
 /** The mode a given connection status calls for. */
 export const modeFor = ({ variant, details }: Status): Mode => {
   switch (variant) {
+    // warning is settled, not in progress: a denied stream checks on the
+    // slow cadence like a healthy one
     case "success":
-    // a denied stream is settled, not in progress: check on the slow cadence
     case "warning":
       return "heartbeat";
     case "disabled":

--- a/client/ts/src/connection/client.ts
+++ b/client/ts/src/connection/client.ts
@@ -37,7 +37,7 @@ import {
   reduce,
   type Status,
 } from "@/connection/status";
-import { DisconnectedError, errorsMiddleware } from "@/errors";
+import { AccessDeniedError, DisconnectedError, errorsMiddleware } from "@/errors";
 import { Transport } from "@/transport";
 
 const CHECK_ENDPOINT = "/connectivity/check";
@@ -112,6 +112,8 @@ export type Mode = "checking" | "heartbeat" | "idle";
 export const modeFor = ({ variant, details }: Status): Mode => {
   switch (variant) {
     case "success":
+    // a denied stream is settled, not in progress: check on the slow cadence
+    case "warning":
       return "heartbeat";
     case "disabled":
       return "idle";
@@ -146,10 +148,16 @@ export type FactEvent = Extract<
       | "auth.failure"
       | "stream.live"
       | "stream.drop"
+      | "stream.denied"
       | "credentials.replaced"
       | "epoch.advanced";
   }
 >;
+
+/** Heartbeats between re-probes of a denied change stream. */
+const DEFAULT_DENIED_STREAM_PROBE_AFTER = 10;
+
+const STREAM_DENIED = "cannot stream changes: live updates are unavailable";
 
 export interface ClientParams {
   /**
@@ -173,6 +181,11 @@ export interface ClientParams {
   retry?: breaker.Config;
   /** Check cadence while connected. Defaults to 30 seconds. */
   heartbeatInterval?: CrudeTimeSpan;
+  /**
+   * Heartbeats between re-probes of a denied change stream. Only a policy
+   * change lifts a denial, and the client cannot hear about one. Defaults to 10.
+   */
+  deniedStreamProbeAfter?: number;
   /** Levers on the change stream, pulled when transitions demand it. */
   stream?: {
     /** Tears down cached state after a cluster replacement. */
@@ -197,6 +210,7 @@ export class Client implements Handle {
   private readonly config: Config;
   private readonly retry: breaker.Config;
   private readonly heartbeatInterval: TimeSpan;
+  private readonly deniedStreamProbeAfter: number;
   private readonly stream?: ClientParams["stream"];
   private readonly onInternalError: (error: Error) => void;
   private readonly observer = new observe.Observer<Status>();
@@ -207,6 +221,7 @@ export class Client implements Handle {
   private closed = false;
   private attempts = 0;
   private generation = 0;
+  private probeCountdown = 0;
   private brk: breaker.Breaker | null = null;
   private versionWarned = false;
 
@@ -219,6 +234,7 @@ export class Client implements Handle {
     requiresStream = false,
     retry,
     heartbeatInterval = TimeSpan.seconds(30),
+    deniedStreamProbeAfter = DEFAULT_DENIED_STREAM_PROBE_AFTER,
     stream,
     onInternalError = console.error,
   }: ClientParams) {
@@ -233,6 +249,7 @@ export class Client implements Handle {
     };
     this.retry = { ...DEFAULT_RETRY, ...retry };
     this.heartbeatInterval = new TimeSpan(heartbeatInterval);
+    this.deniedStreamProbeAfter = deniedStreamProbeAfter;
     this.stream = stream;
     this.onInternalError = onInternalError;
     this.current = createInitialStatus(this.config);
@@ -261,9 +278,10 @@ export class Client implements Handle {
   }
 
   /**
-   * Resolves once the connection reaches success. Rejects with the stored
-   * failure when it settles on an error variant or is closed. An
-   * already-connected client resolves without waiting.
+   * Resolves once the connection is usable: success, or warning when the
+   * cluster refuses live updates. Rejects with the stored failure when it
+   * settles on an error variant or is closed. An already-connected client
+   * resolves without waiting.
    * @throws {Error} if the timeout elapses first.
    */
   async connect(timeout?: CrudeTimeSpan): Promise<Status> {
@@ -272,7 +290,16 @@ export class Client implements Handle {
 
   /** Folds an outside fact into the connection status. */
   notify(event: FactEvent): void {
+    const wasDenied = this.current.details.streamDenied;
     this.dispatch(event);
+    if (event.type === "stream.denied") {
+      this.probeCountdown = this.deniedStreamProbeAfter;
+      // every probe hits the same refusal; only the first is news
+      if (!wasDenied)
+        this.onInternalError(
+          new AccessDeniedError(STREAM_DENIED, { cause: event.error }),
+        );
+    }
     // a reopened stream may lead to a replaced cluster, and new credentials
     // deserve an immediate verdict: both check right away
     if (event.type === "stream.live" || event.type === "credentials.replaced")
@@ -356,6 +383,22 @@ export class Client implements Handle {
     this.notifier.notify();
   }
 
+  /**
+   * Consumes this check's turn at re-demanding a dark stream, returning whether
+   * it gets one. A denied stream probes on a slow cadence: every probe costs an
+   * open the cluster refuses until an administrator changes the caller's
+   * policies.
+   */
+  private takeStreamProbe(): boolean {
+    if (!this.current.details.streamDenied) return true;
+    if (this.probeCountdown > 0) {
+      this.probeCountdown -= 1;
+      return false;
+    }
+    this.probeCountdown = this.deniedStreamProbeAfter;
+    return true;
+  }
+
   private async runCheck(): Promise<void> {
     const generation = this.generation;
     const prevKey = this.current.details.clusterKey;
@@ -369,14 +412,19 @@ export class Client implements Handle {
       const replaced = prevKey !== "" && info.clusterKey !== prevKey;
       // reachable but the stream is still dark: re-demand it, in case its own
       // retry budget was exhausted. Replacement already brings it up.
-      if (!replaced && this.config.requiresStream && !this.current.details.streamLive)
-        this.stream
-          ?.ensure()
-          .catch((err: unknown) =>
-            this.onInternalError(
-              new Error("failed to bring up change stream", { cause: err }),
-            ),
+      if (
+        !replaced &&
+        this.config.requiresStream &&
+        !this.current.details.streamLive &&
+        this.takeStreamProbe()
+      )
+        this.stream?.ensure().catch((err: unknown) => {
+          // the transition into denied already reported it
+          if (AccessDeniedError.matches(err)) return;
+          this.onInternalError(
+            new Error("failed to bring up change stream", { cause: err }),
           );
+        });
     } catch (err) {
       if (generation !== this.generation || this.closed) return;
       this.attempts += 1;

--- a/client/ts/src/connection/connection.spec.ts
+++ b/client/ts/src/connection/connection.spec.ts
@@ -21,7 +21,7 @@ import {
   materialChange,
   reduce,
 } from "@/connection/status";
-import { AuthError, DisconnectedError } from "@/errors";
+import { AccessDeniedError, AuthError, DisconnectedError } from "@/errors";
 import { TEST_CLIENT_PARAMS, waitForStatus } from "@/testutil";
 import { Transport } from "@/transport";
 
@@ -344,6 +344,43 @@ describe("connection", () => {
       expect(reopened.variant).toEqual("success");
     });
 
+    it("should settle on warning when the cluster denies the stream", () => {
+      const config = createConfig({ requiresStream: true });
+      const denied = apply(
+        config,
+        { type: "check.success", info: createInfo() },
+        { type: "stream.denied" },
+      );
+      expect(denied.variant).toEqual("warning");
+      expect(denied.details.streamDenied).toBe(true);
+      expect(denied.details.streamLive).toBe(false);
+      expect(denied.description).not.toEqual("");
+      // later checks must not drag the settled denial back into loading
+      const checked = reduce(
+        denied,
+        { type: "check.success", info: createInfo() },
+        config,
+      );
+      expect(checked.variant).toEqual("warning");
+      expect(checked.details.streamDenied).toBe(true);
+    });
+
+    it("should clear a denial when the stream comes up or credentials change", () => {
+      const config = createConfig({ requiresStream: true });
+      const denied = apply(
+        config,
+        { type: "check.success", info: createInfo() },
+        { type: "stream.denied" },
+      );
+      const live = reduce(denied, { type: "stream.live" }, config);
+      expect(live.variant).toEqual("success");
+      expect(live.details.streamDenied).toBe(false);
+      expect(live.description).toEqual("");
+      const replaced = reduce(denied, { type: "credentials.replaced" }, config);
+      expect(replaced.variant).toEqual("loading");
+      expect(replaced.details.streamDenied).toBe(false);
+    });
+
     it("should degrade to reconnecting when a heartbeat fails while connected", () => {
       const config = createConfig();
       const connected = apply(config, { type: "check.success", info: createInfo() });
@@ -562,6 +599,7 @@ describe("connection", () => {
         "error",
         "authenticated",
         "streamLive",
+        "streamDenied",
         "epoch",
         "clusterKey",
         "clientVersion",
@@ -590,6 +628,7 @@ describe("connection", () => {
       });
       expect(modeFor(initial)).toEqual("checking");
       expect(modeFor({ ...initial, variant: "success" })).toEqual("heartbeat");
+      expect(modeFor({ ...initial, variant: "warning" })).toEqual("heartbeat");
       expect(modeFor(asError("unreachable"))).toEqual("checking");
       expect(modeFor(asError("auth"))).toEqual("idle");
       expect(modeFor({ ...initial, variant: "disabled" })).toEqual("idle");
@@ -766,6 +805,38 @@ describe("connection", () => {
       expect(client.status.variant).toEqual("loading");
       client.notify({ type: "stream.live" });
       expect(client.status.variant).toEqual("success");
+      await client.close();
+    });
+
+    it("should probe a denied stream on a slow cadence and report it once", async () => {
+      const internal: Error[] = [];
+      let checks = 0;
+      let probes = 0;
+      const unary = mockUnary(() => {
+        checks += 1;
+        return TimeStamp.now();
+      });
+      const client: connection.Client = createClient(unary, {
+        requiresStream: true,
+        deniedStreamProbeAfter: 3,
+        stream: {
+          reset: async () => {},
+          ensure: async () => {
+            probes += 1;
+            client.notify({ type: "stream.denied" });
+            throw new AccessDeniedError("no permission to stream");
+          },
+        },
+        onInternalError: (error) => internal.push(error),
+      });
+      await waitForStatus(client, (s) => s.details.streamDenied);
+      expect(client.status.variant).toEqual("warning");
+      expect(probes).toEqual(1);
+      const checksAtDenial = checks;
+      while (probes < 2) await sleep(TimeSpan.milliseconds(1));
+      expect(checks - checksAtDenial).toBeGreaterThanOrEqual(3);
+      expect(internal).toHaveLength(1);
+      expect(AccessDeniedError.matches(internal[0])).toBe(true);
       await client.close();
     });
 

--- a/client/ts/src/connection/status.ts
+++ b/client/ts/src/connection/status.ts
@@ -32,6 +32,9 @@ export const statusDetailsZ = z.object({
   error: z.instanceof(Error).optional(),
   authenticated: z.boolean(),
   streamLive: z.boolean(),
+  // The cluster refused the change stream. Unary calls the user is allowed to
+  // make still work; live updates do not arrive.
+  streamDenied: z.boolean(),
   epoch: z.number(),
   clusterKey: z.string(),
   clientVersion: z.string(),
@@ -80,6 +83,7 @@ export type Status = ErrorStatus | NonErrorStatus;
 const DEFAULT_STATUS_DETAILS: StatusDetails = {
   authenticated: false,
   streamLive: false,
+  streamDenied: false,
   epoch: 0,
   clusterKey: "",
   clientVersion: __VERSION__,
@@ -131,12 +135,16 @@ export interface Handle {
 }
 
 const isSettled = ({ variant }: Status): boolean =>
-  variant === "success" || variant === "error" || variant === "disabled";
+  variant === "success" ||
+  variant === "warning" ||
+  variant === "error" ||
+  variant === "disabled";
 
 /**
- * Resolves once the connection reaches success. Rejects with the stored failure
- * when it settles on an error variant or is closed. The current status is
- * evaluated first, so an already-connected handle resolves without waiting.
+ * Resolves once the connection is usable: success, or warning when the cluster
+ * refuses live updates. Rejects with the stored failure when it settles on an
+ * error variant or is closed. The current status is evaluated first, so an
+ * already-connected handle resolves without waiting.
  * @throws {Error} if the timeout elapses first.
  */
 export const awaitConnected = async (
@@ -144,7 +152,7 @@ export const awaitConnected = async (
   timeout?: CrudeTimeSpan,
 ): Promise<Status> => {
   const settled = await observe.until(handle, () => handle.status, isSettled, timeout);
-  if (settled.variant !== "success")
+  if (settled.variant !== "success" && settled.variant !== "warning")
     throw settled.details.error ?? new DisconnectedError(settled.message);
   return settled;
 };
@@ -168,6 +176,7 @@ export type Event =
   | { type: "check.failure"; error: Error; attempt: number }
   | { type: "stream.live" }
   | { type: "stream.drop"; error?: Error }
+  | { type: "stream.denied"; error?: Error }
   | { type: "auth.success" }
   | { type: "auth.failure"; error: Error }
   | { type: "epoch.advanced"; epoch: number }
@@ -180,6 +189,8 @@ export type Event =
 const CONNECTING = "Connecting";
 const RECONNECTING = "Reconnecting";
 const UNREACHABLE = "Cannot reach cluster";
+const STREAM_DENIED =
+  "Live updates are unavailable. This user cannot read the change channels.";
 
 const connectedMessage = ({ name }: Config): string =>
   `Connected to ${name ?? "cluster"}`;
@@ -207,12 +218,13 @@ const enter = (
   variant: Exclude<status.Variant, "error">,
   message: string,
   details: Partial<StatusDetails> = {},
+  description: string = "",
 ): NonErrorStatus => {
   const { reason: _, ...merged }: StatusDetails & { reason?: Reason } = {
     ...prev.details,
     ...details,
   };
-  return { ...prev, variant, message, details: merged };
+  return { ...prev, variant, message, description, details: merged };
 };
 
 const enterError = (
@@ -224,6 +236,7 @@ const enterError = (
   ...prev,
   variant: "error",
   message,
+  description: "",
   details: { ...prev.details, ...details, reason },
 });
 
@@ -244,6 +257,27 @@ const checkFacts = (info: Info, config: Config): Partial<StatusDetails> => ({
   clientServerCompatible: isCompatible(info.nodeVersion, config.clientVersion),
 });
 
+// Connected, with live updates refused. A settled outcome: only a policy
+// change lifts it, so the machine rests here instead of chasing the stream.
+const enterStreamDenied = (
+  prev: Status,
+  config: Config,
+  details: Partial<StatusDetails> = {},
+): Status =>
+  enter(
+    prev,
+    "warning",
+    connectedMessage(config),
+    {
+      ...details,
+      streamDenied: true,
+      streamLive: false,
+      error: undefined,
+      retry: null,
+    },
+    STREAM_DENIED,
+  );
+
 const reduceCheckSuccess = (prev: Status, info: Info, config: Config): Status => {
   const { clusterKey } = prev.details;
   if (clusterKey !== "" && info.clusterKey !== clusterKey)
@@ -254,6 +288,7 @@ const reduceCheckSuccess = (prev: Status, info: Info, config: Config): Status =>
   // lift out of error: the short circuit it drives would starve the very
   // stream reopen this state waits on.
   if (config.requiresStream && !prev.details.streamLive) {
+    if (prev.details.streamDenied) return enterStreamDenied(prev, config, facts);
     if (prev.variant === "error" && prev.details.reason === "unreachable")
       return enter(prev, "loading", RECONNECTING, {
         ...facts,
@@ -277,6 +312,7 @@ const reduceClusterReplaced = (prev: Status, info: Info, config: Config): Status
   enter(prev, "loading", `Connecting to ${config.name ?? "cluster"}`, {
     ...checkFacts(info, config),
     streamLive: false,
+    streamDenied: false,
     epoch: 0,
     error: undefined,
     retry: null,
@@ -306,9 +342,10 @@ const reduceCheckFailure = (
 
 const reduceStreamLive = (prev: Status, config: Config): Status => {
   const parked = prev.variant === "error" && prev.details.reason !== "unreachable";
-  if (parked) return update(prev, { streamLive: true });
+  if (parked) return update(prev, { streamLive: true, streamDenied: false });
   return enter(prev, "success", connectedMessage(config), {
     streamLive: true,
+    streamDenied: false,
     error: undefined,
     retry: null,
   });
@@ -345,6 +382,8 @@ export const reduce = (prev: Status, event: Event, config: Config): Status => {
       return reduceStreamLive(prev, config);
     case "stream.drop":
       return reduceStreamDrop(prev, event.error);
+    case "stream.denied":
+      return enterStreamDenied(prev, config);
     case "auth.success":
       return update(prev, { authenticated: true });
     case "auth.failure":
@@ -362,7 +401,11 @@ export const reduce = (prev: Status, event: Event, config: Config): Status => {
         return prev;
       return enter(prev, "loading", CONNECTING);
     case "credentials.replaced":
-      return enter(prev, "loading", CONNECTING, { error: undefined });
+      // the new user may hold the permissions the old one lacked
+      return enter(prev, "loading", CONNECTING, {
+        error: undefined,
+        streamDenied: false,
+      });
     case "closed":
       return enter(prev, "disabled", "Closed", {
         streamLive: false,

--- a/client/ts/src/device/access.spec.ts
+++ b/client/ts/src/device/access.spec.ts
@@ -11,7 +11,7 @@ import { id } from "@synnaxlabs/x";
 import { describe, expect, it } from "vitest";
 
 import { device } from "@/device";
-import { AuthError, NotFoundError } from "@/errors";
+import { AccessDeniedError, NotFoundError } from "@/errors";
 import { createTestClient, createTestClientWithPolicy } from "@/testutil";
 
 const client = createTestClient();
@@ -36,8 +36,8 @@ describe("device", () => {
         model: "test",
         properties: {},
       });
-      await expect(userClient.devices.retrieve(randomDevice.key)).rejects.toThrow(
-        AuthError,
+      await expect(userClient.devices.retrieve(randomDevice.key)).rejects.toSatisfy(
+        AccessDeniedError.matches,
       );
     });
 
@@ -103,7 +103,7 @@ describe("device", () => {
           model: "test",
           properties: {},
         }),
-      ).rejects.toThrow(AuthError);
+      ).rejects.toSatisfy(AccessDeniedError.matches);
     });
 
     it("should allow the caller to delete devices with the correct policy", async () => {
@@ -148,8 +148,8 @@ describe("device", () => {
         model: "test",
         properties: {},
       });
-      await expect(userClient.devices.delete(randomDevice.key)).rejects.toThrow(
-        AuthError,
+      await expect(userClient.devices.delete(randomDevice.key)).rejects.toSatisfy(
+        AccessDeniedError.matches,
       );
     });
   });

--- a/client/ts/src/errors.ts
+++ b/client/ts/src/errors.ts
@@ -63,6 +63,7 @@ export class InvalidTokenError extends AuthError.sub("invalid_token") {}
 
 export class ExpiredTokenError extends AuthError.sub("expired_token") {}
 
+/** Raised when the caller's policies do not permit the action. */
 export class AccessDeniedError extends AuthError.sub("access_denied") {}
 
 /**
@@ -135,6 +136,8 @@ const decode = (payload: errors.Payload): Error | null => {
       return new InvalidTokenError(payload.data);
     if (payload.type.startsWith(ExpiredTokenError.TYPE))
       return new ExpiredTokenError(payload.data);
+    if (payload.type.startsWith(AccessDeniedError.TYPE))
+      return new AccessDeniedError(payload.data);
     return new AuthError(payload.data);
   }
 

--- a/client/ts/src/framer/streamer.spec.ts
+++ b/client/ts/src/framer/streamer.spec.ts
@@ -21,6 +21,7 @@ import {
 import { describe, expect, it, test, vi } from "vitest";
 
 import { type channel } from "@/channel";
+import { AccessDeniedError } from "@/errors";
 import { Frame } from "@/framer/frame";
 import {
   HardenedStreamer,
@@ -822,6 +823,21 @@ describe("Streamer", () => {
       ).rejects.toThrow("very unreachable");
     });
 
+    it("should give up on the first denial instead of retrying", async () => {
+      const openerMock = vi.fn();
+      await expect(
+        HardenedStreamer.open(
+          async () => {
+            openerMock();
+            throw new AccessDeniedError("no permission to stream");
+          },
+          { channels: [1] },
+          { maxRetries: 3, baseInterval: TimeSpan.milliseconds(1) },
+        ),
+      ).rejects.toThrow(AccessDeniedError);
+      expect(openerMock).toHaveBeenCalledTimes(1);
+    });
+
     it("should fire onDrop when the stream fails and onReopen after recovery", async () => {
       const streamer1 = new MockStreamer();
       const streamer2 = new MockStreamer();
@@ -1020,6 +1036,28 @@ describe("Streamer", () => {
       await observable.close();
 
       expect(mockStreamer.closeMock).toHaveBeenCalled();
+    });
+
+    test("should report the failure that ended the stream", async () => {
+      const mockStreamer = new MockStreamer();
+      mockStreamer.responses = [[new Frame(), new AccessDeniedError("access revoked")]];
+      const onDead = vi.fn();
+      const observable = new ObservableStreamer(mockStreamer, undefined, onDead);
+
+      await expect.poll(() => onDead.mock.calls.length).toBe(1);
+      expect(AccessDeniedError.matches(onDead.mock.calls[0][0])).toBe(true);
+
+      await observable.close();
+    });
+
+    test("should not report a stream the caller closed", async () => {
+      const mockStreamer = new MockStreamer();
+      const onDead = vi.fn();
+      const observable = new ObservableStreamer(mockStreamer, undefined, onDead);
+
+      await observable.close();
+
+      expect(onDead).not.toHaveBeenCalled();
     });
   });
 });

--- a/client/ts/src/framer/streamer.ts
+++ b/client/ts/src/framer/streamer.ts
@@ -21,6 +21,7 @@ import { z } from "zod";
 
 import { type channel } from "@/channel";
 import { paramsZ } from "@/channel/payload";
+import { AccessDeniedError } from "@/errors";
 import { ReadAdapter } from "@/framer/adapter";
 import { WSStreamerCodec } from "@/framer/codec";
 import { Frame, frameZ } from "@/framer/frame";
@@ -312,7 +313,9 @@ export class HardenedStreamer implements Streamer {
       } catch (e) {
         this.current = null;
         if (this.closed) break;
-        if (!(await this.breaker.wait())) throw errors.fromUnknown(e);
+        // only a policy change lifts a denial, and no reconnect carries one
+        if (AccessDeniedError.matches(e) || !(await this.breaker.wait()))
+          throw errors.fromUnknown(e);
         console.error("failed to open streamer", e);
       }
     throw new EOF();
@@ -386,17 +389,26 @@ export class ObservableStreamer<V = Frame>
 {
   private readonly streamer: Streamer;
   private readonly closePromise: Promise<void>;
+  private readonly onDead?: (error: Error) => void;
+  private closeRequested = false;
 
   /**
    * Creates a new observable streamer.
    * @param streamer - The streamer to wrap
    * @param transform - An optional transform function to apply to each frame
+   * @param onDead - Called when the stream ends on a failure the wrapped
+   * streamer will not recover from. No frames follow.
    * @template V - The type of the transformed value. Only relevant if transform is
    * provided. Defaults to Frame.
    */
-  constructor(streamer: Streamer, transform?: observe.Transform<Frame, V>) {
+  constructor(
+    streamer: Streamer,
+    transform?: observe.Transform<Frame, V>,
+    onDead?: (error: Error) => void,
+  ) {
     super(transform);
     this.streamer = streamer;
+    this.onDead = onDead;
     this.closePromise = this.stream();
   }
 
@@ -405,11 +417,18 @@ export class ObservableStreamer<V = Frame>
   }
 
   async close(): Promise<void> {
+    this.closeRequested = true;
     this.streamer.close();
     await this.closePromise;
   }
 
   private async stream(): Promise<void> {
-    for await (const frame of this.streamer) this.notify(frame);
+    try {
+      for await (const frame of this.streamer) this.notify(frame);
+    } catch (exc) {
+      this.onDead?.(errors.fromUnknown(exc));
+      return;
+    }
+    if (!this.closeRequested) this.onDead?.(new EOF());
   }
 }

--- a/client/ts/src/group/access.spec.ts
+++ b/client/ts/src/group/access.spec.ts
@@ -10,7 +10,7 @@
 import { id } from "@synnaxlabs/x";
 import { describe, expect, it } from "vitest";
 
-import { AuthError } from "@/errors";
+import { AccessDeniedError } from "@/errors";
 import { group } from "@/group";
 import { ontology } from "@/ontology";
 import { createTestClient, createTestClientWithPolicy } from "@/testutil";
@@ -42,7 +42,7 @@ describe("group", () => {
           parent: ontology.ROOT_ID,
           name: `test-${id.create()}`,
         }),
-      ).rejects.toThrow(AuthError);
+      ).rejects.toSatisfy(AccessDeniedError.matches);
     });
 
     it("should allow the caller to delete groups with the correct policy", async () => {
@@ -68,8 +68,8 @@ describe("group", () => {
         parent: ontology.ROOT_ID,
         name: `test-${id.create()}`,
       });
-      await expect(userClient.groups.delete(randomGroup.key)).rejects.toThrow(
-        AuthError,
+      await expect(userClient.groups.delete(randomGroup.key)).rejects.toSatisfy(
+        AccessDeniedError.matches,
       );
     });
   });

--- a/client/ts/src/label/access.spec.ts
+++ b/client/ts/src/label/access.spec.ts
@@ -9,7 +9,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { AuthError, NotFoundError } from "@/errors";
+import { AccessDeniedError, NotFoundError } from "@/errors";
 import { label } from "@/label";
 import { createTestClient, createTestClientWithPolicy } from "@/testutil";
 
@@ -27,8 +27,8 @@ describe("label", () => {
         name: "test",
         color: "#E774D0",
       });
-      await expect(userClient.labels.retrieve(randomLabel.key)).rejects.toThrow(
-        AuthError,
+      await expect(userClient.labels.retrieve(randomLabel.key)).rejects.toSatisfy(
+        AccessDeniedError.matches,
       );
     });
 
@@ -71,7 +71,7 @@ describe("label", () => {
           name: "test",
           color: "#E774D0",
         }),
-      ).rejects.toThrow(AuthError);
+      ).rejects.toSatisfy(AccessDeniedError.matches);
     });
 
     it("should allow the caller to delete labels with the correct policy", async () => {
@@ -100,8 +100,8 @@ describe("label", () => {
         name: "test",
         color: "#E774D0",
       });
-      await expect(userClient.labels.delete(randomLabel.key)).rejects.toThrow(
-        AuthError,
+      await expect(userClient.labels.delete(randomLabel.key)).rejects.toSatisfy(
+        AccessDeniedError.matches,
       );
     });
   });

--- a/client/ts/src/lineplot/access.spec.ts
+++ b/client/ts/src/lineplot/access.spec.ts
@@ -9,7 +9,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { AuthError, NotFoundError } from "@/errors";
+import { AccessDeniedError, NotFoundError } from "@/errors";
 import { lineplot } from "@/lineplot";
 import { createTestClient, createTestClientWithPolicy } from "@/testutil";
 
@@ -25,8 +25,8 @@ describe("lineplot", () => {
       });
       const proj = await client.projects.create({ name: "test", layout: {} });
       const randomLinePlot = await client.lineplots.create(proj.key, { name: "test" });
-      await expect(userClient.lineplots.retrieve(randomLinePlot.key)).rejects.toThrow(
-        AuthError,
+      await expect(userClient.lineplots.retrieve(randomLinePlot.key)).rejects.toSatisfy(
+        AccessDeniedError.matches,
       );
     });
 
@@ -62,7 +62,7 @@ describe("lineplot", () => {
       const proj = await client.projects.create({ name: "test", layout: {} });
       await expect(
         userClient.lineplots.create(proj.key, { name: "test" }),
-      ).rejects.toThrow(AuthError);
+      ).rejects.toSatisfy(AccessDeniedError.matches);
     });
 
     it("should allow the caller to delete lineplots with the correct policy", async () => {
@@ -87,8 +87,8 @@ describe("lineplot", () => {
       });
       const proj = await client.projects.create({ name: "test", layout: {} });
       const randomLinePlot = await client.lineplots.create(proj.key, { name: "test" });
-      await expect(userClient.lineplots.delete(randomLinePlot.key)).rejects.toThrow(
-        AuthError,
+      await expect(userClient.lineplots.delete(randomLinePlot.key)).rejects.toSatisfy(
+        AccessDeniedError.matches,
       );
     });
   });

--- a/client/ts/src/log/access.spec.ts
+++ b/client/ts/src/log/access.spec.ts
@@ -9,7 +9,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { AuthError, NotFoundError } from "@/errors";
+import { AccessDeniedError, NotFoundError } from "@/errors";
 import { log } from "@/log";
 import { createTestClient, createTestClientWithPolicy } from "@/testutil";
 
@@ -25,7 +25,9 @@ describe("log", () => {
       });
       const proj = await client.projects.create({ name: "test", layout: {} });
       const randomLog = await client.logs.create(proj.key, { name: "test" });
-      await expect(userClient.logs.retrieve(randomLog.key)).rejects.toThrow(AuthError);
+      await expect(userClient.logs.retrieve(randomLog.key)).rejects.toSatisfy(
+        AccessDeniedError.matches,
+      );
     });
 
     it("should allow the caller to retrieve logs with the correct policy", async () => {
@@ -58,9 +60,9 @@ describe("log", () => {
         actions: [],
       });
       const proj = await client.projects.create({ name: "test", layout: {} });
-      await expect(userClient.logs.create(proj.key, { name: "test" })).rejects.toThrow(
-        AuthError,
-      );
+      await expect(
+        userClient.logs.create(proj.key, { name: "test" }),
+      ).rejects.toSatisfy(AccessDeniedError.matches);
     });
 
     it("should allow the caller to delete logs with the correct policy", async () => {
@@ -85,7 +87,9 @@ describe("log", () => {
       });
       const proj = await client.projects.create({ name: "test", layout: {} });
       const randomLog = await client.logs.create(proj.key, { name: "test" });
-      await expect(userClient.logs.delete(randomLog.key)).rejects.toThrow(AuthError);
+      await expect(userClient.logs.delete(randomLog.key)).rejects.toSatisfy(
+        AccessDeniedError.matches,
+      );
     });
   });
 });

--- a/client/ts/src/project/access.spec.ts
+++ b/client/ts/src/project/access.spec.ts
@@ -9,7 +9,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { AuthError, NotFoundError } from "@/errors";
+import { AccessDeniedError, NotFoundError } from "@/errors";
 import { project } from "@/project";
 import { createTestClient, createTestClientWithPolicy } from "@/testutil";
 
@@ -27,8 +27,8 @@ describe("project", () => {
         name: "test",
         layout: {},
       });
-      await expect(userClient.projects.retrieve(randomProject.key)).rejects.toThrow(
-        AuthError,
+      await expect(userClient.projects.retrieve(randomProject.key)).rejects.toSatisfy(
+        AccessDeniedError.matches,
       );
     });
 
@@ -70,7 +70,7 @@ describe("project", () => {
           name: "test",
           layout: {},
         }),
-      ).rejects.toThrow(AuthError);
+      ).rejects.toSatisfy(AccessDeniedError.matches);
     });
 
     it("should allow the caller to delete projects with the correct policy", async () => {
@@ -99,8 +99,8 @@ describe("project", () => {
         name: "test",
         layout: {},
       });
-      await expect(userClient.projects.delete(randomProject.key)).rejects.toThrow(
-        AuthError,
+      await expect(userClient.projects.delete(randomProject.key)).rejects.toSatisfy(
+        AccessDeniedError.matches,
       );
     });
   });

--- a/client/ts/src/query/cache.spec.ts
+++ b/client/ts/src/query/cache.spec.ts
@@ -13,7 +13,7 @@ import { describe, expect, it, vi } from "vitest";
 import z from "zod";
 
 import { type channel } from "@/channel";
-import { DisconnectedError, NotFoundError } from "@/errors";
+import { AccessDeniedError, DisconnectedError, NotFoundError } from "@/errors";
 import { framer } from "@/framer";
 import { query } from "@/query";
 
@@ -58,7 +58,7 @@ class MockStreamer implements framer.Streamer {
 
 const wrapOpener =
   (opener: framer.StreamOpener): query.StreamOpener =>
-  async (channels, { onOpen, onReopen }) => {
+  async (channels, { onOpen, onReopen, onDead }) => {
     const hardened = await framer.HardenedStreamer.open(
       opener,
       channels,
@@ -67,7 +67,7 @@ const wrapOpener =
       onReopen,
     );
     onOpen?.();
-    return new framer.ObservableStreamer(hardened);
+    return new framer.ObservableStreamer(hardened, undefined, onDead);
   };
 
 const makeEngine = (openStreamer?: framer.StreamOpener) =>
@@ -146,6 +146,34 @@ describe("Cache", () => {
       expect(cache.epoch).toEqual(0);
       const late = () => cache.createTable({ name: "late" });
       expect(late).not.toThrow();
+      await cache.close();
+    });
+
+    it("refetches subscribed answers, as nothing keeps them current", async () => {
+      const cache = new query.Cache({ openStreamer: null, onError: vi.fn() });
+      const table = cache.createTable<string, Doc>({ name: "docs" });
+      let name = "first";
+      const fetch = vi.fn(async (key: string) => {
+        table.set(key, { key, name });
+        return [key];
+      });
+      const space = cache.queries<string, Doc, string, Doc>({
+        name: "docs",
+        table,
+        fetch,
+        compose: (records) => records[0],
+        keyOf: (query) => query,
+        single: true,
+      });
+      const detach = space.onChange("k1", vi.fn());
+      await expect(space.retrieve("k1")).resolves.toEqual({ key: "k1", name: "first" });
+      name = "second";
+      await expect(space.retrieve("k1")).resolves.toEqual({
+        key: "k1",
+        name: "second",
+      });
+      expect(fetch).toHaveBeenCalledTimes(2);
+      detach();
       await cache.close();
     });
   });
@@ -322,6 +350,111 @@ describe("Cache", () => {
         name: "deleted-on-server",
       });
       expect(table.get("kept")).toEqual({ key: "kept", name: "kept-fresh" });
+      await cache.close();
+    });
+  });
+
+  describe("denied change stream", () => {
+    /** An opener the cluster refuses until `allow` flips. */
+    const deniedOpener = () => {
+      const state = { allow: false, opens: 0 };
+      const opener = async (): Promise<framer.Streamer> => {
+        state.opens += 1;
+        if (!state.allow) throw new AccessDeniedError("no permission to stream");
+        return new MockStreamer();
+      };
+      return { state, opener };
+    };
+
+    it("rejects ensureStreaming and stays at epoch 0", async () => {
+      const { opener } = deniedOpener();
+      const cache = makeEngine(opener);
+      cache.createTable<string, Doc>({ name: "docs" });
+      await expect(cache.ensureStreaming()).rejects.toThrow(AccessDeniedError);
+      expect(cache.epoch).toBe(0);
+      await cache.close();
+    });
+
+    it("refetches subscribed answers until the stream is allowed", async () => {
+      const { state, opener } = deniedOpener();
+      const cache = makeEngine(opener);
+      const table = cache.createTable<string, Doc>({ name: "docs" });
+      let name = "first";
+      const fetch = vi.fn(async (key: string) => {
+        table.set(key, { key, name });
+        return [key];
+      });
+      const space = cache.queries<string, Doc, string, Doc>({
+        name: "docs",
+        table,
+        fetch,
+        compose: (records) => records[0],
+        keyOf: (query) => query,
+        single: true,
+      });
+      const detach = space.onChange("k1", vi.fn());
+      await space.retrieve("k1");
+      await expect.poll(() => state.opens).toBeGreaterThan(0);
+      name = "second";
+      // denied: the subscribed answer has nothing keeping it current
+      await expect(space.retrieve("k1")).resolves.toEqual({
+        key: "k1",
+        name: "second",
+      });
+      expect(fetch).toHaveBeenCalledTimes(2);
+      state.allow = true;
+      await cache.ensureStreaming();
+      // the epoch bump reconfirms maintained answers: let it land before
+      // measuring what the next read costs
+      await expect.poll(() => fetch.mock.calls.length).toBeGreaterThan(2);
+      const reconfirmed = fetch.mock.calls.length;
+      name = "third";
+      // live again: maintenance is trustworthy, so the read serves the cache
+      await expect(space.retrieve("k1")).resolves.toEqual({
+        key: "k1",
+        name: "second",
+      });
+      expect(fetch).toHaveBeenCalledTimes(reconfirmed);
+      detach();
+      await cache.close();
+    });
+
+    it("stops maintaining answers when the stream is revoked mid-session", async () => {
+      const state = { opens: 0 };
+      const opener = async (): Promise<framer.Streamer> => {
+        state.opens += 1;
+        if (state.opens === 1) return failingStreamer();
+        throw new AccessDeniedError("access revoked");
+      };
+      const cache = makeEngine(opener);
+      const table = cache.createTable<string, Doc>({ name: "docs" });
+      let name = "first";
+      const fetch = vi.fn(async (key: string) => {
+        table.set(key, { key, name });
+        return [key];
+      });
+      const space = cache.queries<string, Doc, string, Doc>({
+        name: "docs",
+        table,
+        fetch,
+        compose: (records) => records[0],
+        keyOf: (query) => query,
+        single: true,
+      });
+      const detach = space.onChange("k1", vi.fn());
+      await cache.ensureStreaming();
+      await space.retrieve("k1");
+      await expect.poll(() => state.opens).toBeGreaterThan(1);
+      name = "second";
+      await expect(space.retrieve("k1")).resolves.toEqual({
+        key: "k1",
+        name: "second",
+      });
+      // the dead stream is discarded, so the next demand asks the cluster again
+      const opens = state.opens;
+      await expect(cache.ensureStreaming()).rejects.toThrow(AccessDeniedError);
+      expect(state.opens).toBeGreaterThan(opens);
+      detach();
       await cache.close();
     });
   });

--- a/client/ts/src/query/cache.spec.ts
+++ b/client/ts/src/query/cache.spec.ts
@@ -8,7 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { EOF, Unreachable } from "@synnaxlabs/freighter";
-import { type record, Series, TimeSpan } from "@synnaxlabs/x";
+import { type breaker, type record, Series, TimeSpan } from "@synnaxlabs/x";
 import { describe, expect, it, vi } from "vitest";
 import z from "zod";
 
@@ -57,22 +57,22 @@ class MockStreamer implements framer.Streamer {
 }
 
 const wrapOpener =
-  (opener: framer.StreamOpener): query.StreamOpener =>
+  (opener: framer.StreamOpener, retry?: breaker.Config): query.StreamOpener =>
   async (channels, { onOpen, onReopen, onDead }) => {
     const hardened = await framer.HardenedStreamer.open(
       opener,
       channels,
       // near-zero backoff so forced reopens land within poll timeouts
-      { baseInterval: TimeSpan.milliseconds(1) },
+      { baseInterval: TimeSpan.milliseconds(1), ...retry },
       onReopen,
     );
     onOpen?.();
     return new framer.ObservableStreamer(hardened, undefined, onDead);
   };
 
-const makeEngine = (openStreamer?: framer.StreamOpener) =>
+const makeEngine = (openStreamer?: framer.StreamOpener, retry?: breaker.Config) =>
   new query.Cache({
-    openStreamer: wrapOpener(openStreamer ?? (async () => new MockStreamer())),
+    openStreamer: wrapOpener(openStreamer ?? (async () => new MockStreamer()), retry),
     onError: vi.fn(),
   });
 
@@ -454,6 +454,36 @@ describe("Cache", () => {
       const opens = state.opens;
       await expect(cache.ensureStreaming()).rejects.toThrow(AccessDeniedError);
       expect(state.opens).toBeGreaterThan(opens);
+      detach();
+      await cache.close();
+    });
+  });
+
+  describe("dead change stream", () => {
+    it("stops maintaining answers once reconnects run out", async () => {
+      const cache = makeEngine(async () => failingStreamer(), { maxRetries: 1 });
+      const table = cache.createTable<string, Doc>({ name: "docs" });
+      let name = "first";
+      const fetch = vi.fn(async (key: string) => {
+        table.set(key, { key, name });
+        return [key];
+      });
+      const space = cache.queries<string, Doc, string, Doc>({
+        name: "docs",
+        table,
+        fetch,
+        compose: (records) => records[0],
+        keyOf: (query) => query,
+        single: true,
+      });
+      const detach = space.onChange("k1", vi.fn());
+      await cache.ensureStreaming();
+      await space.retrieve("k1");
+      name = "second";
+      // the cached answer stands until the stream gives up reconnecting
+      await expect
+        .poll(async () => (await space.retrieve("k1")).name)
+        .toEqual("second");
       detach();
       await cache.close();
     });

--- a/client/ts/src/query/cache.ts
+++ b/client/ts/src/query/cache.ts
@@ -10,7 +10,7 @@
 import { type destructor, observe, type record, type state } from "@synnaxlabs/x";
 import type z from "zod";
 
-import { AccessDeniedError, isConnectionError } from "@/errors";
+import { isConnectionError } from "@/errors";
 import { bindDerived, type DeriveParams } from "@/query/derived";
 import { Queries, type QueriesParams, type Retrieves } from "@/query/query";
 import {
@@ -93,7 +93,7 @@ export class Cache {
   private readonly openStreamer: StreamOpener | null;
   private streamer: Streamer | null = null;
   private epochCount = 0;
-  private denied = false;
+  private unmaintained = false;
 
   /**
    * Stable error sink for machinery built on this cache (dispatch
@@ -176,7 +176,7 @@ export class Cache {
     const space = new Queries(params, {
       ensureStreaming: async () => await this.ensureStreaming(),
       onEpoch: (callback) => this.onEpoch(callback),
-      maintained: () => !this.denied && this.openStreamer != null,
+      maintained: () => !this.unmaintained && this.openStreamer != null,
       onError: this.onError,
     });
     this.spaces.push(space);
@@ -205,7 +205,7 @@ export class Cache {
         onError: this.onError,
         onOpen: () => {
           if (this.streamer !== streamer) return;
-          this.denied = false;
+          this.unmaintained = false;
           this.epochCount = 1;
           this.epochObserver.notify(this.epochCount);
         },
@@ -213,9 +213,9 @@ export class Cache {
           if (this.streamer !== streamer) return;
           this.bumpEpoch();
         },
-        onDead: (error) => {
+        onDead: () => {
           if (this.streamer !== streamer) return;
-          if (AccessDeniedError.matches(error)) this.denied = true;
+          this.unmaintained = true;
         },
       });
       this.streamer = streamer;
@@ -223,7 +223,7 @@ export class Cache {
     try {
       await this.streamer.demand();
     } catch (exc) {
-      if (AccessDeniedError.matches(exc)) this.denied = true;
+      this.unmaintained = true;
       throw exc;
     }
   }
@@ -280,7 +280,7 @@ export class Cache {
     }
     this.entries.forEach(({ reset }) => reset());
     this.spaces.forEach((space) => space.reset());
-    this.denied = false;
+    this.unmaintained = false;
     this.epochCount = 0;
     this.epochObserver.notify(0);
   }

--- a/client/ts/src/query/cache.ts
+++ b/client/ts/src/query/cache.ts
@@ -10,7 +10,7 @@
 import { type destructor, observe, type record, type state } from "@synnaxlabs/x";
 import type z from "zod";
 
-import { isConnectionError } from "@/errors";
+import { AccessDeniedError, isConnectionError } from "@/errors";
 import { bindDerived, type DeriveParams } from "@/query/derived";
 import { Queries, type QueriesParams, type Retrieves } from "@/query/query";
 import {
@@ -93,6 +93,7 @@ export class Cache {
   private readonly openStreamer: StreamOpener | null;
   private streamer: Streamer | null = null;
   private epochCount = 0;
+  private denied = false;
 
   /**
    * Stable error sink for machinery built on this cache (dispatch
@@ -175,6 +176,7 @@ export class Cache {
     const space = new Queries(params, {
       ensureStreaming: async () => await this.ensureStreaming(),
       onEpoch: (callback) => this.onEpoch(callback),
+      maintained: () => !this.denied && this.openStreamer != null,
       onError: this.onError,
     });
     this.spaces.push(space);
@@ -185,6 +187,8 @@ export class Cache {
    * Ensures the change stream is open, opening it on first call. Callers that
    * populate or read tables await this first so no change is missed between a
    * fetch and the stream opening.
+   * @throws {AccessDeniedError} if the caller cannot stream the mirrored
+   * channels. Answers stop being maintained until a later call succeeds.
    */
   async ensureStreaming(): Promise<void> {
     const { openStreamer } = this;
@@ -201,6 +205,7 @@ export class Cache {
         onError: this.onError,
         onOpen: () => {
           if (this.streamer !== streamer) return;
+          this.denied = false;
           this.epochCount = 1;
           this.epochObserver.notify(this.epochCount);
         },
@@ -208,10 +213,19 @@ export class Cache {
           if (this.streamer !== streamer) return;
           this.bumpEpoch();
         },
+        onDead: (error) => {
+          if (this.streamer !== streamer) return;
+          if (AccessDeniedError.matches(error)) this.denied = true;
+        },
       });
       this.streamer = streamer;
     }
-    await this.streamer.demand();
+    try {
+      await this.streamer.demand();
+    } catch (exc) {
+      if (AccessDeniedError.matches(exc)) this.denied = true;
+      throw exc;
+    }
   }
 
   /**
@@ -266,6 +280,7 @@ export class Cache {
     }
     this.entries.forEach(({ reset }) => reset());
     this.spaces.forEach((space) => space.reset());
+    this.denied = false;
     this.epochCount = 0;
     this.epochObserver.notify(0);
   }

--- a/client/ts/src/query/cache.ts
+++ b/client/ts/src/query/cache.ts
@@ -7,7 +7,13 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { type destructor, observe, type record, type state } from "@synnaxlabs/x";
+import {
+  type destructor,
+  errors,
+  observe,
+  type record,
+  type state,
+} from "@synnaxlabs/x";
 import type z from "zod";
 
 import { isConnectionError } from "@/errors";
@@ -224,7 +230,7 @@ export class Cache {
       await this.streamer.demand();
     } catch (exc) {
       this.unmaintained = true;
-      throw exc;
+      throw errors.fromUnknown(exc);
     }
   }
 

--- a/client/ts/src/query/query.spec.ts
+++ b/client/ts/src/query/query.spec.ts
@@ -10,7 +10,7 @@
 import { type record, TimeStamp } from "@synnaxlabs/x";
 import { describe, expect, it, vi } from "vitest";
 
-import { NotFoundError } from "@/errors";
+import { AccessDeniedError, NotFoundError } from "@/errors";
 import { query } from "@/query";
 import { Deleted } from "@/query/deleted";
 import { type AnswersHooks, Queries } from "@/query/query";
@@ -319,6 +319,47 @@ describe("Answers", () => {
       );
       expect(await answers.retrieve(qA)).toEqual(1);
       expect(ensureStreaming).toHaveBeenCalledTimes(1);
+    });
+
+    it("should refetch every read of a subscribed query while unmaintained", async () => {
+      const table = newTable();
+      let maintained = true;
+      let value = 1;
+      const fetch = vi.fn(async () => {
+        table.set("a", rec("a", value));
+        return ["a"];
+      });
+      const answers = singleSpace(table, fetch, { maintained: () => maintained });
+      answers.onChange(qA, vi.fn());
+      expect(await answers.retrieve(qA)).toEqual(1);
+      value = 2;
+      // maintained and streaming: the cached answer stands
+      expect(await answers.retrieve(qA)).toEqual(1);
+      maintained = false;
+      // nothing feeds the table now, so the answer must be reconfirmed
+      expect(await answers.retrieve(qA)).toEqual(2);
+      expect(fetch).toHaveBeenCalledTimes(2);
+    });
+
+    it("should stay silent when the change stream is denied", async () => {
+      const table = newTable();
+      const onError = vi.fn();
+      const answers = singleSpace(
+        table,
+        async () => {
+          table.set("a", rec("a", 1));
+          return ["a"];
+        },
+        {
+          ensureStreaming: async () => {
+            throw new AccessDeniedError("no permission to stream");
+          },
+          onError,
+        },
+      );
+      expect(await answers.retrieve(qA)).toEqual(1);
+      await wait(5);
+      expect(onError).not.toHaveBeenCalled();
     });
   });
 

--- a/client/ts/src/query/query.ts
+++ b/client/ts/src/query/query.ts
@@ -16,7 +16,7 @@ import {
   TimeSpan,
 } from "@synnaxlabs/x";
 
-import { NotFoundError } from "@/errors";
+import { AccessDeniedError, NotFoundError } from "@/errors";
 import { Deleted } from "@/query/deleted";
 import { type Table, type TableEvent } from "@/query/table";
 import { type Data, type FetchOptions, type Params } from "@/query/types";
@@ -175,6 +175,11 @@ export interface AnswersHooks {
   ensureStreaming?: () => Promise<void>;
   /** Subscribes to connection-epoch changes; maintained answers refetch on bump. */
   onEpoch?: (callback: (epoch: number) => void) => destructor.Destructor;
+  /**
+   * Whether change delivery keeps subscribed answers current. False when the
+   * cache is detached or the cluster refused the stream. Defaults to true.
+   */
+  maintained?: () => boolean;
   /** Reports maintenance errors that have no caller to throw to. Defaults to
    *  console logging. */
   onError?: (error: Error) => void;
@@ -247,14 +252,16 @@ export class Queries<
    * Returns the answer to the query: instantly when cached and subscribed,
    * joining the in-flight fetch when one exists, fetching otherwise. Settled
    * answers are kept fresh only while subscribed, so an unsubscribed read
-   * always refetches. A previously failed query refetches.
+   * always refetches. A previously failed query refetches. Every read refetches
+   * while change delivery is off, as nothing keeps a subscribed answer
+   * current.
    * @throws {NotFoundError} if the queried record was deleted.
    */
   retrieve(query: Q, options?: FetchOptions): Promise<D> {
     const entry = this.ensure(query);
     const { state } = entry;
     if (state.variant === "loading") return state.promise;
-    if (entry.teardown != null)
+    if (entry.teardown != null && this.hooks.maintained?.() !== false)
       switch (state.variant) {
         case "ready":
           return Promise.resolve(this.compose(state.keys, entry.query));
@@ -359,9 +366,13 @@ export class Queries<
   }
 
   private startStreaming(): void {
-    // Streaming failure (e.g. no streamer permission) must never block reads,
-    // so the change stream opens in the background rather than being awaited.
-    void this.hooks.ensureStreaming?.().catch((exc: unknown) => this.report(exc));
+    // Streaming failure must never block reads, so the change stream opens in
+    // the background rather than being awaited. A denial belongs to the
+    // connection, which reports it once, not to every query that reads.
+    void this.hooks.ensureStreaming?.().catch((exc: unknown) => {
+      if (AccessDeniedError.matches(exc)) return;
+      this.report(exc);
+    });
   }
 
   private report(

--- a/client/ts/src/query/retriever.spec.ts
+++ b/client/ts/src/query/retriever.spec.ts
@@ -32,7 +32,15 @@ interface Request extends z.infer<typeof requestZ> {}
 
 const paramsZ = requestZ.or(query.keyListZ(z.string()));
 
-const newCache = () => new query.Cache({ openStreamer: null });
+// A live but silent stream: subscribed answers stay maintained, so reads
+// serve from the cache without a network fetch.
+const newCache = () =>
+  new query.Cache({
+    openStreamer: async (_, { onOpen }) => {
+      onOpen?.();
+      return { onChange: () => {}, close: async () => {} };
+    },
+  });
 
 class Client extends query.Retriever<typeof paramsZ, string, Thing> {
   constructor(

--- a/client/ts/src/query/streamer.ts
+++ b/client/ts/src/query/streamer.ts
@@ -58,12 +58,14 @@ export interface ObservableStream {
 
 /**
  * Hooks passed to a {@link StreamOpener}. The implementation must fire onOpen
- * after the stream is live but before any frame is delivered, and onReopen
- * after every successful reconnect (not the initial open).
+ * after the stream is live but before any frame is delivered, onReopen after
+ * every successful reconnect (not the initial open), and onDead when the
+ * stream ends on a failure it cannot recover from.
  */
 export interface StreamOpenerHooks {
   onOpen?: () => void;
   onReopen?: () => void;
+  onDead?: (error: Error) => void;
 }
 
 /**
@@ -96,6 +98,11 @@ export interface StreamerParams {
    * initial open). Changes may have been missed while disconnected.
    */
   onReopen?: () => void;
+  /**
+   * Called when the stream ends on a failure it cannot recover from. The next
+   * demand opens a new stream.
+   */
+  onDead?: (error: Error) => void;
 }
 
 /**
@@ -126,6 +133,7 @@ export const createStreamer = ({
   onError,
   onOpen,
   onReopen,
+  onDead,
 }: StreamerParams): Streamer => {
   let opened: Promise<ObservableStream> | null = null;
   const report = (exc: unknown, message: string) => {
@@ -142,7 +150,15 @@ export const createStreamer = ({
       const { channel } = lis;
       listenersForChannels[channel] = [...(listenersForChannels[channel] || []), lis];
     });
-    const stream = await streamOpener(channels, { onOpen, onReopen });
+    const stream = await streamOpener(channels, {
+      onOpen,
+      onReopen,
+      onDead: (error) => {
+        // drop the memoized stream so the next demand opens a fresh one
+        opened = null;
+        onDead?.(error);
+      },
+    });
     const handleChange = (frame: framer.Frame) => {
       const namesInFrame = [...frame.uniqueNames];
       namesInFrame.sort(channelNameSort);

--- a/client/ts/src/rack/access.spec.ts
+++ b/client/ts/src/rack/access.spec.ts
@@ -9,7 +9,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { AuthError, NotFoundError } from "@/errors";
+import { AccessDeniedError, NotFoundError } from "@/errors";
 import { rack } from "@/rack";
 import { createTestClient, createTestClientWithPolicy } from "@/testutil";
 
@@ -26,8 +26,8 @@ describe("rack", () => {
       const randomRack = await client.racks.create({
         name: "test",
       });
-      await expect(userClient.racks.retrieve(randomRack.key)).rejects.toThrow(
-        AuthError,
+      await expect(userClient.racks.retrieve(randomRack.key)).rejects.toSatisfy(
+        AccessDeniedError.matches,
       );
     });
 
@@ -66,7 +66,7 @@ describe("rack", () => {
         userClient.racks.create({
           name: "test",
         }),
-      ).rejects.toThrow(AuthError);
+      ).rejects.toSatisfy(AccessDeniedError.matches);
     });
 
     it("should allow the caller to delete racks with the correct policy", async () => {
@@ -93,7 +93,9 @@ describe("rack", () => {
       const randomRack = await client.racks.create({
         name: "test",
       });
-      await expect(userClient.racks.delete(randomRack.key)).rejects.toThrow(AuthError);
+      await expect(userClient.racks.delete(randomRack.key)).rejects.toSatisfy(
+        AccessDeniedError.matches,
+      );
     });
   });
 });

--- a/client/ts/src/ranger/access.spec.ts
+++ b/client/ts/src/ranger/access.spec.ts
@@ -10,7 +10,7 @@
 import { TimeRange } from "@synnaxlabs/x";
 import { describe, expect, it } from "vitest";
 
-import { AuthError, NotFoundError } from "@/errors";
+import { AccessDeniedError, NotFoundError } from "@/errors";
 import { ranger } from "@/ranger";
 import { createTestClient, createTestClientWithPolicy } from "@/testutil";
 
@@ -29,8 +29,8 @@ describe("range", () => {
         timeRange: new TimeRange(1n, 1000n),
         color: "#E774D0",
       });
-      await expect(userClient.ranges.retrieve(randomRange.key)).rejects.toThrow(
-        AuthError,
+      await expect(userClient.ranges.retrieve(randomRange.key)).rejects.toSatisfy(
+        AccessDeniedError.matches,
       );
     });
 
@@ -75,7 +75,7 @@ describe("range", () => {
           timeRange: new TimeRange(1n, 1000n),
           color: "#E774D0",
         }),
-      ).rejects.toThrow(AuthError);
+      ).rejects.toSatisfy(AccessDeniedError.matches);
     });
 
     it("should allow the caller to delete ranges with the correct policy", async () => {
@@ -106,8 +106,8 @@ describe("range", () => {
         timeRange: new TimeRange(1n, 1000n),
         color: "#E774D0",
       });
-      await expect(userClient.ranges.delete(randomRange.key)).rejects.toThrow(
-        AuthError,
+      await expect(userClient.ranges.delete(randomRange.key)).rejects.toSatisfy(
+        AccessDeniedError.matches,
       );
     });
   });

--- a/client/ts/src/schematic/access.spec.ts
+++ b/client/ts/src/schematic/access.spec.ts
@@ -9,7 +9,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { AuthError, NotFoundError } from "@/errors";
+import { AccessDeniedError, NotFoundError } from "@/errors";
 import { schematic } from "@/schematic";
 import { createTestClient, createTestClientWithPolicy } from "@/testutil";
 
@@ -30,9 +30,9 @@ describe("schematic", () => {
       const randomSchematic = await client.schematics.create(proj.key, {
         name: "test",
       });
-      await expect(userClient.schematics.retrieve(randomSchematic.key)).rejects.toThrow(
-        AuthError,
-      );
+      await expect(
+        userClient.schematics.retrieve(randomSchematic.key),
+      ).rejects.toSatisfy(AccessDeniedError.matches);
     });
 
     it("should allow the caller to retrieve schematics with the correct policy", async () => {
@@ -82,7 +82,7 @@ describe("schematic", () => {
         userClient.schematics.create(proj.key, {
           name: "test",
         }),
-      ).rejects.toThrow(AuthError);
+      ).rejects.toSatisfy(AccessDeniedError.matches);
     });
 
     it("should allow the caller to delete schematics with the correct policy", async () => {
@@ -117,8 +117,8 @@ describe("schematic", () => {
       const randomSchematic = await client.schematics.create(proj.key, {
         name: "test",
       });
-      await expect(userClient.schematics.delete(randomSchematic.key)).rejects.toThrow(
-        AuthError,
+      await expect(userClient.schematics.delete(randomSchematic.key)).rejects.toSatisfy(
+        AccessDeniedError.matches,
       );
     });
   });

--- a/client/ts/src/schematic/symbol/access.spec.ts
+++ b/client/ts/src/schematic/symbol/access.spec.ts
@@ -9,7 +9,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { AuthError, NotFoundError } from "@/errors";
+import { AccessDeniedError, NotFoundError } from "@/errors";
 import { group } from "@/group";
 import { ontology } from "@/ontology";
 import { symbol } from "@/schematic/symbol";
@@ -41,7 +41,7 @@ describe("schematic_symbol", () => {
       });
       await expect(
         userClient.schematics.symbols.retrieve(randomSymbol.key),
-      ).rejects.toThrow(AuthError);
+      ).rejects.toSatisfy(AccessDeniedError.matches);
     });
 
     it("should allow the caller to retrieve symbols with the correct policy", async () => {
@@ -112,7 +112,7 @@ describe("schematic_symbol", () => {
           },
           parent: group.ontologyID(symbolGroup.key),
         }),
-      ).rejects.toThrow(AuthError);
+      ).rejects.toSatisfy(AccessDeniedError.matches);
     });
 
     it("should allow the caller to delete symbols with the correct policy", async () => {
@@ -163,7 +163,7 @@ describe("schematic_symbol", () => {
       });
       await expect(
         userClient.schematics.symbols.delete(randomSymbol.key),
-      ).rejects.toThrow(AuthError);
+      ).rejects.toSatisfy(AccessDeniedError.matches);
     });
   });
 });

--- a/client/ts/src/status/access.spec.ts
+++ b/client/ts/src/status/access.spec.ts
@@ -10,7 +10,7 @@
 import { TimeStamp, uuid } from "@synnaxlabs/x";
 import { describe, expect, it } from "vitest";
 
-import { AuthError, NotFoundError } from "@/errors";
+import { AccessDeniedError, NotFoundError } from "@/errors";
 import { status } from "@/status";
 import { createTestClient, createTestClientWithPolicy } from "@/testutil";
 
@@ -31,8 +31,8 @@ describe("status", () => {
         message: "test",
         time: TimeStamp.now(),
       });
-      await expect(userClient.statuses.retrieve(randomStatus.key)).rejects.toThrow(
-        AuthError,
+      await expect(userClient.statuses.retrieve(randomStatus.key)).rejects.toSatisfy(
+        AccessDeniedError.matches,
       );
     });
 
@@ -83,7 +83,7 @@ describe("status", () => {
           message: "test",
           time: TimeStamp.now(),
         }),
-      ).rejects.toThrow(AuthError);
+      ).rejects.toSatisfy(AccessDeniedError.matches);
     });
 
     it("should allow the caller to delete statuses with the correct policy", async () => {
@@ -118,8 +118,8 @@ describe("status", () => {
         message: "test",
         time: TimeStamp.now(),
       });
-      await expect(userClient.statuses.delete(randomStatus.key)).rejects.toThrow(
-        AuthError,
+      await expect(userClient.statuses.delete(randomStatus.key)).rejects.toSatisfy(
+        AccessDeniedError.matches,
       );
     });
   });

--- a/client/ts/src/table/access.spec.ts
+++ b/client/ts/src/table/access.spec.ts
@@ -9,7 +9,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { AuthError, NotFoundError } from "@/errors";
+import { AccessDeniedError, NotFoundError } from "@/errors";
 import { table } from "@/table";
 import { createTestClient, createTestClientWithPolicy } from "@/testutil";
 
@@ -30,8 +30,8 @@ describe("table", () => {
       const randomTable = await client.tables.create(proj.key, {
         name: "test",
       });
-      await expect(userClient.tables.retrieve(randomTable.key)).rejects.toThrow(
-        AuthError,
+      await expect(userClient.tables.retrieve(randomTable.key)).rejects.toSatisfy(
+        AccessDeniedError.matches,
       );
     });
 
@@ -82,7 +82,7 @@ describe("table", () => {
         userClient.tables.create(proj.key, {
           name: "test",
         }),
-      ).rejects.toThrow(AuthError);
+      ).rejects.toSatisfy(AccessDeniedError.matches);
     });
 
     it("should allow the caller to delete tables with the correct policy", async () => {
@@ -117,8 +117,8 @@ describe("table", () => {
       const randomTable = await client.tables.create(proj.key, {
         name: "test",
       });
-      await expect(userClient.tables.delete(randomTable.key)).rejects.toThrow(
-        AuthError,
+      await expect(userClient.tables.delete(randomTable.key)).rejects.toSatisfy(
+        AccessDeniedError.matches,
       );
     });
   });

--- a/client/ts/src/task/access.spec.ts
+++ b/client/ts/src/task/access.spec.ts
@@ -9,7 +9,7 @@
 
 import { describe, expect, it } from "vitest";
 
-import { AuthError, NotFoundError } from "@/errors";
+import { AccessDeniedError, NotFoundError } from "@/errors";
 import { rack } from "@/rack";
 import { task } from "@/task";
 import { createTestClient, createTestClientWithPolicy } from "@/testutil";
@@ -32,8 +32,8 @@ describe("task", () => {
         type: "ni",
         config: {},
       });
-      await expect(userClient.tasks.retrieve(randomTask.key)).rejects.toThrow(
-        AuthError,
+      await expect(userClient.tasks.retrieve(randomTask.key)).rejects.toSatisfy(
+        AccessDeniedError.matches,
       );
     });
 
@@ -85,7 +85,7 @@ describe("task", () => {
           type: "ni",
           config: {},
         }),
-      ).rejects.toThrow(AuthError);
+      ).rejects.toSatisfy(AccessDeniedError.matches);
     });
 
     it("should allow the caller to delete tasks with the correct policy", async () => {
@@ -122,7 +122,9 @@ describe("task", () => {
         type: "ni",
         config: {},
       });
-      await expect(userClient.tasks.delete(randomTask.key)).rejects.toThrow(AuthError);
+      await expect(userClient.tasks.delete(randomTask.key)).rejects.toSatisfy(
+        AccessDeniedError.matches,
+      );
     });
   });
 });

--- a/client/ts/src/user/access.spec.ts
+++ b/client/ts/src/user/access.spec.ts
@@ -10,7 +10,7 @@
 import { id } from "@synnaxlabs/x";
 import { describe, expect, it } from "vitest";
 
-import { AuthError, NotFoundError } from "@/errors";
+import { AccessDeniedError, NotFoundError } from "@/errors";
 import { createTestClient, createTestClientWithPolicy } from "@/testutil";
 import { user } from "@/user";
 
@@ -28,8 +28,8 @@ describe("user", () => {
         username: id.create(),
         password: "test",
       });
-      await expect(userClient.users.retrieve(randomUser.key)).rejects.toThrow(
-        AuthError,
+      await expect(userClient.users.retrieve(randomUser.key)).rejects.toSatisfy(
+        AccessDeniedError.matches,
       );
     });
 
@@ -71,7 +71,7 @@ describe("user", () => {
           username: id.create(),
           password: "test",
         }),
-      ).rejects.toThrow(AuthError);
+      ).rejects.toSatisfy(AccessDeniedError.matches);
     });
 
     it("should allow the caller to delete users with the correct policy", async () => {
@@ -100,7 +100,9 @@ describe("user", () => {
         username: id.create(),
         password: "test",
       });
-      await expect(userClient.users.delete(randomUser.key)).rejects.toThrow(AuthError);
+      await expect(userClient.users.delete(randomUser.key)).rejects.toSatisfy(
+        AccessDeniedError.matches,
+      );
     });
   });
 });

--- a/core/pkg/service/access/errors.go
+++ b/core/pkg/service/access/errors.go
@@ -9,9 +9,8 @@
 
 package access
 
-import (
-	"github.com/synnaxlabs/synnax/pkg/service/auth"
-	"github.com/synnaxlabs/x/errors"
-)
+import "github.com/synnaxlabs/synnax/pkg/service/auth"
 
-var ErrDenied = errors.Wrap(auth.ErrAuth, "access denied")
+// ErrDenied is returned when a subject does not have permission to perform an
+// action on a resource.
+var ErrDenied = auth.ErrAccessDenied

--- a/core/pkg/service/auth/errors.go
+++ b/core/pkg/service/auth/errors.go
@@ -28,6 +28,9 @@ var (
 	ErrInvalidToken = errors.Wrap(ErrAuth, "invalid token")
 	// ErrExpiredToken is returned when a bearer token has expired.
 	ErrExpiredToken = errors.Wrap(ErrAuth, "expired token")
+	// ErrAccessDenied is returned when a subject does not have permission to
+	// perform an action on a resource.
+	ErrAccessDenied = errors.Wrap(ErrAuth, "access denied")
 )
 
 const (
@@ -36,6 +39,7 @@ const (
 	invalidTokenType       = errorType + ".invalid_token"
 	expiredTokenType       = errorType + ".expired_token"
 	repeatedUsernameType   = errorType + ".repeated-username"
+	accessDeniedType       = errorType + ".access_denied"
 )
 
 func encode(_ context.Context, err error) (errors.Payload, bool) {
@@ -50,6 +54,9 @@ func encode(_ context.Context, err error) (errors.Payload, bool) {
 	}
 	if errors.CheapIs(err, ErrRepeatedUsername) {
 		return errors.Payload{Type: repeatedUsernameType, Data: err.Error()}, true
+	}
+	if errors.CheapIs(err, ErrAccessDenied) {
+		return errors.Payload{Type: accessDeniedType, Data: err.Error()}, true
 	}
 	if errors.CheapIs(err, ErrAuth) {
 		return errors.Payload{Type: errorType, Data: err.Error()}, true
@@ -67,6 +74,8 @@ func decode(_ context.Context, p errors.Payload) (error, bool) {
 		return errors.Wrap(ErrRepeatedUsername, p.Data), true
 	case expiredTokenType:
 		return errors.Wrap(ErrExpiredToken, p.Data), true
+	case accessDeniedType:
+		return errors.Wrap(ErrAccessDenied, p.Data), true
 	}
 	if strings.HasPrefix(p.Type, errorType) {
 		return errors.Wrap(ErrAuth, p.Data), true

--- a/core/pkg/service/auth/errors_test.go
+++ b/core/pkg/service/auth/errors_test.go
@@ -27,8 +27,15 @@ var _ = Describe("Errors", func() {
 		Entry("RepeatedUsername", auth.ErrRepeatedUsername),
 		Entry("InvalidToken", auth.ErrInvalidToken),
 		Entry("ExpiredToken", auth.ErrExpiredToken),
+		Entry("AccessDenied", auth.ErrAccessDenied),
 		Entry("Auth", auth.ErrAuth),
 	)
+	It("Should keep a denial distinct from a plain auth error", func(ctx SpecContext) {
+		pld := errors.Encode(ctx, auth.ErrAccessDenied, false)
+		Expect(errors.Is(errors.Decode(ctx, pld), auth.ErrAccessDenied)).To(BeTrue())
+		pld = errors.Encode(ctx, auth.ErrAuth, false)
+		Expect(errors.Is(errors.Decode(ctx, pld), auth.ErrAccessDenied)).To(BeFalse())
+	})
 	It("Should defer non-auth errors to other encoders", func(ctx SpecContext) {
 		errTest := errors.New("test error")
 		pld := errors.Encode(ctx, errTest, false)

--- a/pluto/src/synnax/Provider.tsx
+++ b/pluto/src/synnax/Provider.tsx
@@ -159,7 +159,11 @@ export const Provider = ({
         prev.message !== connStatus.message ||
         reasonOf(prev) !== reasonOf(connStatus)
       )
-        addStatus({ variant: connStatus.variant, message: connStatus.message });
+        addStatus({
+          variant: connStatus.variant,
+          message: connStatus.message,
+          description: connStatus.description,
+        });
       if (connStatus.variant === "success") {
         if (connStatus.details.clockSkewExceeded)
           addClockSkewStatus(addStatus, connStatus);

--- a/pluto/src/synnax/Provider.tsx
+++ b/pluto/src/synnax/Provider.tsx
@@ -159,11 +159,7 @@ export const Provider = ({
         prev.message !== connStatus.message ||
         reasonOf(prev) !== reasonOf(connStatus)
       )
-        addStatus({
-          variant: connStatus.variant,
-          message: connStatus.message,
-          description: connStatus.description,
-        });
+        addStatus(connStatus);
       if (connStatus.variant === "success") {
         if (connStatus.details.clockSkewExceeded)
           addClockSkewStatus(addStatus, connStatus);


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4559](https://linear.app/synnax/issue/SY-4559)

## Description

A client whose policies do not permit `retrieve` on the cache's channels cannot open
the change stream. Until now it kept going as if it could: every subscribed answer
stayed in memory and was served forever, with nothing to invalidate it. The user saw
stale records with no sign that anything was wrong, the connection sat on
"Connecting...", and every heartbeat retried the refused stream four times with
backoff, printing the failure once per attempt.

The Core now sends a policy refusal as its own wire type, `sy.auth.access_denied`, so
a client can tell "you are not allowed" from "your password is wrong". `access.ErrDenied`
aliases the new `auth.ErrAccessDenied`, so no call site changed. TypeScript decodes it
as `AccessDeniedError` and Python as `AccessDenied`.

With that distinction, the client:

- Gives up on the first refusal instead of backing off four times, since only a policy
  change lifts a denial.
- Settles the connection on `warning` rather than `loading`, so `connect()` resolves and
  the Console stops waiting. The status carries a `streamDenied` detail and an
  explanation of what still works.
- Reports the denial once, then re-probes on a slow cadence instead of every heartbeat.
- Refetches on every read while nothing keeps the cache current, so answers are correct
  but no longer free.

Two further cases reach the same state and are now handled the same way. A stream
revoked mid-session tells the cache and the connection through a new `onDead` callback,
instead of ending an unobserved read loop and leaving `demand()` a permanent no-op. And
a client built with `cache: false` reports itself unmaintained, which fixes a gap
against RFC 0047: a subscribed query on such a client used to answer from memory forever
rather than going to the network.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR distinguishes policy denials from authentication failures and prevents the TypeScript query cache from trusting subscribed answers while its change stream is unavailable.
- Adds cross-language access-denied error encoding and decoding.
- Transitions denied streams into a settled warning state with periodic re-probing.
- Marks caches unmaintained after every terminal stream failure so subsequent reads refetch.
- Propagates degraded connection state through the Pluto provider.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains; current HEAD marks the cache unmaintained for every terminal change-stream failure and refetches subscribed answers while the stream is unavailable.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| client/ts/src/query/cache.ts | Terminal stream failures now unconditionally mark cached query answers unmaintained, resolving the previously reported stale-read path. |
| client/ts/src/query/query.ts | Subscribed retrievals now consult cache maintenance state and refetch when no active stream keeps their answers current. |
| client/ts/src/query/streamer.ts | Terminal stream callbacks clear the memoized open stream so later demand can establish a replacement. |
| client/ts/src/framer/streamer.ts | Observable streamers now report unexpected terminal errors or completion while suppressing caller-requested closure. |
| client/ts/src/connection/client.ts | Denied streams settle into warning status, are reported once, and are re-probed on a slower heartbeat cadence. |
| client/ts/src/connection/status.ts | Connection state now represents stream denial separately from authentication and reachability failures. |
| core/pkg/service/auth/errors.go | Core authentication errors now expose a distinct wire type for authorization denial. |
| pluto/src/synnax/Provider.tsx | The provider propagates the client’s degraded-but-usable connection status to consumers. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Open change stream] --> B{Result}
  B -->|Live| C[Mark stream live]
  C --> D[Trust maintained subscribed answers]
  B -->|Access denied| E[Connection warning]
  B -->|Other terminal failure| F[Connection stream drop]
  E --> G[Mark cache unmaintained]
  F --> G
  G --> H[Subscribed read]
  H --> I[Refetch through unary API]
  E --> J[Periodic stream re-probe]
  F --> K[Re-demand stream]
  J --> A
  K --> A
```

<sub>Reviews (2): Last reviewed commit: ["SY-4559: Satisfy the lint rules on the n..."](https://github.com/synnaxlabs/synnax/commit/d6c915382958c7c6125721a00fbbd89febbc28b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51666617)</sub>

<details><summary><h4>Context used (3)</h4></summary>

- Knowledge Base — [Client SDKs](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/client-sdks.md)
- Knowledge Base — [Core Server](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/core-server.md)
- Knowledge Base — [Pluto Component and Visualization Library](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/pluto-components.md)
</details>

<!-- /greptile_comment -->