### PR TITLE
SY-4584: Fix closed tab selection mechanics

### DIFF
--- a/console/src/feature/panel/Mosaic.spec.tsx
+++ b/console/src/feature/panel/Mosaic.spec.tsx
@@ -235,7 +235,7 @@ describe("Panel.Mosaic keep-alive", () => {
     await waitFor(() => expect(screen.getByText(`content-${b.key}`)).toBeTruthy());
 
     act(() => {
-      store.dispatch(Session.Panel.remove(a.key));
+      store.dispatch(Session.Panel.remove({ keys: a.key }));
     });
     await waitFor(() => expect(unmounts).toEqual([a.key]));
     expect(screen.getByText(`content-${b.key}`)).toBeTruthy();

--- a/console/src/feature/panel/Mosaic.tsx
+++ b/console/src/feature/panel/Mosaic.tsx
@@ -331,7 +331,9 @@ const PanelFallback = (props: Errors.FallbackProps): ReactElement => {
       description="This window references a panel that no longer exists."
     >
       {panelKey != null && (
-        <Button.Button onClick={() => dispatch(Session.Panel.remove(panelKey))}>
+        <Button.Button
+          onClick={() => dispatch(Session.Panel.remove({ keys: panelKey }))}
+        >
           Close
         </Button.Button>
       )}

--- a/console/src/feature/panel/Selector.spec.tsx
+++ b/console/src/feature/panel/Selector.spec.tsx
@@ -7,15 +7,67 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+import { type panel, project } from "@synnaxlabs/client";
 import { createTestClient } from "@synnaxlabs/client/testutil";
+import { uuid } from "@synnaxlabs/x";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { Selector } from "@/feature/panel/Selector";
+import { Modals } from "@/platform/modals";
 import { createPanelWrapper } from "@/platform/panel/testutil";
+import { findModalButton } from "@/platform/tree/menuTestutil";
 import { Session } from "@/session";
+import { type TestStore, uniqueName } from "@/testutil";
 
 const client = createTestClient();
+
+const createProjectPanel = async (projectKey: project.Key): Promise<panel.Panel> =>
+  await client.panels.create({
+    key: uuid.create(),
+    name: uniqueName("panel"),
+    parent: project.ontologyID(projectKey),
+    root: {
+      variant: "leaf",
+      tabs: [{ variant: "view", key: uuid.create(), type: "t", args: {} }],
+    },
+  });
+
+// The strip's own order decides which panel is a neighbor, so the row is read back
+// from the rendered pills instead of assumed from creation order.
+const renderStrip = async (
+  panels: panel.Panel[],
+  projectKey: project.Key,
+): Promise<{ store: TestStore; row: panel.Panel[] }> => {
+  const { wrapper, store } = await createPanelWrapper({ client, project: projectKey });
+  await act(async () => {
+    render(
+      <>
+        <Selector />
+        <Modals.Stack />
+      </>,
+      { wrapper },
+    );
+  });
+  await waitFor(() =>
+    panels.forEach(({ name }) => expect(screen.getByText(name)).toBeTruthy()),
+  );
+  const row = screen
+    .getAllByRole("tab")
+    .map((pill) => panels.find(({ name }) => pill.textContent?.includes(name)))
+    .filter((pan) => pan != null);
+  expect(row).toHaveLength(panels.length);
+  return { store, row };
+};
+
+const deletePanel = async (pan: panel.Panel): Promise<void> => {
+  fireEvent.contextMenu(screen.getByText(pan.name));
+  fireEvent.click(await screen.findByText("Delete"));
+  await screen.findByText(`Are you sure you want to delete ${pan.name}?`);
+  await act(async () => {
+    fireEvent.click(findModalButton("Delete"));
+  });
+};
 
 describe("Panel.Selector", () => {
   it("should select a newly created panel", async () => {
@@ -33,5 +85,51 @@ describe("Panel.Selector", () => {
     const selected = Session.Panel.selectSelected(store.getState());
     expect(selected).toBeDefined();
     await waitFor(() => expect(screen.getByText("New Panel")).toBeTruthy());
+  });
+
+  // Deleting the selected panel hands the window to the panel beside it in the
+  // strip, the way closing a browser tab does.
+  describe("delete", () => {
+    const createStrip = async (): Promise<{ store: TestStore; row: panel.Panel[] }> => {
+      const { key: projectKey } = await client.projects.create({
+        name: uniqueName("project"),
+        layout: {},
+      });
+      const panels = [
+        await createProjectPanel(projectKey),
+        await createProjectPanel(projectKey),
+        await createProjectPanel(projectKey),
+      ];
+      return await renderStrip(panels, projectKey);
+    };
+
+    const select = async (store: TestStore, pan: panel.Panel): Promise<void> => {
+      await act(async () => {
+        fireEvent.click(screen.getByText(pan.name));
+      });
+      expect(Session.Panel.selectSelected(store.getState())).toEqual(pan.key);
+    };
+
+    // Each test visits the far end of the strip first, so the neighbor and the
+    // most recently used panel are different panels.
+    it("should select the panel to the right of the deleted one", async () => {
+      const { store, row } = await createStrip();
+      await select(store, row[2]);
+      await select(store, row[0]);
+      await deletePanel(row[0]);
+      await waitFor(() =>
+        expect(Session.Panel.selectSelected(store.getState())).toEqual(row[1].key),
+      );
+    });
+
+    it("should select the panel to the left when the deleted one was last", async () => {
+      const { store, row } = await createStrip();
+      await select(store, row[0]);
+      await select(store, row[2]);
+      await deletePanel(row[2]);
+      await waitFor(() =>
+        expect(Session.Panel.selectSelected(store.getState())).toEqual(row[1].key),
+      );
+    });
   });
 });

--- a/console/src/feature/panel/Selector.tsx
+++ b/console/src/feature/panel/Selector.tsx
@@ -13,7 +13,7 @@ import { panel, query } from "@synnaxlabs/client";
 import {
   Access,
   Button,
-  Component,
+  type Component,
   CSS as PCSS,
   Errors,
   type Flux,
@@ -37,7 +37,12 @@ import { CSS } from "@/platform/css";
 import { Modals } from "@/platform/modals";
 import { Session } from "@/session";
 
-const ContextMenu = ({ keys }: Menu.ContextMenuMenuProps): ReactElement | null => {
+interface ContextMenuProps extends Menu.ContextMenuMenuProps {
+  /** The strip's panels in render order, so a delete can hand the selection on. */
+  order: panel.Key[];
+}
+
+const ContextMenu = ({ keys, order }: ContextMenuProps): ReactElement | null => {
   const ids = panel.ontologyID(keys);
   const hasUpdatePermission = Access.useUpdateGranted(ids);
   const hasDeletePermission = Access.useDeleteGranted(ids);
@@ -55,10 +60,10 @@ const ContextMenu = ({ keys }: Menu.ContextMenuMenuProps): ReactElement | null =
           return { name: query.isLive(cached) ? cached.name : "this panel" };
         });
         if (!(await confirm(items))) return false;
-        dispatch(Session.Panel.remove(panelKeys));
+        dispatch(Session.Panel.remove({ keys: panelKeys, order }));
         return data;
       },
-      [client, confirm, dispatch],
+      [client, confirm, dispatch, order],
     ),
   });
   if (keys.length === 0) return null;
@@ -127,8 +132,6 @@ const TabContent = ({ tabKey }: TabProps): ReactElement => {
   );
 };
 
-const contextMenu = Component.renderProp(ContextMenu);
-
 const Internal = (): ReactElement => {
   const dispatch = useDispatch();
   const selected = Session.Panel.useSelectSelected();
@@ -142,6 +145,10 @@ const Internal = (): ReactElement => {
 
   const handleCreate = useCreate();
   const menuProps = Menu.useContextMenu();
+  const contextMenu = useCallback<Component.RenderProp<Menu.ContextMenuMenuProps>>(
+    (props) => <ContextMenu {...props} order={keys} />,
+    [keys],
+  );
 
   return (
     <Menu.ContextMenu menu={contextMenu} {...menuProps}>

--- a/console/src/session/panel/slice.spec.ts
+++ b/console/src/session/panel/slice.spec.ts
@@ -133,7 +133,7 @@ describe("Panel Slice", () => {
       const state = run(
         Panel.select({ key: KEYS[0] }),
         Panel.select({ windowKey: "other", key: KEYS[0] }),
-        Panel.remove(KEYS[0]),
+        Panel.remove({ keys: KEYS[0] }),
       );
       expect(Panel.selectMounted(state)).toEqual([]);
       expect(state[Panel.SLICE_NAME].windows.other.mounted).toEqual([]);
@@ -146,7 +146,7 @@ describe("Panel Slice", () => {
         Panel.select({ key: KEYS[0] }),
         Panel.select({ key: KEYS[1] }),
         Panel.select({ key: KEYS[2] }),
-        Panel.remove(KEYS[2]),
+        Panel.remove({ keys: KEYS[2] }),
       );
       expect(Panel.selectSelected(state)).toEqual(KEYS[1]);
       expect(Panel.selectMounted(state)).toEqual([KEYS[1], KEYS[0]]);
@@ -300,12 +300,14 @@ describe("Panel Slice", () => {
       expect(Panel.selectSelectedTabs(state, PANEL)).toEqual([OTHER_TAB]);
     });
 
-    it("should drop keys no longer in the tree and fill empty leaves with their last tab", () => {
+    // With no row to place the dropped key in, the leaf falls back to the tab the
+    // mosaic already shows while the selection is unresolved: its first.
+    it("should drop keys no longer in the tree and fill empty leaves with their first tab", () => {
       const state = run(
         Panel.internalSelectTab({ key: PANEL, tabKey: TAB, otherTabKeys: [TAB] }),
         Panel.reconcileSelection({ key: PANEL, leaves: [[OTHER_TAB, THIRD_TAB]] }),
       );
-      expect(Panel.selectSelectedTabs(state, PANEL)).toEqual([THIRD_TAB]);
+      expect(Panel.selectSelectedTabs(state, PANEL)).toEqual([OTHER_TAB]);
     });
 
     it("should keep one recency-ordered tab per leaf across a split", () => {
@@ -328,7 +330,7 @@ describe("Panel Slice", () => {
           leaves: [[TAB, OTHER_TAB], [THIRD_TAB]],
         }),
       );
-      expect(Panel.selectSelectedTabs(state, PANEL)).toEqual([OTHER_TAB, THIRD_TAB]);
+      expect(Panel.selectSelectedTabs(state, PANEL)).toEqual([TAB, THIRD_TAB]);
     });
 
     // Closing a tab with the X or the context menu removes it from the panel document
@@ -418,6 +420,124 @@ describe("Panel Slice", () => {
     });
   });
 
+  // The neighbor rule every tab strip follows: the tab beside the closed one takes
+  // its place, so closing several in a row needs no re-aiming.
+  describe("reconcileSelection closed tabs", () => {
+    const TABS = Array.from({ length: 4 }, () => uuid.create());
+    const [A, B, C, D] = TABS;
+
+    // The row is what the reconcile before the close saw, exactly as the
+    // synchronizer supplies it.
+    const close = (
+      selected: panel.TabKey,
+      previous: panel.TabKey[][],
+      leaves: panel.TabKey[][],
+    ): TestState =>
+      run(
+        Panel.internalSelectTab({
+          key: PANEL,
+          tabKey: selected,
+          otherTabKeys: previous.flat(),
+        }),
+        Panel.reconcileSelection({ key: PANEL, leaves, previous }),
+      );
+
+    it("should select the tab to the right of the closed one", () => {
+      const state = close(B, [[A, B, C, D]], [[A, C, D]]);
+      expect(Panel.selectSelectedTabs(state, PANEL)).toEqual([C]);
+    });
+
+    it("should select the tab to the left when the closed tab was last", () => {
+      const state = close(C, [[A, B, C]], [[A, B]]);
+      expect(Panel.selectSelectedTabs(state, PANEL)).toEqual([B]);
+    });
+
+    it("should skip tabs closed in the same change", () => {
+      const state = close(B, [[A, B, C, D]], [[A, D]]);
+      expect(Panel.selectSelectedTabs(state, PANEL)).toEqual([D]);
+    });
+
+    // Focus follows the replacement: the head of the list is the focused tab, so a
+    // closed tab's neighbor inherits its place in the recency order.
+    it("should focus the replacement when the focused tab is closed", () => {
+      const state = run(
+        Panel.internalSelectTab({ key: PANEL, tabKey: C, otherTabKeys: [C, D] }),
+        Panel.internalSelectTab({ key: PANEL, tabKey: A, otherTabKeys: [A, B] }),
+        Panel.reconcileSelection({
+          key: PANEL,
+          leaves: [[B], [C, D]],
+          previous: [
+            [A, B],
+            [C, D],
+          ],
+        }),
+      );
+      expect(Panel.selectSelectedTabs(state, PANEL)).toEqual([B, C]);
+    });
+
+    // Its leaf is gone, so there is no neighbor to inherit the place; the surviving
+    // leaves keep their own selections.
+    it("should drop the entry when the closed tab was alone in its leaf", () => {
+      const state = run(
+        Panel.internalSelectTab({ key: PANEL, tabKey: C, otherTabKeys: [C, D] }),
+        Panel.internalSelectTab({ key: PANEL, tabKey: A, otherTabKeys: [A] }),
+        Panel.reconcileSelection({
+          key: PANEL,
+          leaves: [[C, D]],
+          previous: [[A], [C, D]],
+        }),
+      );
+      expect(Panel.selectSelectedTabs(state, PANEL)).toEqual([C]);
+    });
+
+    it("should fall back to the first tab when the closed tab's row is unknown", () => {
+      const state = close(B, [], [[A, C]]);
+      expect(Panel.selectSelectedTabs(state, PANEL)).toEqual([A]);
+    });
+  });
+
+  // A tab dragged into another leaf leaves the same hole a close does, so the leaf
+  // it came from answers the same way.
+  describe("reconcileSelection dragged tabs", () => {
+    const TABS = Array.from({ length: 4 }, () => uuid.create());
+    const [A, B, C, D] = TABS;
+
+    // Leaves [A, B, C] and [D]; the dropped tab is selected by the mosaic's drop
+    // handler, then the tree change arrives.
+    const drag = (dragged: panel.TabKey, selected: panel.TabKey): TestState =>
+      run(
+        Panel.internalSelectTab({ key: PANEL, tabKey: D, otherTabKeys: [D] }),
+        Panel.internalSelectTab({
+          key: PANEL,
+          tabKey: selected,
+          otherTabKeys: [A, B, C],
+        }),
+        Panel.internalSelectTab({
+          key: PANEL,
+          tabKey: dragged,
+          otherTabKeys: [D, dragged],
+        }),
+        Panel.reconcileSelection({
+          key: PANEL,
+          leaves: [[A, B, C].filter((tab) => tab !== dragged), [D, dragged]],
+          previous: [[A, B, C], [D]],
+        }),
+      );
+
+    it("should show the dragged tab where it landed", () => {
+      expect(Panel.selectSelectedTabs(drag(B, B), PANEL)[0]).toEqual(B);
+    });
+
+    it("should show the tab beside the one dragged out", () => {
+      expect(Panel.selectSelectedTabs(drag(B, B), PANEL)).toEqual([B, C]);
+    });
+
+    // Dragging a tab the leaf was not showing takes nothing from it.
+    it("should leave the leaf alone when an unshown tab is dragged out", () => {
+      expect(Panel.selectSelectedTabs(drag(C, A), PANEL)).toEqual([C, A]);
+    });
+  });
+
   describe("remove", () => {
     it("should drop a panel's per-panel state", () => {
       const state = run(
@@ -427,7 +547,7 @@ describe("Panel Slice", () => {
           otherTabKeys: [OTHER_TAB],
         }),
         Panel.internalSelectTab({ key: PANEL, tabKey: TAB, otherTabKeys: [TAB] }),
-        Panel.remove(PANEL),
+        Panel.remove({ keys: PANEL }),
       );
       expect(Panel.selectSelectedTabs(state, PANEL)).toEqual([]);
       expect(Panel.selectSelectedTabs(state, OTHER_PANEL)).toEqual([OTHER_TAB]);
@@ -437,7 +557,7 @@ describe("Panel Slice", () => {
       const state = run(
         Panel.select({ key: PANEL }),
         Panel.internalSelectTab({ key: PANEL, tabKey: TAB, otherTabKeys: [TAB] }),
-        Panel.remove(PANEL),
+        Panel.remove({ keys: PANEL }),
       );
       expect(Panel.selectSelected(state)).toBeUndefined();
     });
@@ -447,7 +567,7 @@ describe("Panel Slice", () => {
         Panel.select({ key: PANEL }),
         Panel.internalSelectTab({ key: PANEL, tabKey: TAB, otherTabKeys: [TAB] }),
         Panel.startOverlaying({}),
-        Panel.remove(PANEL),
+        Panel.remove({ keys: PANEL }),
       );
       expect(overlaid(state)).toBe(false);
     });
@@ -461,7 +581,7 @@ describe("Panel Slice", () => {
           tabKey: OTHER_TAB,
           otherTabKeys: [OTHER_TAB],
         }),
-        Panel.remove(PANEL),
+        Panel.remove({ keys: PANEL }),
       );
       expect(Panel.selectSelected(state)).toEqual(OTHER_PANEL);
       expect(Panel.selectSelectedTabs(state, OTHER_PANEL)).toEqual([OTHER_TAB]);
@@ -477,7 +597,7 @@ describe("Panel Slice", () => {
           tabKey: OTHER_TAB,
           otherTabKeys: [OTHER_TAB],
         }),
-        Panel.remove(OTHER_PANEL),
+        Panel.remove({ keys: OTHER_PANEL }),
       );
       expect(Panel.selectSelected(state)).toEqual(PANEL);
     });
@@ -492,11 +612,46 @@ describe("Panel Slice", () => {
           tabKey: TAB,
           otherTabKeys: [TAB],
         }),
-        Panel.remove(PANEL),
+        Panel.remove({ keys: PANEL }),
       );
       expect(Panel.selectSelected(state)).toBeUndefined();
       Object.values(state[Panel.SLICE_NAME].windows).forEach((win) => {
         expect(win.panels[PANEL]).toBeUndefined();
+      });
+    });
+
+    // The strip lays panels out in a row, so a deleted panel hands the window to the
+    // panel beside it rather than to the one it happened to visit last.
+    describe("order", () => {
+      const ROW = Array.from({ length: 4 }, () => uuid.create());
+      const [FIRST, SECOND, THIRD, FOURTH] = ROW;
+
+      const deleteFrom = (selected: panel.Key, ...keys: panel.Key[]): TestState =>
+        run(Panel.select({ key: selected }), Panel.remove({ keys, order: ROW }));
+
+      it("should select the panel to the right of the deleted one", () => {
+        expect(Panel.selectSelected(deleteFrom(SECOND, SECOND))).toEqual(THIRD);
+      });
+
+      it("should select the panel to the left when the deleted one was last", () => {
+        expect(Panel.selectSelected(deleteFrom(FOURTH, FOURTH))).toEqual(THIRD);
+      });
+
+      it("should skip panels deleted in the same change", () => {
+        expect(Panel.selectSelected(deleteFrom(SECOND, SECOND, THIRD))).toEqual(FOURTH);
+      });
+
+      it("should take the neighbor over the most recently used panel", () => {
+        const state = run(
+          Panel.select({ key: FOURTH }),
+          Panel.select({ key: FIRST }),
+          Panel.remove({ keys: FIRST, order: ROW }),
+        );
+        expect(Panel.selectSelected(state)).toEqual(SECOND);
+      });
+
+      it("should leave a window whose selection survives alone", () => {
+        expect(Panel.selectSelected(deleteFrom(FIRST, SECOND))).toEqual(FIRST);
       });
     });
 
@@ -514,7 +669,7 @@ describe("Panel Slice", () => {
           tabKey: TAB,
           otherTabKeys: [TAB],
         }),
-        Panel.remove([PANEL]),
+        Panel.remove({ keys: [PANEL] }),
       );
       expect(Panel.selectSelected(state)).toEqual(OTHER_PANEL);
       expect(Panel.selectSelectedTabs(state, OTHER_PANEL)).toEqual([OTHER_TAB]);

--- a/console/src/session/panel/slice.ts
+++ b/console/src/session/panel/slice.ts
@@ -64,7 +64,15 @@ export interface TabAndPanelKeyPayload extends PanelKeyPayload {
   tabKey: string;
 }
 
-export type RemovePayload = panel.Key | panel.Key[];
+export interface RemovePayload {
+  keys: panel.Key | panel.Key[];
+  /**
+   * The panels in the order the selector shows them, as of before the removal. A
+   * window that loses its selected panel takes the nearest survivor beside it.
+   * Without the row it falls back to its most recently used panel.
+   */
+  order?: panel.Key[];
+}
 
 interface SelectTabPayload extends TabAndPanelKeyPayload {
   otherTabKeys: panel.TabKey[];
@@ -72,6 +80,11 @@ interface SelectTabPayload extends TabAndPanelKeyPayload {
 
 export interface ReconcileSelectionPayload extends PanelKeyPayload {
   leaves: panel.TabKey[][];
+  /**
+   * The leaves the last reconcile saw, holding the row a lost tab's replacement
+   * comes from. Without it a lost tab has no neighbor and its leaf falls back.
+   */
+  previous?: panel.TabKey[][];
 }
 
 const withWindowKey = Window.createWithKeyHandler(windowStateZ);
@@ -88,6 +101,41 @@ const withSelectedState = <Payload extends PanelKeyPayload>(
   withWindowKey<Payload, SliceState>((win, action) => {
     handler(panelState(win, action.payload.key), action);
   });
+
+// What takes a closed entry's place in a row of tabs or panels: the nearest
+// survivor to its right, else to its left. Closing several in a row then needs no
+// re-aiming, since the replacement lands where the cursor already is.
+const neighbor = <K extends string>(
+  row: K[],
+  key: K,
+  survives: (key: K) => boolean,
+): K | undefined => {
+  const idx = row.indexOf(key);
+  if (idx < 0) return undefined;
+  return row.slice(idx + 1).find(survives) ?? row.slice(0, idx).findLast(survives);
+};
+
+// The tab taking a lost tab's place: its neighbor in the leaf it last sat in.
+const replacement = (
+  previous: panel.TabKey[][],
+  tab: panel.TabKey,
+  survives: (tab: panel.TabKey) => boolean,
+): panel.TabKey | undefined =>
+  neighbor(previous.find((tabs) => tabs.includes(tab)) ?? [], tab, survives);
+
+// What a leaf with no selected tab shows: the neighbor of the tab it lost, whether
+// that tab was closed or dragged into another leaf, else its first tab.
+const leafSelection = (
+  previous: panel.TabKey[][],
+  selected: panel.TabKey[],
+  tabs: panel.TabKey[],
+): panel.TabKey => {
+  const inLeaf = (tab: panel.TabKey): boolean => tabs.includes(tab);
+  const row = previous.find((prev) => prev.some(inLeaf)) ?? [];
+  const lost = row.find((tab) => selected.includes(tab) && !inLeaf(tab));
+  if (lost == null) return tabs[0];
+  return neighbor(row, lost, inLeaf) ?? tabs[0];
+};
 
 // A hidden panel stops rendering but keeps streaming its channels, so the set is
 // bounded. Five covers alternating between a few panels; an evicted one pays a
@@ -125,23 +173,29 @@ const { actions, reducer } = createSlice({
       win.isOverlaid = true;
     }),
     // reconcileSelection converges a panel's selection to its live tree: one tab
-    // per leaf, most recent first; a leaf with no selected tab contributes its
-    // last tab.
+    // per leaf, most recent first. A leaf that lost its selected tab, to a close or
+    // to a drag into another leaf, shows the tab beside it; one that never had a
+    // selection shows its first tab, the same tab the mosaic shows until the
+    // selection lands.
     reconcileSelection: withWindowKey<ReconcileSelectionPayload, SliceState>(
-      (win, { payload: { key, leaves } }) => {
+      (win, { payload: { key, leaves, previous = [] } }) => {
         const pan = panelState(win, key);
         const leafOf = new Map<panel.TabKey, number>();
         leaves.forEach((tabs, i) => tabs.forEach((tab) => leafOf.set(tab, i)));
+        const survives = (tab: panel.TabKey): boolean => leafOf.has(tab);
         const claimed = new Set<number>();
         const next: panel.TabKey[] = [];
         pan.selectedTabs.forEach((k) => {
-          const leaf = leafOf.get(k);
+          const tab = survives(k) ? k : replacement(previous, k, survives);
+          if (tab == null) return;
+          const leaf = leafOf.get(tab);
           if (leaf == null || claimed.has(leaf)) return;
           claimed.add(leaf);
-          next.push(k);
+          next.push(tab);
         });
         leaves.forEach((tabs, i) => {
-          if (!claimed.has(i) && tabs.length > 0) next.push(tabs[tabs.length - 1]);
+          if (!claimed.has(i) && tabs.length > 0)
+            next.push(leafSelection(previous, pan.selectedTabs, tabs));
         });
         // Overlaying shows the selected panel's focused tab. Losing that tab ends the
         // overlay; the flag would otherwise pull in whichever tab is focused next, or
@@ -155,18 +209,25 @@ const { actions, reducer } = createSlice({
     stopOverlaying: withWindowKey<Window.OptionalKeyParams, SliceState>((win) => {
       win.isOverlaid = false;
     }),
-    remove: (state, { payload: keys }: PayloadAction<RemovePayload>) => {
+    remove: (
+      state,
+      { payload: { keys, order = [] } }: PayloadAction<RemovePayload>,
+    ) => {
       const removed = array.toArray(keys);
+      const survives = (key: panel.Key): boolean => !removed.includes(key);
       Object.values(state.windows).forEach((win) => {
         removed.forEach((key) => delete win.panels[key]);
-        win.mounted = win.mounted.filter((key) => !removed.includes(key));
-        if (win.selected == null || !removed.includes(win.selected)) return;
+        win.mounted = win.mounted.filter(survives);
+        if (win.selected == null || survives(win.selected)) return;
         // The overlaid tab belongs to the selected panel, so losing it ends the
         // overlay.
         win.isOverlaid = false;
-        // Prefers the most recently used survivor, falling back to any panel the
-        // window has state for: mounted is empty until the window selects again.
-        const next = win.mounted[0] ?? Object.keys(win.panels).at(-1);
+        // Off the row, the most recently used survivor, then any panel the window
+        // has state for: mounted is empty until it selects again.
+        const next =
+          neighbor(order, win.selected, survives) ??
+          win.mounted[0] ??
+          Object.keys(win.panels).at(-1);
         win.selected = next;
         if (next != null) mount(win, next);
       });

--- a/console/src/session/panel/synchronizer.spec.ts
+++ b/console/src/session/panel/synchronizer.spec.ts
@@ -95,6 +95,54 @@ describe("Panel.WINDOW_SYNCHRONIZERS", () => {
     });
   });
 
+  // The closed tab's row lives in the synchronizer: the client holds one version of
+  // the document, so the tree the tab sat in is gone once the change lands.
+  const closeTab = async (
+    store: TestStore,
+    panelKey: panel.Key,
+    tabKeys: panel.TabKey[],
+    closed: panel.TabKey,
+  ): Promise<void> => {
+    act(() => selectTab(store, panelKey, closed));
+    await act(async () => {
+      await createPanel(panelKey, leaf(...tabKeys));
+    });
+    await waitFor(() => {
+      expect(Session.Panel.selectSelectedTabs(store.getState(), panelKey)).toEqual([
+        closed,
+      ]);
+    });
+    await act(async () => {
+      await client.panels.dispatch(panelKey, panel.removeTab({ key: closed }));
+    });
+  };
+
+  // Four tabs, closing the second: the neighbor and the row's last tab are
+  // different tabs, so the assertion can tell the two rules apart.
+  it("selects the tab to the right of a closed tab", async () => {
+    const panelKey = uuid.create();
+    const tabs = Array.from({ length: 4 }, () => uuid.create());
+    const { store } = await mount();
+    await closeTab(store, panelKey, tabs, tabs[1]);
+    await waitFor(() => {
+      expect(Session.Panel.selectSelectedTabs(store.getState(), panelKey)).toEqual([
+        tabs[2],
+      ]);
+    });
+  });
+
+  it("selects the tab to the left when the closed tab was last", async () => {
+    const panelKey = uuid.create();
+    const tabs = [uuid.create(), uuid.create(), uuid.create()];
+    const { store } = await mount();
+    await closeTab(store, panelKey, tabs, tabs[2]);
+    await waitFor(() => {
+      expect(Session.Panel.selectSelectedTabs(store.getState(), panelKey)).toEqual([
+        tabs[1],
+      ]);
+    });
+  });
+
   it("reconciles from the cache when an already-cached panel is selected", async () => {
     const panelKey = uuid.create();
     const tab = uuid.create();
@@ -202,7 +250,7 @@ describe("useReconcileSelection", () => {
         violations.push(selected);
     });
     await act(async () => {
-      store.dispatch(Session.Panel.remove(pan.key));
+      store.dispatch(Session.Panel.remove({ keys: pan.key }));
       await client.panels.delete(pan.key);
       // The racing repair retrieve resolves after the delete; give every
       // in-flight repair a full round-trip to land before judging.

--- a/console/src/session/panel/synchronizer.ts
+++ b/console/src/session/panel/synchronizer.ts
@@ -10,6 +10,7 @@
 import { panel, project, query } from "@synnaxlabs/client";
 import { Drift } from "@synnaxlabs/drift";
 import { destructor } from "@synnaxlabs/x";
+import { useRef } from "react";
 
 import { selectActiveWindow, selectSelected } from "@/session/panel/selectors";
 import {
@@ -45,7 +46,7 @@ export const SYNCHRONIZERS: Synchronizer.Synchronizers<
     name: "remove deleted panels",
     domain: (client) => client.panels,
     selectKeys,
-    remove,
+    remove: (keys) => remove({ keys }),
   }),
 ];
 
@@ -158,23 +159,38 @@ const windowTitle: Synchronizer.Callbacks<RequiredStoreState, RequiredAction> = 
   },
 };
 
-const reconcileTabs = (store: RequiredStore, pan: panel.Panel): void => {
+// The leaves each panel last reconciled against. The client holds one version of a
+// panel document, so the row a closed tab sat in is gone by the time the change
+// arrives; keeping it here is what lets the selection move to the tab beside the
+// closed one rather than to a fixed position.
+type LeafGroups = Map<panel.Key, panel.TabKey[][]>;
+
+const reconcileTabs = (
+  store: RequiredStore,
+  leafGroups: LeafGroups,
+  pan: panel.Panel,
+): void => {
   const win = selectActiveWindow(store.getState());
   if (win == null) return;
   if (win.state.selected !== pan.key && win.state.panels[pan.key] == null) return;
+  const leaves = panel.leafTabGroups(pan.root);
   store.dispatch(
     reconcileSelection({
       windowKey: win.key,
       key: pan.key,
-      leaves: panel.leafTabGroups(pan.root),
+      leaves,
+      previous: leafGroups.get(pan.key),
     }),
   );
+  leafGroups.set(pan.key, leaves);
 };
 
 // Converges the window's tab selections to each referenced panel's live tree.
 // Runs per window off its own cache feed, so the selection and the tree
 // update in the same tick; cross-window echoes of the action are no-ops.
-const tabSelections: Synchronizer.Callbacks<RequiredStoreState, RequiredAction> = {
+const createTabSelections = (
+  leafGroups: LeafGroups,
+): Synchronizer.Callbacks<RequiredStoreState, RequiredAction> => ({
   reconcile: async ({ client, store }) => {
     const win = selectActiveWindow(store.getState());
     if (win == null) return;
@@ -185,20 +201,30 @@ const tabSelections: Synchronizer.Callbacks<RequiredStoreState, RequiredAction> 
       keys: [...keys],
       ignoreNotFoundError: true,
     });
-    panels.forEach((pan) => reconcileTabs(store, pan));
+    panels.forEach((pan) => reconcileTabs(store, leafGroups, pan));
   },
   listen: ({ client, store }) => {
-    const removeOnSet = client.panels.onSet((pan) => reconcileTabs(store, pan));
+    const removeOnSet = client.panels.onSet((pan) =>
+      reconcileTabs(store, leafGroups, pan),
+    );
     // A panel cached before the window first selects it fires no set event, so
     // the selection change itself reconciles against the cached tree.
     const unwatchSelected = Synchronizer.watch(store, selectSelected, (selected) => {
       if (selected == null) return;
       const cached = client.panels.getCached(selected);
       if (!query.isLive(cached)) return;
-      reconcileTabs(store, cached);
+      reconcileTabs(store, leafGroups, cached);
     });
     return () => destructor.unwind(removeOnSet, unwatchSelected);
   },
+});
+
+const useTabSelections = (): Synchronizer.Callbacks<
+  RequiredStoreState,
+  RequiredAction
+> => {
+  const leafGroups = useRef<LeafGroups>(new Map());
+  return createTabSelections(leafGroups.current);
 };
 
 export const WINDOW_SYNCHRONIZERS: Synchronizer.Synchronizers<
@@ -207,5 +233,5 @@ export const WINDOW_SYNCHRONIZERS: Synchronizer.Synchronizers<
 > = [
   { name: "reconcile panel selection", use: () => selection },
   { name: "sync window title", use: () => windowTitle },
-  { name: "reconcile tab selections", use: () => tabSelections },
+  { name: "reconcile tab selections", use: useTabSelections },
 ];

--- a/pluto/src/panel/Mosaic.spec.tsx
+++ b/pluto/src/panel/Mosaic.spec.tsx
@@ -900,5 +900,49 @@ describe("Panel.Mosaic", () => {
         ]);
       }, ROUND_TRIP);
     });
+
+    // Another client can close the dragged tab before the drop lands. The move is
+    // then a no-op, and naming the tab to a selection handler would name one this
+    // panel no longer holds.
+    it("should not select a dragged tab another client closed mid-drag", async () => {
+      const moved = resourceTab();
+      const stays = resourceTab();
+      const p = await splitPanel(moved, stays, resourceTab(), resourceTab());
+      const onSelect = vi.fn();
+      let utils!: RenderResult;
+      await act(async () => {
+        utils = render(
+          <Haul.Provider>
+            <Errors.SuspenseBoundary loading={<div>loading</div>}>
+              <Panel.Suspended panelKey={p.key}>
+                <Panel.Mosaic tabName={() => <TabKeyNameProbe />} onSelect={onSelect}>
+                  {children}
+                </Panel.Mosaic>
+              </Panel.Suspended>
+            </Errors.SuspenseBoundary>
+          </Haul.Provider>,
+          { wrapper },
+        );
+      });
+      await waitFor(() => expect(utils.getByText(`name:${moved.key}`)).toBeTruthy());
+
+      const leaves = utils.container.querySelectorAll(".pluto-mosaic__leaf");
+      await act(async () => {
+        fireEvent.dragStart(utils.getByText(`name:${moved.key}`));
+      });
+      await writer.panels.retrieve(p.key);
+      await act(async () => {
+        await writer.panels.dispatch(p.key, [panel.removeTab({ key: moved.key })]);
+      });
+      await waitFor(
+        () => expect(utils.queryByText(`name:${moved.key}`)).toBeNull(),
+        ROUND_TRIP,
+      );
+
+      await act(async () => {
+        drop(leaves[1]);
+      });
+      expect(onSelect).not.toHaveBeenCalled();
+    });
   });
 });

--- a/pluto/src/panel/Mosaic.spec.tsx
+++ b/pluto/src/panel/Mosaic.spec.tsx
@@ -859,5 +859,46 @@ describe("Panel.Mosaic", () => {
         expect(panel.findTab(fetched.root, second.key)).toBeDefined();
       }, ROUND_TRIP);
     });
+
+    // A drag fires no click, so a tab moved between leaves of one panel reaches its
+    // new leaf unselected unless the drop selects it.
+    it("should select a tab dropped into another leaf of the same panel", async () => {
+      const moved = resourceTab();
+      const stays = resourceTab();
+      const p = await splitPanel(moved, stays, resourceTab(), resourceTab());
+      const onSelect = vi.fn();
+      let utils!: RenderResult;
+      await act(async () => {
+        utils = render(
+          <Haul.Provider>
+            <Errors.SuspenseBoundary loading={<div>loading</div>}>
+              <Panel.Suspended panelKey={p.key}>
+                <Panel.Mosaic tabName={() => <TabKeyNameProbe />} onSelect={onSelect}>
+                  {children}
+                </Panel.Mosaic>
+              </Panel.Suspended>
+            </Errors.SuspenseBoundary>
+          </Haul.Provider>,
+          { wrapper },
+        );
+      });
+      await waitFor(() => expect(utils.getByText(`name:${moved.key}`)).toBeTruthy());
+
+      const leaves = utils.container.querySelectorAll(".pluto-mosaic__leaf");
+      expect(leaves).toHaveLength(2);
+      await act(async () => {
+        fireEvent.dragStart(utils.getByText(`name:${moved.key}`));
+        drop(leaves[1]);
+      });
+
+      expect(onSelect).toHaveBeenCalledWith(moved.key);
+      await waitFor(async () => {
+        const fetched = await client.panels.retrieve(p.key);
+        expect(panel.leafTabGroups(fetched.root)).toEqual([
+          [stays.key],
+          expect.arrayContaining([moved.key]),
+        ]);
+      }, ROUND_TRIP);
+    });
   });
 });

--- a/pluto/src/panel/Mosaic.tsx
+++ b/pluto/src/panel/Mosaic.tsx
@@ -336,6 +336,7 @@ export const Mosaic = ({
 }: MosaicProps): ReactElement | null => {
   const dispatch = useSingleDispatch();
   const key = Scope.use();
+  const client = Synnax.use();
   const { dispatch: dispatchTo } = useDispatch();
 
   // A tab dropped from another panel is removed there and inserted here: the two
@@ -347,7 +348,11 @@ export const Mosaic = ({
       const source = parseTabDragPayload(data);
       if (source == null || source.panel === key) {
         dispatch(panel.moveTab({ key: tabKey, targetLeaf: nodeKey, index, location }));
-        onSelect?.(tabKey);
+        // Another client can close the tab mid-drag, leaving the move a no-op and
+        // the key naming a tab this panel no longer holds.
+        const cached = client?.panels.getCached(key);
+        if (query.isLive(cached) && panel.findTab(cached.root, tabKey) != null)
+          onSelect?.(tabKey);
         return;
       }
       dispatchTo({
@@ -362,7 +367,7 @@ export const Mosaic = ({
       dispatchTo({ key: source.panel, actions: panel.removeTab({ key: tabKey }) });
       onSelect?.(tabKey);
     },
-    [dispatch, dispatchTo, key, onSelect],
+    [client, dispatch, dispatchTo, key, onSelect],
   );
 
   const handleResize = useCallback(

--- a/pluto/src/panel/Mosaic.tsx
+++ b/pluto/src/panel/Mosaic.tsx
@@ -347,6 +347,7 @@ export const Mosaic = ({
       const source = parseTabDragPayload(data);
       if (source == null || source.panel === key) {
         dispatch(panel.moveTab({ key: tabKey, targetLeaf: nodeKey, index, location }));
+        onSelect?.(tabKey);
         return;
       }
       dispatchTo({


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4584](https://linear.app/synnax/issue/SY-4584)

## Description

Closing a tab used to select the last tab in its group, and deleting a panel used to
select whichever panel the window visited most recently. Both jump: the user loses their
place in the strip. Every tab strip users know, from browsers to Figma to VS Code, hands
the selection to the entry beside the one that went away.

Closing a tab, deleting a panel, and dragging a tab into another leaf now all select the
nearest survivor to the right, else to the left. One `neighbor` helper serves all three.
A group with no selection at all shows its first tab, matching what the mosaic already
draws while the selection resolves, so a panel no longer flashes on open.

Picking a neighbor needs the row as it looked before the change, and the client holds
only the panel document's current version. The tab-selection synchronizer keeps the
leaves it last reconciled against and passes them in the action; the panel strip passes
its rendered order on delete. Nothing server-derived was added to session state.

Dragging a tab between leaves of one panel also never selected it, so a tab could land
out of sight. The drop now selects it, as the other three insert paths already did.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes panel and tab removal behavior to select the nearest surviving item. It also selects tabs after same-panel drops and adds regression tests.
- Adds shared neighbor-selection logic for panels and tabs.
- Preserves prior leaf groups so tab reconciliation can use the pre-change order.
- Passes rendered panel order into deletion actions.
- Selects tabs moved between leaves in the same panel.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The changed selection paths use pre-change ordering to choose surviving neighbors, preserve existing fallbacks, and include focused regression coverage for panel deletion, tab closure, and same-panel moves.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| console/src/session/panel/slice.ts | Adds neighbor-based replacement logic to panel removal and tab reconciliation. |
| console/src/session/panel/synchronizer.ts | Retains the last reconciled leaf groups and supplies them to selection reconciliation. |
| console/src/feature/panel/Selector.tsx | Supplies the rendered panel order when deleting panels. |
| pluto/src/panel/Mosaic.tsx | Selects a tab after a same-panel drop, consistent with cross-panel drops. |
| console/src/session/panel/slice.spec.ts | Covers neighbor selection for panel deletion, tab closure, and tab movement. |
| console/src/session/panel/synchronizer.spec.ts | Covers right and left neighbor selection after synchronized tab removal. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Panel or tab is removed] --> B{Right survivor exists?}
  B -->|Yes| C[Select right survivor]
  B -->|No| D{Left survivor exists?}
  D -->|Yes| E[Select left survivor]
  D -->|No| F[Use fallback or clear selection]
```

<sub>Reviews (1): Last reviewed commit: ["SY-4584: Select the neighbor when a tab ..."](https://github.com/synnaxlabs/synnax/commit/9f50c28930c94c8f8e43ae31d2f60b3ff9018bbc) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53368265)</sub>

<!-- /greptile_comment -->