### PR TITLE
SY-4591: Fix table values drifting on scroll

### DIFF
--- a/console/src/feature/table/Table.css
+++ b/console/src/feature/table/Table.css
@@ -12,7 +12,6 @@
 .console-table {
     width: 100%;
     height: 100%;
-    overflow: auto;
     padding: 1rem;
 }
 

--- a/pluto/src/table/Table.css
+++ b/pluto/src/table/Table.css
@@ -23,6 +23,12 @@
         position: absolute;
         inset: 0;
     }
+
+    & .pluto-table-surface__scroll {
+        position: absolute;
+        inset: 0;
+        overflow: auto;
+    }
 }
 
 .pluto-table-frame {

--- a/pluto/src/table/Table.spec.tsx
+++ b/pluto/src/table/Table.spec.tsx
@@ -9,7 +9,7 @@
 
 import { table } from "@synnaxlabs/client";
 import { createTestClient } from "@synnaxlabs/client/testutil";
-import { box, xy } from "@synnaxlabs/x";
+import { box, type scale, xy } from "@synnaxlabs/x";
 import { act, fireEvent, render, renderHook, waitFor } from "@testing-library/react";
 import { type PropsWithChildren, type ReactElement } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -74,7 +74,7 @@ class ImmediateResizeObserver {
   disconnect(): void {}
 }
 
-describe("Table centering", () => {
+describe("Table", () => {
   let wrapper: React.FC<PropsWithChildren>;
   let key: table.Key;
   let recorder: canvasTest.Recorder;
@@ -132,12 +132,16 @@ describe("Table centering", () => {
       </Table.Suspended>
     );
     const { container } = render(<Wrapped />, { wrapper });
-    const frame = (): HTMLElement => {
-      const el = container.querySelector<HTMLElement>(".pluto-table-frame");
-      if (el == null) throw new Error("the table frame did not render");
+    const query = (selector: string) => (): HTMLElement => {
+      const el = container.querySelector<HTMLElement>(selector);
+      if (el == null) throw new Error(`${selector} did not render`);
       return el;
     };
-    return { frame };
+    return {
+      frame: query(".pluto-table-frame"),
+      scroller: query(".pluto-table-surface__scroll"),
+      probe: query(".pluto-table-surface__canvas"),
+    };
   };
 
   const resizeRow = async (size: number): Promise<void> => {
@@ -185,54 +189,110 @@ describe("Table centering", () => {
       expect(box.dims(b)).toEqual({ width: COL_SIZE, height: rowSize });
     });
 
-  it("leaves an uncentered table untranslated", async () => {
-    const { frame } = renderTable(false);
-    await expectPlacement(frame, xy.ZERO);
+  describe("centering", () => {
+    it("leaves an uncentered table untranslated", async () => {
+      const { frame } = renderTable(false);
+      await expectPlacement(frame, xy.ZERO);
+    });
+
+    it("centers on both axes when the table fits", async () => {
+      const { frame } = renderTable(true);
+      await expectPlacement(frame, expectedOffset(COL_SIZE, ROW_SIZE));
+    });
+
+    it("clamps to zero on an axis the table overflows", async () => {
+      const { frame } = renderTable(true);
+      await resizeRow(SURFACE_HEIGHT * 2);
+      await expectPlacement(
+        frame,
+        { ...expectedOffset(COL_SIZE, SURFACE_HEIGHT * 2), y: 0 },
+        SURFACE_HEIGHT * 2,
+      );
+    });
+
+    it("recenters when the table changes size", async () => {
+      const { frame } = renderTable(true);
+      await expectPlacement(frame, expectedOffset(COL_SIZE, ROW_SIZE));
+      await resizeRow(200);
+      await expectPlacement(frame, expectedOffset(COL_SIZE, 200), 200);
+    });
+
+    it("holds the offset while the pointer is down", async () => {
+      const { frame } = renderTable(true);
+      const settled = expectedOffset(COL_SIZE, ROW_SIZE);
+      await expectPlacement(frame, settled);
+      fireEvent.pointerDown(frame());
+      await resizeRow(200);
+      expect(frame().style.transform).toEqual(
+        `translate(${settled.x}px, ${settled.y}px)`,
+      );
+      // The cell grew but its origin must stay held with the frame.
+      await expectPlacement(frame, settled, 200);
+      fireEvent.pointerUp(window);
+      await expectPlacement(frame, expectedOffset(COL_SIZE, 200), 200);
+    });
+
+    it("releases the held offset on pointer cancellation", async () => {
+      const { frame } = renderTable(true);
+      await expectPlacement(frame, expectedOffset(COL_SIZE, ROW_SIZE));
+      fireEvent.pointerDown(frame());
+      await resizeRow(200);
+      fireEvent.pointerCancel(window);
+      await expectPlacement(frame, expectedOffset(COL_SIZE, 200), 200);
+    });
   });
 
-  it("centers on both axes when the table fits", async () => {
-    const { frame } = renderTable(true);
-    await expectPlacement(frame, expectedOffset(COL_SIZE, ROW_SIZE));
-  });
+  describe("scrolling", () => {
+    const ORIGIN: xy.XY = { x: INDICATOR_SIZE, y: INDICATOR_SIZE };
 
-  it("clamps to zero on an axis the table overflows", async () => {
-    const { frame } = renderTable(true);
-    await resizeRow(SURFACE_HEIGHT * 2);
-    await expectPlacement(
-      frame,
-      { ...expectedOffset(COL_SIZE, SURFACE_HEIGHT * 2), y: 0 },
-      SURFACE_HEIGHT * 2,
-    );
-  });
+    const drawnAt = (): xy.XY => {
+      const applied = recorder.upper2d.calls.findLast((c) => c.op === "applyScale");
+      if (applied == null) throw new Error("no cell draw was recorded");
+      return (applied.args[0] as scale.XY).pos(box.topLeft(lastCellBox()));
+    };
 
-  it("recenters when the table changes size", async () => {
-    const { frame } = renderTable(true);
-    await expectPlacement(frame, expectedOffset(COL_SIZE, ROW_SIZE));
-    await resizeRow(200);
-    await expectPlacement(frame, expectedOffset(COL_SIZE, 200), 200);
-  });
+    const scrollTo = (scroller: () => HTMLElement, to: xy.XY): void => {
+      const el = scroller();
+      el.scrollLeft = to.x;
+      el.scrollTop = to.y;
+      fireEvent.scroll(el);
+    };
 
-  it("holds the offset while the pointer is down", async () => {
-    const { frame } = renderTable(true);
-    const settled = expectedOffset(COL_SIZE, ROW_SIZE);
-    await expectPlacement(frame, settled);
-    fireEvent.pointerDown(frame());
-    await resizeRow(200);
-    expect(frame().style.transform).toEqual(
-      `translate(${settled.x}px, ${settled.y}px)`,
-    );
-    // The cell grew but its origin must stay held with the frame.
-    await expectPlacement(frame, settled, 200);
-    fireEvent.pointerUp(window);
-    await expectPlacement(frame, expectedOffset(COL_SIZE, 200), 200);
-  });
+    const expectDrawnAt = async (expected: xy.XY) =>
+      await waitFor(() => {
+        pumpRender();
+        expect(drawnAt()).toEqual(expected);
+      });
 
-  it("releases the held offset on pointer cancellation", async () => {
-    const { frame } = renderTable(true);
-    await expectPlacement(frame, expectedOffset(COL_SIZE, ROW_SIZE));
-    fireEvent.pointerDown(frame());
-    await resizeRow(200);
-    fireEvent.pointerCancel(window);
-    await expectPlacement(frame, expectedOffset(COL_SIZE, 200), 200);
+    it("measures the region from outside the scroll container", () => {
+      const { scroller, probe } = renderTable(false);
+      expect(scroller().contains(probe())).toBe(false);
+    });
+
+    it("draws values at their layout position before any scroll", async () => {
+      renderTable(false);
+      await expectDrawnAt(ORIGIN);
+    });
+
+    it("shifts drawn values by the scroll offset", async () => {
+      const { scroller } = renderTable(false);
+      await expectDrawnAt(ORIGIN);
+      scrollTo(scroller, { x: 40, y: 120 });
+      await expectDrawnAt({ x: ORIGIN.x - 40, y: ORIGIN.y - 120 });
+    });
+
+    it("keeps clipping to the region the table occupies on screen", async () => {
+      const { scroller } = renderTable(false);
+      await expectDrawnAt(ORIGIN);
+      scrollTo(scroller, { x: 40, y: 120 });
+      await expectDrawnAt({ x: ORIGIN.x - 40, y: ORIGIN.y - 120 });
+      const clip = recorder.scissorCalls.at(-1)?.region;
+      if (clip == null) throw new Error("the table did not clip its draw");
+      expect(box.topLeft(clip)).toEqual(xy.ZERO);
+      expect(box.dims(clip)).toEqual({
+        width: SURFACE_WIDTH,
+        height: SURFACE_HEIGHT,
+      });
+    });
   });
 });

--- a/pluto/src/table/Table.spec.tsx
+++ b/pluto/src/table/Table.spec.tsx
@@ -269,30 +269,11 @@ describe("Table", () => {
       expect(scroller().contains(probe())).toBe(false);
     });
 
-    it("draws values at their layout position before any scroll", async () => {
-      renderTable(false);
-      await expectDrawnAt(ORIGIN);
-    });
-
     it("shifts drawn values by the scroll offset", async () => {
       const { scroller } = renderTable(false);
       await expectDrawnAt(ORIGIN);
-      scrollTo(scroller, { x: 40, y: 120 });
-      await expectDrawnAt({ x: ORIGIN.x - 40, y: ORIGIN.y - 120 });
-    });
-
-    it("keeps clipping to the region the table occupies on screen", async () => {
-      const { scroller } = renderTable(false);
-      await expectDrawnAt(ORIGIN);
-      scrollTo(scroller, { x: 40, y: 120 });
-      await expectDrawnAt({ x: ORIGIN.x - 40, y: ORIGIN.y - 120 });
-      const clip = recorder.scissorCalls.at(-1)?.region;
-      if (clip == null) throw new Error("the table did not clip its draw");
-      expect(box.topLeft(clip)).toEqual(xy.ZERO);
-      expect(box.dims(clip)).toEqual({
-        width: SURFACE_WIDTH,
-        height: SURFACE_HEIGHT,
-      });
+      scrollTo(scroller, { x: 10, y: 20 });
+      await expectDrawnAt({ x: ORIGIN.x - 10, y: ORIGIN.y - 20 });
     });
   });
 });

--- a/pluto/src/table/Table.tsx
+++ b/pluto/src/table/Table.tsx
@@ -271,7 +271,7 @@ export const Table = ({
     ],
   );
 
-  const [{ path }, , setState] = Aether.use({
+  const { path, setState } = Aether.useLifecycle({
     type: aetherTable.Table.TYPE,
     schema: aetherTable.Table.stateZ,
     initialState: { region: box.ZERO, visible },
@@ -284,6 +284,12 @@ export const Table = ({
     setRegion(b);
     setState((s) => ({ ...s, region: b }));
   });
+
+  const handleScroll = useCallback(
+    ({ currentTarget: { scrollLeft, scrollTop } }: React.UIEvent<HTMLDivElement>) =>
+      setState((s) => ({ ...s, scroll: { x: scrollLeft, y: scrollTop } })),
+    [setState],
+  );
 
   const selectedRef = useSyncedRef(selected);
   const lastSelectedRef = useRef<string | null>(null);
@@ -517,75 +523,77 @@ export const Table = ({
       {...rest}
     >
       <div ref={canvasRef} className={CSS.BE("table-surface", "canvas")} />
-      <div
-        className={CSS(CSS.B("table-frame"), CSS.editable(editable))}
-        style={frameStyle}
-        onPointerDown={handlePointerDown}
-      >
-        <Menu.ContextMenu menu={renderMenu} {...menuProps}>
-          <table
-            ref={tableElRef}
-            className={CSS(CSS.B("table"), menuProps.className)}
-            style={tableStyle}
-            onCopy={onCopy}
-            onPaste={editable ? onPaste : undefined}
-            onKeyDown={handleKeyDown}
-            tabIndex={-1}
-          >
-            <tbody>
-              <Aether.Composite path={path}>
-                <Selection.Context value={selected}>
-                  {showIndicators && (
-                    <ColumnIndicators
-                      columns={colSizes}
-                      rows={rows}
-                      selected={selected}
-                      editable={editable}
-                      onSelect={handleColSelect}
-                      onSelectAll={handleSelectAll}
-                      onResize={handleColResize}
-                    />
-                  )}
-                  {rows.map((row, rowIndex) => {
-                    const yPos = rowYCursor;
-                    rowYCursor += row.size;
-                    return (
-                      <Row
-                        key={rowIndex}
-                        index={rowIndex}
-                        resourceKey={key}
-                        cells={row.cells}
+      <div className={CSS.BE("table-surface", "scroll")} onScroll={handleScroll}>
+        <div
+          className={CSS(CSS.B("table-frame"), CSS.editable(editable))}
+          style={frameStyle}
+          onPointerDown={handlePointerDown}
+        >
+          <Menu.ContextMenu menu={renderMenu} {...menuProps}>
+            <table
+              ref={tableElRef}
+              className={CSS(CSS.B("table"), menuProps.className)}
+              style={tableStyle}
+              onCopy={onCopy}
+              onPaste={editable ? onPaste : undefined}
+              onKeyDown={handleKeyDown}
+              tabIndex={-1}
+            >
+              <tbody>
+                <Aether.Composite path={path}>
+                  <Selection.Context value={selected}>
+                    {showIndicators && (
+                      <ColumnIndicators
                         columns={colSizes}
-                        x={cellXOrigin}
-                        y={yPos}
-                        size={row.size}
+                        rows={rows}
+                        selected={selected}
                         editable={editable}
-                        showIndicator={showIndicators}
-                        onSelect={handleRowSelect}
-                        onResize={handleRowResize}
-                        onCellSelect={handleCellSelect}
+                        onSelect={handleColSelect}
+                        onSelectAll={handleSelectAll}
+                        onResize={handleColResize}
                       />
-                    );
-                  })}
-                </Selection.Context>
-              </Aether.Composite>
-            </tbody>
-          </table>
-        </Menu.ContextMenu>
-        {editable && (
-          <>
-            <AddCountControl
-              className={CSS.BE("table-frame", "add-col")}
-              resourceName="column"
-              onAdd={(n) => addCol(undefined, n)}
-            />
-            <AddCountControl
-              className={CSS.BE("table-frame", "add-row")}
-              resourceName="row"
-              onAdd={(n) => addRow(undefined, n)}
-            />
-          </>
-        )}
+                    )}
+                    {rows.map((row, rowIndex) => {
+                      const yPos = rowYCursor;
+                      rowYCursor += row.size;
+                      return (
+                        <Row
+                          key={rowIndex}
+                          index={rowIndex}
+                          resourceKey={key}
+                          cells={row.cells}
+                          columns={colSizes}
+                          x={cellXOrigin}
+                          y={yPos}
+                          size={row.size}
+                          editable={editable}
+                          showIndicator={showIndicators}
+                          onSelect={handleRowSelect}
+                          onResize={handleRowResize}
+                          onCellSelect={handleCellSelect}
+                        />
+                      );
+                    })}
+                  </Selection.Context>
+                </Aether.Composite>
+              </tbody>
+            </table>
+          </Menu.ContextMenu>
+          {editable && (
+            <>
+              <AddCountControl
+                className={CSS.BE("table-frame", "add-col")}
+                resourceName="column"
+                onAdd={(n) => addCol(undefined, n)}
+              />
+              <AddCountControl
+                className={CSS.BE("table-frame", "add-row")}
+                resourceName="row"
+                onAdd={(n) => addRow(undefined, n)}
+              />
+            </>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/pluto/src/table/aether/Table.spec.ts
+++ b/pluto/src/table/aether/Table.spec.ts
@@ -1,0 +1,232 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { box, type scale, xy } from "@synnaxlabs/x";
+import { describe, expect, it, vi } from "vitest";
+import { type z } from "zod";
+
+import { type Cell, Table, type tableStateZ } from "@/table/aether/Table";
+import { type MountChild, renderAether } from "@/testutil/renderAether";
+import { type render } from "@/vis/render";
+import { canvasTest } from "@/vis/render/test";
+import { value } from "@/vis/value/aether";
+
+const REGION = box.construct({ x: 100, y: 50 }, { width: 400, height: 300 });
+
+const cell = (x: number, y: number, width = 60, height = 30): box.Box =>
+  box.construct({ x, y }, { width, height });
+
+// The request a cleanup receives. The table ignores it.
+const CLEANUP_REQUEST: render.Request = {
+  key: "table",
+  priority: "high",
+  canvases: [],
+  render: () => {},
+};
+
+// clip makes each drawn cell scissor its own box, which is how drawn() sees it.
+const cellChild = (b: box.Box): MountChild => ({
+  type: value.Value.TYPE,
+  state: { box: b, clip: true },
+});
+
+const mount = (
+  cells: Record<string, box.Box>,
+  state: Partial<z.input<typeof tableStateZ>> = {},
+) => {
+  const recorder = canvasTest.record();
+  const h = renderAether(Table, {
+    state: { region: REGION, ...state },
+    render: recorder,
+    registry: value.REGISTRY,
+    children: Object.fromEntries(
+      Object.entries(cells).map(([key, b]) => [key, cellChild(b)]),
+    ),
+  });
+  const draw = (): void => {
+    recorder.clear();
+    h.component.render();
+  };
+  const drawn = (): box.Box[] =>
+    recorder.upper2d.calls
+      .filter((c) => c.op === "scissor")
+      .map((c) => c.args[0] as box.Box);
+  const origin = (): xy.XY => {
+    const applied = recorder.upper2d.calls.find((c) => c.op === "applyScale");
+    if (applied == null) throw new Error("no cell drew");
+    return (applied.args[0] as scale.XY).pos(xy.ZERO);
+  };
+  return { h, recorder, draw, drawn, origin };
+};
+
+describe("aether Table", () => {
+  describe("origin", () => {
+    it("draws cells relative to the top left of the region", () => {
+      const { draw, origin } = mount({ a: cell(0, 0) });
+      draw();
+      expect(origin()).toEqual(box.topLeft(REGION));
+    });
+
+    it("shifts the origin back by the scroll offset", () => {
+      const { draw, origin } = mount(
+        { a: cell(40, 120) },
+        { scroll: { x: 40, y: 120 } },
+      );
+      draw();
+      expect(origin()).toEqual({ x: 100 - 40, y: 50 - 120 });
+    });
+
+    it("moves the origin when the scroll changes", () => {
+      const { h, draw, origin } = mount({ a: cell(0, 0) });
+      h.setState((p) => ({ ...p, scroll: { x: 10, y: 20 } }));
+      draw();
+      expect(origin()).toEqual({ x: 90, y: 30 });
+    });
+  });
+
+  describe("clipping", () => {
+    it("clips to the region", () => {
+      const { recorder, draw } = mount({ a: cell(0, 0) });
+      draw();
+      expect(recorder.scissorCalls.at(-1)?.region).toEqual(REGION);
+    });
+
+    it("keeps the clip on the region while scrolled", () => {
+      const { recorder, draw } = mount(
+        { a: cell(40, 120) },
+        { scroll: { x: 40, y: 120 } },
+      );
+      draw();
+      expect(recorder.scissorCalls.at(-1)?.region).toEqual(REGION);
+    });
+
+    it("clips to both 2d canvases", () => {
+      const { recorder, draw } = mount({ a: cell(0, 0) });
+      draw();
+      expect(recorder.scissorCalls.at(-1)?.canvases).toEqual(["upper2d", "lower2d"]);
+    });
+
+    it("widens the clip by the clear overscan", () => {
+      const { recorder, draw } = mount({ a: cell(0, 0) }, { clearOverScan: 5 });
+      draw();
+      expect(recorder.scissorCalls.at(-1)?.overScan).toEqual({ x: 5, y: 5 });
+    });
+  });
+
+  describe("culling", () => {
+    it("draws every cell inside the region", () => {
+      const boxes = { a: cell(0, 0), b: cell(60, 0), c: cell(0, 30) };
+      const { draw, drawn } = mount(boxes);
+      draw();
+      expect(drawn()).toEqual([boxes.a, boxes.b, boxes.c]);
+    });
+
+    it("skips a cell past the bottom of the region", () => {
+      const boxes = { a: cell(0, 0), b: cell(0, 400) };
+      const { draw, drawn } = mount(boxes);
+      draw();
+      expect(drawn()).toEqual([boxes.a]);
+    });
+
+    it("skips a cell past the right of the region", () => {
+      const boxes = { a: cell(0, 0), b: cell(500, 0) };
+      const { draw, drawn } = mount(boxes);
+      draw();
+      expect(drawn()).toEqual([boxes.a]);
+    });
+
+    it("draws a cell that only partly overlaps the region", () => {
+      const boxes = { a: cell(0, 290) };
+      const { draw, drawn } = mount(boxes);
+      draw();
+      expect(drawn()).toEqual([boxes.a]);
+    });
+
+    it("skips a cell that only touches the edge of the region", () => {
+      const boxes = { a: cell(0, 300) };
+      const { draw, drawn } = mount(boxes);
+      draw();
+      expect(drawn()).toEqual([]);
+    });
+
+    it("draws a cell the scroll brings into view", () => {
+      const boxes = { a: cell(0, 400) };
+      const { h, draw, drawn } = mount(boxes);
+      draw();
+      expect(drawn()).toEqual([]);
+      h.setState((p) => ({ ...p, scroll: { x: 0, y: 200 } }));
+      draw();
+      expect(drawn()).toEqual([boxes.a]);
+    });
+
+    it("skips a cell the scroll takes out of view", () => {
+      const boxes = { a: cell(0, 0), b: cell(0, 250) };
+      const { h, draw, drawn } = mount(boxes);
+      draw();
+      expect(drawn()).toEqual([boxes.a, boxes.b]);
+      h.setState((p) => ({ ...p, scroll: { x: 0, y: 200 } }));
+      draw();
+      expect(drawn()).toEqual([boxes.b]);
+    });
+  });
+
+  describe("visibility", () => {
+    it("draws no cells while hidden", () => {
+      const { draw, drawn } = mount({ a: cell(0, 0) }, { visible: false });
+      draw();
+      expect(drawn()).toEqual([]);
+    });
+
+    it("erases the region while hidden", () => {
+      const { recorder, h } = mount({ a: cell(0, 0) }, { visible: false });
+      recorder.clear();
+      h.component.render()?.(CLEANUP_REQUEST);
+      expect(recorder.eraseCalls.at(-1)?.region).toEqual(REGION);
+    });
+
+    it("erases the region after a visible draw", () => {
+      const { recorder, h } = mount({ a: cell(0, 0) });
+      recorder.clear();
+      h.component.render()?.(CLEANUP_REQUEST);
+      expect(recorder.eraseCalls.at(-1)?.region).toEqual(REGION);
+    });
+  });
+
+  describe("render requests", () => {
+    it("requests a render when the state changes", () => {
+      const { recorder, h } = mount({ a: cell(0, 0) });
+      recorder.clear();
+      h.setState((p) => ({ ...p, scroll: { x: 0, y: 10 } }));
+      expect(recorder.loopCalls).toHaveLength(1);
+    });
+
+    it("requests one last render on becoming hidden, then stops", () => {
+      const { recorder, h } = mount({ a: cell(0, 0) });
+      recorder.clear();
+      h.setState((p) => ({ ...p, visible: false }));
+      expect(recorder.loopCalls).toHaveLength(1);
+      recorder.clear();
+      h.setState((p) => ({ ...p, scroll: { x: 0, y: 10 } }));
+      expect(recorder.loopCalls).toHaveLength(0);
+    });
+  });
+
+  describe("cell failures", () => {
+    it("reports a failing cell instead of throwing", () => {
+      const { h, draw } = mount({ a: cell(0, 0) });
+      vi.spyOn(h.child<Cell>("a"), "render").mockImplementation(() => {
+        throw new Error("cell blew up");
+      });
+      expect(() => draw()).not.toThrow();
+      expect(h.providers.status?.state.statuses.at(-1)?.message).toEqual(
+        "Failed to render table",
+      );
+    });
+  });
+});

--- a/pluto/src/table/aether/Table.ts
+++ b/pluto/src/table/aether/Table.ts
@@ -16,6 +16,7 @@ import { render } from "@/vis/render";
 
 export const tableStateZ = z.object({
   region: box.box,
+  scroll: xy.xyZ.default(xy.ZERO),
   clearOverScan: xy.crudeZ.default(0),
   visible: z.boolean().default(true),
   autoRenderInterval: z.number().default(1000),
@@ -70,7 +71,9 @@ export class Table extends aether.Composite<typeof tableStateZ, InternalState, C
     if (!this.state.visible)
       return () => this.internal.renderCtx.erase(eraseRegion, this.state.clearOverScan);
     const { renderCtx, handleError } = this.internal;
-    const viewportScale = scale.XY.translate(box.topLeft(this.state.region));
+    const viewportScale = scale.XY.translate(
+      xy.sub(box.topLeft(this.state.region), this.state.scroll),
+    );
     const clearScissor = renderCtx.scissor(
       this.state.region,
       xy.construct(this.state.clearOverScan),

--- a/pluto/src/table/aether/Table.ts
+++ b/pluto/src/table/aether/Table.ts
@@ -27,6 +27,8 @@ interface CellProps {
 }
 
 export interface Cell extends aether.Component {
+  /** The cell's position in the table's unscrolled layout coordinates. */
+  readonly box: box.Box;
   render: ({ viewportScale }: CellProps) => void;
 }
 
@@ -80,8 +82,11 @@ export class Table extends aether.Composite<typeof tableStateZ, InternalState, C
       CANVASES,
     );
 
+    const visible = box.construct(this.state.scroll, box.dims(this.state.region));
     try {
-      for (const child of this.children) child.render({ viewportScale });
+      for (const child of this.children)
+        if (!box.areaIsZero(box.intersection(child.box, visible)))
+          child.render({ viewportScale });
     } catch (e) {
       handleError(e, "Failed to render table");
     } finally {

--- a/pluto/src/vis/value/aether/value.ts
+++ b/pluto/src/vis/value/aether/value.ts
@@ -123,6 +123,10 @@ export class Value
     else void this.render({});
   }
 
+  get box(): box.Box {
+    return this.state.box;
+  }
+
   private get fontHeight(): number {
     const { theme } = this.internal;
     return theme.typography[this.state.level].size * theme.sizes.base;


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4591](https://linear.app/synnax/issue/SY-4591/fix-table-scroll-rendering)

## Description

Table cells draw in two places: the `<td>` chrome in the DOM, and the value itself on the shared canvas through Aether. The canvas half learned the table's on-screen position from a `ResizeObserver`, which fires on size changes only. Scrolling moves the table without resizing it, so the position stayed stale and the values kept drawing where the table used to be, offset by exactly the scroll distance.

The scroll offset now enters at the single transform the worker already applies to every cell, so a scroll frame costs one small message regardless of cell count. The table also drops from `Aether.use` to `Aether.useLifecycle`, since the subscription would otherwise re-render the whole table on every scroll frame; nothing here read the Aether state back.

Scrolling moved onto its own element inside the table surface, a sibling of the canvas probe rather than its parent. The probe stays still, so the measured region keeps clipping the visible band at every scroll position. Measuring the probe alone would have slid the clip off screen, cutting values off at the bottom and painting them over the toolbar. The console gives up `overflow: auto` in exchange; Pluto owns the scroll container now.

Values still trail their cells by about one frame during a fast scroll, because the grid scrolls on the compositor while the canvas repaints on the worker. Removing that would mean moving value rendering out of the canvas, which is out of scope here.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves table scrolling into Pluto and sends each scroll offset to the Aether table renderer so canvas values remain aligned with DOM cells.
- Adds a dedicated scroll container beside the fixed canvas-region probe.
- Applies the scroll offset to canvas rendering and visible-cell culling.
- Adds component and Aether tests for scrolling, clipping, culling, and lifecycle behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pluto/src/table/Table.tsx | Adds the dedicated scroll container and forwards absolute scroll offsets through the Aether lifecycle handle. |
| pluto/src/table/aether/Table.ts | Applies scroll translation, preserves fixed clipping, and skips cells outside the visible layout region. |
| pluto/src/table/Table.css | Defines the full-surface scrolling layer as a sibling of the canvas probe. |
| console/src/feature/table/Table.css | Removes the Console-owned overflow behavior because Pluto now owns table scrolling. |
| pluto/src/table/Table.spec.tsx | Tests the scroll-container structure and verifies that scrolling shifts rendered values. |
| pluto/src/table/aether/Table.spec.ts | Adds focused coverage for translation, clipping, culling, visibility, render requests, and child failures. |
| pluto/src/vis/value/aether/value.ts | Exposes each value component's layout box for table-level visibility culling. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant User
  participant Scroller as Pluto scroll container
  participant React as React table
  participant Aether as Aether table renderer
  participant Canvas
  User->>Scroller: Scroll table
  Scroller->>React: onScroll(scrollLeft, scrollTop)
  React->>Aether: Update scroll offset
  Aether->>Aether: Cull cells against visible region
  Aether->>Canvas: Draw at region origin minus scroll
```

<sub>Reviews (2): Last reviewed commit: ["SY-4591: Cull table cells outside the vi..."](https://github.com/synnaxlabs/synnax/commit/e9daab10e003dc4395b825c0df0aa89013c7210f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53476936)</sub>

**Context used:**

- Knowledge Base — [Pluto Component and Visualization Library](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/pluto-components.md)
- Knowledge Base — [Console App](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/console-app.md)

<!-- /greptile_comment -->