### PR TITLE
SY-4601: Clip line plot auto bounds to the visible x window

### DIFF
--- a/pluto/src/lineplot/aether/LinePlot.ts
+++ b/pluto/src/lineplot/aether/LinePlot.ts
@@ -139,10 +139,11 @@ export class LinePlot
     const bounds: AxesBounds = {};
     this.axes.forEach((v) => {
       const axisKey = v.state.axisKey ?? v.key;
-      bounds[axisKey] = v.bounds(this.state.hold);
+      const xBounds = v.bounds(this.state.hold);
+      bounds[axisKey] = xBounds;
       v.yAxes.forEach((y) => {
         const yAxisKey = y.state.axisKey ?? y.key;
-        bounds[yAxisKey] = y.bounds(this.state.hold);
+        bounds[yAxisKey] = y.bounds(this.state.hold, xBounds);
       });
     });
     return bounds;

--- a/pluto/src/lineplot/aether/XAxis.ts
+++ b/pluto/src/lineplot/aether/XAxis.ts
@@ -26,13 +26,13 @@ export class XAxis extends BaseAxis<typeof baseAxisStateZ, YAxis | range.Provide
 
   render(props: XAxisRenderProps): void {
     if (this.deleted) return;
-    const [dataToDecimal, err] = this.dataToDecimalScale(
+    const [dataToDecimal, xBounds, err] = this.dataToDecimalScale(
       props.hold,
       this.dataBounds.bind(this),
       props.viewport,
     );
     this.renderAxis(props, dataToDecimal.reverse());
-    this.renderYAxes(props, dataToDecimal);
+    this.renderYAxes(props, dataToDecimal, xBounds);
     this.renderRanges(props, dataToDecimal);
     // Throw the error here to that the user still has a visible axis.
     if (err != null) throw err;
@@ -42,7 +42,7 @@ export class XAxis extends BaseAxis<typeof baseAxisStateZ, YAxis | range.Provide
     props: Omit<XAxisRenderProps, "canvases">,
     target: number,
   ): FindResult[] {
-    const [scale, err] = this.dataToDecimalScale(
+    const [scale, , err] = this.dataToDecimalScale(
       props.hold,
       this.dataBounds.bind(this),
       props.viewport,
@@ -55,18 +55,22 @@ export class XAxis extends BaseAxis<typeof baseAxisStateZ, YAxis | range.Provide
     props: Omit<XAxisRenderProps, "canvases">,
     target: number,
   ): FindResult[] {
-    const [xDataToDecimalScale, error] = this.dataToDecimalScale(
+    const [xDataToDecimalScale, xBounds, error] = this.dataToDecimalScale(
       props.hold,
       this.dataBounds.bind(this),
       props.viewport,
     );
     if (error != null) throw error;
-    const p = { ...props, xDataToDecimalScale };
+    const p = { ...props, xDataToDecimalScale, xBounds };
     return this.yAxes.map((el) => el.findByXValue(p, target)).flat();
   }
 
-  private renderYAxes(props: XAxisRenderProps, xDataToDecimalScale: scale.Scale): void {
-    const p = { ...props, xDataToDecimalScale };
+  private renderYAxes(
+    props: XAxisRenderProps,
+    xDataToDecimalScale: scale.Scale,
+    xBounds: bounds.Bounds,
+  ): void {
+    const p = { ...props, xDataToDecimalScale, xBounds };
     this.yAxes.forEach((el) => el.render(p));
   }
 

--- a/pluto/src/lineplot/aether/YAxis.ts
+++ b/pluto/src/lineplot/aether/YAxis.ts
@@ -19,6 +19,8 @@ export const yAxisStateZ = baseAxisStateZ.extend({
 
 export interface YAxisProps extends AxisRenderProps {
   xDataToDecimalScale: scale.Scale;
+  /** Bounds of the parent x axis; y bounds cover only samples inside them. */
+  xBounds: bounds.Bounds;
   exposure: number;
 }
 
@@ -43,17 +45,17 @@ export class YAxis extends BaseAxis<typeof baseAxisStateZ, Children> {
     );
   }
 
-  bounds(hold: boolean): bounds.Bounds {
-    const [bound, err] = this.iBounds(hold, this.dataBounds.bind(this));
+  bounds(hold: boolean, xBounds: bounds.Bounds): bounds.Bounds {
+    const [bound, err] = this.iBounds(hold, () => this.dataBounds(xBounds));
     if (err != null) throw err;
     return bound;
   }
 
   render(props: YAxisProps): void {
     if (this.deleted) return;
-    const [dataToDecimalScale, error] = this.dataToDecimalScale(
+    const [dataToDecimalScale, , error] = this.dataToDecimalScale(
       props.hold,
-      this.dataBounds.bind(this),
+      () => this.dataBounds(props.xBounds),
       props.viewport,
     );
     // We need to invert scale because the y-axis is inverted in decimal space.
@@ -101,6 +103,7 @@ export class YAxis extends BaseAxis<typeof baseAxisStateZ, Children> {
   findByXValue(
     {
       xDataToDecimalScale,
+      xBounds,
       plot,
       viewport,
       hold,
@@ -108,9 +111,9 @@ export class YAxis extends BaseAxis<typeof baseAxisStateZ, Children> {
     }: Omit<YAxisProps, "canvases">,
     target: number,
   ): line.FindResult[] {
-    const [yDataToDecimalScale, error] = this.dataToDecimalScale(
+    const [yDataToDecimalScale, , error] = this.dataToDecimalScale(
       hold,
-      this.dataBounds.bind(this),
+      () => this.dataBounds(xBounds),
       viewport,
     );
     if (error != null) throw error;
@@ -122,8 +125,8 @@ export class YAxis extends BaseAxis<typeof baseAxisStateZ, Children> {
     }));
   }
 
-  private dataBounds(): bounds.Bounds[] {
-    return this.lines.map((el) => el.yBounds());
+  private dataBounds(xBounds: bounds.Bounds): bounds.Bounds[] {
+    return this.lines.map((el) => el.yBounds(xBounds));
   }
 
   private get lines(): readonly line.Line[] {

--- a/pluto/src/lineplot/aether/axis.ts
+++ b/pluto/src/lineplot/aether/axis.ts
@@ -191,7 +191,7 @@ export class BaseAxis<
     hold: boolean,
     fetchDataBounds: () => bounds.Bounds[],
     viewport: box.Box,
-  ): [scale.Scale, Error | null] {
+  ): [scale.Scale, bounds.Bounds, Error | null] {
     const [bounds, err] = this.iBounds(hold, fetchDataBounds);
     const dir = direction.swap(direction.construct(this.state.location));
     return [
@@ -199,6 +199,7 @@ export class BaseAxis<
         .scale(1)
         .translate(-box.root(viewport)[dir])
         .magnify(1 / box.dim(viewport, dir)),
+      bounds,
       err,
     ];
   }

--- a/pluto/src/telem/aether/noop.ts
+++ b/pluto/src/telem/aether/noop.ts
@@ -160,7 +160,7 @@ class NoopSeries extends Noop implements SeriesSource {
   static readonly TYPE = "noop-series";
 
   value(): [bounds.Bounds, MultiSeries] {
-    return [bounds.ZERO, new MultiSeries([])];
+    return [bounds.INVALID, new MultiSeries([])];
   }
 }
 

--- a/pluto/src/telem/aether/remote.spec.ts
+++ b/pluto/src/telem/aether/remote.spec.ts
@@ -519,7 +519,7 @@ describe("remote", () => {
       c = new MockClient();
     });
 
-    it("should return a zero value when no channel has been set", async () => {
+    it("should return invalid bounds when no channel has been set", async () => {
       const props = {
         timeRange: TimeRange.MAX,
         channel: 0,
@@ -529,13 +529,13 @@ describe("remote", () => {
       cd.onChange(handleChange);
       const [b, data] = cd.value();
       expect(handleChange.mock.calls.length).toBe(0);
-      expect(b).toStrictEqual(bounds.ZERO);
+      expect(b).toStrictEqual(bounds.INVALID);
       expect(data).toHaveLength(0);
       expect(c.readMock).not.toHaveBeenCalled();
       expect(c.retrieveChannelMock).not.toHaveBeenCalled();
     });
 
-    it("should return a zero value when the time range is empty", async () => {
+    it("should return invalid bounds when the time range is empty", async () => {
       const props = {
         timeRange: TimeRange.ZERO,
         channel: c.channel.key,
@@ -544,7 +544,7 @@ describe("remote", () => {
       const handleChange = vi.fn();
       const [b, data] = cd.value();
       expect(handleChange.mock.calls.length).toBe(0);
-      expect(b).toStrictEqual(bounds.ZERO);
+      expect(b).toStrictEqual(bounds.INVALID);
       expect(data).toHaveLength(0);
       expect(c.readMock).not.toHaveBeenCalled();
       expect(c.retrieveChannelMock).not.toHaveBeenCalled();
@@ -604,6 +604,25 @@ describe("remote", () => {
       expect(b).toStrictEqual({ lower: 0, upper: 4 });
       expect(data.series).toHaveLength(1);
       expect(data.series[0]).toBe(series);
+    });
+
+    it("should return invalid bounds when the data lies outside the requested range", async () => {
+      const series = new Series({
+        data: new BigInt64Array([
+          TimeStamp.seconds(1).valueOf(),
+          TimeStamp.seconds(2).valueOf(),
+        ]),
+        dataType: DataType.TIMESTAMP,
+        timeRange: TimeStamp.seconds(1).range(TimeStamp.seconds(3)),
+      });
+      c.response = { [c.channel.index]: new MultiSeries([series]) };
+      const cd = new ChannelData(c, {
+        timeRange: TimeStamp.seconds(20).range(TimeStamp.seconds(30)),
+        channel: c.channel.key,
+        useIndexOfChannel: true,
+      });
+      const [b] = await waitForResolve(cd);
+      expect(b).toStrictEqual(bounds.INVALID);
     });
 
     it("should not retain data when cleaned up while reading", async () => {
@@ -688,14 +707,14 @@ describe("remote", () => {
       vi.resetAllMocks();
     });
 
-    it("should return a zero value when no channel has been set", async () => {
+    it("should return invalid bounds when no channel has been set", async () => {
       const props: StreamChannelDataProps = {
         timeSpan: TimeSpan.MAX,
         channel: 0,
       };
       const cd = new StreamChannelData(c, props);
       const [b, data] = cd.value();
-      expect(b).toStrictEqual(bounds.ZERO);
+      expect(b).toStrictEqual(bounds.INVALID);
       expect(data).toHaveLength(0);
     });
 
@@ -1003,7 +1022,7 @@ describe("remote", () => {
       });
       c.streamHandler?.(new Map([[c.channel.key, new MultiSeries([d])]]));
       const [b, data] = cd.value();
-      expect(b).toStrictEqual(bounds.ZERO);
+      expect(b).toStrictEqual(bounds.INVALID);
       expect(data.series).toHaveLength(1);
       expect(data.series[0]).toBe(d);
     });
@@ -1039,7 +1058,7 @@ describe("remote", () => {
         { onStatusChange: (s) => statuses.push(s) },
       );
       const [b, data] = cd.value();
-      expect(b).toStrictEqual(bounds.ZERO);
+      expect(b).toStrictEqual(bounds.INVALID);
       expect(data).toHaveLength(0);
       expect(statuses).toHaveLength(1);
       expect(statuses[0].variant).toEqual("warning");

--- a/pluto/src/telem/aether/remote.ts
+++ b/pluto/src/telem/aether/remote.ts
@@ -215,13 +215,16 @@ export class ChannelData
     const { channel, timeRange } = this.props;
     // If either of these conditions is true, leave the telem invalid
     // and return an empty array.
-    if (timeRange.span.isZero || channel === 0) return [bounds.ZERO, this.data];
+    if (timeRange.span.isZero || channel === 0) return [bounds.INVALID, this.data];
     if (!this.valid) void this.read();
     const { channel: ch, data } = this;
-    if (ch == null) return [bounds.ZERO, this.data];
+    if (ch == null) return [bounds.INVALID, this.data];
     let b = data.bounds;
-    if (ch.dataType.equals(DataType.TIMESTAMP))
+    if (ch.dataType.equals(DataType.TIMESTAMP)) {
       b = bounds.min([b, timeRange.numericBounds]);
+      // A reversed intersection means the data lies outside the requested range.
+      if (b.lower > b.upper) b = bounds.INVALID;
+    }
     return [b, data];
   }
 
@@ -289,11 +292,11 @@ export class StreamChannelData
 
   value(): [bounds.Bounds, MultiSeries] {
     const { channel, timeSpan } = this.props;
-    if (channel === 0) return [bounds.ZERO, this.data];
+    if (channel === 0) return [bounds.INVALID, this.data];
     if (!this.valid) void this.read();
     const { data, channel: ch } = this;
     const now = this.now();
-    if (ch != null && ch.dataType.isVariable) return [bounds.ZERO, this.data];
+    if (ch != null && ch.dataType.isVariable) return [bounds.INVALID, this.data];
     const filtered = data.series
       .filter((d) => d.timeRange.end.after(now.sub(timeSpan)))
       .map((d) => d.bounds);

--- a/pluto/src/vis/line/aether/bounds.spec.ts
+++ b/pluto/src/vis/line/aether/bounds.spec.ts
@@ -17,7 +17,7 @@ import {
 } from "@synnaxlabs/x";
 import { describe, expect, it } from "vitest";
 
-import { BoundsCache } from "@/vis/line/aether/bounds";
+import { windowBounds } from "@/vis/line/aether/bounds";
 
 const THRESHOLD = TimeSpan.milliseconds(2);
 
@@ -54,114 +54,55 @@ const xWindow = (loSec: number, hiSec: number): bounds.Bounds => ({
   upper: Number(TimeStamp.seconds(hiSec).valueOf()),
 });
 
-const calc = (
-  cache: BoundsCache,
-  x: Series[],
-  y: Series[],
-  win: bounds.Bounds,
-): bounds.Bounds => cache.value(new MultiSeries(x), new MultiSeries(y), win, THRESHOLD);
+const calc = (x: Series[], y: Series[], win: bounds.Bounds): bounds.Bounds =>
+  windowBounds(new MultiSeries(x), new MultiSeries(y), win, THRESHOLD);
 
-describe("BoundsCache", () => {
+describe("windowBounds", () => {
   it("should bound only the samples inside the window", () => {
-    const cache = new BoundsCache();
     const x = stamps(0, 10);
     const y = values(0, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
-    const b = calc(cache, [x], [y], xWindow(2, 5));
-    expect(b).toStrictEqual({ lower: 2, upper: 5 });
+    expect(calc([x], [y], xWindow(2, 5))).toStrictEqual({ lower: 2, upper: 5 });
   });
 
   it("should exclude an out-of-window outlier", () => {
-    const cache = new BoundsCache();
     const x = stamps(0, 10);
     const y = values(0, [9999, -250, -240, -230, -220, -210, -205, -202, -201, -200]);
-    const b = calc(cache, [x], [y], xWindow(1, 9));
-    expect(b).toStrictEqual({ lower: -250, upper: -200 });
+    expect(calc([x], [y], xWindow(1, 9))).toStrictEqual({ lower: -250, upper: -200 });
   });
 
   it("should return non-finite bounds when no samples fall in the window", () => {
-    const cache = new BoundsCache();
     const x = stamps(0, 10);
     const y = values(0, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-    const b = calc(cache, [x], [y], xWindow(20, 30));
-    expect(bounds.isFinite(b)).toBe(false);
+    expect(bounds.isFinite(calc([x], [y], xWindow(20, 30)))).toBe(false);
   });
 
   it("should pair series with offset alignments", () => {
-    const cache = new BoundsCache();
     const x = stamps(0, 10, 0n);
     // Pairs with x samples at 3s through 9s.
     const y = values(3, [30, 40, 50, 60, 70, 80, 90], 3n);
-    const b = calc(cache, [x], [y], xWindow(4, 6));
-    expect(b).toStrictEqual({ lower: 40, upper: 60 });
+    expect(calc([x], [y], xWindow(4, 6))).toStrictEqual({ lower: 40, upper: 60 });
   });
 
   it("should union bounds across consecutive series pairs", () => {
-    const cache = new BoundsCache();
     const x1 = stamps(0, 5, 0n);
     const x2 = stamps(5, 5, 5n);
     const y1 = values(0, [1, 2, 3, 4, 5], 0n);
     const y2 = values(5, [6, 7, 8, 9, 10], 5n);
-    const b = calc(cache, [x1, x2], [y1, y2], xWindow(3, 7));
-    expect(b).toStrictEqual({ lower: 4, upper: 8 });
+    expect(calc([x1, x2], [y1, y2], xWindow(3, 7))).toStrictEqual({
+      lower: 4,
+      upper: 8,
+    });
   });
 
   it("should not pair series whose time ranges do not overlap", () => {
-    const cache = new BoundsCache();
     const x = stamps(0, 5, 0n);
     const y = values(100, [1, 2, 3, 4, 5], 0n);
-    const b = calc(cache, [x], [y], xWindow(0, 5));
-    expect(bounds.isFinite(b)).toBe(false);
+    expect(bounds.isFinite(calc([x], [y], xWindow(0, 5)))).toBe(false);
   });
 
   it("should apply the series sample offset", () => {
-    const cache = new BoundsCache();
     const x = stamps(0, 3);
     const y = values(0, [1, 2, 3], 0n, 10);
-    const b = calc(cache, [x], [y], xWindow(0, 2));
-    expect(b).toStrictEqual({ lower: 11, upper: 13 });
-  });
-
-  describe("block caching", () => {
-    it("should answer queries that mix cached blocks and raw edges", () => {
-      const cache = new BoundsCache(4);
-      const x = stamps(0, 10);
-      const y = values(0, [0, -500, 2, 3, 4, 5, 6, 7, 8, 900]);
-      expect(calc(cache, [x], [y], xWindow(0, 9))).toStrictEqual({
-        lower: -500,
-        upper: 900,
-      });
-      // Repeats hit the now-warm block summaries.
-      expect(calc(cache, [x], [y], xWindow(0, 9))).toStrictEqual({
-        lower: -500,
-        upper: 900,
-      });
-      // The partial first block is scanned raw, so the outlier at index 1 is
-      // excluded once the window starts past it.
-      expect(calc(cache, [x], [y], xWindow(2, 9))).toStrictEqual({
-        lower: 2,
-        upper: 900,
-      });
-    });
-
-    it("should include samples appended after blocks were cached", () => {
-      const cache = new BoundsCache(4);
-      const x = stamps(0, 10);
-      const y = Series.alloc({
-        capacity: 10,
-        dataType: DataType.FLOAT32,
-        timeRange: TimeStamp.seconds(0).range(TimeStamp.seconds(10)),
-        alignment: 0n,
-      });
-      y.write(values(0, [1, 2, 3, 4, 5, 6]));
-      expect(calc(cache, [x], [y], xWindow(0, 9))).toStrictEqual({
-        lower: 1,
-        upper: 6,
-      });
-      y.write(values(6, [7, 8, -900], 6n));
-      expect(calc(cache, [x], [y], xWindow(0, 9))).toStrictEqual({
-        lower: -900,
-        upper: 8,
-      });
-    });
+    expect(calc([x], [y], xWindow(0, 2))).toStrictEqual({ lower: 11, upper: 13 });
   });
 });

--- a/pluto/src/vis/line/aether/bounds.spec.ts
+++ b/pluto/src/vis/line/aether/bounds.spec.ts
@@ -1,0 +1,167 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import {
+  bounds,
+  DataType,
+  MultiSeries,
+  Series,
+  TimeSpan,
+  TimeStamp,
+} from "@synnaxlabs/x";
+import { describe, expect, it } from "vitest";
+
+import { BoundsCache } from "@/vis/line/aether/bounds";
+
+const THRESHOLD = TimeSpan.milliseconds(2);
+
+const stamps = (startSec: number, count: number, alignment: bigint = 0n): Series =>
+  new Series({
+    data: new BigInt64Array(
+      Array.from({ length: count }, (_, i) =>
+        TimeStamp.seconds(startSec + i).valueOf(),
+      ),
+    ),
+    dataType: DataType.TIMESTAMP,
+    timeRange: TimeStamp.seconds(startSec).range(TimeStamp.seconds(startSec + count)),
+    alignment,
+  });
+
+const values = (
+  startSec: number,
+  data: number[],
+  alignment: bigint = 0n,
+  sampleOffset: number = 0,
+): Series =>
+  new Series({
+    data: new Float32Array(data),
+    dataType: DataType.FLOAT32,
+    timeRange: TimeStamp.seconds(startSec).range(
+      TimeStamp.seconds(startSec + data.length),
+    ),
+    alignment,
+    sampleOffset,
+  });
+
+const xWindow = (loSec: number, hiSec: number): bounds.Bounds => ({
+  lower: Number(TimeStamp.seconds(loSec).valueOf()),
+  upper: Number(TimeStamp.seconds(hiSec).valueOf()),
+});
+
+const calc = (
+  cache: BoundsCache,
+  x: Series[],
+  y: Series[],
+  win: bounds.Bounds,
+): bounds.Bounds => cache.value(new MultiSeries(x), new MultiSeries(y), win, THRESHOLD);
+
+describe("BoundsCache", () => {
+  it("should bound only the samples inside the window", () => {
+    const cache = new BoundsCache();
+    const x = stamps(0, 10);
+    const y = values(0, [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    const b = calc(cache, [x], [y], xWindow(2, 5));
+    expect(b).toStrictEqual({ lower: 2, upper: 5 });
+  });
+
+  it("should exclude an out-of-window outlier", () => {
+    const cache = new BoundsCache();
+    const x = stamps(0, 10);
+    const y = values(0, [9999, -250, -240, -230, -220, -210, -205, -202, -201, -200]);
+    const b = calc(cache, [x], [y], xWindow(1, 9));
+    expect(b).toStrictEqual({ lower: -250, upper: -200 });
+  });
+
+  it("should return non-finite bounds when no samples fall in the window", () => {
+    const cache = new BoundsCache();
+    const x = stamps(0, 10);
+    const y = values(0, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    const b = calc(cache, [x], [y], xWindow(20, 30));
+    expect(bounds.isFinite(b)).toBe(false);
+  });
+
+  it("should pair series with offset alignments", () => {
+    const cache = new BoundsCache();
+    const x = stamps(0, 10, 0n);
+    // Pairs with x samples at 3s through 9s.
+    const y = values(3, [30, 40, 50, 60, 70, 80, 90], 3n);
+    const b = calc(cache, [x], [y], xWindow(4, 6));
+    expect(b).toStrictEqual({ lower: 40, upper: 60 });
+  });
+
+  it("should union bounds across consecutive series pairs", () => {
+    const cache = new BoundsCache();
+    const x1 = stamps(0, 5, 0n);
+    const x2 = stamps(5, 5, 5n);
+    const y1 = values(0, [1, 2, 3, 4, 5], 0n);
+    const y2 = values(5, [6, 7, 8, 9, 10], 5n);
+    const b = calc(cache, [x1, x2], [y1, y2], xWindow(3, 7));
+    expect(b).toStrictEqual({ lower: 4, upper: 8 });
+  });
+
+  it("should not pair series whose time ranges do not overlap", () => {
+    const cache = new BoundsCache();
+    const x = stamps(0, 5, 0n);
+    const y = values(100, [1, 2, 3, 4, 5], 0n);
+    const b = calc(cache, [x], [y], xWindow(0, 5));
+    expect(bounds.isFinite(b)).toBe(false);
+  });
+
+  it("should apply the series sample offset", () => {
+    const cache = new BoundsCache();
+    const x = stamps(0, 3);
+    const y = values(0, [1, 2, 3], 0n, 10);
+    const b = calc(cache, [x], [y], xWindow(0, 2));
+    expect(b).toStrictEqual({ lower: 11, upper: 13 });
+  });
+
+  describe("block caching", () => {
+    it("should answer queries that mix cached blocks and raw edges", () => {
+      const cache = new BoundsCache(4);
+      const x = stamps(0, 10);
+      const y = values(0, [0, -500, 2, 3, 4, 5, 6, 7, 8, 900]);
+      expect(calc(cache, [x], [y], xWindow(0, 9))).toStrictEqual({
+        lower: -500,
+        upper: 900,
+      });
+      // Repeats hit the now-warm block summaries.
+      expect(calc(cache, [x], [y], xWindow(0, 9))).toStrictEqual({
+        lower: -500,
+        upper: 900,
+      });
+      // The partial first block is scanned raw, so the outlier at index 1 is
+      // excluded once the window starts past it.
+      expect(calc(cache, [x], [y], xWindow(2, 9))).toStrictEqual({
+        lower: 2,
+        upper: 900,
+      });
+    });
+
+    it("should include samples appended after blocks were cached", () => {
+      const cache = new BoundsCache(4);
+      const x = stamps(0, 10);
+      const y = Series.alloc({
+        capacity: 10,
+        dataType: DataType.FLOAT32,
+        timeRange: TimeStamp.seconds(0).range(TimeStamp.seconds(10)),
+        alignment: 0n,
+      });
+      y.write(values(0, [1, 2, 3, 4, 5, 6]));
+      expect(calc(cache, [x], [y], xWindow(0, 9))).toStrictEqual({
+        lower: 1,
+        upper: 6,
+      });
+      y.write(values(6, [7, 8, -900], 6n));
+      expect(calc(cache, [x], [y], xWindow(0, 9))).toStrictEqual({
+        lower: -900,
+        upper: 8,
+      });
+    });
+  });
+});

--- a/pluto/src/vis/line/aether/bounds.ts
+++ b/pluto/src/vis/line/aether/bounds.ts
@@ -1,0 +1,152 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { bounds, type MultiSeries, type Series, type TimeSpan } from "@synnaxlabs/x";
+
+export const seriesOverlap = (
+  x: Series,
+  ys: Series,
+  overlapThreshold: TimeSpan,
+): boolean => {
+  if (x.alignmentMultiple !== ys.alignmentMultiple) {
+    console.warn(
+      "encountered two series with different alignment multiples in draw operations",
+      { x: x.digest, y: ys.digest },
+    );
+    return false;
+  }
+  // If the time ranges of the x and y series overlap, we meet the first condition
+  // for drawing them together. Dynamic buffering can sometimes lead to very slight,
+  // unintended overlaps, so we only consider them overlapping if they overlap by a
+  // certain threshold.
+  const timeRangesOverlap = x.timeRange.overlapsWith(ys.timeRange, overlapThreshold);
+  // If the 'indexes' of the x and y series overlap, we meet the second condition
+  // for drawing them together.
+  const alignmentsOverlap = bounds.overlapsWith(x.alignmentBounds, ys.alignmentBounds);
+  return timeRangesOverlap && alignmentsOverlap;
+};
+
+const BLOCK_SIZE = 4096;
+
+interface BlockSummary {
+  mins: number[];
+  maxs: number[];
+}
+
+/**
+ * @returns the y index range [lo, hi) of samples whose paired x value falls inside
+ * the window, or null when the pair shares no samples there.
+ */
+const clip = (
+  x: Series,
+  y: Series,
+  xWindow: bounds.Bounds,
+  overlapThreshold: TimeSpan,
+): [number, number] | null => {
+  if (y.dataType.isVariable || !seriesOverlap(x, y, overlapThreshold)) return null;
+  const mult = x.alignmentMultiple;
+  const start = x.alignment > y.alignment ? x.alignment : y.alignment;
+  const xUpper = x.alignmentBounds.upper;
+  const yUpper = y.alignmentBounds.upper;
+  const end = xUpper < yUpper ? xUpper : yUpper;
+  if (end <= start) return null;
+  const xLo = x.binarySearch(xWindow.lower);
+  let xHi = x.binarySearch(xWindow.upper);
+  if (xHi < x.length && Number(x.at(xHi, true)) === xWindow.upper) xHi++;
+  const winStart = x.alignment + BigInt(xLo) * mult;
+  const winEnd = x.alignment + BigInt(xHi) * mult;
+  const s = winStart > start ? winStart : start;
+  const e = winEnd < end ? winEnd : end;
+  if (e <= s) return null;
+  return [Number((s - y.alignment) / mult), Number((e - y.alignment) / mult)];
+};
+
+/**
+ * Computes the min/max of y samples whose paired x value falls inside a window.
+ * Summaries are cached per completed block of samples; series are append-only, so a
+ * cached block never invalidates and the still-filling tail is always scanned raw.
+ */
+export class BoundsCache {
+  private readonly summaries = new WeakMap<Series, BlockSummary>();
+  private readonly blockSize: number;
+
+  constructor(blockSize: number = BLOCK_SIZE) {
+    this.blockSize = blockSize;
+  }
+
+  /**
+   * @param xData - the x (timestamp) series.
+   * @param yData - the y series, paired with x by time range and alignment overlap.
+   * @param xWindow - the x range to bound over.
+   * @param overlapThreshold - minimum time range overlap for an x/y pair to count.
+   * @returns the bounds of y samples inside the window. Non-finite when none are.
+   */
+  value(
+    xData: MultiSeries,
+    yData: MultiSeries,
+    xWindow: bounds.Bounds,
+    overlapThreshold: TimeSpan,
+  ): bounds.Bounds {
+    let lower = Infinity;
+    let upper = -Infinity;
+    for (const x of xData.series)
+      for (const y of yData.series) {
+        const range = clip(x, y, xWindow, overlapThreshold);
+        if (range == null) continue;
+        const b = this.query(y, range[0], range[1]);
+        if (b.lower < lower) lower = b.lower;
+        if (b.upper > upper) upper = b.upper;
+      }
+    return { lower, upper };
+  }
+
+  private query(series: Series, lo: number, hi: number): bounds.Bounds {
+    const { blockSize } = this;
+    let summary = this.summaries.get(series);
+    if (summary == null) {
+      summary = { mins: [], maxs: [] };
+      this.summaries.set(series, summary);
+    }
+    const { data } = series;
+    const complete = Math.floor(series.length / blockSize);
+    for (let b = summary.mins.length; b < complete; b++) {
+      let min = Infinity;
+      let max = -Infinity;
+      const end = (b + 1) * blockSize;
+      for (let i = b * blockSize; i < end; i++) {
+        const v = Number(data[i]);
+        if (v < min) min = v;
+        if (v > max) max = v;
+      }
+      summary.mins.push(min);
+      summary.maxs.push(max);
+    }
+    let lower = Infinity;
+    let upper = -Infinity;
+    let i = lo;
+    while (i < hi) {
+      const block = Math.floor(i / blockSize);
+      const blockEnd = (block + 1) * blockSize;
+      if (i === block * blockSize && blockEnd <= hi && block < summary.mins.length) {
+        if (summary.mins[block] < lower) lower = summary.mins[block];
+        if (summary.maxs[block] > upper) upper = summary.maxs[block];
+        i = blockEnd;
+        continue;
+      }
+      const end = Math.min(hi, blockEnd);
+      for (; i < end; i++) {
+        const v = Number(data[i]);
+        if (v < lower) lower = v;
+        if (v > upper) upper = v;
+      }
+    }
+    const offset = Number(series.sampleOffset);
+    return { lower: lower + offset, upper: upper + offset };
+  }
+}

--- a/pluto/src/vis/line/aether/bounds.ts
+++ b/pluto/src/vis/line/aether/bounds.ts
@@ -32,13 +32,6 @@ export const seriesOverlap = (
   return timeRangesOverlap && alignmentsOverlap;
 };
 
-const BLOCK_SIZE = 4096;
-
-interface BlockSummary {
-  mins: number[];
-  maxs: number[];
-}
-
 /**
  * @returns the y index range [lo, hi) of samples whose paired x value falls inside
  * the window, or null when the pair shares no samples there.
@@ -68,85 +61,28 @@ const clip = (
 };
 
 /**
- * Computes the min/max of y samples whose paired x value falls inside a window.
- * Summaries are cached per completed block of samples; series are append-only, so a
- * cached block never invalidates and the still-filling tail is always scanned raw.
+ * @param xData - the x (timestamp) series.
+ * @param yData - the y series, paired with x by time range and alignment overlap.
+ * @param xWindow - the x range to bound over.
+ * @param overlapThreshold - minimum time range overlap for an x/y pair to count.
+ * @returns the bounds of y samples whose paired x value falls inside the window.
+ * Non-finite when none do.
  */
-export class BoundsCache {
-  private readonly summaries = new WeakMap<Series, BlockSummary>();
-  private readonly blockSize: number;
-
-  constructor(blockSize: number = BLOCK_SIZE) {
-    this.blockSize = blockSize;
-  }
-
-  /**
-   * @param xData - the x (timestamp) series.
-   * @param yData - the y series, paired with x by time range and alignment overlap.
-   * @param xWindow - the x range to bound over.
-   * @param overlapThreshold - minimum time range overlap for an x/y pair to count.
-   * @returns the bounds of y samples inside the window. Non-finite when none are.
-   */
-  value(
-    xData: MultiSeries,
-    yData: MultiSeries,
-    xWindow: bounds.Bounds,
-    overlapThreshold: TimeSpan,
-  ): bounds.Bounds {
-    let lower = Infinity;
-    let upper = -Infinity;
-    for (const x of xData.series)
-      for (const y of yData.series) {
-        const range = clip(x, y, xWindow, overlapThreshold);
-        if (range == null) continue;
-        const b = this.query(y, range[0], range[1]);
-        if (b.lower < lower) lower = b.lower;
-        if (b.upper > upper) upper = b.upper;
-      }
-    return { lower, upper };
-  }
-
-  private query(series: Series, lo: number, hi: number): bounds.Bounds {
-    const { blockSize } = this;
-    let summary = this.summaries.get(series);
-    if (summary == null) {
-      summary = { mins: [], maxs: [] };
-      this.summaries.set(series, summary);
+export const windowBounds = (
+  xData: MultiSeries,
+  yData: MultiSeries,
+  xWindow: bounds.Bounds,
+  overlapThreshold: TimeSpan,
+): bounds.Bounds => {
+  let lower = Infinity;
+  let upper = -Infinity;
+  for (const x of xData.series)
+    for (const y of yData.series) {
+      const range = clip(x, y, xWindow, overlapThreshold);
+      if (range == null) continue;
+      const b = y.boundsFor(range[0], range[1]);
+      if (b.lower < lower) lower = b.lower;
+      if (b.upper > upper) upper = b.upper;
     }
-    const { data } = series;
-    const complete = Math.floor(series.length / blockSize);
-    for (let b = summary.mins.length; b < complete; b++) {
-      let min = Infinity;
-      let max = -Infinity;
-      const end = (b + 1) * blockSize;
-      for (let i = b * blockSize; i < end; i++) {
-        const v = Number(data[i]);
-        if (v < min) min = v;
-        if (v > max) max = v;
-      }
-      summary.mins.push(min);
-      summary.maxs.push(max);
-    }
-    let lower = Infinity;
-    let upper = -Infinity;
-    let i = lo;
-    while (i < hi) {
-      const block = Math.floor(i / blockSize);
-      const blockEnd = (block + 1) * blockSize;
-      if (i === block * blockSize && blockEnd <= hi && block < summary.mins.length) {
-        if (summary.mins[block] < lower) lower = summary.mins[block];
-        if (summary.maxs[block] > upper) upper = summary.maxs[block];
-        i = blockEnd;
-        continue;
-      }
-      const end = Math.min(hi, blockEnd);
-      for (; i < end; i++) {
-        const v = Number(data[i]);
-        if (v < lower) lower = v;
-        if (v > upper) upper = v;
-      }
-    }
-    const offset = Number(series.sampleOffset);
-    return { lower: lower + offset, upper: upper + offset };
-  }
-}
+  return { lower, upper };
+};

--- a/pluto/src/vis/line/aether/line.ts
+++ b/pluto/src/vis/line/aether/line.ts
@@ -30,7 +30,7 @@ import { aether } from "@/aether/aether";
 import { alamos } from "@/alamos/aether";
 import { status } from "@/status/aether";
 import { telem } from "@/telem/aether";
-import { BoundsCache, seriesOverlap } from "@/vis/line/aether/bounds";
+import { seriesOverlap, windowBounds } from "@/vis/line/aether/bounds";
 import FRAG_SHADER from "@/vis/line/aether/frag.glsl?raw";
 import F32_VERT_SHADER from "@/vis/line/aether/vert_f32.glsl?raw";
 import HYBRID_VERT_SHADER from "@/vis/line/aether/vert_hybrid.glsl?raw";
@@ -275,7 +275,6 @@ interface InternalState {
 
   xDownsampler: telem.SeriesDownsampler;
   yDownsampler: telem.SeriesDownsampler;
-  boundsCache: BoundsCache;
 }
 
 export class Line extends aether.Leaf<typeof stateZ, InternalState> {
@@ -289,7 +288,6 @@ export class Line extends aether.Leaf<typeof stateZ, InternalState> {
     };
     i.xTelem = telem.useSource(ctx, this.state.x, i.xTelem, createOptions);
     i.yTelem = telem.useSource(ctx, this.state.y, i.yTelem, createOptions);
-    i.boundsCache ??= new BoundsCache();
     i.instrumentation = alamos.useInstrumentation(ctx, "line");
     i.lineCtx = Context.use(ctx);
     i.requestRender = render.useRequestor(ctx);
@@ -330,11 +328,11 @@ export class Line extends aether.Leaf<typeof stateZ, InternalState> {
    * @returns the y bounds of this line's samples inside the window.
    */
   yBounds(xWindow: bounds.Bounds): bounds.Bounds {
-    const { xTelem, yTelem, boundsCache } = this.internal;
+    const { xTelem, yTelem } = this.internal;
     const [b, yData] = yTelem.value();
     if (!bounds.isFinite(xWindow)) return b;
     const [, xData] = xTelem.value();
-    return boundsCache.value(xData, yData, xWindow, DEFAULT_OVERLAP_THRESHOLD);
+    return windowBounds(xData, yData, xWindow, DEFAULT_OVERLAP_THRESHOLD);
   }
 
   findByXValue(props: LineProps, target: number): FindResult {

--- a/pluto/src/vis/line/aether/line.ts
+++ b/pluto/src/vis/line/aether/line.ts
@@ -30,6 +30,7 @@ import { aether } from "@/aether/aether";
 import { alamos } from "@/alamos/aether";
 import { status } from "@/status/aether";
 import { telem } from "@/telem/aether";
+import { BoundsCache, seriesOverlap } from "@/vis/line/aether/bounds";
 import FRAG_SHADER from "@/vis/line/aether/frag.glsl?raw";
 import F32_VERT_SHADER from "@/vis/line/aether/vert_f32.glsl?raw";
 import HYBRID_VERT_SHADER from "@/vis/line/aether/vert_hybrid.glsl?raw";
@@ -274,6 +275,7 @@ interface InternalState {
 
   xDownsampler: telem.SeriesDownsampler;
   yDownsampler: telem.SeriesDownsampler;
+  boundsCache: BoundsCache;
 }
 
 export class Line extends aether.Leaf<typeof stateZ, InternalState> {
@@ -287,6 +289,7 @@ export class Line extends aether.Leaf<typeof stateZ, InternalState> {
     };
     i.xTelem = telem.useSource(ctx, this.state.x, i.xTelem, createOptions);
     i.yTelem = telem.useSource(ctx, this.state.y, i.yTelem, createOptions);
+    i.boundsCache ??= new BoundsCache();
     i.instrumentation = alamos.useInstrumentation(ctx, "line");
     i.lineCtx = Context.use(ctx);
     i.requestRender = render.useRequestor(ctx);
@@ -321,8 +324,17 @@ export class Line extends aether.Leaf<typeof stateZ, InternalState> {
     return this.internal.xTelem.value()[0];
   }
 
-  yBounds(): bounds.Bounds {
-    return this.internal.yTelem.value()[0];
+  /**
+   * @param xWindow - the visible x range. Bounds cover only samples whose x value
+   * falls inside it; non-finite windows fall back to the source's full bounds.
+   * @returns the y bounds of this line's samples inside the window.
+   */
+  yBounds(xWindow: bounds.Bounds): bounds.Bounds {
+    const { xTelem, yTelem, boundsCache } = this.internal;
+    const [b, yData] = yTelem.value();
+    if (!bounds.isFinite(xWindow)) return b;
+    const [, xData] = xTelem.value();
+    return boundsCache.value(xData, yData, xWindow, DEFAULT_OVERLAP_THRESHOLD);
   }
 
   findByXValue(props: LineProps, target: number): FindResult {
@@ -505,22 +517,3 @@ export const buildDrawOperations = (
 
 const digests = (ops: DrawOperation[]): DrawOperationDigest[] =>
   ops.map((op) => ({ ...op, x: op.x.digest, y: op.y.digest }));
-
-const seriesOverlap = (x: Series, ys: Series, overlapThreshold: TimeSpan): boolean => {
-  if (x.alignmentMultiple !== ys.alignmentMultiple) {
-    console.warn(
-      "encountered two series with different alignment multiples in draw operations",
-      { x: x.digest, y: ys.digest },
-    );
-    return false;
-  }
-  // If the time ranges of the x and y series overlap, we meet the first condition
-  // for drawing them together. Dynamic buffering can sometimes lead to very slight,
-  // unintended overlaps, so we only consider them overlapping if they overlap by a
-  // certain threshold.
-  const timeRangesOverlap = x.timeRange.overlapsWith(ys.timeRange, overlapThreshold);
-  // If the 'indexes' of the x and y series overlap, we meet the second condition
-  // for drawing them together.
-  const alignmentsOverlap = bounds.overlapsWith(x.alignmentBounds, ys.alignmentBounds);
-  return timeRangesOverlap && alignmentsOverlap;
-};

--- a/x/ts/src/spatial/bounds/bounds.spec.ts
+++ b/x/ts/src/spatial/bounds/bounds.spec.ts
@@ -146,6 +146,14 @@ describe("Bounds", () => {
       expect(bound.lower).toEqual(-1);
       expect(bound.upper).toEqual(2);
     });
+    it("should treat INVALID as the union identity", () => {
+      const bound = bounds.max([[-250, -100], bounds.INVALID]);
+      expect(bound).toStrictEqual({ lower: -250, upper: -100 });
+    });
+    it("should preserve a reversed member instead of reordering it", () => {
+      const bound = bounds.max([{ lower: 20, upper: 10 }]);
+      expect(bound).toStrictEqual({ lower: 20, upper: 10 });
+    });
   });
   describe("min", () => {
     it("should return the bound with the minimum possible span", () => {
@@ -157,6 +165,17 @@ describe("Bounds", () => {
       expect(bound.lower).toEqual(1);
       expect(bound.upper).toEqual(1);
     });
+    it("should treat INVALID as absorbing", () => {
+      const bound = bounds.min([[-250, -100], bounds.INVALID]);
+      expect(bound).toStrictEqual(bounds.INVALID);
+    });
+    it("should produce reversed bounds for disjoint inputs", () => {
+      const bound = bounds.min([
+        [0, 10],
+        [20, 30],
+      ]);
+      expect(bound).toStrictEqual({ lower: 20, upper: 10 });
+    });
   });
   describe("isFinite", () => {
     it("should return false if either bound is infinite", () => {
@@ -166,6 +185,9 @@ describe("Bounds", () => {
     it("should return true if both bounds are finite", () => {
       const b = bounds.construct([1, 2]);
       expect(bounds.isFinite(b)).toEqual(true);
+    });
+    it("should return false for INVALID", () => {
+      expect(bounds.isFinite(bounds.INVALID)).toEqual(false);
     });
   });
   describe("overlapsWith", () => {

--- a/x/ts/src/spatial/bounds/bounds.ts
+++ b/x/ts/src/spatial/bounds/bounds.ts
@@ -171,6 +171,11 @@ export const construct: Construct = <T extends numeric.Value>(
 export const ZERO: Bounds = Object.freeze({ lower: 0, upper: 0 });
 /** A lower bound of -Infinity and an upper bound of Infinity. */
 export const INFINITE: Bounds = Object.freeze({ lower: -Infinity, upper: Infinity });
+/**
+ * Bounds containing no values: the identity for {@link max} unions and the dual of
+ * {@link INFINITE}. Use as the "no data" sentinel; {@link isFinite} rejects it.
+ */
+export const INVALID: Bounds = Object.freeze({ lower: Infinity, upper: -Infinity });
 /** A lower bound of 0 and an upper bound of 1. */
 export const DECIMAL: Bounds = Object.freeze({ lower: 0, upper: 1 });
 /** Clip space bounds i.e. a lower bound of -1 and an upper bound of 1. */
@@ -318,22 +323,24 @@ export const mean = (a: Crude): number => {
 
 /**
  * @returns bounds that have the maximum span of the given bounds i.e. the min of all
- * of the lower bounds and the max of all of the upper bounds.
+ * of the lower bounds and the max of all of the upper bounds. Members are not
+ * reordered, so {@link INVALID} entries act as the identity instead of widening the
+ * result to infinity.
  */
 export const max = (bounds: Crude[]): Bounds => ({
-  lower: Math.min(...bounds.map((b) => construct(b).lower)),
-  upper: Math.max(...bounds.map((b) => construct(b).upper)),
+  lower: Math.min(...bounds.map((b) => construct(b, { makeValid: false }).lower)),
+  upper: Math.max(...bounds.map((b) => construct(b, { makeValid: false }).upper)),
 });
 
 /**
  * @returns bounds that have the minimum span of the given bounds i.e. the max of all
  * of the lower bounds and the min of all of the upper bounds. Note that this function
  * may create invalid bounds if the highest lower bound is greater than the lowest upper
- * bound.
+ * bound. Members are not reordered.
  */
 export const min = (bounds: Crude[]): Bounds => ({
-  lower: Math.max(...bounds.map((b) => construct(b).lower)),
-  upper: Math.min(...bounds.map((b) => construct(b).upper)),
+  lower: Math.max(...bounds.map((b) => construct(b, { makeValid: false }).lower)),
+  upper: Math.min(...bounds.map((b) => construct(b, { makeValid: false }).upper)),
 });
 
 /**

--- a/x/ts/src/telem/series.bench.ts
+++ b/x/ts/src/telem/series.bench.ts
@@ -26,6 +26,40 @@ describe("write", () => {
   });
 });
 
+// Rolling plots query y bounds over a moving sub-range every frame. The block
+// summaries should keep the warm query cost flat as the series grows, while a
+// naive scan grows linearly with the window.
+describe("boundsFor", () => {
+  const makeSeries = (samples: number): Series => {
+    const data = new Float32Array(samples);
+    for (let i = 0; i < data.length; i++) data[i] = Math.sin(i);
+    return new Series({ data, dataType: DataType.FLOAT32 });
+  };
+  const sink = { bounds: 0 };
+  const small = makeSeries(10_000);
+  const large = makeSeries(1_500_000);
+  // Warm the block summaries so the benchmarks measure steady-state queries.
+  small.boundsFor(1, 10_000);
+  large.boundsFor(1, 1_500_000);
+  bench("warm sub-range query 10k", () => {
+    sink.bounds += small.boundsFor(1, 9_999).lower;
+  });
+  bench("warm sub-range query 1.5m", () => {
+    sink.bounds += large.boundsFor(1, 1_499_999).lower;
+  });
+  const raw = large.data as Float32Array;
+  bench("naive full scan 1.5m", () => {
+    let min = Infinity;
+    let max = -Infinity;
+    for (let i = 1; i < 1_499_999; i++) {
+      const v = raw[i];
+      if (v < min) min = v;
+      if (v > max) max = v;
+    }
+    sink.bounds += min + max;
+  });
+});
+
 describe("data access", () => {
   const partial = Series.alloc({ capacity: 1000, dataType: DataType.FLOAT32 });
   partial.write(new Series({ data: new Float32Array(500) }));

--- a/x/ts/src/telem/series.spec.ts
+++ b/x/ts/src/telem/series.spec.ts
@@ -1873,6 +1873,15 @@ describe("Series", () => {
       expect(series.boundsFor(-5, 100)).toStrictEqual({ lower: 1, upper: 3 });
     });
 
+    // Exercises the bigint samples against the number Infinity sentinels in both the
+    // block-build and tail scans.
+    it("should compute bounds for bigint-backed series", () => {
+      const data = new BigInt64Array(5000);
+      for (let i = 0; i < data.length; i++) data[i] = BigInt(i);
+      const series = new Series({ data, dataType: DataType.INT64 });
+      expect(series.boundsFor(1, 4999)).toStrictEqual({ lower: 1, upper: 4998 });
+    });
+
     it("should return invalid bounds for an empty range", () => {
       const series = new Series({ data: new Float32Array([1, 2, 3]) });
       const b = series.boundsFor(2, 2);

--- a/x/ts/src/telem/series.spec.ts
+++ b/x/ts/src/telem/series.spec.ts
@@ -798,12 +798,12 @@ describe("Series", () => {
       expect(series.data[0]).toEqual(42);
     });
 
-    it("should keep typed-array-backed data insulated from source mutation", () => {
+    it("should share typed-array-backed data with the source without copying", () => {
       const src = new Float32Array([1, 2]);
       const series = new Series({ data: src });
       const first = series.data;
       src[0] = 99;
-      expect(first[0]).toEqual(1);
+      expect(first[0]).toEqual(99);
       expect(series.data[0]).toEqual(99);
     });
 
@@ -1859,6 +1859,65 @@ describe("Series", () => {
         dataType: DataType.FLOAT32,
       });
       expect(series.bounds).toEqual({ lower: Infinity, upper: -Infinity });
+    });
+  });
+
+  describe("boundsFor", () => {
+    it("should bound only the samples in the index range", () => {
+      const series = new Series({ data: new Float32Array([9999, -3, -2, -1, 9999]) });
+      expect(series.boundsFor(1, 4)).toStrictEqual({ lower: -3, upper: -1 });
+    });
+
+    it("should clamp out-of-range indices", () => {
+      const series = new Series({ data: new Float32Array([1, 2, 3]) });
+      expect(series.boundsFor(-5, 100)).toStrictEqual({ lower: 1, upper: 3 });
+    });
+
+    it("should return invalid bounds for an empty range", () => {
+      const series = new Series({ data: new Float32Array([1, 2, 3]) });
+      const b = series.boundsFor(2, 2);
+      expect(b.lower).toBeGreaterThan(b.upper);
+    });
+
+    it("should apply the sample offset", () => {
+      const series = new Series({
+        data: new Float32Array([1, 2, 3]),
+        sampleOffset: 10,
+      });
+      expect(series.boundsFor(0, 2)).toStrictEqual({ lower: 11, upper: 12 });
+    });
+
+    it("should throw on variable length data types", () => {
+      const series = new Series({ data: ["a", "b"] });
+      expect(() => series.boundsFor(0, 1)).toThrow(
+        "cannot calculate bounds on a variable length data type",
+      );
+    });
+
+    it("should answer queries that mix cached blocks and raw edges", () => {
+      // 10k samples spans two complete 4096-sample blocks plus a raw tail.
+      const data = new Float32Array(10_000).fill(5);
+      data[1] = -500;
+      data[9_999] = 900;
+      const series = new Series({ data });
+      expect(series.boundsFor(0, 10_000)).toStrictEqual({ lower: -500, upper: 900 });
+      // Repeats hit the now-warm block summaries.
+      expect(series.boundsFor(0, 10_000)).toStrictEqual({ lower: -500, upper: 900 });
+      // The partial first block is scanned raw, so the outlier at index 1 is
+      // excluded once the range starts past it.
+      expect(series.boundsFor(2, 10_000)).toStrictEqual({ lower: 5, upper: 900 });
+    });
+
+    it("should include samples appended after blocks were cached", () => {
+      const series = Series.alloc({ capacity: 10_000, dataType: DataType.FLOAT32 });
+      series.write(new Series({ data: new Float32Array(6_000).fill(5) }));
+      // A sub-range query, so the completed first block gets summarized rather
+      // than hitting the whole-series fast path.
+      expect(series.boundsFor(1, 6_000)).toStrictEqual({ lower: 5, upper: 5 });
+      const next = new Float32Array(4_000).fill(5);
+      next[3_999] = -900;
+      series.write(new Series({ data: next }));
+      expect(series.boundsFor(2, 10_000)).toStrictEqual({ lower: -900, upper: 5 });
     });
   });
 

--- a/x/ts/src/telem/series.ts
+++ b/x/ts/src/telem/series.ts
@@ -106,6 +106,8 @@ export interface SeriesAllocParams extends BaseSeriesParams {
 }
 
 const FULL_BUFFER = -1;
+/** Samples summarized per cached min/max block in boundsFor. */
+const BOUNDS_BLOCK_SIZE = 4096;
 
 const noopIterableIterator: IterableIterator<never> = {
   [Symbol.iterator]: () => noopIterableIterator,
@@ -189,6 +191,10 @@ export class Series<T extends TelemValue = TelemValue>
   private cachedMin?: math.Numeric;
   /** A cached maximum value. */
   private cachedMax?: math.Numeric;
+  /** Cached per-block minimums for boundsFor. Blocks are append-only. */
+  private blockMins?: number[];
+  /** Cached per-block maximums for boundsFor. Blocks are append-only. */
+  private blockMaxs?: number[];
   /** The write position of the buffer. */
   private writePos: number = FULL_BUFFER;
   /** Tracks the number of entities currently using this array. */
@@ -557,12 +563,13 @@ export class Series<T extends TelemValue = TelemValue>
     return this._data;
   }
 
-  // Views are cached only for ArrayBuffer backing: the buffer and data type never
-  // change after construction, so a cached view stays a live window over the data.
+  // The backing store and data type never change after construction, so views and
+  // type conversions are cached. A typed-array constructor given a typed array
+  // copies every element, so an already-matching array is returned as is.
   private get underlyingData(): TypedArray {
     const data = this._data as ArrayBuffer | TypedArray;
-    if (!(data instanceof ArrayBuffer)) return new this.dataType.Array(this._data);
-    return (this.cachedUnderlyingView ??= new this.dataType.Array(data));
+    if (data instanceof this.dataType.Array) return data;
+    return (this.cachedUnderlyingView ??= new this.dataType.Array(this._data));
   }
 
   /**
@@ -762,6 +769,63 @@ export class Series<T extends TelemValue = TelemValue>
   /** @returns the bounds of the series. */
   get bounds(): bounds.Bounds {
     return bounds.construct(Number(this.min), Number(this.max), { makeValid: false });
+  }
+
+  /**
+   * @returns the bounds of the samples in the index range [start, end), clamped to
+   * the series length. The result is invalid (lower > upper) when the range is
+   * empty. Repeated queries are cheap: min/max summaries are cached per completed
+   * block, and only partial edge blocks are rescanned.
+   * @param start - the inclusive start index of the range.
+   * @param end - the exclusive end index of the range.
+   * @throws {Error} on variable length data types.
+   */
+  boundsFor(start: number, end: number): bounds.Bounds {
+    if (this.dataType.isVariable)
+      throw new Error("cannot calculate bounds on a variable length data type");
+    const lo = Math.max(0, start);
+    const hi = Math.min(this.length, end);
+    if (lo === 0 && hi === this.length && hi > 0) return this.bounds;
+    // Casting monomorphizes the scans; bigint elements still compare correctly and
+    // are converted once at the end. Same trick as calcRawMax.
+    const d = this.data as Float64Array;
+    const mins = (this.blockMins ??= []);
+    const maxs = (this.blockMaxs ??= []);
+    const complete = Math.floor(this.length / BOUNDS_BLOCK_SIZE);
+    for (let b = mins.length; b < complete; b++) {
+      let min = Infinity;
+      let max = -Infinity;
+      const blockEnd = (b + 1) * BOUNDS_BLOCK_SIZE;
+      for (let i = b * BOUNDS_BLOCK_SIZE; i < blockEnd; i++) {
+        const v = d[i];
+        if (v < min) min = v;
+        if (v > max) max = v;
+      }
+      mins.push(Number(min));
+      maxs.push(Number(max));
+    }
+    let lower = Infinity;
+    let upper = -Infinity;
+    let i = lo;
+    while (i < hi) {
+      const block = Math.floor(i / BOUNDS_BLOCK_SIZE);
+      const blockEnd = (block + 1) * BOUNDS_BLOCK_SIZE;
+      const aligned = i === block * BOUNDS_BLOCK_SIZE;
+      if (aligned && blockEnd <= hi && block < mins.length) {
+        if (mins[block] < lower) lower = mins[block];
+        if (maxs[block] > upper) upper = maxs[block];
+        i = blockEnd;
+        continue;
+      }
+      const stop = Math.min(hi, blockEnd);
+      for (; i < stop; i++) {
+        const v = d[i];
+        if (v < lower) lower = v;
+        if (v > upper) upper = v;
+      }
+    }
+    const offset = Number(this.sampleOffset);
+    return { lower: Number(lower) + offset, upper: Number(upper) + offset };
   }
 
   private maybeRecomputeMinMax(update: Series): void {


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4601](https://linear.app/synnax/issue/SY-4601/line-plot-auto-bounds-include-samples-outside-the-visible-window)

## Description

Line plot y auto bounds were computed from whole cached series instead of the samples on screen. A rolling plot's live buffer holds about a minute of history and always overlaps the window, so an old spike (or a single 0 sample) stretched the y axis long after it scrolled away; fixed-range plots included every overfetched sample outside the requested range.

`Line` now computes y bounds over only the samples whose paired x value falls inside the x axis bounds: a binary search on the x series finds the window, and per-block min/max summaries (cached per completed 4096-sample block, append-only so never invalidated) keep the per-frame cost flat at any sample rate. The x axis bounds are plumbed from `XAxis` and `LinePlot` into `Line.yBounds`.

Separately, the "no data" sentinel moved from `{0, 0}` to a new `bounds.INVALID` (`{Infinity, -Infinity}`). The zero sentinel was finite, so a line with an unset or still-loading channel joined the axis union and clamped all-negative axes (thermocouples) at 0. `bounds.max`/`min` no longer reorder members, which makes `INVALID` a true union identity and fixes a latent bug where one empty series blew a union out to infinite; `ChannelData` returns `INVALID` when the requested range and fetched data are disjoint instead of a reversed intersection.

Covered by unit tests for the windowed bounds helper (window clipping, alignment pairing, block caching, append-after-cache), the `INVALID` algebra in x, and the disjoint-range guard in `remote.spec.ts`.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR clips line-plot y auto-bounds to samples within the parent x-axis data range and introduces invalid-bound semantics for sources with no applicable data.
- Propagates x-axis bounds through line-plot rendering, lookup, and aggregate-bounds paths.
- Adds alignment-aware windowed bounds calculations backed by cached per-block series summaries.
- Introduces `bounds.INVALID` and updates telemetry sources and intersection handling to use it for absent or disjoint data.
- Adds unit tests and benchmarks for clipping, alignment, invalid-bound algebra, and cached range queries.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pluto/src/lineplot/aether/XAxis.ts | Propagates the x-axis data bounds to child y axes while intentionally preserving existing viewport zoom semantics. |
| pluto/src/lineplot/aether/YAxis.ts | Uses the parent x-axis bounds when calculating line-derived y-axis bounds across render, lookup, and aggregate paths. |
| pluto/src/vis/line/aether/bounds.ts | Adds alignment-aware clipping of paired x/y series and complies with the repository’s line-length requirement. |
| pluto/src/vis/line/aether/line.ts | Computes y bounds from samples inside a finite x window while retaining full-source bounds for non-finite windows. |
| x/ts/src/telem/series.ts | Adds cached block-level min/max summaries for efficient index-range bounds queries. |
| x/ts/src/spatial/bounds/bounds.ts | Adds an invalid empty-set sentinel and preserves reversed bounds so union and intersection algebra behaves consistently. |
| pluto/src/telem/aether/remote.ts | Returns invalid bounds for absent, unsupported, or disjoint telemetry data instead of treating zero as data. |

<sub>Reviews (2): Last reviewed commit: ["Pin bigint series through boundsFor"](https://github.com/synnaxlabs/synnax/commit/f75c9c30739f390139510f10d8860f008aa284bf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53730944)</sub>

**Context used:**

- Knowledge Base — [Pluto Component and Visualization Library](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/pluto-components.md)
- Knowledge Base — [x: Shared Cross-Language Utilities](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/x-shared-utils.md)

<!-- /greptile_comment -->