### PR TITLE
SY-4571: Consolidate Oracle generator changes and add union-field defaults

### DIFF
--- a/arc/go/graph/versions/v1/codec.gen.go
+++ b/arc/go/graph/versions/v1/codec.gen.go
@@ -42,11 +42,11 @@ func (e *Edge) DecodeOrc(r *orc.Reader) error {
 		return err
 	}
 	{
-		v, err := r.Int64()
+		rawV, err := r.Int64()
 		if err != nil {
 			return err
 		}
-		e.Kind = ir.EdgeKind(v)
+		e.Kind = ir.EdgeKind(rawV)
 	}
 	if e.Key, err = r.String(); err != nil {
 		return err

--- a/arc/go/graph/versions/v1/codec_gen_test.go
+++ b/arc/go/graph/versions/v1/codec_gen_test.go
@@ -87,7 +87,7 @@ var _ = Describe("Codec", func() {
 									Constraint:    new(types.Type{}),
 									ChanDirection: types.ChanDirection(0),
 								},
-								Value: map[string]interface{}{"key_16": "value_16"},
+								Value: any(map[string]any{"key_16": "value_16"}),
 							},
 						},
 						Outputs: []types.Param{
@@ -105,7 +105,7 @@ var _ = Describe("Codec", func() {
 									Constraint:    new(types.Type{}),
 									ChanDirection: types.ChanDirection(0),
 								},
-								Value: map[string]interface{}{"key_28": "value_28"},
+								Value: any(map[string]any{"key_28": "value_28"}),
 							},
 						},
 						Channels: types.Channels{
@@ -203,7 +203,7 @@ func BenchmarkEncodeDecodeGraph(b *testing.B) {
 							Constraint:    new(types.Type{}),
 							ChanDirection: types.ChanDirection(0),
 						},
-						Value: map[string]interface{}{"key_16": "value_16"},
+						Value: any(map[string]any{"key_16": "value_16"}),
 					},
 				},
 				Outputs: []types.Param{
@@ -221,7 +221,7 @@ func BenchmarkEncodeDecodeGraph(b *testing.B) {
 							Constraint:    new(types.Type{}),
 							ChanDirection: types.ChanDirection(0),
 						},
-						Value: map[string]interface{}{"key_28": "value_28"},
+						Value: any(map[string]any{"key_28": "value_28"}),
 					},
 				},
 				Channels: types.Channels{
@@ -350,7 +350,7 @@ func FuzzDecodeGraph(f *testing.F) {
 								Constraint:    new(types.Type{}),
 								ChanDirection: types.ChanDirection(0),
 							},
-							Value: map[string]interface{}{"key_16": "value_16"},
+							Value: any(map[string]any{"key_16": "value_16"}),
 						},
 					},
 					Outputs: []types.Param{
@@ -368,7 +368,7 @@ func FuzzDecodeGraph(f *testing.F) {
 								Constraint:    new(types.Type{}),
 								ChanDirection: types.ChanDirection(0),
 							},
-							Value: map[string]interface{}{"key_28": "value_28"},
+							Value: any(map[string]any{"key_28": "value_28"}),
 						},
 					},
 					Channels: types.Channels{

--- a/arc/go/ir/versions/v1/codec_gen_test.go
+++ b/arc/go/ir/versions/v1/codec_gen_test.go
@@ -47,14 +47,14 @@ var _ = Describe("Codec", func() {
 									{
 										Name:  "test_8",
 										Type:  types.Type{},
-										Value: map[string]interface{}{"key_10": "value_10"},
+										Value: any(map[string]any{"key_10": "value_10"}),
 									},
 								},
 								Outputs: []types.Param{
 									{
 										Name:  "test_12",
 										Type:  types.Type{},
-										Value: map[string]interface{}{"key_14": "value_14"},
+										Value: any(map[string]any{"key_14": "value_14"}),
 									},
 								},
 							},
@@ -91,7 +91,7 @@ var _ = Describe("Codec", func() {
 							}),
 							ChanDirection: types.ChanDirection(0),
 						},
-						Value: map[string]interface{}{"key_40": "value_40"},
+						Value: any(map[string]any{"key_40": "value_40"}),
 					},
 				},
 				Outputs: []types.Param{
@@ -103,14 +103,14 @@ var _ = Describe("Codec", func() {
 									{
 										Name:  "test_45",
 										Type:  types.Type{},
-										Value: map[string]interface{}{"key_47": "value_47"},
+										Value: any(map[string]any{"key_47": "value_47"}),
 									},
 								},
 								Outputs: []types.Param{
 									{
 										Name:  "test_49",
 										Type:  types.Type{},
-										Value: map[string]interface{}{"key_51": "value_51"},
+										Value: any(map[string]any{"key_51": "value_51"}),
 									},
 								},
 							},
@@ -147,7 +147,7 @@ var _ = Describe("Codec", func() {
 							}),
 							ChanDirection: types.ChanDirection(0),
 						},
-						Value: map[string]interface{}{"key_77": "value_77"},
+						Value: any(map[string]any{"key_77": "value_77"}),
 					},
 				},
 				Channels: types.Channels{
@@ -186,14 +186,14 @@ func BenchmarkEncodeDecodeFunction(b *testing.B) {
 							{
 								Name:  "test_8",
 								Type:  types.Type{},
-								Value: map[string]interface{}{"key_10": "value_10"},
+								Value: any(map[string]any{"key_10": "value_10"}),
 							},
 						},
 						Outputs: []types.Param{
 							{
 								Name:  "test_12",
 								Type:  types.Type{},
-								Value: map[string]interface{}{"key_14": "value_14"},
+								Value: any(map[string]any{"key_14": "value_14"}),
 							},
 						},
 					},
@@ -230,7 +230,7 @@ func BenchmarkEncodeDecodeFunction(b *testing.B) {
 					}),
 					ChanDirection: types.ChanDirection(0),
 				},
-				Value: map[string]interface{}{"key_40": "value_40"},
+				Value: any(map[string]any{"key_40": "value_40"}),
 			},
 		},
 		Outputs: []types.Param{
@@ -242,14 +242,14 @@ func BenchmarkEncodeDecodeFunction(b *testing.B) {
 							{
 								Name:  "test_45",
 								Type:  types.Type{},
-								Value: map[string]interface{}{"key_47": "value_47"},
+								Value: any(map[string]any{"key_47": "value_47"}),
 							},
 						},
 						Outputs: []types.Param{
 							{
 								Name:  "test_49",
 								Type:  types.Type{},
-								Value: map[string]interface{}{"key_51": "value_51"},
+								Value: any(map[string]any{"key_51": "value_51"}),
 							},
 						},
 					},
@@ -286,7 +286,7 @@ func BenchmarkEncodeDecodeFunction(b *testing.B) {
 					}),
 					ChanDirection: types.ChanDirection(0),
 				},
-				Value: map[string]interface{}{"key_77": "value_77"},
+				Value: any(map[string]any{"key_77": "value_77"}),
 			},
 		},
 		Channels: types.Channels{
@@ -323,14 +323,14 @@ func FuzzDecodeFunction(f *testing.F) {
 								{
 									Name:  "test_8",
 									Type:  types.Type{},
-									Value: map[string]interface{}{"key_10": "value_10"},
+									Value: any(map[string]any{"key_10": "value_10"}),
 								},
 							},
 							Outputs: []types.Param{
 								{
 									Name:  "test_12",
 									Type:  types.Type{},
-									Value: map[string]interface{}{"key_14": "value_14"},
+									Value: any(map[string]any{"key_14": "value_14"}),
 								},
 							},
 						},
@@ -367,7 +367,7 @@ func FuzzDecodeFunction(f *testing.F) {
 						}),
 						ChanDirection: types.ChanDirection(0),
 					},
-					Value: map[string]interface{}{"key_40": "value_40"},
+					Value: any(map[string]any{"key_40": "value_40"}),
 				},
 			},
 			Outputs: []types.Param{
@@ -379,14 +379,14 @@ func FuzzDecodeFunction(f *testing.F) {
 								{
 									Name:  "test_45",
 									Type:  types.Type{},
-									Value: map[string]interface{}{"key_47": "value_47"},
+									Value: any(map[string]any{"key_47": "value_47"}),
 								},
 							},
 							Outputs: []types.Param{
 								{
 									Name:  "test_49",
 									Type:  types.Type{},
-									Value: map[string]interface{}{"key_51": "value_51"},
+									Value: any(map[string]any{"key_51": "value_51"}),
 								},
 							},
 						},
@@ -423,7 +423,7 @@ func FuzzDecodeFunction(f *testing.F) {
 						}),
 						ChanDirection: types.ChanDirection(0),
 					},
-					Value: map[string]interface{}{"key_77": "value_77"},
+					Value: any(map[string]any{"key_77": "value_77"}),
 				},
 			},
 			Channels: types.Channels{

--- a/arc/go/types/versions/v1/codec.gen.go
+++ b/arc/go/types/versions/v1/codec.gen.go
@@ -220,11 +220,11 @@ func (t *Type) DecodeOrc(r *orc.Reader) error {
 		}
 	}
 	{
-		v, err := r.Int64()
+		rawV, err := r.Int64()
 		if err != nil {
 			return err
 		}
-		t.Kind = Kind(v)
+		t.Kind = Kind(rawV)
 	}
 	if t.Name, err = r.String(); err != nil {
 		return err
@@ -269,11 +269,11 @@ func (t *Type) DecodeOrc(r *orc.Reader) error {
 		}
 	}
 	{
-		v, err := r.Int64()
+		rawV, err := r.Int64()
 		if err != nil {
 			return err
 		}
-		t.ChanDirection = ChanDirection(v)
+		t.ChanDirection = ChanDirection(rawV)
 	}
 	return nil
 }

--- a/arc/go/types/versions/v1/codec_gen_test.go
+++ b/arc/go/types/versions/v1/codec_gen_test.go
@@ -44,14 +44,14 @@ var _ = Describe("Codec", func() {
 									{
 										Name:  "test_5",
 										Type:  v1.Type{},
-										Value: map[string]interface{}{"key_7": "value_7"},
+										Value: any(map[string]any{"key_7": "value_7"}),
 									},
 								},
 								Outputs: []v1.Param{
 									{
 										Name:  "test_9",
 										Type:  v1.Type{},
-										Value: map[string]interface{}{"key_11": "value_11"},
+										Value: any(map[string]any{"key_11": "value_11"}),
 									},
 								},
 							},
@@ -88,7 +88,7 @@ var _ = Describe("Codec", func() {
 							}),
 							ChanDirection: v1.ChanDirection(0),
 						},
-						Value: map[string]interface{}{"key_37": "value_37"},
+						Value: any(map[string]any{"key_37": "value_37"}),
 					},
 				},
 				Outputs: []v1.Param{
@@ -100,14 +100,14 @@ var _ = Describe("Codec", func() {
 									{
 										Name:  "test_42",
 										Type:  v1.Type{},
-										Value: map[string]interface{}{"key_44": "value_44"},
+										Value: any(map[string]any{"key_44": "value_44"}),
 									},
 								},
 								Outputs: []v1.Param{
 									{
 										Name:  "test_46",
 										Type:  v1.Type{},
-										Value: map[string]interface{}{"key_48": "value_48"},
+										Value: any(map[string]any{"key_48": "value_48"}),
 									},
 								},
 							},
@@ -144,7 +144,7 @@ var _ = Describe("Codec", func() {
 							}),
 							ChanDirection: v1.ChanDirection(0),
 						},
-						Value: map[string]interface{}{"key_74": "value_74"},
+						Value: any(map[string]any{"key_74": "value_74"}),
 					},
 				},
 			}),
@@ -182,7 +182,7 @@ var _ = Describe("Codec", func() {
 									Constraint:    new(v1.Type{}),
 									ChanDirection: v1.ChanDirection(0),
 								},
-								Value: map[string]interface{}{"key_14": "value_14"},
+								Value: any(map[string]any{"key_14": "value_14"}),
 							},
 						},
 						Outputs: []v1.Param{
@@ -200,7 +200,7 @@ var _ = Describe("Codec", func() {
 									Constraint:    new(v1.Type{}),
 									ChanDirection: v1.ChanDirection(0),
 								},
-								Value: map[string]interface{}{"key_26": "value_26"},
+								Value: any(map[string]any{"key_26": "value_26"}),
 							},
 						},
 					},
@@ -212,14 +212,14 @@ var _ = Describe("Codec", func() {
 								{
 									Name:  "test_31",
 									Type:  v1.Type{},
-									Value: map[string]interface{}{"key_33": "value_33"},
+									Value: any(map[string]any{"key_33": "value_33"}),
 								},
 							},
 							Outputs: []v1.Param{
 								{
 									Name:  "test_35",
 									Type:  v1.Type{},
-									Value: map[string]interface{}{"key_37": "value_37"},
+									Value: any(map[string]any{"key_37": "value_37"}),
 								},
 							},
 						},
@@ -276,14 +276,14 @@ var _ = Describe("Codec", func() {
 								{
 									Name:  "test_77",
 									Type:  v1.Type{},
-									Value: map[string]interface{}{"key_79": "value_79"},
+									Value: any(map[string]any{"key_79": "value_79"}),
 								},
 							},
 							Outputs: []v1.Param{
 								{
 									Name:  "test_81",
 									Type:  v1.Type{},
-									Value: map[string]interface{}{"key_83": "value_83"},
+									Value: any(map[string]any{"key_83": "value_83"}),
 								},
 							},
 						},
@@ -322,7 +322,7 @@ var _ = Describe("Codec", func() {
 					}),
 					ChanDirection: v1.ChanDirection(0),
 				},
-				Value: map[string]interface{}{"key_110": "value_110"},
+				Value: any(map[string]any{"key_110": "value_110"}),
 			}),
 			Entry("zero values", v1.Param{
 				Name: "",
@@ -361,14 +361,14 @@ var _ = Describe("Codec", func() {
 										{
 											Name:  "test_5",
 											Type:  v1.Type{},
-											Value: map[string]interface{}{"key_7": "value_7"},
+											Value: any(map[string]any{"key_7": "value_7"}),
 										},
 									},
 									Outputs: []v1.Param{
 										{
 											Name:  "test_9",
 											Type:  v1.Type{},
-											Value: map[string]interface{}{"key_11": "value_11"},
+											Value: any(map[string]any{"key_11": "value_11"}),
 										},
 									},
 								},
@@ -405,7 +405,7 @@ var _ = Describe("Codec", func() {
 								}),
 								ChanDirection: v1.ChanDirection(0),
 							},
-							Value: map[string]interface{}{"key_37": "value_37"},
+							Value: any(map[string]any{"key_37": "value_37"}),
 						},
 					},
 					Outputs: []v1.Param{
@@ -417,14 +417,14 @@ var _ = Describe("Codec", func() {
 										{
 											Name:  "test_42",
 											Type:  v1.Type{},
-											Value: map[string]interface{}{"key_44": "value_44"},
+											Value: any(map[string]any{"key_44": "value_44"}),
 										},
 									},
 									Outputs: []v1.Param{
 										{
 											Name:  "test_46",
 											Type:  v1.Type{},
-											Value: map[string]interface{}{"key_48": "value_48"},
+											Value: any(map[string]any{"key_48": "value_48"}),
 										},
 									},
 								},
@@ -461,7 +461,7 @@ var _ = Describe("Codec", func() {
 								}),
 								ChanDirection: v1.ChanDirection(0),
 							},
-							Value: map[string]interface{}{"key_74": "value_74"},
+							Value: any(map[string]any{"key_74": "value_74"}),
 						},
 					},
 				},
@@ -484,7 +484,7 @@ var _ = Describe("Codec", func() {
 									Constraint:    new(v1.Type{}),
 									ChanDirection: v1.ChanDirection(0),
 								},
-								Value: map[string]interface{}{"key_89": "value_89"},
+								Value: any(map[string]any{"key_89": "value_89"}),
 							},
 						},
 						Outputs: []v1.Param{
@@ -502,7 +502,7 @@ var _ = Describe("Codec", func() {
 									Constraint:    new(v1.Type{}),
 									ChanDirection: v1.ChanDirection(0),
 								},
-								Value: map[string]interface{}{"key_101": "value_101"},
+								Value: any(map[string]any{"key_101": "value_101"}),
 							},
 						},
 					},
@@ -514,14 +514,14 @@ var _ = Describe("Codec", func() {
 								{
 									Name:  "test_106",
 									Type:  v1.Type{},
-									Value: map[string]interface{}{"key_108": "value_108"},
+									Value: any(map[string]any{"key_108": "value_108"}),
 								},
 							},
 							Outputs: []v1.Param{
 								{
 									Name:  "test_110",
 									Type:  v1.Type{},
-									Value: map[string]interface{}{"key_112": "value_112"},
+									Value: any(map[string]any{"key_112": "value_112"}),
 								},
 							},
 						},
@@ -578,14 +578,14 @@ var _ = Describe("Codec", func() {
 								{
 									Name:  "test_152",
 									Type:  v1.Type{},
-									Value: map[string]interface{}{"key_154": "value_154"},
+									Value: any(map[string]any{"key_154": "value_154"}),
 								},
 							},
 							Outputs: []v1.Param{
 								{
 									Name:  "test_156",
 									Type:  v1.Type{},
-									Value: map[string]interface{}{"key_158": "value_158"},
+									Value: any(map[string]any{"key_158": "value_158"}),
 								},
 							},
 						},
@@ -655,7 +655,7 @@ var _ = Describe("Codec", func() {
 									Constraint:    new(v1.Type{}),
 									ChanDirection: v1.ChanDirection(0),
 								},
-								Value: map[string]interface{}{"key_209": "value_209"},
+								Value: any(map[string]any{"key_209": "value_209"}),
 							},
 						},
 						Outputs: []v1.Param{
@@ -673,7 +673,7 @@ var _ = Describe("Codec", func() {
 									Constraint:    new(v1.Type{}),
 									ChanDirection: v1.ChanDirection(0),
 								},
-								Value: map[string]interface{}{"key_221": "value_221"},
+								Value: any(map[string]any{"key_221": "value_221"}),
 							},
 						},
 					},
@@ -685,14 +685,14 @@ var _ = Describe("Codec", func() {
 								{
 									Name:  "test_226",
 									Type:  v1.Type{},
-									Value: map[string]interface{}{"key_228": "value_228"},
+									Value: any(map[string]any{"key_228": "value_228"}),
 								},
 							},
 							Outputs: []v1.Param{
 								{
 									Name:  "test_230",
 									Type:  v1.Type{},
-									Value: map[string]interface{}{"key_232": "value_232"},
+									Value: any(map[string]any{"key_232": "value_232"}),
 								},
 							},
 						},
@@ -749,14 +749,14 @@ var _ = Describe("Codec", func() {
 								{
 									Name:  "test_272",
 									Type:  v1.Type{},
-									Value: map[string]interface{}{"key_274": "value_274"},
+									Value: any(map[string]any{"key_274": "value_274"}),
 								},
 							},
 							Outputs: []v1.Param{
 								{
 									Name:  "test_276",
 									Type:  v1.Type{},
-									Value: map[string]interface{}{"key_278": "value_278"},
+									Value: any(map[string]any{"key_278": "value_278"}),
 								},
 							},
 						},
@@ -997,14 +997,14 @@ func BenchmarkEncodeDecodeFunctionProperties(b *testing.B) {
 							{
 								Name:  "test_5",
 								Type:  v1.Type{},
-								Value: map[string]interface{}{"key_7": "value_7"},
+								Value: any(map[string]any{"key_7": "value_7"}),
 							},
 						},
 						Outputs: []v1.Param{
 							{
 								Name:  "test_9",
 								Type:  v1.Type{},
-								Value: map[string]interface{}{"key_11": "value_11"},
+								Value: any(map[string]any{"key_11": "value_11"}),
 							},
 						},
 					},
@@ -1041,7 +1041,7 @@ func BenchmarkEncodeDecodeFunctionProperties(b *testing.B) {
 					}),
 					ChanDirection: v1.ChanDirection(0),
 				},
-				Value: map[string]interface{}{"key_37": "value_37"},
+				Value: any(map[string]any{"key_37": "value_37"}),
 			},
 		},
 		Outputs: []v1.Param{
@@ -1053,14 +1053,14 @@ func BenchmarkEncodeDecodeFunctionProperties(b *testing.B) {
 							{
 								Name:  "test_42",
 								Type:  v1.Type{},
-								Value: map[string]interface{}{"key_44": "value_44"},
+								Value: any(map[string]any{"key_44": "value_44"}),
 							},
 						},
 						Outputs: []v1.Param{
 							{
 								Name:  "test_46",
 								Type:  v1.Type{},
-								Value: map[string]interface{}{"key_48": "value_48"},
+								Value: any(map[string]any{"key_48": "value_48"}),
 							},
 						},
 					},
@@ -1097,7 +1097,7 @@ func BenchmarkEncodeDecodeFunctionProperties(b *testing.B) {
 					}),
 					ChanDirection: v1.ChanDirection(0),
 				},
-				Value: map[string]interface{}{"key_74": "value_74"},
+				Value: any(map[string]any{"key_74": "value_74"}),
 			},
 		},
 	}
@@ -1136,7 +1136,7 @@ func BenchmarkEncodeDecodeParam(b *testing.B) {
 							Constraint:    new(v1.Type{}),
 							ChanDirection: v1.ChanDirection(0),
 						},
-						Value: map[string]interface{}{"key_14": "value_14"},
+						Value: any(map[string]any{"key_14": "value_14"}),
 					},
 				},
 				Outputs: []v1.Param{
@@ -1154,7 +1154,7 @@ func BenchmarkEncodeDecodeParam(b *testing.B) {
 							Constraint:    new(v1.Type{}),
 							ChanDirection: v1.ChanDirection(0),
 						},
-						Value: map[string]interface{}{"key_26": "value_26"},
+						Value: any(map[string]any{"key_26": "value_26"}),
 					},
 				},
 			},
@@ -1166,14 +1166,14 @@ func BenchmarkEncodeDecodeParam(b *testing.B) {
 						{
 							Name:  "test_31",
 							Type:  v1.Type{},
-							Value: map[string]interface{}{"key_33": "value_33"},
+							Value: any(map[string]any{"key_33": "value_33"}),
 						},
 					},
 					Outputs: []v1.Param{
 						{
 							Name:  "test_35",
 							Type:  v1.Type{},
-							Value: map[string]interface{}{"key_37": "value_37"},
+							Value: any(map[string]any{"key_37": "value_37"}),
 						},
 					},
 				},
@@ -1230,14 +1230,14 @@ func BenchmarkEncodeDecodeParam(b *testing.B) {
 						{
 							Name:  "test_77",
 							Type:  v1.Type{},
-							Value: map[string]interface{}{"key_79": "value_79"},
+							Value: any(map[string]any{"key_79": "value_79"}),
 						},
 					},
 					Outputs: []v1.Param{
 						{
 							Name:  "test_81",
 							Type:  v1.Type{},
-							Value: map[string]interface{}{"key_83": "value_83"},
+							Value: any(map[string]any{"key_83": "value_83"}),
 						},
 					},
 				},
@@ -1276,7 +1276,7 @@ func BenchmarkEncodeDecodeParam(b *testing.B) {
 			}),
 			ChanDirection: v1.ChanDirection(0),
 		},
-		Value: map[string]interface{}{"key_110": "value_110"},
+		Value: any(map[string]any{"key_110": "value_110"}),
 	}
 	w := orc.NewWriter(0)
 	r := orc.NewReader(nil)
@@ -1305,14 +1305,14 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 								{
 									Name:  "test_5",
 									Type:  v1.Type{},
-									Value: map[string]interface{}{"key_7": "value_7"},
+									Value: any(map[string]any{"key_7": "value_7"}),
 								},
 							},
 							Outputs: []v1.Param{
 								{
 									Name:  "test_9",
 									Type:  v1.Type{},
-									Value: map[string]interface{}{"key_11": "value_11"},
+									Value: any(map[string]any{"key_11": "value_11"}),
 								},
 							},
 						},
@@ -1349,7 +1349,7 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 						}),
 						ChanDirection: v1.ChanDirection(0),
 					},
-					Value: map[string]interface{}{"key_37": "value_37"},
+					Value: any(map[string]any{"key_37": "value_37"}),
 				},
 			},
 			Outputs: []v1.Param{
@@ -1361,14 +1361,14 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 								{
 									Name:  "test_42",
 									Type:  v1.Type{},
-									Value: map[string]interface{}{"key_44": "value_44"},
+									Value: any(map[string]any{"key_44": "value_44"}),
 								},
 							},
 							Outputs: []v1.Param{
 								{
 									Name:  "test_46",
 									Type:  v1.Type{},
-									Value: map[string]interface{}{"key_48": "value_48"},
+									Value: any(map[string]any{"key_48": "value_48"}),
 								},
 							},
 						},
@@ -1405,7 +1405,7 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 						}),
 						ChanDirection: v1.ChanDirection(0),
 					},
-					Value: map[string]interface{}{"key_74": "value_74"},
+					Value: any(map[string]any{"key_74": "value_74"}),
 				},
 			},
 		},
@@ -1428,7 +1428,7 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 							Constraint:    new(v1.Type{}),
 							ChanDirection: v1.ChanDirection(0),
 						},
-						Value: map[string]interface{}{"key_89": "value_89"},
+						Value: any(map[string]any{"key_89": "value_89"}),
 					},
 				},
 				Outputs: []v1.Param{
@@ -1446,7 +1446,7 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 							Constraint:    new(v1.Type{}),
 							ChanDirection: v1.ChanDirection(0),
 						},
-						Value: map[string]interface{}{"key_101": "value_101"},
+						Value: any(map[string]any{"key_101": "value_101"}),
 					},
 				},
 			},
@@ -1458,14 +1458,14 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 						{
 							Name:  "test_106",
 							Type:  v1.Type{},
-							Value: map[string]interface{}{"key_108": "value_108"},
+							Value: any(map[string]any{"key_108": "value_108"}),
 						},
 					},
 					Outputs: []v1.Param{
 						{
 							Name:  "test_110",
 							Type:  v1.Type{},
-							Value: map[string]interface{}{"key_112": "value_112"},
+							Value: any(map[string]any{"key_112": "value_112"}),
 						},
 					},
 				},
@@ -1522,14 +1522,14 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 						{
 							Name:  "test_152",
 							Type:  v1.Type{},
-							Value: map[string]interface{}{"key_154": "value_154"},
+							Value: any(map[string]any{"key_154": "value_154"}),
 						},
 					},
 					Outputs: []v1.Param{
 						{
 							Name:  "test_156",
 							Type:  v1.Type{},
-							Value: map[string]interface{}{"key_158": "value_158"},
+							Value: any(map[string]any{"key_158": "value_158"}),
 						},
 					},
 				},
@@ -1599,7 +1599,7 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 							Constraint:    new(v1.Type{}),
 							ChanDirection: v1.ChanDirection(0),
 						},
-						Value: map[string]interface{}{"key_209": "value_209"},
+						Value: any(map[string]any{"key_209": "value_209"}),
 					},
 				},
 				Outputs: []v1.Param{
@@ -1617,7 +1617,7 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 							Constraint:    new(v1.Type{}),
 							ChanDirection: v1.ChanDirection(0),
 						},
-						Value: map[string]interface{}{"key_221": "value_221"},
+						Value: any(map[string]any{"key_221": "value_221"}),
 					},
 				},
 			},
@@ -1629,14 +1629,14 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 						{
 							Name:  "test_226",
 							Type:  v1.Type{},
-							Value: map[string]interface{}{"key_228": "value_228"},
+							Value: any(map[string]any{"key_228": "value_228"}),
 						},
 					},
 					Outputs: []v1.Param{
 						{
 							Name:  "test_230",
 							Type:  v1.Type{},
-							Value: map[string]interface{}{"key_232": "value_232"},
+							Value: any(map[string]any{"key_232": "value_232"}),
 						},
 					},
 				},
@@ -1693,14 +1693,14 @@ func BenchmarkEncodeDecodeType(b *testing.B) {
 						{
 							Name:  "test_272",
 							Type:  v1.Type{},
-							Value: map[string]interface{}{"key_274": "value_274"},
+							Value: any(map[string]any{"key_274": "value_274"}),
 						},
 					},
 					Outputs: []v1.Param{
 						{
 							Name:  "test_276",
 							Type:  v1.Type{},
-							Value: map[string]interface{}{"key_278": "value_278"},
+							Value: any(map[string]any{"key_278": "value_278"}),
 						},
 					},
 				},
@@ -1768,14 +1768,14 @@ func FuzzDecodeFunctionProperties(f *testing.F) {
 								{
 									Name:  "test_5",
 									Type:  v1.Type{},
-									Value: map[string]interface{}{"key_7": "value_7"},
+									Value: any(map[string]any{"key_7": "value_7"}),
 								},
 							},
 							Outputs: []v1.Param{
 								{
 									Name:  "test_9",
 									Type:  v1.Type{},
-									Value: map[string]interface{}{"key_11": "value_11"},
+									Value: any(map[string]any{"key_11": "value_11"}),
 								},
 							},
 						},
@@ -1812,7 +1812,7 @@ func FuzzDecodeFunctionProperties(f *testing.F) {
 						}),
 						ChanDirection: v1.ChanDirection(0),
 					},
-					Value: map[string]interface{}{"key_37": "value_37"},
+					Value: any(map[string]any{"key_37": "value_37"}),
 				},
 			},
 			Outputs: []v1.Param{
@@ -1824,14 +1824,14 @@ func FuzzDecodeFunctionProperties(f *testing.F) {
 								{
 									Name:  "test_42",
 									Type:  v1.Type{},
-									Value: map[string]interface{}{"key_44": "value_44"},
+									Value: any(map[string]any{"key_44": "value_44"}),
 								},
 							},
 							Outputs: []v1.Param{
 								{
 									Name:  "test_46",
 									Type:  v1.Type{},
-									Value: map[string]interface{}{"key_48": "value_48"},
+									Value: any(map[string]any{"key_48": "value_48"}),
 								},
 							},
 						},
@@ -1868,7 +1868,7 @@ func FuzzDecodeFunctionProperties(f *testing.F) {
 						}),
 						ChanDirection: v1.ChanDirection(0),
 					},
-					Value: map[string]interface{}{"key_74": "value_74"},
+					Value: any(map[string]any{"key_74": "value_74"}),
 				},
 			},
 		}
@@ -1937,7 +1937,7 @@ func FuzzDecodeParam(f *testing.F) {
 								Constraint:    new(v1.Type{}),
 								ChanDirection: v1.ChanDirection(0),
 							},
-							Value: map[string]interface{}{"key_14": "value_14"},
+							Value: any(map[string]any{"key_14": "value_14"}),
 						},
 					},
 					Outputs: []v1.Param{
@@ -1955,7 +1955,7 @@ func FuzzDecodeParam(f *testing.F) {
 								Constraint:    new(v1.Type{}),
 								ChanDirection: v1.ChanDirection(0),
 							},
-							Value: map[string]interface{}{"key_26": "value_26"},
+							Value: any(map[string]any{"key_26": "value_26"}),
 						},
 					},
 				},
@@ -1967,14 +1967,14 @@ func FuzzDecodeParam(f *testing.F) {
 							{
 								Name:  "test_31",
 								Type:  v1.Type{},
-								Value: map[string]interface{}{"key_33": "value_33"},
+								Value: any(map[string]any{"key_33": "value_33"}),
 							},
 						},
 						Outputs: []v1.Param{
 							{
 								Name:  "test_35",
 								Type:  v1.Type{},
-								Value: map[string]interface{}{"key_37": "value_37"},
+								Value: any(map[string]any{"key_37": "value_37"}),
 							},
 						},
 					},
@@ -2031,14 +2031,14 @@ func FuzzDecodeParam(f *testing.F) {
 							{
 								Name:  "test_77",
 								Type:  v1.Type{},
-								Value: map[string]interface{}{"key_79": "value_79"},
+								Value: any(map[string]any{"key_79": "value_79"}),
 							},
 						},
 						Outputs: []v1.Param{
 							{
 								Name:  "test_81",
 								Type:  v1.Type{},
-								Value: map[string]interface{}{"key_83": "value_83"},
+								Value: any(map[string]any{"key_83": "value_83"}),
 							},
 						},
 					},
@@ -2077,7 +2077,7 @@ func FuzzDecodeParam(f *testing.F) {
 				}),
 				ChanDirection: v1.ChanDirection(0),
 			},
-			Value: map[string]interface{}{"key_110": "value_110"},
+			Value: any(map[string]any{"key_110": "value_110"}),
 		}
 		w := orc.NewWriter(0)
 		if err := seed.EncodeOrc(w); err != nil {
@@ -2140,14 +2140,14 @@ func FuzzDecodeType(f *testing.F) {
 									{
 										Name:  "test_5",
 										Type:  v1.Type{},
-										Value: map[string]interface{}{"key_7": "value_7"},
+										Value: any(map[string]any{"key_7": "value_7"}),
 									},
 								},
 								Outputs: []v1.Param{
 									{
 										Name:  "test_9",
 										Type:  v1.Type{},
-										Value: map[string]interface{}{"key_11": "value_11"},
+										Value: any(map[string]any{"key_11": "value_11"}),
 									},
 								},
 							},
@@ -2184,7 +2184,7 @@ func FuzzDecodeType(f *testing.F) {
 							}),
 							ChanDirection: v1.ChanDirection(0),
 						},
-						Value: map[string]interface{}{"key_37": "value_37"},
+						Value: any(map[string]any{"key_37": "value_37"}),
 					},
 				},
 				Outputs: []v1.Param{
@@ -2196,14 +2196,14 @@ func FuzzDecodeType(f *testing.F) {
 									{
 										Name:  "test_42",
 										Type:  v1.Type{},
-										Value: map[string]interface{}{"key_44": "value_44"},
+										Value: any(map[string]any{"key_44": "value_44"}),
 									},
 								},
 								Outputs: []v1.Param{
 									{
 										Name:  "test_46",
 										Type:  v1.Type{},
-										Value: map[string]interface{}{"key_48": "value_48"},
+										Value: any(map[string]any{"key_48": "value_48"}),
 									},
 								},
 							},
@@ -2240,7 +2240,7 @@ func FuzzDecodeType(f *testing.F) {
 							}),
 							ChanDirection: v1.ChanDirection(0),
 						},
-						Value: map[string]interface{}{"key_74": "value_74"},
+						Value: any(map[string]any{"key_74": "value_74"}),
 					},
 				},
 			},
@@ -2263,7 +2263,7 @@ func FuzzDecodeType(f *testing.F) {
 								Constraint:    new(v1.Type{}),
 								ChanDirection: v1.ChanDirection(0),
 							},
-							Value: map[string]interface{}{"key_89": "value_89"},
+							Value: any(map[string]any{"key_89": "value_89"}),
 						},
 					},
 					Outputs: []v1.Param{
@@ -2281,7 +2281,7 @@ func FuzzDecodeType(f *testing.F) {
 								Constraint:    new(v1.Type{}),
 								ChanDirection: v1.ChanDirection(0),
 							},
-							Value: map[string]interface{}{"key_101": "value_101"},
+							Value: any(map[string]any{"key_101": "value_101"}),
 						},
 					},
 				},
@@ -2293,14 +2293,14 @@ func FuzzDecodeType(f *testing.F) {
 							{
 								Name:  "test_106",
 								Type:  v1.Type{},
-								Value: map[string]interface{}{"key_108": "value_108"},
+								Value: any(map[string]any{"key_108": "value_108"}),
 							},
 						},
 						Outputs: []v1.Param{
 							{
 								Name:  "test_110",
 								Type:  v1.Type{},
-								Value: map[string]interface{}{"key_112": "value_112"},
+								Value: any(map[string]any{"key_112": "value_112"}),
 							},
 						},
 					},
@@ -2357,14 +2357,14 @@ func FuzzDecodeType(f *testing.F) {
 							{
 								Name:  "test_152",
 								Type:  v1.Type{},
-								Value: map[string]interface{}{"key_154": "value_154"},
+								Value: any(map[string]any{"key_154": "value_154"}),
 							},
 						},
 						Outputs: []v1.Param{
 							{
 								Name:  "test_156",
 								Type:  v1.Type{},
-								Value: map[string]interface{}{"key_158": "value_158"},
+								Value: any(map[string]any{"key_158": "value_158"}),
 							},
 						},
 					},
@@ -2434,7 +2434,7 @@ func FuzzDecodeType(f *testing.F) {
 								Constraint:    new(v1.Type{}),
 								ChanDirection: v1.ChanDirection(0),
 							},
-							Value: map[string]interface{}{"key_209": "value_209"},
+							Value: any(map[string]any{"key_209": "value_209"}),
 						},
 					},
 					Outputs: []v1.Param{
@@ -2452,7 +2452,7 @@ func FuzzDecodeType(f *testing.F) {
 								Constraint:    new(v1.Type{}),
 								ChanDirection: v1.ChanDirection(0),
 							},
-							Value: map[string]interface{}{"key_221": "value_221"},
+							Value: any(map[string]any{"key_221": "value_221"}),
 						},
 					},
 				},
@@ -2464,14 +2464,14 @@ func FuzzDecodeType(f *testing.F) {
 							{
 								Name:  "test_226",
 								Type:  v1.Type{},
-								Value: map[string]interface{}{"key_228": "value_228"},
+								Value: any(map[string]any{"key_228": "value_228"}),
 							},
 						},
 						Outputs: []v1.Param{
 							{
 								Name:  "test_230",
 								Type:  v1.Type{},
-								Value: map[string]interface{}{"key_232": "value_232"},
+								Value: any(map[string]any{"key_232": "value_232"}),
 							},
 						},
 					},
@@ -2528,14 +2528,14 @@ func FuzzDecodeType(f *testing.F) {
 							{
 								Name:  "test_272",
 								Type:  v1.Type{},
-								Value: map[string]interface{}{"key_274": "value_274"},
+								Value: any(map[string]any{"key_274": "value_274"}),
 							},
 						},
 						Outputs: []v1.Param{
 							{
 								Name:  "test_276",
 								Type:  v1.Type{},
-								Value: map[string]interface{}{"key_278": "value_278"},
+								Value: any(map[string]any{"key_278": "value_278"}),
 							},
 						},
 					},

--- a/client/cpp/arc/json.gen.h
+++ b/client/cpp/arc/json.gen.h
@@ -37,7 +37,7 @@ inline x::json::json StatusDetails::to_json() const {
 
 inline Arc Arc::parse(x::json::Parser parser) {
     return Arc{
-        .key = parser.field<Key>("key"),
+        .key = parser.field<Key>("key", x::uuid::create()),
         .name = parser.field<std::string>("name"),
         .mode = parser.field<std::string>("mode"),
         .graph = parser.field<::arc::graph::Graph>("graph"),

--- a/client/cpp/channel/json.gen.h
+++ b/client/cpp/channel/json.gen.h
@@ -25,9 +25,11 @@ namespace synnax::channel {
 inline Operation Operation::parse(x::json::Parser parser) {
     return Operation{
         .type = parser.field<std::string>("type"),
-        .reset_channel = parser.field<Key>("reset_channel", 0),
-        .duration = parser
-                        .field<::x::telem::TimeSpan>("duration", x::telem::TimeSpan(0)),
+        .reset_channel = parser.field<Key>("reset_channel", Key(0)),
+        .duration = parser.field<::x::telem::TimeSpan>(
+            "duration",
+            ::x::telem::TimeSpan(0)
+        ),
     };
 }
 
@@ -41,12 +43,15 @@ inline x::json::json Operation::to_json() const {
 
 inline Channel Channel::parse(x::json::Parser parser) {
     return Channel{
-        .key = parser.field<Key>("key", 0),
+        .key = parser.field<Key>("key", Key(0)),
         .name = parser.field<Name>("name"),
-        .leaseholder = parser.field<::synnax::node::Key>("leaseholder", 0),
+        .leaseholder = parser.field<::synnax::node::Key>(
+            "leaseholder",
+            ::synnax::node::Key(0)
+        ),
         .data_type = parser.field<::x::telem::DataType>("data_type"),
         .is_index = parser.field<bool>("is_index", false),
-        .index = parser.field<Key>("index", 0),
+        .index = parser.field<Key>("index", Key(0)),
         .alias = parser.field<std::optional<std::string>>("alias"),
         .is_virtual = parser.field<bool>("virtual", false),
         .internal = parser.field<bool>("internal", false),

--- a/client/cpp/channel/types.gen.h
+++ b/client/cpp/channel/types.gen.h
@@ -58,9 +58,9 @@ struct Operation {
     /// @brief reset_channel is the channel key that triggers reset of the aggregation.
     /// If
     /// 0, duration-based reset is used.
-    Key reset_channel = 0;
+    Key reset_channel = Key(0);
     /// @brief duration is the time window for aggregation when reset_channel is 0.
-    ::x::telem::TimeSpan duration = x::telem::TimeSpan(0);
+    ::x::telem::TimeSpan duration = ::x::telem::TimeSpan(0);
 
     static Operation parse(x::json::Parser parser);
     [[nodiscard]] x::json::json to_json() const;
@@ -78,12 +78,12 @@ struct Operation {
 struct Channel {
     /// @brief key is the unique identifier for this channel, automatically assigned by
     /// Synnax.
-    Key key = 0;
+    Key key = Key(0);
     /// @brief name is the human-readable channel name.
     Name name;
     /// @brief leaseholder is the node that holds the lease for this channel. Mostly for
     /// internal use.
-    ::synnax::node::Key leaseholder = 0;
+    ::synnax::node::Key leaseholder = ::synnax::node::Key(0);
     /// @brief data_type is the data type of samples stored in this channel (e.g.,
     /// Float64,
     /// Int32, TimeStamp).
@@ -96,7 +96,7 @@ struct Channel {
     /// @brief index is the channel used to index this channel's values, associating
     /// each
     /// value with a timestamp.
-    Key index = 0;
+    Key index = Key(0);
     /// @brief alias is an optional alternate name for the channel within a specific
     /// context.
     std::optional<std::string> alias;

--- a/client/cpp/label/json.gen.h
+++ b/client/cpp/label/json.gen.h
@@ -21,7 +21,7 @@ namespace synnax::label {
 
 inline Label Label::parse(x::json::Parser parser) {
     return Label{
-        .key = parser.field<Key>("key"),
+        .key = parser.field<Key>("key", x::uuid::create()),
         .name = parser.field<std::string>("name"),
         .color = parser.field<::x::color::Color>("color"),
     };

--- a/client/cpp/task/json.gen.h
+++ b/client/cpp/task/json.gen.h
@@ -21,7 +21,7 @@ namespace synnax::task {
 
 inline StatusDetails StatusDetails::parse(x::json::Parser parser) {
     return StatusDetails{
-        .task = parser.field<Key>("task", 0),
+        .task = parser.field<Key>("task", Key(0)),
         .running = parser.field<bool>("running"),
         .cmd = parser.field<std::string>("cmd", ""),
         .data = parser.field<std::optional<x::json::json::object_t>>("data"),
@@ -39,7 +39,7 @@ inline x::json::json StatusDetails::to_json() const {
 
 inline Task Task::parse(x::json::Parser parser) {
     return Task{
-        .key = parser.field<Key>("key", 0),
+        .key = parser.field<Key>("key", Key(0)),
         .name = parser.field<std::string>("name"),
         .type = parser.field<std::string>("type"),
         .config = parser.field<x::json::json::object_t>("config"),

--- a/client/cpp/task/types.gen.h
+++ b/client/cpp/task/types.gen.h
@@ -36,7 +36,7 @@ using Key = std::uint64_t;
 /// state.
 struct StatusDetails {
     /// @brief task is the key of the task this status pertains to.
-    Key task = 0;
+    Key task = Key(0);
     /// @brief running is true if the task is currently executing.
     bool running = false;
     /// @brief cmd is the last command executed on this task.
@@ -82,7 +82,7 @@ using Status = ::synnax::status::Status<StatusDetails>;
 /// or scanning for devices.
 struct Task {
     /// @brief key is the composite identifier for this task.
-    Key key = 0;
+    Key key = Key(0);
     /// @brief name is a human-readable name for the task.
     std::string name;
     /// @brief type is the task type (e.g., 'modbus_read', 'labjack_write', 'opc_scan').

--- a/client/cpp/view/json.gen.h
+++ b/client/cpp/view/json.gen.h
@@ -20,7 +20,7 @@ namespace synnax::view {
 
 inline View View::parse(x::json::Parser parser) {
     return View{
-        .key = parser.field<Key>("key"),
+        .key = parser.field<Key>("key", x::uuid::create()),
         .name = parser.field<std::string>("name"),
         .type = parser.field<std::string>("type"),
         .query = parser.field<x::json::json::object_t>("query"),

--- a/core/pkg/service/access/rbac/policy/versions/v1/codec.gen.go
+++ b/core/pkg/service/access/rbac/policy/versions/v1/codec.gen.go
@@ -81,11 +81,11 @@ func (p *Policy) DecodeOrc(r *orc.Reader) error {
 			p.Actions = make([]access.Action, n)
 			for i := range p.Actions {
 				{
-					v, err := r.String()
+					rawV, err := r.String()
 					if err != nil {
 						return err
 					}
-					p.Actions[i] = access.Action(v)
+					p.Actions[i] = access.Action(rawV)
 				}
 			}
 		}

--- a/core/pkg/service/arc/versions/v3/codec.gen.go
+++ b/core/pkg/service/arc/versions/v3/codec.gen.go
@@ -37,11 +37,11 @@ func (a *Arc) DecodeOrc(r *orc.Reader) error {
 		return err
 	}
 	{
-		v, err := r.String()
+		rawV, err := r.String()
 		if err != nil {
 			return err
 		}
-		a.Mode = Mode(v)
+		a.Mode = Mode(rawV)
 	}
 	if err = a.Graph.DecodeOrc(r); err != nil {
 		return err

--- a/core/pkg/service/arc/versions/v3/codec_gen_test.go
+++ b/core/pkg/service/arc/versions/v3/codec_gen_test.go
@@ -55,14 +55,14 @@ var _ = Describe("Codec", func() {
 								{
 									Name:  "test_10",
 									Type:  types.Type{},
-									Value: map[string]interface{}{"key_12": "value_12"},
+									Value: any(map[string]any{"key_12": "value_12"}),
 								},
 							},
 							Outputs: []types.Param{
 								{
 									Name:  "test_14",
 									Type:  types.Type{},
-									Value: map[string]interface{}{"key_16": "value_16"},
+									Value: any(map[string]any{"key_16": "value_16"}),
 								},
 							},
 							Channels: types.Channels{
@@ -128,14 +128,14 @@ func BenchmarkEncodeDecodeArc(b *testing.B) {
 						{
 							Name:  "test_10",
 							Type:  types.Type{},
-							Value: map[string]interface{}{"key_12": "value_12"},
+							Value: any(map[string]any{"key_12": "value_12"}),
 						},
 					},
 					Outputs: []types.Param{
 						{
 							Name:  "test_14",
 							Type:  types.Type{},
-							Value: map[string]interface{}{"key_16": "value_16"},
+							Value: any(map[string]any{"key_16": "value_16"}),
 						},
 					},
 					Channels: types.Channels{
@@ -201,14 +201,14 @@ func FuzzDecodeArc(f *testing.F) {
 							{
 								Name:  "test_10",
 								Type:  types.Type{},
-								Value: map[string]interface{}{"key_12": "value_12"},
+								Value: any(map[string]any{"key_12": "value_12"}),
 							},
 						},
 						Outputs: []types.Param{
 							{
 								Name:  "test_14",
 								Type:  types.Type{},
-								Value: map[string]interface{}{"key_16": "value_16"},
+								Value: any(map[string]any{"key_16": "value_16"}),
 							},
 						},
 						Channels: types.Channels{

--- a/core/pkg/service/channel/versions/v0/codec.gen.go
+++ b/core/pkg/service/channel/versions/v0/codec.gen.go
@@ -49,45 +49,45 @@ func (c *Channel) DecodeOrc(r *orc.Reader) error {
 		return err
 	}
 	{
-		v, err := r.Uint16()
+		rawV, err := r.Uint16()
 		if err != nil {
 			return err
 		}
-		c.Leaseholder = node.Key(v)
+		c.Leaseholder = node.Key(rawV)
 	}
 	{
-		v, err := r.String()
+		rawV, err := r.String()
 		if err != nil {
 			return err
 		}
-		c.DataType = telem.DataType(v)
+		c.DataType = telem.DataType(rawV)
 	}
 	if c.IsIndex, err = r.Bool(); err != nil {
 		return err
 	}
 	{
-		v, err := r.Uint32()
+		rawV, err := r.Uint32()
 		if err != nil {
 			return err
 		}
-		c.LocalKey = LocalKey(v)
+		c.LocalKey = LocalKey(rawV)
 	}
 	{
-		v, err := r.Uint32()
+		rawV, err := r.Uint32()
 		if err != nil {
 			return err
 		}
-		c.LocalIndex = LocalKey(v)
+		c.LocalIndex = LocalKey(rawV)
 	}
 	if c.Virtual, err = r.Bool(); err != nil {
 		return err
 	}
 	{
-		v, err := r.Int64()
+		rawV, err := r.Int64()
 		if err != nil {
 			return err
 		}
-		c.Concurrency = control.Concurrency(v)
+		c.Concurrency = control.Concurrency(rawV)
 	}
 	if c.Internal, err = r.Bool(); err != nil {
 		return err
@@ -127,25 +127,25 @@ func (o Operation) EncodeOrc(w *orc.Writer) error {
 // DecodeOrc reads the value from r in the Orc binary format.
 func (o *Operation) DecodeOrc(r *orc.Reader) error {
 	{
-		v, err := r.String()
+		rawV, err := r.String()
 		if err != nil {
 			return err
 		}
-		o.Type = OperationType(v)
+		o.Type = OperationType(rawV)
 	}
 	{
-		v, err := r.Uint32()
+		rawV, err := r.Uint32()
 		if err != nil {
 			return err
 		}
-		o.ResetChannel = Key(v)
+		o.ResetChannel = Key(rawV)
 	}
 	{
-		v, err := r.Int64()
+		rawV, err := r.Int64()
 		if err != nil {
 			return err
 		}
-		o.Duration = telem.TimeSpan(v)
+		o.Duration = telem.TimeSpan(rawV)
 	}
 	return nil
 }

--- a/core/pkg/service/device/versions/v1/codec.gen.go
+++ b/core/pkg/service/device/versions/v1/codec.gen.go
@@ -44,11 +44,11 @@ func (d *Device) DecodeOrc(r *orc.Reader) error {
 		return err
 	}
 	{
-		v, err := r.Uint32()
+		rawV, err := r.Uint32()
 		if err != nil {
 			return err
 		}
-		d.Rack = rack.Key(v)
+		d.Rack = rack.Key(rawV)
 	}
 	if d.Location, err = r.String(); err != nil {
 		return err

--- a/core/pkg/service/lineplot/versions/v5/codec.gen.go
+++ b/core/pkg/service/lineplot/versions/v5/codec.gen.go
@@ -91,28 +91,28 @@ func (a Axis) EncodeOrc(w *orc.Writer) error {
 func (a *Axis) DecodeOrc(r *orc.Reader) error {
 	var err error
 	{
-		v, err := r.String()
+		rawV, err := r.String()
 		if err != nil {
 			return err
 		}
-		a.Key = AxisKey(v)
+		a.Key = AxisKey(rawV)
 	}
 	if a.Label, err = r.String(); err != nil {
 		return err
 	}
 	{
-		v, err := r.String()
+		rawV, err := r.String()
 		if err != nil {
 			return err
 		}
-		a.LabelDirection = spatial.Direction(v)
+		a.LabelDirection = spatial.Direction(rawV)
 	}
 	{
-		v, err := r.String()
+		rawV, err := r.String()
 		if err != nil {
 			return err
 		}
-		a.LabelLevel = text.Level(v)
+		a.LabelLevel = text.Level(rawV)
 	}
 	if a.Bounds.Lower, err = r.Float64(); err != nil {
 		return err
@@ -134,11 +134,11 @@ func (a *Axis) DecodeOrc(r *orc.Reader) error {
 		if present {
 			var hv TickType
 			{
-				v, err := r.String()
+				rawV, err := r.String()
 				if err != nil {
 					return err
 				}
-				hv = TickType(v)
+				hv = TickType(rawV)
 			}
 			a.Type = &hv
 		}
@@ -184,18 +184,18 @@ func (c Channels) EncodeOrc(w *orc.Writer) error {
 // DecodeOrc reads the value from r in the Orc binary format.
 func (c *Channels) DecodeOrc(r *orc.Reader) error {
 	{
-		v, err := r.Uint32()
+		rawV, err := r.Uint32()
 		if err != nil {
 			return err
 		}
-		c.X1 = channel.Key(v)
+		c.X1 = channel.Key(rawV)
 	}
 	{
-		v, err := r.Uint32()
+		rawV, err := r.Uint32()
 		if err != nil {
 			return err
 		}
-		c.X2 = channel.Key(v)
+		c.X2 = channel.Key(rawV)
 	}
 	{
 		present, err := r.Bool()
@@ -210,11 +210,11 @@ func (c *Channels) DecodeOrc(r *orc.Reader) error {
 			c.Y1 = make([]channel.Key, n)
 			for i := range c.Y1 {
 				{
-					v, err := r.Uint32()
+					rawV, err := r.Uint32()
 					if err != nil {
 						return err
 					}
-					c.Y1[i] = channel.Key(v)
+					c.Y1[i] = channel.Key(rawV)
 				}
 			}
 		}
@@ -232,11 +232,11 @@ func (c *Channels) DecodeOrc(r *orc.Reader) error {
 			c.Y2 = make([]channel.Key, n)
 			for i := range c.Y2 {
 				{
-					v, err := r.Uint32()
+					rawV, err := r.Uint32()
 					if err != nil {
 						return err
 					}
-					c.Y2[i] = channel.Key(v)
+					c.Y2[i] = channel.Key(rawV)
 				}
 			}
 		}
@@ -254,11 +254,11 @@ func (c *Channels) DecodeOrc(r *orc.Reader) error {
 			c.Y3 = make([]channel.Key, n)
 			for i := range c.Y3 {
 				{
-					v, err := r.Uint32()
+					rawV, err := r.Uint32()
 					if err != nil {
 						return err
 					}
-					c.Y3[i] = channel.Key(v)
+					c.Y3[i] = channel.Key(rawV)
 				}
 			}
 		}
@@ -276,11 +276,11 @@ func (c *Channels) DecodeOrc(r *orc.Reader) error {
 			c.Y4 = make([]channel.Key, n)
 			for i := range c.Y4 {
 				{
-					v, err := r.Uint32()
+					rawV, err := r.Uint32()
 					if err != nil {
 						return err
 					}
-					c.Y4[i] = channel.Key(v)
+					c.Y4[i] = channel.Key(rawV)
 				}
 			}
 		}
@@ -371,11 +371,11 @@ func (lv *Line) DecodeOrc(r *orc.Reader) error {
 		return err
 	}
 	{
-		v, err := r.String()
+		rawV, err := r.String()
 		if err != nil {
 			return err
 		}
-		lv.DownsampleMode = DownsampleMode(v)
+		lv.DownsampleMode = DownsampleMode(rawV)
 	}
 	return nil
 }
@@ -605,11 +605,11 @@ func (rv *Rule) DecodeOrc(r *orc.Reader) error {
 		}
 	}
 	{
-		v, err := r.String()
+		rawV, err := r.String()
 		if err != nil {
 			return err
 		}
-		rv.Axis = AxisKey(v)
+		rv.Axis = AxisKey(rawV)
 	}
 	if rv.LineWidth, err = r.Float64(); err != nil {
 		return err
@@ -637,11 +637,11 @@ func (t Title) EncodeOrc(w *orc.Writer) error {
 func (t *Title) DecodeOrc(r *orc.Reader) error {
 	var err error
 	{
-		v, err := r.String()
+		rawV, err := r.String()
 		if err != nil {
 			return err
 		}
-		t.Level = text.Level(v)
+		t.Level = text.Level(rawV)
 	}
 	if t.Visible, err = r.Bool(); err != nil {
 		return err

--- a/core/pkg/service/log/versions/v2/codec.gen.go
+++ b/core/pkg/service/log/versions/v2/codec.gen.go
@@ -37,21 +37,21 @@ func (ce ChannelEntry) EncodeOrc(w *orc.Writer) error {
 func (ce *ChannelEntry) DecodeOrc(r *orc.Reader) error {
 	var err error
 	{
-		v, err := r.Uint32()
+		rawV, err := r.Uint32()
 		if err != nil {
 			return err
 		}
-		ce.Channel = channel.Key(v)
+		ce.Channel = channel.Key(rawV)
 	}
 	if err = ce.Color.DecodeOrc(r); err != nil {
 		return err
 	}
 	{
-		v, err := r.String()
+		rawV, err := r.String()
 		if err != nil {
 			return err
 		}
-		ce.Notation = notation.Notation(v)
+		ce.Notation = notation.Notation(rawV)
 	}
 	if ce.Precision, err = r.Int32(); err != nil {
 		return err
@@ -133,18 +133,18 @@ func (tc TimestampConfig) EncodeOrc(w *orc.Writer) error {
 // DecodeOrc reads the value from r in the Orc binary format.
 func (tc *TimestampConfig) DecodeOrc(r *orc.Reader) error {
 	{
-		v, err := r.String()
+		rawV, err := r.String()
 		if err != nil {
 			return err
 		}
-		tc.Format = telem.TimestampFormat(v)
+		tc.Format = telem.TimestampFormat(rawV)
 	}
 	{
-		v, err := r.String()
+		rawV, err := r.String()
 		if err != nil {
 			return err
 		}
-		tc.Tz = telem.TimeZone(v)
+		tc.Tz = telem.TimeZone(rawV)
 	}
 	return nil
 }

--- a/core/pkg/service/ontology/versions/v0/codec.gen.go
+++ b/core/pkg/service/ontology/versions/v0/codec.gen.go
@@ -24,11 +24,11 @@ func (id ID) EncodeOrc(w *orc.Writer) error {
 func (id *ID) DecodeOrc(r *orc.Reader) error {
 	var err error
 	{
-		v, err := r.String()
+		rawV, err := r.String()
 		if err != nil {
 			return err
 		}
-		id.Type = ResourceType(v)
+		id.Type = ResourceType(rawV)
 	}
 	if id.Key, err = r.String(); err != nil {
 		return err
@@ -55,11 +55,11 @@ func (rv *Relationship) DecodeOrc(r *orc.Reader) error {
 		return err
 	}
 	{
-		v, err := r.String()
+		rawV, err := r.String()
 		if err != nil {
 			return err
 		}
-		rv.Type = RelationshipType(v)
+		rv.Type = RelationshipType(rawV)
 	}
 	if err = rv.To.DecodeOrc(r); err != nil {
 		return err

--- a/core/pkg/service/panel/versions/v0/codec.gen.go
+++ b/core/pkg/service/panel/versions/v0/codec.gen.go
@@ -150,11 +150,11 @@ func (s *Split) DecodeOrc(r *orc.Reader) error {
 	defer r.PopDepth()
 	var err error
 	{
-		v, err := r.String()
+		rawV, err := r.String()
 		if err != nil {
 			return err
 		}
-		s.Direction = spatial.Direction(v)
+		s.Direction = spatial.Direction(rawV)
 	}
 	if s.Size, err = r.Float64(); err != nil {
 		return err

--- a/core/pkg/service/rack/versions/v1/codec.gen.go
+++ b/core/pkg/service/rack/versions/v1/codec.gen.go
@@ -33,11 +33,11 @@ func (rv Rack) EncodeOrc(w *orc.Writer) error {
 func (rv *Rack) DecodeOrc(r *orc.Reader) error {
 	var err error
 	{
-		v, err := r.Uint32()
+		rawV, err := r.Uint32()
 		if err != nil {
 			return err
 		}
-		rv.Key = Key(v)
+		rv.Key = Key(rawV)
 	}
 	if rv.Name, err = r.String(); err != nil {
 		return err

--- a/core/pkg/service/ranger/alias/versions/v0/codec.gen.go
+++ b/core/pkg/service/ranger/alias/versions/v0/codec.gen.go
@@ -31,11 +31,11 @@ func (a *Alias) DecodeOrc(r *orc.Reader) error {
 		return err
 	}
 	{
-		v, err := r.Uint32()
+		rawV, err := r.Uint32()
 		if err != nil {
 			return err
 		}
-		a.Channel = channel.Key(v)
+		a.Channel = channel.Key(rawV)
 	}
 	if a.Alias, err = r.String(); err != nil {
 		return err

--- a/core/pkg/service/schematic/symbol/versions/v2/codec.gen.go
+++ b/core/pkg/service/schematic/symbol/versions/v2/codec.gen.go
@@ -37,11 +37,11 @@ func (h *Handle) DecodeOrc(r *orc.Reader) error {
 		return err
 	}
 	{
-		v, err := r.String()
+		rawV, err := r.String()
 		if err != nil {
 			return err
 		}
-		h.Orientation = spatial.OuterLocation(v)
+		h.Orientation = spatial.OuterLocation(rawV)
 	}
 	return nil
 }

--- a/core/pkg/service/status/versions/v1/codec.gen.go
+++ b/core/pkg/service/status/versions/v1/codec.gen.go
@@ -46,11 +46,11 @@ func (s *Status[Details]) DecodeOrc(r *orc.Reader) error {
 		return err
 	}
 	{
-		v, err := r.String()
+		rawV, err := r.String()
 		if err != nil {
 			return err
 		}
-		s.Variant = Variant(v)
+		s.Variant = Variant(rawV)
 	}
 	if s.Message, err = r.String(); err != nil {
 		return err
@@ -59,11 +59,11 @@ func (s *Status[Details]) DecodeOrc(r *orc.Reader) error {
 		return err
 	}
 	{
-		v, err := r.Int64()
+		rawV, err := r.Int64()
 		if err != nil {
 			return err
 		}
-		s.Time = telem.TimeStamp(v)
+		s.Time = telem.TimeStamp(rawV)
 	}
 	{
 		b, err := r.ReadWithLen()

--- a/core/pkg/service/task/versions/v1/codec.gen.go
+++ b/core/pkg/service/task/versions/v1/codec.gen.go
@@ -38,11 +38,11 @@ func (t Task) EncodeOrc(w *orc.Writer) error {
 func (t *Task) DecodeOrc(r *orc.Reader) error {
 	var err error
 	{
-		v, err := r.Uint64()
+		rawV, err := r.Uint64()
 		if err != nil {
 			return err
 		}
-		t.Key = Key(v)
+		t.Key = Key(rawV)
 	}
 	if t.Name, err = r.String(); err != nil {
 		return err

--- a/oracle/analyzer/analyzer.go
+++ b/oracle/analyzer/analyzer.go
@@ -234,6 +234,8 @@ func analyze(c *analysisCtx) {
 	finalizeActionExtends(c)
 	checkOptionalDefaultInvariant(c)
 	checkDefaultInvariant(c)
+	checkIdentDefaultResolves(c)
+	checkUnionDefaultConstructible(c)
 	synthesizeCreateTypes(c)
 }
 

--- a/oracle/analyzer/analyzer_test.go
+++ b/oracle/analyzer/analyzer_test.go
@@ -2612,14 +2612,21 @@ var _ = Describe("Analyzer", func() {
 	})
 
 	Describe("Identifier Defaults", func() {
-		const unionSource = `CJC union on source {
+		const unionSource = `ChanPayload struct {
+    port int32
+}
+
+SafePayload struct {
+    port int32 = 0
+}
+
+CJC union on source {
     built_in {}
     const_val {
         val float64 = 0
     }
-    chan {
-        port int32
-    }
+    chan ChanPayload
+    safe SafePayload
 }
 
 Mode enum {
@@ -2659,7 +2666,7 @@ Mode enum {
 		)
 
 		It(
-			"Should reject a union default whose variant cannot be constructed",
+			"Should reject a union default whose named payload cannot be constructed",
 			func(ctx SpecContext) {
 				Expect(analyze(ctx, "cjc CJC = chan").Error()).To(SatisfyAll(
 					ContainSubstring("defaults to union variant \"chan\""),
@@ -2670,11 +2677,14 @@ Mode enum {
 			},
 		)
 
-		It(
+		DescribeTable(
 			"Should accept a union default whose variant fields are all defaulted",
-			func(ctx SpecContext) {
-				Expect(analyze(ctx, "cjc CJC = const_val").Ok()).To(BeTrue())
+			func(ctx SpecContext, fieldDecl string) {
+				Expect(analyze(ctx, fieldDecl).Ok()).To(BeTrue())
 			},
+			Entry("inline variant", "cjc CJC = const_val"),
+			Entry("named payload", "cjc CJC = safe"),
+			Entry("empty inline variant", "cjc CJC = built_in"),
 		)
 	})
 

--- a/oracle/analyzer/analyzer_test.go
+++ b/oracle/analyzer/analyzer_test.go
@@ -2501,7 +2501,8 @@ var _ = Describe("Analyzer", func() {
 	Describe("Field Defaults", func() {
 		defaultOf := func(ctx SpecContext, fieldDecl string) *resolution.ExpressionValue {
 			GinkgoHelper()
-			source := "Item struct {\n\t" + fieldDecl + "\n}\n"
+			source := "Mode enum {\n\texclusive = \"Exclusive\"\n}\n\n" +
+				"Item struct {\n\t" + fieldDecl + "\n}\n"
 			table, diag := analyzer.AnalyzeSource(ctx, source, "test", loader)
 			Expect(diag.Ok()).To(BeTrue())
 			form := table.MustGet("test.Item").Form.(resolution.StructForm)
@@ -2552,10 +2553,10 @@ var _ = Describe("Analyzer", func() {
 			),
 			Entry(
 				"qualified ident",
-				"mode string = control.Exclusive",
+				"mode Mode = test.ModeExclusive",
 				resolution.ExpressionValue{
 					Kind:       resolution.ValueKindIdent,
-					IdentValue: "control.Exclusive",
+					IdentValue: "test.ModeExclusive",
 				},
 			),
 		)
@@ -2606,6 +2607,73 @@ var _ = Describe("Analyzer", func() {
 				Expect(
 					def.Elements[1],
 				).To(Equal(resolution.ExpressionValue{Kind: resolution.ValueKindFloat, FloatValue: 2.5}))
+			},
+		)
+	})
+
+	Describe("Identifier Defaults", func() {
+		const unionSource = `CJC union on source {
+    built_in {}
+    const_val {
+        val float64 = 0
+    }
+    chan {
+        port int32
+    }
+}
+
+Mode enum {
+    fast = "Fast"
+}
+
+`
+		analyze := func(ctx SpecContext, fieldDecl string) *diagnostics.Files {
+			GinkgoHelper()
+			source := unionSource + "Item struct {\n\t" + fieldDecl + "\n}\n"
+			_, diag := analyzer.AnalyzeSource(ctx, source, "test", loader)
+			return diag
+		}
+
+		DescribeTable(
+			"Should accept an identifier default the generators can emit",
+			func(ctx SpecContext, fieldDecl string) {
+				Expect(analyze(ctx, fieldDecl).Ok()).To(BeTrue())
+			},
+			Entry("enum member", "mode Mode = fast"),
+			Entry("union variant", "cjc CJC = built_in"),
+			Entry("union variant, prefixed", "cjc CJC = CJCBuiltIn"),
+			Entry("create sentinel", "key string = create"),
+			Entry("now sentinel", "at int64 = now"),
+		)
+
+		DescribeTable(
+			"Should reject an identifier default that names nothing",
+			func(ctx SpecContext, fieldDecl string) {
+				Expect(analyze(ctx, fieldDecl).Error()).To(ContainSubstring(
+					"names neither a member of its enum type nor a variant of its union type",
+				))
+			},
+			Entry("misspelled enum member", "mode Mode = fest"),
+			Entry("misspelled union variant", "cjc CJC = buit_in"),
+			Entry("variant of another union", "mode Mode = built_in"),
+		)
+
+		It(
+			"Should reject a union default whose variant cannot be constructed",
+			func(ctx SpecContext) {
+				Expect(analyze(ctx, "cjc CJC = chan").Error()).To(SatisfyAll(
+					ContainSubstring("defaults to union variant \"chan\""),
+					ContainSubstring(
+						"whose field \"port\" is required and has no default",
+					),
+				))
+			},
+		)
+
+		It(
+			"Should accept a union default whose variant fields are all defaulted",
+			func(ctx SpecContext) {
+				Expect(analyze(ctx, "cjc CJC = const_val").Ok()).To(BeTrue())
 			},
 		)
 	})

--- a/oracle/analyzer/invariant.go
+++ b/oracle/analyzer/invariant.go
@@ -10,6 +10,7 @@
 package analyzer
 
 import (
+	"github.com/samber/lo"
 	"github.com/synnaxlabs/oracle/domain/validation"
 	"github.com/synnaxlabs/oracle/resolution"
 	"github.com/synnaxlabs/x/diagnostics"
@@ -81,6 +82,100 @@ func checkDefaultInvariant(c *analysisCtx) {
 					"the default to the type's zero value.",
 				f.Name, typ.Name, reason,
 			))
+		}
+	}
+}
+
+// identDefaultSentinels are the identifier defaults the generators compute at a
+// boundary rather than resolving against the field's type.
+var identDefaultSentinels = []string{"create", "now", "true", "false"}
+
+// checkIdentDefaultResolves enforces that an identifier default names something the
+// generators can emit: an enum member, a union variant, or a boundary sentinel. Each
+// plugin renders an identifier default from its own resolve-or-fall-through branch, so
+// an unresolvable identifier is not a hard error anywhere. It generates nothing, in
+// every language, with no diagnostic. Rejecting it here is what keeps a typo, or a
+// language a feature was never wired into, from shipping as a silently missing default.
+func checkIdentDefaultResolves(c *analysisCtx) {
+	forEachDefaultedField(c, func(typ resolution.Type, f resolution.Field) {
+		if f.Default.Kind != resolution.ValueKindIdent {
+			return
+		}
+		ident := f.Default.IdentValue
+		if lo.Contains(identDefaultSentinels, ident) {
+			return
+		}
+		if _, ok := validation.ResolveEnumVariant(ident, f.Type, c.table); ok {
+			return
+		}
+		if _, ok := validation.ResolveUnionVariant(ident, f.Type, c.table); ok {
+			return
+		}
+		c.diag.Add(diagnostics.Errorf(
+			nil,
+			"default %q on field %q in %q names neither a member of its enum type nor a "+
+				"variant of its union type. Check the spelling against the type's "+
+				"declaration.",
+			ident,
+			f.Name,
+			typ.Name,
+		))
+	})
+}
+
+// checkUnionDefaultConstructible enforces that every field of the variant a union
+// default names is itself defaulted or optional. TypeScript and Python build the
+// default value eagerly, so a variant carrying a required undefaulted field yields a
+// schema that throws the first time anything constructs it. Go and C++ would emit a
+// zero-valued struct instead, so the shapes disagree across languages as well.
+func checkUnionDefaultConstructible(c *analysisCtx) {
+	forEachDefaultedField(c, func(typ resolution.Type, f resolution.Field) {
+		if f.Default.Kind != resolution.ValueKindIdent {
+			return
+		}
+		uv, ok := validation.ResolveUnionVariant(f.Default.IdentValue, f.Type, c.table)
+		if !ok {
+			return
+		}
+		payload, ok := uv.Variant.Type.Resolve(c.table)
+		if !ok {
+			return
+		}
+		for _, vf := range resolution.UnifiedFields(payload, c.table) {
+			if vf.Default != nil || vf.Optional {
+				continue
+			}
+			c.diag.Add(diagnostics.Errorf(
+				nil,
+				"field %q in %q defaults to union variant %q, whose field %q is required "+
+					"and has no default, so the default value cannot be constructed. Give "+
+					"%q a default, make it optional, or default to another variant.",
+				f.Name,
+				typ.Name,
+				uv.Variant.Name,
+				vf.Name,
+				vf.Name,
+			))
+		}
+	})
+}
+
+// forEachDefaultedField calls fn for every field carrying a default on every struct
+// declared in the namespace under analysis.
+func forEachDefaultedField(c *analysisCtx, fn func(resolution.Type, resolution.Field)) {
+	for _, typ := range c.table.Types {
+		if typ.Namespace != c.namespace {
+			continue
+		}
+		form, ok := typ.Form.(resolution.StructForm)
+		if !ok {
+			continue
+		}
+		for _, f := range form.Fields {
+			if f.Default == nil {
+				continue
+			}
+			fn(typ, f)
 		}
 	}
 }

--- a/oracle/domain/validation/union.go
+++ b/oracle/domain/validation/union.go
@@ -1,0 +1,71 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+package validation
+
+import (
+	"strings"
+
+	"github.com/synnaxlabs/oracle/resolution"
+)
+
+// UnionVariant contains resolved information about a union variant reference from
+// a field's default expression.
+type UnionVariant struct {
+	Type    resolution.Type
+	Union   resolution.UnionForm
+	Variant resolution.UnionVariant
+}
+
+// ResolveUnionVariant attempts to resolve an identifier-based default value as a
+// union variant. It uses the field's type reference to find the union type, then
+// matches the identifier against the union's variants.
+//
+// The identifier is the bare variant name (`= built_in`), optionally namespace
+// qualified (`= ni.built_in`), or the generated UnionName-prefixed form
+// (`= CJCBuiltIn`), mirroring ResolveEnumVariant.
+func ResolveUnionVariant(
+	identValue string,
+	typeRef resolution.TypeRef,
+	table *resolution.Table,
+) (UnionVariant, bool) {
+	resolved, ok := typeRef.Resolve(table)
+	if !ok {
+		return UnionVariant{}, false
+	}
+	unionForm, ok := resolved.Form.(resolution.UnionForm)
+	if !ok {
+		return UnionVariant{}, false
+	}
+
+	memberName := identValue
+	if idx := strings.LastIndex(identValue, "."); idx >= 0 {
+		memberName = identValue[idx+1:]
+	}
+
+	if variant, ok := unionForm.Variant(memberName); ok {
+		return UnionVariant{Type: resolved, Union: unionForm, Variant: variant}, true
+	}
+
+	// Fallback: the generated UnionName-prefixed form, e.g. `= CJCBuiltIn` for
+	// union CJC variant `built_in`. Underscores collapse when PascalCasing, so
+	// compare with them stripped.
+	variantPascal := strings.TrimPrefix(memberName, resolved.Name)
+	if variantPascal == memberName {
+		return UnionVariant{}, false
+	}
+	target := strings.ToLower(variantPascal)
+	for _, v := range unionForm.Variants {
+		if strings.ToLower(strings.ReplaceAll(v.Name, "_", "")) == target {
+			return UnionVariant{Type: resolved, Union: unionForm, Variant: v}, true
+		}
+	}
+
+	return UnionVariant{}, false
+}

--- a/oracle/domain/validation/union_test.go
+++ b/oracle/domain/validation/union_test.go
@@ -1,0 +1,82 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+package validation_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/synnaxlabs/oracle/domain/validation"
+	"github.com/synnaxlabs/oracle/resolution"
+	. "github.com/synnaxlabs/x/testutil"
+)
+
+var _ = Describe("ResolveUnionVariant", func() {
+	var (
+		table    *resolution.Table
+		unionRef = resolution.TypeRef{Name: "test.CJC"}
+	)
+
+	BeforeEach(func() {
+		table = resolution.NewTable()
+		Expect(table.Add(resolution.Type{
+			Name:          "CJC",
+			Namespace:     "test",
+			QualifiedName: "test.CJC",
+			Form: resolution.UnionForm{
+				Discriminator: "source",
+				Variants: []resolution.UnionVariant{
+					{
+						Name: "built_in",
+						Type: resolution.TypeRef{Name: "test.CJCBuiltIn"},
+					},
+					{
+						Name: "const_val",
+						Type: resolution.TypeRef{Name: "test.CJCConstVal"},
+					},
+				},
+			},
+		})).To(Succeed())
+		Expect(table.Add(resolution.Type{
+			Name:          "Mode",
+			Namespace:     "test",
+			QualifiedName: "test.Mode",
+			Form: resolution.EnumForm{
+				Values: []resolution.EnumValue{{Name: "fast", Value: "Fast"}},
+			},
+		})).To(Succeed())
+	})
+
+	DescribeTable(
+		"Should resolve an identifier naming one of the union's variants",
+		func(ident, expected string) {
+			uv := MustBeOk(validation.ResolveUnionVariant(ident, unionRef, table))
+			Expect(uv.Variant.Name).To(Equal(expected))
+			Expect(uv.Union.Discriminator).To(Equal("source"))
+			Expect(uv.Type.QualifiedName).To(Equal("test.CJC"))
+		},
+		Entry("bare variant name", "built_in", "built_in"),
+		Entry("namespace qualified", "test.built_in", "built_in"),
+		Entry("union-name prefixed", "CJCBuiltIn", "built_in"),
+		Entry("union-name prefixed, multi-word", "CJCConstVal", "const_val"),
+	)
+
+	DescribeTable(
+		"Should not resolve an identifier that names no variant",
+		func(ident string, ref resolution.TypeRef) {
+			_, ok := validation.ResolveUnionVariant(ident, ref, table)
+			Expect(ok).To(BeFalse())
+		},
+		Entry("unknown variant", "chan", unionRef),
+		Entry("prefix without a variant", "CJCMissing", unionRef),
+		Entry("enum type, not a union", "fast", resolution.TypeRef{Name: "test.Mode"}),
+		Entry("unresolvable type", "built_in", resolution.TypeRef{Name: "test.Absent"}),
+		Entry("primitive type", "built_in", resolution.TypeRef{Name: "string"}),
+	)
+})

--- a/oracle/plugin/cpp/json/json.go
+++ b/oracle/plugin/cpp/json/json.go
@@ -835,18 +835,12 @@ func (p *Plugin) parseExprForField(
 	}
 	if hasDefault {
 		if defaultVal := jsonDefaultLiteral(field, data.table); defaultVal != "" {
-			// Telem time types have explicit integer constructors, so bare
-			// numeric defaults must be wrapped to bind as the fallback value.
-			if field.Default != nil &&
-				(field.Default.Kind == resolution.ValueKindInt ||
-					field.Default.Kind == resolution.ValueKindFloat) {
-				if strings.Contains(cppType, "::telem::TimeStamp") {
-					defaultVal = fmt.Sprintf("x::telem::TimeStamp(%s)", defaultVal)
-				} else if strings.Contains(cppType, "::telem::TimeSpan") {
-					defaultVal = fmt.Sprintf("x::telem::TimeSpan(%s)", defaultVal)
-				} else if strings.Contains(cppType, "::telem::Rate") {
-					defaultVal = fmt.Sprintf("x::telem::Rate(%s)", defaultVal)
-				}
+			// Hand-written distinct types such as x::telem::Rate and
+			// x::telem::DataType expose only explicit constructors, so a bare
+			// literal fails to bind as the fallback value.
+			if isScalarDefault(field.Default) &&
+				resolution.IsDistinct(field.Type, data.table) {
+				defaultVal = fmt.Sprintf("%s(%s)", cppType, defaultVal)
 			}
 			return fmt.Sprintf(
 				`parser.field<%s>("%s", %s)`,
@@ -1116,6 +1110,21 @@ func hasRenderableDefault(field resolution.Field, table *resolution.Table) bool 
 		return true
 	}
 	return jsonDefaultLiteral(field, table) != ""
+}
+
+// isScalarDefault reports whether the default renders as a bare string, integer,
+// or float literal, the three kinds a distinct type's constructor must wrap.
+func isScalarDefault(val *resolution.ExpressionValue) bool {
+	if val == nil {
+		return false
+	}
+	switch val.Kind {
+	case resolution.ValueKindString,
+		resolution.ValueKindInt,
+		resolution.ValueKindFloat:
+		return true
+	}
+	return false
 }
 
 // jsonDefaultLiteral renders a field's schema default as a C++ literal usable as

--- a/oracle/plugin/cpp/json/json.go
+++ b/oracle/plugin/cpp/json/json.go
@@ -774,7 +774,7 @@ func (p *Plugin) parseExprForField(
 					fallback = fmt.Sprintf(
 						"%s{%s{}}",
 						cppType,
-						cppnaming.VariantTypeName(cppType, uv.Variant.Name),
+						cppnaming.QualifiedVariantTypeName(cppType, uv.Variant.Name),
 					)
 				}
 				return fmt.Sprintf(

--- a/oracle/plugin/cpp/json/json.go
+++ b/oracle/plugin/cpp/json/json.go
@@ -1100,8 +1100,8 @@ func (p *Plugin) toJSONExprForField(
 
 // hasRenderableDefault reports whether the field declares a default the parse
 // expression can honor. Struct and array defaults count (their branches render
-// them); identifier defaults count only when they resolve to an enum variant or
-// boolean literal, so sentinels like create do not relax a required field.
+// them); identifier defaults count only when they resolve to an enum variant, a
+// boolean literal, or the create sentinel on a UUID field.
 func hasRenderableDefault(field resolution.Field, table *resolution.Table) bool {
 	if field.Default == nil {
 		return false
@@ -1161,7 +1161,13 @@ func jsonDefaultLiteral(field resolution.Field, table *resolution.Table) string 
 		if v.IdentValue == "true" || v.IdentValue == "false" {
 			return v.IdentValue
 		}
-		// Unresolvable idents (magic defaults like create/now) have no C++
+		// The create sentinel mints a fresh UUID on parse, matching the TS
+		// (uuid.create) and Python (uuid4) generators.
+		if v.IdentValue == "create" &&
+			resolution.PrimitiveBase(field.Type, table) == "uuid" {
+			return "x::uuid::create()"
+		}
+		// Other unresolvable idents (magic defaults like now) have no C++
 		// rendering; the field stays required.
 		return ""
 	}

--- a/oracle/plugin/cpp/json/json.go
+++ b/oracle/plugin/cpp/json/json.go
@@ -18,6 +18,7 @@ import (
 	"github.com/synnaxlabs/oracle/domain/validation"
 	"github.com/synnaxlabs/oracle/plugin"
 	"github.com/synnaxlabs/oracle/plugin/cpp/keywords"
+	cppnaming "github.com/synnaxlabs/oracle/plugin/cpp/naming"
 	cppprimitives "github.com/synnaxlabs/oracle/plugin/cpp/primitives"
 	"github.com/synnaxlabs/oracle/plugin/domain"
 	"github.com/synnaxlabs/oracle/plugin/framework"
@@ -762,9 +763,23 @@ func (p *Plugin) parseExprForField(
 				)
 			}
 			if hasDefault {
+				// std::variant default-constructs its first alternative, so a
+				// default naming any other variant must be written out.
+				fallback := cppType + "{}"
+				if uv, ok := validation.ResolveUnionVariant(
+					defaultIdent(field),
+					field.Type,
+					data.table,
+				); ok {
+					fallback = fmt.Sprintf(
+						"%s{%s{}}",
+						cppType,
+						cppnaming.VariantTypeName(cppType, uv.Variant.Name),
+					)
+				}
 				return fmt.Sprintf(
-					`parser.has("%s") ? %s(parser.child("%s")) : %s{}`,
-					jsonName, parseFn, jsonName, cppType,
+					`parser.has("%s") ? %s(parser.child("%s")) : %s`,
+					jsonName, parseFn, jsonName, fallback,
 				)
 			}
 			return fmt.Sprintf(`%s(parser.child("%s"))`, parseFn, jsonName)
@@ -1112,6 +1127,15 @@ func hasRenderableDefault(field resolution.Field, table *resolution.Table) bool 
 	return jsonDefaultLiteral(field, table) != ""
 }
 
+// defaultIdent returns the field's identifier default, or "" when it has no
+// default or the default is not an identifier.
+func defaultIdent(field resolution.Field) string {
+	if field.Default == nil || field.Default.Kind != resolution.ValueKindIdent {
+		return ""
+	}
+	return field.Default.IdentValue
+}
+
 // isScalarDefault reports whether the default renders as a bare string, integer,
 // or float literal, the three kinds a distinct type's constructor must wrap.
 func isScalarDefault(val *resolution.ExpressionValue) bool {
@@ -1166,6 +1190,15 @@ func jsonDefaultLiteral(field resolution.Field, table *resolution.Table) string 
 		if v.IdentValue == "create" &&
 			resolution.PrimitiveBase(field.Type, table) == "uuid" {
 			return "x::uuid::create()"
+		}
+		// A union default renders in the union parse branch, not as a
+		// parser.field fallback, so report it renderable without a literal here.
+		if _, ok := validation.ResolveUnionVariant(
+			v.IdentValue,
+			field.Type,
+			table,
+		); ok {
+			return "{}"
 		}
 		// Other unresolvable idents (magic defaults like now) have no C++
 		// rendering; the field stays required.

--- a/oracle/plugin/cpp/json/json.go
+++ b/oracle/plugin/cpp/json/json.go
@@ -493,11 +493,19 @@ func (p *Plugin) typeRefToCpp(typeRef resolution.TypeRef, data *templateData) st
 		targetOutputPath := output.GetPath(resolved, "cpp")
 		if targetOutputPath != "" {
 			var includePath string
-			if p.isFixedSizeUint8ArrayType(resolved) {
-				headerName := lo.SnakeCase(resolved.Name)
-				includePath = fmt.Sprintf("%s/%s.h", targetOutputPath, headerName)
-			} else {
-				includePath = data.jsonInclude(targetOutputPath)
+			if cppDomain, ok := resolved.Domains["cpp"]; ok {
+				if expr, found := cppDomain.Expressions.Find("include"); found &&
+					len(expr.Values) > 0 {
+					includePath = expr.Values[0].StringValue
+				}
+			}
+			if includePath == "" {
+				if p.isFixedSizeUint8ArrayType(resolved) {
+					headerName := lo.SnakeCase(resolved.Name)
+					includePath = fmt.Sprintf("%s/%s.h", targetOutputPath, headerName)
+				} else {
+					includePath = data.jsonInclude(targetOutputPath)
+				}
 			}
 			data.includes.addInternal(includePath)
 			ns := deriveNamespace(targetOutputPath)

--- a/oracle/plugin/cpp/json/json_test.go
+++ b/oracle/plugin/cpp/json/json_test.go
@@ -1412,6 +1412,25 @@ var _ = Describe("C++ JSON Union Generation", func() {
 				`.name = parser.field<std::string>("name", ""),`,
 			)
 	})
+
+	It("Should mint a UUID for create-defaulted uuid fields", func(ctx SpecContext) {
+		source := `
+			@cpp output "out"
+
+			Key = uuid
+
+			Record struct {
+				key    uuid = create
+				parent Key = create
+			}
+		`
+		resp := MustGenerate(ctx, source, "config", loader, jsonPlugin)
+		ExpectContent(resp, "json.gen.h").
+			ToContain(
+				`.key = parser.field<x::uuid::UUID>("key", x::uuid::create()),`,
+				`.parent = parser.field<Key>("parent", x::uuid::create()),`,
+			)
+	})
 })
 
 var _ = Describe("C++ JSON Union Array Fields", func() {

--- a/oracle/plugin/cpp/json/json_test.go
+++ b/oracle/plugin/cpp/json/json_test.go
@@ -811,6 +811,34 @@ var _ = Describe("C++ JSON Plugin", func() {
 						ToNotContain(`#include "client/cpp/node/json.gen.h"`)
 				},
 			)
+
+			It(
+				"Should include the header declared by @cpp include on a reference",
+				func(ctx SpecContext) {
+					loader.Add("schemas/node", `
+					@cpp output "client/cpp/node"
+
+					Key uint32 {
+						@cpp include "client/cpp/node/key.h"
+					}
+				`)
+
+					source := `
+					import "schemas/node"
+
+					@cpp output "client/cpp/channel"
+
+					Channel struct {
+						leaseholder node.Key
+					}
+				`
+					resp := MustGenerate(ctx, source, "channel", loader, jsonPlugin)
+
+					ExpectContent(resp, "channel/json.gen.h").
+						ToContain(`#include "client/cpp/node/key.h"`).
+						ToNotContain(`#include "client/cpp/node/types.gen.h"`)
+				},
+			)
 		})
 
 		Context("cross-namespace union references", func() {

--- a/oracle/plugin/cpp/json/json_test.go
+++ b/oracle/plugin/cpp/json/json_test.go
@@ -1176,6 +1176,30 @@ var _ = Describe("C++ JSON Union Generation", func() {
 	)
 
 	It(
+		"Should fall back to the defaulted variant when the field is absent",
+		func(ctx SpecContext) {
+			source := `
+			@cpp output "out"
+
+			LinearScale struct { slope float64 = 1 }
+			NoneScale struct {}
+
+			Scale union on type {
+				linear LinearScale
+				none NoneScale
+			}
+
+			Item struct { scale Scale = none }
+		`
+			resp := MustGenerate(ctx, source, "ni", loader, jsonPlugin)
+			ExpectContent(resp, "json.gen.h").ToContain(
+				`parser.has("scale") ? parse_scale(parser.child("scale")) ` +
+					`: Scale{ScaleNone{}}`,
+			)
+		},
+	)
+
+	It(
 		"Should parse inline variant fields directly on the variant struct",
 		func(ctx SpecContext) {
 			source := `

--- a/oracle/plugin/cpp/json/json_test.go
+++ b/oracle/plugin/cpp/json/json_test.go
@@ -590,8 +590,72 @@ var _ = Describe("C++ JSON Plugin", func() {
 					resp := MustGenerate(ctx, source, "config", loader, jsonPlugin)
 					ExpectContent(resp, "out/json.gen.h").
 						ToContain(
-							`parser.field<::x::telem::Rate>("stream_rate", x::telem::Rate(5))`,
-							`parser.field<::x::telem::TimeSpan>("duration", x::telem::TimeSpan(0))`,
+							`parser.field<::x::telem::Rate>("stream_rate", ::x::telem::Rate(5))`,
+							`parser.field<::x::telem::TimeSpan>("duration", ::x::telem::TimeSpan(0))`,
+						)
+				},
+			)
+
+			It(
+				"Should wrap distinct string defaults in their constructors",
+				func(ctx SpecContext) {
+					loader.Add("schemas/telem", `
+					@cpp output "x/cpp/telem"
+
+					DataType string {
+						@cpp hand
+					}
+				`)
+					source := `
+					import "schemas/telem"
+
+					@cpp output "out"
+
+					Config struct {
+						data_type telem.DataType = "float32"
+						label     string = "dflt"
+					}
+				`
+					resp := MustGenerate(ctx, source, "config", loader, jsonPlugin)
+					ExpectContent(resp, "out/json.gen.h").
+						ToContain(
+							`parser.field<::x::telem::DataType>("data_type", ::x::telem::DataType("float32"))`,
+							`parser.field<std::string>("label", "dflt")`,
+						)
+				},
+			)
+
+			It(
+				"Should wrap distinct numeric defaults in their constructors",
+				func(ctx SpecContext) {
+					loader.Add("schemas/telem", `
+					@cpp output "x/cpp/telem"
+
+					Size int64 {
+						@cpp hand
+					}
+
+					Alignment uint64 {
+						@cpp hand
+					}
+				`)
+					source := `
+					import "schemas/telem"
+
+					@cpp output "out"
+
+					Config struct {
+						threshold telem.Size = 1024
+						start     telem.Alignment = 0
+						count     int32 = 7
+					}
+				`
+					resp := MustGenerate(ctx, source, "config", loader, jsonPlugin)
+					ExpectContent(resp, "out/json.gen.h").
+						ToContain(
+							`parser.field<::x::telem::Size>("threshold", ::x::telem::Size(1024))`,
+							`parser.field<::x::telem::Alignment>("start", ::x::telem::Alignment(0))`,
+							`parser.field<std::int32_t>("count", 7)`,
 						)
 				},
 			)
@@ -1303,7 +1367,7 @@ var _ = Describe("C++ JSON Union Generation", func() {
 		`
 			resp := MustGenerate(ctx, source, "config", loader, jsonPlugin)
 			ExpectContent(resp, "json.gen.h").
-				ToContain(`.device = parser.field<Key>("device", ""),`)
+				ToContain(`.device = parser.field<Key>("device", Key("")),`)
 		},
 	)
 
@@ -1328,7 +1392,7 @@ var _ = Describe("C++ JSON Union Generation", func() {
 		`
 			resp := MustGenerate(ctx, source, "config", loader, jsonPlugin)
 			ExpectContent(resp, "out/json.gen.h").
-				ToContain(`.duration = parser.field<::x::telem::TimeSpan>("duration", x::telem::TimeSpan(0)),`)
+				ToContain(`.duration = parser.field<::x::telem::TimeSpan>("duration", ::x::telem::TimeSpan(0)),`)
 		},
 	)
 

--- a/oracle/plugin/cpp/naming/naming.go
+++ b/oracle/plugin/cpp/naming/naming.go
@@ -22,3 +22,9 @@ import "github.com/synnaxlabs/oracle/plugin/internal/casing"
 func VariantTypeName(unionCppName, variantValue string) string {
 	return casing.VariantTypeName(unionCppName, variantValue)
 }
+
+// QualifiedVariantTypeName is VariantTypeName for a union name that may carry a
+// C++ namespace qualifier (e.g. "::ni::AIChannel").
+func QualifiedVariantTypeName(unionCppName, variantValue string) string {
+	return casing.QualifiedVariantTypeName(unionCppName, variantValue, "::")
+}

--- a/oracle/plugin/cpp/types/types.go
+++ b/oracle/plugin/cpp/types/types.go
@@ -24,6 +24,7 @@ import (
 	"github.com/synnaxlabs/oracle/domain/validation"
 	"github.com/synnaxlabs/oracle/plugin"
 	"github.com/synnaxlabs/oracle/plugin/cpp/keywords"
+	cppnaming "github.com/synnaxlabs/oracle/plugin/cpp/naming"
 	cppprimitives "github.com/synnaxlabs/oracle/plugin/cpp/primitives"
 	"github.com/synnaxlabs/oracle/plugin/domain"
 	"github.com/synnaxlabs/oracle/plugin/enum"
@@ -919,6 +920,18 @@ func (p *Plugin) cppDefaultLiteral(
 		if val.IdentValue == "now" &&
 			strings.Contains(p.typeRefToCpp(typeRef, data), "::telem::TimeStamp") {
 			return "x::telem::TimeStamp::now()"
+		}
+		if uv, ok := validation.ResolveUnionVariant(
+			val.IdentValue,
+			typeRef,
+			data.table,
+		); ok {
+			// std::variant default-constructs its first alternative, so a default
+			// naming any other variant must be written out explicitly.
+			return cppnaming.VariantTypeName(
+				p.typeRefToCpp(typeRef, data),
+				uv.Variant.Name,
+			) + "{}"
 		}
 		// Unresolvable idents (magic defaults like create) have no C++
 		// rendering; the caller falls back to the type's zero value.

--- a/oracle/plugin/cpp/types/types.go
+++ b/oracle/plugin/cpp/types/types.go
@@ -594,7 +594,10 @@ func (p *Plugin) aliasTargetToCpp(
 				name = fmt.Sprintf("::%s::%s", resolved.Namespace, name)
 			}
 		} else {
-			includePath := fmt.Sprintf("%s/%s", targetOutputPath, "types.gen.h")
+			includePath := cppInclude
+			if includePath == "" {
+				includePath = fmt.Sprintf("%s/%s", targetOutputPath, "types.gen.h")
+			}
 			data.includes.addInternal(includePath)
 			ns := deriveNamespace(targetOutputPath)
 			name = fmt.Sprintf("::%s::%s", ns, name)
@@ -1174,6 +1177,21 @@ func (p *Plugin) resolveEnumType(
 	return name
 }
 
+// explicitInclude returns the header declared via `@cpp include` on the type,
+// letting a type override the default <output>/types.gen.h include (e.g. to break
+// a header cycle with a small hand-written header).
+func explicitInclude(resolved resolution.Type) string {
+	cppDomain, ok := resolved.Domains["cpp"]
+	if !ok {
+		return ""
+	}
+	expr, found := cppDomain.Expressions.Find("include")
+	if !found || len(expr.Values) == 0 {
+		return ""
+	}
+	return expr.Values[0].StringValue
+}
+
 func (p *Plugin) resolveDistinctType(
 	resolved resolution.Type,
 	data *templateData,
@@ -1183,7 +1201,10 @@ func (p *Plugin) resolveDistinctType(
 	if resolved.Namespace != data.rawNs {
 		targetOutputPath := output.GetPath(resolved, "cpp")
 		if targetOutputPath != "" {
-			includePath := fmt.Sprintf("%s/%s", targetOutputPath, "types.gen.h")
+			includePath := explicitInclude(resolved)
+			if includePath == "" {
+				includePath = fmt.Sprintf("%s/%s", targetOutputPath, "types.gen.h")
+			}
 			data.includes.addInternal(includePath)
 		}
 		ns := deriveNamespace(targetOutputPath)
@@ -1201,7 +1222,10 @@ func (p *Plugin) resolveAliasType(
 	if resolved.Namespace != data.rawNs {
 		targetOutputPath := output.GetPath(resolved, "cpp")
 		if targetOutputPath != "" {
-			includePath := fmt.Sprintf("%s/%s", targetOutputPath, "types.gen.h")
+			includePath := explicitInclude(resolved)
+			if includePath == "" {
+				includePath = fmt.Sprintf("%s/%s", targetOutputPath, "types.gen.h")
+			}
 			data.includes.addInternal(includePath)
 			ns := deriveNamespace(targetOutputPath)
 			name = fmt.Sprintf("::%s::%s", ns, name)
@@ -1265,9 +1289,10 @@ func (p *Plugin) buildGenericType(
 // template params. Optional params (without explicit defaults) DO become template
 // params with implicit std::monostate default.
 //
-// This function returns true when: - The type has at least one type param without
-// explicit default (making it a C++ template) - All such params are optional (giving
-// them implicit defaults)
+// This function returns true when:
+//   - The type has at least one type param without explicit default (making it a C++
+//     template)
+//   - All such params are optional (giving them implicit defaults)
 func isCppTemplateWithAllDefaults(t resolution.Type) bool {
 	form, ok := t.Form.(resolution.StructForm)
 	if !ok {

--- a/oracle/plugin/cpp/types/types.go
+++ b/oracle/plugin/cpp/types/types.go
@@ -928,7 +928,7 @@ func (p *Plugin) cppDefaultLiteral(
 		); ok {
 			// std::variant default-constructs its first alternative, so a default
 			// naming any other variant must be written out explicitly.
-			return cppnaming.VariantTypeName(
+			return cppnaming.QualifiedVariantTypeName(
 				p.typeRefToCpp(typeRef, data),
 				uv.Variant.Name,
 			) + "{}"

--- a/oracle/plugin/cpp/types/types.go
+++ b/oracle/plugin/cpp/types/types.go
@@ -809,18 +809,21 @@ func cppDefaultValue(cppType, underlyingPrimitive string) string {
 	return ""
 }
 
-// wrapCppTelemNumeric wraps a bare numeric default literal in its telem scalar
-// class constructor when cppType is one of those classes. They expose only
-// explicit numeric constructors, so a bare literal fails copy-initialization
-// both as a struct member initializer and as the fallback argument to
-// parser.field.
-func wrapCppTelemNumeric(cppType, literal string) string {
-	for _, t := range []string{"TimeStamp", "TimeSpan", "Rate", "Size", "Alignment"} {
-		if strings.Contains(cppType, "::telem::"+t) {
-			return fmt.Sprintf("x::telem::%s(%s)", t, literal)
-		}
+// wrapCppDistinct direct-initializes a scalar default literal with its C++ type
+// when the field's type resolves to a distinct type. Hand-written distinct types
+// such as x::telem::Rate and x::telem::DataType expose only explicit
+// constructors, so a bare literal fails copy-initialization both as a struct
+// member initializer and as the fallback argument to parser.field. Generated
+// distinct types are scalar typedefs, where the direct-init is a no-op cast.
+func (p *Plugin) wrapCppDistinct(
+	typeRef resolution.TypeRef,
+	literal string,
+	data *templateData,
+) string {
+	if !resolution.IsDistinct(typeRef, data.table) {
+		return literal
 	}
-	return literal
+	return fmt.Sprintf("%s(%s)", p.typeRefToCpp(typeRef, data), literal)
 }
 
 func getUnderlyingPrimitive(
@@ -895,15 +898,11 @@ func (p *Plugin) cppDefaultLiteral(
 ) string {
 	switch val.Kind {
 	case resolution.ValueKindString:
-		return fmt.Sprintf("%q", val.StringValue)
+		return p.wrapCppDistinct(typeRef, fmt.Sprintf("%q", val.StringValue), data)
 	case resolution.ValueKindInt:
-		return wrapCppTelemNumeric(
-			p.typeRefToCpp(typeRef, data), fmt.Sprintf("%d", val.IntValue),
-		)
+		return p.wrapCppDistinct(typeRef, fmt.Sprintf("%d", val.IntValue), data)
 	case resolution.ValueKindFloat:
-		return wrapCppTelemNumeric(
-			p.typeRefToCpp(typeRef, data), fmt.Sprintf("%f", val.FloatValue),
-		)
+		return p.wrapCppDistinct(typeRef, fmt.Sprintf("%f", val.FloatValue), data)
 	case resolution.ValueKindBool:
 		return fmt.Sprintf("%t", val.BoolValue)
 	case resolution.ValueKindIdent:

--- a/oracle/plugin/cpp/types/types_test.go
+++ b/oracle/plugin/cpp/types/types_test.go
@@ -2164,6 +2164,30 @@ var _ = Describe("C++ Union Generation", func() {
 				ToContain(`Scale custom_scale;`)
 		},
 	)
+
+	It(
+		"Should initialize a union-typed field with its defaulted variant",
+		func(ctx SpecContext) {
+			source := `
+			@cpp output "out"
+
+			LinearScale struct { slope float64 = 1 }
+			NoneScale struct {}
+
+			Scale union on type {
+				linear LinearScale
+				none NoneScale
+			}
+
+			Channel struct {
+				customScale Scale = none
+			}
+		`
+			resp := MustGenerate(ctx, source, "ni", loader, cppPlugin)
+			ExpectContent(resp, "types.gen.h").
+				ToContain(`Scale custom_scale = ScaleNone{};`)
+		},
+	)
 })
 
 var _ = Describe("C++ Union Variant Doc Coverage", func() {

--- a/oracle/plugin/cpp/types/types_test.go
+++ b/oracle/plugin/cpp/types/types_test.go
@@ -1474,6 +1474,93 @@ var _ = Describe("C++ Types Plugin", func() {
 			)
 		})
 
+		Describe("Explicit @cpp include", func() {
+			It(
+				"Should include the declared header for a cross-namespace distinct type",
+				func(ctx SpecContext) {
+					loader.Add("schemas/rack", `
+					@cpp output "client/cpp/rack"
+
+					Key uint32 {
+						@cpp include "client/cpp/rack/key.h"
+					}
+				`)
+
+					source := `
+					import "schemas/rack"
+
+					@cpp output "client/cpp/task"
+
+					Task struct {
+						rack rack.Key
+					}
+				`
+					resp := MustGenerate(ctx, source, "task", loader, cppPlugin)
+
+					ExpectContent(resp, "types.gen.h").
+						ToContain(`#include "client/cpp/rack/key.h"`).
+						ToNotContain(`#include "client/cpp/rack/types.gen.h"`)
+				},
+			)
+
+			It(
+				"Should include the declared header for a cross-namespace alias",
+				func(ctx SpecContext) {
+					loader.Add("schemas/status", `
+					@cpp output "client/cpp/status"
+
+					Detail struct {
+						message string
+					}
+
+					Summary = Detail {
+						@cpp include "client/cpp/status/summary.h"
+					}
+				`)
+
+					source := `
+					import "schemas/status"
+
+					@cpp output "client/cpp/task"
+
+					Task struct {
+						summary status.Summary
+					}
+				`
+					resp := MustGenerate(ctx, source, "task", loader, cppPlugin)
+
+					ExpectContent(resp, "types.gen.h").
+						ToContain(`#include "client/cpp/status/summary.h"`).
+						ToNotContain(`#include "client/cpp/status/types.gen.h"`)
+				},
+			)
+
+			It(
+				"Should fall back to types.gen.h when no header is declared",
+				func(ctx SpecContext) {
+					loader.Add("schemas/rack", `
+					@cpp output "client/cpp/rack"
+
+					Key uint32
+				`)
+
+					source := `
+					import "schemas/rack"
+
+					@cpp output "client/cpp/task"
+
+					Task struct {
+						rack rack.Key
+					}
+				`
+					resp := MustGenerate(ctx, source, "task", loader, cppPlugin)
+
+					ExpectContent(resp, "types.gen.h").
+						ToContain(`#include "client/cpp/rack/types.gen.h"`)
+				},
+			)
+		})
+
 		Describe("Array Wrapper Generation", func() {
 			It(
 				"Should generate wrapper struct for array distinct types",

--- a/oracle/plugin/cpp/types/types_test.go
+++ b/oracle/plugin/cpp/types/types_test.go
@@ -1829,10 +1829,72 @@ var _ = Describe("C++ Types Plugin", func() {
 					resp := MustGenerate(ctx, source, "config", loader, cppPlugin)
 					ExpectContent(resp, "out/types.gen.h").
 						ToContain(
-							`duration = x::telem::TimeSpan(0);`,
-							`start = x::telem::TimeStamp(5);`,
-							`sample_rate = x::telem::Rate(10);`,
-							`stream_rate = x::telem::Rate(2.500000);`,
+							`duration = ::x::telem::TimeSpan(0);`,
+							`start = ::x::telem::TimeStamp(5);`,
+							`sample_rate = ::x::telem::Rate(10);`,
+							`stream_rate = ::x::telem::Rate(2.500000);`,
+						)
+				},
+			)
+
+			It(
+				"Should wrap string defaults in the distinct type's constructor",
+				func(ctx SpecContext) {
+					loader.Add("schemas/telem", `
+					@cpp output "x/cpp/telem"
+
+					DataType string {
+						@cpp hand
+					}
+				`)
+					source := `
+					import "schemas/telem"
+
+					@cpp output "out"
+
+					Config struct {
+						data_type telem.DataType = "float32"
+						label     string = "dflt"
+					}
+				`
+					resp := MustGenerate(ctx, source, "config", loader, cppPlugin)
+					ExpectContent(resp, "out/types.gen.h").
+						ToContain(
+							`data_type = ::x::telem::DataType("float32");`,
+							`std::string label = "dflt";`,
+						)
+				},
+			)
+
+			It(
+				"Should wrap numeric defaults on distinct types outside x::telem",
+				func(ctx SpecContext) {
+					loader.Add("schemas/units", `
+					@cpp output "x/cpp/units"
+
+					Voltage float64 {
+						@cpp hand
+					}
+
+					Count uint32 {
+						@cpp hand
+					}
+				`)
+					source := `
+					import "schemas/units"
+
+					@cpp output "out"
+
+					Config struct {
+						limit   units.Voltage = 5.5
+						retries units.Count = 3
+					}
+				`
+					resp := MustGenerate(ctx, source, "config", loader, cppPlugin)
+					ExpectContent(resp, "out/types.gen.h").
+						ToContain(
+							`limit = ::x::units::Voltage(5.500000);`,
+							`retries = ::x::units::Count(3);`,
 						)
 				},
 			)

--- a/oracle/plugin/go/marshal/encoder.go
+++ b/oracle/plugin/go/marshal/encoder.go
@@ -985,7 +985,7 @@ func (b *encoderBuilder) processLeaf(
 				ind+fmt.Sprintf("w.String(string(%s))", valPath))
 			b.decodeLine(
 				ind + fmt.Sprintf(
-					"{ v, err := r.String(); if err != nil { return err }; %s = %s(v) }",
+					"{ rawV, err := r.String(); if err != nil { return err }; %s = %s(rawV) }",
 					setPath,
 					goTypeCast,
 				),
@@ -1135,7 +1135,7 @@ func (b *encoderBuilder) addIntLeaf(
 	if goTypeCast != "" {
 		b.decodeLine(
 			ind + fmt.Sprintf(
-				"{ v, err := r.%s(); if err != nil { return err }; %s = %s(v) }",
+				"{ rawV, err := r.%s(); if err != nil { return err }; %s = %s(rawV) }",
 				writerMethod,
 				setPath,
 				cast,

--- a/oracle/plugin/go/marshal/marshal_test.go
+++ b/oracle/plugin/go/marshal/marshal_test.go
@@ -165,7 +165,7 @@ var _ = Describe("Go Marshal Plugin", func() {
 					resp := MustGenerate(ctx, source, "test", loader, marshalPlugin)
 					content := ExpectContent(resp, "codec.gen.go")
 					content.ToContain("var hv TickType")
-					content.ToContain("hv = TickType(v)")
+					content.ToContain("hv = TickType(rawV)")
 					content.ToContain("a.Type = &hv")
 					content.ToNotContain("var v TickType")
 				},
@@ -198,7 +198,7 @@ var _ = Describe("Go Marshal Plugin", func() {
 					content := ExpectContent(resp, "codec.gen.go")
 					content.ToContain("var hv Level")
 					content.ToContain("iv.Level = &hv")
-					content.ToContain("hv = Level(v)")
+					content.ToContain("hv = Level(rawV)")
 					content.ToNotContain("var v Level")
 				},
 			)
@@ -361,7 +361,7 @@ var _ = Describe("Go Marshal Plugin", func() {
 					resp := MustGenerate(ctx, source, "test", loader, marshalPlugin)
 					content := ExpectContent(resp, "codec.gen.go")
 					content.ToContain("w.String(string(p.AxisKey))")
-					content.ToContain("p.AxisKey = AxisKey(v)")
+					content.ToContain("p.AxisKey = AxisKey(rawV)")
 				},
 			)
 		})

--- a/oracle/plugin/go/marshal/test_gen.go
+++ b/oracle/plugin/go/marshal/test_gen.go
@@ -585,7 +585,7 @@ func (b *testValueBuilder) isGoPointerField(ref resolution.TypeRef) bool {
 	case resolution.BuiltinGenericForm:
 		return form.Name != "Array" && form.Name != "Map"
 	case resolution.PrimitiveForm:
-		return form.Name != "record" && form.Name != "any"
+		return form.Name != "record"
 	}
 	return true
 }
@@ -902,7 +902,9 @@ func (b *testValueBuilder) primitiveExpr(typ resolution.Type) (string, error) {
 		}
 		base = fmt.Sprintf(`%s.EncodedJSON{"key_%d": "value_%d"}`, qualifier, idx, idx)
 	case "any":
-		base = fmt.Sprintf(`map[string]interface{}{"key_%d": "value_%d"}`, idx, idx)
+		// Wrap in any(...) so an optional field pointerizes to *any instead of
+		// *map[string]any.
+		base = fmt.Sprintf(`any(map[string]any{"key_%d": "value_%d"})`, idx, idx)
 	default:
 		return "", errors.Newf("unsupported primitive for test value: %s", primName)
 	}

--- a/oracle/plugin/go/query/query.go
+++ b/oracle/plugin/go/query/query.go
@@ -286,8 +286,7 @@ func extractRetrieveInfo(
 	r *resolver.Resolver,
 	ctx *resolver.Context,
 ) *retrieveInfo {
-	form, ok := typ.Form.(resolution.StructForm)
-	if !ok {
+	if _, ok := typ.Form.(resolution.StructForm); !ok {
 		return nil
 	}
 
@@ -310,9 +309,10 @@ func extractRetrieveInfo(
 		keyPrimitive = key.ResolvePrimitive(keyRef, table)
 	} else {
 		var keyField *resolution.Field
-		for i := range form.Fields {
-			if plugindomain.HasDomainFromField(form.Fields[i], "key") {
-				keyField = &form.Fields[i]
+		fields := resolution.UnifiedFields(typ, table)
+		for i := range fields {
+			if plugindomain.HasDomainFromField(fields[i], "key") {
+				keyField = &fields[i]
 				break
 			}
 		}

--- a/oracle/plugin/go/query/query_test.go
+++ b/oracle/plugin/go/query/query_test.go
@@ -87,6 +87,37 @@ var _ = Describe("Go Query Plugin", func() {
 			)
 		})
 
+		Context("inherited key", func() {
+			It(
+				"Should find the @key field on a base struct",
+				func(ctx SpecContext) {
+					source := `
+					@go output "core/pkg/service/foo"
+
+					Base struct {
+						key uuid {
+							@key
+						}
+					}
+
+					Foo struct extends Base {
+						name string
+						@ontology type "foo"
+						@retrieve
+					}
+				`
+					resp := MustGenerate(ctx, source, "foo", loader, p)
+					Expect(resp.Files).To(HaveLen(1))
+
+					ExpectContent(resp, "retrieve.gen.go").
+						ToContain(
+							"gorp.Retrieve[uuid.UUID, Foo]",
+							"func MatchKeys(keys ...uuid.UUID) Filter",
+						)
+				},
+			)
+		})
+
 		Context("search", func() {
 			It(
 				"Should generate search methods with ontology type inferred from @ontology",

--- a/oracle/plugin/go/types/defaults.go
+++ b/oracle/plugin/go/types/defaults.go
@@ -148,7 +148,11 @@ func scalarFill(
 			return defaultFillData{
 				GoName:  goName + ".Variant",
 				ZeroLit: "nil",
-				Expr:    casing.VariantTypeName(unionType, uv.Variant.Name) + "{}",
+				Expr: casing.QualifiedVariantTypeName(
+					unionType,
+					uv.Variant.Name,
+					".",
+				) + "{}",
 			}, true
 		}
 		ev, ok := validation.ResolveEnumVariant(d.IdentValue, typeRef, data.table)

--- a/oracle/plugin/go/types/defaults.go
+++ b/oracle/plugin/go/types/defaults.go
@@ -137,6 +137,20 @@ func scalarFill(
 			Expr:    strconv.FormatFloat(d.FloatValue, 'g', -1, 64),
 		}, true
 	case resolution.ValueKindIdent:
+		if uv, ok := validation.ResolveUnionVariant(
+			d.IdentValue,
+			typeRef,
+			data.table,
+		); ok {
+			// The wrapper holds the active variant behind a nil-able interface, so
+			// the fill targets that field rather than the wrapper itself.
+			unionType := stripPointer(data.resolver.ResolveTypeRef(typeRef, data.ctx))
+			return defaultFillData{
+				GoName:  goName + ".Variant",
+				ZeroLit: "nil",
+				Expr:    casing.VariantTypeName(unionType, uv.Variant.Name) + "{}",
+			}, true
+		}
 		ev, ok := validation.ResolveEnumVariant(d.IdentValue, typeRef, data.table)
 		if !ok {
 			return defaultFillData{}, false

--- a/oracle/plugin/go/types/defaults_test.go
+++ b/oracle/plugin/go/types/defaults_test.go
@@ -715,4 +715,31 @@ var _ = Describe("ApplyDefaults and Validate generation", func() {
 			},
 		)
 	})
+
+	Describe("Union-typed field defaults", func() {
+		const source = `
+			@go output "core/pkg/service/x"
+
+			CJC union on source {
+				built_in {}
+				const_val {
+					val float64 = 0
+				}
+			}
+
+			Item struct { cjc CJC = const_val }
+		`
+
+		It(
+			"Should fill the nil variant with the defaulted one",
+			func(ctx SpecContext) {
+				resp := MustGenerate(ctx, source, "x", loader, goPlugin)
+				ExpectContent(resp, "types.gen.go").ToContain(
+					"func (i *Item) ApplyDefaults() {",
+					"if i.Cjc.Variant == nil {",
+					"i.Cjc.Variant = CJCConstVal{}",
+				)
+			},
+		)
+	})
 })

--- a/oracle/plugin/go/types/defaults_test.go
+++ b/oracle/plugin/go/types/defaults_test.go
@@ -10,7 +10,10 @@
 package types_test
 
 import (
+	"strings"
+
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/synnaxlabs/oracle/plugin/go/types"
 	. "github.com/synnaxlabs/oracle/testutil"
 )
@@ -739,6 +742,35 @@ var _ = Describe("ApplyDefaults and Validate generation", func() {
 					"if i.Cjc.Variant == nil {",
 					"i.Cjc.Variant = CJCConstVal{}",
 				)
+			},
+		)
+
+		It(
+			"Should recurse into the filled variant so its own defaults land",
+			func(ctx SpecContext) {
+				withVariantDefault := `
+					@go output "core/pkg/service/x"
+
+					CJC union on source {
+						built_in {}
+						const_val {
+							val float64 = 25
+						}
+					}
+
+					Item struct { cjc CJC = const_val }
+				`
+				resp := MustGenerate(ctx, withVariantDefault, "x", loader, goPlugin)
+				content := MustContentOf(resp, "types.gen.go")
+				ExpectContent(resp, "types.gen.go").ToContain(
+					"func (c *CJCConstVal) ApplyDefaults() {",
+					"c.Val = 25",
+					"i.Cjc.ApplyDefaults()",
+				)
+				// The fill must precede the recursion: a nil variant has no
+				// ApplyDefaults to dispatch to.
+				Expect(strings.Index(content, "i.Cjc.Variant = CJCConstVal{}")).
+					To(BeNumerically("<", strings.Index(content, "i.Cjc.ApplyDefaults()")))
 			},
 		)
 	})

--- a/oracle/plugin/go/types/defaults_test.go
+++ b/oracle/plugin/go/types/defaults_test.go
@@ -658,4 +658,61 @@ var _ = Describe("ApplyDefaults and Validate generation", func() {
 			},
 		)
 	})
+
+	Describe("Inline union variants with own defaults", func() {
+		const source = `
+			@go output "core/pkg/service/x"
+
+			Kind enum { number = "number" text = "text" }
+
+			Field union on type {
+				static {
+					kind Kind = KindNumber
+					name string {
+						@validate min_length 2
+					}
+				}
+				generated {}
+			}
+
+			Container struct { fields Field[] }
+		`
+
+		It(
+			"Should fill and validate inline fields on the variant",
+			func(ctx SpecContext) {
+				resp := MustGenerate(ctx, source, "x", loader, goPlugin)
+				ExpectContent(resp, "types.gen.go").ToContain(
+					"func (f *FieldStatic) ApplyDefaults() {",
+					"f.Kind = KindNumber",
+					"func (f FieldStatic) Validate() error {",
+					"!f.Kind.IsValid()",
+				)
+			},
+		)
+
+		It(
+			"Should emit constraint checks for inline variant fields",
+			func(ctx SpecContext) {
+				resp := MustGenerate(ctx, source, "x", loader, goPlugin)
+				ExpectContent(resp, "types.gen.go").ToContain(
+					`v.Ternaryf("name", len(f.Name) < 2, ` +
+						`"must be at least 2 characters long")`,
+				)
+			},
+		)
+
+		It(
+			"Should dispatch the wrapper methods the container recurses into",
+			func(ctx SpecContext) {
+				resp := MustGenerate(ctx, source, "x", loader, goPlugin)
+				ExpectContent(resp, "types.gen.go").ToContain(
+					"func (u *Field) ApplyDefaults() {",
+					"func (u Field) Validate() error {",
+					"func (c *Container) ApplyDefaults() {",
+					"c.Fields[i].ApplyDefaults()",
+				)
+			},
+		)
+	})
 })

--- a/oracle/plugin/go/types/types.go
+++ b/oracle/plugin/go/types/types.go
@@ -1396,6 +1396,11 @@ func ({{.TypeName}}) {{$u.Marker}}() {}
 
 // ApplyDefaults fills zero-valued fields with their schema-declared defaults.
 func ({{$vt.Receiver}} *{{$vt.TypeName}}) ApplyDefaults() {
+{{- range $vt.DefaultFills}}
+	if {{$vt.Receiver}}.{{.GoName}} == {{.ZeroLit}} {
+		{{$vt.Receiver}}.{{.GoName}} = {{.Expr}}
+	}
+{{- end}}
 {{- range $vt.DefaultRecurse}}
 {{- if eq (printf "%s" .Kind) "value"}}
 	{{$vt.Receiver}}.{{.GoName}}.ApplyDefaults()
@@ -1422,6 +1427,24 @@ func ({{$vt.Receiver}} *{{$vt.TypeName}}) ApplyDefaults() {
 // schema constraints.
 func ({{$vt.Receiver}} {{$vt.TypeName}}) Validate() error {
 	v := validate.New("{{$vt.TypeName}}")
+{{- range $vt.EnumChecks}}
+	v.Ternaryf("{{.FieldName}}", !{{$vt.Receiver}}.{{.GoName}}.IsValid(), "invalid {{.FieldName}}: %v", {{$vt.Receiver}}.{{.GoName}})
+{{- end}}
+{{- range $vt.ConstraintChecks}}
+{{- if eq .Kind "non_empty_string"}}
+	validate.NotEmptyString(v, "{{.FieldName}}", {{$vt.Receiver}}.{{.GoName}})
+{{- else if eq .Kind "non_zero"}}
+	validate.NonZero(v, "{{.FieldName}}", {{$vt.Receiver}}.{{.GoName}})
+{{- else if eq .Kind "min_len"}}
+	v.Ternaryf("{{.FieldName}}", len({{$vt.Receiver}}.{{.GoName}}) < {{.Arg}}, "must be at least {{.Arg}} characters long")
+{{- else if eq .Kind "max_len"}}
+	v.Ternaryf("{{.FieldName}}", len({{$vt.Receiver}}.{{.GoName}}) > {{.Arg}}, "must be at most {{.Arg}} characters long")
+{{- else if eq .Kind "ge"}}
+	validate.GreaterThanEq(v, "{{.FieldName}}", {{$vt.Receiver}}.{{.GoName}}, {{.Arg}})
+{{- else if eq .Kind "le"}}
+	validate.LessThanEq(v, "{{.FieldName}}", {{$vt.Receiver}}.{{.GoName}}, {{.Arg}})
+{{- end}}
+{{- end}}
 {{- range $vt.ValidateRecurse}}
 {{- if eq (printf "%s" .Kind) "value"}}
 {{- if .JSONName}}

--- a/oracle/plugin/go/types/union.go
+++ b/oracle/plugin/go/types/union.go
@@ -75,6 +75,11 @@ type unionVariantData struct {
 	// so they take no Validate path segment.
 	DefaultRecurse  []recurseStepData
 	ValidateRecurse []recurseStepData
+	// DefaultFills, EnumChecks, and ConstraintChecks are the variant's own inline
+	// fields' fills and assertions, mirroring the struct-level equivalents.
+	DefaultFills     []defaultFillData
+	EnumChecks       []enumCheckData
+	ConstraintChecks []constraintCheckData
 	// NeedsApplyDefaults and NeedsValidate report whether the variant emits the
 	// respective method.
 	NeedsApplyDefaults bool
@@ -140,6 +145,18 @@ func processUnion(entry resolution.Type, data *templateData) unionData {
 				inlineFields = pform.Fields
 				for _, f := range pform.Fields {
 					vd.Fields = append(vd.Fields, processField(f, data))
+					vd.DefaultFills = append(
+						vd.DefaultFills,
+						goDefaultFills(f, data)...)
+					if validateSkip(f, data) {
+						continue
+					}
+					if chk, ok := goEnumCheck(f, data); ok {
+						vd.EnumChecks = append(vd.EnumChecks, chk)
+					}
+					vd.ConstraintChecks = append(
+						vd.ConstraintChecks,
+						goConstraintChecks(f, data)...)
 				}
 			}
 		} else {
@@ -168,8 +185,10 @@ func processUnion(entry resolution.Type, data *templateData) unionData {
 			validateHasOwn,
 			validateSkip,
 		)
-		vd.NeedsApplyDefaults = len(vd.DefaultRecurse) > 0
-		vd.NeedsValidate = len(vd.ValidateRecurse) > 0
+		vd.NeedsApplyDefaults = len(vd.DefaultRecurse) > 0 ||
+			len(vd.DefaultFills) > 0
+		vd.NeedsValidate = len(vd.ValidateRecurse) > 0 ||
+			len(vd.EnumChecks) > 0 || len(vd.ConstraintChecks) > 0
 		if vd.NeedsApplyDefaults {
 			ud.NeedsApplyDefaults = true
 		}

--- a/oracle/plugin/internal/casing/casing.go
+++ b/oracle/plugin/internal/casing/casing.go
@@ -116,6 +116,20 @@ func VariantTypeName(unionName, variantValue string) string {
 	return unionName + variant
 }
 
+// QualifiedVariantTypeName is VariantTypeName for a union name that may carry a
+// language qualifier (Go "ni.AIChannel", C++ "::ni::AIChannel"). The acronym rules
+// read the leading characters of the name, so they must see the bare name: applying
+// them to a qualified one silently skips the collapse and yields a variant name that
+// disagrees with the union's own declaration. sep is the qualifier separator.
+func QualifiedVariantTypeName(unionName, variantValue, sep string) string {
+	idx := strings.LastIndex(unionName, sep)
+	if idx < 0 {
+		return VariantTypeName(unionName, variantValue)
+	}
+	split := idx + len(sep)
+	return unionName[:split] + VariantTypeName(unionName[split:], variantValue)
+}
+
 // leadingAcronym returns the run of leading uppercase letters of s that form an
 // acronym, excluding the final uppercase letter when it begins the next
 // PascalCase word ("AIChannel" -> "AI", "RTDConfig" -> "RTD", "Scale" -> "").

--- a/oracle/plugin/internal/casing/casing_test.go
+++ b/oracle/plugin/internal/casing/casing_test.go
@@ -176,3 +176,49 @@ var _ = Describe("VariantTypeName", func() {
 		),
 	)
 })
+
+var _ = Describe("QualifiedVariantTypeName", func() {
+	DescribeTable(
+		"should apply the acronym rules to the bare name and keep the qualifier",
+		func(union, variant, sep, expected string) {
+			Expect(
+				casing.QualifiedVariantTypeName(union, variant, sep),
+			).To(Equal(expected))
+		},
+		Entry(
+			"unqualified go name",
+			"AIChannel",
+			"ai_voltage",
+			".",
+			"AIVoltageChannel",
+		),
+		Entry(
+			"qualified go name still factors the acronym",
+			"ni.AIChannel",
+			"ai_voltage",
+			".",
+			"ni.AIVoltageChannel",
+		),
+		Entry(
+			"qualified cpp name still factors the acronym",
+			"::ni::AIChannel",
+			"ai_voltage",
+			"::",
+			"::ni::AIVoltageChannel",
+		),
+		Entry(
+			"qualified plain union keeps the union prefix",
+			"ni.Scale",
+			"linear",
+			".",
+			"ni.ScaleLinear",
+		),
+		Entry(
+			"cpp name with a leading separator only",
+			"::Scale",
+			"linear",
+			"::",
+			"::ScaleLinear",
+		),
+	)
+})

--- a/oracle/plugin/py/types/types.go
+++ b/oracle/plugin/py/types/types.go
@@ -1070,15 +1070,29 @@ func collectValidation(
 				)
 			}
 		case resolution.ValueKindFloat:
-			constraints = append(
-				constraints,
-				fmt.Sprintf("default=%f", defaultVal.FloatValue),
-			)
+			if wrapper := resolveDistinctWrapper(typeRef, table, data); wrapper != "" {
+				constraints = append(
+					constraints,
+					fmt.Sprintf("default=%s(%f)", wrapper, defaultVal.FloatValue),
+				)
+			} else {
+				constraints = append(
+					constraints,
+					fmt.Sprintf("default=%f", defaultVal.FloatValue),
+				)
+			}
 		case resolution.ValueKindString:
-			constraints = append(
-				constraints,
-				fmt.Sprintf("default=%q", defaultVal.StringValue),
-			)
+			if wrapper := resolveDistinctWrapper(typeRef, table, data); wrapper != "" {
+				constraints = append(
+					constraints,
+					fmt.Sprintf("default=%s(%q)", wrapper, defaultVal.StringValue),
+				)
+			} else {
+				constraints = append(
+					constraints,
+					fmt.Sprintf("default=%q", defaultVal.StringValue),
+				)
+			}
 		case resolution.ValueKindIdent:
 			// Handle identifier-based defaults like "now" for timestamps
 			if defaultVal.IdentValue == "now" && isTimeStampType(typeRef, table) {

--- a/oracle/plugin/py/types/types.go
+++ b/oracle/plugin/py/types/types.go
@@ -1134,7 +1134,7 @@ func collectValidation(
 				// passed explicitly.
 				constraints = append(constraints, fmt.Sprintf(
 					"default_factory=lambda: %s(%s=%q)",
-					casing.VariantTypeName(getPyName(uv.Type), uv.Variant.Name),
+					unionVariantToPython(uv, table, data),
 					keywords.Escape(uv.Union.Discriminator),
 					uv.Variant.Name,
 				))
@@ -1331,6 +1331,24 @@ func enumVariantToPython(
 		variantRef = fmt.Sprintf("%s.%s", qualifiedEnum, ev.Variant.Name)
 	}
 	return variantRef
+}
+
+// unionVariantToPython renders the variant class a union default names, qualified
+// with its module alias when the union is declared in another schema.
+func unionVariantToPython(
+	uv validation.UnionVariant,
+	table *resolution.Table,
+	data *templateData,
+) string {
+	variantName := casing.VariantTypeName(getPyName(uv.Type), uv.Variant.Name)
+	if uv.Type.Namespace == data.Namespace {
+		return variantName
+	}
+	outputPath := enum.FindOutputPath(uv.Type, table, "py")
+	if outputPath == "" {
+		outputPath = uv.Type.Namespace
+	}
+	return addCrossNamespaceImport(toPythonModulePath(outputPath), variantName, data)
 }
 
 // isUUIDType checks if a type reference is or resolves to the uuid primitive type.

--- a/oracle/plugin/py/types/types.go
+++ b/oracle/plugin/py/types/types.go
@@ -26,6 +26,7 @@ import (
 	"github.com/synnaxlabs/oracle/plugin/domain"
 	"github.com/synnaxlabs/oracle/plugin/enum"
 	"github.com/synnaxlabs/oracle/plugin/framework"
+	"github.com/synnaxlabs/oracle/plugin/internal/casing"
 	"github.com/synnaxlabs/oracle/plugin/output"
 	"github.com/synnaxlabs/oracle/plugin/py/keywords"
 	pyprimitives "github.com/synnaxlabs/oracle/plugin/py/primitives"
@@ -1122,6 +1123,21 @@ func collectValidation(
 			); ok {
 				variantRef := enumVariantToPython(ev, table, data)
 				constraints = append(constraints, fmt.Sprintf("default=%s", variantRef))
+			}
+			if uv, ok := validation.ResolveUnionVariant(
+				defaultVal.IdentValue,
+				typeRef,
+				table,
+			); ok {
+				// Models are mutable, so the variant needs default_factory. The
+				// discriminator Literal carries no default of its own and must be
+				// passed explicitly.
+				constraints = append(constraints, fmt.Sprintf(
+					"default_factory=lambda: %s(%s=%q)",
+					casing.VariantTypeName(getPyName(uv.Type), uv.Variant.Name),
+					keywords.Escape(uv.Union.Discriminator),
+					uv.Variant.Name,
+				))
 			}
 		case resolution.ValueKindArray:
 			// Lists are mutable, so they must use default_factory, never default=.

--- a/oracle/plugin/py/types/types_test.go
+++ b/oracle/plugin/py/types/types_test.go
@@ -694,6 +694,44 @@ var _ = Describe("Python Types Plugin", func() {
 		)
 
 		It(
+			"Should wrap float defaults in distinct type constructor",
+			func(ctx SpecContext) {
+				source := `
+				@py output "out"
+
+				Rate float64
+
+				Config struct {
+					rate Rate = 0.2
+				}
+			`
+				resp := MustGenerate(ctx, source, "config", loader, typesPlugin)
+				content := MustContentOf(resp, "types_gen.py")
+				Expect(content).To(ContainSubstring(`rate: Rate = Rate(0.200000)`))
+			},
+		)
+
+		It(
+			"Should wrap string defaults in distinct type constructor",
+			func(ctx SpecContext) {
+				source := `
+				@py output "out"
+
+				DataType string
+
+				Config struct {
+					data_type DataType = "float32"
+				}
+			`
+				resp := MustGenerate(ctx, source, "config", loader, typesPlugin)
+				content := MustContentOf(resp, "types_gen.py")
+				Expect(content).To(ContainSubstring(
+					`data_type: DataType = DataType("float32")`,
+				))
+			},
+		)
+
+		It(
 			"Should wrap int defaults in cross-namespace distinct type constructor",
 			func(ctx SpecContext) {
 				loader.Add("schemas/telem", `

--- a/oracle/plugin/py/types/types_test.go
+++ b/oracle/plugin/py/types/types_test.go
@@ -825,6 +825,37 @@ var _ = Describe("Python Types Plugin", func() {
 		)
 
 		It(
+			"Should qualify a union default whose union lives in another module",
+			func(ctx SpecContext) {
+				loader.Add("schemas/common", `
+				@py output "client/py/synnax/common"
+
+				Scale union on type {
+					none {}
+					linear {
+						slope float64 = 1
+					}
+				}
+			`)
+				source := `
+				import "schemas/common"
+
+				@py output "client/py/synnax/ni"
+
+				Channel struct {
+					scale common.Scale = none
+				}
+			`
+				resp := MustGenerate(ctx, source, "ni", loader, typesPlugin)
+				content := MustContentOf(resp, "types_gen.py")
+				Expect(content).To(ContainSubstring(`from synnax import common`))
+				Expect(content).To(ContainSubstring(
+					`default_factory=lambda: common.ScaleNone(type="none")`,
+				))
+			},
+		)
+
+		It(
 			"Should inline parent fields when child makes required fields optional",
 			func(ctx SpecContext) {
 				source := `

--- a/oracle/plugin/py/types/types_test.go
+++ b/oracle/plugin/py/types/types_test.go
@@ -2134,6 +2134,19 @@ var _ = Describe("Python Union Field & Variant Coverage", func() {
 			).ToContain("scales: list[Scale] = Field(default_factory=list)")
 		},
 	)
+
+	It(
+		"Should default a union-typed field to a factory constructing the variant",
+		func(ctx SpecContext) {
+			withDefault := source + `
+			Item struct { scale Scale = none }
+		`
+			resp := MustGenerate(ctx, withDefault, "ni", loader, typesPlugin)
+			ExpectContent(resp, "types_gen.py").ToContain(
+				`default_factory=lambda: ScaleNone(type="none")`,
+			)
+		},
+	)
 })
 
 var _ = Describe("Collection type aliases and maps", func() {

--- a/oracle/plugin/ts/types/typedef_test.go
+++ b/oracle/plugin/ts/types/typedef_test.go
@@ -77,6 +77,33 @@ var _ = Describe("Type Definition Generation", func() {
 		)
 	})
 
+	Describe("Union field defaults", func() {
+		It(
+			"Should prefault a union-typed field with its variant discriminator",
+			func(ctx SpecContext) {
+				source := `
+				@ts output "out"
+
+				CJC union on source {
+					built_in {}
+					const_val {
+						val float64 = 0
+					}
+				}
+
+				Item struct {
+					cjc CJC = const_val
+				}
+			`
+				resp := MustGenerate(ctx, source, "cjc", loader, p)
+				content := MustContentOf(resp, "types.gen.ts")
+				Expect(content).To(ContainSubstring(
+					`prefault({ source: "const_val" })`,
+				))
+			},
+		)
+	})
+
 	Describe("Aliased array types", func() {
 		It(
 			"Should render an array alias as a defaulted z.array",

--- a/oracle/plugin/ts/types/typedef_test.go
+++ b/oracle/plugin/ts/types/typedef_test.go
@@ -94,4 +94,31 @@ var _ = Describe("Type Definition Generation", func() {
 			},
 		)
 	})
+
+	Describe("Alias schema type annotations", func() {
+		It(
+			"Should annotate an alias-typed field with typeof on the alias schema",
+			func(ctx SpecContext) {
+				source := `
+				@ts output "out"
+
+				Inner struct {
+					value string
+				}
+
+				Aliased = Inner
+
+				Details struct<Data? = record> {
+					thing Aliased
+					data  Data?
+
+					@ts concrete_types
+				}
+			`
+				resp := MustGenerate(ctx, source, "details", loader, p)
+				content := MustContentOf(resp, "types.gen.ts")
+				Expect(content).To(ContainSubstring("thing: typeof aliasedZ;"))
+			},
+		)
+	})
 })

--- a/oracle/plugin/ts/types/types.go
+++ b/oracle/plugin/ts/types/types.go
@@ -2501,6 +2501,9 @@ func (p *Plugin) typeRefToZodSchemaType(
 	case resolution.DistinctForm:
 		return fmt.Sprintf("typeof %s%sZ", prefix, camelCase(tsName))
 
+	case resolution.AliasForm:
+		return fmt.Sprintf("typeof %s%sZ", prefix, camelCase(tsName))
+
 	case resolution.UnionForm:
 		// A union schema's inferred type depends on every variant schema, so a
 		// `typeof xZ` annotation in a getter would re-enter the inference cycle the

--- a/oracle/plugin/ts/types/types.go
+++ b/oracle/plugin/ts/types/types.go
@@ -2735,6 +2735,21 @@ func (p *Plugin) applyValidation(
 					p.enumVariantToTS(ev, data),
 				)
 			}
+			if uv, ok := validation.ResolveUnionVariant(
+				defaultVal.IdentValue,
+				typeRef,
+				table,
+			); ok {
+				// .prefault re-parses the discriminator literal, so the variant's own
+				// field defaults fill in rather than being demanded of the caller.
+				zodType = fmt.Sprintf(
+					"%s.prefault({ %s: %q })",
+					zodType,
+					fieldCamel(uv.Union.Discriminator),
+					uv.Variant.Name,
+				)
+				isPrefault = true
+			}
 		case resolution.ValueKindArray:
 			zodType = fmt.Sprintf(
 				"%s.default(%s)",

--- a/oracle/resolution/type.go
+++ b/oracle/resolution/type.go
@@ -229,6 +229,20 @@ func (r TypeRef) MustResolve(table *Table) Type {
 	return table.MustGet(r.Name)
 }
 
+// IsDistinct reports whether ref resolves to a distinct type. Primitives and
+// references the table cannot resolve are not distinct.
+func IsDistinct(ref TypeRef, table *Table) bool {
+	if IsPrimitive(ref.Name) {
+		return false
+	}
+	resolved, ok := ref.Resolve(table)
+	if !ok {
+		return false
+	}
+	_, isDistinct := resolved.Form.(DistinctForm)
+	return isDistinct
+}
+
 // RefersTo reports whether ref directly or transitively references a type
 // identified by targetQualifiedName. The search follows type arguments, struct
 // field types and extends bases, union bases and variant payloads, alias

--- a/x/go/crdt/versions/v0/codec.gen.go
+++ b/x/go/crdt/versions/v0/codec.gen.go
@@ -75,11 +75,11 @@ func (iv *Insert) DecodeOrc(r *orc.Reader) error {
 		return err
 	}
 	{
-		v, err := r.String()
+		rawV, err := r.String()
 		if err != nil {
 			return err
 		}
-		iv.Side = spatial.XLocation(v)
+		iv.Side = spatial.XLocation(rawV)
 	}
 	if iv.Char, err = r.Int32(); err != nil {
 		return err

--- a/x/go/spatial/versions/v0/codec.gen.go
+++ b/x/go/spatial/versions/v0/codec.gen.go
@@ -42,18 +42,18 @@ func (cl CornerLocation) EncodeOrc(w *orc.Writer) error {
 // DecodeOrc reads the value from r in the Orc binary format.
 func (cl *CornerLocation) DecodeOrc(r *orc.Reader) error {
 	{
-		v, err := r.String()
+		rawV, err := r.String()
 		if err != nil {
 			return err
 		}
-		cl.X = XLocation(v)
+		cl.X = XLocation(rawV)
 	}
 	{
-		v, err := r.String()
+		rawV, err := r.String()
 		if err != nil {
 			return err
 		}
-		cl.Y = YLocation(v)
+		cl.Y = YLocation(rawV)
 	}
 	return nil
 }
@@ -68,18 +68,18 @@ func (su StickyUnits) EncodeOrc(w *orc.Writer) error {
 // DecodeOrc reads the value from r in the Orc binary format.
 func (su *StickyUnits) DecodeOrc(r *orc.Reader) error {
 	{
-		v, err := r.String()
+		rawV, err := r.String()
 		if err != nil {
 			return err
 		}
-		su.X = StickyUnit(v)
+		su.X = StickyUnit(rawV)
 	}
 	{
-		v, err := r.String()
+		rawV, err := r.String()
 		if err != nil {
 			return err
 		}
-		su.Y = StickyUnit(v)
+		su.Y = StickyUnit(rawV)
 	}
 	return nil
 }

--- a/x/go/telem/versions/v0/codec.gen.go
+++ b/x/go/telem/versions/v0/codec.gen.go
@@ -23,18 +23,18 @@ func (tr TimeRange) EncodeOrc(w *orc.Writer) error {
 // DecodeOrc reads the value from r in the Orc binary format.
 func (tr *TimeRange) DecodeOrc(r *orc.Reader) error {
 	{
-		v, err := r.Int64()
+		rawV, err := r.Int64()
 		if err != nil {
 			return err
 		}
-		tr.Start = TimeStamp(v)
+		tr.Start = TimeStamp(rawV)
 	}
 	{
-		v, err := r.Int64()
+		rawV, err := r.Int64()
 		if err != nil {
 			return err
 		}
-		tr.End = TimeStamp(v)
+		tr.End = TimeStamp(rawV)
 	}
 	return nil
 }


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4571](https://linear.app/synnax/issue/SY-4571/consolidate-oracle-generator-changes-onto-rc-and-add-union-field)

## Description

Oracle generator changes were spread across four PRs in the SY-4299 task-typing stack,
the deepest of them eleven merges below rc. Generator code belongs on rc. This pulls all
of it into one Oracle-only PR and adds union-field defaults on top.

**Extracted, one commit per source PR.** #2603 (C++ and TS codegen fixes), #2668
(distinct-type default wrapping), #2669 (Go union variant defaults and validation),
#2671 (UUID create sentinel and query key lookup). The resulting `oracle/` tree matches
the stack's final state byte for byte, so once rc backmerges down the stack the changes
drop out of those four diffs on their own.

**Union-field defaults.** A field of a union type can now declare a variant as its
default, which is what `cjc CJC = built_in` and `custom_scale Scale = none` need.
TypeScript prefaults the discriminator so the variant's own field defaults still fill,
Python builds the variant through a factory, Go fills the nil variant in
`ApplyDefaults`, and C++ writes both the member initializer and the JSON parse fallback.
`std::variant` default-constructs its first alternative, so C++ is the one language
where a non-first variant has to be written out explicitly.

Two analyzer rules keep the feature from failing quietly. Each plugin resolves an
identifier default through its own fall-through branch, so an identifier naming nothing
generates nothing, in every language, with no diagnostic; that is now an error. A union
default naming a variant with a required undefaulted field is also an error, because
TypeScript and Python construct the value eagerly and would throw.

Regeneration ships here: the marshal decoder rename and the C++ distinct-default
wrapping churn 29 generated files repo-wide. `oracle check` passes all five gates.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR consolidates Oracle generator updates and adds cross-language defaults for union fields.
- Adds analyzer validation for unresolved and non-constructible defaults.
- Generates union defaults for Go, TypeScript, Python, and C++.
- Regenerates affected Go and C++ outputs.
- Fixes imported acronym variant naming by applying variant rules to the unqualified type name.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| oracle/plugin/go/types/defaults.go | Union defaults now use qualified variant naming that preserves the package and correctly factors leading acronyms. |
| oracle/plugin/internal/casing/casing.go | The new helper separates qualifiers before deriving variant names, which resolves the previously reported mismatch. |
| oracle/plugin/internal/casing/casing_test.go | Focused tests cover imported acronym unions, plain unions, and C++ qualified names. |
| oracle/analyzer/invariant.go | New analyzer checks reject unresolved identifier defaults and union variants that cannot be constructed. |

<sub>Reviews (2): Last reviewed commit: ["Qualify union-default variant names corr..."](https://github.com/synnaxlabs/synnax/commit/0f344832d038bf596a6cad592feaf60649d485ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52444300)</sub>

**Context used:**

- Knowledge Base — [Oracle Codegen](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/oracle-codegen.md)

<!-- /greptile_comment -->