### PR TITLE
SY-4593: Refresh the Console error overlay chrome

### DIFF
--- a/console/src/feature/auth/ConnectionGuard.tsx
+++ b/console/src/feature/auth/ConnectionGuard.tsx
@@ -21,9 +21,10 @@ import {
 } from "react";
 
 import { Login } from "@/feature/auth/Login";
+import { Shell } from "@/feature/shell";
 import { Cluster } from "@/platform/cluster";
 import { CSS } from "@/platform/css";
-import { Shell } from "@/platform/shell";
+import { Shell as PlatformShell } from "@/platform/shell";
 import { Session } from "@/session";
 
 /**
@@ -62,7 +63,7 @@ interface CountdownCoreProps {
 }
 
 const CountdownCore = ({ retry, checking }: CountdownCoreProps): ReactElement => {
-  const remaining = Shell.useCountdown(retry.nextAt);
+  const remaining = PlatformShell.useCountdown(retry.nextAt);
   return (
     <>
       <Text.Text level="h3" color={11} className={CSS.BE("connection", "countdown")}>
@@ -110,7 +111,7 @@ const Splash = ({ client, status }: SplashProps): ReactElement => {
         gap={8}
         className={CSS(CSS.BE("connection", "body"), revealed && CSS.M("revealed"))}
       >
-        <Status.Orbital core={<Shell.Mark>{core}</Shell.Mark>} />
+        <Status.Orbital core={<PlatformShell.Mark>{core}</PlatformShell.Mark>} />
         {troubled ? (
           <Trouble client={client} status={status} checking={checking} />
         ) : (
@@ -155,12 +156,12 @@ const Trouble = ({ client, status, checking }: TroubleProps): ReactElement => {
           </Text.Text>
         )}
         <Text.Text status={variant} className={CSS.BE("connection", "status")}>
-          <span>{checking ? "Retrying" : Shell.STATUS_LABELS[variant]}</span>
+          <span>{checking ? "Retrying" : PlatformShell.STATUS_LABELS[variant]}</span>
           <span className={CSS.M("ghost")} aria-hidden>
             Retrying
           </span>
           <span className={CSS.M("ghost")} aria-hidden>
-            {Shell.STATUS_LABELS[variant]}
+            {PlatformShell.STATUS_LABELS[variant]}
           </span>
         </Text.Text>
       </Flex.Box>

--- a/console/src/feature/auth/Login.tsx
+++ b/console/src/feature/auth/Login.tsx
@@ -23,9 +23,10 @@ import { uuid } from "@synnaxlabs/x";
 import { type ReactElement, useCallback, useState } from "react";
 import { z } from "zod";
 
+import { Shell } from "@/feature/shell";
 import { Cluster } from "@/platform/cluster";
 import { CSS } from "@/platform/css";
-import { Shell } from "@/platform/shell";
+import { Shell as PlatformShell } from "@/platform/shell";
 import { Session } from "@/session";
 
 const LOG_IN_TRIGGER: Triggers.Trigger = ["Enter"];
@@ -123,7 +124,7 @@ export const Login = (): ReactElement => {
           )}
           <Form.Form<typeof credentialsZ> {...methods}>
             <Flex.Box y align="center" justify="center" grow gap="huge" shrink={false}>
-              <Shell.Mark />
+              <PlatformShell.Mark />
               <Flex.Box y full="x" empty>
                 <Form.TextField
                   path="username"

--- a/console/src/feature/project/Splash.tsx
+++ b/console/src/feature/project/Splash.tsx
@@ -27,11 +27,11 @@ import {
 import { type ReactElement, useCallback, useEffect, useState } from "react";
 
 import { ContextMenu, listItem } from "@/feature/project/Selector";
+import { Shell } from "@/feature/shell";
 import { Button } from "@/platform/button";
 import { CSS } from "@/platform/css";
 import { Empty } from "@/platform/empty";
 import { Project as PlatformProject } from "@/platform/project";
-import { Shell } from "@/platform/shell";
 import { Session } from "@/session";
 
 /** Full-window project picker shown when the session has no active project. */

--- a/console/src/feature/shell/Frame.tsx
+++ b/console/src/feature/shell/Frame.tsx
@@ -7,20 +7,19 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import "@/platform/shell/Shell.css";
+import "@/feature/shell/Shell.css";
 
 import { Flex } from "@synnaxlabs/pluto";
 import { type ReactElement, type ReactNode } from "react";
 
+import { Nav } from "@/feature/shell/Nav";
 import { CSS } from "@/platform/css";
-import { type ConnectionCluster } from "@/platform/shell/Connection";
-import { Nav } from "@/platform/shell/Nav";
-import { Nebula } from "@/platform/shell/Nebula";
+import { Shell } from "@/platform/shell";
 
 export interface FrameProps {
   className?: string;
   /** Target Core shown in the connection island; omit to hide it. */
-  connection?: ConnectionCluster | null;
+  connection?: Shell.ConnectionCluster | null;
   children: ReactNode;
 }
 
@@ -45,7 +44,7 @@ export const Frame = ({
       data-tauri-drag-region
       className={CSS.BE("shell", "content")}
     >
-      <Nebula />
+      <Shell.Nebula />
       <Flex.Box className={CSS.BE("shell", "stage")} grow={false}>
         <Flex.Box
           y

--- a/console/src/feature/shell/Nav.tsx
+++ b/console/src/feature/shell/Nav.tsx
@@ -10,15 +10,13 @@
 import { Flex, OS } from "@synnaxlabs/pluto";
 import { type ReactElement } from "react";
 
-import { CSS } from "@/platform/css";
-import { Connection, type ConnectionCluster } from "@/platform/shell/Connection";
-import { Island } from "@/platform/shell/Island";
+import { Shell } from "@/platform/shell";
 import { Version } from "@/platform/version";
 import { Window } from "@/platform/window";
 import { Session } from "@/session";
 
 export interface NavProps {
-  connection?: ConnectionCluster | null;
+  connection?: Shell.ConnectionCluster | null;
 }
 
 /**
@@ -30,27 +28,27 @@ export const Nav = ({ connection }: NavProps): ReactElement => {
   const os = OS.use();
   const chrome = Session.Runtime.ENGINE === "tauri" && Session.Runtime.isMainWindow();
   return (
-    <Flex.Box x justify="between" align="start" className={CSS.BE("shell", "islands")}>
+    <Shell.Islands>
       <Flex.Box x align="center" gap="medium">
         {chrome && os === "macOS" && (
-          <Island>
+          <Shell.Island>
             <Window.Controls visibleIfOS="macOS" forceOS={os} />
-          </Island>
+          </Shell.Island>
         )}
         {chrome && (
-          <Island data-tauri-drag-region>
+          <Shell.Island data-tauri-drag-region>
             <Version.Badge />
-          </Island>
+          </Shell.Island>
         )}
       </Flex.Box>
       <Flex.Box x align="center" gap="medium">
-        <Connection cluster={connection} />
+        <Shell.Connection cluster={connection} />
         {chrome && os === "Windows" && (
-          <Island>
+          <Shell.Island>
             <Window.Controls visibleIfOS="Windows" forceOS={os} />
-          </Island>
+          </Shell.Island>
         )}
       </Flex.Box>
-    </Flex.Box>
+    </Shell.Islands>
   );
 };

--- a/console/src/feature/shell/Shell.css
+++ b/console/src/feature/shell/Shell.css
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2026 Synnax Labs, Inc.
+ *
+ * Use of this software is governed by the Business Source License included in the file
+ * licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source
+ * License, use of this software will be governed by the Apache License, Version 2.0,
+ * included in the file licenses/APL.txt.
+ */
+
+.console-shell {
+    position: relative;
+    overflow: hidden;
+}
+
+.console-shell__content {
+    cursor: default;
+    position: relative;
+    /* Stacking context holds the nebula's negative z-index above this fill. */
+    z-index: 0;
+}
+
+.console-shell__stage {
+    position: relative;
+    z-index: 0;
+}
+
+.console-shell__stage::before,
+.console-shell__stage::after {
+    content: "";
+    position: absolute;
+    pointer-events: none;
+}
+
+.console-shell__stage::before {
+    inset: -2.5rem;
+    border: var(--pluto-border-width) solid
+        color-mix(in srgb, var(--pluto-gray-l7) 45%, transparent);
+    border-radius: calc(var(--pluto-border-radius-huge) + 2.5rem);
+}
+
+.console-shell__stage::after {
+    inset: -5.5rem;
+    border: var(--pluto-border-width) solid
+        color-mix(in srgb, var(--pluto-gray-l7) 20%, transparent);
+    border-radius: calc(var(--pluto-border-radius-huge) + 5.5rem);
+}
+
+/* One fixed size, so guard handoffs read as content changes, not page swaps. */
+.console-shell__card {
+    position: relative;
+    width: 420px;
+    height: 480px;
+    overflow: hidden;
+    border-radius: var(--pluto-border-radius-huge);
+    transition:
+        width 0.25s ease,
+        height 0.25s ease;
+}
+
+/* Keeps sub-250ms transients faint by fading them in. */
+.console-shell__card > * {
+    animation: console-shell-reveal 0.25s ease;
+}
+
+@keyframes console-shell-reveal {
+    from {
+        opacity: 0;
+    }
+    to {
+        opacity: 1;
+    }
+}

--- a/console/src/feature/shell/external.ts
+++ b/console/src/feature/shell/external.ts
@@ -7,8 +7,4 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-export * from "@/platform/shell/Connection";
-export * from "@/platform/shell/Island";
-export * from "@/platform/shell/Mark";
-export * from "@/platform/shell/Nebula";
-export * from "@/platform/shell/useCountdown";
+export * from "@/feature/shell/Frame";

--- a/console/src/feature/shell/index.ts
+++ b/console/src/feature/shell/index.ts
@@ -7,8 +7,4 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-export * from "@/platform/shell/Connection";
-export * from "@/platform/shell/Island";
-export * from "@/platform/shell/Mark";
-export * from "@/platform/shell/Nebula";
-export * from "@/platform/shell/useCountdown";
+export * as Shell from "@/feature/shell/external";

--- a/console/src/platform/errors/Overlay.css
+++ b/console/src/platform/errors/Overlay.css
@@ -10,9 +10,17 @@
  */
 
 .console-error-overlay {
+    /* Anchors the absolutely-positioned island row. */
+    position: relative;
     height: 100vh;
-    & > .pluto-navbar.pluto--location-top {
-        padding-left: 2rem;
-        padding-right: 1rem;
+
+    /* Tauri drags only when the click target is the drag region itself, and the
+       fallback's wrapper covers the whole overlay. Passing it through makes the
+       background draggable; the card takes its own clicks back. */
+    & > .pluto-error-fallback__container {
+        pointer-events: none;
+    }
+    & .pluto-error-fallback__content {
+        pointer-events: auto;
     }
 }

--- a/console/src/platform/errors/Overlay.tsx
+++ b/console/src/platform/errors/Overlay.tsx
@@ -9,18 +9,16 @@
 
 import "@/platform/errors/Overlay.css";
 
-import { Logo } from "@synnaxlabs/media";
 import {
   Button,
   CSS as PCSS,
   Errors,
   Flex,
-  Nav,
   OS,
   Synnax,
   Theming,
 } from "@synnaxlabs/pluto";
-import { type record } from "@synnaxlabs/x";
+import { type record, type runtime } from "@synnaxlabs/x";
 import { getVersion } from "@tauri-apps/api/app";
 import { getCurrentWindow } from "@tauri-apps/api/window";
 import {
@@ -32,6 +30,7 @@ import {
 } from "react";
 
 import { CSS } from "@/platform/css";
+import { Shell } from "@/platform/shell";
 import { Session } from "@/session";
 
 export interface OverlayProps extends PropsWithChildren {}
@@ -100,6 +99,38 @@ const FallbackRenderWithoutStore = ({ error }: Errors.FallbackProps): ReactEleme
   );
 };
 
+// Tauri-direct rather than Window.Controls: the store-less overlay catches failures
+// from above the store, where that component's Drift selectors are unavailable.
+const windowAction = (action: "close" | "minimize" | "maximize") => (): void => {
+  if (Session.Runtime.ENGINE !== "tauri") return;
+  void getCurrentWindow()[action]();
+};
+
+const handleClose = windowAction("close");
+const handleMinimize = windowAction("minimize");
+const handleMaximize = windowAction("maximize");
+
+interface WindowControlsProps {
+  os: runtime.OS;
+}
+
+const WindowControls = ({ os }: WindowControlsProps): ReactElement | null => {
+  if (Session.Runtime.ENGINE !== "tauri") return null;
+  if (os !== "macOS" && os !== "Windows") return null;
+  return (
+    <Shell.Islands justify={os === "macOS" ? "start" : "end"}>
+      <Shell.Island>
+        <OS.Controls
+          forceOS={os}
+          onClose={handleClose}
+          onMinimize={handleMinimize}
+          onMaximize={handleMaximize}
+        />
+      </Shell.Island>
+    </Shell.Islands>
+  );
+};
+
 interface FallbackRenderContentProps<
   ExtraInfo extends record.Unknown = record.Unknown,
 > {
@@ -134,52 +165,15 @@ const FallBackRenderContent = <ExtraInfo extends record.Unknown = record.Unknown
   }, [onTryAgain]);
 
   return (
-    <Flex.Box y className={CSS.B("error-overlay")}>
-      <Nav.Bar
-        location="top"
-        size="7rem"
-        bordered
-        data-tauri-drag-region
-        background={2}
-      >
-        <Nav.Bar.Start>
-          <OS.Controls
-            visibleIfOS="macOS"
-            forceOS={os}
-            onClose={() => {
-              if (Session.Runtime.ENGINE === "tauri") void getCurrentWindow().close();
-            }}
-            onMinimize={() => {
-              if (Session.Runtime.ENGINE === "tauri")
-                void getCurrentWindow().minimize();
-            }}
-            onMaximize={() => {
-              if (Session.Runtime.ENGINE === "tauri")
-                void getCurrentWindow().maximize();
-            }}
-          />
-          {os === "Windows" && (
-            <Logo className="console-main-nav-top__logo" variant="icon" />
-          )}
-        </Nav.Bar.Start>
-        <Nav.Bar.End justify="end">
-          <OS.Controls
-            visibleIfOS="Windows"
-            forceOS={os}
-            onClose={() => {
-              if (Session.Runtime.ENGINE === "tauri") void getCurrentWindow().close();
-            }}
-            onMinimize={() => {
-              if (Session.Runtime.ENGINE === "tauri")
-                void getCurrentWindow().minimize();
-            }}
-            onMaximize={() => {
-              if (Session.Runtime.ENGINE === "tauri")
-                void getCurrentWindow().maximize();
-            }}
-          />
-        </Nav.Bar.End>
-      </Nav.Bar>
+    <Flex.Box
+      y
+      full
+      empty
+      background={1}
+      data-tauri-drag-region
+      className={CSS.B("error-overlay")}
+    >
+      <WindowControls os={os} />
       <Errors.Fallback
         error={error}
         resetErrorBoundary={resetErrorBoundary}

--- a/console/src/platform/shell/Island.tsx
+++ b/console/src/platform/shell/Island.tsx
@@ -7,10 +7,25 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+import "@/platform/shell/Shell.css";
+
 import { Flex } from "@synnaxlabs/pluto";
 import { type ReactElement } from "react";
 
 import { CSS } from "@/platform/css";
+
+export interface IslandsProps extends Flex.BoxProps {}
+
+/** The row that floats islands over the top edge of a full-window surface. */
+export const Islands = ({ className, ...rest }: IslandsProps): ReactElement => (
+  <Flex.Box
+    x
+    justify="between"
+    align="start"
+    className={CSS(CSS.BE("shell", "islands"), className)}
+    {...rest}
+  />
+);
 
 export interface IslandProps extends Flex.BoxProps {}
 

--- a/console/src/platform/shell/Shell.css
+++ b/console/src/platform/shell/Shell.css
@@ -9,42 +9,13 @@
  * included in the file licenses/APL.txt.
  */
 
-.console-shell {
-    position: relative;
-    overflow: hidden;
-}
-
-.console-shell__content {
-    cursor: default;
-    position: relative;
-    /* Stacking context holds the nebula's negative z-index above this fill. */
-    z-index: 0;
-}
-
-.console-shell__stage {
-    position: relative;
-    z-index: 0;
-}
-
-.console-shell__stage::before,
-.console-shell__stage::after {
-    content: "";
-    position: absolute;
-    pointer-events: none;
-}
-
-.console-shell__stage::before {
-    inset: -2.5rem;
-    border: var(--pluto-border-width) solid
-        color-mix(in srgb, var(--pluto-gray-l7) 45%, transparent);
-    border-radius: calc(var(--pluto-border-radius-huge) + 2.5rem);
-}
-
-.console-shell__stage::after {
-    inset: -5.5rem;
-    border: var(--pluto-border-width) solid
-        color-mix(in srgb, var(--pluto-gray-l7) 20%, transparent);
-    border-radius: calc(var(--pluto-border-radius-huge) + 5.5rem);
+/* One fixed height, so cluster and project surfaces match. The doubled class beats
+   the bordered and background variants. */
+.console-shell__list.console-shell__list {
+    width: 100%;
+    height: 100%;
+    border: none;
+    background: transparent;
 }
 
 /* The one frosted-glass recipe; shape stays with each surface that wears it. */
@@ -54,41 +25,6 @@
     backdrop-filter: blur(3.5rem) saturate(140%);
     border: var(--pluto-border-width) solid var(--pluto-gray-l6);
     box-shadow: var(--pluto-shadow-lift);
-}
-
-/* One fixed size, so guard handoffs read as content changes, not page swaps. */
-.console-shell__card {
-    position: relative;
-    width: 420px;
-    height: 480px;
-    overflow: hidden;
-    border-radius: var(--pluto-border-radius-huge);
-    transition:
-        width 0.25s ease,
-        height 0.25s ease;
-}
-
-/* Keeps sub-250ms transients faint by fading them in. */
-.console-shell__card > * {
-    animation: console-shell-reveal 0.25s ease;
-}
-
-@keyframes console-shell-reveal {
-    from {
-        opacity: 0;
-    }
-    to {
-        opacity: 1;
-    }
-}
-
-/* One fixed height, so cluster and project surfaces match. The doubled class beats
-   the bordered and background variants. */
-.console-shell__list.console-shell__list {
-    width: 100%;
-    height: 100%;
-    border: none;
-    background: transparent;
 }
 
 .console-shell__islands {

--- a/pluto/src/errors/Fallback.css
+++ b/pluto/src/errors/Fallback.css
@@ -23,7 +23,6 @@
         width: 100%;
         overflow: hidden;
         border-color: var(--pluto-error-z-40);
-        border-width: 1px;
 
         .pluto-error-fallback__body {
             padding: 2rem 3rem;

--- a/pluto/src/errors/Fallback.tsx
+++ b/pluto/src/errors/Fallback.tsx
@@ -100,10 +100,11 @@ export const Fallback = ({
     <Flex.Box className={CSS.BE("error-fallback", "container")} y grow center>
       <Flex.Box
         background={2}
-        rounded
         className={CSS.BE("error-fallback", "content")}
         bordered
-        borderColor={5}
+        borderColor="var(--pluto-error-z-40)"
+        borderWidth={1}
+        rounded="large"
         empty
       >
         <Bar location="top" bordered size="6rem">


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4593](https://linear.app/synnax/issue/SY-4593/refresh-the-console-error-overlay-chrome)

## Description

Both Console error overlays kept pre-redesign chrome: a bordered top `Nav.Bar` with window controls built from four duplicated `getCurrentWindow()` handlers, a hardcoded `size="7rem"` in place of `var(--console-top-bar-size)`, OS padding in `Overlay.css` that re-implemented `Nav.css` and applied the macOS and Windows values at once, and a `console-main-nav-top__logo` class matching no rule in the repo. They now use the same floating island row as the login, connection guard, and project splash surfaces.

The background around the card is a Tauri drag region, so the crash screen can be moved. Tauri drags only when the click target is the drag region itself, and the fallback's wrapper covers the whole overlay, so the wrapper passes pointer events through and the card takes its own back. Clicks on the card, its buttons, and the stack-trace text still behave normally.

Reaching the shell's island primitives from `platform/errors` closed a cycle: `shell -> version -> modals -> errors`. `platform/shell/Nav.tsx` is the only file in the domain importing `version`, and `Nav` is internal to `Frame`, so both move to `feature/shell` and the primitives stay below the cycle. `platform/shell` now holds Island, Islands, Connection, Mark, Nebula, and useCountdown, and imports nothing above `platform/css`.

One Pluto fix rides along. `Fallback.css` declares `border-color: var(--pluto-error-z-40)` on the error card, but `borderColor={5}` on the same box won on source order, so the red ring rendered gray. The border now comes from props.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR refreshes the Console error overlay with shared shell islands and relocates feature-level shell components to remove an import cycle.
- Replaces the old error-overlay navigation bar with draggable floating window controls.
- Moves `Frame` and `Nav` from the platform shell to the feature shell.
- Updates Pluto fallback border styling and corner radius.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The changed exports have updated consumers, and the new overlay preserves interaction for the fallback card and window controls across supported runtimes.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| console/src/platform/errors/Overlay.tsx | Replaces duplicated navigation controls with guarded shared shell islands and a full-window drag region. |
| console/src/platform/errors/Overlay.css | Anchors the floating controls and preserves pointer interaction within the fallback card. |
| console/src/feature/shell/Frame.tsx | Relocates the feature-level shell frame while retaining platform shell primitives. |
| console/src/feature/shell/Nav.tsx | Composes navigation chrome from platform shell islands and connection components. |
| console/src/platform/shell/Island.tsx | Adds the reusable floating islands row component. |
| pluto/src/errors/Fallback.tsx | Moves the error border configuration into component props and applies the updated radius. |

<sub>Reviews (1): Last reviewed commit: ["SY-4593: Refresh the Console error overl..."](https://github.com/synnaxlabs/synnax/commit/9a3a8b3fc71c019e99e8947396d9ab190f8180f0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53639478)</sub>

**Context used:**

- Knowledge Base — [Console App](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/console-app.md)
- Knowledge Base — [Pluto Component and Visualization Library](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/pluto-components.md)

<!-- /greptile_comment -->