### PR TITLE
SY-2509: Hide multi-window mechanics for the browser runtime

### DIFF
--- a/console/src/app/triggers/use.spec.tsx
+++ b/console/src/app/triggers/use.spec.tsx
@@ -14,7 +14,14 @@ import { Text, Triggers as PTriggers } from "@synnaxlabs/pluto";
 import { uuid } from "@synnaxlabs/x";
 import { act, fireEvent, renderHook, screen, waitFor } from "@testing-library/react";
 import { type PropsWithChildren, type ReactElement, type ReactNode } from "react";
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted((): { engine: "web" | "tauri" } => ({ engine: "web" }));
+
+vi.mock("@/session/runtime/runtime", async (importOriginal) => {
+  const { mockRuntimeEngine } = await import("@/testutil/runtime");
+  return await mockRuntimeEngine(importOriginal, mocks);
+});
 
 import { Triggers } from "@/app/triggers";
 import { useSelectorVisible } from "@/app/vis/Selector";
@@ -131,6 +138,10 @@ const leafTabs = async (key: panel.Key): Promise<panel.Tab[]> => {
 const Noop: Modals.Content = () => null;
 
 describe("app/triggers", () => {
+  beforeEach(() => {
+    mocks.engine = "web";
+  });
+
   afterEach(() => {
     vi.useRealTimers();
   });
@@ -210,6 +221,7 @@ describe("app/triggers", () => {
     });
 
     it("should close the window when the shortcut is held with nothing open", async () => {
+      mocks.engine = "tauri";
       const { store } = await renderTriggers();
       expect(isWindowOpen(store)).toBe(true);
       vi.useFakeTimers();
@@ -218,7 +230,18 @@ describe("app/triggers", () => {
       expect(isWindowOpen(store)).toBe(false);
     });
 
+    // A browser page cannot close its own tab, so the reducer must not drop the
+    // window either: the panel selectors key off it.
+    it("should spare the window in the browser", async () => {
+      const { store } = await renderTriggers();
+      vi.useFakeTimers();
+      act(() => hold(CONTROL, "KeyW"));
+      act(() => void vi.advanceTimersByTime(400));
+      expect(isWindowOpen(store)).toBe(true);
+    });
+
     it("should spare the window when the shortcut is released first", async () => {
+      mocks.engine = "tauri";
       const { store } = await renderTriggers();
       vi.useFakeTimers();
       act(() => hold(CONTROL, "KeyW"));

--- a/console/src/app/triggers/use.spec.tsx
+++ b/console/src/app/triggers/use.spec.tsx
@@ -264,6 +264,41 @@ describe("app/triggers", () => {
     });
   });
 
+  describe("open window", () => {
+    const openedWindows = (store: TestStore): string[] =>
+      Drift.selectWindows(store.getState())
+        .filter(({ key, reserved }) => key !== Drift.MAIN_WINDOW && reserved)
+        .map(({ key }) => key);
+
+    const selectPanel = async (): Promise<TestStore> => {
+      const { store } = await renderTriggers();
+      act(() => void store.dispatch(Session.Panel.select({ key: PANEL })));
+      return store;
+    };
+
+    it("should open a window on the selected panel", async () => {
+      mocks.engine = "tauri";
+      const store = await selectPanel();
+      act(() => press(CONTROL, "KeyO"));
+      const [opened] = openedWindows(store);
+      expect(opened).toBeDefined();
+      expect(store.getState().panels.windows[opened]?.selected).toEqual(PANEL);
+    });
+
+    it("should leave the selected panel where it is", async () => {
+      mocks.engine = "tauri";
+      const store = await selectPanel();
+      act(() => press(CONTROL, "KeyO"));
+      expect(Session.Panel.selectSelected(store.getState())).toEqual(PANEL);
+    });
+
+    it("should do nothing in the browser", async () => {
+      const store = await selectPanel();
+      act(() => press(CONTROL, "KeyO"));
+      expect(openedWindows(store)).toEqual([]);
+    });
+  });
+
   describe("create tab", () => {
     it("should open a component selector tab in the selected panel", async () => {
       const seed = viewTab();

--- a/console/src/app/triggers/use.spec.tsx
+++ b/console/src/app/triggers/use.spec.tsx
@@ -270,7 +270,7 @@ describe("app/triggers", () => {
         .filter(({ key, reserved }) => key !== Drift.MAIN_WINDOW && reserved)
         .map(({ key }) => key);
 
-    const selectPanel = async (): Promise<TestStore> => {
+    const renderWithSelectedPanel = async (): Promise<TestStore> => {
       const { store } = await renderTriggers();
       act(() => void store.dispatch(Session.Panel.select({ key: PANEL })));
       return store;
@@ -278,22 +278,15 @@ describe("app/triggers", () => {
 
     it("should open a window on the selected panel", async () => {
       mocks.engine = "tauri";
-      const store = await selectPanel();
+      const store = await renderWithSelectedPanel();
       act(() => press(CONTROL, "KeyO"));
       const [opened] = openedWindows(store);
       expect(opened).toBeDefined();
       expect(store.getState().panels.windows[opened]?.selected).toEqual(PANEL);
     });
 
-    it("should leave the selected panel where it is", async () => {
-      mocks.engine = "tauri";
-      const store = await selectPanel();
-      act(() => press(CONTROL, "KeyO"));
-      expect(Session.Panel.selectSelected(store.getState())).toEqual(PANEL);
-    });
-
     it("should do nothing in the browser", async () => {
-      const store = await selectPanel();
+      const store = await renderWithSelectedPanel();
       act(() => press(CONTROL, "KeyO"));
       expect(openedWindows(store)).toEqual([]);
     });

--- a/console/src/app/triggers/use.ts
+++ b/console/src/app/triggers/use.ts
@@ -9,11 +9,12 @@
 
 import { panel } from "@synnaxlabs/client";
 import { Drift } from "@synnaxlabs/drift";
-import { Panel, TimeSpan, Triggers } from "@synnaxlabs/pluto";
+import { Panel as PPanel, TimeSpan, Triggers } from "@synnaxlabs/pluto";
 import { useCallback, useRef } from "react";
 
 import { Palette } from "@/app/palette";
 import { useSelectorVisible } from "@/app/vis/Selector";
+import { Panel } from "@/feature/panel";
 import { Panel as PlatformPanel } from "@/platform/panel";
 import { Selector } from "@/platform/selector";
 import { Session } from "@/session";
@@ -23,7 +24,7 @@ const PREVENT_DEFAULT_ON: Triggers.Trigger[] = [
   Palette.SEARCH_TRIGGER,
   Palette.COMMAND_TRIGGER,
   ["Control", "MouseLeft"],
-  Panel.CLOSE_TRIGGER,
+  PPanel.CLOSE_TRIGGER,
 ];
 
 export const PROVIDER_PROPS: Triggers.ProviderProps = {
@@ -31,16 +32,14 @@ export const PROVIDER_PROPS: Triggers.ProviderProps = {
   preventDefaultOptions: { double: true },
 };
 
-const OVERLAY_TRIGGERS: Triggers.Trigger[] = [Panel.OVERLAY_TRIGGER];
+const OVERLAY_TRIGGERS: Triggers.Trigger[] = [PPanel.OVERLAY_TRIGGER];
 const ESCAPE_TRIGGERS: Triggers.Trigger[] = [Triggers.ESCAPE];
-const CLOSE_TRIGGERS: Triggers.Trigger[] = [Panel.CLOSE_TRIGGER];
+const CLOSE_TRIGGERS: Triggers.Trigger[] = [PPanel.CLOSE_TRIGGER];
 const RENAME_TRIGGERS: Triggers.Trigger[] = [PlatformPanel.RENAME_TRIGGER];
 const CREATE_TAB_TRIGGERS: Triggers.Trigger[] = [["Control", "T"]];
+const OPEN_WINDOW_TRIGGERS: Triggers.Trigger[] = [Panel.OPEN_WINDOW_TRIGGER];
 
 const CLOSE_WINDOW_TIMEOUT = TimeSpan.milliseconds(350);
-
-// TODO(SY-4370): open-in-new-window gesture (formerly Control+O) needs a panel
-// equivalent: create a Drift window and select the panel in it.
 
 export const use = (): void => {
   const sessionDispatch = Session.useDispatch();
@@ -48,7 +47,8 @@ export const use = (): void => {
   const getSelectedPanel = Session.Panel.useGetSelected();
   const getIsOverlaid = Session.Panel.useGetIsOverlaid();
   const getFocusedTab = Session.Panel.useGetFocusedTab();
-  const { dispatch } = Panel.useDispatch();
+  const { dispatch } = PPanel.useDispatch();
+  const openWindow = Panel.useOpenWindow();
   const closeWindowTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
   const createTabEnabled = useSelectorVisible();
   const openSelector = Selector.useOpenTab();
@@ -131,6 +131,17 @@ export const use = (): void => {
         PlatformPanel.editTabName(focused);
       },
       [getFocusedTab],
+    ),
+  });
+  Triggers.use({
+    triggers: OPEN_WINDOW_TRIGGERS,
+    loose: true,
+    callback: useCallback(
+      ({ stage }: Triggers.UseEvent) => {
+        if (stage !== "start" || Session.Runtime.ENGINE !== "tauri") return;
+        openWindow(getSelectedPanel());
+      },
+      [openWindow, getSelectedPanel],
     ),
   });
   Triggers.use({

--- a/console/src/app/triggers/use.ts
+++ b/console/src/app/triggers/use.ts
@@ -103,6 +103,8 @@ export const use = (): void => {
           });
           return;
         }
+        // A page cannot close the tab that holds it.
+        if (Session.Runtime.ENGINE !== "tauri") return;
         closeWindowTimeout.current = setTimeout(
           () => sessionDispatch(Drift.closeWindow({})),
           CLOSE_WINDOW_TIMEOUT.milliseconds,

--- a/console/src/feature/panel/ContextMenu.spec.tsx
+++ b/console/src/feature/panel/ContextMenu.spec.tsx
@@ -22,7 +22,14 @@ import {
   waitFor,
 } from "@testing-library/react";
 import { type FC, type PropsWithChildren } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted((): { engine: "web" | "tauri" } => ({ engine: "web" }));
+
+vi.mock("@/session/runtime/runtime", async (importOriginal) => {
+  const { mockRuntimeEngine } = await import("@/testutil/runtime");
+  return await mockRuntimeEngine(importOriginal, mocks);
+});
 
 import { Panel as PanelFeature } from "@/feature/panel";
 import { Modals } from "@/platform/modals";
@@ -80,6 +87,10 @@ const renderMenu = (wrapper: FC<PropsWithChildren>, keys: string[]) =>
   );
 
 describe("Panel.TabMenuItems", () => {
+  beforeEach(() => {
+    mocks.engine = "web";
+  });
+
   describe("rename", () => {
     it("offers rename for a resource tab", async () => {
       const tab = resourceTab();
@@ -166,7 +177,16 @@ describe("Panel.TabMenuItems", () => {
   });
 
   describe("move to new window", () => {
+    it("hides the item in the browser, which cannot open a window", async () => {
+      const tab = resourceTab();
+      const { wrapper } = await setup([tab], tab.key);
+      renderMenu(wrapper, [tab.key]);
+      await waitFor(() => expect(screen.getByText("Move to panel")).toBeTruthy());
+      expect(screen.queryByText("Move to new window")).toBeNull();
+    });
+
     it("mints a panel holding the tab and opens a window showing it", async () => {
+      mocks.engine = "tauri";
       const moved = resourceTab();
       const stays = resourceTab();
       const existing = await createServerPanel(client, {

--- a/console/src/feature/panel/ContextMenu.tsx
+++ b/console/src/feature/panel/ContextMenu.tsx
@@ -81,13 +81,14 @@ const MoveToPanelItem = (): ReactElement => {
   );
 };
 
-const MoveToNewWindowItem = (): ReactElement => {
+const MoveToNewWindowItem = (): ReactElement | null => {
   const getOrigin = useOrigin();
   const tearOff = useTearOffTab();
   const handleMove = useCallback(() => {
     const origin = getOrigin();
     if (origin != null) tearOff(origin);
   }, [getOrigin, tearOff]);
+  if (Session.Runtime.ENGINE !== "tauri") return null;
   return (
     <Menu.Item itemKey="move-to-new-window" onClick={handleMove}>
       <Icon.OpenInNewWindow />

--- a/console/src/feature/panel/Selector.spec.tsx
+++ b/console/src/feature/panel/Selector.spec.tsx
@@ -508,5 +508,34 @@ describe("Panel.Selector", () => {
       await openPillMenu();
       expect(screen.queryByText("Open in new window")).toBeNull();
     });
+
+    const openPillMenuBeside = async (onSelected: boolean): Promise<void> => {
+      const { key: projectKey } = await client.projects.create({
+        name: uniqueName("project"),
+        layout: {},
+      });
+      const panels = [
+        await createProjectPanel(projectKey, { name: "alpha" }),
+        await createProjectPanel(projectKey, { name: "bravo" }),
+      ];
+      const { row } = await renderStrip(panels, projectKey);
+      await act(async () => {
+        fireEvent.click(screen.getByText(row[0].name));
+      });
+      fireEvent.contextMenu(screen.getByText(row[onSelected ? 0 : 1].name));
+      await screen.findByText("Open in new window");
+    };
+
+    it("should show the shortcut on the selected pill", async () => {
+      mocks.engine = "tauri";
+      await openPillMenuBeside(true);
+      expect(screen.queryByLabelText("trigger-indicator")).not.toBeNull();
+    });
+
+    it("should hide the shortcut on a pill that is not selected", async () => {
+      mocks.engine = "tauri";
+      await openPillMenuBeside(false);
+      expect(screen.queryByLabelText("trigger-indicator")).toBeNull();
+    });
   });
 });

--- a/console/src/feature/panel/Selector.spec.tsx
+++ b/console/src/feature/panel/Selector.spec.tsx
@@ -14,7 +14,14 @@ import { fireDragEvent } from "@synnaxlabs/pluto/testutil";
 import { uuid } from "@synnaxlabs/x";
 import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { type FC, type PropsWithChildren, type ReactElement } from "react";
-import { describe, expect, it } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted((): { engine: "web" | "tauri" } => ({ engine: "web" }));
+
+vi.mock("@/session/runtime/runtime", async (importOriginal) => {
+  const { mockRuntimeEngine } = await import("@/testutil/runtime");
+  return await mockRuntimeEngine(importOriginal, mocks);
+});
 
 import { Selector } from "@/feature/panel/Selector";
 import { Modals } from "@/platform/modals";
@@ -137,6 +144,10 @@ const fireDrop = (el: Element): void => fireDragEvent(el, "drop", CURSOR);
 const fireDragOver = (el: Element): void => fireDragEvent(el, "dragOver", CURSOR);
 
 describe("Panel.Selector", () => {
+  beforeEach(() => {
+    mocks.engine = "web";
+  });
+
   it("should select a newly created panel", async () => {
     const { wrapper, store } = await createPanelWrapper({ client });
     await act(async () => {
@@ -471,6 +482,31 @@ describe("Panel.Selector", () => {
       await waitFor(() =>
         expect(Session.Panel.selectSelected(store.getState())).toEqual(row[1].key),
       );
+    });
+  });
+
+  describe("open in new window", () => {
+    // Waits on Delete so the menu is proven open before the window item is missed.
+    const openPillMenu = async (): Promise<void> => {
+      const { key: projectKey } = await client.projects.create({
+        name: uniqueName("project"),
+        layout: {},
+      });
+      const pan = await createProjectPanel(projectKey);
+      await renderStrip([pan], projectKey);
+      fireEvent.contextMenu(screen.getByText(pan.name));
+      await screen.findByText("Delete");
+    };
+
+    it("should offer the panel in a second window in the tauri engine", async () => {
+      mocks.engine = "tauri";
+      await openPillMenu();
+      expect(screen.getByText("Open in new window")).toBeTruthy();
+    });
+
+    it("should hide the item in the browser, which cannot open a window", async () => {
+      await openPillMenu();
+      expect(screen.queryByText("Open in new window")).toBeNull();
     });
   });
 });

--- a/console/src/feature/panel/Selector.tsx
+++ b/console/src/feature/panel/Selector.tsx
@@ -42,7 +42,7 @@ import {
   useMoveTab,
   useMoveTabToNewPanel,
 } from "@/feature/panel/useMoveTab";
-import { useOpenWindow } from "@/feature/panel/useOpenWindow";
+import { OPEN_WINDOW_TRIGGER, useOpenWindow } from "@/feature/panel/useOpenWindow";
 import { ContextMenu as CMenu } from "@/platform/context-menu";
 import { CSS } from "@/platform/css";
 import { Modals } from "@/platform/modals";
@@ -86,7 +86,11 @@ const ContextMenu = ({ keys, order }: ContextMenuProps): ReactElement | null => 
       )}
       <Menu.Divider />
       {keys.length === 1 && Session.Runtime.ENGINE === "tauri" && (
-        <Menu.Item itemKey="open-in-new-window" onClick={() => openWindow(key)}>
+        <Menu.Item
+          itemKey="open-in-new-window"
+          onClick={() => openWindow(key)}
+          triggerIndicator={OPEN_WINDOW_TRIGGER}
+        >
           <Icon.OpenInNewWindow />
           Open in new window
         </Menu.Item>

--- a/console/src/feature/panel/Selector.tsx
+++ b/console/src/feature/panel/Selector.tsx
@@ -85,7 +85,7 @@ const ContextMenu = ({ keys, order }: ContextMenuProps): ReactElement | null => 
         <CMenu.RenameItem onClick={() => Text.edit(PCSS.B(`tab-${key}`))} />
       )}
       <Menu.Divider />
-      {keys.length === 1 && (
+      {keys.length === 1 && Session.Runtime.ENGINE === "tauri" && (
         <Menu.Item itemKey="open-in-new-window" onClick={() => openWindow(key)}>
           <Icon.OpenInNewWindow />
           Open in new window

--- a/console/src/feature/panel/Selector.tsx
+++ b/console/src/feature/panel/Selector.tsx
@@ -61,6 +61,7 @@ const ContextMenu = ({ keys, order }: ContextMenuProps): ReactElement | null => 
   const dispatch = useDispatch();
   const client = Synnax.use();
   const openWindow = useOpenWindow();
+  const selected = Session.Panel.useSelectSelected();
   const { update: del } = Panel.useDelete({
     beforeUpdate: useCallback(
       async ({ data }: Flux.BeforeUpdateParams<panel.Key | panel.Key[]>) => {
@@ -89,7 +90,7 @@ const ContextMenu = ({ keys, order }: ContextMenuProps): ReactElement | null => 
         <Menu.Item
           itemKey="open-in-new-window"
           onClick={() => openWindow(key)}
-          triggerIndicator={OPEN_WINDOW_TRIGGER}
+          triggerIndicator={key === selected ? OPEN_WINDOW_TRIGGER : undefined}
         >
           <Icon.OpenInNewWindow />
           Open in new window

--- a/console/src/feature/panel/commands.spec.tsx
+++ b/console/src/feature/panel/commands.spec.tsx
@@ -1,0 +1,75 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { Drift } from "@synnaxlabs/drift";
+import { Icon } from "@synnaxlabs/pluto";
+import { uuid } from "@synnaxlabs/x";
+import { act, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted((): { engine: "web" | "tauri" } => ({ engine: "web" }));
+
+vi.mock("@/session/runtime/runtime", async (importOriginal) => {
+  const { mockRuntimeEngine } = await import("@/testutil/runtime");
+  return await mockRuntimeEngine(importOriginal, mocks);
+});
+
+import { renderPalette } from "@/feature/command/testutil";
+import { Panel } from "@/feature/panel";
+import { Command } from "@/platform/command";
+import { Session } from "@/session";
+
+// Proves the list rendered before the window command is missed.
+const SentinelCommand = Command.create({
+  key: "sentinel",
+  name: "Sentinel command",
+  icon: <Icon.Info />,
+  useOnSelect: () => () => {},
+});
+
+const NAME = "Open a new window";
+
+describe("Panel Commands", () => {
+  beforeEach(() => {
+    mocks.engine = "web";
+  });
+
+  it("should open a window on the selected panel", async () => {
+    mocks.engine = "tauri";
+    const panelKey = uuid.create();
+    const { openCommandPalette, selectCommand, store } = await renderPalette({
+      commands: Panel.COMMANDS,
+    });
+    act(() => {
+      store.dispatch(
+        Session.Panel.select({ key: panelKey, windowKey: Drift.MAIN_WINDOW }),
+      );
+    });
+    await openCommandPalette();
+    await selectCommand(NAME);
+
+    await waitFor(() => {
+      const state = store.getState();
+      const win = Drift.selectWindows(state).find(
+        ({ key, reserved }) => key !== Drift.MAIN_WINDOW && reserved,
+      );
+      expect(win).toBeDefined();
+      expect(state.panels.windows[win!.key]?.selected).toEqual(panelKey);
+    });
+  });
+
+  it("should hide the command in the browser, which cannot open a window", async () => {
+    const { openCommandPalette } = await renderPalette({
+      commands: [...Panel.COMMANDS, SentinelCommand],
+    });
+    await openCommandPalette();
+    await screen.findByText("Sentinel command");
+    expect(screen.queryByText(NAME)).toBeNull();
+  });
+});

--- a/console/src/feature/panel/commands.tsx
+++ b/console/src/feature/panel/commands.tsx
@@ -25,6 +25,7 @@ const OpenWindowCommand = Command.create({
   name: "Open a new window",
   icon: <Icon.OpenInNewWindow />,
   useOnSelect: useOpenNewWindow,
+  useVisible: () => Session.Runtime.ENGINE === "tauri",
 });
 
 export const COMMANDS = [OpenWindowCommand];

--- a/console/src/feature/panel/useOpenWindow.ts
+++ b/console/src/feature/panel/useOpenWindow.ts
@@ -9,10 +9,13 @@
 
 import { type panel } from "@synnaxlabs/client";
 import { Drift } from "@synnaxlabs/drift";
+import { type Triggers } from "@synnaxlabs/pluto";
 import { id } from "@synnaxlabs/x";
 import { useCallback } from "react";
 
 import { Session } from "@/session";
+
+export const OPEN_WINDOW_TRIGGER: Triggers.Trigger = ["Control", "O"];
 
 export interface OpenWindow {
   (key?: panel.Key, props?: Omit<Drift.WindowProps, "key">): void;

--- a/console/src/session/store.ts
+++ b/console/src/session/store.ts
@@ -171,6 +171,7 @@ export type Store = BaseStore<State, Action>;
 
 const DEFAULT_WINDOW_PROPS: Omit<Drift.WindowProps, "key"> = {
   visible: IS_DEV,
+  size: { width: 800, height: 600 },
   minSize: { width: 625, height: 375 },
 };
 

--- a/drift/src/configureStore.spec.ts
+++ b/drift/src/configureStore.spec.ts
@@ -1,0 +1,95 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { describe, expect, it } from "vitest";
+
+import { resetInitialState } from "@/configureStore";
+import { type StoreState, ZERO_SLICE_STATE } from "@/state";
+import { INITIAL_WINDOW_STATE, MAIN_WINDOW, type WindowState } from "@/window";
+
+const stored = (props: Partial<WindowState> = {}): StoreState => ({
+  drift: {
+    ...ZERO_SLICE_STATE,
+    windows: {
+      [MAIN_WINDOW]: {
+        ...INITIAL_WINDOW_STATE,
+        key: MAIN_WINDOW,
+        reserved: true,
+        ordinal: 1,
+        ...props,
+      },
+    },
+  },
+});
+
+const restored = (props: Partial<WindowState> = {}): WindowState => {
+  const state = resetInitialState(undefined, false, stored(props));
+  const win = state?.drift.windows[MAIN_WINDOW];
+  if (win == null) throw new Error("the main window did not survive the reset");
+  return win;
+};
+
+describe("resetInitialState", () => {
+  // A window comes back the way the user would open it fresh, not the way they left
+  // it: launching is a request to see the app.
+  it("should show a window stored minimized", () => {
+    expect(restored({ minimized: true }).minimized).toBeUndefined();
+  });
+
+  it("should show a window stored fullscreen", () => {
+    expect(restored({ fullscreen: true }).fullscreen).toBeUndefined();
+  });
+
+  // Controls grey out the macOS traffic lights on a blurred window, so a stored blur
+  // leaves them dead until the runtime reports a focus.
+  it("should drop a stored blur", () => {
+    expect(restored({ focus: false }).focus).toBeUndefined();
+  });
+
+  // completeProcess reloads a window it finds mid-reload, so the stage has to start
+  // over or the next process to finish reloads the fresh window.
+  it("should start the lifecycle over", () => {
+    expect(restored({ stage: "reloading" }).stage).toEqual("creating");
+  });
+
+  it("should drop a stored error", () => {
+    expect(restored({ error: "stale" }).error).toBeUndefined();
+  });
+
+  it("should zero the counters", () => {
+    expect(restored({ focusCount: 3, centerCount: 2, processCount: 1 })).toMatchObject({
+      focusCount: 0,
+      centerCount: 0,
+      processCount: 0,
+    });
+  });
+
+  it("should keep the window's geometry", () => {
+    const geometry: Partial<WindowState> = {
+      position: { x: 10, y: 20 },
+      size: { width: 800, height: 600 },
+      maximized: true,
+    };
+    expect(restored({ ...geometry, minimized: true })).toMatchObject(geometry);
+  });
+
+  it("should take visibility from the default window props", () => {
+    const state = resetInitialState(
+      { visible: true },
+      false,
+      stored({ visible: false }),
+    );
+    expect(state?.drift.windows[MAIN_WINDOW].visible).toEqual(true);
+  });
+
+  it("should drop windows that were never reserved", () => {
+    const state = resetInitialState(undefined, false, stored({ reserved: false }));
+    expect(state?.drift.windows[MAIN_WINDOW]).toBeUndefined();
+  });
+});

--- a/drift/src/configureStore.ts
+++ b/drift/src/configureStore.ts
@@ -32,7 +32,7 @@ import {
 import { sugar } from "@/sugar";
 import { syncInitial } from "@/sync";
 import { validateAction } from "@/validate";
-import { MAIN_WINDOW, type WindowProps } from "@/window";
+import { MAIN_WINDOW, resetTransientState, type WindowProps } from "@/window";
 
 export type Enhancers = readonly StoreEnhancer[];
 
@@ -203,12 +203,10 @@ export const resetInitialState = <S extends StoreState>(
     Object.entries(drift.windows)
       .filter(([, window]) => window.reserved)
       .map(([key, window]) => {
+        const next = resetTransientState(window);
         if (defaultWindowProps?.visible != null)
-          window.visible = defaultWindowProps.visible;
-        window.focusCount = 0;
-        window.centerCount = 0;
-        window.processCount = 0;
-        return [key, window];
+          next.visible = defaultWindowProps.visible;
+        return [key, next];
       }),
   );
   ensureOrdinals(drift);

--- a/drift/src/state.spec.ts
+++ b/drift/src/state.spec.ts
@@ -52,6 +52,55 @@ describe("createWindow", () => {
     config: { ...ZERO_SLICE_STATE.config, enablePrerender: false },
   };
 
+  // The main window sits at 100,100 and is 1000x800, so its center is 600,500. A
+  // 400x200 window centered on it starts at 400,400.
+  const withMain = (config: Partial<SliceState["config"]> = {}): SliceState => ({
+    ...sliceState({
+      [MAIN_WINDOW]: reserved(MAIN_WINDOW, {
+        ordinal: 1,
+        position: { x: 100, y: 100 },
+        size: { width: 1000, height: 800 },
+      }),
+    }),
+    config: { ...ZERO_SLICE_STATE.config, enablePrerender: false, ...config },
+  });
+
+  const created = (s: SliceState, size?: { width: number; height: number }) =>
+    reducer(s, createWindow({ key: "a", label: "la", prerenderLabel: "pa", size }))
+      .windows.la;
+
+  it("should center a new window on the main window", () => {
+    expect(created(withMain(), { width: 400, height: 200 }).position).toEqual({
+      x: 400,
+      y: 400,
+    });
+  });
+
+  it("should center a sizeless window using the default window props", () => {
+    const s = withMain({ defaultWindowProps: { size: { width: 400, height: 200 } } });
+    expect(created(s).position).toEqual({ x: 400, y: 400 });
+  });
+
+  // Centering a window of unknown size would place its top left at the main window's
+  // center, dropping it well below and right of where it belongs.
+  it("should leave a sizeless window unplaced when no default size exists", () => {
+    expect(created(withMain()).position).toBeUndefined();
+  });
+
+  it("should keep a position the caller asked for", () => {
+    const s = withMain({ defaultWindowProps: { size: { width: 400, height: 200 } } });
+    const next = reducer(
+      s,
+      createWindow({
+        key: "a",
+        label: "la",
+        prerenderLabel: "pa",
+        position: { x: 12, y: 34 },
+      }),
+    );
+    expect(next.windows.la.position).toEqual({ x: 12, y: 34 });
+  });
+
   it("should assign increasing ordinals to freshly created windows", () => {
     let s = noPrerender;
     s = reducer(s, createWindow({ key: "a", label: "la", prerenderLabel: "pa" }));

--- a/drift/src/state.spec.ts
+++ b/drift/src/state.spec.ts
@@ -186,6 +186,39 @@ describe("restoreWindows", () => {
     });
   });
 
+  it("should drop how a restored window looked when its process ended", () => {
+    const next = restoreWindows(
+      sliceState({ [MAIN_WINDOW]: reserved(MAIN_WINDOW) }),
+      sliceState({
+        incoming: reserved("new", {
+          stage: "reloading",
+          minimized: true,
+          fullscreen: true,
+          focus: false,
+          error: "stale",
+        }),
+      }),
+    );
+    expect(next.windows.incoming).toMatchObject({ stage: "creating" });
+    expect(next.windows.incoming?.minimized).toBeUndefined();
+    expect(next.windows.incoming?.fullscreen).toBeUndefined();
+    expect(next.windows.incoming?.focus).toBeUndefined();
+    expect(next.windows.incoming?.error).toBeUndefined();
+  });
+
+  it("should keep a restored window's geometry", () => {
+    const geometry: Partial<WindowState> = {
+      position: { x: 10, y: 20 },
+      size: { width: 800, height: 600 },
+      maximized: true,
+    };
+    const next = restoreWindows(
+      sliceState({ [MAIN_WINDOW]: reserved(MAIN_WINDOW) }),
+      sliceState({ incoming: reserved("new", { ...geometry, minimized: true }) }),
+    );
+    expect(next.windows.incoming).toMatchObject(geometry);
+  });
+
   it("should keep unused pre-rendered windows out of the swap", () => {
     const spare = { ...INITIAL_PRERENDER_WINDOW_STATE };
     const next = restoreWindows(

--- a/drift/src/state.spec.ts
+++ b/drift/src/state.spec.ts
@@ -14,6 +14,7 @@ import {
   assignLabel,
   createWindow,
   type CreateWindowPayload,
+  internalSetInitial,
   reducer,
   restoreWindows,
   runtimeSetWindowProps,
@@ -145,6 +146,30 @@ describe("setWindowProps", () => {
     expect(s.windows.pre.visible).toEqual(true);
     s = reducer(s, runtimeSetWindowProps({ label: "pre", position: { x: 5, y: 5 } }));
     expect(s.windows.pre.position).toEqual({ x: 5, y: 5 });
+  });
+});
+
+describe("internalSetInitial", () => {
+  it("should keep the default window props when the caller omits them", () => {
+    const s: SliceState = {
+      ...ZERO_SLICE_STATE,
+      config: {
+        ...ZERO_SLICE_STATE.config,
+        defaultWindowProps: { size: { width: 400, height: 200 } },
+      },
+    };
+    const next = reducer(
+      s,
+      internalSetInitial({
+        label: MAIN_WINDOW,
+        enablePrerender: false,
+        debug: false,
+        defaultWindowProps: undefined,
+      }),
+    );
+    expect(next.config.defaultWindowProps).toEqual({
+      size: { width: 400, height: 200 },
+    });
   });
 });
 

--- a/drift/src/state.ts
+++ b/drift/src/state.ts
@@ -419,8 +419,13 @@ export const reduceInternalSetInitial = (
   s: SliceState,
   a: PayloadAction<InternalSetInitialPayload>,
 ): void => {
-  s.config = { ...s.config, ...a.payload };
-  s.label = a.payload.label;
+  // configureStore passes every config key, so an option the caller omitted arrives
+  // as an explicit undefined that a spread would write over the default.
+  const { label, enablePrerender, defaultWindowProps, debug } = a.payload;
+  if (enablePrerender != null) s.config.enablePrerender = enablePrerender;
+  if (defaultWindowProps != null) s.config.defaultWindowProps = defaultWindowProps;
+  if (debug != null) s.config.debug = debug;
+  s.label = label;
   if (s.label === MAIN_WINDOW && s.config.enablePrerender) {
     const prerenderLabel = id.create();
     s.windows[prerenderLabel] = {

--- a/drift/src/state.ts
+++ b/drift/src/state.ts
@@ -228,10 +228,17 @@ const maybePositionInCenter = (
   position?: xy.XY,
   size?: dimensions.Dimensions,
 ): xy.XY | undefined => {
-  if (mainWin.position != null && mainWin.size != null && position == null)
+  // Without the new window's size there is nothing to center, so leave placement to
+  // the runtime.
+  if (
+    mainWin.position != null &&
+    mainWin.size != null &&
+    position == null &&
+    size != null
+  )
     return box.topLeft(
       box.positionInCenter(
-        box.construct(xy.ZERO, size ?? xy.ZERO),
+        box.construct(xy.ZERO, size),
         box.construct(mainWin.position, mainWin.size),
       ),
     );
@@ -250,7 +257,11 @@ const reduceCreateWindow = (
   group(s.config.debug, "reducer create window");
 
   const mainWin = s.windows.main;
-  payload.position = maybePositionInCenter(mainWin, payload.position, payload.size);
+  payload.position = maybePositionInCenter(
+    mainWin,
+    payload.position,
+    payload.size ?? s.config.defaultWindowProps.size,
+  );
 
   // If the window already exists, un-minimize and focus it
   if (key in s.keyLabels) {

--- a/drift/src/state.ts
+++ b/drift/src/state.ts
@@ -16,6 +16,7 @@ import {
   INITIAL_WINDOW_STATE,
   MAIN_WINDOW,
   PRERENDER_WINDOW,
+  resetTransientState,
   type WindowProps,
   type WindowStage,
   type WindowState,
@@ -515,7 +516,7 @@ export const restoreWindows = (current: SliceState, stored: SliceState): SliceSt
   });
   Object.entries(stored.windows).forEach(([label, win]) => {
     if (label === MAIN_WINDOW || !win.reserved) return;
-    windows[label] = { ...win, focusCount: 0, centerCount: 0, processCount: 0 };
+    windows[label] = resetTransientState(win);
   });
   const labelKeys: Record<string, string> = {};
   const keyLabels: Record<string, string> = {};

--- a/drift/src/window.ts
+++ b/drift/src/window.ts
@@ -56,6 +56,22 @@ export const INITIAL_PRERENDER_WINDOW_STATE: WindowState = {
   visible: false,
 };
 
+/**
+ * Clears how the window was presented and where it was in its lifecycle when its
+ * process ended. Identity and geometry survive.
+ */
+export const resetTransientState = (window: WindowState): WindowState => ({
+  ...window,
+  stage: "creating",
+  processCount: 0,
+  focusCount: 0,
+  centerCount: 0,
+  focus: undefined,
+  minimized: undefined,
+  fullscreen: undefined,
+  error: undefined,
+});
+
 /** State of a window managed by drift  */
 export interface WindowState extends WindowProps, WindowStateExtensionProps {}
 


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-2509](https://linear.app/synnax/issue/SY-2509/hide-multi-window-mechanics-for-browser-runtime)

## Description

The web engine swaps Drift for a no-op runtime, so every window entry in the Console
did nothing, or worse. "Move to new window" minted a panel and moved the tab into it
before opening a window that never appeared, so the tab vanished from view. Holding the
close shortcut deleted the main window from the Drift slice, which the panel selectors
key off, while the browser tab stayed open. The pill menu, tab menu, palette command,
and close shortcut are now hidden or inert outside Tauri.

Fixing the window paths surfaced three defects in Drift that also affect the desktop
build.

A window came back from disk the way the user left it, including whether it was
minimized, fullscreen, focused, and where it sat in its lifecycle. Quitting while
minimized relaunched the Console straight into the Dock; quitting while blurred brought
back greyed-out macOS window controls; a stored reloading stage made the next completed
process reload the fresh window. Those fields now reset on launch and on a project
switch. Position, size, and maximized stay durable, since the user chose those.

A new window was meant to open centered on the main window, but centering needs the new
window's size and no caller passed one. The size fell back to zero, so the main window's
center became the new window's top left corner and the window landed well below and
right of where it belonged. The Console now declares the size it wants for a new window
instead of inheriting Tauri's default, and Drift refuses to center a window whose size
it does not know.

`configureStore` passes every config key, so an option the caller omitted arrived as an
explicit `undefined` and the spread wrote it over the default. `defaultWindowProps` ended
up undefined despite its type promising otherwise.

Finally, Control+O is back. The panel refactor dropped it because a tab had nowhere to
go. It now opens a second window on the selected panel rather than moving the focused
tab, so a bare accelerator no longer relocates work. Tearing a tab off keeps its own
homes in the tab context menu and the desktop drag.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR disables multi-window actions in the browser and repairs Drift window restoration and placement.

- Limits window shortcuts, menus, and commands to Tauri.
- Resets transient window state during launch and session restoration.
- Adds a known secondary-window size and restores Control+O.
- Preserves configured defaults when omitted options arrive as `undefined`.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| console/src/app/triggers/use.ts | Adds the Tauri-only Control+O path and prevents browser close-window state changes. |
| console/src/feature/panel/Selector.tsx | Hides the new-window menu item in browsers and shows its shortcut only for the selected panel. |
| console/src/feature/panel/ContextMenu.tsx | Removes the tab tear-off action when the runtime cannot create native windows. |
| console/src/feature/panel/commands.tsx | Limits the open-window palette command to Tauri. |
| console/src/session/store.ts | Defines the secondary-window size used for native creation and centering. |
| drift/src/configureStore.ts | Resets transient persisted state before Drift initializes restored windows. |
| drift/src/state.ts | Preserves omitted configuration defaults, centers only sized windows, and resets restored window lifecycle state. |
| drift/src/window.ts | Adds the shared transient-state reset while retaining window identity and geometry. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  A[Window action] --> B{Runtime is Tauri?}
  B -->|No| C[Hide or ignore action]
  B -->|Yes| D[Create Drift window]
  D --> E[Apply configured size]
  E --> F[Center on main window]
  G[Stored window state] --> H[Reset transient fields]
  H --> I[Restore identity and geometry]
```

<sub>Reviews (2): Last reviewed commit: ["Show the open-window shortcut only on th..."](https://github.com/synnaxlabs/synnax/commit/9b2d84c7e5057231c52b33ac87fed9943b74bfdb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53722419)</sub>

**Context used:**

- Knowledge Base — [Console App](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/console-app.md)
- Knowledge Base — [Drift: Multi-Window State Synchronization](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/drift-state.md)

<!-- /greptile_comment -->