### PR TITLE
SY-4573: Doc Updates 2

### DIFF
--- a/docs/site/src/components/article/Article.astro
+++ b/docs/site/src/components/article/Article.astro
@@ -31,7 +31,11 @@ const visibleTitleLength = String(title ?? "").replace(/`/g, "").length;
 ---
 
 <article transition:animate="none">
-    {showBreadcrumb && url.split("/").length > 2 && <Breadcrumb url={url} />}
+    {
+        showBreadcrumb && url.split("/").length > 2 && (
+            <Breadcrumb url={url} title={title} />
+        )
+    }
     {
         published && (
             <div class="blog-meta">
@@ -76,12 +80,6 @@ const visibleTitleLength = String(title ?? "").replace(/`/g, "").length;
         .article-title {
             display: inline-block;
             width: fit-content;
-
-            & code {
-                background: none;
-                border: none;
-                padding: 0;
-            }
         }
 
         & .pluto-breadcrumb {

--- a/docs/site/src/components/article/Breadcrumb.tsx
+++ b/docs/site/src/components/article/Breadcrumb.tsx
@@ -10,8 +10,11 @@
 import { Breadcrumb as Base } from "@synnaxlabs/pluto";
 import { caseconv } from "@synnaxlabs/x";
 
+import { parseSegments } from "@/components/text/InlineCode";
+
 export interface BreadcrumbProps {
   url: string;
+  title?: string;
 }
 
 // not exactly best coding practices but is a quick fix for the breadcrumb
@@ -35,12 +38,29 @@ const breadcrumbOverrides: Record<string, string> = {
 const capitalize = (str: string): string =>
   breadcrumbOverrides[str] ?? caseconv.capitalize(str);
 
-export const Breadcrumb = ({ url }: BreadcrumbProps) => (
-  <Base.Breadcrumb level="small" highlightVariant="last">
-    {Base.mapURLSegments(url.slice(1), ({ segment, href, index }) => (
-      <Base.Segment href={`/${href}`} key={index}>
-        {segment.split("-").map(capitalize).join(" ")}
-      </Base.Segment>
-    ))}
-  </Base.Breadcrumb>
-);
+// The URL slug drops the casing of a code title, so a fully backticked title supplies
+// the text of the last segment itself.
+const codeTitle = (title?: string): string | null => {
+  const segments = parseSegments(title);
+  if (segments.length !== 1 || !segments[0].code) return null;
+  return segments[0].text;
+};
+
+export const Breadcrumb = ({ url, title }: BreadcrumbProps) => {
+  const code = codeTitle(title);
+  const path = url.slice(1);
+  const lastIndex = path.split("/").length - 1;
+  return (
+    <Base.Breadcrumb level="small" highlightVariant="last">
+      {Base.mapURLSegments(path, ({ segment, href, index }) => (
+        <Base.Segment href={`/${href}`} key={index}>
+          {code != null && index === lastIndex ? (
+            <code>{code}</code>
+          ) : (
+            segment.split("-").map(capitalize).join(" ")
+          )}
+        </Base.Segment>
+      ))}
+    </Base.Breadcrumb>
+  );
+};

--- a/docs/site/src/components/console/ControlChip.astro
+++ b/docs/site/src/components/console/ControlChip.astro
@@ -1,0 +1,56 @@
+---
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { Icon } from "@synnaxlabs/pluto";
+
+interface Props {
+    variant: "control" | "absolute" | "other";
+}
+
+const COLORS: Record<Props["variant"], string> = {
+    control: "var(--pluto-primary-z)",
+    absolute: "var(--pluto-secondary-z)",
+    other: "var(--pluto-error-z)",
+};
+
+const { variant } = Astro.props;
+const color = COLORS[variant];
+---
+
+<span class:list={["control-chip", `control-chip--${variant}`]}>
+    {
+        variant === "other" ? (
+            <Icon.Square color={color} />
+        ) : (
+            <Icon.Circle color={color} />
+        )
+    }
+</span>
+
+<style is:global>
+    .control-chip {
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        box-sizing: border-box;
+        height: 1em;
+        width: 1em;
+        border-radius: 0.5rem;
+
+        & svg {
+            height: 0.6em;
+            width: 0.6em;
+        }
+
+        &.control-chip--absolute {
+            background: var(--pluto-secondary-z-30);
+        }
+    }
+</style>

--- a/docs/site/src/components/params/Params.astro
+++ b/docs/site/src/components/params/Params.astro
@@ -1,0 +1,75 @@
+---
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { grammar as arcGrammar } from "@synnaxlabs/arc";
+
+import Inline from "@/components/code/Inline.astro";
+import { InlineCode } from "@/components/text/InlineCode";
+
+interface Param {
+    name: string;
+    type: string;
+    required?: boolean;
+    description: string;
+}
+
+interface Output {
+    type?: string;
+    description: string;
+}
+
+interface Props {
+    fn: string;
+    input?: string;
+    params?: Param[];
+    output?: Output;
+}
+
+const { fn, input, params = [], output } = Astro.props;
+
+const args = params
+    .map(({ name, type, required = false }) => `${name}${required ? "" : "?"}: ${type}`)
+    .join(", ");
+let signature = `${fn}{${args}}`;
+if (input != null) signature = `${input} -> ${signature}`;
+if (output?.type != null) signature = `${signature} -> ${output.type}`;
+---
+
+<div class="params">
+    <Inline code={signature} lang={arcGrammar} theme="css-variables" />
+    {
+        params.length > 0 && (
+            <>
+                <p>
+                    <strong>Parameters</strong>
+                </p>
+                <ul>
+                    {params.map(({ name, description }) => (
+                        <li>
+                            <code>{name}</code>: <InlineCode text={description} />
+                        </li>
+                    ))}
+                </ul>
+            </>
+        )
+    }
+    {
+        output != null && (
+            <>
+                <p>
+                    <strong>Output</strong>
+                </p>
+                <p>
+                    <InlineCode text={output.description} />
+                </p>
+            </>
+        )
+    }
+</div>

--- a/docs/site/src/components/search/Search.tsx
+++ b/docs/site/src/components/search/Search.tsx
@@ -23,6 +23,8 @@ import { caseconv, deep } from "@synnaxlabs/x";
 import { type ReactElement, useCallback, useRef, useState } from "react";
 import z from "zod";
 
+import { codifyHTML } from "@/components/text/InlineCode";
+
 interface SearchResult {
   key: string;
   title: string;
@@ -108,7 +110,11 @@ export const SearchListItem = (props: List.ItemRenderProps<string>) => {
       {...props}
     >
       <Flex.Box direction="y" empty>
-        <Text.Text level="h5" dangerouslySetInnerHTML={{ __html: title }} empty />
+        <Text.Text
+          level="h5"
+          dangerouslySetInnerHTML={{ __html: codifyHTML(title) }}
+          empty
+        />
         {path.length > 0 && (
           <Breadcrumb.Breadcrumb level="small" gap="tiny" highlightVariant="last">
             {icon}

--- a/docs/site/src/components/text/InlineCode.tsx
+++ b/docs/site/src/components/text/InlineCode.tsx
@@ -25,6 +25,13 @@ export const parseSegments = (text?: string): Segment[] =>
         : { text: s, code: false },
     );
 
+/**
+ * Rewrites backtick-delimited spans in an HTML string as inline code elements. Use for
+ * text that must stay HTML, such as Algolia snippets that carry highlight markup.
+ */
+export const codifyHTML = (html?: string): string =>
+  String(html ?? "").replace(/`([^`]+)`/g, "<code>$1</code>");
+
 export interface SegmentsProps {
   segments: Segment[];
 }

--- a/docs/site/src/pages/reference/console/schematics.mdx
+++ b/docs/site/src/pages/reference/console/schematics.mdx
@@ -13,6 +13,7 @@ import { Divider, Note, Icon, Flex } from "@synnaxlabs/pluto";
 import { Image, Video } from "@/components/media/Media";
 import { Table } from "@/components";
 import Diagram from "@/components/diagram/Diagram.astro";
+import ControlChip from "@/components/console/ControlChip.astro";
 import { mdxOverrides } from "@/components/mdxOverrides";
 export const components = mdxOverrides;
 
@@ -323,18 +324,15 @@ of the system. Clicking on an actionable element, such as a valve, switch, or bu
 allows you to activate the output channel on that element. The indicator next to the
 element displays the control status.
 
-<Icon.Circle color="var(--pluto-primary-z)" /> Blue circle is indicates the current user
-has control.
+<ControlChip variant="control" /> Blue circle is indicates the current user has control.
 
-<Icon.Circle color="var(--pluto-secondary-z)" /> Green circle indicates the current user
-has absolute control.
+<ControlChip variant="absolute" /> Green circle indicates the current user has absolute
+control.
 
-<Icon.Circle color="var(--pluto-error-z)" /> Red circle indicates the current user does
-not have control as the command channel is being controlled by another user or an
-automated sequence.
+<ControlChip variant="other" /> Red square indicates the current user does not have
+control because authority is held by another user or process.
 
-The color of the bar indicates what is controlling the elements on the schematic. There
-is a legend on the display indicating what controlling node is what color.
+The color of the bar and legend indicate what has control over the channel.
 
 <Video client:only="react" id="console/schematics/valve" />
 

--- a/docs/site/src/pages/reference/control/arc/reference/standard-library/control.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/standard-library/control.mdx
@@ -29,13 +29,13 @@ values take priority, and setting the authority to `0` releases control.
       type: "u8",
       required: true,
       description:
-        "The authority level, `0`-`255`. Higher values take priority; `0` releases control.",
+        "Authority level `0`-`255`. Higher values take priority; `0` releases control.",
     },
     {
       name: "channel",
       type: "chan",
       description:
-        "The write channel to target. If omitted, the change applies to all of the program's write channels.",
+        "The write channel to target. If omitted, applies to all write channels.",
     },
   ]}
   output={{

--- a/docs/site/src/pages/reference/control/arc/reference/standard-library/control.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/standard-library/control.mdx
@@ -8,9 +8,8 @@ next: "`math`"
 nextURL: "/reference/control/arc/reference/standard-library/math"
 ---
 
-import { Icon, Text } from "@synnaxlabs/pluto";
-import Details from "@/components/details/Details.astro";
 import { mdxOverrides } from "@/components/mdxOverrides";
+import Params from "@/components/params/Params.astro";
 
 export const components = mdxOverrides;
 
@@ -22,17 +21,27 @@ promote or release writes that target shared channels.
 Dynamically changes the control authority of write channels at runtime. Higher authority
 values take priority, and setting the authority to `0` releases control.
 
-<Details>
-<Text.Text slot="summary" level="p"><Icon.Details /> Parameters</Text.Text>
-
-| Parameter | Type   | Required | Description                                                                                         |
-| --------- | ------ | -------- | --------------------------------------------------------------------------------------------------- |
-| `value`   | `u8`   | Yes      | The authority level, `0`-`255`. Higher values take priority; `0` releases control.                  |
-| `channel` | `chan` | No       | The write channel to target. If omitted, the change applies to all of the program's write channels. |
-
-**Output** none: changes authority as a side effect and emits no value.
-
-</Details>
+<Params
+  fn="control.set_authority"
+  params={[
+    {
+      name: "value",
+      type: "u8",
+      required: true,
+      description:
+        "The authority level, `0`-`255`. Higher values take priority; `0` releases control.",
+    },
+    {
+      name: "channel",
+      type: "chan",
+      description:
+        "The write channel to target. If omitted, the change applies to all of the program's write channels.",
+    },
+  ]}
+  output={{
+    description: "None; changes authority as a side effect and emits no value.",
+  }}
+/>
 
 ```arc
 // `flow` only

--- a/docs/site/src/pages/reference/control/arc/reference/standard-library/math.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/standard-library/math.mdx
@@ -9,9 +9,9 @@ next: "`ranges`"
 nextURL: "/reference/control/arc/reference/standard-library/ranges"
 ---
 
-import { Divider, Icon, Text } from "@synnaxlabs/pluto";
-import Details from "@/components/details/Details.astro";
+import { Divider } from "@synnaxlabs/pluto";
 import { mdxOverrides } from "@/components/mdxOverrides";
+import Params from "@/components/params/Params.astro";
 
 export const components = mdxOverrides;
 
@@ -24,17 +24,26 @@ Computes a running average of input values, emitting the updated average on each
 By default the average accumulates over every sample; set `duration` or `count` to reset
 the window periodically.
 
-<Details>
-<Text.Text slot="summary" level="p"><Icon.Details /> Parameters</Text.Text>
-
-| Parameter  | Type     | Required | Description                                                    |
-| ---------- | -------- | -------- | -------------------------------------------------------------- |
-| `duration` | `i64 ns` | No       | Reset the average after this much time elapses (such as `5s`). |
-| `count`    | `i64`    | No       | Reset the average after this many samples.                     |
-
-**Output** `numeric`: the running average, matching the input type.
-
-</Details>
+<Params
+  fn="math.avg"
+  input="numeric"
+  params={[
+    {
+      name: "duration",
+      type: "i64 ns",
+      description: "Reset the average after this much time elapses (such as `5s`).",
+    },
+    {
+      name: "count",
+      type: "i64",
+      description: "Reset the average after this many samples.",
+    },
+  ]}
+  output={{
+    type: "numeric",
+    description: "The running average, matching the input type.",
+  }}
+/>
 
 ```arc
 // `flow` only
@@ -52,12 +61,14 @@ sensor -> math.avg{duration=5s} -> output
 Computes the rate of change of input values with respect to time. The output is always
 `f64`, regardless of the input type.
 
-<Details>
-<Text.Text slot="summary" level="p"><Icon.Details /> Parameters</Text.Text>
-
-**Output** `f64`: the rate of change between consecutive samples.
-
-</Details>
+<Params
+  fn="math.derivative"
+  input="numeric"
+  output={{
+    type: "f64",
+    description: "The rate of change between consecutive samples.",
+  }}
+/>
 
 ```arc
 // `flow` only
@@ -72,17 +83,26 @@ Tracks the running maximum of input values, emitting the updated maximum on each
 By default the maximum accumulates over every sample; set `duration` or `count` to reset
 the window periodically.
 
-<Details>
-<Text.Text slot="summary" level="p"><Icon.Details /> Parameters</Text.Text>
-
-| Parameter  | Type     | Required | Description                                                    |
-| ---------- | -------- | -------- | -------------------------------------------------------------- |
-| `duration` | `i64 ns` | No       | Reset the maximum after this much time elapses (such as `5s`). |
-| `count`    | `i64`    | No       | Reset the maximum after this many samples.                     |
-
-**Output** `numeric`: the running maximum, matching the input type.
-
-</Details>
+<Params
+  fn="math.max"
+  input="numeric"
+  params={[
+    {
+      name: "duration",
+      type: "i64 ns",
+      description: "Reset the maximum after this much time elapses (such as `5s`).",
+    },
+    {
+      name: "count",
+      type: "i64",
+      description: "Reset the maximum after this many samples.",
+    },
+  ]}
+  output={{
+    type: "numeric",
+    description: "The running maximum, matching the input type.",
+  }}
+/>
 
 ```arc
 // `flow` only
@@ -101,17 +121,26 @@ Tracks the running minimum of input values, emitting the updated minimum on each
 By default the minimum accumulates over every sample; set `duration` or `count` to reset
 the window periodically.
 
-<Details>
-<Text.Text slot="summary" level="p"><Icon.Details /> Parameters</Text.Text>
-
-| Parameter  | Type     | Required | Description                                                    |
-| ---------- | -------- | -------- | -------------------------------------------------------------- |
-| `duration` | `i64 ns` | No       | Reset the minimum after this much time elapses (such as `5s`). |
-| `count`    | `i64`    | No       | Reset the minimum after this many samples.                     |
-
-**Output** `numeric`: the running minimum, matching the input type.
-
-</Details>
+<Params
+  fn="math.min"
+  input="numeric"
+  params={[
+    {
+      name: "duration",
+      type: "i64 ns",
+      description: "Reset the minimum after this much time elapses (such as `5s`).",
+    },
+    {
+      name: "count",
+      type: "i64",
+      description: "Reset the minimum after this many samples.",
+    },
+  ]}
+  output={{
+    type: "numeric",
+    description: "The running minimum, matching the input type.",
+  }}
+/>
 
 ```arc
 // `flow` only

--- a/docs/site/src/pages/reference/control/arc/reference/standard-library/ranges.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/standard-library/ranges.mdx
@@ -8,10 +8,10 @@ next: "`status`"
 nextURL: "/reference/control/arc/reference/standard-library/status"
 ---
 
-import { Note, Icon, Text } from "@synnaxlabs/pluto";
+import { Divider } from "@synnaxlabs/pluto";
 import { Arc } from "@/components";
-import Details from "@/components/details/Details.astro";
 import { mdxOverrides } from "@/components/mdxOverrides";
+import Params from "@/components/params/Params.astro";
 
 export const components = mdxOverrides;
 
@@ -20,21 +20,33 @@ regions of time as an automation runs.
 
 ## `create`
 
-Creates a range that starts now and stays open (its end is set to the maximum timestamp,
-shown as "In Progress"), and outputs the new range key.
+Creates a range that starts now and stays open. Its end is set to the maximum timestamp,
+shown as "In Progress". Outputs the new range key.
 
-<Details>
-<Text.Text slot="summary" level="p"><Icon.Details /> Parameters</Text.Text>
-
-| Parameter | Type  | Required | Description                                                                     |
-| --------- | ----- | -------- | ------------------------------------------------------------------------------- |
-| `name`    | `str` | Yes      | A human-readable name for the range.                                            |
-| `parent`  | `str` | No       | The key of an existing range to nest the new range under. No parent if omitted. |
-| `color`   | `str` | No       | A display color: hex (`#3bc454`), `rgb(r, g, b)`, or `rgba(r, g, b, a)`.        |
-
-**Output** `str`: the new range key.
-
-</Details>
+<Params
+  fn="ranges.create"
+  params={[
+    {
+      name: "name",
+      type: "str",
+      required: true,
+      description: "A human-readable name for the range.",
+    },
+    {
+      name: "parent",
+      type: "str",
+      description:
+        "The key of an existing range to nest the new range under. No parent if omitted.",
+    },
+    {
+      name: "color",
+      type: "str",
+      description:
+        "A display color: hex (`#3bc454`), `rgb(r, g, b)`, or `rgba(r, g, b, a)`.",
+    },
+  ]}
+  output={{ type: "str", description: "The new range key." }}
+/>
 
 <Arc.Tabs client:load>
 
@@ -60,21 +72,25 @@ func ranges_create() {
 
 </Arc.Tabs>
 
+<Divider.Divider x />
+
 ## `end`
 
 Sets the end bound of an existing range to now, closing an open range, and outputs the
 range key.
 
-<Details>
-<Text.Text slot="summary" level="p"><Icon.Details /> Parameters</Text.Text>
-
-| Parameter | Type  | Required | Description                    |
-| --------- | ----- | -------- | ------------------------------ |
-| `key`     | `str` | Yes      | The key of the range to close. |
-
-**Output** `str`: the range key that was closed.
-
-</Details>
+<Params
+  fn="ranges.end"
+  params={[
+    {
+      name: "key",
+      type: "str",
+      required: true,
+      description: "The key of the range to close.",
+    },
+  ]}
+  output={{ type: "str", description: "The range key that was closed." }}
+/>
 
 <Arc.Tabs client:load>
 

--- a/docs/site/src/pages/reference/control/arc/reference/standard-library/ranges.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/standard-library/ranges.mdx
@@ -35,8 +35,7 @@ shown as "In Progress". Outputs the new range key.
     {
       name: "parent",
       type: "str",
-      description:
-        "The key of an existing range to nest the new range under. No parent if omitted.",
+      description: "The key of an existing range to nest under. No parent if omitted.",
     },
     {
       name: "color",

--- a/docs/site/src/pages/reference/control/arc/reference/standard-library/status.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/standard-library/status.mdx
@@ -8,10 +8,10 @@ next: "`time`"
 nextURL: "/reference/control/arc/reference/standard-library/time"
 ---
 
-import { Note, Icon, Text } from "@synnaxlabs/pluto";
+import { Note } from "@synnaxlabs/pluto";
 import { Arc } from "@/components";
-import Details from "@/components/details/Details.astro";
 import { mdxOverrides } from "@/components/mdxOverrides";
+import Params from "@/components/params/Params.astro";
 
 export const components = mdxOverrides;
 
@@ -23,23 +23,37 @@ states) to the Core.
 Sets a status notification (an alarm, warning, or operational state) on the Core,
 addressing it by name or by key, and outputs the resolved status key.
 
-<Details>
-<Text.Text slot="summary" level="p"><Icon.Details /> Parameters</Text.Text>
-
-| Parameter     | Type  | Required | Description                                                                                                                                                                                               |
-| ------------- | ----- | -------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `key_or_name` | `str` | Yes      | An existing status key or name. A match is updated in place; if none matches, a new status is created with this name; if several statuses share the name, the first is updated and a warning is surfaced. |
-| `message`     | `str` | Yes      | The message body shown on the status.                                                                                                                                                                     |
-| `variant`     | `str` | Yes      | One of `success`, `info`, `warning`, `error`, `loading`, or `disabled`.                                                                                                                                   |
-
-**Output** `str`: the resolved status key that was set.
+<Params
+  fn="status.set"
+  params={[
+    {
+      name: "key_or_name",
+      type: "str",
+      required: true,
+      description:
+        "An existing status key or name. A match is updated in place; if none matches, a new status is created with this name; if several statuses share the name, the first is updated and a warning is surfaced.",
+    },
+    {
+      name: "message",
+      type: "str",
+      required: true,
+      description: "The message body shown on the status.",
+    },
+    {
+      name: "variant",
+      type: "str",
+      required: true,
+      description:
+        "One of `success`, `info`, `warning`, `error`, `loading`, or `disabled`.",
+    },
+  ]}
+  output={{ type: "str", description: "The resolved status key that was set." }}
+/>
 
 <Note.Note variant="info" className="compact">
   If a `status.set` fails (for example, an empty `key_or_name` or a database error), it
   reports a `warning` and the automation keeps running.
 </Note.Note>
-
-</Details>
 
 <Arc.Tabs client:load>
 

--- a/docs/site/src/pages/reference/control/arc/reference/standard-library/status.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/standard-library/status.mdx
@@ -31,7 +31,7 @@ addressing it by name or by key, and outputs the resolved status key.
       type: "str",
       required: true,
       description:
-        "An existing status key or name. A match is updated in place; if none matches, a new status is created with this name; if several statuses share the name, the first is updated and a warning is surfaced.",
+        "An existing status key or name. If no status matches, a new one is created.",
     },
     {
       name: "message",
@@ -51,8 +51,9 @@ addressing it by name or by key, and outputs the resolved status key.
 />
 
 <Note.Note variant="info" className="compact">
-  If a `status.set` fails (for example, an empty `key_or_name` or a database error), it
-  reports a `warning` and the automation keeps running.
+  If several statuses share a name, the first match is updated. If a `status.set` fails
+  (for example, an empty `key_or_name` or a database error), it reports a `warning` and
+  the automation keeps running.
 </Note.Note>
 
 <Arc.Tabs client:load>

--- a/docs/site/src/pages/reference/control/arc/reference/standard-library/time.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/standard-library/time.mdx
@@ -31,7 +31,7 @@ control loops, periodic sampling, and generating test data.
       type: "i64 ns",
       required: true,
       description:
-        "Time between fires, written as a duration literal (such as `200ms`, `1s`).",
+        "Time between fires, written as a duration literal (e.g. `200ms`, `1s`).",
     },
   ]}
   output={{ type: "u8", description: "Emits `1` on each fire." }}
@@ -92,7 +92,7 @@ Fires once after a fixed duration, then stops.
       type: "i64 ns",
       required: true,
       description:
-        "How long to wait before firing, written as a duration literal (such as `30s`).",
+        "How long to wait before firing, as a duration literal (e.g. `30s`).",
     },
   ]}
   output={{ type: "u8", description: "Emits `1` once the duration elapses." }}

--- a/docs/site/src/pages/reference/control/arc/reference/standard-library/time.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/standard-library/time.mdx
@@ -9,10 +9,10 @@ next: "Errors"
 nextURL: "/reference/control/arc/reference/errors"
 ---
 
-import { Divider, Icon, Text } from "@synnaxlabs/pluto";
+import { Divider } from "@synnaxlabs/pluto";
 import { Arc } from "@/components";
-import Details from "@/components/details/Details.astro";
 import { mdxOverrides } from "@/components/mdxOverrides";
+import Params from "@/components/params/Params.astro";
 
 export const components = mdxOverrides;
 
@@ -23,16 +23,19 @@ The `time` module provides timing functions for timestamps, periodic firing, and
 Fires repeatedly at a fixed period, emitting `1` on each tick. Common for driving
 control loops, periodic sampling, and generating test data.
 
-<Details>
-<Text.Text slot="summary" level="p"><Icon.Details /> Parameters</Text.Text>
-
-| Parameter | Type     | Required | Description                                                                |
-| --------- | -------- | -------- | -------------------------------------------------------------------------- |
-| `period`  | `i64 ns` | Yes      | Time between fires, written as a duration literal (such as `200ms`, `1s`). |
-
-**Output** `u8`: emits `1` on each fire.
-
-</Details>
+<Params
+  fn="time.interval"
+  params={[
+    {
+      name: "period",
+      type: "i64 ns",
+      required: true,
+      description:
+        "Time between fires, written as a duration literal (such as `200ms`, `1s`).",
+    },
+  ]}
+  output={{ type: "u8", description: "Emits `1` on each fire." }}
+/>
 
 ```arc
 // `flow` only
@@ -46,12 +49,10 @@ time.interval{period=1s} -> tick
 Returns the current timestamp. `time.now` works both as a flow node and as a direct
 function call, so it can be wired into a chain or called inside a `func`.
 
-<Details>
-<Text.Text slot="summary" level="p"><Icon.Details /> Parameters</Text.Text>
-
-**Output** `i64 ns`: the current timestamp.
-
-</Details>
+<Params
+  fn="time.now"
+  output={{ type: "i64 ns", description: "The current timestamp." }}
+/>
 
 <Arc.Tabs client:load>
 
@@ -83,16 +84,19 @@ func stamp() {
 
 Fires once after a fixed duration, then stops.
 
-<Details>
-<Text.Text slot="summary" level="p"><Icon.Details /> Parameters</Text.Text>
-
-| Parameter  | Type     | Required | Description                                                                    |
-| ---------- | -------- | -------- | ------------------------------------------------------------------------------ |
-| `duration` | `i64 ns` | Yes      | How long to wait before firing, written as a duration literal (such as `30s`). |
-
-**Output** `u8`: emits `1` once the duration elapses.
-
-</Details>
+<Params
+  fn="time.wait"
+  params={[
+    {
+      name: "duration",
+      type: "i64 ns",
+      required: true,
+      description:
+        "How long to wait before firing, written as a duration literal (such as `30s`).",
+    },
+  ]}
+  output={{ type: "u8", description: "Emits `1` once the duration elapses." }}
+/>
 
 ```arc
 // `flow` only

--- a/docs/site/src/styles/pluto.css
+++ b/docs/site/src/styles/pluto.css
@@ -161,8 +161,9 @@ article table code {
     white-space: nowrap;
 }
 
-/* Let nav code chips follow the state colors of the item that holds them. */
+/* Let code chips follow the state colors of the item that holds them. */
 .pluto-tree code,
+.pluto-breadcrumb code,
 .on-this-page-item code {
     color: inherit;
     font-size: inherit;


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4573](https://linear.app/synnax/issue/SY-4573)

## Description

- Arc standard library functions document their parameters and output in a signature-first `Params` component instead of a collapsed table.
- The schematic control mode legend uses a `ControlChip` component that matches the Console: blue circle, green circle on a tinted chip, and red square.
- Backticked page titles render as inline code in search results, the article title, and the last breadcrumb segment.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates the documentation site's presentation of inline-code titles, Arc function signatures, and schematic control-state indicators.
- Adds reusable `Params` and `ControlChip` components.
- Renders backticked titles as inline code in articles, breadcrumbs, and search results.
- Converts Arc standard-library parameter documentation to signature-first sections.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/site/src/components/params/Params.astro | Introduces a reusable signature-first component for Arc parameter and output documentation. |
| docs/site/src/components/text/InlineCode.tsx | Adds shared parsing and HTML transformation helpers for backticked inline-code spans. |
| docs/site/src/components/search/Search.tsx | Applies inline-code rendering to backticked titles in Algolia search results. |
| docs/site/src/components/article/Breadcrumb.tsx | Uses fully backticked article titles for the final breadcrumb segment. |
| docs/site/src/pages/reference/control/arc/reference/standard-library/status.mdx | Converts status function documentation to the new parameter-signature presentation and keeps changed prose within the repository line limit. |
| docs/site/src/components/console/ControlChip.astro | Adds visual chips matching the Console's control-authority indicators. |

<sub>Reviews (2): Last reviewed commit: ["SY-4573: Condense descriptions to fit 88..."](https://github.com/synnaxlabs/synnax/commit/190b205ff4b26c69e1ff8c0a4c38903eac12d54c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53168979)</sub>

<!-- /greptile_comment -->