### PR TITLE
SY-4603: Acquire driver hardware on task start instead of at configure

### DIFF
--- a/driver/common/write_task.h
+++ b/driver/common/write_task.h
@@ -252,9 +252,10 @@ public:
     /// @param propagate_state whether the task will be reconfigured after it was
     /// stopped.
     bool stop(const std::string &cmd_key, const bool propagate_state) {
-        const auto write_pipe_stopped = this->cmd_write_pipe.stop();
-        const auto state_pipe_stopped = this->state_write_pipe.stop();
-        const auto stopped = write_pipe_stopped && state_pipe_stopped;
+        // The state pipe never starts without state channels, so only the command
+        // pipe records whether the sink holds hardware.
+        const auto stopped = this->cmd_write_pipe.stop();
+        this->state_write_pipe.stop();
         if (stopped) this->state.error(this->sink->internal->stop());
         if (propagate_state) this->state.send_stop(cmd_key);
         return stopped;

--- a/driver/common/write_task_test.cpp
+++ b/driver/common/write_task_test.cpp
@@ -18,6 +18,11 @@
 namespace driver::common {
 class MockSink final : public Sink, public pipeline::mock::Sink {
 public:
+    /// @brief number of times start() was called.
+    size_t start_count = 0;
+    /// @brief number of times stop() was called.
+    size_t stop_count = 0;
+
     MockSink(
         const x::telem::Rate state_rate,
         const std::set<synnax::channel::Key> &state_indexes,
@@ -35,6 +40,16 @@ public:
             data_saving_disabled
         ),
         driver::pipeline::mock::Sink(writes, errors) {}
+
+    x::errors::Error start() override {
+        this->start_count++;
+        return x::errors::NIL;
+    }
+
+    x::errors::Error stop() override {
+        this->stop_count++;
+        return x::errors::NIL;
+    }
 
     x::errors::Error write(x::telem::Frame &frame) override {
         auto err = pipeline::mock::Sink::write(frame);
@@ -283,6 +298,55 @@ TEST(TestCommonWriteTask, testStartWhileRunningAcks) {
     // The live sink was not closed and reopened.
     EXPECT_EQ(mock_streamer_factory->streamer_opens.load(std::memory_order_acquire), 1);
     ASSERT_TRUE(write_task.stop("stop_cmd", true));
+}
+
+/// @brief a task whose sink has no state channels never starts the state pipeline.
+/// Stopping it must still release the sink, and must release it exactly once, so a
+/// sink that claims hardware on start does not hold it while the task is stopped.
+TEST(TestCommonWriteTask, testStopReleasesSinkWithoutStateChannels) {
+    auto mock_writer_factory = std::make_shared<pipeline::mock::WriterFactory>();
+    const auto cmd_reads = std::make_shared<std::vector<x::telem::Frame>>();
+    auto mock_streamer_factory = pipeline::mock::simple_streamer_factory(
+        std::vector<synnax::channel::Key>{1},
+        cmd_reads
+    );
+    auto sink = std::make_unique<MockSink>(
+        x::telem::Rate(0),
+        std::set<synnax::channel::Key>{},
+        std::vector<synnax::channel::Channel>{},
+        std::vector<synnax::channel::Key>{1},
+        false,
+        std::make_shared<std::vector<x::telem::Frame>>(),
+        std::make_shared<std::vector<x::errors::Error>>()
+    );
+    auto *raw_sink = sink.get();
+    synnax::task::Task task;
+    task.key = x::uuid::create();
+    auto ctx = std::make_shared<driver::task::MockContext>(nullptr);
+    WriteTask write_task(
+        task,
+        ctx,
+        x::breaker::default_config("cat"),
+        std::move(sink),
+        mock_writer_factory,
+        mock_streamer_factory
+    );
+
+    ASSERT_TRUE(write_task.start("start_cmd"));
+    ASSERT_EVENTUALLY_EQ(ctx->statuses.size(), 1);
+    EXPECT_EQ(raw_sink->start_count, 1);
+    EXPECT_EQ(raw_sink->stop_count, 0);
+
+    ASSERT_TRUE(write_task.stop("stop_cmd", true));
+    EXPECT_EQ(raw_sink->stop_count, 1);
+
+    ASSERT_FALSE(write_task.stop("stop_cmd_2", true));
+    EXPECT_EQ(raw_sink->stop_count, 1);
+
+    ASSERT_TRUE(write_task.start("start_cmd_2"));
+    EXPECT_EQ(raw_sink->start_count, 2);
+    ASSERT_TRUE(write_task.stop("stop_cmd_3", true));
+    EXPECT_EQ(raw_sink->stop_count, 2);
 }
 
 /// @brief it should parse a device key from the config.

--- a/driver/labjack/BUILD.bazel
+++ b/driver/labjack/BUILD.bazel
@@ -57,6 +57,7 @@ cc_test(
     name = "labjack_test",
     srcs = [
         "read_task_test.cpp",
+        "write_task_test.cpp",
     ],
     deps = [
         "//client/cpp/testutil",

--- a/driver/labjack/BUILD.bazel
+++ b/driver/labjack/BUILD.bazel
@@ -62,6 +62,7 @@ cc_test(
     deps = [
         "//client/cpp/testutil",
         "//driver/labjack",
+        "//driver/labjack/device:mock",
         "//x/cpp/test",
         "@googletest//:gtest_main",
     ],

--- a/driver/labjack/device/BUILD.bazel
+++ b/driver/labjack/device/BUILD.bazel
@@ -11,10 +11,15 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 cc_library(
     name = "device",
-    srcs = [
-        "device.h",
-        "mock.h",
-    ],
+    srcs = ["device.h"],
     visibility = ["//visibility:public"],
     deps = ["//driver/labjack/ljm"],
+)
+
+cc_library(
+    name = "mock",
+    testonly = True,
+    hdrs = ["mock.h"],
+    visibility = ["//visibility:public"],
+    deps = [":device"],
 )

--- a/driver/labjack/device/BUILD.bazel
+++ b/driver/labjack/device/BUILD.bazel
@@ -11,7 +11,10 @@ load("@rules_cc//cc:cc_library.bzl", "cc_library")
 
 cc_library(
     name = "device",
-    srcs = ["device.h"],
+    srcs = [
+        "device.h",
+        "mock.h",
+    ],
     visibility = ["//visibility:public"],
     deps = ["//driver/labjack/ljm"],
 )

--- a/driver/labjack/device/device.h
+++ b/driver/labjack/device/device.h
@@ -252,16 +252,37 @@ public:
 /// @brief manager handles the lifecycle of LabJack devices, allowing callers to
 /// acquire and release devices for use at will.
 class Manager {
+public:
+    virtual ~Manager() = default;
+
+    /// @brief lists the devices visible to the LJM library.
+    virtual x::errors::Error list_all(
+        int dev_type,
+        int conn_type,
+        int *num_found,
+        int *dev_types,
+        int *conn_types,
+        int *serial_numbers,
+        int *ip_addresses
+    ) = 0;
+
+    /// @brief acquires the device with the given serial number, opening it if no
+    /// other caller currently holds it.
+    virtual std::pair<std::shared_ptr<Device>, x::errors::Error>
+    acquire(const std::string &serial_number) = 0;
+};
+
+/// @brief a Manager that opens devices through the LJM library, sharing one handle
+/// among concurrent holders of the same device.
+class LJMManager final : public Manager {
     std::mutex mu;
     std::map<std::string, std::weak_ptr<Device>> handles;
     std::shared_ptr<ljm::API> ljm;
 
 public:
-    explicit Manager(const std::shared_ptr<ljm::API> &ljm): ljm(ljm) {}
+    explicit LJMManager(const std::shared_ptr<ljm::API> &ljm): ljm(ljm) {}
 
-    virtual ~Manager() = default;
-
-    virtual x::errors::Error list_all(
+    x::errors::Error list_all(
         const int dev_type,
         const int conn_type,
         int *num_found,
@@ -269,7 +290,7 @@ public:
         int *conn_types,
         int *serial_numbers,
         int *ip_addresses
-    ) {
+    ) override {
         std::lock_guard lock(this->mu);
         return parse_error(
             ljm,
@@ -285,8 +306,8 @@ public:
         );
     }
 
-    virtual std::pair<std::shared_ptr<Device>, x::errors::Error>
-    acquire(const std::string &serial_number) {
+    std::pair<std::shared_ptr<Device>, x::errors::Error>
+    acquire(const std::string &serial_number) override {
         {
             std::lock_guard lock(mu);
             const auto it = this->handles.find(serial_number);

--- a/driver/labjack/device/device.h
+++ b/driver/labjack/device/device.h
@@ -275,9 +275,25 @@ public:
 /// @brief a Manager that opens devices through the LJM library, sharing one handle
 /// among concurrent holders of the same device.
 class LJMManager final : public Manager {
+    /// @brief guards the handle cache.
     std::mutex mu;
+    /// @brief serializes opens. LJM returns the same handle when an open device is
+    /// opened again, so two racing opens of one device would let the loser's close
+    /// kill the winner's connection.
+    std::mutex open_mu;
     std::map<std::string, std::weak_ptr<Device>> handles;
     std::shared_ptr<ljm::API> ljm;
+
+    /// @brief returns the cached device for the serial number, if a holder still
+    /// exists.
+    std::shared_ptr<Device> cached(const std::string &serial_number) {
+        std::lock_guard lock(this->mu);
+        const auto it = this->handles.find(serial_number);
+        if (it == this->handles.end()) return nullptr;
+        if (auto existing = it->second.lock()) return existing;
+        this->handles.erase(it);
+        return nullptr;
+    }
 
 public:
     explicit LJMManager(const std::shared_ptr<ljm::API> &ljm): ljm(ljm) {}
@@ -291,7 +307,8 @@ public:
         int *serial_numbers,
         int *ip_addresses
     ) override {
-        std::lock_guard lock(this->mu);
+        // LJM is thread-safe and the handle cache is untouched here, so no lock:
+        // a slow open must not block scanning.
         return parse_error(
             ljm,
             ljm->list_all(
@@ -308,31 +325,21 @@ public:
 
     std::pair<std::shared_ptr<Device>, x::errors::Error>
     acquire(const std::string &serial_number) override {
-        {
-            std::lock_guard lock(mu);
-            const auto it = this->handles.find(serial_number);
-            if (it != handles.end()) {
-                const auto existing = it->second.lock();
-                if (existing != nullptr) return {existing, x::errors::NIL};
-                this->handles.erase(it);
-            }
-        }
-
-        // Opening can block for seconds on an unreachable device, so the lock is
-        // released to keep other callers (notably the scanner) unblocked.
+        if (auto existing = this->cached(serial_number))
+            return {existing, x::errors::NIL};
+        // Opening can block for seconds on an unreachable device; only other
+        // opens wait on it, never cache hits or the scanner.
+        std::lock_guard open_lock(this->open_mu);
+        // A racing caller may have opened the device while we waited.
+        if (auto existing = this->cached(serial_number))
+            return {existing, x::errors::NIL};
         int dev_handle;
         const int
             err = ljm->open(LJM_dtANY, LJM_ctANY, serial_number.c_str(), &dev_handle);
         if (err != 0) return {nullptr, parse_error(ljm, err)};
-
         auto dev = std::make_shared<LJMDevice>(ljm, dev_handle);
-        std::lock_guard lock(mu);
-        // Another caller may have opened the device while the lock was released;
-        // prefer the cached handle and let ours close.
-        if (const auto it = this->handles.find(serial_number); it != handles.end())
-            if (const auto existing = it->second.lock())
-                return {existing, x::errors::NIL};
-        this->handles[serial_number] = dev; // Stores weak_ptr automatically
+        std::lock_guard lock(this->mu);
+        this->handles[serial_number] = dev;
         return {dev, x::errors::NIL};
     }
 };

--- a/driver/labjack/device/device.h
+++ b/driver/labjack/device/device.h
@@ -259,7 +259,9 @@ class Manager {
 public:
     explicit Manager(const std::shared_ptr<ljm::API> &ljm): ljm(ljm) {}
 
-    x::errors::Error list_all(
+    virtual ~Manager() = default;
+
+    virtual x::errors::Error list_all(
         const int dev_type,
         const int conn_type,
         int *num_found,
@@ -283,23 +285,32 @@ public:
         );
     }
 
-    std::pair<std::shared_ptr<Device>, x::errors::Error>
+    virtual std::pair<std::shared_ptr<Device>, x::errors::Error>
     acquire(const std::string &serial_number) {
-        std::lock_guard lock(mu);
-
-        const auto it = this->handles.find(serial_number);
-        if (it != handles.end()) {
-            const auto existing = it->second.lock();
-            if (existing != nullptr) return {existing, x::errors::NIL};
-            this->handles.erase(it);
+        {
+            std::lock_guard lock(mu);
+            const auto it = this->handles.find(serial_number);
+            if (it != handles.end()) {
+                const auto existing = it->second.lock();
+                if (existing != nullptr) return {existing, x::errors::NIL};
+                this->handles.erase(it);
+            }
         }
 
+        // Opening can block for seconds on an unreachable device, so the lock is
+        // released to keep other callers (notably the scanner) unblocked.
         int dev_handle;
         const int
             err = ljm->open(LJM_dtANY, LJM_ctANY, serial_number.c_str(), &dev_handle);
         if (err != 0) return {nullptr, parse_error(ljm, err)};
 
         auto dev = std::make_shared<LJMDevice>(ljm, dev_handle);
+        std::lock_guard lock(mu);
+        // Another caller may have opened the device while the lock was released;
+        // prefer the cached handle and let ours close.
+        if (const auto it = this->handles.find(serial_number); it != handles.end())
+            if (const auto existing = it->second.lock())
+                return {existing, x::errors::NIL};
         this->handles[serial_number] = dev; // Stores weak_ptr automatically
         return {dev, x::errors::NIL};
     }

--- a/driver/labjack/device/mock.h
+++ b/driver/labjack/device/mock.h
@@ -9,7 +9,9 @@
 
 #pragma once
 
+#include <functional>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <string>
 #include <vector>
@@ -140,17 +142,22 @@ private:
 /// @brief a Manager that serves scripted devices for tests instead of opening LJM
 /// handles.
 class MockManager final : public Manager {
+    /// @brief the device handed to callers while a holder is still alive.
+    std::weak_ptr<Device> cached;
+
 public:
     /// @brief errors to return from acquire() calls in sequence. Calls past the end
     /// of the sequence succeed.
     std::vector<x::errors::Error> acquire_errors;
     /// @brief number of times acquire() was called.
     size_t acquire_call_count = 0;
-    /// @brief the device returned by successful acquire() calls.
+    /// @brief opens a device when no holder remains. Defaults to serving dev.
+    std::function<std::shared_ptr<Device>()> open;
+    /// @brief the device the default open() serves.
     std::shared_ptr<Device> dev;
 
     explicit MockManager(std::shared_ptr<Device> dev = std::make_shared<Mock>()):
-        dev(std::move(dev)) {}
+        open([this] { return this->dev; }), dev(std::move(dev)) {}
 
     x::errors::Error list_all(int, int, int *, int *, int *, int *, int *) override {
         return x::errors::NIL;
@@ -161,7 +168,10 @@ public:
         const auto i = this->acquire_call_count++;
         if (i < this->acquire_errors.size() && this->acquire_errors[i])
             return {nullptr, this->acquire_errors[i]};
-        return {this->dev, x::errors::NIL};
+        if (auto existing = this->cached.lock()) return {existing, x::errors::NIL};
+        auto opened = this->open();
+        this->cached = opened;
+        return {opened, x::errors::NIL};
     }
 };
 }

--- a/driver/labjack/device/mock.h
+++ b/driver/labjack/device/mock.h
@@ -150,7 +150,11 @@ public:
     std::shared_ptr<Device> dev;
 
     explicit MockManager(std::shared_ptr<Device> dev = std::make_shared<Mock>()):
-        Manager(nullptr), dev(std::move(dev)) {}
+        dev(std::move(dev)) {}
+
+    x::errors::Error list_all(int, int, int *, int *, int *, int *, int *) override {
+        return x::errors::NIL;
+    }
 
     std::pair<std::shared_ptr<Device>, x::errors::Error>
     acquire(const std::string &) override {

--- a/driver/labjack/device/mock.h
+++ b/driver/labjack/device/mock.h
@@ -62,6 +62,18 @@ public:
         return x::errors::NIL;
     }
 
+    [[nodiscard]] x::errors::Error clean_interval(int interval_handle) const override {
+        if (should_fail_) return x::errors::Error("mock failure");
+        return x::errors::NIL;
+    }
+
+    [[nodiscard]] x::errors::Error
+    e_read_name(const char *name, double *value) const override {
+        if (should_fail_) return x::errors::Error("mock failure");
+        *value = 0;
+        return x::errors::NIL;
+    }
+
     [[nodiscard]] x::errors::Error
     e_write_name(const char *name, double value) const override {
         if (should_fail_) return x::errors::Error("mock failure");
@@ -123,5 +135,29 @@ public:
 private:
     bool should_fail_{false};
     double requested_scan_rate_{1000.0};
+};
+
+/// @brief a Manager that serves scripted devices for tests instead of opening LJM
+/// handles.
+class MockManager final : public Manager {
+public:
+    /// @brief errors to return from acquire() calls in sequence. Calls past the end
+    /// of the sequence succeed.
+    std::vector<x::errors::Error> acquire_errors;
+    /// @brief number of times acquire() was called.
+    size_t acquire_call_count = 0;
+    /// @brief the device returned by successful acquire() calls.
+    std::shared_ptr<Device> dev;
+
+    explicit MockManager(std::shared_ptr<Device> dev = std::make_shared<Mock>()):
+        Manager(nullptr), dev(std::move(dev)) {}
+
+    std::pair<std::shared_ptr<Device>, x::errors::Error>
+    acquire(const std::string &) override {
+        const auto i = this->acquire_call_count++;
+        if (i < this->acquire_errors.size() && this->acquire_errors[i])
+            return {nullptr, this->acquire_errors[i]};
+        return {this->dev, x::errors::NIL};
+    }
 };
 }

--- a/driver/labjack/factory.cpp
+++ b/driver/labjack/factory.cpp
@@ -123,7 +123,7 @@ std::unique_ptr<Factory> Factory::create(common::TimingConfig timing_cfg) {
     auto [ljm, ljm_err] = ljm::API::load();
     if (ljm_err) LOG(WARNING) << ljm_err;
     return std::make_unique<Factory>(
-        ljm != nullptr ? std::make_shared<device::Manager>(ljm) : nullptr,
+        ljm != nullptr ? std::make_shared<device::LJMManager>(ljm) : nullptr,
         timing_cfg
     );
 }

--- a/driver/labjack/factory.cpp
+++ b/driver/labjack/factory.cpp
@@ -28,13 +28,11 @@ std::pair<common::ConfigureResult, x::errors::Error> configure_read(
     common::ConfigureResult result;
     auto [cfg, err] = ReadTaskConfig::parse(ctx->client, task, timing_cfg);
     if (err) return {std::move(result), err};
-    auto [dev, d_err] = devs->acquire(cfg.device_key);
-    if (d_err) return {std::move(result), d_err};
     std::unique_ptr<common::Source> source;
     if (cfg.has_thermocouples())
-        source = std::make_unique<UnarySource>(dev, std::move(cfg));
+        source = std::make_unique<UnarySource>(devs, std::move(cfg));
     else
-        source = std::make_unique<StreamSource>(dev, std::move(cfg));
+        source = std::make_unique<StreamSource>(devs, std::move(cfg));
     result.auto_start = cfg.auto_start;
     result.task = std::make_unique<common::ReadTask>(
         task,
@@ -53,14 +51,12 @@ std::pair<common::ConfigureResult, x::errors::Error> configure_write(
     common::ConfigureResult result;
     auto [cfg, err] = WriteTaskConfig::parse(ctx->client, task);
     if (err) return {std::move(result), err};
-    auto [dev, d_err] = devs->acquire(cfg.device);
-    if (d_err) return {std::move(result), d_err};
     result.auto_start = cfg.auto_start;
     result.task = std::make_unique<common::WriteTask>(
         task,
         ctx,
         x::breaker::default_config(task.name),
-        std::make_unique<WriteSink>(dev, std::move(cfg))
+        std::make_unique<WriteSink>(devs, std::move(cfg))
     );
     return {std::move(result), x::errors::NIL};
 }

--- a/driver/labjack/read_task.h
+++ b/driver/labjack/read_task.h
@@ -504,21 +504,36 @@ struct ReadTaskConfig : common::BaseReadTaskConfig {
 class UnarySource final : public common::Source {
     /// @brief the configuration for the read task.
     ReadTaskConfig cfg;
-    /// @brief the API of the device we're reading from.
-    const std::shared_ptr<device::Device> dev;
+    /// @brief acquires the device on each start.
+    const std::shared_ptr<device::Manager> devs;
+    /// @brief the API of the device we're reading from. Populated on start and
+    /// released on stop.
+    std::shared_ptr<device::Device> dev;
     /// @brief a handle to the interval that is regulating the sample clock.
     const int interval_handle;
 
 public:
-    UnarySource(const std::shared_ptr<device::Device> &dev, ReadTaskConfig cfg):
-        cfg(std::move(cfg)), dev(dev), interval_handle(0) {}
+    UnarySource(const std::shared_ptr<device::Manager> &devs, ReadTaskConfig cfg):
+        cfg(std::move(cfg)), devs(devs), interval_handle(0) {}
 
+    /// @brief claims the device on every start so a device that disconnects and
+    /// returns between runs gets a fresh LJM handle on the next start.
     x::errors::Error start() override {
-        if (const auto err = this->cfg.apply(this->dev)) return err;
-        return this->dev->start_interval(
-            this->interval_handle,
-            static_cast<int>(this->cfg.sample_rate.period().microseconds())
-        );
+        auto [d, err] = this->devs->acquire(this->cfg.device_key);
+        if (err) return err;
+        this->dev = std::move(d);
+        if (const auto apply_err = this->cfg.apply(this->dev)) {
+            this->dev.reset();
+            return apply_err;
+        }
+        if (const auto interval_err = this->dev->start_interval(
+                this->interval_handle,
+                static_cast<int>(this->cfg.sample_rate.period().microseconds())
+            )) {
+            this->dev.reset();
+            return interval_err;
+        }
+        return x::errors::NIL;
     }
 
     [[nodiscard]] std::vector<synnax::channel::Channel> channels() const override {
@@ -526,7 +541,10 @@ public:
     }
 
     x::errors::Error stop() override {
-        return this->dev->clean_interval(this->interval_handle);
+        if (this->dev == nullptr) return x::errors::NIL;
+        const auto err = this->dev->clean_interval(this->interval_handle);
+        this->dev.reset();
+        return err;
     }
 
     common::ReadResult
@@ -586,8 +604,11 @@ public:
 class StreamSource final : public common::Source {
     /// @brief the configuration for the read task.
     ReadTaskConfig cfg;
-    /// @brief the API to the device we're reading from.
-    const std::shared_ptr<device::Device> dev;
+    /// @brief acquires the device on each start.
+    const std::shared_ptr<device::Manager> devs;
+    /// @brief the API to the device we're reading from. Populated on start and
+    /// released on stop.
+    std::shared_ptr<device::Device> dev;
     /// @brief sample clock used to get timestamp information for the task.
     common::HardwareTimedSampleClock sample_clock;
     /// @brief buffer containing interleaved data directly from device
@@ -609,9 +630,9 @@ class StreamSource final : public common::Source {
     }
 
 public:
-    StreamSource(const std::shared_ptr<device::Device> &dev, ReadTaskConfig cfg):
+    StreamSource(const std::shared_ptr<device::Manager> &devs, ReadTaskConfig cfg):
         cfg(std::move(cfg)),
-        dev(dev),
+        devs(devs),
         sample_clock(
             common::HardwareTimedSampleClockConfig::create_simple(
                 this->cfg.sample_rate,
@@ -627,15 +648,31 @@ public:
         return this->cfg.writer();
     }
 
-    x::errors::Error start() override { return this->restart(false); }
+    x::errors::Error start() override {
+        if (const auto err = this->restart(false)) {
+            this->dev.reset();
+            return err;
+        }
+        return x::errors::NIL;
+    }
 
     [[nodiscard]] std::vector<synnax::channel::Channel> channels() const override {
         return this->cfg.sy_channels();
     }
 
-    /// @brief restarts the source.
+    /// @brief restarts the source, claiming the device again so a disconnect and
+    /// reconnect between runs gets a fresh LJM handle.
     x::errors::Error restart(const bool force) {
+        const auto prev = this->dev;
         this->stop();
+        auto [d, acquire_err] = this->devs->acquire(this->cfg.device_key);
+        if (acquire_err) {
+            // Keep the previous claim so mid-run recovery retries on the old
+            // handle instead of dereferencing null.
+            this->dev = prev;
+            return acquire_err;
+        }
+        this->dev = std::move(d);
         if (const auto err = this->cfg.apply(this->dev); err && !force) return err;
         std::vector<int> temp_ports(this->cfg.channels.size());
         std::vector<const char *> physical_channels;
@@ -661,7 +698,12 @@ public:
         return x::errors::NIL;
     }
 
-    x::errors::Error stop() override { return this->dev->e_stream_stop(); }
+    x::errors::Error stop() override {
+        if (this->dev == nullptr) return x::errors::NIL;
+        const auto err = this->dev->e_stream_stop();
+        this->dev.reset();
+        return err;
+    }
 
     common::ReadResult
     read(x::breaker::Breaker &breaker, x::telem::Frame &fr) override {

--- a/driver/labjack/read_task.h
+++ b/driver/labjack/read_task.h
@@ -660,18 +660,12 @@ public:
         return this->cfg.sy_channels();
     }
 
-    /// @brief restarts the source, claiming the device again so a disconnect and
-    /// reconnect between runs gets a fresh LJM handle.
+    /// @brief restarts the source. The claim is released before the acquire so a
+    /// device that reconnects gets a fresh LJM handle instead of the cached one.
     x::errors::Error restart(const bool force) {
-        const auto prev = this->dev;
         this->stop();
         auto [d, acquire_err] = this->devs->acquire(this->cfg.device_key);
-        if (acquire_err) {
-            // Keep the previous claim so mid-run recovery retries on the old
-            // handle instead of dereferencing null.
-            this->dev = prev;
-            return acquire_err;
-        }
+        if (acquire_err) return acquire_err;
         this->dev = std::move(d);
         if (const auto err = this->cfg.apply(this->dev); err && !force) return err;
         std::vector<int> temp_ports(this->cfg.channels.size());
@@ -708,6 +702,12 @@ public:
     common::ReadResult
     read(x::breaker::Breaker &breaker, x::telem::Frame &fr) override {
         common::ReadResult res;
+        // A failed restart leaves no device. The pipeline retries temporary errors,
+        // giving recovery a chance on every attempt.
+        if (this->dev == nullptr) {
+            res.error = translate_error(this->restart(true));
+            if (res.error) return res;
+        }
         const auto n_channels = this->cfg.channels.size();
         const auto n_samples = this->cfg.samples_per_chan;
         common::initialize_frame(fr, this->cfg.channels, this->cfg.indexes, n_samples);

--- a/driver/labjack/read_task_test.cpp
+++ b/driver/labjack/read_task_test.cpp
@@ -509,6 +509,7 @@ TEST_F(SourceClaimTest, testStreamSourceReadReclaimsAfterFailedRestart) {
     breaker.start();
     x::telem::Frame fr(0);
     const auto res = source.read(breaker, fr);
+    breaker.stop();
     ASSERT_NIL(res.error);
     EXPECT_EQ(devs->acquire_call_count, 3);
     ASSERT_NIL(source.stop());

--- a/driver/labjack/read_task_test.cpp
+++ b/driver/labjack/read_task_test.cpp
@@ -474,4 +474,43 @@ TEST_F(SourceClaimTest, testStreamSourceRestartReclaimsDevice) {
     ASSERT_NIL(source.stop());
     EXPECT_EQ(devs->dev.use_count(), 1);
 }
+
+/// @brief a restart must drop its claim before acquiring. The manager shares one
+/// handle per device while a holder is alive, so a source that keeps the old claim
+/// across the acquire gets the dead handle back instead of a reopened one.
+TEST_F(SourceClaimTest, testStreamSourceRestartOpensAFreshHandle) {
+    parse_config(false);
+    size_t opens = 0;
+    devs->open = [&opens] {
+        ++opens;
+        return std::make_shared<device::Mock>();
+    };
+    StreamSource source(devs, std::move(*cfg));
+    ASSERT_NIL(source.start());
+    EXPECT_EQ(opens, 1);
+    ASSERT_NIL(source.restart(true));
+    EXPECT_EQ(opens, 2);
+    ASSERT_NIL(source.stop());
+}
+
+/// @brief a read after a restart that failed to acquire must claim the device again
+/// instead of dereferencing a released one.
+TEST_F(SourceClaimTest, testStreamSourceReadReclaimsAfterFailedRestart) {
+    parse_config(false);
+    devs->acquire_errors = {
+        x::errors::NIL,
+        x::errors::Error(ljm::CRITICAL_ERROR, "device not found")
+    };
+    StreamSource source(devs, std::move(*cfg));
+    ASSERT_NIL(source.start());
+    ASSERT_OCCURRED_AS(source.restart(true), ljm::CRITICAL_ERROR);
+
+    x::breaker::Breaker breaker(x::breaker::default_config("read"));
+    breaker.start();
+    x::telem::Frame fr(0);
+    const auto res = source.read(breaker, fr);
+    ASSERT_NIL(res.error);
+    EXPECT_EQ(devs->acquire_call_count, 3);
+    ASSERT_NIL(source.stop());
+}
 }

--- a/driver/labjack/read_task_test.cpp
+++ b/driver/labjack/read_task_test.cpp
@@ -15,6 +15,7 @@
 #include "x/cpp/json/json.h"
 #include "x/cpp/test/test.h"
 
+#include "driver/labjack/device/mock.h"
 #include "driver/labjack/read_task.h"
 
 namespace driver::labjack {
@@ -341,5 +342,136 @@ TEST(TestReadTaskConfigParse, testLabJackDriverSetsAutoCommitTrue) {
     // Verify that writer_config has enable_auto_commit set to true
     auto writer_cfg = cfg->writer();
     ASSERT_TRUE(writer_cfg.enable_auto_commit);
+}
+
+class SourceClaimTest : public ::testing::Test {
+protected:
+    std::unique_ptr<ReadTaskConfig> cfg;
+    std::shared_ptr<device::MockManager> devs;
+
+    /// @brief parses a single-channel config. A thermocouple channel selects the
+    /// UnarySource path; an analog channel selects the StreamSource path.
+    void parse_config(const bool thermocouple) {
+        auto client = std::make_shared<synnax::Synnax>(new_test_client());
+        auto rack = ASSERT_NIL_P(client->racks.create("cat"));
+        auto dev = synnax::device::Device{
+            .key = "230227d9-02aa-47e4-b370-0d590add1bc1",
+            .rack = rack.key,
+            .location = "dev1",
+            .make = "labjack",
+            .model = "T7",
+            .name = "my_device",
+        };
+        ASSERT_NIL(client->devices.create(dev));
+        auto ch = ASSERT_NIL_P(client->channels.create(
+            make_unique_channel_name("claim_channel"),
+            x::telem::FLOAT64_T,
+            true
+        ));
+        auto j = basic_read_task_config();
+        if (thermocouple)
+            j["channels"] = x::json::json::array(
+                {{{"port", "AIN0"},
+                  {"disabled", false},
+                  {"key", "8hYJO9zt6eS"},
+                  {"channel", ch.key},
+                  {"type", "thermocouple"},
+                  {"range", 0},
+                  {"scale", {{"type", "none"}}},
+                  {"thermocouple_type", "K"},
+                  {"pos_chan", 0},
+                  {"neg_chan", 199},
+                  {"units", "K"},
+                  {"cjc_source", "TEMPERATURE_DEVICE_K"},
+                  {"cjc_slope", 1},
+                  {"cjc_offset", 0}}}
+            );
+        else
+            j["channels"] = x::json::json::array(
+                {{{"port", "AIN0"},
+                  {"disabled", false},
+                  {"key", "8hYJO9zt6eS"},
+                  {"channel", ch.key},
+                  {"type", "analog"},
+                  {"range", 5},
+                  {"scale", {{"type", "none"}}}}}
+            );
+        auto p = x::json::Parser(j);
+        this->cfg = std::make_unique<ReadTaskConfig>(client, p);
+        ASSERT_NIL(p.error());
+        this->devs = std::make_shared<device::MockManager>();
+    }
+};
+
+/// @brief it should claim the device on start and release it on stop, so a device
+/// that disconnects and returns between runs gets a fresh handle on the next start.
+TEST_F(SourceClaimTest, testUnarySourceClaimsDeviceOnStart) {
+    parse_config(true);
+    UnarySource source(devs, std::move(*cfg));
+    EXPECT_EQ(devs->acquire_call_count, 0);
+    EXPECT_EQ(devs->dev.use_count(), 1);
+    ASSERT_NIL(source.start());
+    EXPECT_EQ(devs->acquire_call_count, 1);
+    EXPECT_EQ(devs->dev.use_count(), 2);
+    ASSERT_NIL(source.stop());
+    EXPECT_EQ(devs->dev.use_count(), 1);
+    ASSERT_NIL(source.start());
+    EXPECT_EQ(devs->acquire_call_count, 2);
+    ASSERT_NIL(source.stop());
+}
+
+/// @brief it should surface an acquire failure on start and retry the acquisition
+/// on the next start.
+TEST_F(SourceClaimTest, testUnarySourceAcquireFailureRetriesOnNextStart) {
+    parse_config(true);
+    devs->acquire_errors = {x::errors::Error(ljm::CRITICAL_ERROR, "device not found")};
+    UnarySource source(devs, std::move(*cfg));
+    ASSERT_OCCURRED_AS(source.start(), ljm::CRITICAL_ERROR);
+    EXPECT_EQ(devs->dev.use_count(), 1);
+    ASSERT_NIL(source.start());
+    EXPECT_EQ(devs->acquire_call_count, 2);
+    ASSERT_NIL(source.stop());
+}
+
+/// @brief it should claim the device on start and release it on stop.
+TEST_F(SourceClaimTest, testStreamSourceClaimsDeviceOnStart) {
+    parse_config(false);
+    StreamSource source(devs, std::move(*cfg));
+    EXPECT_EQ(devs->acquire_call_count, 0);
+    EXPECT_EQ(devs->dev.use_count(), 1);
+    ASSERT_NIL(source.start());
+    EXPECT_EQ(devs->acquire_call_count, 1);
+    EXPECT_EQ(devs->dev.use_count(), 2);
+    ASSERT_NIL(source.stop());
+    EXPECT_EQ(devs->dev.use_count(), 1);
+    ASSERT_NIL(source.start());
+    EXPECT_EQ(devs->acquire_call_count, 2);
+    ASSERT_NIL(source.stop());
+}
+
+/// @brief it should surface an acquire failure on start and retry the acquisition
+/// on the next start.
+TEST_F(SourceClaimTest, testStreamSourceAcquireFailureRetriesOnNextStart) {
+    parse_config(false);
+    devs->acquire_errors = {x::errors::Error(ljm::CRITICAL_ERROR, "device not found")};
+    StreamSource source(devs, std::move(*cfg));
+    ASSERT_OCCURRED_AS(source.start(), ljm::CRITICAL_ERROR);
+    EXPECT_EQ(devs->dev.use_count(), 1);
+    ASSERT_NIL(source.start());
+    EXPECT_EQ(devs->acquire_call_count, 2);
+    ASSERT_NIL(source.stop());
+}
+
+/// @brief it should claim the device again on restart.
+TEST_F(SourceClaimTest, testStreamSourceRestartReclaimsDevice) {
+    parse_config(false);
+    StreamSource source(devs, std::move(*cfg));
+    ASSERT_NIL(source.start());
+    EXPECT_EQ(devs->acquire_call_count, 1);
+    ASSERT_NIL(source.restart(false));
+    EXPECT_EQ(devs->acquire_call_count, 2);
+    EXPECT_EQ(devs->dev.use_count(), 2);
+    ASSERT_NIL(source.stop());
+    EXPECT_EQ(devs->dev.use_count(), 1);
 }
 }

--- a/driver/labjack/write_task.h
+++ b/driver/labjack/write_task.h
@@ -141,8 +141,11 @@ struct WriteTaskConfig : ::synnax::labjack::WriteConfig {
 class WriteSink final : public common::Sink {
     /// @brief the configuration for the sink.
     const WriteTaskConfig cfg;
-    /// @brief the API of the device we're writing to.
-    const std::shared_ptr<device::Device> dev;
+    /// @brief acquires the device on each start.
+    const std::shared_ptr<device::Manager> devs;
+    /// @brief the API of the device we're writing to. Populated on start and
+    /// released on stop.
+    std::shared_ptr<device::Device> dev;
     /// @brief the buffer of ports to use for the next write.
     std::vector<const char *> ports_buf;
     /// @brief the buffer of values to use for the next write.
@@ -152,7 +155,10 @@ class WriteSink final : public common::Sink {
     x::errors::Error curr_dev_err = x::errors::NIL;
 
 public:
-    explicit WriteSink(const std::shared_ptr<device::Device> &dev, WriteTaskConfig cfg):
+    explicit WriteSink(
+        const std::shared_ptr<device::Manager> &devs,
+        WriteTaskConfig cfg
+    ):
         Sink(
             cfg.state_rate,
             cfg.state_index_keys,
@@ -161,7 +167,7 @@ public:
             cfg.data_saving_disabled
         ),
         cfg(std::move(cfg)),
-        dev(dev) {}
+        devs(devs) {}
 
     /// @brief clears the current write port and values buffer and re-reserves it
     /// to the allocated size.
@@ -172,8 +178,25 @@ public:
         this->values_buf.reserve(alloc);
     }
 
-    /// @brief starts the sink, pulling values to their initial state.
-    x::errors::Error start() override { return this->write_curr_state_to_dev(); }
+    /// @brief claims the device and pulls values to their initial state. Claiming
+    /// on every start means a device that disconnects and returns between runs
+    /// gets a fresh LJM handle on the next start.
+    x::errors::Error start() override {
+        auto [d, err] = this->devs->acquire(this->cfg.device);
+        if (err) return err;
+        this->dev = std::move(d);
+        if (const auto write_err = this->write_curr_state_to_dev()) {
+            this->dev.reset();
+            return write_err;
+        }
+        return x::errors::NIL;
+    }
+
+    /// @brief releases the claim on the device.
+    x::errors::Error stop() override {
+        this->dev.reset();
+        return x::errors::NIL;
+    }
 
     x::errors::Error write_curr_state_to_dev() {
         /// pull all values to the initial state (which is the current state).

--- a/driver/labjack/write_task_test.cpp
+++ b/driver/labjack/write_task_test.cpp
@@ -112,11 +112,15 @@ TEST_F(SinkClaimTest, testSinkReleasesClaimOnFailedInitialWrite) {
     mock_dev->set_should_fail(true);
     devs = std::make_shared<device::MockManager>(mock_dev);
     WriteSink sink(devs, std::move(*cfg));
+    // The local mock_dev and the manager both hold the device.
+    EXPECT_EQ(devs->dev.use_count(), 2);
     ASSERT_OCCURRED_AS(sink.start(), x::errors::Error("mock failure"));
-    EXPECT_EQ(devs->dev.use_count(), 1);
+    EXPECT_EQ(devs->dev.use_count(), 2);
     mock_dev->set_should_fail(false);
     ASSERT_NIL(sink.start());
     EXPECT_EQ(devs->acquire_call_count, 2);
+    EXPECT_EQ(devs->dev.use_count(), 3);
     ASSERT_NIL(sink.stop());
+    EXPECT_EQ(devs->dev.use_count(), 2);
 }
 }

--- a/driver/labjack/write_task_test.cpp
+++ b/driver/labjack/write_task_test.cpp
@@ -1,0 +1,122 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+#include "gtest/gtest.h"
+
+#include "client/cpp/testutil/testutil.h"
+#include "x/cpp/json/json.h"
+#include "x/cpp/test/test.h"
+
+#include "driver/labjack/device/mock.h"
+#include "driver/labjack/write_task.h"
+
+namespace driver::labjack {
+class SinkClaimTest : public ::testing::Test {
+protected:
+    std::unique_ptr<WriteTaskConfig> cfg;
+    std::shared_ptr<device::MockManager> devs;
+    synnax::channel::Channel state_idx_ch = synnax::channel::Channel{
+        .name = make_unique_channel_name("state_idx_ch"),
+        .data_type = x::telem::TIMESTAMP_T,
+        .is_index = true
+    };
+    synnax::channel::Channel state_ch = synnax::channel::Channel{
+        .name = make_unique_channel_name("state_ch"),
+        .data_type = x::telem::FLOAT64_T
+    };
+    synnax::channel::Channel cmd_ch = synnax::channel::Channel{
+        .name = make_unique_channel_name("cmd_ch"),
+        .data_type = x::telem::FLOAT64_T,
+        .is_virtual = true
+    };
+
+    void parse_config() {
+        auto client = std::make_shared<synnax::Synnax>(new_test_client());
+        auto rack = ASSERT_NIL_P(client->racks.create("cat"));
+        auto dev = synnax::device::Device{
+            .key = "230227d9-02aa-47e4-b370-0d590add1bc1",
+            .rack = rack.key,
+            .location = "dev1",
+            .make = "labjack",
+            .model = "T7",
+            .name = "my_device",
+        };
+        ASSERT_NIL(client->devices.create(dev));
+        ASSERT_NIL(client->channels.create(state_idx_ch));
+        state_ch.index = state_idx_ch.key;
+        ASSERT_NIL(client->channels.create(state_ch));
+        ASSERT_NIL(client->channels.create(cmd_ch));
+
+        const x::json::json j{
+            {"device", dev.key},
+            {"state_rate", 10},
+            {"data_saving_disabled", false},
+            {"channels",
+             x::json::json::array(
+                 {{{"type", "analog"},
+                   {"key", "hCzuNC9glqc"},
+                   {"port", "DAC0"},
+                   {"disabled", false},
+                   {"cmd_channel", cmd_ch.key},
+                   {"state_channel", state_ch.key}}}
+             )}
+        };
+        auto p = x::json::Parser(j);
+        this->cfg = std::make_unique<WriteTaskConfig>(client, p);
+        ASSERT_NIL(p.error());
+        this->devs = std::make_shared<device::MockManager>();
+    }
+};
+
+/// @brief it should claim the device on start and release it on stop, so a device
+/// that disconnects and returns between runs gets a fresh handle on the next start.
+TEST_F(SinkClaimTest, testSinkClaimsDeviceOnStart) {
+    parse_config();
+    WriteSink sink(devs, std::move(*cfg));
+    EXPECT_EQ(devs->acquire_call_count, 0);
+    EXPECT_EQ(devs->dev.use_count(), 1);
+    ASSERT_NIL(sink.start());
+    EXPECT_EQ(devs->acquire_call_count, 1);
+    EXPECT_EQ(devs->dev.use_count(), 2);
+    ASSERT_NIL(sink.stop());
+    EXPECT_EQ(devs->dev.use_count(), 1);
+    ASSERT_NIL(sink.start());
+    EXPECT_EQ(devs->acquire_call_count, 2);
+    ASSERT_NIL(sink.stop());
+}
+
+/// @brief it should surface an acquire failure on start and retry the acquisition
+/// on the next start.
+TEST_F(SinkClaimTest, testSinkAcquireFailureRetriesOnNextStart) {
+    parse_config();
+    devs->acquire_errors = {x::errors::Error(ljm::CRITICAL_ERROR, "device not found")};
+    WriteSink sink(devs, std::move(*cfg));
+    ASSERT_OCCURRED_AS(sink.start(), ljm::CRITICAL_ERROR);
+    EXPECT_EQ(devs->dev.use_count(), 1);
+    ASSERT_NIL(sink.start());
+    EXPECT_EQ(devs->acquire_call_count, 2);
+    ASSERT_NIL(sink.stop());
+}
+
+/// @brief it should release the claim when the initial state write fails so the
+/// next start acquires again.
+TEST_F(SinkClaimTest, testSinkReleasesClaimOnFailedInitialWrite) {
+    parse_config();
+    auto mock_dev = std::make_shared<device::Mock>();
+    mock_dev->set_should_fail(true);
+    devs = std::make_shared<device::MockManager>(mock_dev);
+    WriteSink sink(devs, std::move(*cfg));
+    ASSERT_OCCURRED_AS(sink.start(), x::errors::Error("mock failure"));
+    EXPECT_EQ(devs->dev.use_count(), 1);
+    mock_dev->set_should_fail(false);
+    ASSERT_NIL(sink.start());
+    EXPECT_EQ(devs->acquire_call_count, 2);
+    ASSERT_NIL(sink.stop());
+}
+}

--- a/driver/modbus/factory.cpp
+++ b/driver/modbus/factory.cpp
@@ -31,14 +31,12 @@ std::pair<common::ConfigureResult, x::errors::Error> configure_read(
     common::ConfigureResult result;
     auto [cfg, err] = ReadTaskConfig::parse(ctx->client, task);
     if (err) return {std::move(result), err};
-    auto [dev, d_err] = devs->acquire(cfg.conn);
-    if (d_err) return {std::move(result), d_err};
     result.auto_start = cfg.auto_start;
     result.task = std::make_unique<common::ReadTask>(
         task,
         ctx,
         x::breaker::default_config(task.name),
-        std::make_unique<ReadTaskSource>(dev, std::move(cfg))
+        std::make_unique<ReadTaskSource>(devs, std::move(cfg))
     );
     return {std::move(result), x::errors::NIL};
 }
@@ -71,14 +69,12 @@ std::pair<common::ConfigureResult, x::errors::Error> configure_write(
     common::ConfigureResult result;
     auto [cfg, err] = WriteTaskConfig::parse(ctx->client, task);
     if (err) return {std::move(result), err};
-    auto [dev, d_err] = devs->acquire(cfg.conn);
-    if (d_err) return {std::move(result), d_err};
     result.auto_start = cfg.auto_start;
     result.task = std::make_unique<common::WriteTask>(
         task,
         ctx,
         x::breaker::default_config(task.name),
-        std::make_unique<WriteTaskSink>(dev, std::move(cfg))
+        std::make_unique<WriteTaskSink>(devs, std::move(cfg))
     );
     return {std::move(result), x::errors::NIL};
 }

--- a/driver/modbus/read_task.h
+++ b/driver/modbus/read_task.h
@@ -343,17 +343,33 @@ struct ReadTaskConfig : common::BaseReadTaskConfig {
 class ReadTaskSource final : public common::Source {
     /// @brief the configuration for the task.
     const ReadTaskConfig config;
-    /// @brief the device to read from.
+    /// @brief creates the device connection on each start.
+    const std::shared_ptr<device::Manager> devs;
+    /// @brief the device to read from. Populated on start.
     std::shared_ptr<device::Device> dev;
     /// @brief the sample clock to regulate the read rate.
     common::SoftwareTimedSampleClock sample_clock;
 
 public:
     explicit ReadTaskSource(
-        const std::shared_ptr<device::Device> &dev,
+        const std::shared_ptr<device::Manager> &devs,
         ReadTaskConfig cfg
     ):
-        config(std::move(cfg)), dev(dev), sample_clock(this->config.sample_rate) {}
+        config(std::move(cfg)), devs(devs), sample_clock(this->config.sample_rate) {}
+
+    /// @brief connects on every start so a server restart between runs cannot
+    /// leave the task reading from a dead socket.
+    x::errors::Error start() override {
+        auto [d, err] = this->devs->acquire(this->config.conn);
+        if (err) return err;
+        this->dev = std::move(d);
+        return x::errors::NIL;
+    }
+
+    x::errors::Error stop() override {
+        this->dev.reset();
+        return x::errors::NIL;
+    }
 
     common::ReadResult
     read(x::breaker::Breaker &breaker, x::telem::Frame &fr) override {

--- a/driver/modbus/read_task_test.cpp
+++ b/driver/modbus/read_task_test.cpp
@@ -295,15 +295,11 @@ TEST(ReadTask, testBasicReadTask) {
 
     auto devs = std::make_shared<device::Manager>();
 
-    auto modbus_dev = ASSERT_NIL_P(
-        devs->acquire(device::ConnectionConfig{"127.0.0.1", 1502})
-    );
-
     auto task = common::ReadTask(
         tsk,
         ctx,
         x::breaker::default_config(tsk.name),
-        std::make_unique<ReadTaskSource>(modbus_dev, std::move(*cfg)),
+        std::make_unique<ReadTaskSource>(devs, std::move(*cfg)),
         factory
     );
 
@@ -333,6 +329,105 @@ TEST(ReadTask, testBasicReadTask) {
     ASSERT_EQ(fr.contains(index_channel.key), true);
     ASSERT_EQ(fr.at<uint8_t>(data_channel.key, 0), 1);
     ASSERT_GE(fr.at<uint64_t>(index_channel.key, 0), 0);
+}
+
+/// @brief it should reconnect to a restarted server on the next start.
+TEST(ReadTask, testReconnectAfterServerRestart) {
+    mock::SlaveConfig slave_cfg;
+    slave_cfg.coils[0] = 1;
+    slave_cfg.coils[1] = 0;
+    slave_cfg.host = "127.0.0.1";
+    slave_cfg.port = 1502;
+
+    auto slave = std::make_unique<mock::Slave>(slave_cfg);
+    ASSERT_NIL(slave->start());
+
+    auto index_channel = synnax::channel::Channel{
+        .name = make_unique_channel_name("time_channel"),
+        .data_type = x::telem::TIMESTAMP_T,
+        .is_index = true,
+        .index = 0
+    };
+    auto data_channel = synnax::channel::Channel{
+        .name = make_unique_channel_name("data_channel"),
+        .data_type = x::telem::UINT8_T,
+        .is_index = false,
+        .index = index_channel.key
+    };
+
+    auto client = std::make_shared<synnax::Synnax>(new_test_client());
+    ASSERT_NIL(client->channels.create(index_channel));
+    data_channel.index = index_channel.key;
+    ASSERT_NIL(client->channels.create(data_channel));
+
+    auto rack = ASSERT_NIL_P(client->racks.create("reconnect_rack"));
+
+    auto conn_cfg = device::ConnectionConfig{"127.0.0.1", 1502};
+    x::json::json properties{{"connection", conn_cfg.to_json()}};
+    synnax::device::Device dev{
+        .key = "modbus_reconnect_dev",
+        .rack = rack.key,
+        .location = "dev1",
+        .make = "modbus",
+        .model = "Modbus Device",
+        .name = "modbus_reconnect_dev",
+        .properties = properties,
+    };
+    ASSERT_NIL(client->devices.create(dev));
+
+    auto tsk = synnax::task::Task{
+        .rack = rack.key,
+        .name = "reconnect_task",
+        .type = "modbus_read",
+    };
+
+    x::json::json j{
+        {"data_saving_disabled", true},
+        {"sample_rate", 25},
+        {"stream_rate", 25},
+        {"device", dev.key},
+        {"channels",
+         x::json::json::array(
+             {{{"type", "coil"},
+               {"disabled", false},
+               {"channel", data_channel.key},
+               {"address", 0}}}
+         )}
+    };
+    auto p = x::json::Parser(j);
+    auto cfg = std::make_unique<ReadTaskConfig>(client, p);
+    ASSERT_NIL(p.error());
+
+    auto ctx = std::make_shared<driver::task::MockContext>(client);
+    auto factory = std::make_shared<driver::pipeline::mock::WriterFactory>();
+    auto devs = std::make_shared<device::Manager>();
+
+    auto task = common::ReadTask(
+        tsk,
+        ctx,
+        x::breaker::default_config(tsk.name),
+        std::make_unique<ReadTaskSource>(devs, std::move(*cfg)),
+        factory
+    );
+
+    task.start("start_cmd");
+    ASSERT_EVENTUALLY_GE(ctx->statuses.size(), 1);
+    EXPECT_EQ(ctx->statuses[0].variant, synnax::status::VARIANT_SUCCESS);
+    ASSERT_EVENTUALLY_GE(factory->writer_opens.load(std::memory_order_acquire), 1);
+    task.stop("stop_cmd", true);
+    ASSERT_EVENTUALLY_GE(ctx->statuses.size(), 2);
+
+    slave->stop();
+    slave = std::make_unique<mock::Slave>(slave_cfg);
+    ASSERT_NIL(slave->start());
+    x::defer::defer stop_slave([&slave] { slave->stop(); });
+
+    task.start("start_cmd_2");
+    ASSERT_EVENTUALLY_GE(ctx->statuses.size(), 3);
+    EXPECT_EQ(ctx->statuses[2].variant, synnax::status::VARIANT_SUCCESS);
+    EXPECT_EQ(ctx->statuses[2].message, "Task started successfully");
+    ASSERT_EVENTUALLY_GE(factory->writer_opens.load(std::memory_order_acquire), 2);
+    task.stop("stop_cmd_2", true);
 }
 
 /// @brief it should read discrete input values from Modbus device.
@@ -365,10 +460,6 @@ TEST_F(ModbusReadTest, testDiscreteInputRead) {
     ASSERT_NIL(p.error());
 
     auto devs = std::make_shared<device::Manager>();
-    auto modbus_dev = ASSERT_NIL_P(
-        devs->acquire(device::ConnectionConfig{"127.0.0.1", 1502})
-    );
-
     auto task = common::ReadTask(
         synnax::task::Task{
             .rack = rack.key,
@@ -377,7 +468,7 @@ TEST_F(ModbusReadTest, testDiscreteInputRead) {
         },
         ctx,
         x::breaker::default_config("discrete_test"),
-        std::make_unique<ReadTaskSource>(modbus_dev, std::move(*task_cfg)),
+        std::make_unique<ReadTaskSource>(devs, std::move(*task_cfg)),
         mock_factory
     );
 
@@ -423,10 +514,6 @@ TEST_F(ModbusReadTest, testHoldingRegisterRead) {
     ASSERT_NIL(p.error());
 
     auto devs = std::make_shared<device::Manager>();
-    auto modbus_dev = ASSERT_NIL_P(
-        devs->acquire(device::ConnectionConfig{"127.0.0.1", 1502})
-    );
-
     auto task = common::ReadTask(
         synnax::task::Task{
             .rack = rack.key,
@@ -435,7 +522,7 @@ TEST_F(ModbusReadTest, testHoldingRegisterRead) {
         },
         ctx,
         x::breaker::default_config("holding_test"),
-        std::make_unique<ReadTaskSource>(modbus_dev, std::move(*task_cfg)),
+        std::make_unique<ReadTaskSource>(devs, std::move(*task_cfg)),
         mock_factory
     );
 
@@ -498,10 +585,6 @@ TEST_F(ModbusReadTest, testMultiChannelRead) {
     ASSERT_NIL(p.error());
 
     auto devs = std::make_shared<device::Manager>();
-    auto modbus_dev = ASSERT_NIL_P(
-        devs->acquire(device::ConnectionConfig{"127.0.0.1", 1502})
-    );
-
     auto task = common::ReadTask(
         synnax::task::Task{
             .rack = rack.key,
@@ -510,7 +593,7 @@ TEST_F(ModbusReadTest, testMultiChannelRead) {
         },
         ctx,
         x::breaker::default_config("multi_test"),
-        std::make_unique<ReadTaskSource>(modbus_dev, std::move(*task_cfg)),
+        std::make_unique<ReadTaskSource>(devs, std::move(*task_cfg)),
         mock_factory
     );
 
@@ -595,10 +678,6 @@ TEST_F(ModbusReadTest, testMultipleUint8InputRegisters) {
     ASSERT_NIL(p.error());
 
     auto devs = std::make_shared<device::Manager>();
-    auto modbus_dev = ASSERT_NIL_P(
-        devs->acquire(device::ConnectionConfig{"127.0.0.1", 1502})
-    );
-
     auto task = common::ReadTask(
         synnax::task::Task{
             .rack = rack.key,
@@ -607,7 +686,7 @@ TEST_F(ModbusReadTest, testMultipleUint8InputRegisters) {
         },
         ctx,
         x::breaker::default_config("uint8_test"),
-        std::make_unique<ReadTaskSource>(modbus_dev, std::move(*task_cfg)),
+        std::make_unique<ReadTaskSource>(devs, std::move(*task_cfg)),
         mock_factory
     );
 
@@ -667,10 +746,6 @@ TEST_F(ModbusReadTest, testMultipleUint8HoldingRegisters) {
     ASSERT_NIL(p.error());
 
     auto devs = std::make_shared<device::Manager>();
-    auto modbus_dev = ASSERT_NIL_P(
-        devs->acquire(device::ConnectionConfig{"127.0.0.1", 1502})
-    );
-
     auto task = common::ReadTask(
         synnax::task::Task{
             .rack = rack.key,
@@ -679,7 +754,7 @@ TEST_F(ModbusReadTest, testMultipleUint8HoldingRegisters) {
         },
         ctx,
         x::breaker::default_config("uint8_holding_test"),
-        std::make_unique<ReadTaskSource>(modbus_dev, std::move(*task_cfg)),
+        std::make_unique<ReadTaskSource>(devs, std::move(*task_cfg)),
         mock_factory
     );
 

--- a/driver/modbus/write_task.h
+++ b/driver/modbus/write_task.h
@@ -221,14 +221,30 @@ struct WriteTaskConfig : common::BaseWriteTaskConfig {
 class WriteTaskSink final : public common::Sink {
     /// @brief the configuration for the task.
     const WriteTaskConfig config;
-    /// @brief the device to write to.
+    /// @brief creates the device connection on each start.
+    const std::shared_ptr<device::Manager> devs;
+    /// @brief the device to write to. Populated on start.
     std::shared_ptr<device::Device> dev;
 
 public:
-    WriteTaskSink(const std::shared_ptr<device::Device> &dev, WriteTaskConfig cfg):
+    WriteTaskSink(const std::shared_ptr<device::Manager> &devs, WriteTaskConfig cfg):
         Sink(x::telem::Rate(0), {}, {}, cfg.cmd_keys(), cfg.data_saving_disabled),
         config(std::move(cfg)),
-        dev(dev) {}
+        devs(devs) {}
+
+    /// @brief connects on every start so a server restart between runs cannot
+    /// leave the task writing to a dead socket.
+    x::errors::Error start() override {
+        auto [d, err] = this->devs->acquire(this->config.conn);
+        if (err) return err;
+        this->dev = std::move(d);
+        return x::errors::NIL;
+    }
+
+    x::errors::Error stop() override {
+        this->dev.reset();
+        return x::errors::NIL;
+    }
 
     x::errors::Error write(x::telem::Frame &frame) override {
         for (const auto &writer: config.writers)

--- a/driver/modbus/write_task_test.cpp
+++ b/driver/modbus/write_task_test.cpp
@@ -115,13 +115,11 @@ TEST_F(ModbusWriteTest, testBasicWrite) {
         reads
     );
 
-    auto dev = ASSERT_NIL_P(devs->acquire(cfg->conn));
-
     auto wt = std::make_unique<common::WriteTask>(
         task,
         ctx,
         x::breaker::default_config(task.name),
-        std::make_unique<WriteTaskSink>(dev, std::move(*cfg)),
+        std::make_unique<WriteTaskSink>(devs, std::move(*cfg)),
         nullptr,
         mock_streamer_factory
     );
@@ -223,13 +221,11 @@ TEST_F(ModbusWriteTest, testMultipleDataTypes) {
         reads
     );
 
-    auto dev = ASSERT_NIL_P(devs->acquire(cfg->conn));
-
     auto wt = std::make_unique<common::WriteTask>(
         task,
         ctx,
         x::breaker::default_config(task.name),
-        std::make_unique<WriteTaskSink>(dev, std::move(*cfg)),
+        std::make_unique<WriteTaskSink>(devs, std::move(*cfg)),
         nullptr,
         mock_streamer_factory
     );
@@ -383,13 +379,11 @@ TEST_F(ModbusWriteTest, testConcurrentWrites) {
         reads
     );
 
-    auto dev = ASSERT_NIL_P(devs->acquire(cfg->conn));
-
     auto wt = std::make_unique<common::WriteTask>(
         task,
         ctx,
         x::breaker::default_config(task.name),
-        std::make_unique<WriteTaskSink>(dev, std::move(*cfg)),
+        std::make_unique<WriteTaskSink>(devs, std::move(*cfg)),
         nullptr,
         mock_streamer_factory
     );
@@ -451,13 +445,11 @@ TEST_F(ModbusWriteTest, testWriteVerification) {
         reads
     );
 
-    auto dev = ASSERT_NIL_P(devs->acquire(cfg->conn));
-
     auto wt = std::make_unique<common::WriteTask>(
         task,
         ctx,
         x::breaker::default_config(task.name),
-        std::make_unique<WriteTaskSink>(dev, std::move(*cfg)),
+        std::make_unique<WriteTaskSink>(devs, std::move(*cfg)),
         nullptr,
         mock_streamer_factory
     );
@@ -534,13 +526,11 @@ TEST_F(ModbusWriteTest, testLastWriteWins) {
         reads
     );
 
-    auto dev = ASSERT_NIL_P(devs->acquire(cfg->conn));
-
     auto wt = std::make_unique<common::WriteTask>(
         task,
         ctx,
         x::breaker::default_config(task.name),
-        std::make_unique<WriteTaskSink>(dev, std::move(*cfg)),
+        std::make_unique<WriteTaskSink>(devs, std::move(*cfg)),
         nullptr,
         mock_streamer_factory
     );
@@ -625,13 +615,11 @@ TEST_F(ModbusWriteTest, testMultipleUint8HoldingRegisters) {
         reads
     );
 
-    auto dev = ASSERT_NIL_P(devs->acquire(cfg->conn));
-
     auto wt = std::make_unique<common::WriteTask>(
         task,
         ctx,
         x::breaker::default_config(task.name),
-        std::make_unique<WriteTaskSink>(dev, std::move(*cfg)),
+        std::make_unique<WriteTaskSink>(devs, std::move(*cfg)),
         nullptr,
         mock_streamer_factory
     );

--- a/driver/ni/channel/scale.h
+++ b/driver/ni/channel/scale.h
@@ -45,6 +45,10 @@ struct Scale {
 struct BaseScale : Scale {
     const std::string scaled_units;
     const int pre_scaled_units;
+    /// @brief key of the scale created on the first apply. DAQmx scales are
+    /// process-global, so later applies reuse the definition instead of minting a
+    /// new one per run.
+    std::string key;
 
     bool is_none() override { return false; }
 
@@ -68,17 +72,18 @@ struct LinearScale final : BaseScale {
 
     std::pair<std::string, x::errors::Error>
     apply(const std::shared_ptr<daqmx::SugaredAPI> &dmx) override {
-        auto key = next_scale_key();
-        return {
-            key,
-            dmx->CreateLinScale(
-                key.c_str(),
+        if (!this->key.empty()) return {this->key, x::errors::NIL};
+        const auto k = next_scale_key();
+        if (const auto err = dmx->CreateLinScale(
+                k.c_str(),
                 this->slope,
                 this->offset,
                 this->pre_scaled_units,
                 this->scaled_units.c_str()
-            )
-        };
+            ))
+            return {"", err};
+        this->key = k;
+        return {k, x::errors::NIL};
     }
 };
 
@@ -104,19 +109,20 @@ struct MapScale final : BaseScale {
 
     std::pair<std::string, x::errors::Error>
     apply(const std::shared_ptr<daqmx::SugaredAPI> &dmx) override {
-        auto key = next_scale_key();
-        return {
-            key,
-            dmx->CreateMapScale(
-                key.c_str(),
+        if (!this->key.empty()) return {this->key, x::errors::NIL};
+        const auto k = next_scale_key();
+        if (const auto err = dmx->CreateMapScale(
+                k.c_str(),
                 this->pre_scaled_min,
                 this->pre_scaled_max,
                 this->scaled_min,
                 this->scaled_max,
                 this->pre_scaled_units,
                 this->scaled_units.c_str()
-            )
-        };
+            ))
+            return {"", err};
+        this->key = k;
+        return {k, x::errors::NIL};
     }
 };
 
@@ -136,19 +142,20 @@ struct PolynomialScale final : BaseScale {
 
     std::pair<std::string, x::errors::Error>
     apply(const std::shared_ptr<daqmx::SugaredAPI> &dmx) override {
-        auto key = next_scale_key();
-        return {
-            key,
-            dmx->CreatePolynomialScale(
-                key.c_str(),
+        if (!this->key.empty()) return {this->key, x::errors::NIL};
+        const auto k = next_scale_key();
+        if (const auto err = dmx->CreatePolynomialScale(
+                k.c_str(),
                 this->forward_coeffs.data(),
                 this->forward_coeffs.size(),
                 this->reverse_coeffs.data(),
                 this->reverse_coeffs.size(),
                 this->pre_scaled_units,
                 this->scaled_units.c_str()
-            )
-        };
+            ))
+            return {"", err};
+        this->key = k;
+        return {k, x::errors::NIL};
     }
 };
 
@@ -168,19 +175,20 @@ struct TableScale final : BaseScale {
 
     std::pair<std::string, x::errors::Error>
     apply(const std::shared_ptr<daqmx::SugaredAPI> &dmx) override {
-        auto key = next_scale_key();
-        return {
-            key,
-            dmx->CreateTableScale(
-                key.c_str(),
+        if (!this->key.empty()) return {this->key, x::errors::NIL};
+        const auto k = next_scale_key();
+        if (const auto err = dmx->CreateTableScale(
+                k.c_str(),
                 this->pre_scaled.data(),
                 this->pre_scaled.size(),
                 this->scaled.data(),
                 this->pre_scaled.size(),
                 this->pre_scaled_units,
                 this->scaled_units.c_str()
-            )
-        };
+            ))
+            return {"", err};
+        this->key = k;
+        return {k, x::errors::NIL};
     }
 };
 

--- a/driver/ni/hardware/hardware.h
+++ b/driver/ni/hardware/hardware.h
@@ -204,6 +204,40 @@ public:
     ReadResult read(size_t samples_per_channel, std::vector<T> &data) override;
 };
 
+/// @brief forwards to a shared mock reader so tests that build hardware on every
+/// start keep one scripted mock across runs.
+template<typename T>
+class SharedReader final : public hardware::Reader<T> {
+    std::shared_ptr<hardware::Reader<T>> wrapped;
+
+public:
+    explicit SharedReader(std::shared_ptr<hardware::Reader<T>> wrapped):
+        wrapped(std::move(wrapped)) {}
+
+    x::errors::Error start() override { return this->wrapped->start(); }
+    x::errors::Error stop() override { return this->wrapped->stop(); }
+    ReadResult read(size_t samples_per_channel, std::vector<T> &data) override {
+        return this->wrapped->read(samples_per_channel, data);
+    }
+};
+
+/// @brief forwards to a shared mock writer so tests that build hardware on every
+/// start keep one scripted mock across runs.
+template<typename T>
+class SharedWriter final : public hardware::Writer<T> {
+    std::shared_ptr<hardware::Writer<T>> wrapped;
+
+public:
+    explicit SharedWriter(std::shared_ptr<hardware::Writer<T>> wrapped):
+        wrapped(std::move(wrapped)) {}
+
+    x::errors::Error start() override { return this->wrapped->start(); }
+    x::errors::Error stop() override { return this->wrapped->stop(); }
+    x::errors::Error write(const std::vector<T> &data) override {
+        return this->wrapped->write(data);
+    }
+};
+
 /// @brief Mock implementation of Writer interface for testing
 /// @tparam T The data type to write (uint8_t for digital, double for analog)
 template<typename T>

--- a/driver/ni/ni.h
+++ b/driver/ni/ni.h
@@ -119,29 +119,28 @@ public:
         common::ConfigureResult result;
         auto [cfg, cfg_err] = ConfigT::parse(ctx->client, task, this->timing_cfg);
         if (cfg_err) return {std::move(result), cfg_err};
-        TaskHandle handle;
         const std::string dmx_task_name = task.name + " (" + task.key.to_string() + ")";
-        if (const auto err = this->dmx->CreateTask(dmx_task_name.c_str(), &handle))
-            return {std::move(result), err};
-        // Very important that we instantiate the Hardware API here, as we pass
-        // ownership over the lifecycle of the task handle to it. If we encounter
-        // any errors when applying the configuration or cycling the task, we need
-        // to make sure it gets cleared.
-        auto hw = std::make_unique<HardwareT>(this->dmx, handle);
-        if (const auto err = cfg.apply(this->dmx, handle))
-            return {std::move(result), err};
-        // NI will look for invalid configuration parameters internally, so we
-        // quickly cycle the task to catch and communicate any errors as
-        // soon as possible.
-        if (const auto err = hw->start()) return {std::move(result), err};
-        if (const auto err = hw->stop()) return {std::move(result), err};
+        using Hardware = typename SourceSinkT::Hardware;
+        typename SourceSinkT::MakeHardware make_hw =
+            [dmx = this->dmx, dmx_task_name](
+                const ConfigT &run_cfg
+            ) -> std::pair<std::unique_ptr<Hardware>, x::errors::Error> {
+            TaskHandle handle = nullptr;
+            if (const auto err = dmx->CreateTask(dmx_task_name.c_str(), &handle))
+                return {nullptr, err};
+            // The hardware owns the handle from here, so a failed apply still
+            // clears it.
+            auto hw = std::make_unique<HardwareT>(dmx, handle);
+            if (const auto err = run_cfg.apply(dmx, handle)) return {nullptr, err};
+            return {std::move(hw), x::errors::NIL};
+        };
+        result.auto_start = cfg.auto_start;
         result.task = std::make_unique<TaskT>(
             task,
             ctx,
             x::breaker::default_config(task.name),
-            std::make_unique<SourceSinkT>(std::move(cfg), std::move(hw))
+            std::make_unique<SourceSinkT>(std::move(cfg), std::move(make_hw))
         );
-        result.auto_start = cfg.auto_start;
         return {std::move(result), x::errors::NIL};
     }
 

--- a/driver/ni/read_task.h
+++ b/driver/ni/read_task.h
@@ -294,6 +294,8 @@ private:
     }
 
     x::errors::Error start() override {
+        // DAQmx rejects a second task with a live task's name.
+        this->hw_reader.reset();
         auto [hw, err] = this->make_hw(this->cfg);
         if (err) return err;
         this->hw_reader = std::move(hw);

--- a/driver/ni/read_task.h
+++ b/driver/ni/read_task.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <functional>
 #include <set>
 #include <sstream>
 #include <string>
@@ -170,9 +171,7 @@ struct ReadTaskConfig : common::BaseReadTaskConfig {
         return chs;
     }
 
-    [[nodiscard]]
-
-    x::errors::Error apply(
+    [[nodiscard]] x::errors::Error apply(
         const std::shared_ptr<daqmx::SugaredAPI> &dmx,
         const TaskHandle handle
     ) const {
@@ -258,25 +257,31 @@ struct ReadTaskConfig : common::BaseReadTaskConfig {
 template<typename T>
 class ReadTaskSource final : public common::Source {
 public:
+    /// @brief the hardware interface this source reads from.
+    using Hardware = hardware::Reader<T>;
+    /// @brief builds the hardware for a run. Called on every start so each run
+    /// claims a fresh DAQmx task instead of reusing a handle from a prior run.
+    using MakeHardware = std::function<
+        std::pair<std::unique_ptr<Hardware>, x::errors::Error>(const ReadTaskConfig &)>;
+
     /// @brief constructs a source bound to the provided parent read task.
-    explicit ReadTaskSource(
-        ReadTaskConfig cfg,
-        std::unique_ptr<hardware::Reader<T>> hw_reader
-    ):
+    explicit ReadTaskSource(ReadTaskConfig cfg, MakeHardware make_hw):
         cfg(std::move(cfg)),
         buf(this->cfg.samples_per_chan * this->cfg.channels.size()),
-        hw_reader(std::move(hw_reader)),
+        make_hw(std::move(make_hw)),
         sample_clock(this->cfg.sample_clock()) {}
 
 private:
-    /// @brief the raw synnax task configuration.
     /// @brief the parsed configuration for the task.
     const ReadTaskConfig cfg;
     /// @brief the buffer used to read data from the hardware. This vector is
     /// pre-allocated and reused.
     std::vector<T> buf;
-    /// @brief interface used to read data from the hardware.
-    std::unique_ptr<hardware::Reader<T>> hw_reader;
+    /// @brief builds the hardware for each run.
+    MakeHardware make_hw;
+    /// @brief interface used to read data from the hardware. Populated on start
+    /// and released on stop.
+    std::unique_ptr<Hardware> hw_reader;
     /// @brief the timestamp at which the hardware task was started. We use this to
     /// interpolate the correct timestamps of recorded samples.
     std::unique_ptr<common::SampleClock> sample_clock;
@@ -289,18 +294,27 @@ private:
     }
 
     x::errors::Error start() override {
+        auto [hw, err] = this->make_hw(this->cfg);
+        if (err) return err;
+        this->hw_reader = std::move(hw);
         this->sample_clock->reset();
-        auto err = this->hw_reader->start();
+        if (const auto start_err = this->hw_reader->start()) {
+            this->hw_reader.reset();
+            return start_err;
+        }
+        return x::errors::NIL;
+    }
+
+    x::errors::Error stop() override {
+        if (this->hw_reader == nullptr) return x::errors::NIL;
+        const auto err = this->hw_reader->stop();
+        this->hw_reader.reset();
         return err;
     }
 
-    x::errors::Error stop() override { return this->hw_reader->stop(); }
-
     x::errors::Error restart() {
-        if (const auto err = this->hw_reader->stop()) return err;
-        if (const auto err = this->hw_reader->start()) return err;
-        this->sample_clock->reset();
-        return x::errors::NIL;
+        if (const auto err = this->stop()) return err;
+        return this->start();
     }
 
     [[nodiscard]] synnax::framer::WriterConfig writer_config() const override {
@@ -310,6 +324,14 @@ private:
     common::ReadResult
     read(x::breaker::Breaker &breaker, x::telem::Frame &fr) override {
         common::ReadResult res;
+        // A failed in-loop restart leaves no hardware, so claim it again before
+        // reading. The pipeline retries temporary errors, giving recovery a
+        // chance on every attempt.
+        if (this->hw_reader == nullptr) {
+            res.error = translate_error(this->start());
+            this->curr_read_err = res.error;
+            if (res.error) return res;
+        }
         const auto n_channels = this->cfg.channels.size();
         const auto n_samples = this->cfg.samples_per_chan;
         common::initialize_frame(fr, this->cfg.channels, this->cfg.indexes, n_samples);

--- a/driver/ni/read_task_test.cpp
+++ b/driver/ni/read_task_test.cpp
@@ -215,6 +215,8 @@ protected:
     std::unique_ptr<ni::ReadTaskConfig> cfg;
     std::shared_ptr<task::MockContext> ctx;
     std::shared_ptr<pipeline::mock::WriterFactory> mock_factory;
+    std::shared_ptr<hardware::mock::Reader<double>> mock_hw;
+    std::size_t make_hw_calls = 0;
     synnax::channel::Channel index_channel = synnax::channel::Channel{
         .name = make_unique_channel_name("time_channel"),
         .data_type = x::telem::TIMESTAMP_T,
@@ -289,14 +291,29 @@ protected:
     }
 
     std::unique_ptr<common::ReadTask>
-    create_task(std::unique_ptr<hardware::mock::Reader<double>> mock_hw) {
+    create_task(std::unique_ptr<hardware::mock::Reader<double>> hw) {
+        this->mock_hw = std::move(hw);
+        ni::ReadTaskSource<double>::MakeHardware make_hw =
+            [this](const ni::ReadTaskConfig &)
+            -> std::pair<std::unique_ptr<hardware::Reader<double>>, x::errors::Error> {
+            ++this->make_hw_calls;
+            return {
+                std::make_unique<hardware::mock::SharedReader<double>>(this->mock_hw),
+                x::errors::NIL
+            };
+        };
+        return this->create_task(std::move(make_hw));
+    }
+
+    std::unique_ptr<common::ReadTask>
+    create_task(ni::ReadTaskSource<double>::MakeHardware make_hw) {
         return std::make_unique<common::ReadTask>(
             task,
             ctx,
             x::breaker::default_config(task.name),
             std::make_unique<ni::ReadTaskSource<double>>(
                 std::move(*cfg),
-                std::move(mock_hw)
+                std::move(make_hw)
             ),
             mock_factory
         );
@@ -512,6 +529,73 @@ TEST_F(AnalogReadTest, testDoubleStop) {
     EXPECT_EQ(stop_state_2.message, "Task stopped successfully");
 }
 
+/// @brief every start should claim fresh hardware and every stop should release
+/// it, so a device that disconnects and returns between runs gets a new DAQmx
+/// task on the next start.
+TEST_F(AnalogReadTest, testStartClaimsFreshHardware) {
+    parse_config();
+    const auto rt = create_task(std::make_unique<hardware::mock::Reader<double>>());
+
+    rt->start("start_cmd");
+    ASSERT_EVENTUALLY_GE(ctx->statuses.size(), 1);
+    EXPECT_EQ(make_hw_calls, 1);
+    // The fixture and the running source both hold the mock.
+    EXPECT_EQ(mock_hw.use_count(), 2);
+
+    rt->stop("stop_cmd", true);
+    ASSERT_EVENTUALLY_GE(ctx->statuses.size(), 2);
+    // The stop released the source's claim on the hardware.
+    EXPECT_EQ(mock_hw.use_count(), 1);
+
+    rt->start("start_cmd_2");
+    ASSERT_EVENTUALLY_GE(ctx->statuses.size(), 3);
+    EXPECT_EQ(make_hw_calls, 2);
+    EXPECT_EQ(ctx->statuses[2].variant, synnax::status::VARIANT_SUCCESS);
+    rt->stop("stop_cmd_2", true);
+}
+
+/// @brief a start whose hardware build fails should report the error and leave
+/// the task able to start once the hardware comes back.
+TEST_F(AnalogReadTest, testHardwareBuildFailureRetriesOnNextStart) {
+    parse_config();
+    mock_hw = std::make_shared<hardware::mock::Reader<double>>();
+    size_t calls = 0;
+    const auto rt = create_task(
+        [&](
+            const ni::ReadTaskConfig &
+        ) -> std::pair<std::unique_ptr<hardware::Reader<double>>, x::errors::Error> {
+            if (++calls == 1)
+                return {
+                    nullptr,
+                    x::errors::Error(
+                        errors::CRITICAL_HARDWARE_ERROR,
+                        "device not found"
+                    )
+                };
+            return {
+                std::make_unique<hardware::mock::SharedReader<double>>(mock_hw),
+                x::errors::NIL
+            };
+        }
+    );
+
+    rt->start("start_cmd");
+    ASSERT_EVENTUALLY_GE(ctx->statuses.size(), 1);
+    const auto failed = ctx->statuses[0];
+    EXPECT_EQ(failed.details.cmd, "start_cmd");
+    EXPECT_EQ(failed.variant, synnax::status::VARIANT_ERROR);
+    EXPECT_EQ(failed.message, "device not found");
+
+    rt->start("start_cmd_2");
+    ASSERT_EVENTUALLY_GE(ctx->statuses.size(), 2);
+    const auto recovered = ctx->statuses[1];
+    EXPECT_EQ(recovered.details.cmd, "start_cmd_2");
+    EXPECT_EQ(recovered.variant, synnax::status::VARIANT_SUCCESS);
+    EXPECT_EQ(recovered.message, "Task started successfully");
+    EXPECT_EQ(calls, 2);
+    rt->stop("stop_cmd", true);
+}
+
 class DigitalReadTest : public ::testing::Test {
 protected:
     std::shared_ptr<synnax::Synnax> client;
@@ -519,6 +603,7 @@ protected:
     std::unique_ptr<ni::ReadTaskConfig> cfg;
     std::shared_ptr<task::MockContext> ctx;
     std::shared_ptr<pipeline::mock::WriterFactory> mock_factory;
+    std::shared_ptr<hardware::mock::Reader<uint8_t>> mock_hw;
     synnax::channel::Channel index_channel = synnax::channel::Channel{
         .name = make_unique_channel_name("time_channel"),
         .data_type = x::telem::TIMESTAMP_T,
@@ -582,14 +667,22 @@ protected:
     }
 
     std::unique_ptr<common::ReadTask>
-    create_task(std::unique_ptr<hardware::mock::Reader<uint8_t>> mock_hw) {
+    create_task(std::unique_ptr<hardware::mock::Reader<uint8_t>> hw) {
+        this->mock_hw = std::move(hw);
+        ReadTaskSource<uint8_t>::MakeHardware make_hw = [this](const ReadTaskConfig &)
+            -> std::pair<std::unique_ptr<hardware::Reader<uint8_t>>, x::errors::Error> {
+            return {
+                std::make_unique<hardware::mock::SharedReader<uint8_t>>(this->mock_hw),
+                x::errors::NIL
+            };
+        };
         return std::make_unique<common::ReadTask>(
             task,
             ctx,
             x::breaker::default_config(task.name),
             std::make_unique<ReadTaskSource<uint8_t>>(
                 std::move(*cfg),
-                std::move(mock_hw)
+                std::move(make_hw)
             ),
             mock_factory
         );
@@ -708,6 +801,7 @@ protected:
     std::unique_ptr<ni::ReadTaskConfig> cfg;
     std::shared_ptr<task::MockContext> ctx;
     std::shared_ptr<pipeline::mock::WriterFactory> mock_factory;
+    std::shared_ptr<hardware::mock::Reader<double>> mock_hw;
     synnax::channel::Channel index_channel = synnax::channel::Channel{
         .name = make_unique_channel_name("time_channel"),
         .data_type = x::telem::TIMESTAMP_T,
@@ -780,14 +874,23 @@ protected:
     }
 
     std::unique_ptr<common::ReadTask>
-    create_task(std::unique_ptr<hardware::mock::Reader<double>> mock_hw) {
+    create_task(std::unique_ptr<hardware::mock::Reader<double>> hw) {
+        this->mock_hw = std::move(hw);
+        ni::ReadTaskSource<double>::MakeHardware make_hw =
+            [this](const ni::ReadTaskConfig &)
+            -> std::pair<std::unique_ptr<hardware::Reader<double>>, x::errors::Error> {
+            return {
+                std::make_unique<hardware::mock::SharedReader<double>>(this->mock_hw),
+                x::errors::NIL
+            };
+        };
         return std::make_unique<common::ReadTask>(
             task,
             ctx,
             x::breaker::default_config(task.name),
             std::make_unique<ni::ReadTaskSource<double>>(
                 std::move(*cfg),
-                std::move(mock_hw)
+                std::move(make_hw)
             ),
             mock_factory
         );

--- a/driver/ni/read_task_test.cpp
+++ b/driver/ni/read_task_test.cpp
@@ -596,6 +596,49 @@ TEST_F(AnalogReadTest, testHardwareBuildFailureRetriesOnNextStart) {
     rt->stop("stop_cmd", true);
 }
 
+/// @brief a failed in-loop restart should claim fresh hardware on the next read
+/// attempt instead of dereferencing released hardware.
+TEST_F(AnalogReadTest, testFailedInLoopRestartReclaimsOnNextRead) {
+    parse_config();
+    mock_hw = std::make_shared<hardware::mock::Reader<double>>(
+        std::vector{x::errors::NIL},
+        std::vector{x::errors::NIL},
+        std::vector<hardware::mock::Reader<double>::ReadResponse>{
+            {.error = daqmx::RESOURCE_RESERVED},
+            {.data = {0.5}}
+        }
+    );
+    size_t calls = 0;
+    const auto rt = create_task(
+        [&](
+            const ni::ReadTaskConfig &
+        ) -> std::pair<std::unique_ptr<hardware::Reader<double>>, x::errors::Error> {
+            if (++calls == 2) return {nullptr, daqmx::TEMPORARILY_UNREACHABLE};
+            return {
+                std::make_unique<hardware::mock::SharedReader<double>>(mock_hw),
+                x::errors::NIL
+            };
+        }
+    );
+
+    rt->start("start_cmd");
+    // Read 1 hits RESOURCE_RESERVED and triggers an in-loop restart whose build
+    // fails, releasing the hardware. The retried read claims build 3 and recovers.
+    ASSERT_EVENTUALLY_GE_WITH_TIMEOUT(
+        calls,
+        3,
+        std::chrono::seconds(10),
+        std::chrono::milliseconds(10)
+    );
+    ASSERT_EVENTUALLY_GE_WITH_TIMEOUT(
+        mock_factory->writes->size(),
+        1,
+        std::chrono::seconds(10),
+        std::chrono::milliseconds(10)
+    );
+    rt->stop("stop_cmd", true);
+}
+
 class DigitalReadTest : public ::testing::Test {
 protected:
     std::shared_ptr<synnax::Synnax> client;

--- a/driver/ni/read_task_test.cpp
+++ b/driver/ni/read_task_test.cpp
@@ -7,6 +7,8 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+#include <algorithm>
+#include <atomic>
 #include <utility>
 
 #include "gtest/gtest.h"
@@ -637,6 +639,56 @@ TEST_F(AnalogReadTest, testFailedInLoopRestartReclaimsOnNextRead) {
         std::chrono::milliseconds(10)
     );
     rt->stop("stop_cmd", true);
+}
+
+/// @brief a reader that counts the instances currently alive.
+template<typename T>
+class CountingReader final : public hardware::Reader<T> {
+    std::shared_ptr<std::atomic<int>> live;
+
+public:
+    explicit CountingReader(std::shared_ptr<std::atomic<int>> live):
+        live(std::move(live)) {
+        this->live->fetch_add(1);
+    }
+
+    ~CountingReader() { this->live->fetch_sub(1); }
+
+    x::errors::Error start() override { return x::errors::NIL; }
+    x::errors::Error stop() override { return x::errors::NIL; }
+
+    hardware::ReadResult read(size_t, std::vector<T> &) override {
+        hardware::ReadResult res;
+        return res;
+    }
+};
+
+/// @brief a start must never build hardware over a live claim: DAQmx names each task
+/// after the Synnax task and rejects a duplicate name.
+TEST_F(AnalogReadTest, testStartNeverBuildsOverALiveClaim) {
+    parse_config();
+    const auto live = std::make_shared<std::atomic<int>>(0);
+    size_t builds = 0;
+    int live_at_build = 0;
+    const std::unique_ptr<common::Source> source = std::make_unique<
+        ni::ReadTaskSource<double>>(
+        std::move(*cfg),
+        [&](const ni::ReadTaskConfig &)
+            -> std::pair<std::unique_ptr<hardware::Reader<double>>, x::errors::Error> {
+            ++builds;
+            live_at_build = std::max(live_at_build, live->load());
+            return {std::make_unique<CountingReader<double>>(live), x::errors::NIL};
+        }
+    );
+
+    ASSERT_NIL(source->start());
+    EXPECT_EQ(live->load(), 1);
+    ASSERT_NIL(source->start());
+    EXPECT_EQ(builds, 2);
+    EXPECT_EQ(live_at_build, 0);
+    EXPECT_EQ(live->load(), 1);
+    ASSERT_NIL(source->stop());
+    EXPECT_EQ(live->load(), 0);
 }
 
 class DigitalReadTest : public ::testing::Test {

--- a/driver/ni/write_task.h
+++ b/driver/ni/write_task.h
@@ -142,7 +142,7 @@ struct WriteTaskConfig : ::synnax::ni::WriteConfig {
 
     /// @brief applies the configuration to the given DAQmx task.
     x::errors::Error
-    apply(const std::shared_ptr<daqmx::SugaredAPI> &dmx, TaskHandle task_handle) {
+    apply(const std::shared_ptr<daqmx::SugaredAPI> &dmx, TaskHandle task_handle) const {
         for (const auto &[_, ch]: channels)
             if (const auto err = ch->apply(dmx, task_handle)) return err;
         return x::errors::NIL;
@@ -156,11 +156,16 @@ class WriteTaskSink final : public common::Sink {
     const WriteTaskConfig cfg;
 
 public:
+    /// @brief the hardware interface this sink writes to.
+    using Hardware = hardware::Writer<T>;
+    /// @brief builds the hardware for a run. Called on every start so each run
+    /// claims a fresh DAQmx task instead of reusing a handle from a prior run.
+    using MakeHardware = std::function<
+        std::pair<std::unique_ptr<Hardware>, x::errors::Error>(const WriteTaskConfig
+                                                                   &)>;
+
     /// @brief constructs a CommandSink bound to the provided parent WriteTask.
-    explicit WriteTaskSink(
-        WriteTaskConfig cfg,
-        std::unique_ptr<hardware::Writer<T>> hw_writer
-    ):
+    explicit WriteTaskSink(WriteTaskConfig cfg, MakeHardware make_hw):
         Sink(
             cfg.state_rate,
             cfg.state_indexes(),
@@ -169,22 +174,38 @@ public:
             cfg.data_saving_disabled
         ),
         cfg(std::move(cfg)),
-        hw_writer(std::move(hw_writer)),
+        make_hw(std::move(make_hw)),
         buf(this->cfg.channels.size()) {}
 
 private:
-    /// @brief the underlying DAQmx hardware we write data to.
-    const std::unique_ptr<hardware::Writer<T>> hw_writer;
-    /// @brief the parent write task.
+    /// @brief builds the hardware for each run.
+    MakeHardware make_hw;
+    /// @brief the underlying DAQmx hardware we write data to. Populated on start
+    /// and released on stop.
+    std::unique_ptr<Hardware> hw_writer;
     /// @brief a pre-allocated write buffer that is flushed to the device every
     /// time a command is provided.
     std::vector<T> buf;
 
-    /// @brief implements common::Task to start the hardware writer.
-    x::errors::Error start() override { return this->hw_writer->start(); }
+    /// @brief implements common::Sink to claim the hardware and start it.
+    x::errors::Error start() override {
+        auto [hw, err] = this->make_hw(this->cfg);
+        if (err) return err;
+        this->hw_writer = std::move(hw);
+        if (const auto start_err = this->hw_writer->start()) {
+            this->hw_writer.reset();
+            return start_err;
+        }
+        return x::errors::NIL;
+    }
 
-    /// @brief implements common::Task to stop the hardware writer.
-    x::errors::Error stop() override { return this->hw_writer->stop(); }
+    /// @brief implements common::Sink to stop the hardware and release it.
+    x::errors::Error stop() override {
+        if (this->hw_writer == nullptr) return x::errors::NIL;
+        const auto err = this->hw_writer->stop();
+        this->hw_writer.reset();
+        return err;
+    }
 
     /// @brief implements driver::pipeline::Sink to write the incoming frame to the
     /// underlying hardware. If the values are successfully written, updates

--- a/driver/ni/write_task.h
+++ b/driver/ni/write_task.h
@@ -189,6 +189,8 @@ private:
 
     /// @brief implements common::Sink to claim the hardware and start it.
     x::errors::Error start() override {
+        // DAQmx rejects a second task with a live task's name.
+        this->hw_writer.reset();
         auto [hw, err] = this->make_hw(this->cfg);
         if (err) return err;
         this->hw_writer = std::move(hw);

--- a/driver/ni/write_task_test.cpp
+++ b/driver/ni/write_task_test.cpp
@@ -127,21 +127,62 @@ protected:
         mock_writer_factory = std::make_shared<driver::pipeline::mock::WriterFactory>();
     }
 
+    std::shared_ptr<hardware::mock::Writer<double>> mock_hw;
+    std::size_t make_hw_calls = 0;
+
     std::unique_ptr<common::WriteTask>
-    create_task(std::unique_ptr<hardware::mock::Writer<double>> mock_hw) {
+    create_task(std::unique_ptr<hardware::mock::Writer<double>> hw) {
+        this->mock_hw = std::move(hw);
+        WriteTaskSink<double>::MakeHardware make_hw = [this](const WriteTaskConfig &)
+            -> std::pair<std::unique_ptr<hardware::Writer<double>>, x::errors::Error> {
+            ++this->make_hw_calls;
+            return {
+                std::make_unique<hardware::mock::SharedWriter<double>>(this->mock_hw),
+                x::errors::NIL
+            };
+        };
         return std::make_unique<common::WriteTask>(
             task,
             ctx,
             x::breaker::default_config(task.name),
             std::make_unique<WriteTaskSink<double>>(
                 std::move(*cfg),
-                std::move(mock_hw)
+                std::move(make_hw)
             ),
             mock_writer_factory,
             mock_streamer_factory
         );
     }
 };
+
+/// @brief every start should claim fresh hardware and every stop should release
+/// it, so a device that disconnects and returns between runs gets a new DAQmx
+/// task on the next start.
+TEST_F(SingleChannelAnalogWriteTest, testStartClaimsFreshHardware) {
+    parse_config();
+    mock_streamer_factory = pipeline::mock::simple_streamer_factory(
+        {cmd_ch_2.key},
+        std::make_shared<std::vector<x::telem::Frame>>()
+    );
+    auto wt = create_task(std::make_unique<hardware::mock::Writer<double>>());
+
+    wt->start("start_cmd");
+    ASSERT_EVENTUALLY_GE(ctx->statuses.size(), 1);
+    EXPECT_EQ(make_hw_calls, 1);
+    // The fixture and the running sink both hold the mock.
+    EXPECT_EQ(mock_hw.use_count(), 2);
+
+    wt->stop("stop_cmd", true);
+    ASSERT_EVENTUALLY_GE(ctx->statuses.size(), 2);
+    // The stop released the sink's claim on the hardware.
+    EXPECT_EQ(mock_hw.use_count(), 1);
+
+    wt->start("start_cmd_2");
+    ASSERT_EVENTUALLY_GE(ctx->statuses.size(), 3);
+    EXPECT_EQ(make_hw_calls, 2);
+    EXPECT_EQ(ctx->statuses[2].variant, synnax::status::VARIANT_SUCCESS);
+    wt->stop("stop_cmd_2", true);
+}
 
 /// @brief it should write analog values and update state channels correctly.
 TEST_F(SingleChannelAnalogWriteTest, testBasicAnalogWrite) {

--- a/driver/ni/write_task_test.cpp
+++ b/driver/ni/write_task_test.cpp
@@ -7,6 +7,8 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+#include <algorithm>
+#include <atomic>
 #include <utility>
 
 #include "gtest/gtest.h"
@@ -182,6 +184,51 @@ TEST_F(SingleChannelAnalogWriteTest, testStartClaimsFreshHardware) {
     EXPECT_EQ(make_hw_calls, 2);
     EXPECT_EQ(ctx->statuses[2].variant, synnax::status::VARIANT_SUCCESS);
     wt->stop("stop_cmd_2", true);
+}
+
+/// @brief a writer that counts the instances currently alive.
+template<typename T>
+class CountingWriter final : public hardware::Writer<T> {
+    std::shared_ptr<std::atomic<int>> live;
+
+public:
+    explicit CountingWriter(std::shared_ptr<std::atomic<int>> live):
+        live(std::move(live)) {
+        this->live->fetch_add(1);
+    }
+
+    ~CountingWriter() { this->live->fetch_sub(1); }
+
+    x::errors::Error start() override { return x::errors::NIL; }
+    x::errors::Error stop() override { return x::errors::NIL; }
+    x::errors::Error write(const std::vector<T> &) override { return x::errors::NIL; }
+};
+
+/// @brief a start must never build hardware over a live claim: DAQmx names each task
+/// after the Synnax task and rejects a duplicate name.
+TEST_F(SingleChannelAnalogWriteTest, testStartNeverBuildsOverALiveClaim) {
+    parse_config();
+    const auto live = std::make_shared<std::atomic<int>>(0);
+    size_t builds = 0;
+    int live_at_build = 0;
+    const std::unique_ptr<common::Sink> sink = std::make_unique<WriteTaskSink<double>>(
+        std::move(*cfg),
+        [&](const WriteTaskConfig &)
+            -> std::pair<std::unique_ptr<hardware::Writer<double>>, x::errors::Error> {
+            ++builds;
+            live_at_build = std::max(live_at_build, live->load());
+            return {std::make_unique<CountingWriter<double>>(live), x::errors::NIL};
+        }
+    );
+
+    ASSERT_NIL(sink->start());
+    EXPECT_EQ(live->load(), 1);
+    ASSERT_NIL(sink->start());
+    EXPECT_EQ(builds, 2);
+    EXPECT_EQ(live_at_build, 0);
+    EXPECT_EQ(live->load(), 1);
+    ASSERT_NIL(sink->stop());
+    EXPECT_EQ(live->load(), 0);
 }
 
 /// @brief it should write analog values and update state channels correctly.


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4603](https://linear.app/synnax/issue/SY-4603)

## Description

Read and write tasks acquired their device at configure time and reused the task instance across hash-matched starts, so anything that happened to the hardware between runs left the task on a dead handle. A Modbus server restart between runs stranded the task on a closed socket ("Connection reset by peer"); NI and LabJack had the same shape.

LabJack, Modbus, and NI now acquire hardware on start and release it on stop.

Alongside that:

- The LabJack Manager splits into an interface and an LJM implementation, and LJM opens serialize so a racing open cannot close a live handle.
- NI custom scale keys are cached process-wide, so a repeated start reuses the existing scale definition instead of failing to redefine it.
- An NI read task that fails to recover in the loop reclaims its hardware on the next start.

Merge after #2722: the integration suite needs those helpers to pass.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves LabJack, Modbus, and NI hardware acquisition from task configuration to task start, then releases hardware when each task stops.
- Adds per-run hardware acquisition and recovery paths.
- Serializes LabJack opens to protect shared handles.
- Adds lifecycle and reconnection tests for the changed drivers.
- Reuses NI custom-scale keys across repeated applications.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| driver/common/write_task.h | Uses the command pipeline state to release sinks for write tasks without state channels. |
| driver/labjack/device/device.h | Introduces an injectable manager interface and serializes LJM device opens. |
| driver/labjack/read_task.h | Acquires LabJack devices at start and releases them at stop or failed recovery. |
| driver/labjack/write_task.h | Moves LabJack write-device ownership to the active task run. |
| driver/modbus/read_task.h | Reconnects the Modbus read device on each task start. |
| driver/modbus/write_task.h | Reconnects the Modbus write device on each task start. |
| driver/ni/ni.h | Defers DAQmx task creation and configuration until each task start. |
| driver/ni/read_task.h | Recreates NI read hardware per run and retries acquisition after failed recovery. |
| driver/ni/write_task.h | Recreates NI write hardware per run and releases it on stop. |
| driver/ni/channel/scale.h | Caches generated DAQmx custom-scale keys for reuse. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Operator
  participant Task
  participant SourceSink as Source or sink
  participant Manager as Hardware manager
  participant Device

  Operator->>Task: Start
  Task->>SourceSink: start()
  SourceSink->>Manager: acquire(config)
  Manager->>Device: Open or create hardware task
  Device-->>SourceSink: Live hardware handle
  SourceSink-->>Task: Started

  Operator->>Task: Stop
  Task->>SourceSink: stop()
  SourceSink->>Device: Stop hardware
  SourceSink->>SourceSink: Release handle
  SourceSink-->>Task: Stopped

  Operator->>Task: Start again
  Task->>SourceSink: start()
  SourceSink->>Manager: acquire(config)
  Manager->>Device: Open fresh hardware
```

<sub>Reviews (2): Last reviewed commit: ["Move the LabJack device mock into a test..."](https://github.com/synnaxlabs/synnax/commit/fdd4394266ab4575ac4fdaf216178d478d3e1778) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53800884)</sub>

**Context used:**

- Knowledge Base — [Driver: Connecting Physical Devices to Synnax](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/driver-devices.md)

<!-- /greptile_comment -->