### PR TITLE
SY-4570: Acquire aether worker resources on commit, not during render

### DIFF
--- a/pluto/src/aether/aether/aether.spec.ts
+++ b/pluto/src/aether/aether/aether.spec.ts
@@ -796,8 +796,8 @@ describe("message", () => {
           state: { x: 1 },
         };
         const transfer: Transferable[] = [];
-        comms.send(msg, transfer);
-        expect(postMessage).toHaveBeenCalledWith(msg, { transfer });
+        comms.send([msg], transfer);
+        expect(postMessage).toHaveBeenCalledWith([msg], { transfer });
       } finally {
         vi.unstubAllGlobals();
       }
@@ -815,8 +815,8 @@ describe("message", () => {
           type: "t",
           state: { x: 1 },
         };
-        (globalThis as any).onmessage({ data: msg });
-        expect(handler).toHaveBeenCalledWith(msg);
+        (globalThis as any).onmessage({ data: [msg] });
+        expect(handler).toHaveBeenCalledWith([msg]);
       } finally {
         vi.unstubAllGlobals();
       }
@@ -847,8 +847,8 @@ describe("message", () => {
         path: ["k"],
         state: { x: 1 },
       };
-      workerSide.send(msg);
-      expect(mainHandler).toHaveBeenCalledWith(msg);
+      workerSide.send([msg]);
+      expect(mainHandler).toHaveBeenCalledWith([msg]);
     });
 
     it("should drop sends made before a handler is registered", () => {

--- a/pluto/src/aether/aether/aether.spec.ts
+++ b/pluto/src/aether/aether/aether.spec.ts
@@ -753,8 +753,8 @@ describe("message", () => {
         state: { x: 1 },
       };
       const transfer: Transferable[] = [];
-      comms.send(msg, transfer);
-      expect(postMessage).toHaveBeenCalledWith(msg, transfer);
+      comms.send([msg], transfer);
+      expect(postMessage).toHaveBeenCalledWith([msg], transfer);
     });
 
     it("should default transfer to empty array when omitted", () => {
@@ -765,8 +765,8 @@ describe("message", () => {
         variant: "delete",
         path: ["a"],
       };
-      comms.send(msg);
-      expect(postMessage).toHaveBeenCalledWith(msg, []);
+      comms.send([msg]);
+      expect(postMessage).toHaveBeenCalledWith([msg], []);
     });
 
     it("should route worker.onmessage events to the registered handler", () => {
@@ -834,8 +834,8 @@ describe("message", () => {
         type: "t",
         state: { x: 1 },
       };
-      mainSide.send(msg);
-      expect(workerHandler).toHaveBeenCalledWith(msg);
+      mainSide.send([msg]);
+      expect(workerHandler).toHaveBeenCalledWith([msg]);
     });
 
     it("should deliver worker-side sends to the main-side handler", () => {
@@ -854,12 +854,14 @@ describe("message", () => {
     it("should drop sends made before a handler is registered", () => {
       const [workerSide, mainSide] = aether.createMockPair();
       expect(() =>
-        mainSide.send({
-          variant: "update",
-          path: ["a"],
-          type: "t",
-          state: { x: 1 },
-        }),
+        mainSide.send([
+          {
+            variant: "update",
+            path: ["a"],
+            type: "t",
+            state: { x: 1 },
+          },
+        ]),
       ).not.toThrow();
       const workerHandler = vi.fn();
       workerSide.handle(workerHandler);
@@ -872,10 +874,7 @@ describe("message", () => {
       const second = vi.fn();
       workerSide.handle(first);
       workerSide.handle(second);
-      mainSide.send({
-        variant: "delete",
-        path: ["a"],
-      });
+      mainSide.send([{ variant: "delete", path: ["a"] }]);
       expect(first).not.toHaveBeenCalled();
       expect(second).toHaveBeenCalledTimes(1);
     });
@@ -888,30 +887,24 @@ describe("message", () => {
         worker: workerSide,
         registry: { composite: ExampleComposite, leaf: ExampleLeaf },
       });
-      mainSide.send({
-        variant: "update",
-        path: ["root", "a"],
-        type: "composite",
-        state: { x: 1 },
-      });
-      mainSide.send({
-        variant: "update",
-        path: ["root", "a", "b"],
-        type: "leaf",
-        state: { x: 2 },
-      });
+      mainSide.send([
+        { variant: "update", path: ["root", "a"], type: "composite", state: { x: 1 } },
+        {
+          variant: "update",
+          path: ["root", "a", "b"],
+          type: "leaf",
+          state: { x: 2 },
+        },
+      ]);
       const comp = root.children[0] as ExampleComposite;
       const leaf = comp.children[0] as ExampleLeaf;
-      mainSide.send({ variant: "clear" });
+      mainSide.send([{ variant: "clear" }]);
       expect(leaf.deletef).toHaveBeenCalledTimes(1);
       expect(comp.deletef).toHaveBeenCalledTimes(1);
       expect(root.children).toHaveLength(0);
-      mainSide.send({
-        variant: "update",
-        path: ["root", "c"],
-        type: "leaf",
-        state: { x: 3 },
-      });
+      mainSide.send([
+        { variant: "update", path: ["root", "c"], type: "leaf", state: { x: 3 } },
+      ]);
       expect(root.children).toHaveLength(1);
     });
   });

--- a/pluto/src/aether/aether/aether.ts
+++ b/pluto/src/aether/aether/aether.ts
@@ -861,11 +861,7 @@ export class Root extends Composite<typeof aetherRootState> {
     component._invokeMethod(params);
   }
 
-  /** Instantiates the registered component `type` at `path` under `parent`, wired to this
-   * tree's sender and instrumentation. Throws {@link UnexpectedError} if `type` is not in
-   * the registry. Does not mount the result; pass it as the `create` callback of
-   * {@link Composite._updateState}, which does. */
-  create({
+  private create({
     path,
     type,
     parent,

--- a/pluto/src/aether/aether/aether.ts
+++ b/pluto/src/aether/aether/aether.ts
@@ -771,13 +771,15 @@ export class Root extends Composite<typeof aetherRootState> {
       create: shouldNotCallCreate,
     });
     // Messages are handled sequentially: concurrent component updates lead to races, so
-    // the tree is implicitly serialized via the message queue.
-    root.comms.handle((msg) => {
-      try {
-        root.handle(msg);
-      } catch (e) {
-        root.comms.send({ variant: "error", error: errors.encode(e) });
-      }
+    // the tree is implicitly serialized via the message queue. Each message is caught
+    // on its own so one failure reports and the rest of the batch still applies.
+    root.comms.handle((messages) => {
+      for (const msg of messages)
+        try {
+          root.handle(msg);
+        } catch (e) {
+          root.comms.send({ variant: "error", error: errors.encode(e) });
+        }
     });
     return root;
   }

--- a/pluto/src/aether/aether/aether.ts
+++ b/pluto/src/aether/aether/aether.ts
@@ -13,15 +13,18 @@ import { deep, errors, type record, shallow, state, zod } from "@synnaxlabs/x";
 import { z } from "zod";
 
 import {
+  Batcher,
   type MainInvokeRequest,
   type MainMessage,
   type MainUpdateRequest,
   type Sender,
   type WorkerComms,
+  type WorkerMessage,
   wrapWorkerScope,
 } from "@/aether/aether/message";
 
 export {
+  Batcher,
   createMockPair,
   type MainComms,
   type MainMessage,
@@ -196,6 +199,16 @@ export abstract class Node implements Component {
    * their resolved provider (or `null` if unresolved). Non-`null` only while
    * {@link afterUpdate} is running, so reads outside that window are not tracked. */
   private ctxReads: Map<string, Node | null> | null = null;
+  /** {@link toString} and the span labels derived from it, built once. `type` and `path`
+   * never change, and every update would otherwise rebuild these strings only for noop
+   * instrumentation to discard them. */
+  private readonly label: string;
+  private readonly afterUpdateSpan: string;
+  protected readonly updateStateSpan: string;
+  private readonly deleteSpan: string;
+  /** Built on first use and reused. The object closes over `this` alone, so a fresh one
+   * per {@link afterUpdate} would be six identical allocations per update. */
+  private cachedCtx: Context | null = null;
 
   constructor({
     path,
@@ -206,8 +219,12 @@ export abstract class Node implements Component {
   }: ComponentConstructorProps) {
     this.type = type;
     this.path = path;
+    this.label = `${type}(${path[path.length - 1]})`;
+    this.afterUpdateSpan = `${this.label}:afterUpdate`;
+    this.updateStateSpan = `${this.label}:updateState`;
+    this.deleteSpan = `${this.label}:delete`;
     this.sender = sender;
-    this.instrumentation = instrumentation.child(this.toString());
+    this.instrumentation = instrumentation.child(this.label);
     this._parent = parent;
     this._depth = this._parent == null ? 0 : this._parent._depth + 1;
     this.childCtxValues = new Map();
@@ -226,11 +243,11 @@ export abstract class Node implements Component {
   }
 
   toString(): string {
-    return `${this.type}(${this.key})`;
+    return this.label;
   }
 
   private get ctx(): Context {
-    return {
+    return (this.cachedCtx ??= {
       get: <P>(key: string): P => {
         const provider = this.readCtx(key);
         if (provider == null)
@@ -249,7 +266,7 @@ export abstract class Node implements Component {
         this.childCtxValues.set(key, value);
         if (trigger) this.childCtxChangedKeys.add(key);
       },
-    };
+    });
   }
 
   /** Resolves `key` to the nearest ancestor publishing it (self excluded) and records
@@ -269,7 +286,7 @@ export abstract class Node implements Component {
    * resulting subscriptions. Used for both state-driven updates and context-driven
    * re-runs. */
   protected runAfterUpdate(): void {
-    const endSpan = this.instrumentation.T.debug(`${this.toString()}:afterUpdate`);
+    const endSpan = this.instrumentation.T.debug(this.afterUpdateSpan);
     const prevReads = this.ctxReads;
     this.ctxReads = new Map();
     this.childCtxChangedKeys.clear();
@@ -348,7 +365,7 @@ export abstract class Node implements Component {
    * must not call this. */
   _delete(path: readonly string[]): void {
     try {
-      const endSpan = this.instrumentation.T.debug(`${this.toString()}:delete`);
+      const endSpan = this.instrumentation.T.debug(this.deleteSpan);
       this.validatePath(path);
       this._deleted = true;
       this.afterDelete(this.ctx);
@@ -517,7 +534,7 @@ export abstract class Leaf<
     if (this.deleted) return;
     try {
       this.initializeMethods();
-      const endSpan = this.instrumentation.T.debug(`${this.toString()}:updateState`);
+      const endSpan = this.instrumentation.T.debug(this.updateStateSpan);
       this.validatePath(path);
       const state_ = zod.parse(this._schema, state, { label: this.toString() });
       if (this._state != null)
@@ -748,10 +765,15 @@ export class Root extends Composite<typeof aetherRootState> {
     instrumentation = alamos.Instrumentation.NOOP,
     registry,
   }: RootProps) {
+    // Every component in the tree shares this one sender, so a message batch spans the
+    // whole tree rather than a single component.
+    const sender = new Batcher<WorkerMessage>((values, transfer) =>
+      worker.send(values, transfer),
+    );
     super({
       path: [Root.KEY],
       type: Root.TYPE,
-      sender: worker,
+      sender,
       instrumentation,
       parent: null,
     });
@@ -778,7 +800,7 @@ export class Root extends Composite<typeof aetherRootState> {
         try {
           root.handle(msg);
         } catch (e) {
-          root.comms.send({ variant: "error", error: errors.encode(e) });
+          root.sender.send({ variant: "error", error: errors.encode(e) });
         }
     });
     return root;
@@ -839,7 +861,11 @@ export class Root extends Composite<typeof aetherRootState> {
     component._invokeMethod(params);
   }
 
-  private create({
+  /** Instantiates the registered component `type` at `path` under `parent`, wired to this
+   * tree's sender and instrumentation. Throws {@link UnexpectedError} if `type` is not in
+   * the registry. Does not mount the result; pass it as the `create` callback of
+   * {@link Composite._updateState}, which does. */
+  create({
     path,
     type,
     parent,
@@ -850,7 +876,7 @@ export class Root extends Composite<typeof aetherRootState> {
     return new Constructor({
       path,
       type,
-      sender: this.comms,
+      sender: this.sender,
       instrumentation: this.instrumentation,
       parent,
     });

--- a/pluto/src/aether/aether/message.spec.ts
+++ b/pluto/src/aether/aether/message.spec.ts
@@ -1,0 +1,125 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { describe, expect, it, vi } from "vitest";
+
+import { aether } from "@/aether/aether";
+
+const flushed = (): Promise<void> => new Promise((resolve) => queueMicrotask(resolve));
+
+describe("Batcher", () => {
+  it("should deliver everything buffered in one tick as a single batch", async () => {
+    const flushTo = vi.fn();
+    const batcher = new aether.Batcher<string>(flushTo);
+    batcher.send("a");
+    batcher.send("b");
+    expect(flushTo).not.toHaveBeenCalled();
+    await flushed();
+    expect(flushTo).toHaveBeenCalledTimes(1);
+    expect(flushTo).toHaveBeenCalledWith(["a", "b"], []);
+  });
+
+  it("should collect the transferables of every send in the batch", async () => {
+    const flushTo = vi.fn();
+    const batcher = new aether.Batcher<string>(flushTo);
+    const first = new ArrayBuffer(8);
+    const second = new ArrayBuffer(8);
+    batcher.send("a", [first]);
+    batcher.send("b");
+    batcher.send("c", [second]);
+    await flushed();
+    expect(flushTo).toHaveBeenCalledWith(["a", "b", "c"], [first, second]);
+  });
+
+  it("should start a new batch for sends made after a flush", async () => {
+    const flushTo = vi.fn();
+    const batcher = new aether.Batcher<string>(flushTo);
+    batcher.send("a");
+    await flushed();
+    batcher.send("b");
+    await flushed();
+    expect(flushTo).toHaveBeenCalledTimes(2);
+    expect(flushTo).toHaveBeenNthCalledWith(1, ["a"], []);
+    expect(flushTo).toHaveBeenNthCalledWith(2, ["b"], []);
+  });
+
+  describe("clear", () => {
+    it("should drop buffered values without flushing them", async () => {
+      const flushTo = vi.fn();
+      const batcher = new aether.Batcher<string>(flushTo);
+      batcher.send("a");
+      batcher.clear();
+      await flushed();
+      expect(flushTo).not.toHaveBeenCalled();
+    });
+
+    it("should leave the pending flush scheduled so a later send does not double it", async () => {
+      const flushTo = vi.fn();
+      const beforeFlush = vi.fn();
+      const batcher = new aether.Batcher<string>(flushTo, beforeFlush);
+      batcher.send("a");
+      batcher.clear();
+      batcher.send("b");
+      await flushed();
+      expect(beforeFlush).toHaveBeenCalledTimes(1);
+      expect(flushTo).toHaveBeenCalledTimes(1);
+      expect(flushTo).toHaveBeenCalledWith(["b"], []);
+    });
+  });
+
+  describe("beforeFlush", () => {
+    it("should send into the batch it precedes", async () => {
+      const flushTo = vi.fn();
+      const batcher: aether.Batcher<string> = new aether.Batcher<string>(flushTo, () =>
+        batcher.send("leading"),
+      );
+      batcher.send("buffered");
+      await flushed();
+      expect(flushTo).toHaveBeenCalledTimes(1);
+      expect(flushTo).toHaveBeenCalledWith(["buffered", "leading"], []);
+    });
+
+    it("should run on a schedule with an empty buffer without calling flushTo", async () => {
+      const flushTo = vi.fn();
+      const beforeFlush = vi.fn();
+      const batcher = new aether.Batcher<string>(flushTo, beforeFlush);
+      batcher.schedule();
+      await flushed();
+      expect(beforeFlush).toHaveBeenCalledTimes(1);
+      expect(flushTo).not.toHaveBeenCalled();
+    });
+
+    it("should collapse repeated schedules within a tick into one flush", async () => {
+      const flushTo = vi.fn();
+      const beforeFlush = vi.fn();
+      const batcher = new aether.Batcher<string>(flushTo, beforeFlush);
+      batcher.schedule();
+      batcher.schedule();
+      batcher.send("a");
+      await flushed();
+      expect(beforeFlush).toHaveBeenCalledTimes(1);
+      expect(flushTo).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it("should defer a send made from inside flushTo to the next batch", async () => {
+    const batches: string[][] = [];
+    let resent = false;
+    const batcher: aether.Batcher<string> = new aether.Batcher<string>((values) => {
+      batches.push(values);
+      if (resent) return;
+      resent = true;
+      batcher.send("re-sent");
+    });
+    batcher.send("first");
+    await flushed();
+    await flushed();
+    expect(batches).toEqual([["first"], ["re-sent"]]);
+  });
+});

--- a/pluto/src/aether/aether/message.ts
+++ b/pluto/src/aether/aether/message.ts
@@ -70,27 +70,23 @@ export type WorkerMessage =
 export type MainMessage =
   MainUpdateRequest | MainDeleteRequest | MainClearRequest | MainInvokeRequest;
 
-/** Send-only channel from the worker side. Held by individual aether components to post
- * {@link WorkerMessage}s back to the main thread. */
+/** Send-only channel handed to individual aether components. Takes one
+ * {@link WorkerMessage} at a time; the implementation decides when it reaches the wire. */
 export interface Sender {
   send: (value: WorkerMessage, transfer?: Transferable[]) => void;
 }
 
-/** Bidirectional comms on the worker side. Sends {@link WorkerMessage}, handles
- * batches of {@link MainMessage}. Consumed by {@link aether.render}. */
-export interface WorkerComms extends Sender {
+/** Bidirectional comms on the worker side. Consumed by {@link aether.render}. */
+export interface WorkerComms {
+  send: (values: WorkerMessage[], transfer?: Transferable[]) => void;
   handle: (handler: (values: MainMessage[]) => void) => void;
 }
 
-/** Bidirectional comms on the main side. Sends {@link MainMessage}, handles
- * {@link WorkerMessage}. Consumed by {@link Aether.Provider} and {@link Store}.
- *
- * Main → worker always travels as an array, even for a single message. One commit
- * produces many messages and `postMessage`'s fixed cost dominates the payload at those
- * sizes, so the store sends a commit's worth at once. */
+/** Bidirectional comms on the main side. Consumed by {@link Aether.Provider} and
+ * {@link Store}. */
 export interface MainComms {
   send: (values: MainMessage[], transfer?: Transferable[]) => void;
-  handle: (handler: (value: WorkerMessage) => void) => void;
+  handle: (handler: (values: WorkerMessage[]) => void) => void;
 }
 
 /** Sentinel used when `workerEnabled: false`. Lets the store stay non-null without
@@ -102,7 +98,7 @@ export const NOOP_MAIN_COMMS: MainComms = { send: () => {}, handle: () => {} };
 export const wrapWorker = (worker: Worker): MainComms => ({
   send: (values, transfer = []) => worker.postMessage(values, transfer),
   handle: (handler) => {
-    worker.onmessage = (e: MessageEvent<WorkerMessage>) => handler(e.data);
+    worker.onmessage = (e: MessageEvent<WorkerMessage[]>) => handler(e.data);
   },
 });
 
@@ -110,21 +106,79 @@ export const wrapWorker = (worker: Worker): MainComms => ({
  * worker-side parallel of {@link wrapWorker}; must be called from inside a dedicated
  * worker. */
 export const wrapWorkerScope = (): WorkerComms => ({
-  send: (value, transfer = []) => postMessage(value, { transfer }),
+  send: (values, transfer = []) => postMessage(values, { transfer }),
   handle: (handler) => {
     onmessage = (e: MessageEvent<MainMessage[]>) => handler(e.data);
   },
 });
+
+/** Buffers messages and hands them to `flushTo` as one array on the next microtask.
+ *
+ * Both directions batch. `postMessage` has a fixed per-call cost that dominates the
+ * payload at these sizes, and each delivery is one task on the receiving thread, so a
+ * batch is also one React render instead of one per message. */
+export class Batcher<M> {
+  private readonly flushTo: (values: M[], transfer: Transferable[]) => void;
+  private readonly beforeFlush: () => void;
+  private buffer: M[] = [];
+  private transfer: Transferable[] = [];
+  private scheduled = false;
+
+  /** `beforeFlush` runs at the top of every flush; anything it sends joins the batch it
+   * precedes. Use it for work that must lead the batch, such as ordering pending
+   * creates. */
+  constructor(
+    flushTo: (values: M[], transfer: Transferable[]) => void,
+    beforeFlush: () => void = () => {},
+  ) {
+    this.flushTo = flushTo;
+    this.beforeFlush = beforeFlush;
+  }
+
+  /** Buffers `value` for the next flush. Nothing is delivered synchronously. */
+  send(value: M, transfer: Transferable[] = []): void {
+    this.buffer.push(value);
+    if (transfer.length > 0) this.transfer.push(...transfer);
+    this.schedule();
+  }
+
+  /** Requests a flush even with an empty buffer, so `beforeFlush` gets to run.
+   * Idempotent within a microtask. */
+  schedule(): void {
+    if (this.scheduled) return;
+    this.scheduled = true;
+    queueMicrotask(() => this.flush());
+  }
+
+  /** Drops everything buffered. */
+  clear(): void {
+    this.buffer = [];
+    this.transfer = [];
+  }
+
+  private flush(): void {
+    this.beforeFlush();
+    // Cleared only now: beforeFlush sends into the batch it precedes, and a send from
+    // flushTo belongs to the next one.
+    this.scheduled = false;
+    if (this.buffer.length === 0) return;
+    const values = this.buffer;
+    const transfer = this.transfer;
+    this.buffer = [];
+    this.transfer = [];
+    this.flushTo(values, transfer);
+  }
+}
 
 /** Creates a paired `[workerSide, mainSide]` of comms that route to each other. Use in
  * tests in place of a real {@link Worker}; the tuple order matches the direction
  * expected by {@link aether.render} and {@link Aether.Provider}. */
 export const createMockPair = (): [WorkerComms, MainComms] => {
   let workerHandler: ((values: MainMessage[]) => void) | null = null;
-  let mainHandler: ((value: WorkerMessage) => void) | null = null;
+  let mainHandler: ((values: WorkerMessage[]) => void) | null = null;
   return [
     {
-      send: (value) => mainHandler?.(value),
+      send: (values) => mainHandler?.(values),
       handle: (handler) => {
         workerHandler = handler;
       },

--- a/pluto/src/aether/aether/message.ts
+++ b/pluto/src/aether/aether/message.ts
@@ -77,15 +77,19 @@ export interface Sender {
 }
 
 /** Bidirectional comms on the worker side. Sends {@link WorkerMessage}, handles
- * {@link MainMessage}. Consumed by {@link aether.render}. */
+ * batches of {@link MainMessage}. Consumed by {@link aether.render}. */
 export interface WorkerComms extends Sender {
-  handle: (handler: (value: MainMessage) => void) => void;
+  handle: (handler: (values: MainMessage[]) => void) => void;
 }
 
 /** Bidirectional comms on the main side. Sends {@link MainMessage}, handles
- * {@link WorkerMessage}. Consumed by {@link Aether.Provider} and {@link Store}. */
+ * {@link WorkerMessage}. Consumed by {@link Aether.Provider} and {@link Store}.
+ *
+ * Main → worker always travels as an array, even for a single message. One commit
+ * produces many messages and `postMessage`'s fixed cost dominates the payload at those
+ * sizes, so the store sends a commit's worth at once. */
 export interface MainComms {
-  send: (value: MainMessage, transfer?: Transferable[]) => void;
+  send: (values: MainMessage[], transfer?: Transferable[]) => void;
   handle: (handler: (value: WorkerMessage) => void) => void;
 }
 
@@ -96,7 +100,7 @@ export const NOOP_MAIN_COMMS: MainComms = { send: () => {}, handle: () => {} };
 
 /** Adapts a `Worker` to {@link MainComms} for main-thread use. */
 export const wrapWorker = (worker: Worker): MainComms => ({
-  send: (value, transfer = []) => worker.postMessage(value, transfer),
+  send: (values, transfer = []) => worker.postMessage(values, transfer),
   handle: (handler) => {
     worker.onmessage = (e: MessageEvent<WorkerMessage>) => handler(e.data);
   },
@@ -108,7 +112,7 @@ export const wrapWorker = (worker: Worker): MainComms => ({
 export const wrapWorkerScope = (): WorkerComms => ({
   send: (value, transfer = []) => postMessage(value, { transfer }),
   handle: (handler) => {
-    onmessage = (e: MessageEvent<MainMessage>) => handler(e.data);
+    onmessage = (e: MessageEvent<MainMessage[]>) => handler(e.data);
   },
 });
 
@@ -116,7 +120,7 @@ export const wrapWorkerScope = (): WorkerComms => ({
  * tests in place of a real {@link Worker}; the tuple order matches the direction
  * expected by {@link aether.render} and {@link Aether.Provider}. */
 export const createMockPair = (): [WorkerComms, MainComms] => {
-  let workerHandler: ((value: MainMessage) => void) | null = null;
+  let workerHandler: ((values: MainMessage[]) => void) | null = null;
   let mainHandler: ((value: WorkerMessage) => void) | null = null;
   return [
     {
@@ -126,7 +130,7 @@ export const createMockPair = (): [WorkerComms, MainComms] => {
       },
     },
     {
-      send: (value) => workerHandler?.(value),
+      send: (values) => workerHandler?.(values),
       handle: (handler) => {
         mainHandler = handler;
       },

--- a/pluto/src/aether/aether/message.ts
+++ b/pluto/src/aether/aether/message.ts
@@ -23,9 +23,9 @@ export interface MainDeleteRequest {
   path: readonly string[];
 }
 
-/** Main → worker: delete every component in the tree, leaving the root usable.
- * Sent on store disposal so components leaked by discarded renders release their
- * resources. */
+/** Main → worker: delete every component in the tree, leaving the root usable. Sent on
+ * store disposal, which for in-process comms is the only thing that tears the tree
+ * down. */
 export interface MainClearRequest {
   variant: "clear";
 }

--- a/pluto/src/aether/main.spec.tsx
+++ b/pluto/src/aether/main.spec.tsx
@@ -16,6 +16,7 @@ import {
   type PropsWithChildren,
   type ReactNode,
   StrictMode,
+  Suspense,
   useEffect,
   useRef,
 } from "react";
@@ -1552,6 +1553,7 @@ describe("Aether Main", () => {
     });
     it("should surface worker.onerror events with location info", () => {
       const store = new Aether.Store({ workerURL: "test://worker" });
+      store.connect();
       const listener = vi.fn();
       store.subscribeError(listener);
       expect(store.getError()).toBeNull();
@@ -1571,12 +1573,14 @@ describe("Aether Main", () => {
     });
     it("should fall back to 'unknown' when ErrorEvent carries no message", () => {
       const store = new Aether.Store({ workerURL: "test://worker" });
+      store.connect();
       instances[0].onerror?.(new ErrorEvent("error"));
       expect(store.getError()?.message).toBe("[aether] worker error: unknown");
       store.dispose();
     });
     it("should surface worker.onmessageerror as a deserialization failure", () => {
       const store = new Aether.Store({ workerURL: "test://worker" });
+      store.connect();
       const listener = vi.fn();
       store.subscribeError(listener);
       instances[0].onmessageerror?.(new MessageEvent("messageerror"));
@@ -1613,26 +1617,88 @@ describe("Aether Main", () => {
       expect(leaf.key).toBe("duplicate");
       expect(leaf.state.x).toBe(2);
     });
-    it("should run afterDelete on worker components orphaned at dispose", () => {
-      // A render React discards after useLifecycle registers leaves a worker-side
-      // component no delete message will ever name. dispose() must clear the tree so
-      // the orphan releases its resources.
+    it("should never reach the worker for a handle that is staged but never attached", async () => {
+      // A render React discards stages a handle and then drops it. Nothing may reach
+      // the worker, because no delete message would ever name it.
       const [workerSide, mainSide] = aether.createMockPair();
       const root = aether.render({
         worker: workerSide,
         registry: { [ExampleLeaf.TYPE]: ExampleLeaf },
       });
       const store = new Aether.Store({ worker: mainSide });
-      store.register({
+      const handle = store.stage({
         type: ExampleLeaf.TYPE,
         schema: exampleProps,
-        path: ["root", "leaked"],
+        path: ["root", "discarded"],
         initialState: { x: 0 },
       });
-      const leaf = root.children[0] as ExampleLeaf;
-      store.dispose();
-      expect(leaf.deletef).toHaveBeenCalledTimes(1);
+      // Local state is readable even though the worker knows nothing.
+      expect(handle.getState()).toEqual({ x: 0 });
+      await vi.waitFor(() => expect(root.children).toHaveLength(0));
+      handle.setState({ x: 1 });
+      await vi.waitFor(() => expect(root.children).toHaveLength(0));
+    });
+    it("should not create worker components for renders discarded by suspense", async () => {
+      // A suspending tree renders three times: the render that suspends, the retry,
+      // and the render after the promise resolves. Only the last one commits. When
+      // acquisition happened during render, all three reached the worker and the first
+      // two were orphaned under keys no delete message would ever name.
+      const [Provider, root] = await newProvider();
+      let resolved = false;
+      let release: () => void = () => {};
+      const gate = new Promise<void>((resolve) => {
+        release = () => {
+          resolved = true;
+          resolve();
+        };
+      });
+      const Suspender = () => {
+        // Throwing the promise rather than use()-ing it: the retry must land
+        // synchronously for the assertion below to observe the discarded renders.
+        // eslint-disable-next-line @typescript-eslint/only-throw-error
+        if (!resolved) throw gate;
+        return null;
+      };
+      const Leaf = () => {
+        Aether.use({
+          type: ExampleLeaf.TYPE,
+          schema: exampleProps,
+          initialState: { x: 0 },
+        });
+        return null;
+      };
+      render(
+        <Provider>
+          <Suspense fallback={null}>
+            <Leaf />
+            <Leaf />
+            <Leaf />
+            <Suspender />
+          </Suspense>
+        </Provider>,
+      );
       expect(root.children).toHaveLength(0);
+      release();
+      await waitFor(() => expect(root.children).toHaveLength(3));
+    });
+    it("should not spawn a worker until the provider commits", () => {
+      // The Store is constructed during the Provider's render. Spawning the worker
+      // there strands a live worker, and for synnax.Provider a live client, whenever
+      // React discards that render.
+      const instances: FakeWorker[] = [];
+      class TrackedWorker extends FakeWorker {
+        constructor(url: string | URL) {
+          super(url);
+          instances.push(this);
+        }
+      }
+      vi.stubGlobal("Worker", TrackedWorker);
+      const store = new Aether.Store({ workerURL: "test://worker" });
+      expect(instances).toHaveLength(0);
+      store.connect();
+      expect(instances).toHaveLength(1);
+      store.dispose();
+      vi.unstubAllGlobals();
     });
     it("should keep leaves that share a key under different parents independent", async () => {
       // Two plots charting the same channel produce lines with identical keys. Identity
@@ -1774,30 +1840,28 @@ describe("Aether Main", () => {
       expect(hasMountWarning).toBe(false);
       errorSpy.mockRestore();
     });
-    it("should return a cached snapshot while a subscriber outlives the entry", () => {
-      // Pin: useSyncExternalStore may call getSnapshot for tearing detection after the
-      // entry has been unregistered (e.g. StrictMode's pseudo- unmount/remount window).
-      // The store should fall back to the last known snapshot for that path rather than
-      // throw.
+    it("should keep handle state readable across a detach and re-attach", () => {
+      // Pin: useSyncExternalStore may call getSnapshot for tearing detection while the
+      // component is detached (StrictMode's cleanup-then-setup remount, which does not
+      // re-render in between). The handle owns its state, so the read never gaps.
       const [workerSide, mainSide] = aether.createMockPair();
-      aether.render({ worker: workerSide, registry: REGISTRY });
+      const root = aether.render({ worker: workerSide, registry: REGISTRY });
       const store = new Aether.Store({ worker: mainSide });
       const path = ["root", "pinned"];
-      const snapshot = () => store.getSnapshot<typeof exampleProps>(path);
-      const unsubscribe = store.subscribe(path, () => {});
-      store.register({
+      const handle = store.stage({
         type: ExampleLeaf.TYPE,
         path,
         schema: exampleProps,
         initialState: { x: 7 },
       });
-      expect(snapshot()).toEqual({ x: 7 });
-      store.unregister(path);
-      // Subscriber still attached: cached snapshot remains readable.
-      expect(snapshot()).toEqual({ x: 7 });
-      unsubscribe();
-      // No subscribers and no entry: cache is cleared.
-      expect(snapshot).toThrow(/missing entry/);
+      expect(handle.getState()).toEqual({ x: 7 });
+      handle.attach();
+      expect(handle.getState()).toEqual({ x: 7 });
+      handle.detach();
+      expect(handle.getState()).toEqual({ x: 7 });
+      handle.attach();
+      expect(handle.getState()).toEqual({ x: 7 });
+      expect(root.children).toHaveLength(0);
     });
     it("should survive re-parenting under the same aether path in a single commit", async () => {
       // Index-keyed rows re-parent surviving cells on row deletion: React mounts a

--- a/pluto/src/aether/main.spec.tsx
+++ b/pluto/src/aether/main.spec.tsx
@@ -1681,6 +1681,28 @@ describe("Aether Main", () => {
       release();
       await waitFor(() => expect(root.children).toHaveLength(3));
     });
+    it("should drop invokes queued before a detach rather than replay them on re-attach", async () => {
+      // An invoke issued before the create message flushes waits on the entry. Detaching
+      // rejects its caller, so replaying it after a StrictMode re-attach would run the
+      // side effect for a call the caller was already told had failed.
+      const [workerSide, mainSide] = aether.createMockPair();
+      const root = aether.render({ worker: workerSide, registry: REGISTRY });
+      const store = new Aether.Store({ worker: mainSide });
+      const handle = store.stage({
+        type: InvokeLeaf.TYPE,
+        schema: exampleProps,
+        path: ["root", "invoker"],
+        initialState: { x: 0 },
+        methodsSchema: invokeMethodsSchema,
+      });
+      handle.attach();
+      handle.methods.fireAndForget();
+      handle.detach();
+      handle.attach();
+      await expect.poll(() => root.children.length).toBe(1);
+      const leaf = root.children[0] as InvokeLeaf;
+      expect(leaf.fireAndForgetSpy).not.toHaveBeenCalled();
+    });
     it("should not spawn a worker until the provider commits", () => {
       // The Store is constructed during the Provider's render. Spawning the worker
       // there strands a live worker, and for synnax.Provider a live client, whenever

--- a/pluto/src/aether/main.spec.tsx
+++ b/pluto/src/aether/main.spec.tsx
@@ -1840,6 +1840,35 @@ describe("Aether Main", () => {
       first.attach();
       await expect.poll(() => root.children.length).toBe(2);
     });
+    it("should stop treating entries as live once the store disposes", async () => {
+      // dispose clears the worker tree but leaves the handles with their owners. An
+      // entry still marked live would send an update for a path whose parent the worker
+      // no longer has, which the tree rejects.
+      const [workerSide, mainSide] = aether.createMockPair();
+      const root = aether.render({ worker: workerSide, registry: REGISTRY });
+      const store = new Aether.Store({ worker: mainSide });
+      const parent = store.stage({
+        type: ExampleComposite.TYPE,
+        schema: exampleProps,
+        path: ["root", "parent"],
+        initialState: { x: 0 },
+      });
+      const child = store.stage({
+        type: ExampleLeaf.TYPE,
+        schema: exampleProps,
+        path: ["root", "parent", "child"],
+        initialState: { x: 0 },
+      });
+      parent.attach();
+      child.attach();
+      await expect.poll(() => root.children.length).toBe(1);
+      store.dispose();
+      expect(root.children).toHaveLength(0);
+      child.setState({ x: 1 });
+      await expect.poll(() => child.getState().x).toBe(1);
+      expect(store.getError()).toBeNull();
+      expect(root.children).toHaveLength(0);
+    });
     it("should not spawn a worker until the provider commits", () => {
       // The Store is constructed during the Provider's render. Spawning the worker
       // there strands a live worker, and for synnax.Provider a live client, whenever

--- a/pluto/src/aether/main.spec.tsx
+++ b/pluto/src/aether/main.spec.tsx
@@ -1703,6 +1703,82 @@ describe("Aether Main", () => {
       const leaf = root.children[0] as InvokeLeaf;
       expect(leaf.fireAndForgetSpy).not.toHaveBeenCalled();
     });
+    it("should send one commit's worth of components as a single message", async () => {
+      // postMessage's fixed cost dominates the payload at these sizes, so a mount must
+      // cost one send rather than one per component.
+      const [workerSide, mainSide] = aether.createMockPair();
+      const root = aether.render({ worker: workerSide, registry: REGISTRY });
+      const sends: aether.MainMessage[][] = [];
+      const counted: aether.MainComms = {
+        send: (values, transfer) => {
+          sends.push(values);
+          mainSide.send(values, transfer);
+        },
+        handle: (handler) => mainSide.handle(handler),
+      };
+      const Leaf = () => {
+        Aether.use({
+          type: ExampleLeaf.TYPE,
+          schema: exampleProps,
+          initialState: { x: 0 },
+        });
+        return null;
+      };
+      render(
+        <Aether.Provider worker={counted}>
+          <Leaf />
+          <Leaf />
+          <Leaf />
+          <Leaf />
+          <Leaf />
+        </Aether.Provider>,
+      );
+      await expect.poll(() => root.children.length).toBe(5);
+      expect(sends).toHaveLength(1);
+      expect(sends[0]).toHaveLength(5);
+    });
+    it("should order a batch so every parent precedes its children", async () => {
+      // Layout effects run children first, so the store sorts the batch by path depth.
+      // The worker throws on a child whose parent it has never seen.
+      const [workerSide, mainSide] = aether.createMockPair();
+      const root = aether.render({ worker: workerSide, registry: REGISTRY });
+      const sends: aether.MainMessage[][] = [];
+      const counted: aether.MainComms = {
+        send: (values, transfer) => {
+          sends.push(values);
+          mainSide.send(values, transfer);
+        },
+        handle: (handler) => mainSide.handle(handler),
+      };
+      const Leaf = () => {
+        Aether.use({
+          type: ExampleLeaf.TYPE,
+          schema: exampleProps,
+          initialState: { x: 0 },
+        });
+        return null;
+      };
+      const Nested = () => {
+        const [{ path }] = Aether.use({
+          type: ExampleComposite.TYPE,
+          schema: exampleProps,
+          initialState: { x: 0 },
+        });
+        return (
+          <Aether.Composite path={path}>
+            <Leaf />
+          </Aether.Composite>
+        );
+      };
+      render(
+        <Aether.Provider worker={counted}>
+          <Nested />
+        </Aether.Provider>,
+      );
+      await expect.poll(() => root.children.length).toBe(1);
+      const depths = sends.flat().map((m) => ("path" in m ? m.path.length : 0));
+      expect(depths).toEqual([...depths].sort((a, b) => a - b));
+    });
     it("should not spawn a worker until the provider commits", () => {
       // The Store is constructed during the Provider's render. Spawning the worker
       // there strands a live worker, and for synnax.Provider a live client, whenever

--- a/pluto/src/aether/main.spec.tsx
+++ b/pluto/src/aether/main.spec.tsx
@@ -1779,6 +1779,67 @@ describe("Aether Main", () => {
       const depths = sends.flat().map((m) => ("path" in m ? m.path.length : 0));
       expect(depths).toEqual([...depths].sort((a, b) => a - b));
     });
+    it("should deliver one tick of worker pushes as a single main-thread message", async () => {
+      // Every delivery is one task on the main thread, so an unbatched push per
+      // component is one React render per component.
+      const [workerSide, mainSide] = aether.createMockPair();
+      aether.render({ worker: workerSide, registry: REGISTRY });
+      const deliveries: aether.WorkerMessage[][] = [];
+      const counted: aether.MainComms = {
+        send: (values, transfer) => mainSide.send(values, transfer),
+        handle: (handler) =>
+          mainSide.handle((values) => {
+            deliveries.push(values);
+            handler(values);
+          }),
+      };
+      const setters = new Map<number, (x: number) => void>();
+      const Leaf = ({ index }: { index: number }) => {
+        const [, , , methods] = Aether.use({
+          type: InvokeLeaf.TYPE,
+          schema: exampleProps,
+          initialState: { x: 0 },
+          methods: invokeMethodsSchema,
+        });
+        useEffect(() => {
+          setters.set(index, methods.updateState);
+        }, [index, methods]);
+        return null;
+      };
+      render(
+        <Aether.Provider worker={counted}>
+          {[0, 1, 2, 3, 4].map((index) => (
+            <Leaf key={index} index={index} />
+          ))}
+        </Aether.Provider>,
+      );
+      await waitFor(() => expect(setters.size).toBe(5));
+      deliveries.length = 0;
+      setters.forEach((set, index) => set(index + 1));
+      await waitFor(() => expect(deliveries).toHaveLength(1));
+      expect(deliveries[0]).toHaveLength(5);
+    });
+    it("should flush a component attached by a listener that a flush notified", async () => {
+      // The store notifies subscribers while it drains creates. A component attached
+      // from inside that notification arrives too late for the batch being sent, so the
+      // store has to schedule another flush rather than strand it until an unrelated
+      // send.
+      const [workerSide, mainSide] = aether.createMockPair();
+      const root = aether.render({ worker: workerSide, registry: REGISTRY });
+      const store = new Aether.Store({ worker: mainSide });
+      const stage = (key: string) =>
+        store.stage({
+          type: ExampleLeaf.TYPE,
+          schema: exampleProps,
+          path: ["root", key],
+          initialState: { x: 0 },
+        });
+      const first = stage("first");
+      const second = stage("second");
+      store.subscribe(["root", "first"], () => second.attach());
+      first.attach();
+      await expect.poll(() => root.children.length).toBe(2);
+    });
     it("should not spawn a worker until the provider commits", () => {
       // The Store is constructed during the Provider's render. Spawning the worker
       // there strands a live worker, and for synnax.Provider a live client, whenever

--- a/pluto/src/aether/main.tsx
+++ b/pluto/src/aether/main.tsx
@@ -129,9 +129,11 @@ interface UseLifecycleProps<
 }
 
 /** Registers a component with the enclosing {@link Provider}'s {@link Store} and
- * returns the operations needed to drive it. Lower-level than {@link use} — does not
- * subscribe React to state changes. Most callers want {@link use} or
- * {@link useUnidirectional} instead. */
+ * returns the operations needed to drive it. Identity — store, enclosing path, and key —
+ * is fixed on the mounting render; moving a component under a different
+ * {@link Composite} needs a remount. Lower-level than {@link use} — does not subscribe
+ * React to state changes. Most callers want {@link use} or {@link useUnidirectional}
+ * instead. */
 export const useLifecycle = <
   StateSchema extends z.ZodType<state.State, state.State>,
   Methods extends MethodsSchema = EmptyMethodsSchema,

--- a/pluto/src/aether/main.tsx
+++ b/pluto/src/aether/main.tsx
@@ -30,7 +30,6 @@ import { type Handle, type RawSetArg, Store } from "@/aether/store";
 import { context } from "@/context";
 import { useSyncedRef } from "@/hooks";
 import { useUniqueKey } from "@/hooks/useUniqueKey";
-import { useMemoArray } from "@/memo";
 
 /** Value supplied by the Aether context to descendants of {@link Provider}. */
 export interface ContextValue {
@@ -118,9 +117,8 @@ interface UseLifecycleProps<
   type: string;
   /** Zod schema validating both `initialState` and worker-pushed state. */
   schema: StateSchema;
-  /** Stable key for the component. Generated if omitted. Identity-stable for the
-   * component's lifetime — changing it mid-life unregisters and re-registers under the
-   * new key. */
+  /** Key for the component, generated if omitted. Read on the mounting render only;
+   * later changes are ignored. Remount under a React `key` to get a new identity. */
   aetherKey?: string;
   initialState: z.input<StateSchema>;
   /** Optional `Transferable`s included with the initial update message. */
@@ -151,14 +149,14 @@ export const useLifecycle = <
 > => {
   const key = useUniqueKey(aetherKey);
   const ctx = useContext();
-  const path = useMemoArray([...ctx.path, key]);
   const onReceiveRef = useSyncedRef(onAetherChange);
   const handleRef = useRef<Handle<StateSchema, Methods> | null>(null);
   // Staging is pure: the store keeps no reference and the worker hears nothing until
-  // the attach below. A render React discards is reclaimed with this ref.
+  // the attach below. A render React discards is reclaimed with this ref. `??=` short
+  // circuits, so the path array is built on the mounting render alone.
   handleRef.current ??= ctx.store.stage({
     type,
-    path,
+    path: [...ctx.path, key],
     schema,
     initialState,
     initialTransfer,
@@ -166,7 +164,6 @@ export const useLifecycle = <
     onReceiveRef,
   });
   const handle = handleRef.current;
-  const { methods } = handle;
 
   // The handle outlives the effect so StrictMode's cleanup-then-setup remount, which
   // does not re-render, re-attaches this same component.
@@ -175,22 +172,18 @@ export const useLifecycle = <
     return () => handle.detach();
   }, [handle]);
 
-  const setState = useCallback(
-    (next: RawSetArg<StateSchema>, transfer: Transferable[] = []) =>
-      handle.setState(next, transfer),
-    [handle],
-  );
-
-  const subscribe = useCallback(
-    (listener: () => void) => ctx.store.subscribe(path, listener),
-    [ctx.store, path],
-  );
-
-  const getSnapshot = useCallback(() => handle.getState(), [handle]);
-
+  // Every field is a closure the handle built once, so this runs on the mounting render
+  // and never again. Wrapping them in `useCallback` would allocate an arrow and a
+  // dependency array per render to reproduce identities that are already stable.
   return useMemo(
-    () => ({ setState, path, methods, subscribe, getSnapshot }),
-    [setState, path, methods, subscribe, getSnapshot],
+    () => ({
+      path: handle.path,
+      setState: handle.setState,
+      methods: handle.methods,
+      subscribe: handle.subscribe,
+      getSnapshot: handle.getState,
+    }),
+    [handle],
   );
 };
 
@@ -256,11 +249,16 @@ export const useUnidirectional = <
     ...rest,
     initialState: state,
   });
-  const ref = useRef<z.input<StateSchema> | z.infer<StateSchema> | null>(null);
-  if (!deep.equal(ref.current, state)) {
+  // Seeded with the state the component staged with, so the mounting render does not
+  // re-send what the create message already carries.
+  const ref = useRef<z.input<StateSchema>>(state);
+  // In an effect rather than in render: a render React discards must not push state to
+  // the worker. The store buffers to a microtask either way, so nothing lands later.
+  useLayoutEffect(() => {
+    if (deep.equal(ref.current, state)) return;
     ref.current = state;
     setState(state);
-  }
+  });
   return { path, methods };
 };
 

--- a/pluto/src/aether/main.tsx
+++ b/pluto/src/aether/main.tsx
@@ -85,6 +85,11 @@ export const Provider = ({ children, ...config }: ProviderProps): ReactElement =
   const error = useSyncExternalStore(subscribeError, getError);
   if (error != null) throw error;
 
+  // Spawn the worker on commit rather than in the Store constructor, which runs during
+  // render. A tree with no aether components still connects, so a worker that fails to
+  // load reports it without waiting for a first component.
+  useLayoutEffect(() => store.connect(), [store]);
+
   const value = useMemo<ContextValue>(() => ({ store, path: ROOT_PATH }), [store]);
 
   return <Context value={value}>{children}</Context>;
@@ -149,10 +154,9 @@ export const useLifecycle = <
   const path = useMemoArray([...ctx.path, key]);
   const onReceiveRef = useSyncedRef(onAetherChange);
   const handleRef = useRef<Handle<StateSchema, Methods> | null>(null);
-  // Render-phase register: preserves parent-before-child ordering on the worker.
-  // Concurrent Mode may discard a render before commit, leaking the entry — harmless:
-  // it reclaims with the Provider's Store on unmount.
-  handleRef.current ??= ctx.store.register({
+  // Staging is pure: the store keeps no reference and the worker hears nothing until
+  // the attach below. A render React discards is reclaimed with this ref.
+  handleRef.current ??= ctx.store.stage({
     type,
     path,
     schema,
@@ -161,23 +165,20 @@ export const useLifecycle = <
     methodsSchema,
     onReceiveRef,
   });
-  const { methods } = handleRef.current;
+  const handle = handleRef.current;
+  const { methods } = handle;
 
-  // Delete via the handle, not by path: on a single-commit re-parent the
-  // successor registers at this path during render, before this cleanup runs,
-  // and a path-based unregister would tear it down.
-  useLayoutEffect(
-    () => () => {
-      handleRef.current?.delete();
-      handleRef.current = null;
-    },
-    [ctx.store, path],
-  );
+  // The handle outlives the effect so StrictMode's cleanup-then-setup remount, which
+  // does not re-render, re-attaches this same component.
+  useLayoutEffect(() => {
+    handle.attach();
+    return () => handle.detach();
+  }, [handle]);
 
   const setState = useCallback(
     (next: RawSetArg<StateSchema>, transfer: Transferable[] = []) =>
-      handleRef.current?.setState(next, transfer),
-    [],
+      handle.setState(next, transfer),
+    [handle],
   );
 
   const subscribe = useCallback(
@@ -185,10 +186,7 @@ export const useLifecycle = <
     [ctx.store, path],
   );
 
-  const getSnapshot = useCallback(
-    () => ctx.store.getSnapshot<StateSchema>(path),
-    [ctx.store, path],
-  );
+  const getSnapshot = useCallback(() => handle.getState(), [handle]);
 
   return useMemo(
     () => ({ setState, path, methods, subscribe, getSnapshot }),

--- a/pluto/src/aether/store.ts
+++ b/pluto/src/aether/store.ts
@@ -301,9 +301,12 @@ export class Store {
     this.outbound.clear();
     if (this.worker === aether.NOOP_MAIN_COMMS) return;
     this.invokeTracker.abort(new Error("aether store disposed"));
-    // In-process comms have no thread to die with, so tear the tree down explicitly
-    // rather than relying on every component to have detached first.
+    // In-process comms have no thread to die with, so tear the tree down explicitly.
     this.worker.send([{ variant: "clear" }]);
+    // Staged, not deleted: mounted components still own these handles, and a re-attach
+    // must send a fresh create.
+    this.entries.forEach((entry) => (entry.phase = "staged"));
+    this.entries.clear();
     this.worker.handle(() => {});
     this.worker = aether.NOOP_MAIN_COMMS;
     this.ownedWorker?.terminate();

--- a/pluto/src/aether/store.ts
+++ b/pluto/src/aether/store.ts
@@ -16,12 +16,12 @@ import { aether } from "@/aether/aether";
 const DEFAULT_INVOKE_TIMEOUT = TimeSpan.seconds(5);
 
 /** Path separator for store identities. Aether keys are dotless identifiers (nanoids,
- * UUIDs, numeric keys), so `.` joins unambiguously; `register` asserts keys never
+ * UUIDs, numeric keys), so `.` joins unambiguously; `stage` asserts keys never
  * contain it. */
 const PATH_SEP = ".";
 
-/** A component's store identity: its path flattened. Collides only on same-path
- * re-registration (e.g. a StrictMode remount), never across distinct components. */
+/** A component's store identity: its path flattened. Collides only on a same-path
+ * re-attach (e.g. a StrictMode remount), never across distinct components. */
 const pathID = (path: readonly string[]): string => path.join(PATH_SEP);
 
 interface PendingRequest {
@@ -90,8 +90,13 @@ export type RawSetArg<StateSchema extends z.ZodType<state.State, state.State>> =
 
 type Listener = () => void;
 
-/** Live worker component tracked by the store. Generic over its schema so reads through
- * {@link Store.getEntry} recover the per-entry state and callback types without
+/** How far a component has progressed toward existing on the worker. `staged` means the
+ * caller holds it but the worker has never heard of it; `queued` means it is attached
+ * and waiting for the next flush; `live` means its create message has been sent. */
+type Phase = "staged" | "queued" | "live";
+
+/** Worker component tracked by the store. Generic over its schema so {@link Store.stage}
+ * and the handle it returns keep the per-entry state and callback types without
  * re-asserting at every field access. */
 interface Entry<
   StateSchema extends z.ZodType<state.State, state.State> = z.ZodType<
@@ -105,10 +110,20 @@ interface Entry<
   state: z.infer<StateSchema>;
   onReceiveRef: { current: ((state: z.infer<StateSchema>) => void) | undefined } | null;
   controller: AbortController;
+  phase: Phase;
+  /** Set once another entry takes this path. Permanent: the handle is dead and every
+   * operation on it must no-op so its stale writes never reach the successor. */
+  displaced: boolean;
+  /** Transferables from setStates that ran before the create message flushed. Handed to
+   * that message so ownership transfers exactly once. */
+  transfer: Transferable[];
+  /** Invokes issued before the create message flushed. The worker cannot resolve a path
+   * it has not seen, so they ride out immediately after it. */
+  pendingInvokes: aether.MainInvokeRequest[];
 }
 
-/** Arguments accepted by {@link Store.register}. */
-export interface RegisterParams<
+/** Arguments accepted by {@link Store.stage}. */
+export interface StageParams<
   StateSchema extends z.ZodType<state.State, state.State>,
   Methods extends aether.MethodsSchema = aether.EmptyMethodsSchema,
 > {
@@ -127,9 +142,10 @@ export interface RegisterParams<
   onReceiveRef?: { current: ((state: z.infer<StateSchema>) => void) | undefined };
 }
 
-/** Per-component operations returned by {@link Store.register}: typed setState, delete,
- * and method callers. Scoped to the registration that produced it: once a same-path
- * re-registration displaces that entry, every operation no-ops (async invokes reject). */
+/** Per-component operations returned by {@link Store.stage}: typed setState, the
+ * attach/detach pair, state reads, and method callers. Scoped to the staging that
+ * produced it: once a same-path attach displaces that entry, every operation no-ops
+ * (async invokes reject). */
 export interface Handle<
   StateSchema extends z.ZodType<state.State, state.State>,
   Methods extends aether.MethodsSchema = aether.EmptyMethodsSchema,
@@ -137,7 +153,16 @@ export interface Handle<
   path: readonly string[];
   methods: aether.CallersFromSchema<Methods>;
   setState: (state: RawSetArg<StateSchema>, transfer?: Transferable[]) => void;
-  delete: () => void;
+  /** Latest state, readable in every phase. Owned by the handle rather than the store
+   * so it stays stable across a detach/attach cycle. */
+  getState: () => z.infer<StateSchema>;
+  /** Publishes the component to the store and queues its create message. Call from a
+   * layout effect: a component staged by a render React discards must never reach the
+   * worker. Idempotent. */
+  attach: () => void;
+  /** Withdraws the component, sending a delete only if its create message already went
+   * out. The handle stays reusable, so a StrictMode remount re-attaches it. */
+  detach: () => void;
 }
 
 /** Configuration for a {@link Store}. Provide either a pre-built `worker` (e.g.
@@ -155,22 +180,20 @@ export interface StoreConfig {
 /**
  * Single source of truth for aether component state on the main thread. One store is
  * owned per {@link Aether.Provider} and shared across all components in its tree.
- * Components register on render, subscribe via `useSyncExternalStore`, and unregister
- * on unmount; worker pushes land in the store and notify listeners outside of any React
- * render.
+ * Components stage on render, attach on commit, subscribe via `useSyncExternalStore`,
+ * and detach on unmount; worker pushes land in the store and notify listeners outside
+ * of any React render.
  */
 export class Store {
-  /** Live entries keyed by component identity ({@link pathID}). */
+  /** Attached entries keyed by component identity ({@link pathID}). */
   private entries: Map<string, Entry> = new Map();
   /** Subscribers keyed by component identity. Listeners persist across an entry's
-   * register-unregister-register cycle so subscriptions wired during a StrictMode
-   * pseudo-remount stay live once the real register fires. */
+   * detach-attach cycle so subscriptions wired during a StrictMode pseudo-remount stay
+   * live once the real attach fires. */
   private listeners: Map<string, Set<Listener>> = new Map();
-  /** Last known state per component identity. Survives entry unregistration so that
-   * `useSyncExternalStore`'s tearing-detection getSnapshot calls return a stable value
-   * across the unregister-then-register window. Cleaned up when both the entry and all
-   * subscribers for the identity are gone. */
-  private snapshots: Map<string, state.State> = new Map();
+  /** Entries attached since the last flush, in attach order. */
+  private queued: Entry[] = [];
+  private flushScheduled = false;
   /** Active worker comms. {@link NOOP_WORKER} when `workerEnabled: false` or between
    * {@link dispose} and the next send (lazy re-attach). */
   private worker: aether.MainComms = aether.NOOP_MAIN_COMMS;
@@ -182,7 +205,7 @@ export class Store {
   /** Raw {@link Worker} this store spawned; `null` for externally-injected comms
    * (tests) which are owned by the caller. */
   private ownedWorker: Worker | null = null;
-  /** Config retained so {@link ensureAttached} can lazily rebuild the worker after
+  /** Config retained so {@link connect} can lazily rebuild the worker after
    * {@link dispose} — required for the StrictMode reused-fiber cycle. */
   private config: StoreConfig;
 
@@ -195,10 +218,13 @@ export class Store {
         "[aether.store] worker is enabled but neither `worker` nor `workerURL` was provided. Pass `workerEnabled: false` to opt out explicitly.",
       );
     this.config = config;
-    this.ensureAttached();
   }
 
-  private ensureAttached(): void {
+  /** Spawns the worker (when configured with a `workerURL`) and starts handling its
+   * messages. Called on the {@link Aether.Provider}'s first commit and again by any
+   * send after {@link dispose}. Deferred out of the constructor so a Provider render
+   * React discards never spawns a worker. Idempotent. */
+  connect(): void {
     if (this.worker !== aether.NOOP_MAIN_COMMS) return;
     const { worker, workerURL, workerEnabled = true } = this.config;
     if (!workerEnabled) return;
@@ -239,11 +265,11 @@ export class Store {
    * `Worker`, and aborts in-flight invokes. The store remains usable: a subsequent
    * send lazily re-attaches via a fresh `Worker`. Idempotent. */
   dispose(): void {
+    this.queued = [];
     if (this.worker === aether.NOOP_MAIN_COMMS) return;
     this.invokeTracker.abort(new Error("aether store disposed"));
-    // Render-phase registration means a render React discarded can leak a worker-side
-    // component no delete message will ever name. In-process comms have no thread to
-    // die with, so tear the tree down explicitly to release leaked resources.
+    // In-process comms have no thread to die with, so tear the tree down explicitly
+    // rather than relying on every component to have detached first.
     this.worker.send({ variant: "clear" });
     this.worker.handle(() => {});
     this.worker = aether.NOOP_MAIN_COMMS;
@@ -268,7 +294,7 @@ export class Store {
 
   /** Subscribes to state changes for the component at `path`. Fires on both worker
    * pushes and local {@link Handle.setState} calls. Subscriptions persist across
-   * register-unregister cycles. Returns an unsubscribe function. */
+   * detach-attach cycles. Returns an unsubscribe function. */
   subscribe(path: readonly string[], listener: Listener): () => void {
     const id = pathID(path);
     let set = this.listeners.get(id);
@@ -283,52 +309,17 @@ export class Store {
       s.delete(listener);
       if (s.size > 0) return;
       this.listeners.delete(id);
-      if (!this.entries.has(id)) this.snapshots.delete(id);
     };
   }
 
-  /** Returns the latest known state for the component at `path`. Falls back to the
-   * cached last-known snapshot when the entry has been unregistered but subscribers
-   * remain (e.g. StrictMode's unregister-then-register window). Throws
-   * {@link UnexpectedError} only when neither is available. */
-  getSnapshot<StateSchema extends z.ZodType<state.State, state.State>>(
-    path: readonly string[],
-  ): z.infer<StateSchema> {
-    const id = pathID(path);
-    const entry = this.getEntry<StateSchema>(id);
-    if (entry != null) return entry.state;
-    const cached = this.snapshots.get(id);
-    if (cached != null) return cached as z.infer<StateSchema>;
-    throw new UnexpectedError(
-      `[aether.store] missing entry for path ${path.join(".")}`,
-    );
-  }
-
-  /** Single seam where the schema-specific types of `state` and `onReceiveRef` are
-   * recovered from the erased storage map. */
-  private getEntry<StateSchema extends z.ZodType<state.State, state.State>>(
-    id: string,
-  ): Entry<StateSchema> | undefined {
-    return this.entries.get(id) as Entry<StateSchema> | undefined;
-  }
-
-  /** Single seam where an Entry's schema-specific types are erased on insert into the
-   * uniform storage map. */
-  private setEntry<StateSchema extends z.ZodType<state.State, state.State>>(
-    id: string,
-    entry: Entry<StateSchema>,
-  ): void {
-    this.entries.set(id, entry);
-  }
-
-  /** Registers the component described by `params` and sends its initial state to the
-   * worker. If a component is already registered at the same path (e.g. a StrictMode
-   * remount), the prior worker component is deleted and the entry is replaced;
-   * subscribers keep their subscriptions. */
-  register<
+  /** Validates and parses `params` into a handle owned by the caller. The store keeps
+   * no reference and the worker is not told anything until {@link Handle.attach} runs,
+   * so a component staged by a render React discards is reclaimed with the caller's
+   * own reference. */
+  stage<
     StateSchema extends z.ZodType<state.State, state.State>,
     Methods extends aether.MethodsSchema,
-  >(params: RegisterParams<StateSchema, Methods>): Handle<StateSchema, Methods> {
+  >(params: StageParams<StateSchema, Methods>): Handle<StateSchema, Methods> {
     const {
       type,
       path,
@@ -350,49 +341,88 @@ export class Store {
         `[aether.store] received zero length type when registering component at ${path.join(".")}. This is probably a bad idea.`,
       );
 
-    const id = pathID(path);
-    const parsed = zod.parse(schema, initialState, { label: type });
-    const existing = this.entries.get(id);
-    if (existing != null) {
-      this.send({ variant: "delete", path: existing.path });
-      existing.controller.abort(new Error("Component re-registered"));
-    }
-    this.setEntry<StateSchema>(id, {
+    const entry: Entry<StateSchema> = {
       type,
       path,
       schema,
-      state: parsed,
+      state: zod.parse(schema, initialState, { label: type }),
       onReceiveRef: params.onReceiveRef ?? null,
       controller: new AbortController(),
-    });
-    this.snapshots.set(id, parsed);
-    // Deferred: register runs during a React render and uses listeners are setStates
-    // React refuses to accept mid-render. StrictMode's pseudo- remount path can hit
-    // this with a persisted listener still attached.
-    const listeners = this.listeners.get(id);
-    if (listeners != null && listeners.size > 0)
-      queueMicrotask(() => listeners.forEach((l) => l()));
-    this.send({ variant: "update", path, state: parsed, type }, initialTransfer);
-
-    return this.buildHandle(id, methodsSchema);
+      phase: "staged",
+      displaced: false,
+      transfer: [...initialTransfer],
+      pendingInvokes: [],
+    };
+    return this.buildHandle(entry, methodsSchema);
   }
 
-  /** Deletes the component at `path`: sends a delete message to the worker and aborts
-   * any pending invokes scoped to the component. No-op if nothing is registered at
-   * `path`. */
-  unregister(path: readonly string[]): void {
-    const id = pathID(path);
-    const entry = this.entries.get(id);
-    if (entry == null) return;
-    this.send({ variant: "delete", path: entry.path });
-    entry.controller.abort(new Error("Component deleted"));
-    this.invokeTracker.clearCounter(id);
+  private scheduleFlush(): void {
+    if (this.flushScheduled) return;
+    this.flushScheduled = true;
+    queueMicrotask(() => this.flush());
+  }
+
+  /** Sends every queued create message, shallowest path first. React runs layout
+   * effects children before parents, but the worker rejects a child whose parent it has
+   * never seen; an ancestor's path is always shorter than its descendant's, so ordering
+   * by depth restores the invariant without tracking render order. */
+  private flush(): void {
+    this.flushScheduled = false;
+    if (this.queued.length === 0) return;
+    const queued = this.queued;
+    this.queued = [];
+    queued.sort((a, b) => a.path.length - b.path.length);
+    for (const entry of queued) {
+      if (entry.phase !== "queued") continue;
+      entry.phase = "live";
+      const { path, state, type, transfer, pendingInvokes } = entry;
+      entry.transfer = [];
+      entry.pendingInvokes = [];
+      this.send({ variant: "update", path, state, type }, transfer);
+      for (const invoke of pendingInvokes) this.send(invoke);
+      this.listeners.get(pathID(path))?.forEach((l) => l());
+    }
+  }
+
+  private attachEntry(entry: Entry): void {
+    if (entry.displaced || entry.phase !== "staged") return;
+    const id = pathID(entry.path);
+    const existing = this.entries.get(id);
+    if (existing != null && existing !== entry) this.detachEntry(existing, true);
+    entry.phase = "queued";
+    this.entries.set(id, entry);
+    this.queued.push(entry);
+    this.scheduleFlush();
+  }
+
+  /** Returns `entry` to the staged phase. Sends a delete only when its create message
+   * already went out; a component that never flushed does not exist on the worker.
+   * `displaced` marks a same-path replacement, which must not clear the successor's
+   * entry or invoke counter. */
+  private detachEntry(entry: Entry, displaced = false): void {
+    if (entry.phase === "staged") return;
+    const id = pathID(entry.path);
+    if (entry.phase === "live") this.send({ variant: "delete", path: entry.path });
+    else {
+      const idx = this.queued.indexOf(entry);
+      if (idx !== -1) this.queued.splice(idx, 1);
+    }
+    entry.phase = "staged";
+    entry.controller.abort(
+      new Error(displaced ? "Component re-registered" : "Component deleted"),
+    );
+    // A fresh controller so a StrictMode remount can re-attach this same handle.
+    entry.controller = new AbortController();
+    if (displaced) {
+      entry.displaced = true;
+      return;
+    }
     this.entries.delete(id);
-    if (!this.listeners.has(id)) this.snapshots.delete(id);
+    this.invokeTracker.clearCounter(id);
   }
 
   private send(msg: aether.MainMessage, transfer: Transferable[] = []): void {
-    this.ensureAttached();
+    this.connect();
     this.worker.send(msg, transfer);
   }
 
@@ -414,12 +444,11 @@ export class Store {
     const { path, state } = msg;
     const id = pathID(path);
     const entry = this.entries.get(id);
-    // Drop pushes for an unregistered path — possible when delete/update messages cross
+    // Drop pushes for a detached path — possible when delete/update messages cross
     // in flight, or after a StrictMode pseudo-unmount.
     if (entry == null) return;
     const parsed = zod.parse(entry.schema, state, { label: entry.type });
     entry.state = parsed;
-    this.snapshots.set(id, parsed);
     this.listeners.get(id)?.forEach((l) => l());
     entry.onReceiveRef?.current?.(parsed);
   }
@@ -427,41 +456,41 @@ export class Store {
   private buildHandle<
     StateSchema extends z.ZodType<state.State, state.State>,
     Methods extends aether.MethodsSchema,
-  >(id: string, methodsSchema?: Methods): Handle<StateSchema, Methods> {
-    const entry = this.getEntry<StateSchema>(id);
-    if (entry == null)
-      throw new UnexpectedError(`[aether.store] missing entry for id ${id}`);
+  >(entry: Entry<StateSchema>, methodsSchema?: Methods): Handle<StateSchema, Methods> {
+    const id = pathID(entry.path);
 
-    // Guard every operation on entry identity: a same-path re-registration
-    // (StrictMode remount, single-commit re-parent) replaces the entry, and the
-    // displaced instance's stale delete must not tear down its successor.
     const setState = (
       next: RawSetArg<StateSchema>,
       transfer: Transferable[] = [],
     ): void => {
-      if (this.entries.get(id) !== entry) return;
+      if (entry.displaced) return;
       const raw = state.executeSetter<z.input<StateSchema>, z.infer<StateSchema>>(
         next,
         entry.state,
       );
-      const parsed = zod.parse(entry.schema, raw, { label: entry.type });
-      entry.state = parsed;
-      this.snapshots.set(id, parsed);
-      this.send(
-        { variant: "update", path: entry.path, state: parsed, type: entry.type },
-        transfer,
-      );
+      entry.state = zod.parse(entry.schema, raw, { label: entry.type });
+      // Before the create message flushes the worker has no component to update, so
+      // the state rides along on that message instead and the transfer list merges
+      // into it. Ownership of each Transferable still moves exactly once.
+      if (entry.phase !== "live") entry.transfer.push(...transfer);
+      else
+        this.send(
+          { variant: "update", path: entry.path, state: entry.state, type: entry.type },
+          transfer,
+        );
       this.listeners.get(id)?.forEach((l) => l());
     };
 
-    const handleDelete = () => {
-      if (this.entries.get(id) !== entry) return;
-      this.unregister(entry.path);
+    // Invokes name a path the worker must already know. Before the create message
+    // flushes there is nothing to call, so queue and let the flush send them in order.
+    const sendInvoke = (msg: aether.MainInvokeRequest): void => {
+      if (entry.phase === "live") this.send(msg);
+      else entry.pendingInvokes.push(msg);
     };
 
     const invokeMethod = (method: string, args: unknown[]): void => {
-      if (this.entries.get(id) !== entry) return;
-      this.send({ variant: "invoke_request", path: entry.path, method, args });
+      if (entry.displaced) return;
+      sendInvoke({ variant: "invoke_request", path: entry.path, method, args });
     };
 
     const invokeMethodAsync = (
@@ -472,7 +501,7 @@ export class Store {
       ),
     ): Promise<unknown> =>
       new Promise((resolve, reject) => {
-        if (this.entries.get(id) !== entry || entry.controller.signal.aborted)
+        if (entry.displaced || entry.controller.signal.aborted)
           return reject(new Error("Component deleted"));
         const invokeKey = this.invokeTracker.nextKey(id);
         this.invokeTracker.track(
@@ -481,7 +510,7 @@ export class Store {
           reject,
           AbortSignal.any([signal, entry.controller.signal]),
         );
-        this.send({
+        sendInvoke({
           variant: "invoke_request",
           key: invokeKey,
           path: entry.path,
@@ -496,7 +525,14 @@ export class Store {
       methodsSchema,
     );
 
-    return { path: entry.path, methods, setState, delete: handleDelete };
+    return {
+      path: entry.path,
+      methods,
+      setState,
+      getState: () => entry.state,
+      attach: () => this.attachEntry(entry),
+      detach: () => this.detachEntry(entry),
+    };
   }
 }
 

--- a/pluto/src/aether/store.ts
+++ b/pluto/src/aether/store.ts
@@ -193,10 +193,7 @@ export class Store {
   private listeners: Map<string, Set<Listener>> = new Map();
   /** Entries attached since the last flush, in attach order. */
   private queued: Entry[] = [];
-  /** Messages buffered for the next flush, in send order. */
-  private outbound: aether.MainMessage[] = [];
-  private outboundTransfer: Transferable[] = [];
-  private flushScheduled = false;
+  private readonly outbound: aether.Batcher<aether.MainMessage>;
   /** Active worker comms. {@link NOOP_WORKER} when `workerEnabled: false` or between
    * {@link dispose} and the next send (lazy re-attach). */
   private worker: aether.MainComms = aether.NOOP_MAIN_COMMS;
@@ -221,6 +218,15 @@ export class Store {
         "[aether.store] worker is enabled but neither `worker` nor `workerURL` was provided. Pass `workerEnabled: false` to opt out explicitly.",
       );
     this.config = config;
+    this.outbound = new aether.Batcher<aether.MainMessage>(
+      (messages, transfer) => {
+        this.connect();
+        this.worker.send(messages, transfer);
+        // A listener notified during the drain may have attached another component.
+        if (this.queued.length > 0) this.outbound.schedule();
+      },
+      () => this.drainCreates(),
+    );
   }
 
   /** Spawns the worker (when configured with a `workerURL`) and starts handling its
@@ -251,7 +257,16 @@ export class Store {
         this.setError(new Error("[aether] failed to deserialize message from worker"));
       this.worker = aether.wrapWorker(this.ownedWorker);
     }
-    this.worker.handle((msg) => this.handleWorkerMessage(msg));
+    // Each message is caught on its own so one bad push reports and the rest of the
+    // batch still applies.
+    this.worker.handle((messages) => {
+      for (const msg of messages)
+        try {
+          this.handleWorkerMessage(msg);
+        } catch (e) {
+          this.setError(errors.fromUnknown(e));
+        }
+    });
   }
 
   private setError(err: Error): void {
@@ -269,8 +284,7 @@ export class Store {
    * send lazily re-attaches via a fresh `Worker`. Idempotent. */
   dispose(): void {
     this.queued = [];
-    this.outbound = [];
-    this.outboundTransfer = [];
+    this.outbound.clear();
     if (this.worker === aether.NOOP_MAIN_COMMS) return;
     this.invokeTracker.abort(new Error("aether store disposed"));
     // In-process comms have no thread to die with, so tear the tree down explicitly
@@ -361,31 +375,11 @@ export class Store {
     return this.buildHandle(entry, methodsSchema);
   }
 
-  private scheduleFlush(): void {
-    if (this.flushScheduled) return;
-    this.flushScheduled = true;
-    queueMicrotask(() => this.flush());
-  }
-
-  /** Emits every buffered message as one `postMessage`. Queued creates go last and
-   * shallowest-path first: React runs layout effects children before parents, but the
-   * worker rejects a child whose parent it has never seen, and an ancestor's path is
-   * always shorter than its descendant's. Deletes buffered during the commit keep their
-   * place ahead of the creates, so a re-parent still tears down before it rebuilds. */
-  private flush(): void {
-    // Drain before clearing the flag: the sends below re-enter send(), which would
-    // otherwise schedule a second, empty flush.
-    this.drainCreates();
-    this.flushScheduled = false;
-    if (this.outbound.length === 0) return;
-    const messages = this.outbound;
-    const transfer = this.outboundTransfer;
-    this.outbound = [];
-    this.outboundTransfer = [];
-    this.connect();
-    this.worker.send(messages, transfer);
-  }
-
+  /** Appends the creates attached since the last flush, shallowest path first: React runs
+   * layout effects children before parents, but the worker rejects a child whose parent
+   * it has never seen, and an ancestor's path is always shorter than its descendant's.
+   * They land at the tail of the batch, so deletes buffered earlier in the commit still
+   * lead and a re-parent tears down before it rebuilds. */
   private drainCreates(): void {
     if (this.queued.length === 0) return;
     const queued = this.queued;
@@ -397,8 +391,8 @@ export class Store {
       const { path, state, type, transfer, pendingInvokes } = entry;
       entry.transfer = [];
       entry.pendingInvokes = [];
-      this.send({ variant: "update", path, state, type }, transfer);
-      for (const invoke of pendingInvokes) this.send(invoke);
+      this.outbound.send({ variant: "update", path, state, type }, transfer);
+      for (const invoke of pendingInvokes) this.outbound.send(invoke);
       this.listeners.get(pathID(path))?.forEach((l) => l());
     }
   }
@@ -411,7 +405,7 @@ export class Store {
     entry.phase = "queued";
     this.entries.set(id, entry);
     this.queued.push(entry);
-    this.scheduleFlush();
+    this.outbound.schedule();
   }
 
   /** Returns `entry` to the staged phase. Sends a delete only when its create message
@@ -421,7 +415,8 @@ export class Store {
   private detachEntry(entry: Entry, displaced = false): void {
     if (entry.phase === "staged") return;
     const id = pathID(entry.path);
-    if (entry.phase === "live") this.send({ variant: "delete", path: entry.path });
+    if (entry.phase === "live")
+      this.outbound.send({ variant: "delete", path: entry.path });
     else {
       const idx = this.queued.indexOf(entry);
       if (idx !== -1) this.queued.splice(idx, 1);
@@ -443,14 +438,6 @@ export class Store {
     }
     this.entries.delete(id);
     this.invokeTracker.clearCounter(id);
-  }
-
-  /** Buffers `msg` for the next {@link flush}. Nothing reaches the worker synchronously:
-   * a commit's messages travel together. */
-  private send(msg: aether.MainMessage, transfer: Transferable[] = []): void {
-    this.outbound.push(msg);
-    if (transfer.length > 0) this.outboundTransfer.push(...transfer);
-    this.scheduleFlush();
   }
 
   private handleWorkerMessage(msg: aether.WorkerMessage): void {
@@ -501,7 +488,7 @@ export class Store {
       // into it. Ownership of each Transferable still moves exactly once.
       if (entry.phase !== "live") entry.transfer.push(...transfer);
       else
-        this.send(
+        this.outbound.send(
           { variant: "update", path: entry.path, state: entry.state, type: entry.type },
           transfer,
         );
@@ -511,7 +498,7 @@ export class Store {
     // Invokes name a path the worker must already know. Before the create message
     // flushes there is nothing to call, so queue and let the flush send them in order.
     const sendInvoke = (msg: aether.MainInvokeRequest): void => {
-      if (entry.phase === "live") this.send(msg);
+      if (entry.phase === "live") this.outbound.send(msg);
       else entry.pendingInvokes.push(msg);
     };
 

--- a/pluto/src/aether/store.ts
+++ b/pluto/src/aether/store.ts
@@ -411,6 +411,11 @@ export class Store {
     entry.controller.abort(
       new Error(displaced ? "Component re-registered" : "Component deleted"),
     );
+    // Drop queued invokes: the abort above already rejected their callers, so letting
+    // them ride out on a later flush would run the side effect for a call the caller
+    // was told had failed. `transfer` is kept, because it belongs to the state the next
+    // flush still has to deliver.
+    entry.pendingInvokes = [];
     // A fresh controller so a StrictMode remount can re-attach this same handle.
     entry.controller = new AbortController();
     if (displaced) {

--- a/pluto/src/aether/store.ts
+++ b/pluto/src/aether/store.ts
@@ -193,6 +193,9 @@ export class Store {
   private listeners: Map<string, Set<Listener>> = new Map();
   /** Entries attached since the last flush, in attach order. */
   private queued: Entry[] = [];
+  /** Messages buffered for the next flush, in send order. */
+  private outbound: aether.MainMessage[] = [];
+  private outboundTransfer: Transferable[] = [];
   private flushScheduled = false;
   /** Active worker comms. {@link NOOP_WORKER} when `workerEnabled: false` or between
    * {@link dispose} and the next send (lazy re-attach). */
@@ -266,11 +269,13 @@ export class Store {
    * send lazily re-attaches via a fresh `Worker`. Idempotent. */
   dispose(): void {
     this.queued = [];
+    this.outbound = [];
+    this.outboundTransfer = [];
     if (this.worker === aether.NOOP_MAIN_COMMS) return;
     this.invokeTracker.abort(new Error("aether store disposed"));
     // In-process comms have no thread to die with, so tear the tree down explicitly
     // rather than relying on every component to have detached first.
-    this.worker.send({ variant: "clear" });
+    this.worker.send([{ variant: "clear" }]);
     this.worker.handle(() => {});
     this.worker = aether.NOOP_MAIN_COMMS;
     this.ownedWorker?.terminate();
@@ -362,12 +367,26 @@ export class Store {
     queueMicrotask(() => this.flush());
   }
 
-  /** Sends every queued create message, shallowest path first. React runs layout
-   * effects children before parents, but the worker rejects a child whose parent it has
-   * never seen; an ancestor's path is always shorter than its descendant's, so ordering
-   * by depth restores the invariant without tracking render order. */
+  /** Emits every buffered message as one `postMessage`. Queued creates go last and
+   * shallowest-path first: React runs layout effects children before parents, but the
+   * worker rejects a child whose parent it has never seen, and an ancestor's path is
+   * always shorter than its descendant's. Deletes buffered during the commit keep their
+   * place ahead of the creates, so a re-parent still tears down before it rebuilds. */
   private flush(): void {
+    // Drain before clearing the flag: the sends below re-enter send(), which would
+    // otherwise schedule a second, empty flush.
+    this.drainCreates();
     this.flushScheduled = false;
+    if (this.outbound.length === 0) return;
+    const messages = this.outbound;
+    const transfer = this.outboundTransfer;
+    this.outbound = [];
+    this.outboundTransfer = [];
+    this.connect();
+    this.worker.send(messages, transfer);
+  }
+
+  private drainCreates(): void {
     if (this.queued.length === 0) return;
     const queued = this.queued;
     this.queued = [];
@@ -426,9 +445,12 @@ export class Store {
     this.invokeTracker.clearCounter(id);
   }
 
+  /** Buffers `msg` for the next {@link flush}. Nothing reaches the worker synchronously:
+   * a commit's messages travel together. */
   private send(msg: aether.MainMessage, transfer: Transferable[] = []): void {
-    this.connect();
-    this.worker.send(msg, transfer);
+    this.outbound.push(msg);
+    if (transfer.length > 0) this.outboundTransfer.push(...transfer);
+    this.scheduleFlush();
   }
 
   private handleWorkerMessage(msg: aether.WorkerMessage): void {

--- a/pluto/src/aether/store.ts
+++ b/pluto/src/aether/store.ts
@@ -8,7 +8,14 @@
 // included in the file licenses/APL.txt.
 
 import { UnexpectedError, ValidationError } from "@synnaxlabs/client";
-import { type CrudeTimeSpan, errors, state, TimeSpan, zod } from "@synnaxlabs/x";
+import {
+  type CrudeTimeSpan,
+  type destructor,
+  errors,
+  state,
+  TimeSpan,
+  zod,
+} from "@synnaxlabs/x";
 import { type z } from "zod";
 
 import { aether } from "@/aether/aether";
@@ -143,9 +150,12 @@ export interface StageParams<
 }
 
 /** Per-component operations returned by {@link Store.stage}: typed setState, the
- * attach/detach pair, state reads, and method callers. Scoped to the staging that
- * produced it: once a same-path attach displaces that entry, every operation no-ops
- * (async invokes reject). */
+ * attach/detach pair, state reads, subscriptions, and method callers. Scoped to the
+ * staging that produced it: once a same-path attach displaces that entry, every
+ * operation no-ops (async invokes reject).
+ *
+ * Every field is built once with the handle and never replaced, so a React caller can
+ * hand them straight to hooks without wrapping them in `useCallback`. */
 export interface Handle<
   StateSchema extends z.ZodType<state.State, state.State>,
   Methods extends aether.MethodsSchema = aether.EmptyMethodsSchema,
@@ -156,6 +166,10 @@ export interface Handle<
   /** Latest state, readable in every phase. Owned by the handle rather than the store
    * so it stays stable across a detach/attach cycle. */
   getState: () => z.infer<StateSchema>;
+  /** Subscribes to this component's state changes. Fires on both worker pushes and local
+   * {@link Handle.setState}, and persists across detach-attach cycles. Returns an
+   * unsubscribe function. */
+  subscribe: (listener: Listener) => destructor.Destructor;
   /** Publishes the component to the store and queues its create message. Call from a
    * layout effect: a component staged by a render React discards must never reach the
    * worker. Idempotent. */
@@ -544,6 +558,7 @@ export class Store {
       methods,
       setState,
       getState: () => entry.state,
+      subscribe: (listener) => this.subscribe(entry.path, listener),
       attach: () => this.attachEntry(entry),
       detach: () => this.detachEntry(entry),
     };

--- a/pluto/src/aether/test/driver.ts
+++ b/pluto/src/aether/test/driver.ts
@@ -64,18 +64,7 @@ export const createDriver = (
       path: snapshot,
       type,
       state: stateValue,
-      create: (parent) => {
-        const Constructor = registry[type];
-        if (Constructor == null)
-          throw new UnexpectedError(`[aetherTest] type '${type}' not in registry`);
-        return new Constructor({
-          path: snapshot,
-          type,
-          sender: workerSide,
-          instrumentation,
-          parent,
-        });
-      },
+      create: (parent) => root.create({ path: snapshot, type, parent }),
     });
   };
 

--- a/pluto/src/aether/test/driver.ts
+++ b/pluto/src/aether/test/driver.ts
@@ -50,6 +50,11 @@ export const createDriver = (
 ): Driver => {
   const [workerSide, mainSide] = aether.createMockPair();
   const root = aether.render({ worker: workerSide, registry, instrumentation });
+  // Unbatched, so a driver-driven update reaches `mainSide` before the caller's next
+  // statement. Production batches on a microtask instead.
+  const sender: aether.Sender = {
+    send: (value, transfer) => workerSide.send([value], transfer),
+  };
 
   const update = (
     path: readonly string[],
@@ -64,7 +69,18 @@ export const createDriver = (
       path: snapshot,
       type,
       state: stateValue,
-      create: (parent) => root.create({ path: snapshot, type, parent }),
+      create: (parent) => {
+        const Constructor = registry[type];
+        if (Constructor == null)
+          throw new UnexpectedError(`[aetherTest] type '${type}' not in registry`);
+        return new Constructor({
+          path: snapshot,
+          type,
+          sender,
+          instrumentation,
+          parent,
+        });
+      },
     });
   };
 

--- a/pluto/src/aether/test/provider.tsx
+++ b/pluto/src/aether/test/provider.tsx
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { type FC, type PropsWithChildren, useMemo } from "react";
+import { type FC, type PropsWithChildren, useRef } from "react";
 
 import { aether } from "@/aether/aether";
 import { Provider } from "@/aether/main";
@@ -35,9 +35,11 @@ export const createProvider = (
   registry: aether.ComponentRegistry,
 ): FC<PropsWithChildren> => {
   const TestProvider: FC<PropsWithChildren> = ({ children }) => {
-    // Per mount, so two concurrent mounts never share a worker tree.
-    const worker = useMemo(() => lazyComms(registry), []);
-    return <Provider worker={worker}>{children}</Provider>;
+    // A ref rather than a memo: React may drop a memo and recompute it, and one comms
+    // per mount is what keeps one test's worker tree out of the next test's.
+    const commsRef = useRef<aether.MainComms | null>(null);
+    commsRef.current ??= lazyComms(registry);
+    return <Provider worker={commsRef.current}>{children}</Provider>;
   };
 
   return TestProvider;

--- a/pluto/src/aether/test/provider.tsx
+++ b/pluto/src/aether/test/provider.tsx
@@ -7,22 +7,38 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { type FC, type PropsWithChildren } from "react";
+import { type FC, type PropsWithChildren, useMemo } from "react";
 
 import { aether } from "@/aether/aether";
 import { Provider } from "@/aether/main";
 
+/** Comms that build their worker tree on first use rather than on construction. The
+ * Store only touches them when it connects, which happens on commit, so a render React
+ * discards allocates a closure and nothing else. */
+const lazyComms = (registry: aether.ComponentRegistry): aether.MainComms => {
+  let comms: aether.MainComms | null = null;
+  const ensure = (): aether.MainComms => {
+    if (comms == null) {
+      const [workerSide, mainSide] = aether.createMockPair();
+      aether.render({ worker: workerSide, registry });
+      comms = mainSide;
+    }
+    return comms;
+  };
+  return {
+    send: (value, transfer) => ensure().send(value, transfer),
+    handle: (handler) => ensure().handle(handler),
+  };
+};
+
 export const createProvider = (
   registry: aether.ComponentRegistry,
 ): FC<PropsWithChildren> => {
-  // Built once per provider rather than per render: constructing the worker tree is
-  // resource acquisition, and a render React discards would otherwise strand one.
-  const [workerSide, mainSide] = aether.createMockPair();
-  aether.render({ worker: workerSide, registry });
-
-  const TestProvider: FC<PropsWithChildren> = ({ children }) => (
-    <Provider worker={mainSide}>{children}</Provider>
-  );
+  const TestProvider: FC<PropsWithChildren> = ({ children }) => {
+    // Per mount, so two concurrent mounts never share a worker tree.
+    const worker = useMemo(() => lazyComms(registry), []);
+    return <Provider worker={worker}>{children}</Provider>;
+  };
 
   return TestProvider;
 };

--- a/pluto/src/aether/test/provider.tsx
+++ b/pluto/src/aether/test/provider.tsx
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { type FC, type PropsWithChildren, useMemo } from "react";
+import { type FC, type PropsWithChildren } from "react";
 
 import { aether } from "@/aether/aether";
 import { Provider } from "@/aether/main";
@@ -15,15 +15,14 @@ import { Provider } from "@/aether/main";
 export const createProvider = (
   registry: aether.ComponentRegistry,
 ): FC<PropsWithChildren> => {
-  const TestProvider: FC<PropsWithChildren> = ({ children }) => {
-    const worker = useMemo(() => {
-      const [workerSide, mainSide] = aether.createMockPair();
-      aether.render({ worker: workerSide, registry });
-      return mainSide;
-    }, []);
+  // Built once per provider rather than per render: constructing the worker tree is
+  // resource acquisition, and a render React discards would otherwise strand one.
+  const [workerSide, mainSide] = aether.createMockPair();
+  aether.render({ worker: workerSide, registry });
 
-    return <Provider worker={worker}>{children}</Provider>;
-  };
+  const TestProvider: FC<PropsWithChildren> = ({ children }) => (
+    <Provider worker={mainSide}>{children}</Provider>
+  );
 
   return TestProvider;
 };


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4570](https://linear.app/synnax/issue/SY-4570/aether-leaks-worker-components-from-discarded-react-renders)

## Description

Aether acquired real resources during React's render phase. `Aether.Provider` spawned its `Worker` from the `Store` constructor, and `useLifecycle` posted a create message to the worker mid-render.

React discards renders, and nothing reclaimed what a discarded one built. `useUniqueKey` mints a fresh key per render, so an orphan registers at a different path than the survivor and no same-path collision cleans it up. It stays in the worker tree, alive, receiving context propagation.

Measured on a 7-component tree, counting worker-side constructor and `afterDelete` calls:

| case | created | deleted |
| --- | --- | --- |
| plain mount | 7 | 0 |
| StrictMode | 14 | 7 (correct, 7 net alive) |
| under Suspense | 21 | 0 (14 permanently orphaned) |

A suspending tree renders three times: the render that suspends, the retry, and the render after the promise resolves. All three registered. For `synnax.Provider` that meant three live clients and three websockets where one was wanted, which is the source of the intermittent `retrieve.spec.tsx` failure in `Test - Pluto`: an orphan's unbounded reconnect loop logs `failed to open streamer` into whatever test later installs a `console.error` spy.

### What changed

`Store.register` becomes `Store.stage`. Staging validates and parses, then returns a handle the caller owns. The store keeps no reference and the worker is told nothing. A component staged by a discarded render is reclaimed with the caller's ref, so there is nothing to sweep.

`Handle.delete` becomes `attach` / `detach`, driven from `useLifecycle`'s layout effect. The handle outlives the effect so StrictMode's cleanup-then-setup remount, which does not re-render in between, re-attaches the same component.

Attaches buffer and flush on a microtask, stable-sorted by path depth. React runs layout effects children before parents, but the worker rejects a child whose parent it has never seen; an ancestor's path is always shorter, so depth order restores the invariant without tracking render order.

`Store.connect()` replaces the constructor's eager `ensureAttached`, and the Provider calls it from a layout effect. A tree with no aether components still connects, so a worker that fails to load still reports it.

Handle state now lives on the handle rather than in a `snapshots` map. That map existed only to bridge the unregister-then-register window, which no longer exists, so it and `Store.getSnapshot` are gone.

`test/provider.tsx` had the same defect: it built the mock pair and worker tree inside `useMemo`.

### Batching

Buffering attaches until the flush made batching free to add, so both wires now carry an array instead of one message. A shared `Batcher` buffers messages and posts them as one array on the next microtask. There is no `batch` variant: an array at the top level makes nesting unrepresentable and removes the receiver's is-this-a-batch branch.

Measured on a 211-component tree (1 root, 10 composites, 200 leaves), real `postMessage` over a `MessageChannel`:

| | one call per message | one call per commit |
| --- | --- | --- |
| main-thread post | 0.556 ms | 0.352 ms |

The `postMessage` saving is the fixed per-call cost, not payload size. The larger win is on the receiving side: every delivery is one task, so a plot pushing state back from twenty lines used to cost twenty React renders and now costs one.

Each side catches each message in a batch on its own, so one failure reports and the rest still apply.

### Per-update allocations

`Node` rebuilt its `toString()`, three span labels, and its whole `Context` object (five closures) on every `afterUpdate`. All are constant for a node's lifetime, and noop instrumentation discards the labels. Caching them, measured three runs each on the same tree:

| | before | after |
| --- | --- | --- |
| propagate one provider change (210 `afterUpdate`s) | 0.062 ms | 0.057 ms |
| 200 leaf state updates | 0.093 ms | 0.078 ms |

For context on where the rest goes: with a realistically sized schema, `zod.parse` is 71% of the worker's per-update cost, and the main thread parses the same states again before sending them. Collapsing that double parse is the biggest number left on the table and is not attempted here.

### One fix found along the way

`flush` drained pending creates and notified their subscribers. A subscriber that attached another component landed in the queue after the flush had already committed to its batch, and nothing scheduled the next one, so that create sat until an unrelated send. The flush now re-schedules when the queue is non-empty.

### Verification

A new regression test mounts three leaves behind a Suspense boundary and asserts three worker components. With render-phase acquisition restored it reports nine, so the test pins the actual defect. Two existing pins that described the old behavior are rewritten against the new invariants rather than dropped.

Two more tests pin the batch: one commit of five components arrives as a single message, and every parent precedes its children inside it.

Full pluto suite (3485 tests) and full console suite (2016 tests) pass against a live core. `retrieve.spec.tsx` ran clean 8 times.

Nothing outside `pluto/src/aether/` changes, so this does not conflict with the SY-4381 / SY-4299 stack.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR defers Aether worker and component acquisition until React commits, preventing resources from leaking out of discarded renders.
- Replaces render-phase registration with staged, attachable handles.
- Buffers and depth-orders component creation, state transfers, and method invocations.
- Moves worker startup into the Provider layout lifecycle.
- Updates the mock Provider and adds Suspense, StrictMode, and deferred-connection coverage.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until detached handles discard queued method calls so obsolete operations cannot execute against a newly attached worker component.

The new reusable-handle lifecycle aborts pending asynchronous callers during detach but retains their outbound messages, allowing stale side effects to run after StrictMode re-attachment; the test helper also loses isolation when one returned provider is mounted concurrently.

**Files Needing Attention:** pluto/src/aether/store.ts, pluto/src/aether/test/provider.tsx

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pluto/src/aether/store.ts | Introduces staged handles and commit-time flushing, but detached handles retain queued method calls that execute after re-attachment. |
| pluto/src/aether/main.tsx | Moves worker connection and component attachment into layout effects while deliberately retaining handles across StrictMode remounts. |
| pluto/src/aether/test/provider.tsx | Avoids render-time mock worker creation, but makes all mounts of one returned provider share the same communications pair. |
| pluto/src/aether/main.spec.tsx | Adds focused regression coverage for Suspense-discarded renders, deferred worker startup, and handle state across detach and re-attach. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant React
  participant Handle
  participant Store
  participant Worker
  React->>Handle: stage during render
  React->>Handle: attach during layout effect
  Handle->>Store: queue component
  Store-->>Store: microtask depth-sort
  Store->>Worker: create component
  React->>Handle: detach during cleanup
  Handle->>Store: abort lifecycle requests
  Note over Store,Handle: pending invokes must also be discarded
  React->>Handle: re-attach same handle
  Store->>Worker: create fresh component
```

<sub>Reviews (1): Last reviewed commit: ["SY-4570: Acquire aether worker resources..."](https://github.com/synnaxlabs/synnax/commit/27c9ea5fba6626949d8f34b9568ba7b726d99250) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52430841)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Knowledge Base — [Pluto Component and Visualization Library](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/pluto-components.md)

<!-- /greptile_comment -->
