### PR TITLE
SY-4569: Escalate nested sequence completion to the parent

### DIFF
--- a/arc/docs/spec.md
+++ b/arc/docs/spec.md
@@ -560,8 +560,8 @@ test sequences, state machines, and ordered procedures.
 
 ### Core Concepts
 
-**Sequence**: A state machine containing ordered stages. Only one stage is active at a
-time per sequence.
+**Sequence**: An ordered list of steps: flow statements, stages, and nested sequences.
+Only one step is active at a time.
 
 **Stage**: A state within a sequence. When active, its reactive flows execute; when
 inactive, they don't.
@@ -574,11 +574,15 @@ inactive, they don't.
 ### Sequence Syntax
 
 ```
-SequenceDeclaration ::= 'sequence' Identifier '{' StageDeclaration+ '}'
+SequenceDeclaration ::= 'sequence' Identifier? '{' SequenceItem* '}'
 
-StageDeclaration ::= 'stage' Identifier '{' StageItem* '}'
+SequenceItem ::= FlowStatement | Assignment | SingleInvocation
+              | VariableDeclaration | StageDeclaration | SequenceDeclaration
 
-StageItem ::= FlowStatement
+StageDeclaration ::= 'stage' Identifier? '{' StageItem* '}'
+
+StageItem ::= FlowStatement | Assignment | SingleInvocation
+            | VariableDeclaration | SequenceDeclaration
 ```
 
 ### Example
@@ -635,6 +639,19 @@ stage step3 {} // terminal (no outgoing transitions)
 - `=> stage_name` — Jump to any stage in the same sequence
 - `=> sequence_name` — Jump to a different sequence (starts at its first stage)
 
+### Step Completion
+
+A sequence runs its steps in order. When a step completes, the sequence advances; when
+its last step completes, the sequence exits. A completed gated sequence can be triggered
+again.
+
+A nested sequence is one step of its parent: when it completes, the parent advances or
+exits in turn. A sequence declared inside a stage does not advance anything when it
+completes. The stage leaves only through its own `=>` transition.
+
+A flow step completes when its final node fires. Stages do not complete; they leave only
+through an explicit `=>` transition.
+
 ### Reactive vs One-Shot Semantics
 
 **Reactive flows (`->`)**: Execute every time the source produces a value while the
@@ -643,15 +660,15 @@ stage is active.
 **Conditional transitions (`=>`)**: Propagate only when the condition is truthy
 (non-zero). A transition to an already-active stage is a no-op, preventing re-entry.
 
-### Stage Entry Semantics
+### Scope Entry Semantics
 
-When entering a stage:
+When entering a stage or a sequence:
 
 1. Local variables (`:=`) reset to their initial values; stateful variables (`$=`) keep
    their state
-2. Reactive flows start fresh
+2. Reactive flows start fresh; a sequence restarts at its first step
 
-Aside from stateful variables (`$=`), a stage keeps no memory between entries.
+Aside from stateful variables (`$=`), a scope keeps no memory between entries.
 
 ### Cross-Sequence Transitions
 
@@ -660,6 +677,9 @@ When transitioning to another sequence (e.g., `=> abort`):
 1. Source sequence's active stage is deactivated
 2. Target sequence starts at its first defined stage
 3. This is one-way—no built-in "return" mechanism
+4. The source's enclosing sequences do not resume; their remaining steps never run
+
+Activations are independent: several top-level scopes can run at the same time.
 
 ### Top-Level Entry Points
 

--- a/arc/go/sequence_test.go
+++ b/arc/go/sequence_test.go
@@ -65,6 +65,15 @@ var _ = Describe("Sequence", func() {
 		return n
 	}
 
+	// drainStrings collects every string value flushed to a channel in order.
+	drainStrings := func(fr telem.Frame[uint32], key uint32) []string {
+		var out []string
+		for _, ser := range fr.Get(key).Series {
+			out = append(out, telem.UnmarshalSeries[string](ser)...)
+		}
+		return out
+	}
+
 	// trigger ingests a u8=1 onto the given channel and ticks the scheduler
 	// long enough for the on-channel-read → entry → step cascade to settle.
 	trigger := func(h *runtimeHarness, ctx SpecContext, key uint32) {
@@ -80,6 +89,486 @@ var _ = Describe("Sequence", func() {
 		h.Tick(ctx, elapsed)
 		h.channelState.ClearReads()
 	}
+
+	// A nested sequence is one step of its parent: when its last step
+	// completes, the parent advances, or exits when that step was terminal. A
+	// sequence declared inside a stage body freezes on completion instead.
+	Describe("Nested sequence completion", func() {
+		// settle ticks the scheduler enough times for boot activation and
+		// multi-step cascades to fully propagate.
+		settle := func(h *runtimeHarness, ctx SpecContext) {
+			for i := range 5 {
+				advance(h, ctx, telem.TimeSpan(i+1)*telem.Millisecond)
+			}
+		}
+
+		DescribeTable(
+			"Advances past a completed nested sequence to the following step",
+			func(ctx SpecContext, header string) {
+				resolver := channelSymbols(
+					map[string]channelDef{"log": {types.String(), 101}},
+				)
+				h := newRuntimeHarness(ctx, `
+				sequence main {
+				    `+header+` {
+				        "one" -> log
+				    }
+				    "two" -> log
+				}
+				1 => main`, resolver,
+					channels.Digest{Key: 101, DataType: telem.StringT},
+				)
+				defer h.Close(ctx)
+
+				settle(h, ctx)
+				out, _ := h.Flush()
+				Expect(drainStrings(out, 101)).To(Equal([]string{"one", "two"}))
+			},
+			Entry("named", "sequence first"),
+			Entry("anonymous", "sequence"),
+		)
+
+		It("Advances through consecutive nested sequences", func(ctx SpecContext) {
+			resolver := channelSymbols(
+				map[string]channelDef{"log": {types.String(), 101}},
+			)
+			h := newRuntimeHarness(ctx, `
+			sequence main {
+			    sequence a {
+			        "a" -> log
+			    }
+			    sequence b {
+			        "b" -> log
+			    }
+			    "c" -> log
+			}
+			1 => main`, resolver,
+				channels.Digest{Key: 101, DataType: telem.StringT},
+			)
+			defer h.Close(ctx)
+
+			settle(h, ctx)
+			out, _ := h.Flush()
+			Expect(drainStrings(out, 101)).To(Equal([]string{"a", "b", "c"}))
+		})
+
+		It(
+			"Escalates completion through deeply nested sequences",
+			func(ctx SpecContext) {
+				resolver := channelSymbols(
+					map[string]channelDef{"log": {types.String(), 101}},
+				)
+				h := newRuntimeHarness(ctx, `
+				sequence main {
+				    sequence mid {
+				        sequence deep {
+				            "deep" -> log
+				        }
+				    }
+				    "after" -> log
+				}
+				1 => main`, resolver,
+					channels.Digest{Key: 101, DataType: telem.StringT},
+				)
+				defer h.Close(ctx)
+
+				settle(h, ctx)
+				out, _ := h.Flush()
+				Expect(drainStrings(out, 101)).To(Equal([]string{"deep", "after"}))
+			},
+		)
+
+		It(
+			"Exits a gated parent whose last step is a nested sequence and re-triggers",
+			func(ctx SpecContext) {
+				resolver := channelSymbols(map[string]channelDef{
+					"start_cmd": {types.U8(), 100},
+					"log":       {types.String(), 101},
+				})
+				h := newRuntimeHarness(ctx, `
+				sequence main {
+				    sequence only {
+				        "ran" -> log
+				    }
+				}
+				start_cmd => main`, resolver,
+					channels.Digest{Key: 100, DataType: telem.Uint8T},
+					channels.Digest{Key: 101, DataType: telem.StringT},
+				)
+				defer h.Close(ctx)
+
+				trigger(h, ctx, 100)
+				out, _ := h.Flush()
+				Expect(countOf(out, 101, "ran")).To(Equal(1))
+
+				trigger(h, ctx, 100)
+				out, _ = h.Flush()
+				Expect(countOf(out, 101, "ran")).To(Equal(1),
+					"a completed parent must deactivate and accept a new trigger")
+			},
+		)
+
+		It(
+			"Advances past a nested sequence whose only step is an invocation",
+			func(ctx SpecContext) {
+				resolver := channelSymbols(
+					map[string]channelDef{"log": {types.String(), 101}},
+				)
+				h := newRuntimeHarness(ctx, `import time
+				sequence main {
+				    sequence pause {
+				        time.wait{100ms}
+				    }
+				    "done" -> log
+				}
+				1 => main`, resolver,
+					channels.Digest{Key: 101, DataType: telem.StringT},
+				)
+				defer h.Close(ctx)
+
+				advance(h, ctx, telem.Millisecond)
+				out, _ := h.Flush()
+				Expect(out.Get(101).Series).To(BeEmpty(),
+					"main must hold while the nested wait is pending")
+
+				advance(h, ctx, 160*telem.Millisecond)
+				advance(h, ctx, 165*telem.Millisecond)
+				out, _ = h.Flush()
+				Expect(drainStrings(out, 101)).To(Equal([]string{"done"}))
+			},
+		)
+
+		It(
+			"Keeps a sequence inside a stage from exiting the stage on completion",
+			func(ctx SpecContext) {
+				resolver := channelSymbols(map[string]channelDef{
+					"trigger": {types.U8(), 100},
+					"log":     {types.String(), 101},
+				})
+				h := newRuntimeHarness(ctx, `import time
+				sequence main {
+				    stage monitor {
+				        sequence {
+				            "ramp start" -> log
+				            time.wait{100ms}
+				            "ramp done" -> log
+				        }
+				        trigger == 1 => next
+				    }
+				    "after" -> log
+				}
+				1 => main`, resolver,
+					channels.Digest{Key: 100, DataType: telem.Uint8T},
+					channels.Digest{Key: 101, DataType: telem.StringT},
+				)
+				defer h.Close(ctx)
+
+				advance(h, ctx, telem.Millisecond)
+				advance(h, ctx, 160*telem.Millisecond)
+				advance(h, ctx, 200*telem.Millisecond)
+				out, _ := h.Flush()
+				Expect(drainStrings(out, 101)).To(
+					Equal([]string{"ramp start", "ramp done"}),
+					"inner completion must freeze, not exit the stage",
+				)
+
+				h.Ingest(100, telem.NewSeriesV[uint8](1))
+				advance(h, ctx, 210*telem.Millisecond)
+				advance(h, ctx, 220*telem.Millisecond)
+				out, _ = h.Flush()
+				Expect(drainStrings(out, 101)).To(Equal([]string{"after"}))
+			},
+		)
+
+		It(
+			"Advances past a completed inline sequence flow target",
+			func(ctx SpecContext) {
+				resolver := channelSymbols(
+					map[string]channelDef{"log": {types.String(), 101}},
+				)
+				h := newRuntimeHarness(ctx, `
+				sequence main {
+				    "before" -> log
+				    1 -> sequence {
+				        "s1" -> log
+				        "s2" -> log
+				    }
+				    "final" -> log
+				}
+				1 => main`, resolver,
+					channels.Digest{Key: 101, DataType: telem.StringT},
+				)
+				defer h.Close(ctx)
+
+				settle(h, ctx)
+				out, _ := h.Flush()
+				Expect(drainStrings(out, 101)).To(
+					Equal([]string{"before", "s1", "s2", "final"}),
+				)
+			},
+		)
+
+		It(
+			"Preserves stage transitions around nested and inline stages",
+			func(ctx SpecContext) {
+				resolver := channelSymbols(map[string]channelDef{
+					"trigger": {types.U8(), 100},
+					"log":     {types.String(), 101},
+				})
+				h := newRuntimeHarness(ctx, `import time
+				sequence main {
+				    stage pressurize {
+				        "pressurize" -> log
+				        trigger > 0 => next
+				    }
+				    stage hold {
+				        "hold" -> log
+				        time.wait{100ms} -> 50 > 40 => next
+				    }
+				    stage {
+				        "inline" -> log
+				        time.wait{100ms} => pressurize
+				    }
+				}
+				1 => main`, resolver,
+					channels.Digest{Key: 100, DataType: telem.Uint8T},
+					channels.Digest{Key: 101, DataType: telem.StringT},
+				)
+				defer h.Close(ctx)
+
+				advance(h, ctx, telem.Millisecond)
+				trigger(h, ctx, 100)
+				advance(h, ctx, 160*telem.Millisecond)
+				advance(h, ctx, 170*telem.Millisecond)
+				advance(h, ctx, 320*telem.Millisecond)
+				advance(h, ctx, 330*telem.Millisecond)
+				out, _ := h.Flush()
+				Expect(drainStrings(out, 101)).To(
+					Equal([]string{"pressurize", "hold", "inline", "pressurize"}),
+				)
+			},
+		)
+
+		It(
+			"Advances past a nested sequence whose terminal step is an assignment",
+			func(ctx SpecContext) {
+				resolver := channelSymbols(
+					map[string]channelDef{"log": {types.String(), 101}},
+				)
+				h := newRuntimeHarness(ctx, `
+				sequence main {
+				    sequence bump {
+				        x := 1
+				        str(x) -> log
+				        x = x + 1
+				    }
+				    "after" -> log
+				}
+				1 => main`, resolver,
+					channels.Digest{Key: 101, DataType: telem.StringT},
+				)
+				defer h.Close(ctx)
+
+				settle(h, ctx)
+				out, _ := h.Flush()
+				Expect(drainStrings(out, 101)).To(Equal([]string{"1", "after"}))
+			},
+		)
+
+		It(
+			"Holds forever when a nested sequence ends in a transitionless stage",
+			func(ctx SpecContext) {
+				resolver := channelSymbols(
+					map[string]channelDef{"log": {types.String(), 101}},
+				)
+				h := newRuntimeHarness(ctx, `
+				sequence main {
+				    sequence inner {
+				        "held" -> log
+				        stage hold {}
+				    }
+				    "after" -> log
+				}
+				1 => main`, resolver,
+					channels.Digest{Key: 101, DataType: telem.StringT},
+				)
+				defer h.Close(ctx)
+
+				settle(h, ctx)
+				out, _ := h.Flush()
+				Expect(drainStrings(out, 101)).To(Equal([]string{"held"}),
+					"a stage without transitions is a deliberate hold; main must not advance")
+			},
+		)
+
+		It(
+			"Keeps an inline sequence target inside a stage from exiting the stage",
+			func(ctx SpecContext) {
+				resolver := channelSymbols(map[string]channelDef{
+					"trigger": {types.U8(), 100},
+					"log":     {types.String(), 101},
+				})
+				h := newRuntimeHarness(ctx, `
+				sequence main {
+				    stage m {
+				        1 -> sequence {
+				            "body" -> log
+				        }
+				        trigger == 1 => next
+				    }
+				    "after" -> log
+				}
+				1 => main`, resolver,
+					channels.Digest{Key: 100, DataType: telem.Uint8T},
+					channels.Digest{Key: 101, DataType: telem.StringT},
+				)
+				defer h.Close(ctx)
+
+				settle(h, ctx)
+				out, _ := h.Flush()
+				Expect(drainStrings(out, 101)).To(Equal([]string{"body"}),
+					"inline body completion must freeze, not exit the stage")
+
+				h.Ingest(100, telem.NewSeriesV[uint8](1))
+				advance(h, ctx, 10*telem.Millisecond)
+				advance(h, ctx, 11*telem.Millisecond)
+				out, _ = h.Flush()
+				Expect(drainStrings(out, 101)).To(Equal([]string{"after"}))
+			},
+		)
+
+		It(
+			"Re-arms a wait inside a re-entered nested sequence",
+			func(ctx SpecContext) {
+				resolver := channelSymbols(
+					map[string]channelDef{"log": {types.String(), 101}},
+				)
+				h := newRuntimeHarness(ctx, `import time
+				sequence main {
+				    sequence s1 {
+				        time.wait{100ms}
+				        "tick" -> log
+				    }
+				    stage s2 {
+				        time.wait{100ms} => s1
+				    }
+				}
+				1 => main`, resolver,
+					channels.Digest{Key: 101, DataType: telem.StringT},
+				)
+				defer h.Close(ctx)
+
+				// Two passes per boundary so each fire settles before the next.
+				step := func(now telem.TimeSpan) {
+					advance(h, ctx, now)
+					advance(h, ctx, now)
+				}
+				step(0)
+				step(100 * telem.Millisecond)
+				step(200 * telem.Millisecond)
+				step(300 * telem.Millisecond)
+				out, _ := h.Flush()
+				Expect(countOf(out, 101, "tick")).To(Equal(2),
+					"a stale timer would fire immediately on re-entry and over-count")
+			},
+		)
+
+		It(
+			"Advances past a completed routing case body in a sequence step",
+			func(ctx SpecContext) {
+				resolver := channelSymbols(map[string]channelDef{
+					"trigger": {types.U8(), 100},
+					"log":     {types.String(), 101},
+				})
+				h := newRuntimeHarness(ctx, `
+				sequence main {
+				    trigger -> select{} -> {
+				        true: sequence {
+				            "case" -> log
+				        }
+				    }
+				    "after" -> log
+				}
+				1 => main`, resolver,
+					channels.Digest{Key: 100, DataType: telem.Uint8T},
+					channels.Digest{Key: 101, DataType: telem.StringT},
+				)
+				defer h.Close(ctx)
+
+				settle(h, ctx)
+				trigger(h, ctx, 100)
+				out, _ := h.Flush()
+				Expect(drainStrings(out, 101)).To(Equal([]string{"case", "after"}))
+			},
+		)
+
+		It(
+			"Hands off to a top-level scope from inside a nested sequence",
+			func(ctx SpecContext) {
+				resolver := channelSymbols(
+					map[string]channelDef{"log": {types.String(), 101}},
+				)
+				h := newRuntimeHarness(ctx, `
+				sequence main {
+				    sequence ramp {
+				        "ramp" -> log
+				        1 => abort
+				    }
+				    stage hold {
+				        "hold" -> log
+				    }
+				}
+				sequence abort {
+				    "abort" -> log
+				}
+				1 => main`, resolver,
+					channels.Digest{Key: 101, DataType: telem.StringT},
+				)
+				defer h.Close(ctx)
+
+				settle(h, ctx)
+				out, _ := h.Flush()
+				Expect(drainStrings(out, 101)).To(
+					Equal([]string{"ramp", "abort"}),
+					"the cross-scope jump hands control away; hold must not run",
+				)
+			},
+		)
+
+		It(
+			"Skips the steps after an explicit => in a nested sequence",
+			func(ctx SpecContext) {
+				resolver := channelSymbols(map[string]channelDef{
+					"trigger": {types.U8(), 100},
+					"log":     {types.String(), 101},
+				})
+				h := newRuntimeHarness(ctx, `
+				sequence main {
+				    sequence inner {
+				        "inner" -> log
+				        trigger => skip
+				        "unreachable" -> log
+				    }
+				    stage skip {
+				        "skip" -> log
+				    }
+				}
+				1 => main`, resolver,
+					channels.Digest{Key: 100, DataType: telem.Uint8T},
+					channels.Digest{Key: 101, DataType: telem.StringT},
+				)
+				defer h.Close(ctx)
+
+				settle(h, ctx)
+				trigger(h, ctx, 100)
+				out, _ := h.Flush()
+				Expect(drainStrings(out, 101)).To(
+					Equal([]string{"inner", "skip"}),
+					"the write after the explicit => must never run",
+				)
+			},
+		)
+	})
 
 	// A reassignment takes effect when its stage runs, even reached out of source
 	// order or after a skipped stage; guards against the old source-order chain.
@@ -5150,6 +5639,36 @@ var _ = Describe("Sequence", func() {
 					drainStrings(out, 101),
 				).To(Equal([]string{"0", "1", "2", "3", "4"}))
 			},
+		)
+
+		DescribeTable(
+			"Scope-entry reset in a re-entered nested sequence",
+			func(ctx SpecContext, decl string, expected []string) {
+				resolver := channelSymbols(
+					map[string]channelDef{"log": {types.String(), 101}},
+				)
+				h := newRuntimeHarness(ctx, `import time
+				sequence main {
+				    sequence s1 {
+				        counter `+decl+` 0
+				        counter = counter + 1
+				        str(counter) => log
+				    }
+				    stage s2 {
+				        time.wait{100ms} => s1
+				    }
+				}
+				1 => main`, resolver,
+					channels.Digest{Key: 101, DataType: telem.StringT},
+				)
+				defer h.Close(ctx)
+
+				loop(h, ctx)
+				out, _ := h.Flush()
+				Expect(drainStrings(out, 101)).To(Equal(expected))
+			},
+			Entry("a $= variable persists", "$=", []string{"1", "2", "3", "4"}),
+			Entry("a := variable resets", ":=", []string{"1", "1", "1", "1"}),
 		)
 
 		It(

--- a/arc/go/sequence_test.go
+++ b/arc/go/sequence_test.go
@@ -503,6 +503,36 @@ var _ = Describe("Sequence", func() {
 		)
 
 		It(
+			"Holds on a routing case body that is a stage without a transition",
+			func(ctx SpecContext) {
+				resolver := channelSymbols(map[string]channelDef{
+					"trigger": {types.U8(), 100},
+					"log":     {types.String(), 101},
+				})
+				h := newRuntimeHarness(ctx, `
+				sequence main {
+				    trigger -> select{} -> {
+				        true: stage {
+				            "case" -> log
+				        }
+				    }
+				    "after" -> log
+				}
+				1 => main`, resolver,
+					channels.Digest{Key: 100, DataType: telem.Uint8T},
+					channels.Digest{Key: 101, DataType: telem.StringT},
+				)
+				defer h.Close(ctx)
+
+				settle(h, ctx)
+				trigger(h, ctx, 100)
+				out, _ := h.Flush()
+				Expect(drainStrings(out, 101)).To(Equal([]string{"case"}),
+					"a stage case body has no completion; main must hold")
+			},
+		)
+
+		It(
 			"Hands off to a top-level scope from inside a nested sequence",
 			func(ctx SpecContext) {
 				resolver := channelSymbols(

--- a/arc/go/text/analyze.go
+++ b/arc/go/text/analyze.go
@@ -68,6 +68,9 @@ type seqFrame struct {
 	activeIdx int
 	// transitions accumulates the scope's transitions in source order.
 	transitions []ir.Transition
+	// escalatesCompletion hands the sequence's completion to enclosing frames
+	// instead of exiting here; set when the sequence is a step of its parent.
+	escalatesCompletion bool
 }
 
 // nextMember returns the key of the member that follows the currently active
@@ -207,6 +210,23 @@ func (s *shellBuilder) addTransition(t ir.Transition) {
 // scheduler advances that frame's active step.
 func (s *shellBuilder) addTransitionTo(f *seqFrame, t ir.Transition) {
 	f.transitions = append(f.transitions, t)
+}
+
+// addCompletion wires a terminal step's completion: the nearest enclosing
+// frame with a next member advances past its current step; a frame that does
+// not escalate its completion takes the exit instead.
+func (s *shellBuilder) addCompletion(on ir.Handle) {
+	for i := len(s.stack) - 1; ; i-- {
+		f := s.stack[i]
+		if next := f.nextMember(); next != "" {
+			s.addTransitionTo(f, ir.Transition{On: on, TargetKey: new(next)})
+			return
+		}
+		if !f.escalatesCompletion || i == 0 {
+			s.addTransitionTo(f, ir.Transition{On: on})
+			return
+		}
+	}
 }
 
 // resolveTargetFrame walks the shell stack innermost-first and returns the
@@ -2196,8 +2216,8 @@ func addInlineMembers(scope *ir.Scope, members []ir.Member) {
 }
 
 // autoWireTransition appends an auto-wired transition for a flow-step in a
-// sequence: when the step's last node fires, advance to the next step or
-// exit the sequence if the step is terminal.
+// sequence: when the step's last node fires, advance to the next step, or
+// complete the enclosing sequence chain if the step is terminal.
 func autoWireTransition(shell *shellBuilder, lastNode ir.Node, nextMemberKey string) {
 	if len(lastNode.Outputs) == 0 {
 		return
@@ -2206,13 +2226,29 @@ func autoWireTransition(shell *shellBuilder, lastNode ir.Node, nextMemberKey str
 		Node:  lastNode.Key,
 		Param: firstOutputParam(lastNode.Outputs),
 	}
-	var targetKey *string
-	if nextMemberKey != "" {
-		targetKey = new(nextMemberKey)
+	if nextMemberKey == "" {
+		shell.addCompletion(on)
+		return
 	}
-	shell.addTransition(ir.Transition{On: on, TargetKey: targetKey})
+	shell.addTransition(ir.Transition{On: on, TargetKey: new(nextMemberKey)})
 }
 
+// declaredAsStep reports whether decl sits in a step position: its nearest
+// enclosing block is a sequence body rather than a stage body.
+func declaredAsStep(decl antlr.ParserRuleContext) bool {
+	for n := decl.GetParent(); n != nil; n = n.GetParent() {
+		switch n.(type) {
+		case parser.IStageBodyContext:
+			return false
+		case parser.ISequenceDeclarationContext:
+			return true
+		}
+	}
+	return false
+}
+
+// analyzeSequence lowers a sequence declaration to a sequential scope. A
+// sequence in a step position escalates its completion to enclosing frames.
 func analyzeSequence(
 	ctx acontext.Context[parser.ISequenceDeclarationContext],
 	kg *keyGenerator,
@@ -2253,6 +2289,7 @@ func analyzeSequence(
 	}
 
 	frame := shell.pushSeq(seqName, memberKeys)
+	frame.escalatesCompletion = declaredAsStep(ctx.AST)
 	defer shell.popSeq()
 
 	var (

--- a/arc/go/text/text_test.go
+++ b/arc/go/text/text_test.go
@@ -6220,11 +6220,14 @@ time.wait{duration=500ms} -> output`
 					)
 					Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
 
-					// The transition must land on `inner` (innermost sibling
-					// that owns `target`), not on `outer`.
+					// The jump must land on `inner` (innermost sibling that
+					// owns `target`), not on `outer`. outer carries only the
+					// completion exit of its terminal `sequence target` step.
 					outer := findTopLevelScope(inter, "outer")
-					Expect(outer.Transitions).To(BeEmpty(),
-						"outer must not carry the transition — it is shadowed by inner's target")
+					Expect(outer.Transitions).To(HaveLen(1),
+						"outer must carry only its terminal step's completion exit")
+					Expect(outer.Transitions[0].TargetKey).To(BeNil(),
+						"outer's transition must be an exit, not the shadowed jump")
 
 					inner := findMember(outer, "inner").Scope
 					Expect(inner).ToNot(BeNil())
@@ -6330,6 +6333,238 @@ time.wait{duration=500ms} -> output`
 					Expect(other.Activation).ToNot(BeNil(),
 						"=> other from inside main must stamp an Activation handle on other")
 					Expect(other.Activation.Node).To(HavePrefix("on_trigger"))
+				},
+			)
+		})
+
+		Context("Nested sequence completion", func() {
+			It(
+				"Wires a completed mid-sequence nested step to the parent's next member",
+				func(ctx SpecContext) {
+					resolver := []symbol.Symbol{
+						{
+							Name: "a",
+							Kind: symbol.KindChannel,
+							Type: types.Chan(types.U8()),
+							ID:   20101,
+						},
+					}
+					source := `
+				sequence main {
+				    sequence first {
+				        1 -> a
+				    }
+				    stage after {}
+				}`
+					parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
+					inter, diagnostics := text.Analyze(
+						ctx,
+						parsedText,
+						NewRoot(nil, resolver...),
+					)
+					Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
+
+					main := findTopLevelScope(inter, "main")
+					Expect(main.Transitions).To(HaveLen(1),
+						"the parent must own the nested step's completion transition")
+					t := main.Transitions[0]
+					Expect(t.TargetKey).ToNot(BeNil())
+					Expect(*t.TargetKey).To(Equal("after"))
+					Expect(t.On.Node).To(HavePrefix("write_a"))
+
+					first := findMember(main, "first").Scope
+					Expect(first).ToNot(BeNil())
+					Expect(first.Transitions).To(BeEmpty(),
+						"the nested step must not consume its own completion mark")
+				},
+			)
+
+			It(
+				"Exits the parent when its terminal nested step completes",
+				func(ctx SpecContext) {
+					resolver := []symbol.Symbol{
+						{
+							Name: "a",
+							Kind: symbol.KindChannel,
+							Type: types.Chan(types.U8()),
+							ID:   20102,
+						},
+						{
+							Name: "b",
+							Kind: symbol.KindChannel,
+							Type: types.Chan(types.U8()),
+							ID:   20103,
+						},
+					}
+					source := `
+				sequence main {
+				    1 -> a
+				    sequence tail {
+				        1 -> b
+				    }
+				}`
+					parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
+					inter, diagnostics := text.Analyze(
+						ctx,
+						parsedText,
+						NewRoot(nil, resolver...),
+					)
+					Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
+
+					main := findTopLevelScope(inter, "main")
+					Expect(main.Transitions).To(HaveLen(2))
+					Expect(main.Transitions[0].TargetKey).ToNot(BeNil())
+					Expect(*main.Transitions[0].TargetKey).To(Equal("tail"))
+					Expect(main.Transitions[1].TargetKey).To(BeNil(),
+						"the terminal nested step's completion must exit the parent")
+					Expect(main.Transitions[1].On.Node).To(HavePrefix("write_b"))
+
+					tail := findMember(main, "tail").Scope
+					Expect(tail).ToNot(BeNil())
+					Expect(tail.Transitions).To(BeEmpty())
+				},
+			)
+
+			It(
+				"Escalates completion to the outermost frame with a next member",
+				func(ctx SpecContext) {
+					resolver := []symbol.Symbol{
+						{
+							Name: "a",
+							Kind: symbol.KindChannel,
+							Type: types.Chan(types.U8()),
+							ID:   20104,
+						},
+					}
+					source := `
+				sequence main {
+				    sequence mid {
+				        sequence deep {
+				            1 -> a
+				        }
+				    }
+				    stage after {}
+				}`
+					parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
+					inter, diagnostics := text.Analyze(
+						ctx,
+						parsedText,
+						NewRoot(nil, resolver...),
+					)
+					Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
+
+					main := findTopLevelScope(inter, "main")
+					Expect(main.Transitions).To(HaveLen(1),
+						"only the outermost frame with a next member gets the transition")
+					t := main.Transitions[0]
+					Expect(t.TargetKey).ToNot(BeNil())
+					Expect(*t.TargetKey).To(Equal("after"))
+					Expect(t.On.Node).To(HavePrefix("write_a"))
+
+					mid := findMember(main, "mid").Scope
+					Expect(mid).ToNot(BeNil())
+					Expect(mid.Transitions).To(BeEmpty())
+					deep := findMember(*mid, "deep").Scope
+					Expect(deep).ToNot(BeNil())
+					Expect(deep.Transitions).To(BeEmpty())
+				},
+			)
+
+			It(
+				"Keeps a stage-declared sequence's exit on its own frame",
+				func(ctx SpecContext) {
+					resolver := []symbol.Symbol{
+						{
+							Name: "a",
+							Kind: symbol.KindChannel,
+							Type: types.Chan(types.U8()),
+							ID:   20105,
+						},
+					}
+					source := `
+				sequence main {
+				    stage holder {
+				        sequence sub {
+				            1 -> a
+				        }
+				    }
+				}`
+					parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
+					inter, diagnostics := text.Analyze(
+						ctx,
+						parsedText,
+						NewRoot(nil, resolver...),
+					)
+					Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
+
+					main := findTopLevelScope(inter, "main")
+					Expect(main.Transitions).To(BeEmpty(),
+						"a sequence in a stage body must not escalate to the stage's parent")
+					holder := findMember(main, "holder").Scope
+					Expect(holder).ToNot(BeNil())
+					subMember := holder.Strata[0][0]
+					Expect(subMember.Scope).ToNot(BeNil())
+					Expect(subMember.Scope.Transitions).To(HaveLen(1))
+					Expect(subMember.Scope.Transitions[0].TargetKey).To(BeNil(),
+						"the in-stage sequence keeps its own exit")
+				},
+			)
+
+			It(
+				"Skips the completion wire when the nested terminal ends in an explicit =>",
+				func(ctx SpecContext) {
+					resolver := []symbol.Symbol{
+						{
+							Name: "trigger",
+							Kind: symbol.KindChannel,
+							Type: types.Chan(types.U8()),
+							ID:   20106,
+						},
+						{
+							Name: "a",
+							Kind: symbol.KindChannel,
+							Type: types.Chan(types.U8()),
+							ID:   20107,
+						},
+						{
+							Name: "b",
+							Kind: symbol.KindChannel,
+							Type: types.Chan(types.U8()),
+							ID:   20108,
+						},
+					}
+					source := `
+				sequence main {
+				    sequence inner {
+				        1 -> a
+				        trigger => skip
+				    }
+				    stage skip {
+				        1 -> b
+				    }
+				}`
+					parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
+					inter, diagnostics := text.Analyze(
+						ctx,
+						parsedText,
+						NewRoot(nil, resolver...),
+					)
+					Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
+
+					main := findTopLevelScope(inter, "main")
+					Expect(main.Transitions).To(HaveLen(1),
+						"the explicit => must be main's only transition, no completion duplicate")
+					t := main.Transitions[0]
+					Expect(t.TargetKey).ToNot(BeNil())
+					Expect(*t.TargetKey).To(Equal("skip"))
+					Expect(t.On.Node).To(HavePrefix("on_trigger"))
+
+					inner := findMember(main, "inner").Scope
+					Expect(inner).ToNot(BeNil())
+					Expect(inner.Transitions).To(HaveLen(1),
+						"inner keeps only its internal step advance")
+					Expect(inner.Transitions[0].TargetKey).ToNot(BeNil())
+					Expect(*inner.Transitions[0].TargetKey).To(Equal("step_1"))
 				},
 			)
 		})

--- a/docs/site/src/pages/reference/control/arc/reference/sequences.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/sequences.mdx
@@ -74,6 +74,19 @@ sequence prime {
 
 <Divider.Divider x />
 
+## Sequencing Rules
+
+1. When an item completes, the sequence advances; when the last item completes, the
+   sequence exits.
+2. `=> name` to a sibling item jumps there. Re-entry resets
+   [`:=` variables](/reference/control/arc/reference/variables#declaration) and keeps
+   [`$=` variables](/reference/control/arc/concepts/stateful-variables).
+3. `=> name` to a top-level scope hands control away: the target starts, and the
+   sequence you jumped out of never resumes, nor does any sequence containing it.
+4. Activations are independent: several top-level scopes can run at the same time.
+
+<Divider.Divider x />
+
 ## Entry Points
 
 Entry points trigger sequences from external events:


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4569](https://linear.app/synnax/issue/SY-4569/nested-sequence-completion-stalls-the-parent)

## Description

Note: the production change is a single file, `arc/go/text/analyze.go` (about 40 lines). The rest of the diff is test coverage and documentation.

A sequence nested as a step of another sequence ran once and then stalled its parent: the parent never advanced past it. The root cause was that the analyzer wired a nested sequence's terminal exit on its own scope, so the parent never learned the step completed.

```arc
import time

sequence main {
    sequence pressurize {
        "start" -> log
        time.wait{1s}
        "done" -> log    // pressurize completes here
    }
    sequence hold {
        "holding" -> log // before this fix: never runs, main stalls on pressurize
    }                    // after this fix: runs when pressurize completes
}

1 => main
```

The analyzer now "escalates" a terminal step's completion to the nearest enclosing sequence frame that has a next step; when none has one, the outermost frame exits. Sequences declared inside stage bodies keep their own exit and freeze on completion, so a stage still leaves only through an explicit `=>` transition, and a jump to a top-level scope still hands control away without resuming the enclosing sequences. The fix is IR-level, so the C++ runtime needs no change.

Tests: runtime specs in `arc/go/sequence_test.go` cover advancing past named, anonymous, consecutive, and deeply nested sequences, exit and re-trigger of a gated parent, `$=`/`:=` re-entry, wait re-arm, in-stage freeze, inline and routing-case flow targets, cross-scope handoff, and skipped steps. IR specs in `arc/go/text/text_test.go` pin the transition wiring. Reviewer note: the spec at `arc/go/sequence_test.go:476` pins newly chosen semantics, namely that a routing case body in a sequence step advances the parent on completion.

Docs: step completion and scope entry rules in `arc/docs/spec.md`, and a sequencing rules section in the Arc sequences reference page.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves terminal completion from a nested sequence to the nearest enclosing sequence that can advance.

- Adds completion escalation in the Arc text analyzer.
- Adds IR and runtime coverage for nesting, re-entry, routing, waits, stages, and cross-scope jumps.
- Documents sequence completion and scope-entry rules.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The analyzer now assigns nested terminal completion to the enclosing sequence frame, and the tests cover the main transition, re-entry, stage, routing, and handoff paths without showing a blocking defect.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| arc/go/text/analyze.go | Adds frame-aware completion escalation while preserving stage-local exits and explicit transitions. |
| arc/go/sequence_test.go | Adds broad runtime coverage for nested completion, re-entry, waits, routing, and cross-scope control flow. |
| arc/go/text/text_test.go | Verifies transition ownership and generated IR for nested sequence completion. |
| arc/docs/spec.md | Defines sequence-step completion, nested completion, scope entry, and cross-sequence handoff. |
| docs/site/src/pages/reference/control/arc/reference/sequences.mdx | Adds concise user-facing sequencing and control-transfer rules. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Terminal node fires] --> B{Current sequence has a next step?}
  B -->|Yes| C[Advance current sequence]
  B -->|No| D{Sequence is a parent step?}
  D -->|Yes| E[Check enclosing sequence]
  E --> B
  D -->|No| F[Exit current sequence]
```

<sub>Reviews (1): Last reviewed commit: ["SY-4596: Add test"](https://github.com/synnaxlabs/synnax/commit/40b24bda2b53665225aaed05263dc5c9847a325d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52376692)</sub>

**Context used:**

- Knowledge Base — [Arc: Automation Language and Runtime Engine](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/arc-engine.md)

<!-- /greptile_comment -->