### PR TITLE
SY-4600: Fix permanent rolling plot gaps after a stream stops

### DIFF
--- a/client/ts/src/framer/cache/dynamic.ts
+++ b/client/ts/src/framer/cache/dynamic.ts
@@ -261,6 +261,20 @@ export class Dynamic {
     return Math.round(Math.max(Math.min(size, MAX_SIZE), MIN_SIZE));
   }
 
+  /**
+   * Flushes the leading buffer, stamping its end with the last stamped write or
+   * the wall clock.
+   * @returns the flushed buffer, or null when there is none.
+   */
+  flush(): Series | null {
+    const res: WriteResponse = {
+      flushed: new MultiSeries([]),
+      allocated: new MultiSeries([]),
+    };
+    this.flushCurr(res);
+    return res.flushed.series[0] ?? null;
+  }
+
   /** Closes the cache. It must not be used afterwards. */
   close(): void {
     this.curr = null;

--- a/client/ts/src/framer/cache/streamer.spec.ts
+++ b/client/ts/src/framer/cache/streamer.spec.ts
@@ -8,7 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { alamos } from "@synnaxlabs/alamos";
-import { type MultiSeries, Series, sleep, TimeSpan } from "@synnaxlabs/x";
+import { type MultiSeries, Series, sleep, TimeSpan, TimeStamp } from "@synnaxlabs/x";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { type channel } from "@/channel";
@@ -79,6 +79,29 @@ const pendingStreamer = (keys: channel.Key[]): MockStreamer => {
   let closed = false;
   let resolve: ((r: IteratorResult<framer.Frame>) => void) | null = null;
   const ms = new MockStreamer(keys, async () => {
+    if (closed) return { done: true, value: undefined };
+    return await new Promise<IteratorResult<framer.Frame>>((r) => (resolve = r));
+  });
+  const origClose = ms.close.bind(ms);
+  ms.close = () => {
+    closed = true;
+    resolve?.({ done: true, value: undefined });
+    origClose();
+  };
+  return ms;
+};
+
+/** A streamer that delivers one frame, then blocks until close() like
+ * {@link pendingStreamer}. */
+const oneFrameStreamer = (keys: channel.Key[], frame: framer.Frame): MockStreamer => {
+  let sent = false;
+  let closed = false;
+  let resolve: ((r: IteratorResult<framer.Frame>) => void) | null = null;
+  const ms = new MockStreamer(keys, async () => {
+    if (!sent) {
+      sent = true;
+      return { done: false, value: frame };
+    }
     if (closed) return { done: true, value: undefined };
     return await new Promise<IteratorResult<framer.Frame>>((r) => (resolve = r));
   });
@@ -584,6 +607,135 @@ describe("MultiplexedStreamer", () => {
       expect(sub.status(1).variant).toEqual("success");
       expect(transitions).toEqual(["success", "warning", "success"]);
       sub.close();
+    });
+  });
+
+  describe("buffer flushing", () => {
+    const stampedSeries = (): Series =>
+      new Series({
+        data: new Float32Array([1, 2, 3]),
+        alignment: 0n,
+        timeRange: TimeStamp.seconds(10).range(TimeStamp.seconds(13)),
+      });
+
+    it("should flush a channel's buffer when its demand ends", async () => {
+      const cache = new Cache();
+      const streamer = new MultiplexedStreamer({
+        cache,
+        openStreamer: createStreamOpener([
+          oneFrameStreamer([1], new Frame({ 1: stampedSeries() })),
+        ]),
+        removalDelay: TimeSpan.milliseconds(50),
+      });
+      const sub = streamer.stream(() => {}, [1]);
+      await vi.advanceTimersByTimeAsync(200);
+      expect(cache.get(1).leadingBuffer).not.toBeNull();
+
+      sub.close();
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(cache.get(1).leadingBuffer).toBeNull();
+      // The flushed samples stay readable, with a true gap after their end.
+      const { series, gaps } = cache
+        .get(1)
+        .read(TimeStamp.seconds(10).range(TimeStamp.seconds(20)));
+      expect(Array.from(series)).toEqual([1, 2, 3]);
+      expect(gaps).toHaveLength(1);
+      expect(gaps[0].equals(TimeStamp.seconds(13).range(TimeStamp.seconds(20)))).toBe(
+        true,
+      );
+      await streamer.close();
+    });
+
+    it("should flush only the keys that left the stream", async () => {
+      const cache = new Cache();
+      const streamer = new MultiplexedStreamer({
+        cache,
+        openStreamer: createStreamOpener([
+          oneFrameStreamer(
+            [1, 2],
+            new Frame([1, 2], [stampedSeries(), stampedSeries()]),
+          ),
+        ]),
+        removalDelay: TimeSpan.milliseconds(50),
+      });
+      const sub1 = streamer.stream(() => {}, [1]);
+      const sub2 = streamer.stream(() => {}, [2]);
+      await vi.advanceTimersByTimeAsync(200);
+      expect(cache.get(1).leadingBuffer).not.toBeNull();
+      expect(cache.get(2).leadingBuffer).not.toBeNull();
+
+      sub2.close();
+      await vi.advanceTimersByTimeAsync(300);
+
+      expect(cache.get(1).leadingBuffer).not.toBeNull();
+      expect(cache.get(2).leadingBuffer).toBeNull();
+      sub1.close();
+      await streamer.close();
+    });
+
+    it("should flush buffers when the stream drops", async () => {
+      const cache = new Cache();
+      const hooks: StreamHooks[] = [];
+      const streamer = new MultiplexedStreamer({
+        cache,
+        openStreamer: createStreamOpener(
+          [oneFrameStreamer([1], new Frame({ 1: stampedSeries() }))],
+          hooks,
+        ),
+      });
+      const sub = streamer.stream(() => {}, [1]);
+      await vi.advanceTimersByTimeAsync(200);
+      expect(cache.get(1).leadingBuffer).not.toBeNull();
+
+      hooks[0].onDrop(new Error("conn lost"));
+
+      expect(cache.get(1).leadingBuffer).toBeNull();
+      sub.close();
+      await streamer.close();
+    });
+
+    it("should flush buffers when the run loop dies", async () => {
+      const cache = new Cache();
+      const dying = new MockStreamer([1], undefined, [
+        new Frame({ 1: stampedSeries() }),
+      ]);
+      const replacement = pendingStreamer([1]);
+      const streamer = new MultiplexedStreamer({
+        cache,
+        openStreamer: createStreamOpener([dying, replacement]),
+      });
+      const sub = streamer.stream(() => {}, [1]);
+      await vi.advanceTimersByTimeAsync(1000);
+
+      expect(replacement.iteratorVi).toHaveBeenCalled();
+      expect(cache.get(1).leadingBuffer).toBeNull();
+      const { series } = cache
+        .get(1)
+        .read(TimeStamp.seconds(10).range(TimeStamp.seconds(13)));
+      expect(Array.from(series)).toEqual([1, 2, 3]);
+      sub.close();
+      await streamer.close();
+    });
+
+    it("should flush a frame for a key with no demand", async () => {
+      const cache = new Cache();
+      const streamer = new MultiplexedStreamer({
+        cache,
+        openStreamer: createStreamOpener([
+          oneFrameStreamer([1], new Frame({ 2: stampedSeries() })),
+        ]),
+      });
+      const sub = streamer.stream(() => {}, [1]);
+      await vi.advanceTimersByTimeAsync(200);
+
+      expect(cache.get(2).leadingBuffer).toBeNull();
+      const { series } = cache
+        .get(2)
+        .read(TimeStamp.seconds(10).range(TimeStamp.seconds(13)));
+      expect(Array.from(series)).toEqual([1, 2, 3]);
+      sub.close();
+      await streamer.close();
     });
   });
 

--- a/client/ts/src/framer/cache/streamer.ts
+++ b/client/ts/src/framer/cache/streamer.ts
@@ -260,6 +260,13 @@ export class MultiplexedStreamer {
     });
   }
 
+  // A flushed buffer stops claiming live coverage, so reads refetch the span the
+  // stream will not deliver.
+  private flushBuffers(keys: Iterable<channel.Key>): void {
+    const { cache } = this.props;
+    for (const key of keys) cache.get(key).flushDynamic();
+  }
+
   private async reconcile(): Promise<void> {
     const { instrumentation: ins } = this.props;
     let retry = false;
@@ -268,9 +275,11 @@ export class MultiplexedStreamer {
       const desired = this.desiredKeys();
       try {
         if (desired.size === 0) {
+          const removed = this.sentKeys;
           this.sentKeys = new Set();
           this.statuses.clear();
           await this.releaseStream();
+          this.flushBuffers(removed);
           this.breaker.reset();
           ins.L.info("streamer closed, no keys to stream");
           return;
@@ -283,6 +292,7 @@ export class MultiplexedStreamer {
           return;
         const arrKeys = Array.from(desired);
         const fresh = arrKeys.filter((k) => !this.sentKeys.has(k));
+        const removed = Array.from(this.sentKeys).filter((k) => !desired.has(k));
         if (this.streamer == null) {
           ins.L.info("creating new streamer", { keys: arrKeys });
           const streamer = await this.props.openStreamer(
@@ -290,8 +300,12 @@ export class MultiplexedStreamer {
             {
               onReopen: () =>
                 this.sentKeys.forEach((key) => this.setStatus(key, STREAMING)),
-              onDrop: () =>
-                this.sentKeys.forEach((key) => this.setStatus(key, RECONNECTING)),
+              // Frames may drop until the reopen, so the buffers' live-coverage
+              // claims end here.
+              onDrop: () => {
+                this.flushBuffers(this.sentKeys);
+                this.sentKeys.forEach((key) => this.setStatus(key, RECONNECTING));
+              },
             },
           );
           this.streamer = streamer;
@@ -304,6 +318,7 @@ export class MultiplexedStreamer {
           await this.streamer.update(arrKeys);
         }
         this.sentKeys = desired;
+        this.flushBuffers(removed);
         // Existing keys keep their status so a demand change cannot clear a per-key
         // error.
         fresh.forEach((key) => this.setStatus(key, STREAMING));
@@ -337,9 +352,14 @@ export class MultiplexedStreamer {
           else existing.push(s);
         });
         const changed: Map<channel.Key, MultiSeries> = new Map();
+        const demanded = this.desiredKeys();
         grouped.forEach((series, k) => {
           try {
-            changed.set(k, cache.get(k).writeDynamic(new MultiSeries(series)));
+            const unary = cache.get(k);
+            changed.set(k, unary.writeDynamic(new MultiSeries(series)));
+            // A frame for a key with no remaining demand arrived behind the
+            // stream update; its buffer must not claim live coverage.
+            if (!demanded.has(k)) unary.flushDynamic();
             this.setStatus(k, STREAMING);
           } catch (e) {
             this.setStatus(k, status.fromException(e, "failed to buffer channel"));
@@ -362,6 +382,7 @@ export class MultiplexedStreamer {
       if (!this.connMu.closed && this.streamer === streamer) {
         this.streamer = null;
         this.runLoop = null;
+        this.flushBuffers(this.sentKeys);
         this.sentKeys = new Set();
         this.scheduleReconcile(TimeSpan.ZERO);
       }

--- a/client/ts/src/framer/cache/unary.spec.ts
+++ b/client/ts/src/framer/cache/unary.spec.ts
@@ -106,4 +106,33 @@ describe("Unary", () => {
       expect(series.series[0].alignment).toEqual(LEADING_ALIGNMENT);
     });
   });
+
+  describe("flushDynamic", () => {
+    it("should move the leading buffer to static and expose the trailing gap", () => {
+      const u = newUnary();
+      u.writeDynamic(stamped(10, 13, [1, 2, 3], LEADING_ALIGNMENT));
+      u.flushDynamic();
+      expect(u.leadingBuffer).toBeNull();
+      const { series, gaps } = u.read(
+        TimeStamp.seconds(5).range(TimeStamp.seconds(20)),
+      );
+      expect(series.series).toHaveLength(1);
+      expect(Array.from(series.series[0])).toEqual([1, 2, 3]);
+      expect(gaps).toHaveLength(2);
+      expect(gaps[0].equals(TimeStamp.seconds(5).range(TimeStamp.seconds(10)))).toBe(
+        true,
+      );
+      expect(gaps[1].equals(TimeStamp.seconds(13).range(TimeStamp.seconds(20)))).toBe(
+        true,
+      );
+    });
+
+    it("should be a no-op when there is no leading buffer", () => {
+      const u = newUnary();
+      u.flushDynamic();
+      expect(u.leadingBuffer).toBeNull();
+      const { gaps } = u.read(TimeStamp.seconds(5).range(TimeStamp.seconds(20)));
+      expect(gaps).toHaveLength(1);
+    });
+  });
 });

--- a/client/ts/src/framer/cache/unary.ts
+++ b/client/ts/src/framer/cache/unary.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { type MultiSeries, type Series, TimeRange } from "@synnaxlabs/x";
+import { MultiSeries, type Series, TimeRange } from "@synnaxlabs/x";
 
 import { UnexpectedError } from "@/errors";
 import { Dynamic, type DynamicProps } from "@/framer/cache/dynamic";
@@ -51,6 +51,18 @@ export class Unary {
   get leadingBuffer(): Series | null {
     this.checkOpen("leadingBuffer");
     return this.dynamic.leadingBuffer;
+  }
+
+  /**
+   * Flushes the live leading buffer into the static cache with its real end time,
+   * so reads treat the span after it as a gap to fetch. Call when streaming for
+   * the channel stops.
+   */
+  flushDynamic(): void {
+    this.checkOpen("flushDynamic");
+    const flushed = this.dynamic.flush();
+    if (flushed != null && flushed.length > 0)
+      this.static.write(new MultiSeries([flushed]), true);
   }
 
   writeStatic(series: MultiSeries): void {

--- a/client/ts/src/framer/feed.spec.ts
+++ b/client/ts/src/framer/feed.spec.ts
@@ -7,7 +7,15 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { DataType, id, Series, TimeRange, TimeSpan, TimeStamp } from "@synnaxlabs/x";
+import {
+  DataType,
+  id,
+  Series,
+  sleep,
+  TimeRange,
+  TimeSpan,
+  TimeStamp,
+} from "@synnaxlabs/x";
 import { afterAll, describe, expect, it } from "vitest";
 
 import { UnexpectedError } from "@/errors";
@@ -193,6 +201,57 @@ describe("feed", () => {
     // live buffer.
     expect(received.some((s) => res.series.includes(s))).toBe(true);
     sub.close();
+  });
+
+  it("should refetch samples written while a channel was unstreamed", async () => {
+    const { time, data } = await createChannels();
+    const short = client.openFeed({ removalDelay: TimeSpan.milliseconds(100) });
+    try {
+      const start = TimeStamp.now();
+      const w = await client.openWriter({ start, channels: [time.key, data.key] });
+      let value = 0;
+      try {
+        const received: number[] = [];
+        const sub = short.stream(
+          (res) => {
+            const series = res.get(data.key);
+            if (series != null) received.push(...(Array.from(series) as number[]));
+          },
+          [data.key],
+        );
+        await expect
+          .poll(
+            async () => {
+              await w.write({ [time.key]: [TimeStamp.now()], [data.key]: [value++] });
+              return received.length > 0;
+            },
+            { timeout: 10000, interval: 100 },
+          )
+          .toBe(true);
+        // Ends the channel's streaming demand; the wait outlasts the removal delay
+        // and the reconcile that shrinks the stream.
+        sub.close();
+        await sleep.sleep(TimeSpan.milliseconds(500));
+        for (let i = 0; i < 10; i++)
+          await w.write({ [time.key]: [TimeStamp.now()], [data.key]: [value++] });
+        await w.commit();
+      } finally {
+        await w.close();
+      }
+      const tr = new TimeRange(start, TimeStamp.now());
+      const cached = new Set(Array.from(await short.read(tr, data.key)) as number[]);
+      const fresh = client.openFeed();
+      try {
+        const all = Array.from(await fresh.read(tr, data.key)) as number[];
+        expect(all.length).toBeGreaterThanOrEqual(value - 1);
+        const missing = all.filter((v) => !cached.has(v));
+        expect(missing).toHaveLength(0);
+      } finally {
+        await fresh.close();
+      }
+    } finally {
+      await short.close();
+    }
   });
 
   it("should reject reads after the feed closes", async () => {

--- a/client/ts/src/framer/hardened.ts
+++ b/client/ts/src/framer/hardened.ts
@@ -50,6 +50,7 @@ export class HardenedStreamer implements Streamer {
   private readonly stableAfter: TimeSpan;
   private openedAt = TimeStamp.now();
   private closed = false;
+  private reconnecting: Promise<void> | null = null;
 
   constructor(
     opener: StreamOpener,
@@ -169,6 +170,18 @@ export class HardenedStreamer implements Streamer {
     return this.current;
   }
 
+  // A failure during an in-flight reconnect joins it; a second run would open a
+  // competing stream and leak the loser.
+  private async reconnect(error: Error): Promise<void> {
+    if (this.reconnecting == null) {
+      this.onDrop?.(error);
+      this.reconnecting = this.runStreamer().finally(() => {
+        this.reconnecting = null;
+      });
+    }
+    await this.reconnecting;
+  }
+
   async update(channels: channel.Params): Promise<void> {
     if (this.closed) throw new EOF();
     this.config.channels = channels;
@@ -176,8 +189,7 @@ export class HardenedStreamer implements Streamer {
       await this.wrapped.update(channels);
     } catch (e) {
       if (this.closed || EOF.matches(e)) throw errors.fromUnknown(e);
-      this.onDrop?.(errors.fromUnknown(e));
-      await this.runStreamer();
+      await this.reconnect(errors.fromUnknown(e));
       return await this.update(channels);
     }
   }
@@ -199,8 +211,7 @@ export class HardenedStreamer implements Streamer {
       if (this.closed) throw new EOF();
       // an EOF the client did not ask for is a drop: the server ended the
       // stream, so reconnect like any other failure
-      this.onDrop?.(errors.fromUnknown(e));
-      await this.runStreamer();
+      await this.reconnect(errors.fromUnknown(e));
       return await this.read();
     }
   }

--- a/client/ts/src/framer/streamer.spec.ts
+++ b/client/ts/src/framer/streamer.spec.ts
@@ -964,6 +964,77 @@ describe("Streamer", () => {
       await hardened.update([2, 3]);
       expect(openerMock).toHaveBeenCalledTimes(2);
     });
+
+    it("should not leak a stream when an update races a reconnect", async () => {
+      const streamer1 = new MockStreamer();
+      const fr1 = new Frame({ 1: new Series([1]) });
+      streamer1.responses = [
+        [fr1, null],
+        [fr1, new Unreachable({ message: "down" })],
+      ];
+      const streamer2 = new MockStreamer();
+      streamer2.read = async () => await new Promise<never>(() => {});
+      const pendingOpens: ((s: Streamer) => void)[] = [];
+      let opens = 0;
+      const onDrop = vi.fn();
+      const hardened = await HardenedStreamer.open(
+        async () => {
+          opens++;
+          if (opens === 1) return streamer1;
+          return await new Promise<Streamer>((resolve) => pendingOpens.push(resolve));
+        },
+        { channels: [1] },
+        { maxInterval: TimeSpan.milliseconds(5), jitter: 0 },
+        undefined,
+        onDrop,
+      );
+      expect(await hardened.read()).toEqual(fr1);
+      // Age the stream past stableAfter so the reconnect skips the backoff sleep.
+      await sleep.sleep(TimeSpan.milliseconds(10));
+      void hardened.read().catch(() => {});
+      await expect.poll(() => opens).toBe(2);
+      const updateP = hardened.update([1, 2]);
+      await sleep.sleep(TimeSpan.milliseconds(20));
+      expect(opens).toBe(2);
+      pendingOpens[0](streamer2);
+      await updateP;
+      expect(streamer2.updateMock).toHaveBeenCalledWith([1, 2]);
+      expect(opens).toBe(2);
+      expect(onDrop).toHaveBeenCalledTimes(1);
+      hardened.close();
+      expect(streamer1.closeMock).toHaveBeenCalled();
+      expect(streamer2.closeMock).toHaveBeenCalled();
+    });
+
+    it("should reject every joiner when a shared reconnect fails", async () => {
+      const streamer1 = new MockStreamer();
+      const fr1 = new Frame({ 1: new Series([1]) });
+      streamer1.responses = [
+        [fr1, null],
+        [fr1, new Unreachable({ message: "down" })],
+      ];
+      const pendingOpens: ((e: Error) => void)[] = [];
+      let opens = 0;
+      const hardened = await HardenedStreamer.open(
+        async () => {
+          opens++;
+          if (opens === 1) return streamer1;
+          return await new Promise<Streamer>((_, reject) => pendingOpens.push(reject));
+        },
+        { channels: [1] },
+        { maxInterval: TimeSpan.milliseconds(5), jitter: 0 },
+      );
+      expect(await hardened.read()).toEqual(fr1);
+      await sleep.sleep(TimeSpan.milliseconds(10));
+      const readP = hardened.read().catch((e: unknown) => e);
+      await expect.poll(() => opens).toBe(2);
+      const updateP = hardened.update([1, 2]).catch((e: unknown) => e);
+      const denied = new AccessDeniedError("no permission to stream");
+      pendingOpens[0](denied);
+      expect(await readP).toBe(denied);
+      expect(await updateP).toBe(denied);
+      hardened.close();
+    });
   });
 
   describe("observable", () => {


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4600](https://linear.app/synnax/issue/SY-4600/rolling-plots-show-permanent-gaps-after-a-channels-stream-stops-and)

## Description

Rolling line plots showed permanent, double-digit-second holes between the historical fetch and the live stream whenever a channel had been streamed earlier in the session and then stopped. The cache's live leading buffer claims coverage of all time after its start, nothing ended that claim when streaming demand stopped, and `Unary.read` suppressed every gap behind it, so the reader never fetched the unstreamed span from the Core.

The `MultiplexedStreamer` now flushes a channel's leading buffer into the static cache whenever stream continuity breaks: the key leaves the stream on reconcile, the whole stream is released, the connection drops, the run loop dies, or a late frame arrives for a key with no remaining demand. The flush stamps the buffer's real data end (from the SY-4552 streamed-series stamping), so later reads see the true gap and refetch it.

One behavior change: a value consumer that re-subscribes to a channel no longer shows the last cached value instantly. It shows nothing until the first live sample arrives, instead of a potentially stale value.

Covered by a live-core regression test in `feed.spec.ts` (stream, unsubscribe, write, read misses nothing) plus unit tests for each flush path in `streamer.spec.ts` and `unary.spec.ts`.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR ends stale live-cache coverage when stream continuity stops and coordinates concurrent reconnect attempts.
- Flushes dynamic channel buffers into the static cache after demand removal, connection loss, run-loop termination, and late frames.
- Adds regression coverage for cache gaps and stream lifecycle paths.
- Uses one shared reconnect promise to prevent competing replacement streams.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no eligible blocking failure remains.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| client/ts/src/framer/cache/streamer.ts | Flushes leading buffers when stream continuity or demand ends. |
| client/ts/src/framer/cache/unary.ts | Moves a flushed dynamic series into the static cache. |
| client/ts/src/framer/cache/dynamic.ts | Exposes leading-buffer flush as a cache operation. |
| client/ts/src/framer/hardened.ts | Serializes concurrent reconnect attempts through one shared promise. |
| client/ts/src/framer/feed.spec.ts | Adds live-Core coverage for samples written while streaming is inactive. |
| client/ts/src/framer/cache/streamer.spec.ts | Tests buffer flushing across demand, drop, termination, and late-frame paths. |
| client/ts/src/framer/cache/unary.spec.ts | Tests bounded static coverage after a dynamic flush. |
| client/ts/src/framer/streamer.spec.ts | Tests shared reconnect behavior during concurrent reads and updates. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Consumer
  participant Multiplexer
  participant Stream
  participant DynamicCache
  participant StaticCache
  participant Core

  Consumer->>Multiplexer: Subscribe
  Stream-->>Multiplexer: Live samples
  Multiplexer->>DynamicCache: Buffer samples
  Consumer->>Multiplexer: Unsubscribe
  Multiplexer->>Stream: Remove channel
  Multiplexer->>DynamicCache: Flush leading buffer
  DynamicCache->>StaticCache: Store bounded series
  Consumer->>StaticCache: Read time range
  StaticCache->>Core: Fetch exposed gap
  Core-->>Consumer: Persisted samples
```

<sub>Reviews (2): Last reviewed commit: ["Single-flight hardened streamer reconnec..."](https://github.com/synnaxlabs/synnax/commit/0e80c2a3965ca6361f85848e4beb21c8405a0e48) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53726641)</sub>

**Context used:**

- Knowledge Base — [Client SDKs](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/client-sdks.md)

<!-- /greptile_comment -->