### PR TITLE
SY-4562: Remove density and normalize the TypeScript channel constructor

### DIFF
--- a/client/ts/src/channel/channel.spec.ts
+++ b/client/ts/src/channel/channel.spec.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { DataType, id, TimeRange, TimeStamp } from "@synnaxlabs/x";
+import { control, DataType, id, TimeRange, TimeStamp } from "@synnaxlabs/x";
 import { beforeAll, describe, expect, it, test, vi } from "vitest";
 
 import { Channel } from "@/channel/client";
@@ -365,6 +365,19 @@ describe("Channel", () => {
 
       const retrieved = await client.channels.retrieve(channel.key);
       expect(retrieved.name).toEqual(updated.name);
+    });
+  });
+
+  describe("payload", () => {
+    it("keeps shared concurrency through a round trip", () => {
+      const ch = new Channel({
+        name: "shared",
+        dataType: DataType.FLOAT32,
+        virtual: true,
+        concurrency: control.Concurrency.shared,
+      });
+      expect(ch.payload.concurrency).toEqual(control.Concurrency.shared);
+      expect(new Channel(ch.payload).concurrency).toEqual(control.Concurrency.shared);
     });
   });
 });

--- a/client/ts/src/channel/channel.spec.ts
+++ b/client/ts/src/channel/channel.spec.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { control, DataType, id, TimeRange, TimeStamp } from "@synnaxlabs/x";
+import { control, DataType, id, TimeRange, TimeSpan, TimeStamp } from "@synnaxlabs/x";
 import { beforeAll, describe, expect, it, test, vi } from "vitest";
 
 import { Channel } from "@/channel/client";
@@ -378,6 +378,40 @@ describe("Channel", () => {
       });
       expect(ch.payload.concurrency).toEqual(control.Concurrency.shared);
       expect(new Channel(ch.payload).concurrency).toEqual(control.Concurrency.shared);
+    });
+  });
+
+  describe("constructor normalization", () => {
+    it("fills the defaults omitted from a crude operation", () => {
+      const [op] = new Channel({
+        name: "op",
+        dataType: DataType.FLOAT32,
+        operations: [{ type: "avg" }],
+      }).operations;
+      expect(op.resetChannel).toEqual(0);
+      expect(op.duration).toEqual(TimeSpan.ZERO);
+    });
+
+    it("parses a crude status time into a TimeStamp", () => {
+      const date = new Date("2026-08-10T00:00:00.000Z");
+      const ch = new Channel({
+        name: "stat",
+        dataType: DataType.FLOAT32,
+        status: { variant: "error", message: "boom", time: date },
+      });
+      expect(ch.status?.time).toBeInstanceOf(TimeStamp);
+      expect(ch.status?.time).toEqual(new TimeStamp(date));
+    });
+
+    it("throws when the status is malformed", () => {
+      expect(
+        () =>
+          new Channel({
+            name: "bad",
+            dataType: DataType.FLOAT32,
+            status: { variant: "not_a_variant" } as never,
+          }),
+      ).toThrow();
     });
   });
 });

--- a/client/ts/src/channel/client.ts
+++ b/client/ts/src/channel/client.ts
@@ -41,6 +41,7 @@ import {
   type New,
   ontologyID,
   type Operation,
+  operationZ,
   type Payload,
   payloadZ,
   statusZ,
@@ -54,7 +55,7 @@ import { query } from "@/query";
 import { type ranger } from "@/ranger";
 import { createKey, decodeDeleteChange } from "@/ranger/alias/payload";
 import { keyZ as rangerKeyZ } from "@/ranger/types.gen";
-import { status } from "@/status";
+import { type status } from "@/status";
 import { checkForMultipleOrNoResults } from "@/util/retrieve";
 
 export const SET_CHANNEL_NAME = "sy_channel_set";
@@ -144,11 +145,7 @@ export class Channel {
     expression = "",
     operations = [],
     concurrency = control.Concurrency.exclusive,
-  }: New & {
-    frameClient?: framer.Client;
-    status?: status.New;
-    operations?: Operation[];
-  }) {
+  }: New & { frameClient?: framer.Client }) {
     this.key = keyZ.parse(key);
     this.name = name;
     this.dataType = new DataType(dataType);
@@ -159,9 +156,9 @@ export class Channel {
     this.alias = alias;
     this.virtual = virtual;
     this.expression = expression;
-    this.operations = operations;
+    this.operations = operationZ.array().parse(operations);
     this.concurrency = concurrency;
-    if (argsStatus != null) this.status = status.create(argsStatus);
+    if (argsStatus != null) this.status = statusZ.parse(argsStatus);
     this.frameClient = frameClient ?? null;
   }
 

--- a/client/ts/src/channel/client.ts
+++ b/client/ts/src/channel/client.ts
@@ -11,7 +11,6 @@ import { type UnaryClient } from "@synnaxlabs/freighter";
 import {
   array,
   control,
-  type CrudeDensity,
   type CrudeTimeRange,
   type CrudeTimeSpan,
   type CrudeTimeStamp,
@@ -146,9 +145,7 @@ export class Channel {
     operations = [],
     concurrency = control.Concurrency.exclusive,
   }: New & {
-    internal?: boolean;
     frameClient?: framer.Client;
-    density?: CrudeDensity;
     status?: status.New;
     operations?: Operation[];
   }) {
@@ -192,6 +189,7 @@ export class Channel {
       expression: this.expression,
       status: this.status,
       operations: this.operations,
+      concurrency: this.concurrency,
     });
   }
 


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4562](https://linear.app/synnax/issue/SY-4562)

## Description

The TypeScript channel constructor accepted a `density` argument that it never
read. No caller in the client, Pluto, or the Console supplied it. This PR
removes it, then cleans up the rest of the constructor argument type.

That type was `New` intersected with four overrides. All four are now gone:

- `internal` duplicated a field that `New` already carries.
- `density` was unused.
- `status` and `operations` existed because of a mismatch. `New` is the crude
  input side of the channel schema, but the constructor stored these two fields
  raw into class fields declared in the parsed form. The overrides hid the
  mismatch and made callers supply values that were already parsed.

The constructor now normalizes `operations` and `status`, which is what it
already did for `key`, `index`, and `dataType`. A crude operation gets its
`resetChannel` and `duration` defaults, a crude status time becomes a
`TimeStamp`, and a null label array becomes `undefined`. Only `frameClient`
remains as an override, because it is not part of the schema.

The audit also found a dropped value. The constructor stores `concurrency`,
but the `payload` getter did not include it, so `payloadZ.parse` applied the
`exclusive` default on each round trip. The client caches a channel as
`sugar(stripComposed(ch.payload))`, so a virtual channel created with shared
concurrency reported `exclusive` after it entered the cache. The cache table
also compares payloads for equality, so a concurrency change did not
propagate. The getter now carries the field.

## Behavior change

The constructor now throws on a malformed status, the same way it already
threw on a malformed key. Every status that reaches it today is already
parsed, so no current path is affected. `statusZ.parse` also drops unknown
keys that the previous spread kept.

## Verification

`pnpm check-types` passes across all 21 workspace packages, `pnpm lint:client`
is clean, the full client suite passes (1578 tests) against a live core, and
Pluto passes (3521 tests).

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR normalizes crude channel operation and status inputs in the TypeScript constructor and preserves concurrency through payload serialization.

- Removes the unused density constructor argument and redundant type overrides.
- Parses operations and statuses into their normalized forms.
- Includes concurrency in channel payloads and adds focused round-trip and normalization tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| client/ts/src/channel/client.ts | Normalizes constructor inputs and includes concurrency in serialized channel payloads. |
| client/ts/src/channel/channel.spec.ts | Adds focused tests for concurrency round trips, operation defaults, and status validation. |

<sub>Reviews (2): Last reviewed commit: ["SY-4562: Normalize operations and status..."](https://github.com/synnaxlabs/synnax/commit/24d580fb2a92bc73e129457d5385bc228b8773a1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=51910870)</sub>

**Context used:**

- Knowledge Base — [Client SDKs](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/client-sdks.md)

<!-- /greptile_comment -->