### PR TITLE
SY-4589: Fix button hover styles

### DIFF
--- a/console/src/app/window/Window.css
+++ b/console/src/app/window/Window.css
@@ -14,9 +14,13 @@
 
     overflow: hidden;
     background: var(--pluto-gray-l2);
+}
 
-    /* Chrome controls recess toward the canvas instead of lightening; nested
-       panes reset to the standard ladder via their surface classes. */
+/* Outlined chips recess into the chrome rather than rise off it. Scoped to the
+   variant: a text button has no rest fill, so the same band would darken it on
+   hover and then drop it back onto the bar on press. */
+.console-nav__bar .pluto-btn--outlined,
+.console-shell__islands .pluto-btn--outlined {
     --pluto-fill-rest: var(--pluto-gray-l0);
     --pluto-fill-hover: var(--pluto-gray-l1);
     --pluto-fill-press: var(--pluto-gray-l2);

--- a/console/src/feature/panel/Selector.tsx
+++ b/console/src/feature/panel/Selector.tsx
@@ -166,7 +166,7 @@ const Internal = (): ReactElement => {
             <Tab key={key} tabKey={key} />
           ))}
         </Tabs.Selector>
-        <Button.Button variant="text" onClick={handleCreate}>
+        <Button.Button variant="text" textColor={9} onClick={handleCreate}>
           <Icon.Add />
           {selected == null && "New Panel"}
         </Button.Button>

--- a/pluto/src/flex/Box.css
+++ b/pluto/src/flex/Box.css
@@ -226,14 +226,6 @@
         border-color: var(--pluto-gray-l11);
     }
 
-    /* Declaring a canvas or raised surface resets the fill ladder, so panes nested
-       inside recessed chrome resume the standard upward fills. */
-    &.pluto--bg-0,
-    &.pluto--bg-1 {
-        --pluto-fill-rest: var(--pluto-gray-l3);
-        --pluto-fill-hover: var(--pluto-gray-l4);
-        --pluto-fill-press: var(--pluto-gray-l5);
-    }
     &.pluto--bg-0 {
         background-color: var(--pluto-gray-l0);
     }


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4589](https://linear.app/synnax/issue/SY-4589/fix-button-hover-styles)

## Description

Buttons on the console chrome darkened on hover and then lost all fill on press,
landing on the exact color of the bar behind them.

`.console-main` re-pointed the interactive fill band to `l0 → l1 → l2` while
painting itself `l2`. Every escalation step moved toward the surface instead of
away from it, and press landed on it. That also broke the scale's own invariant
that a component fill stays at least one step from any surface.

The band now stays standard for the whole window. The recessed look is kept
where it worked, scoped to the outlined variant on the two chrome containers: an
outlined chip starts at `l0`, so its band is monotonic and its border holds the
shape. A text button has no rest fill, so it keeps the standard `l4`/`l5`.

Dropping the surface-wide re-point makes the `bg-0`/`bg-1` reset in `Box.css`
dead code, so it goes too. That removes the coupling between a paint prop and
interaction feedback: the band no longer depends on whether some ancestor
happened to be painted, and positioned elements like the shell islands can no
longer fall out of scope.

Also sets `textColor={9}` on the panel selector's add button so it reads as
secondary until hovered.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR corrects Console chrome button interaction colors and gives the panel add button a secondary resting color.

- Scopes the recessed fill band to outlined buttons in the navigation bar and shell islands.
- Removes obsolete surface-level fill resets from Pluto boxes.
- Sets the panel selector add button text color to shade 9.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The scoped CSS selectors use the existing Pluto fill variables, the global theme still supplies standard defaults, and the text-color prop follows established Button behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| console/src/app/window/Window.css | Scopes recessed fill tokens to outlined chrome buttons while retaining the standard fill band elsewhere. |
| console/src/feature/panel/Selector.tsx | Adds the established secondary text shade to the panel creation button. |
| pluto/src/flex/Box.css | Removes surface-level fill-token resets that are obsolete after the chrome override is button-scoped. |

<sub>Reviews (1): Last reviewed commit: ["SY-4589: Fix button hover and press fill..."](https://github.com/synnaxlabs/synnax/commit/a1cdee735d06bdfe935c60d1933126f9348bcf1c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53456686)</sub>

**Context used:**

- Knowledge Base — [Console App](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/console-app.md)
- Knowledge Base — [Pluto Component and Visualization Library](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/pluto-components.md)

<!-- /greptile_comment -->