### PR TITLE
SY-4588: Restyle the Windows window controls

### DIFF
--- a/console/src/platform/window/Controls.tsx
+++ b/console/src/platform/window/Controls.tsx
@@ -47,6 +47,7 @@ export const Controls = (props: ControlsProps): ReactElement | null => {
     <OS.Controls
       disabled={disabled}
       focused={window?.focus}
+      maximized={window?.maximized}
       onClose={handleClose}
       onFullscreen={handleFullscreen}
       onMaximize={handleMaximize}

--- a/pluto/src/icon/registry.css
+++ b/pluto/src/icon/registry.css
@@ -99,6 +99,12 @@
     transform: scale(var(--pluto-base-scale));
 }
 
+/* Same reason as boxes: the mark covers 68% of its box. */
+.pluto-icon--close-thin {
+    --pluto-base-scale: 1.15;
+    transform: scale(var(--pluto-base-scale));
+}
+
 .pluto-icon--reset {
     fill: var(--pluto-gray-l11);
 }

--- a/pluto/src/icon/registry.css
+++ b/pluto/src/icon/registry.css
@@ -93,6 +93,12 @@
     transform: scale(var(--pluto-base-scale));
 }
 
+/* The chrome glyph covers 62% of its box, against the 78% Box draws. */
+.pluto-icon--boxes {
+    --pluto-base-scale: 1.25;
+    transform: scale(var(--pluto-base-scale));
+}
+
 .pluto-icon--reset {
     fill: var(--pluto-gray-l11);
 }

--- a/pluto/src/icon/registry.tsx
+++ b/pluto/src/icon/registry.tsx
@@ -19,6 +19,7 @@ import {
   AiFillWarning,
   AiOutlineBorder,
   AiOutlineCheck,
+  AiOutlineClose,
   AiOutlineMinus,
   AiOutlineSync,
 } from "react-icons/ai";
@@ -279,6 +280,7 @@ export const Paste = wrapSVGIcon(MdContentPaste, "paste");
 export const Undo = wrapSVGIcon(MdUndo, "undo");
 export const Redo = wrapSVGIcon(MdRedo, "redo");
 export const Close = wrapSVGIcon(FaXmark, "close");
+export const CloseThin = wrapSVGIcon(AiOutlineClose, "close-thin");
 export const Info = wrapSVGIcon(BsFillInfoSquareFill, "info");
 export const Warning = wrapSVGIcon(AiFillWarning, "warning");
 export const Check = wrapSVGIcon(AiOutlineCheck, "check");
@@ -583,6 +585,7 @@ const icons = {
   Undo,
   Redo,
   Close,
+  CloseThin,
   Info,
   Warning,
   Check,

--- a/pluto/src/icon/registry.tsx
+++ b/pluto/src/icon/registry.tsx
@@ -245,6 +245,7 @@ import {
   TbVariable,
 } from "react-icons/tb";
 import {
+  VscChromeRestore,
   VscSplitHorizontal,
   VscSplitVertical,
   VscSymbolConstant,
@@ -347,6 +348,7 @@ export const Resources = wrapSVGIcon(AiFillFolder, "resources");
 export const Group = wrapSVGIcon(AiFillFolder, "group");
 export const Project = wrapSVGIcon(MdWorkspacesFilled, "project");
 export const Box = wrapSVGIcon(AiOutlineBorder, "box");
+export const Boxes = wrapSVGIcon(VscChromeRestore, "boxes");
 export const Python = wrapSVGIcon(SiPython, "python");
 export const TypeScript = wrapSVGIcon(SiTypescript, "typescript");
 export const CPlusPlus = wrapSVGIcon(SiCplusplus, "cplusplus");
@@ -615,6 +617,7 @@ const icons = {
   Group,
   Project,
   Box,
+  Boxes,
   Python,
   TypeScript,
   CPlusPlus,

--- a/pluto/src/os/Controls/Controls.spec.tsx
+++ b/pluto/src/os/Controls/Controls.spec.tsx
@@ -1,0 +1,149 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { OS } from "@/os";
+
+const WINDOWS_CONTROL = ".pluto-windows-control";
+const MACOS_CONTROL = ".pluto-macos-control";
+
+const control = (c: HTMLElement, os: "windows" | "macos", action: string) =>
+  c.querySelector<HTMLButtonElement>(`.pluto-${os}-control--${action}`);
+
+describe("OS.Controls", () => {
+  describe("os dispatch", () => {
+    it("should render the windows controls when forced to Windows", () => {
+      const { container } = render(<OS.Controls forceOS="Windows" />);
+      expect(container.querySelectorAll(WINDOWS_CONTROL)).toHaveLength(3);
+      expect(container.querySelectorAll(MACOS_CONTROL)).toHaveLength(0);
+    });
+
+    it("should render the macOS controls when forced to macOS", () => {
+      const { container } = render(<OS.Controls forceOS="macOS" />);
+      expect(container.querySelectorAll(MACOS_CONTROL)).toHaveLength(3);
+      expect(container.querySelectorAll(WINDOWS_CONTROL)).toHaveLength(0);
+    });
+
+    it("should render nothing when visibleIfOS does not match the os", () => {
+      const { container } = render(
+        <OS.Controls forceOS="Windows" visibleIfOS="macOS" />,
+      );
+      expect(container.querySelector("button")).toBeNull();
+    });
+
+    it("should render when visibleIfOS matches the os", () => {
+      const { container } = render(<OS.Controls forceOS="macOS" visibleIfOS="macOS" />);
+      expect(container.querySelectorAll(MACOS_CONTROL)).toHaveLength(3);
+    });
+  });
+
+  describe("windows", () => {
+    it("should show the box glyph when the window is not maximized", () => {
+      const { container } = render(<OS.Controls forceOS="Windows" />);
+      const maximize = control(container, "windows", "maximize");
+      expect(maximize?.querySelector(".pluto-icon--box")).not.toBeNull();
+      expect(maximize?.querySelector(".pluto-icon--boxes")).toBeNull();
+    });
+
+    it("should swap in the boxes glyph when the window is maximized", () => {
+      const { container } = render(<OS.Controls forceOS="Windows" maximized />);
+      const maximize = control(container, "windows", "maximize");
+      expect(maximize?.querySelector(".pluto-icon--boxes")).not.toBeNull();
+      expect(maximize?.querySelector(".pluto-icon--box")).toBeNull();
+    });
+
+    it("should close with the thin glyph rather than the heavier Icon.Close", () => {
+      const { container } = render(<OS.Controls forceOS="Windows" />);
+      const close = control(container, "windows", "close");
+      expect(close?.querySelector(".pluto-icon--close-thin")).not.toBeNull();
+      expect(close?.querySelector(".pluto-icon--close")).toBeNull();
+    });
+
+    it("should call the handler matching each control", () => {
+      const onMinimize = vi.fn();
+      const onMaximize = vi.fn();
+      const onClose = vi.fn();
+      const { container } = render(
+        <OS.Controls
+          forceOS="Windows"
+          onClose={onClose}
+          onMaximize={onMaximize}
+          onMinimize={onMinimize}
+        />,
+      );
+      fireEvent.click(control(container, "windows", "minimize") as HTMLElement);
+      fireEvent.click(control(container, "windows", "maximize") as HTMLElement);
+      fireEvent.click(control(container, "windows", "close") as HTMLElement);
+      expect(onMinimize).toHaveBeenCalledTimes(1);
+      expect(onMaximize).toHaveBeenCalledTimes(1);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("should omit a disabled control instead of rendering it inert", () => {
+      const { container } = render(
+        <OS.Controls forceOS="Windows" disabled={["maximize"]} />,
+      );
+      expect(control(container, "windows", "maximize")).toBeNull();
+      expect(container.querySelectorAll(WINDOWS_CONTROL)).toHaveLength(2);
+    });
+  });
+
+  describe("macOS", () => {
+    it("should fullscreen from the maximize light rather than maximize", () => {
+      const onMaximize = vi.fn();
+      const onFullscreen = vi.fn();
+      const { container } = render(
+        <OS.Controls
+          forceOS="macOS"
+          onFullscreen={onFullscreen}
+          onMaximize={onMaximize}
+        />,
+      );
+      fireEvent.click(control(container, "macos", "maximize") as HTMLElement);
+      expect(onFullscreen).toHaveBeenCalledTimes(1);
+      expect(onMaximize).not.toHaveBeenCalled();
+    });
+
+    it("should call the handler matching each remaining control", () => {
+      const onMinimize = vi.fn();
+      const onClose = vi.fn();
+      const { container } = render(
+        <OS.Controls forceOS="macOS" onClose={onClose} onMinimize={onMinimize} />,
+      );
+      fireEvent.click(control(container, "macos", "minimize") as HTMLElement);
+      fireEvent.click(control(container, "macos", "close") as HTMLElement);
+      expect(onMinimize).toHaveBeenCalledTimes(1);
+      expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("should keep a disabled control mounted but inert", () => {
+      const onClose = vi.fn();
+      const { container } = render(
+        <OS.Controls forceOS="macOS" disabled={["close"]} onClose={onClose} />,
+      );
+      const close = control(container, "macos", "close");
+      expect(close).not.toBeNull();
+      expect(close?.disabled).toBe(true);
+      fireEvent.click(close as HTMLElement);
+      expect(onClose).not.toHaveBeenCalled();
+    });
+
+    it("should mark the controls blurred when the window is not focused", () => {
+      const { container } = render(<OS.Controls focused={false} forceOS="macOS" />);
+      expect(container.querySelector(".pluto-macos-controls--blurred")).not.toBeNull();
+    });
+
+    it("should not mark the controls blurred when the window is focused", () => {
+      const { container } = render(<OS.Controls focused forceOS="macOS" />);
+      expect(container.querySelector(".pluto-macos-controls--blurred")).toBeNull();
+    });
+  });
+});

--- a/pluto/src/os/Controls/Mac.tsx
+++ b/pluto/src/os/Controls/Mac.tsx
@@ -78,6 +78,8 @@ export const MacOS = ({
   disabled = [],
   className,
   focused = true,
+  // no-op on macOS
+  maximized: _,
   onMinimize,
   onMaximize,
   onFullscreen,

--- a/pluto/src/os/Controls/Windows.tsx
+++ b/pluto/src/os/Controls/Windows.tsx
@@ -19,6 +19,7 @@ import { type InternalControlsProps } from "@/os/Controls/types";
 
 export const Windows = ({
   disabled = [],
+  maximized = false,
   onMinimize,
   onMaximize,
   onClose,
@@ -40,7 +41,7 @@ export const Windows = ({
       onClick={onMaximize}
       disabled={disabled.includes("maximize")}
     >
-      <Icon.Box />
+      {maximized ? <Icon.Boxes /> : <Icon.Box />}
     </Button>
     <Button
       onClick={onClose}
@@ -61,6 +62,7 @@ const Button = ({
     <BaseButton.Button
       className={CSS(CSS.B("windows-control"), className)}
       tabIndex={-1}
+      variant="text"
       {...rest}
     />
   ) : null;

--- a/pluto/src/os/Controls/Windows.tsx
+++ b/pluto/src/os/Controls/Windows.tsx
@@ -48,7 +48,7 @@ export const Windows = ({
       className={CSS.BM("windows-control", "close")}
       disabled={disabled.includes("close")}
     >
-      <Icon.Close />
+      <Icon.CloseThin />
     </Button>
   </Flex.Box>
 );

--- a/pluto/src/os/Controls/types.ts
+++ b/pluto/src/os/Controls/types.ts
@@ -17,6 +17,7 @@ export interface InternalControlsProps extends Flex.BoxProps {
   forceOS?: runtime.OS;
   disabled?: ControlsAction[];
   focused?: boolean;
+  maximized?: boolean;
   onMinimize?: () => void;
   onMaximize?: () => void;
   onFullscreen?: () => void;


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4588](https://linear.app/synnax/issue/SY-4588/fix-windows-controls-in-console)

## Description

The Windows caption buttons drew outlined borders against the title bar, which no
native window chrome does. They now use the `text` variant, so they sit transparent at
rest and take their hover and press fills from the theme's interactive fill band.

Maximizing a window swaps the maximize glyph for a restore glyph, matching the
behavior every Windows app has. The glyph is registered as `Icon.Boxes` to pair with
`Icon.Box` and to keep "restore" clear of resource-recovery vocabulary. It reads
`maximized` off Drift's window state.

`Icon.Close` moved from `AiOutlineClose` to `FaXmark` in SY-4381. `FaXmark` is heavier
and sits in a non-square viewBox, so once letterboxed into the square em box it drew
narrower than `Subtract` and `Box` next to it. `Icon.CloseThin` brings the original
mark back for window chrome; every other `Icon.Close` caller is untouched.

Both new icons carry a default scale in `registry.css` so the three caption glyphs
share one optical size wherever they are used.

`pluto/src/os/Controls` had no specs. It has 14 now, driven through the public
`OS.Controls` surface. Alongside the glyph swap they pin two per-OS divergences that
were undocumented: Windows drops a disabled control entirely while macOS keeps it
mounted and inert, and the macOS maximize light fullscreens rather than maximizes.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.