### PR TITLE
SY-4604: Raise in the clients when a task start or stop ack carries an error

### DIFF
--- a/client/py/synnax/task/__init__.py
+++ b/client/py/synnax/task/__init__.py
@@ -22,6 +22,7 @@ from synnax.task.types_gen import (
     BaseScanConfig,
     BaseStartConfig,
     BaseWriteConfig,
+    Command,
     Key,
     KeyedConfig,
     Payload,
@@ -45,6 +46,7 @@ __getattr__ = deprecated_getattr(__name__, _DEPRECATED, globals())
 
 __all__ = [
     "Client",
+    "Command",
     "Key",
     "Task",
     "Payload",

--- a/client/py/synnax/task/client.py
+++ b/client/py/synnax/task/client.py
@@ -290,7 +290,8 @@ class StarterStopperMixin:
 
         :raises TimeoutError: If the timeout is reached before the Synnax cluster
             acknowledges the command.
-        :raises ConfigurationError: If the driver fails to stop the task.
+        :raises ConfigurationError: If the task ended in an error state. The task is
+            stopped either way; the error is whatever went wrong while it ran.
         """
         status = self._internal.execute_command_sync("stop", timeout=timeout)
         if status.variant == VARIANT_ERROR:
@@ -301,6 +302,9 @@ class StarterStopperMixin:
         """Context manager that starts the task before entering the block and stops the
         task after exiting the block. This is useful for ensuring that the task is
         properly stopped even if an exception occurs during execution.
+
+        :raises ConfigurationError: If the task failed to start, or ended in an error
+            state. A task that dies mid-block surfaces its cause on exit.
         """
         self.start(timeout)
         try:

--- a/client/py/synnax/task/client.py
+++ b/client/py/synnax/task/client.py
@@ -191,7 +191,9 @@ class Task:
                     "type": type_,
                     "key": key,
                     "config_hash": self.config_hash,
-                    "args": args,
+                    # Readers validate args as a record; a null on the wire fails
+                    # their schema, so an absent value must encode as {}.
+                    "args": args if args is not None else {},
                 }
             ],
         )

--- a/client/py/synnax/task/client.py
+++ b/client/py/synnax/task/client.py
@@ -22,10 +22,12 @@ from alamos import NOOP, Instrumentation
 from freighter import Empty, UnaryClient
 from synnax.device import Client as DeviceClient
 from synnax.device import Device
+from synnax.exceptions import ConfigurationError
 from synnax.framer import Client as FrameClient
 from synnax.ontology.payload import ID
 from synnax.rack import Client as RackClient
 from synnax.rack import Rack
+from synnax.status import VARIANT_ERROR
 from synnax.task.types_gen import Key, Payload, Status, ontology_id
 from synnax.telem import TimeSpan, TimeStamp
 from x.lists import check_for_none, normalize, override
@@ -276,9 +278,11 @@ class StarterStopperMixin:
 
         :raises TimeoutError: If the timeout is reached before the Synnax cluster
             acknowledges the command.
-        :raises Exception: If the Synnax cluster fails to start the task correctly.
+        :raises ConfigurationError: If the driver fails to start the task.
         """
-        self._internal.execute_command_sync("start", timeout=timeout)
+        status = self._internal.execute_command_sync("start", timeout=timeout)
+        if status.variant == VARIANT_ERROR:
+            raise ConfigurationError(status.message)
 
     def stop(self, timeout: float | TimeSpan = 5) -> None:
         """Stops the task and blocks until the Synnax cluster has acknowledged the
@@ -286,9 +290,11 @@ class StarterStopperMixin:
 
         :raises TimeoutError: If the timeout is reached before the Synnax cluster
             acknowledges the command.
-        :raises Exception: If the Synnax cluster fails to stop the task correctly.
+        :raises ConfigurationError: If the driver fails to stop the task.
         """
-        self._internal.execute_command_sync("stop", timeout=timeout)
+        status = self._internal.execute_command_sync("stop", timeout=timeout)
+        if status.variant == VARIANT_ERROR:
+            raise ConfigurationError(status.message)
 
     @contextmanager
     def run(self, timeout: float | TimeSpan = 5) -> Generator[None, None, None]:

--- a/client/py/tests/test_task.py
+++ b/client/py/tests/test_task.py
@@ -70,6 +70,26 @@ class TestTaskClient:
         tsk.execute_command_sync("test", {"key": "value"})
         t.join()
 
+    def test_execute_command_encodes_absent_args_as_empty_record(
+        self, client: sy.Synnax
+    ):
+        """Should write {} for omitted args; readers reject a null record."""
+        tsk = client.tasks.create(name="test", type="pagerduty_alert")
+        with client.open_streamer("sy_task_cmd") as s:
+            key = tsk.execute_command("start")
+            # The command channel is shared, so scan for this command's key.
+            cmd = None
+            for _ in range(10):
+                f = s.read(timeout=1)
+                assert f is not None
+                matches = [c for c in f["sy_task_cmd"] if c["key"] == key]
+                if matches:
+                    cmd = matches[0]
+                    break
+            assert cmd is not None
+            assert cmd["args"] == {}
+            sy.task.Command.model_validate(cmd)
+
     def test_task_configure_saves_without_ack(self, client: sy.Synnax):
         """Should save the task without waiting for a driver acknowledgement."""
         tsk = sy.Task(

--- a/client/py/tests/test_task.py
+++ b/client/py/tests/test_task.py
@@ -15,6 +15,30 @@ import pytest
 import synnax as sy
 
 
+class _StartStopTask(sy.task.StarterStopperMixin):
+    def __init__(self, internal: sy.Task):
+        self._internal = internal
+
+
+def _ack_next_command(client: sy.Synnax, ev: threading.Event, variant, message: str):
+    with client.open_streamer("sy_task_cmd") as s:
+        ev.set()
+        f = s.read(timeout=1)
+        cmd = f["sy_task_cmd"][0]
+        client.statuses.set(
+            sy.Status(
+                key=str(sy.task.ontology_id(cmd["task"])),
+                variant=variant,
+                message=message,
+                details=sy.task.StatusDetails(
+                    task=cmd["task"],
+                    running=False,
+                    cmd=cmd["key"],
+                ),
+            )
+        )
+
+
 @pytest.mark.task
 class TestTaskClient:
     def test_create_single(self, client: sy.Synnax):
@@ -68,6 +92,47 @@ class TestTaskClient:
         tsk = client.tasks.create(name="test", type="pagerduty_alert")
         ev.wait()
         tsk.execute_command_sync("test", {"key": "value"})
+        t.join()
+
+    def test_start_succeeds_on_success_ack(self, client: sy.Synnax):
+        """Should return without raising when the driver acks the start."""
+        ev = threading.Event()
+        t = threading.Thread(
+            target=_ack_next_command,
+            args=(client, ev, sy.status.VARIANT_SUCCESS, "Task started successfully"),
+        )
+        t.start()
+        tsk = _StartStopTask(client.tasks.create(name="test", type="pagerduty_alert"))
+        ev.wait()
+        tsk.start()
+        t.join()
+
+    def test_start_raises_on_error_ack(self, client: sy.Synnax):
+        """Should raise ConfigurationError when the driver acks with an error."""
+        ev = threading.Event()
+        t = threading.Thread(
+            target=_ack_next_command,
+            args=(client, ev, sy.status.VARIANT_ERROR, "failed to reserve device"),
+        )
+        t.start()
+        tsk = _StartStopTask(client.tasks.create(name="test", type="pagerduty_alert"))
+        ev.wait()
+        with pytest.raises(sy.ConfigurationError, match="failed to reserve device"):
+            tsk.start()
+        t.join()
+
+    def test_stop_raises_on_error_ack(self, client: sy.Synnax):
+        """Should raise ConfigurationError when the driver acks with an error."""
+        ev = threading.Event()
+        t = threading.Thread(
+            target=_ack_next_command,
+            args=(client, ev, sy.status.VARIANT_ERROR, "failed to flush hardware"),
+        )
+        t.start()
+        tsk = _StartStopTask(client.tasks.create(name="test", type="pagerduty_alert"))
+        ev.wait()
+        with pytest.raises(sy.ConfigurationError, match="failed to flush hardware"):
+            tsk.stop()
         t.join()
 
     def test_execute_command_encodes_absent_args_as_empty_record(

--- a/client/py/tests/test_task.py
+++ b/client/py/tests/test_task.py
@@ -122,16 +122,16 @@ class TestTaskClient:
         t.join()
 
     def test_stop_raises_on_error_ack(self, client: sy.Synnax):
-        """Should raise ConfigurationError when the driver acks with an error."""
+        """Should raise ConfigurationError when the task ended in an error state."""
         ev = threading.Event()
         t = threading.Thread(
             target=_ack_next_command,
-            args=(client, ev, sy.status.VARIANT_ERROR, "failed to flush hardware"),
+            args=(client, ev, sy.status.VARIANT_ERROR, "device disconnected"),
         )
         t.start()
         tsk = _StartStopTask(client.tasks.create(name="test", type="pagerduty_alert"))
         ev.wait()
-        with pytest.raises(sy.ConfigurationError, match="failed to flush hardware"):
+        with pytest.raises(sy.ConfigurationError, match="device disconnected"):
             tsk.stop()
         t.join()
 

--- a/client/ts/src/errors.ts
+++ b/client/ts/src/errors.ts
@@ -131,6 +131,8 @@ export class ContiguityError extends SynnaxError.sub("contiguity") {}
 
 const decode = (payload: errors.Payload): Error | null => {
   if (!payload.type.startsWith(SynnaxError.TYPE)) return null;
+  if (payload.type.startsWith(ConfigurationError.TYPE))
+    return new ConfigurationError(payload.data);
   if (payload.type.startsWith(ValidationError.TYPE)) {
     if (payload.type === PathError.TYPE) return PathError.decode(payload);
     return new ValidationError(payload.data);

--- a/client/ts/src/errors.ts
+++ b/client/ts/src/errors.ts
@@ -14,6 +14,11 @@ import { z } from "zod";
 export class SynnaxError extends errors.createTyped("sy") {}
 
 /**
+ * Raised when a configuration error occurs.
+ */
+export class ConfigurationError extends SynnaxError.sub("configuration") {}
+
+/**
  * Raised when a validation error occurs.
  */
 export class ValidationError extends SynnaxError.sub("validation") {}

--- a/client/ts/src/index.ts
+++ b/client/ts/src/index.ts
@@ -26,6 +26,7 @@ export { control } from "@/control";
 export { device } from "@/device";
 export {
   AuthError,
+  ConfigurationError,
   ContiguityError,
   DisconnectedError,
   isConnectionError,

--- a/client/ts/src/task/client.ts
+++ b/client/ts/src/task/client.ts
@@ -24,6 +24,7 @@ import {
 } from "@synnaxlabs/x";
 import { z } from "zod";
 
+import { ConfigurationError } from "@/errors";
 import { type framer } from "@/framer";
 import { ontology } from "@/ontology";
 import { query } from "@/query";
@@ -226,12 +227,24 @@ export class Task<S extends Schemas = Schemas> {
     });
   }
 
-  async start(): Promise<void> {
-    await this.executeCommand({ type: "start" });
+  /**
+   * Starts the task and blocks until the driver acknowledges the command.
+   * @param timeout - The maximum time to wait for the acknowledgement.
+   * @throws {ConfigurationError} if the driver fails to start the task.
+   */
+  async start(timeout?: CrudeTimeSpan): Promise<void> {
+    const status = await this.executeCommandSync({ type: "start", timeout });
+    if (status.variant === "error") throw new ConfigurationError(status.message);
   }
 
-  async stop(): Promise<void> {
-    await this.executeCommand({ type: "stop" });
+  /**
+   * Stops the task and blocks until the driver acknowledges the command.
+   * @param timeout - The maximum time to wait for the acknowledgement.
+   * @throws {ConfigurationError} if the driver fails to stop the task.
+   */
+  async stop(timeout?: CrudeTimeSpan): Promise<void> {
+    const status = await this.executeCommandSync({ type: "stop", timeout });
+    if (status.variant === "error") throw new ConfigurationError(status.message);
   }
 
   async run<T>(fn: () => Promise<T>): Promise<T> {

--- a/client/ts/src/task/client.ts
+++ b/client/ts/src/task/client.ts
@@ -251,15 +251,28 @@ export class Task<S extends Schemas = Schemas> {
   /**
    * Starts the task, runs fn, and stops the task.
    * @throws {ConfigurationError} if the task failed to start, or ended in an error
-   * state. A task that dies while fn runs surfaces its cause on stop.
+   * state. A task that dies while fn runs surfaces its cause on stop, with whatever
+   * fn threw attached as the cause.
    */
   async run<T>(fn: () => Promise<T>): Promise<T> {
     await this.start();
+    let value: T;
     try {
-      return await fn();
-    } finally {
-      await this.stop();
+      value = await fn();
+    } catch (error) {
+      const fnError =
+        error instanceof Error ? error : new Error(String(error), { cause: error });
+      try {
+        await this.stop();
+      } catch (stopError) {
+        if (!(stopError instanceof Error)) throw fnError;
+        stopError.cause ??= fnError;
+        throw stopError;
+      }
+      throw fnError;
     }
+    await this.stop();
+    return value;
   }
 
   async snapshottedTo(): Promise<ontology.Resource | null> {

--- a/client/ts/src/task/client.ts
+++ b/client/ts/src/task/client.ts
@@ -240,13 +240,19 @@ export class Task<S extends Schemas = Schemas> {
   /**
    * Stops the task and blocks until the driver acknowledges the command.
    * @param timeout - The maximum time to wait for the acknowledgement.
-   * @throws {ConfigurationError} if the driver fails to stop the task.
+   * @throws {ConfigurationError} if the task ended in an error state. The task is
+   * stopped either way; the error is whatever went wrong while it ran.
    */
   async stop(timeout?: CrudeTimeSpan): Promise<void> {
     const status = await this.executeCommandSync({ type: "stop", timeout });
     if (status.variant === "error") throw new ConfigurationError(status.message);
   }
 
+  /**
+   * Starts the task, runs fn, and stops the task.
+   * @throws {ConfigurationError} if the task failed to start, or ended in an error
+   * state. A task that dies while fn runs surfaces its cause on stop.
+   */
   async run<T>(fn: () => Promise<T>): Promise<T> {
     await this.start();
     try {

--- a/client/ts/src/task/task.spec.ts
+++ b/client/ts/src/task/task.spec.ts
@@ -484,10 +484,14 @@ describe("Task", async () => {
       });
       const streamer = await client.openStreamer(task.COMMAND_CHANNEL_NAME);
       try {
+        // The assertions attach before the ack: start() can reject the moment the
+        // error status lands, and an unhandled rejection fails the whole run.
         const started = t.start();
-        await ackNextCommand(streamer, t.key, "error", "failed to reserve device");
-        await expect(started).rejects.toThrow(ConfigurationError);
-        await expect(started).rejects.toThrow("failed to reserve device");
+        await Promise.all([
+          expect(started).rejects.toThrow(ConfigurationError),
+          expect(started).rejects.toThrow("failed to reserve device"),
+          ackNextCommand(streamer, t.key, "error", "failed to reserve device"),
+        ]);
       } finally {
         streamer.close();
       }
@@ -515,7 +519,7 @@ describe("Task", async () => {
       }
     });
 
-    it("should throw a ConfigurationError when the driver rejects a stop", async () => {
+    it("should throw a ConfigurationError when the task ended in an error", async () => {
       const t = await testRack.createTask({
         name: "lifecycle-stop-error-test",
         config: {},
@@ -524,9 +528,11 @@ describe("Task", async () => {
       const streamer = await client.openStreamer(task.COMMAND_CHANNEL_NAME);
       try {
         const stopped = t.stop();
-        await ackNextCommand(streamer, t.key, "error", "failed to flush hardware");
-        await expect(stopped).rejects.toThrow(ConfigurationError);
-        await expect(stopped).rejects.toThrow("failed to flush hardware");
+        await Promise.all([
+          expect(stopped).rejects.toThrow(ConfigurationError),
+          expect(stopped).rejects.toThrow("device disconnected"),
+          ackNextCommand(streamer, t.key, "error", "device disconnected"),
+        ]);
       } finally {
         streamer.close();
       }
@@ -576,6 +582,7 @@ describe("Task", async () => {
         const ran = t.run(async () => {
           throw new Error("Test error");
         });
+        const rejected = expect(ran).rejects.toThrow("Test error");
         const startCmd = await ackNextCommand(
           streamer,
           t.key,
@@ -591,7 +598,7 @@ describe("Task", async () => {
           "Task stopped successfully",
         );
         expect(stopCmd.type).toBe("stop");
-        await expect(ran).rejects.toThrow("Test error");
+        await rejected;
       } finally {
         streamer.close();
       }

--- a/client/ts/src/task/task.spec.ts
+++ b/client/ts/src/task/task.spec.ts
@@ -11,8 +11,11 @@ import { id, TimeStamp, uuid } from "@synnaxlabs/x";
 import { assert, beforeAll, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 
+import { ConfigurationError } from "@/errors";
+import { type framer } from "@/framer";
 import { ontology } from "@/ontology";
 import { query } from "@/query";
+import { type status } from "@/status";
 import { task } from "@/task";
 import { createTestClient } from "@/testutil";
 
@@ -419,6 +422,38 @@ describe("Task", async () => {
   });
 
   describe("lifecycle methods", () => {
+    /// Plays the driver: reads the task's next command and acks it with a status.
+    /// The command channel is shared, so commands for other tasks are skipped.
+    const ackNextCommand = async (
+      streamer: framer.Streamer,
+      taskKey: task.Key,
+      variant: status.Variant,
+      message: string,
+    ): Promise<task.Command> => {
+      while (true) {
+        const fr = await streamer.read();
+        for (const sample of fr.get(task.COMMAND_CHANNEL_NAME)) {
+          const parsed = task.commandZ.safeParse(sample);
+          if (!parsed.success || parsed.data.task !== taskKey) continue;
+          const cmd = parsed.data;
+          await client.statuses.set({
+            key: id.create(),
+            name: "Task Status",
+            variant,
+            message,
+            time: TimeStamp.now(),
+            details: {
+              task: cmd.task,
+              running: variant !== "error",
+              cmd: cmd.key,
+              data: {},
+            },
+          });
+          return cmd;
+        }
+      }
+    };
+
     it("should start a task", async () => {
       const t = await testRack.createTask({
         name: "lifecycle-start-test",
@@ -426,15 +461,36 @@ describe("Task", async () => {
         type: "pagerduty_alert",
       });
       const streamer = await client.openStreamer(task.COMMAND_CHANNEL_NAME);
-      await t.start();
-      await expect
-        .poll<Promise<task.Command>>(async () => {
-          const fr = await streamer.read();
-          const sample = fr.at(-1)[task.COMMAND_CHANNEL_NAME];
-          return task.commandZ.parse(sample);
-        })
-        .toMatchObject({ task: t.key, type: "start" });
-      streamer.close();
+      try {
+        const started = t.start();
+        const cmd = await ackNextCommand(
+          streamer,
+          t.key,
+          "success",
+          "Task started successfully",
+        );
+        expect(cmd).toMatchObject({ task: t.key, type: "start" });
+        await started;
+      } finally {
+        streamer.close();
+      }
+    });
+
+    it("should throw a ConfigurationError when the driver rejects a start", async () => {
+      const t = await testRack.createTask({
+        name: "lifecycle-start-error-test",
+        config: {},
+        type: "pagerduty_alert",
+      });
+      const streamer = await client.openStreamer(task.COMMAND_CHANNEL_NAME);
+      try {
+        const started = t.start();
+        await ackNextCommand(streamer, t.key, "error", "failed to reserve device");
+        await expect(started).rejects.toThrow(ConfigurationError);
+        await expect(started).rejects.toThrow("failed to reserve device");
+      } finally {
+        streamer.close();
+      }
     });
 
     it("should stop a task", async () => {
@@ -444,15 +500,36 @@ describe("Task", async () => {
         type: "pagerduty_alert",
       });
       const streamer = await client.openStreamer(task.COMMAND_CHANNEL_NAME);
-      await t.stop();
-      await expect
-        .poll<Promise<task.Command>>(async () => {
-          const fr = await streamer.read();
-          const sample = fr.at(-1)[task.COMMAND_CHANNEL_NAME];
-          return task.commandZ.parse(sample);
-        })
-        .toMatchObject({ task: t.key, type: "stop" });
-      streamer.close();
+      try {
+        const stopped = t.stop();
+        const cmd = await ackNextCommand(
+          streamer,
+          t.key,
+          "success",
+          "Task stopped successfully",
+        );
+        expect(cmd).toMatchObject({ task: t.key, type: "stop" });
+        await stopped;
+      } finally {
+        streamer.close();
+      }
+    });
+
+    it("should throw a ConfigurationError when the driver rejects a stop", async () => {
+      const t = await testRack.createTask({
+        name: "lifecycle-stop-error-test",
+        config: {},
+        type: "pagerduty_alert",
+      });
+      const streamer = await client.openStreamer(task.COMMAND_CHANNEL_NAME);
+      try {
+        const stopped = t.stop();
+        await ackNextCommand(streamer, t.key, "error", "failed to flush hardware");
+        await expect(stopped).rejects.toThrow(ConfigurationError);
+        await expect(stopped).rejects.toThrow("failed to flush hardware");
+      } finally {
+        streamer.close();
+      }
     });
 
     it("should run a task with automatic start and stop", async () => {
@@ -462,34 +539,30 @@ describe("Task", async () => {
         type: "pagerduty_alert",
       });
       const streamer = await client.openStreamer(task.COMMAND_CHANNEL_NAME);
-      let executedCallback = false;
-
-      await t.run(async () => {
-        executedCallback = true;
-      });
-
-      expect(executedCallback).toBe(true);
-
-      // Should have received both start and stop commands
-      const commands: task.Command[] = [];
-      await expect
-        .poll(async () => {
-          try {
-            const fr = await streamer.read();
-            const samples = fr.get(task.COMMAND_CHANNEL_NAME);
-            for (const sample of samples) commands.push(task.commandZ.parse(sample));
-
-            return (
-              commands.some((c) => c.task === t.key && c.type === "start") &&
-              commands.some((c) => c.task === t.key && c.type === "stop")
-            );
-          } catch {
-            return false;
-          }
-        })
-        .toBe(true);
-
-      streamer.close();
+      try {
+        let executedCallback = false;
+        const ran = t.run(async () => {
+          executedCallback = true;
+        });
+        const startCmd = await ackNextCommand(
+          streamer,
+          t.key,
+          "success",
+          "Task started successfully",
+        );
+        expect(startCmd.type).toBe("start");
+        const stopCmd = await ackNextCommand(
+          streamer,
+          t.key,
+          "success",
+          "Task stopped successfully",
+        );
+        expect(stopCmd.type).toBe("stop");
+        await ran;
+        expect(executedCallback).toBe(true);
+      } finally {
+        streamer.close();
+      }
     });
 
     it("should stop task even if callback throws error", async () => {
@@ -499,32 +572,29 @@ describe("Task", async () => {
         type: "pagerduty_alert",
       });
       const streamer = await client.openStreamer(task.COMMAND_CHANNEL_NAME);
-
-      await expect(
-        t.run(async () => {
+      try {
+        const ran = t.run(async () => {
           throw new Error("Test error");
-        }),
-      ).rejects.toThrow("Test error");
-
-      // Should still have received stop command
-      const stopCommands: task.Command[] = [];
-      await expect
-        .poll(async () => {
-          try {
-            const fr = await streamer.read();
-            const samples = fr.get(task.COMMAND_CHANNEL_NAME);
-            for (const sample of samples) {
-              const cmd = task.commandZ.parse(sample);
-              if (cmd.task === t.key && cmd.type === "stop") stopCommands.push(cmd);
-            }
-            return stopCommands.length > 0;
-          } catch {
-            return false;
-          }
-        })
-        .toBe(true);
-
-      streamer.close();
+        });
+        const startCmd = await ackNextCommand(
+          streamer,
+          t.key,
+          "success",
+          "Task started successfully",
+        );
+        expect(startCmd.type).toBe("start");
+        // The callback throws, so run() still sends and awaits the stop.
+        const stopCmd = await ackNextCommand(
+          streamer,
+          t.key,
+          "success",
+          "Task stopped successfully",
+        );
+        expect(stopCmd.type).toBe("stop");
+        await expect(ran).rejects.toThrow("Test error");
+      } finally {
+        streamer.close();
+      }
     });
   });
 

--- a/client/ts/src/task/task.spec.ts
+++ b/client/ts/src/task/task.spec.ts
@@ -603,6 +603,30 @@ describe("Task", async () => {
         streamer.close();
       }
     });
+
+    it("should keep the callback error as the cause when stop also fails", async () => {
+      const t = await testRack.createTask({
+        name: "lifecycle-run-both-error-test",
+        config: {},
+        type: "pagerduty_alert",
+      });
+      const streamer = await client.openStreamer(task.COMMAND_CHANNEL_NAME);
+      try {
+        const callbackError = new Error("callback blew up");
+        const ran = t.run(async () => {
+          throw callbackError;
+        });
+        const settled = ran.catch((error: unknown) => error);
+        await ackNextCommand(streamer, t.key, "success", "Task started successfully");
+        await ackNextCommand(streamer, t.key, "error", "device disconnected");
+        const error = await settled;
+        expect(error).toBeInstanceOf(ConfigurationError);
+        expect((error as Error).message).toContain("device disconnected");
+        expect((error as Error).cause).toBe(callbackError);
+      } finally {
+        streamer.close();
+      }
+    });
   });
 
   describe("executeCommand", () => {

--- a/integration/tests/driver/ni_write.py
+++ b/integration/tests/driver/ni_write.py
@@ -129,14 +129,22 @@ class NIDigitalWriteInvalidData(NIDigitalWriteTaskCase):
     def run(self) -> None:
         assert self.tsk is not None
         self.log("Testing: Send invalid digital values (42)")
-        with self.tsk.run():
-            _assert_driver_rejects_value(
-                self.client,
-                self.tsk.key,
-                cmd_keys=self._channel_keys(self.tsk),
-                value=42.0,
-                writer_name=f"{self.task_name}_test_writer",
+        # The rejected write kills the task, so stopping it reports the cause.
+        try:
+            with self.tsk.run():
+                _assert_driver_rejects_value(
+                    self.client,
+                    self.tsk.key,
+                    cmd_keys=self._channel_keys(self.tsk),
+                    value=42.0,
+                    writer_name=f"{self.task_name}_test_writer",
+                )
+        except sy.ConfigurationError as e:
+            assert "not supported" in str(e), (
+                f"Stop should report the rejected write, got: {e}"
             )
+        else:
+            raise AssertionError("Stop should report the rejected write")
         self.log("Driver correctly rejected invalid digital data")
 
 


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4604](https://linear.app/synnax/issue/SY-4604)

## Description

`start()` and `stop()` returned normally when the driver acked with an error status, so a task that failed to start, or died while running, looked successful to the caller. Both clients now raise `ConfigurationError` carrying the driver's message.

The two acks do not mean the same thing, and the contract docs now say so. `send_start` reports the accumulated error on failure, so an error there means the start failed. `send_stop` always clears running and fills the message with any accumulated error, so an error there describes task health, not the stop outcome: the task is stopped either way, and the error is whatever went wrong while it ran. A task that dies while `run()`'s body executes surfaces its cause on stop.

Also in here: absent task command `args` encode as `{}` instead of `null`, which readers reject, and `sy.configuration` payloads decode as `ConfigurationError` in TypeScript.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes Python and TypeScript task lifecycle methods wait for driver acknowledgements and raise ConfigurationError for error statuses. It also fixes absent command argument encoding and adds TypeScript configuration-error decoding.
- Adds acknowledgement error handling to task start and stop operations.
- Encodes omitted Python command arguments as an empty record.
- Exports and decodes ConfigurationError in the TypeScript client.
- Adds client and driver integration coverage.

<h3>Confidence Score: 4/5</h3>

The run error-precedence defect must be fixed before merging because cleanup can hide the caller's primary exception.

Both clients now let an error stop acknowledgement throw from a finally block, which replaces an exception already raised by the run body.

**Files Needing Attention:** client/ts/src/task/client.ts and client/py/synnax/task/client.py

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| client/ts/src/task/client.ts | Start and stop now await acknowledgements, but a stop error can replace an existing run callback error. |
| client/py/synnax/task/client.py | Adds acknowledgement checks and empty-record argument encoding, with the same run exception-precedence defect. |
| client/ts/src/errors.ts | Adds the ConfigurationError type and maps matching payloads to it. |
| client/ts/src/task/task.spec.ts | Adds lifecycle acknowledgement tests but does not cover simultaneous callback and stop errors. |
| client/py/tests/test_task.py | Covers successful and failed acknowledgements and empty argument serialization. |
| integration/tests/driver/ni_write.py | Updates the invalid-write case to require the task health error reported during stop. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Caller
  participant Task
  participant Driver
  Caller->>Task: run(body)
  Task->>Driver: start command
  Driver-->>Task: start acknowledgement
  Task->>Caller: execute body
  Caller--xTask: body exception
  Task->>Driver: stop command
  Driver-->>Task: error acknowledgement
  Task--xCaller: ConfigurationError replaces body exception
```

<sub>Reviews (1): Last reviewed commit: ["Treat a stop ack error as task health, n..."](https://github.com/synnaxlabs/synnax/commit/8c2f0a53cb9fb36b213d84a29b8f80fcd708ac76) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53800886)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->