### PR TITLE
SY-4577: Order undo staleness with a counter, not the clock

### DIFF
--- a/client/ts/src/actions/controller.spec.ts
+++ b/client/ts/src/actions/controller.spec.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { sleep, TimeSpan, TimeStamp } from "@synnaxlabs/x";
+import { sleep, TimeSpan } from "@synnaxlabs/x";
 import { describe, expect, it, vi } from "vitest";
 import z from "zod";
 
@@ -340,8 +340,8 @@ describe("actions.Controller", () => {
         [{ type: "set", key: "b", value: 0 }],
         ["b"],
       );
-      // Mark "b" as remote-touched at a future ts → top entry is stale.
-      controller.markRemoteTouched("k", ["b"], TimeStamp.now().add(TimeSpan.SECOND));
+      // Mark "b" as remote-touched after its entry → top entry is stale.
+      controller.markRemoteTouched("k", ["b"]);
       const r = controller.prepareUndo("k");
       // Walks past the stale "b" entry and returns "a"'s inverse.
       expect(r?.actions).toEqual([{ type: "set", key: "a", value: 0 }]);
@@ -356,7 +356,7 @@ describe("actions.Controller", () => {
         [{ type: "set", key: "a", value: 0 }],
         ["a"],
       );
-      controller.markRemoteTouched("k", ["a"], TimeStamp.now().add(TimeSpan.SECOND));
+      controller.markRemoteTouched("k", ["a"]);
       expect(controller.prepareUndo("k")).toBeNull();
       expect(controller.hasUndo("k")).toBe(false);
     });
@@ -364,15 +364,15 @@ describe("actions.Controller", () => {
     it("ignores a remote touch older than the entry", () => {
       const { docs, controller } = setupStore();
       prime(docs, "k", { a: 0 });
-      // Stamp a touch in the past first.
-      controller.markRemoteTouched("k", ["a"], TimeStamp.now().sub(TimeSpan.MINUTE));
+      // Record the touch before the entry exists.
+      controller.markRemoteTouched("k", ["a"]);
       controller.recordEntry(
         "k",
         [{ type: "set", key: "a", value: 1 }],
         [{ type: "set", key: "a", value: 0 }],
         ["a"],
       );
-      // Entry's ts is after the touch — it is not stale.
+      // The entry was pushed after the touch — it is not stale.
       expect(controller.prepareUndo("k")?.actions).toEqual([
         { type: "set", key: "a", value: 0 },
       ]);
@@ -422,8 +422,8 @@ describe("actions.Controller", () => {
       );
       controller.prepareUndo("k")?.commit();
       controller.prepareUndo("k")?.commit();
-      // Mark "a" as remote-touched at a future ts → top of redo is stale.
-      controller.markRemoteTouched("k", ["a"], TimeStamp.now().add(TimeSpan.SECOND));
+      // Mark "a" as remote-touched after its entry → top of redo is stale.
+      controller.markRemoteTouched("k", ["a"]);
       const r = controller.prepareRedo("k");
       // Walks past the stale "a" entry and returns "b"'s forward.
       expect(r?.actions).toEqual([{ type: "set", key: "b", value: 1 }]);
@@ -439,7 +439,7 @@ describe("actions.Controller", () => {
         ["a"],
       );
       controller.prepareUndo("k")?.commit();
-      controller.markRemoteTouched("k", ["a"], TimeStamp.now().add(TimeSpan.SECOND));
+      controller.markRemoteTouched("k", ["a"]);
       expect(controller.prepareRedo("k")).toBeNull();
       expect(controller.hasRedo("k")).toBe(false);
     });
@@ -447,7 +447,7 @@ describe("actions.Controller", () => {
     it("ignores a remote touch older than the redo entry", () => {
       const { docs, controller } = setupStore();
       prime(docs, "k", { a: 0 });
-      controller.markRemoteTouched("k", ["a"], TimeStamp.now().sub(TimeSpan.MINUTE));
+      controller.markRemoteTouched("k", ["a"]);
       controller.recordEntry(
         "k",
         [{ type: "set", key: "a", value: 1 }],
@@ -606,8 +606,6 @@ describe("actions.Controller", () => {
         [{ type: "set", key: "a", value: 0 }],
         ["a"],
       );
-      // Force a strictly-after timestamp on the remote stamp.
-      await sleep.sleep(TimeSpan.milliseconds(2));
       controller.applyRemote("k", 1, "foreign-1", [
         { type: "set", key: "a", value: 99 },
       ]);
@@ -709,7 +707,6 @@ describe("actions.Controller", () => {
         [{ type: "set", key: "a", value: 0 }],
         ["a"],
       );
-      await sleep.sleep(TimeSpan.milliseconds(2));
       controller.registerOutstandingDispatch("k", "own-1");
       controller.applyRemote("k", 1, "own-1", [{ type: "set", key: "a", value: 1 }]);
       // The local undo entry survives because the echo was own.
@@ -759,19 +756,21 @@ describe("actions.Controller", () => {
       expect(controller.hasUndo("k")).toBe(false);
     });
 
-    it("uses the supplied timestamp", () => {
+    it("orders touches against entries by call order, not the clock", () => {
       const { docs, controller } = setupStore();
       prime(docs, "k", { a: 0 });
-      const ts = TimeStamp.now();
+      // Touch, then entry, with no delay between them: the entry is live.
+      controller.markRemoteTouched("k", ["a"]);
       controller.recordEntry(
         "k",
         [{ type: "set", key: "a", value: 1 }],
         [{ type: "set", key: "a", value: 0 }],
         ["a"],
       );
-      // Stamp at a ts before the entry → entry survives.
-      controller.markRemoteTouched("k", ["a"], ts.sub(TimeSpan.SECOND));
       expect(controller.prepareUndo("k")).not.toBeNull();
+      // Touch again immediately after: the entry is stale.
+      controller.markRemoteTouched("k", ["a"]);
+      expect(controller.prepareUndo("k")).toBeNull();
     });
   });
 

--- a/client/ts/src/actions/controller.spec.ts
+++ b/client/ts/src/actions/controller.spec.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { sleep, TimeSpan } from "@synnaxlabs/x";
+import { TimeSpan, TimeStamp } from "@synnaxlabs/x";
 import { describe, expect, it, vi } from "vitest";
 import z from "zod";
 
@@ -48,6 +48,17 @@ const frameZ = z.object({
   actions: z.array(z.any()),
 }) as unknown as z.ZodType<Frame<string, Action>>;
 
+/** A manually advanced clock, so coalesce-window tests need no real sleeps. */
+const createFakeClock = () => {
+  let current = TimeStamp.now();
+  return {
+    now: () => current,
+    advance: (span: TimeSpan) => {
+      current = current.add(span);
+    },
+  };
+};
+
 const setupStore = (
   opts: Partial<{
     isUndoable: (a: Action) => boolean;
@@ -55,6 +66,7 @@ const setupStore = (
     coalesceWindow: TimeSpan;
     stackCap: number;
     preprocess: (s: Doc, acts: Action[]) => Action[];
+    now: () => TimeStamp;
   }> = {},
 ) => {
   const errors: Error[] = [];
@@ -70,6 +82,7 @@ const setupStore = (
     coalesceWindow: opts.coalesceWindow,
     stackCap: opts.stackCap,
     preprocess: opts.preprocess,
+    now: opts.now,
   });
   return { errors, docs, controller };
 };
@@ -254,14 +267,16 @@ describe("actions.Controller", () => {
       expect(controller.hasUndo("k")).toBe(false);
     });
 
-    it("does not merge when the prior entry is older than the window", async () => {
+    it("does not merge when the prior entry is older than the window", () => {
+      const clock = createFakeClock();
       const { docs, controller } = setupStore({
         coalesceWindow: TimeSpan.NANOSECOND,
+        now: clock.now,
       });
       prime(docs, "k", { a: 0 });
       push(controller, "k", "a", 1, "move");
-      // Force the next entry's TimeStamp.now() to be after the 1ns window.
-      await sleep.sleep(TimeSpan.milliseconds(2));
+      // Move the next entry's stamp past the 1ns window.
+      clock.advance(TimeSpan.milliseconds(2));
       push(controller, "k", "a", 2, "move");
       controller.prepareUndo("k")?.commit();
       expect(controller.hasUndo("k")).toBe(true);
@@ -284,16 +299,18 @@ describe("actions.Controller", () => {
       });
     });
 
-    it("trims to stackCap by dropping the oldest", async () => {
+    it("trims to stackCap by dropping the oldest", () => {
+      const clock = createFakeClock();
       const { docs, controller } = setupStore({
         coalesceWindow: TimeSpan.NANOSECOND,
         stackCap: 2,
+        now: clock.now,
       });
       prime(docs, "k", { a: 0 });
       push(controller, "k", "a", 1, "k1");
-      await sleep.sleep(TimeSpan.milliseconds(2));
+      clock.advance(TimeSpan.milliseconds(2));
       push(controller, "k", "a", 2, "k2");
-      await sleep.sleep(TimeSpan.milliseconds(2));
+      clock.advance(TimeSpan.milliseconds(2));
       push(controller, "k", "a", 3, "k3");
       controller.prepareUndo("k")?.commit();
       controller.prepareUndo("k")?.commit();

--- a/client/ts/src/actions/controller.spec.ts
+++ b/client/ts/src/actions/controller.spec.ts
@@ -299,6 +299,18 @@ describe("actions.Controller", () => {
       });
     });
 
+    it("marks a merged entry stale when a remote touch lands mid-merge", () => {
+      const { docs, controller } = setupStore({ coalesceWindow: TimeSpan.SECOND });
+      prime(docs, "k", { a: 0 });
+      push(controller, "k", "a", 1, "move");
+      controller.markRemoteTouched("k", ["a"]);
+      push(controller, "k", "a", 2, "move");
+      // Undoing the merged entry would restore "a" to 0, wiping the remote
+      // edit that landed between the two pushes.
+      expect(controller.prepareUndo("k")).toBeNull();
+      expect(controller.hasUndo("k")).toBe(false);
+    });
+
     it("trims to stackCap by dropping the oldest", () => {
       const clock = createFakeClock();
       const { docs, controller } = setupStore({

--- a/client/ts/src/actions/controller.ts
+++ b/client/ts/src/actions/controller.ts
@@ -185,6 +185,8 @@ export interface ControllerParams<
   createOf?: (action: Action) => State | undefined;
   coalesceWindow?: TimeSpan;
   stackCap?: number;
+  /** Clock stamping entries for the coalesce window. Defaults to TimeStamp.now. */
+  now?: () => TimeStamp;
 }
 
 /**
@@ -231,6 +233,7 @@ export class Controller<Key extends record.Key, State extends query.Data, Action
       createOf: opts.createOf ?? (() => undefined),
       coalesceWindow: opts.coalesceWindow ?? DEFAULT_COALESCE_WINDOW,
       stackCap: opts.stackCap ?? DEFAULT_STACK_CAP,
+      now: opts.now ?? (() => TimeStamp.now()),
     };
     this.docs = opts.store;
     // Undo states are rebuilt objects on every update; comparing them would
@@ -303,7 +306,7 @@ export class Controller<Key extends record.Key, State extends query.Data, Action
       forward: undoableForward,
       inverse,
       kind: kindOverride ?? this.params.kindOf(forward),
-      ts: TimeStamp.now(),
+      ts: this.params.now(),
       tick: ++this.tick,
       targets,
     };

--- a/client/ts/src/actions/controller.ts
+++ b/client/ts/src/actions/controller.ts
@@ -31,7 +31,7 @@ export interface StackEntry<Action> {
   kind: string;
   /** Wall-clock push time, used only for coalescing. */
   ts: TimeStamp;
-  /** Controller tick at push, used to order the entry against remote touches. */
+  /** Tick of the earliest push, used to order the entry against remote touches. */
   tick: number;
   targets: readonly string[];
 }
@@ -61,7 +61,7 @@ const pushOnto = <A>(
           inverse: [...next.inverse, ...top.inverse],
           kind: next.kind,
           ts: next.ts,
-          tick: next.tick,
+          tick: top.tick,
           targets: top.targets,
         }
       : null;

--- a/client/ts/src/actions/controller.ts
+++ b/client/ts/src/actions/controller.ts
@@ -29,14 +29,17 @@ export interface StackEntry<Action> {
   forward: Action[];
   inverse: Action[];
   kind: string;
+  /** Wall-clock push time, used only for coalescing. */
   ts: TimeStamp;
+  /** Controller tick at push, used to order the entry against remote touches. */
+  tick: number;
   targets: readonly string[];
 }
 
 interface UndoState<Action> {
   undo: StackEntry<Action>[];
   redo: StackEntry<Action>[];
-  remoteTouched: Record<string, TimeStamp>;
+  remoteTouched: Record<string, number>;
 }
 
 const ZERO_UNDO = <A>(): UndoState<A> => ({ undo: [], redo: [], remoteTouched: {} });
@@ -58,6 +61,7 @@ const pushOnto = <A>(
           inverse: [...next.inverse, ...top.inverse],
           kind: next.kind,
           ts: next.ts,
+          tick: next.tick,
           targets: top.targets,
         }
       : null;
@@ -212,6 +216,10 @@ export class Controller<Key extends record.Key, State extends query.Data, Action
     Key,
     Map<string, { disturbed: boolean }>
   >();
+  // Monotonic counter ordering entry pushes against remote touches. Program
+  // order is the ground truth here; the wall clock ties within a millisecond
+  // and steps on sleep/wake or NTP resync, so it cannot be trusted for this.
+  private tick = 0;
 
   constructor(opts: ControllerParams<Key, State, Action>) {
     this.params = {
@@ -296,6 +304,7 @@ export class Controller<Key extends record.Key, State extends query.Data, Action
       inverse,
       kind: kindOverride ?? this.params.kindOf(forward),
       ts: TimeStamp.now(),
+      tick: ++this.tick,
       targets,
     };
     return this.updateUndo(key, (s) => ({
@@ -306,7 +315,7 @@ export class Controller<Key extends record.Key, State extends query.Data, Action
   }
 
   // Walks the chosen stack from the top, skipping entries whose targets were
-  // remote-touched after the entry's push ts. Caps the walk at
+  // remote-touched after the entry was pushed. Caps the walk at
   // STALE_AUTO_ADVANCE_CAP and drops a fully stale tail. On hit, returns the
   // entry's reversal actions (inverse for undo, forward for redo) and a
   // commit that moves the entry to the opposite stack.
@@ -319,7 +328,7 @@ export class Controller<Key extends record.Key, State extends query.Data, Action
     let idx = -1;
     for (let i = stack.length - 1; i >= 0; i--) {
       const e = stack[i];
-      if (e.targets.some((t) => state.remoteTouched[t]?.after(e.ts))) {
+      if (e.targets.some((t) => (state.remoteTouched[t] ?? 0) > e.tick)) {
         stale++;
         if (stale >= STALE_AUTO_ADVANCE_CAP) break;
       } else {
@@ -493,15 +502,12 @@ export class Controller<Key extends record.Key, State extends query.Data, Action
     };
   }
 
-  markRemoteTouched(
-    key: Key,
-    targets: readonly string[],
-    ts: TimeStamp = TimeStamp.now(),
-  ): destructor.Destructor {
+  markRemoteTouched(key: Key, targets: readonly string[]): destructor.Destructor {
     if (targets.length === 0) return destructor.NOOP;
+    const tick = ++this.tick;
     return this.updateUndo(key, (s) => {
       const remoteTouched = { ...s.remoteTouched };
-      for (const t of targets) remoteTouched[t] = ts;
+      for (const t of targets) remoteTouched[t] = tick;
       return { ...s, remoteTouched };
     });
   }

--- a/pluto/src/flux/dispatch.spec.ts
+++ b/pluto/src/flux/dispatch.spec.ts
@@ -9,7 +9,7 @@
 
 import { actions, query, schematic } from "@synnaxlabs/client";
 import { createTestClient } from "@synnaxlabs/client/testutil";
-import { array, TimeSpan, TimeStamp, uuid } from "@synnaxlabs/x";
+import { array, uuid } from "@synnaxlabs/x";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { describe, expect, it, type Mock, vi } from "vitest";
 
@@ -330,10 +330,10 @@ describe("Flux.createDispatch", () => {
         });
       });
       await waitFor(() => expect(result.current.undo.canUndo).toBe(true));
-      // Stamp n1 strictly after the entry's ts so the only entry is stale;
-      // undo should drop it without sending.
+      // Touch n1 after the entry so the only entry is stale; undo should
+      // drop it without sending.
       act(() => {
-        controller.markRemoteTouched(key, ["n1"], TimeStamp.now().add(TimeSpan.SECOND));
+        controller.markRemoteTouched(key, ["n1"]);
       });
       act(() => result.current.undo.undo());
       await waitFor(() => expect(result.current.undo.canUndo).toBe(false));
@@ -412,10 +412,10 @@ describe("Flux.createDispatch", () => {
       });
       act(() => result.current.undo.undo());
       await waitFor(() => expect(result.current.redo.canRedo).toBe(true));
-      // Stamp n1 strictly after the entry's ts so the only redo entry is
-      // stale; redo should drop it without sending.
+      // Touch n1 after the entry so the only redo entry is stale; redo
+      // should drop it without sending.
       act(() => {
-        controller.markRemoteTouched(key, ["n1"], TimeStamp.now().add(TimeSpan.SECOND));
+        controller.markRemoteTouched(key, ["n1"]);
       });
       const callsBefore = send.mock.calls.length;
       act(() => result.current.redo.redo());


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4577](https://linear.app/synnax/issue/SY-4577/use-a-monotonic-counter-instead-of-the-wall-clock-for-undo-staleness)

## Description

The action-dispatch controller decided whether an undo entry was stale by comparing wall-clock stamps with a strict `after`. `TimeStamp.now()` is `Date`-based: millisecond granularity, floored, non-monotonic. A local edit and a foreign frame landing in the same millisecond kept the entry live, so Cmd+Z could overwrite the newer remote change on every dispatch surface (schematics, tables, line plots, logs, Arc). A clock step (sleep/wake, NTP resync) either made undo overwrite arbitrarily newer remote edits or silently dropped live undo history.

Both stamps are always taken on the same thread, so staleness is pure program order. The controller now stamps entries and remote touches with a private monotonic counter and compares integers; ties and clock steps cannot occur. The wall-clock stamp stays on entries solely for coalescing, where human time is the right semantic. Undo state is session-local, so nothing stored or sent changes. `markRemoteTouched` loses its spec-only explicit timestamp parameter; the specs express ordering by call order and drop their 2 ms sleeps, which were also the source of a CI flake in `controller.spec.ts`.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces wall-clock undo-staleness ordering with a controller-local monotonic counter while retaining wall-clock timestamps for coalescing.
- Preserves the earliest tick when local entries coalesce.
- Orders remote touches and local entries by call order.
- Replaces sleep-based timing tests with deterministic clocks and ordering tests.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| client/ts/src/actions/controller.ts | Adds monotonic ordering and preserves the earliest tick across coalesced entries, which resolves the reported stale-undo path. |
| client/ts/src/actions/controller.spec.ts | Adds direct coverage for a remote touch during coalescing and removes timing-dependent sleeps. |
| pluto/src/flux/dispatch.spec.ts | Updates dispatch integration tests to express staleness through call order. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant L as Local edit
  participant C as Action controller
  participant R as Remote edit
  L->>C: Record entry at tick 1
  R->>C: Mark target touched at tick 2
  L->>C: Record coalesced edit at tick 3
  Note over C: Merged entry retains tick 1
  C->>C: "Compare remote tick 2 > entry tick 1"
  C-->>L: Reject stale undo
```

<sub>Reviews (2): Last reviewed commit: ["SY-4577: Keep the oldest tick when coale..."](https://github.com/synnaxlabs/synnax/commit/d935077e086e63fc38ce41cd325da31474733ca4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=52785929)</sub>

<!-- /greptile_comment -->