### PR TITLE
SY-4606: Stop a deleted record coming back through a pending form autosave

### DIFF
--- a/console/src/feature/http/device/useConnectModal.tsx
+++ b/console/src/feature/http/device/useConnectModal.tsx
@@ -63,6 +63,10 @@ const INITIAL_VALUES: Device = {
 
 const useForm = PDevice.createForm(SCHEMAS);
 
+const TEST_CONNECTION_TIMEOUT = TimeSpan.seconds(10);
+// Longer than the usual request timeout to allow for negotiating an SSL handshake.
+const TEST_CONNECTION_REQUEST_TIMEOUT_MS = TimeSpan.seconds(5).milliseconds;
+
 const beforeSave = async ({
   client,
   get,
@@ -79,14 +83,14 @@ const beforeSave = async ({
   const protocol = props.secure ? "https://" : "http://";
   const connection = {
     base_url: `${protocol}${host}`,
-    timeout_ms: TimeSpan.seconds(5).milliseconds, // use longer timeout to allow for negotiating SSL handshake
+    timeout_ms: TEST_CONNECTION_REQUEST_TIMEOUT_MS,
     verify_ssl: props.verifySsl,
     auth: props.auth,
   };
   const healthCheck = props.healthCheck;
   const state = await scanTask.executeCommandSync({
     type: TEST_CONNECTION_COMMAND_TYPE,
-    timeout: TimeSpan.seconds(10),
+    timeout: TEST_CONNECTION_TIMEOUT,
     args: { connection, healthCheck },
   });
   if (state.variant === "error") throw new Error(state.message);

--- a/console/src/feature/lineplot/LinePlot.tsx
+++ b/console/src/feature/lineplot/LinePlot.tsx
@@ -53,6 +53,7 @@ import { Range } from "@/platform/range";
 import { Session } from "@/session";
 
 const CLEAR_OVERSCAN: xy.XY = { x: 5, y: 5 };
+const VIEWPORT_DEBOUNCE = TimeSpan.milliseconds(100);
 
 interface RangeAnnotationContextMenuProps {
   lines: DownloadLine[];
@@ -238,7 +239,7 @@ const Internal = (): ReactElement => {
           }),
         );
     },
-    TimeSpan.milliseconds(100),
+    VIEWPORT_DEBOUNCE,
     [dispatch, key],
   );
 

--- a/console/src/feature/modbus/device/useConnectModal.tsx
+++ b/console/src/feature/modbus/device/useConnectModal.tsx
@@ -37,6 +37,8 @@ import { Triggers } from "@/platform/triggers";
 
 const useForm = PDevice.createForm(SCHEMAS);
 
+const TEST_CONNECTION_TIMEOUT = TimeSpan.seconds(10);
+
 const INITIAL_VALUES: Device = {
   key: "",
   name: "Modbus Server",
@@ -70,7 +72,7 @@ const beforeSave = async ({
   });
   const state = await scanTask.executeCommandSync({
     type: TEST_CONNECTION_COMMAND_TYPE,
-    timeout: TimeSpan.seconds(10),
+    timeout: TEST_CONNECTION_TIMEOUT,
     args: { connection: get("properties.connection").value },
   });
   if (state.variant === "error") throw new Error(state.message);

--- a/console/src/feature/opcua/device/Browser.tsx
+++ b/console/src/feature/opcua/device/Browser.tsx
@@ -98,6 +98,8 @@ const itemRenderProp = Component.renderProp((props: Tree.ItemRenderProps<string>
   );
 });
 
+const BROWSE_TIMEOUT = TimeSpan.seconds(10);
+
 const browseNodes = async (
   client: Client,
   rack: rack.Key,
@@ -107,7 +109,7 @@ const browseNodes = async (
   const scanTask = await retrieveScanTask(client, rack);
   const { details, variant, message } = await scanTask.executeCommandSync({
     type: BROWSE_COMMAND_TYPE,
-    timeout: TimeSpan.seconds(10),
+    timeout: BROWSE_TIMEOUT,
     args: { connection, node_id: id },
   });
   if (variant !== "success") throw new Error(message);

--- a/console/src/feature/opcua/device/useConnectModal.tsx
+++ b/console/src/feature/opcua/device/useConnectModal.tsx
@@ -45,6 +45,8 @@ import { Triggers } from "@/platform/triggers";
 
 const useForm = PDevice.createForm(SCHEMAS);
 
+const TEST_CONNECTION_TIMEOUT = TimeSpan.seconds(10);
+
 const INITIAL_VALUES: Device = {
   key: "",
   name: "OPC UA Server",
@@ -70,7 +72,7 @@ const beforeSave = async ({
   const scanTask = await retrieveScanTask(client, get<rack.Key>("rack").value);
   const scanStatus = await scanTask.executeCommandSync({
     type: TEST_CONNECTION_COMMAND_TYPE,
-    timeout: TimeSpan.seconds(10),
+    timeout: TEST_CONNECTION_TIMEOUT,
     args: { connection: get("properties.connection").value },
   });
   if (scanStatus.variant === "error") throw new Error(scanStatus.message);

--- a/console/src/platform/label/useEditModal.tsx
+++ b/console/src/platform/label/useEditModal.tsx
@@ -26,7 +26,7 @@ import {
   Text,
   useClickOutside,
 } from "@synnaxlabs/pluto";
-import { color } from "@synnaxlabs/x";
+import { color, TimeSpan } from "@synnaxlabs/x";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { Button as PlatformButton } from "@/platform/button";
@@ -48,9 +48,11 @@ const LabelListItem = ({
   const { itemKey } = rest;
   const initialValues = List.useItem<string, label.Label>(itemKey);
   const { form, save } = Label.useForm({
-    query: null,
+    query: isCreate ? null : { key: itemKey },
     initialValues,
     autoSave: !isCreate,
+    // The color picker emits a change per pixel of drag through the gradient.
+    autoSaveDebounce: TimeSpan.milliseconds(500),
     afterSave: useCallback(
       ({ reset }: Flux.AfterSaveParams<query.Params, typeof Label.formSchema>) => {
         onClose?.();

--- a/console/src/platform/label/useEditModal.tsx
+++ b/console/src/platform/label/useEditModal.tsx
@@ -26,7 +26,7 @@ import {
   Text,
   useClickOutside,
 } from "@synnaxlabs/pluto";
-import { color, TimeSpan } from "@synnaxlabs/x";
+import { color } from "@synnaxlabs/x";
 import { useCallback, useEffect, useRef, useState } from "react";
 
 import { Button as PlatformButton } from "@/platform/button";
@@ -51,8 +51,6 @@ const LabelListItem = ({
     query: isCreate ? null : { key: itemKey },
     initialValues,
     autoSave: !isCreate,
-    // The color picker emits a change per pixel of drag through the gradient.
-    autoSaveDebounce: TimeSpan.milliseconds(500),
     afterSave: useCallback(
       ({ reset }: Flux.AfterSaveParams<query.Params, typeof Label.formSchema>) => {
         onClose?.();
@@ -90,15 +88,13 @@ const LabelListItem = ({
     >
       <Flex.Box x gap="small" align="center">
         <Form.Form<typeof Label.formSchema> {...form}>
-          <Form.Field<string>
+          <Form.Field<color.Color>
             hideIfNull
             path="color"
             padHelpText={false}
             showLabel={false}
           >
-            {({ onChange, ...p }) => (
-              <Color.Swatch onChange={(v) => onChange(color.hex(v))} {...p} />
-            )}
+            {(p) => <Color.Swatch onlyChangeOnBlur {...p} />}
           </Form.Field>
           <Form.TextField
             showLabel={false}

--- a/console/src/platform/range/overview/MetaData.spec.tsx
+++ b/console/src/platform/range/overview/MetaData.spec.tsx
@@ -9,7 +9,7 @@
 
 import { type ranger } from "@synnaxlabs/client";
 import { createTestClient } from "@synnaxlabs/client/testutil";
-import { id } from "@synnaxlabs/x";
+import { id, testutil } from "@synnaxlabs/x";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
@@ -63,5 +63,29 @@ describe("Range.MetaData", () => {
     await waitFor(async () => {
       expect(await range.kv.get(metaKey)).toBe(metaValue);
     });
+  });
+
+  it("should not restore a deleted pair whose value edit is still pending", async () => {
+    const range = await createRange();
+    const metaKey = id.create();
+    await range.kv.set(metaKey, "initial");
+    const { wrapper } = await createConsoleWrapper({ client });
+    render(<Range.MetaData rangeKey={range.key} />, { wrapper });
+    await waitFor(() => expect(screen.getByText(metaKey)).toBeTruthy());
+
+    const valueInput = screen.getByDisplayValue("initial");
+    fireEvent.change(valueInput, { target: { value: "edited" } });
+    fireEvent.blur(valueInput);
+
+    const deleteButton = screen
+      .getAllByRole("button")
+      .find((b) => b.classList.contains("console-metadata__delete"));
+    if (deleteButton == null) throw new Error("delete button not found");
+    fireEvent.click(deleteButton);
+
+    await waitFor(() => expect(screen.queryByText(metaKey)).toBeNull());
+    await testutil.expectAlways(async () => {
+      expect(await range.kv.list()).not.toHaveProperty(metaKey);
+    }, 800);
   });
 });

--- a/console/src/platform/range/overview/MetaData.spec.tsx
+++ b/console/src/platform/range/overview/MetaData.spec.tsx
@@ -9,7 +9,7 @@
 
 import { type ranger } from "@synnaxlabs/client";
 import { createTestClient } from "@synnaxlabs/client/testutil";
-import { id, testutil } from "@synnaxlabs/x";
+import { id } from "@synnaxlabs/x";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
@@ -63,29 +63,5 @@ describe("Range.MetaData", () => {
     await waitFor(async () => {
       expect(await range.kv.get(metaKey)).toBe(metaValue);
     });
-  });
-
-  it("should not restore a deleted pair whose value edit is still pending", async () => {
-    const range = await createRange();
-    const metaKey = id.create();
-    await range.kv.set(metaKey, "initial");
-    const { wrapper } = await createConsoleWrapper({ client });
-    render(<Range.MetaData rangeKey={range.key} />, { wrapper });
-    await waitFor(() => expect(screen.getByText(metaKey)).toBeTruthy());
-
-    const valueInput = screen.getByDisplayValue("initial");
-    fireEvent.change(valueInput, { target: { value: "edited" } });
-    fireEvent.blur(valueInput);
-
-    const deleteButton = screen
-      .getAllByRole("button")
-      .find((b) => b.classList.contains("console-metadata__delete"));
-    if (deleteButton == null) throw new Error("delete button not found");
-    fireEvent.click(deleteButton);
-
-    await waitFor(() => expect(screen.queryByText(metaKey)).toBeNull());
-    await testutil.expectAlways(async () => {
-      expect(await range.kv.list()).not.toHaveProperty(metaKey);
-    }, 800);
   });
 });

--- a/console/src/platform/range/overview/MetaData.tsx
+++ b/console/src/platform/range/overview/MetaData.tsx
@@ -84,7 +84,7 @@ const MetaDataListItem = ({
   const inputRef = useRef<HTMLInputElement>(null);
   const { update: handleDelete } = Ranger.useDeleteKV();
   const { form, save } = Ranger.useKVPairForm({
-    query: null,
+    query: isCreate ? null : { rangeKey, key: itemKey },
     autoSave: !isCreate,
     initialValues: initialValues ?? {
       key: "",

--- a/console/src/platform/status/list/Item.tsx
+++ b/console/src/platform/status/list/Item.tsx
@@ -12,7 +12,6 @@ import "@/platform/status/list/Item.css";
 import { type status } from "@synnaxlabs/client";
 import {
   Flex,
-  Form,
   Icon,
   Input,
   List,
@@ -22,7 +21,7 @@ import {
   Telem,
   Text,
 } from "@synnaxlabs/pluto";
-import { type ReactElement, useMemo } from "react";
+import { type ReactElement } from "react";
 
 import { Button } from "@/platform/button";
 import { CSS } from "@/platform/css";
@@ -38,19 +37,6 @@ export const Item = (props: ItemProps): ReactElement | null => {
     dispatch(Session.Status.toggleFavorite(itemKey));
   };
   const item = List.useItem<status.Key, status.Status>(itemKey);
-  const initialValues = useMemo(() => {
-    if (item == null) return undefined;
-    return {
-      ...item,
-      labels: item.labels?.map((l) => l.key) ?? [],
-    };
-  }, [item]);
-  const { form } = Status.useForm({
-    query: null,
-    initialValues,
-    autoSave: true,
-    sync: true,
-  });
   const { selected, onSelect } = Select.useItemState(itemKey);
 
   if (item == null) return null;
@@ -63,50 +49,48 @@ export const Item = (props: ItemProps): ReactElement | null => {
       justify="between"
       selected={selected}
     >
-      <Form.Form<typeof Status.formSchema> {...form}>
-        <Flex.Box x empty>
-          <Input.Checkbox
-            value={selected}
-            onChange={onSelect}
-            size="medium"
-            reveal={!selected}
-          />
-          <Text.Text level="p" weight={450}>
-            <Status.Indicator variant={variant} />
-            <Text.Text el="span" status={variant}>
-              {name}
-            </Text.Text>
-            {message.length > 0 && <Icon.Caret.Right />}
-            <Text.Text el="span" color={9}>
-              {message}
-            </Text.Text>
+      <Flex.Box x empty>
+        <Input.Checkbox
+          value={selected}
+          onChange={onSelect}
+          size="medium"
+          reveal={!selected}
+        />
+        <Text.Text level="p" weight={450}>
+          <Status.Indicator variant={variant} />
+          <Text.Text el="span" status={variant}>
+            {name}
           </Text.Text>
-        </Flex.Box>
-        <Flex.Box x align="center">
-          {labels != null && labels.length > 0 && (
-            <Tag.Tags variant="text">
-              {labels.map(({ key, name, color }) => (
-                <Tag.Tag key={key} color={color} size="small">
-                  {name}
-                </Tag.Tag>
-              ))}
-            </Tag.Tags>
-          )}
-          <Text.Text x>
-            <Telem.Text.TimeSpanSince
-              el="span"
-              level="p"
-              color="gray"
-              format="semantic"
-              variant="code"
-            >
-              {time}
-            </Telem.Text.TimeSpanSince>
-            <Icon.Time color={9} />
+          {message.length > 0 && <Icon.Caret.Right />}
+          <Text.Text el="span" color={9}>
+            {message}
           </Text.Text>
-          <Button.Favorite isFavorite={isFavorite} onFavorite={handleFavorite} reveal />
-        </Flex.Box>
-      </Form.Form>
+        </Text.Text>
+      </Flex.Box>
+      <Flex.Box x align="center">
+        {labels != null && labels.length > 0 && (
+          <Tag.Tags variant="text">
+            {labels.map(({ key, name, color }) => (
+              <Tag.Tag key={key} color={color} size="small">
+                {name}
+              </Tag.Tag>
+            ))}
+          </Tag.Tags>
+        )}
+        <Text.Text x>
+          <Telem.Text.TimeSpanSince
+            el="span"
+            level="p"
+            color="gray"
+            format="semantic"
+            variant="code"
+          >
+            {time}
+          </Telem.Text.TimeSpanSince>
+          <Icon.Time color={9} />
+        </Text.Text>
+        <Button.Favorite isFavorite={isFavorite} onFavorite={handleFavorite} reveal />
+      </Flex.Box>
     </List.Item>
   );
 };

--- a/console/src/platform/task/Form.tsx
+++ b/console/src/platform/task/Form.tsx
@@ -108,7 +108,7 @@ const Header = ({ isSnapshot }: HeaderProps) => (
 const SKIP_AUTOSAVE: PForm.SetOptions = { notifyOnChange: false };
 
 // Numeric fields have drag handles that emit a change per pixel.
-const AUTO_SAVE_DEBOUNCE = TimeSpan.milliseconds(500);
+const AUTO_SAVE_DEBOUNCE = TimeSpan.milliseconds(200);
 
 const issueVariant = (issue: z.core.$ZodIssue): status.Variant =>
   issue.code === "custom" && issue.params != null && "variant" in issue.params

--- a/console/src/platform/task/Form.tsx
+++ b/console/src/platform/task/Form.tsx
@@ -25,7 +25,7 @@ import {
   Synnax as PSynnax,
   Task as PTask,
 } from "@synnaxlabs/pluto";
-import { primitive } from "@synnaxlabs/x";
+import { primitive, TimeSpan } from "@synnaxlabs/x";
 import { type FC, useCallback } from "react";
 import { type z } from "zod";
 
@@ -130,6 +130,8 @@ export const wrapForm = <S extends task.Schemas = task.Schemas>({
     const { form, saveAsync } = useForm({
       query: { key: taskKey },
       autoSave: true,
+      // Numeric fields have drag handles that emit a change per pixel.
+      autoSaveDebounce: TimeSpan.milliseconds(500),
     });
 
     // Deploy pipeline: resolve channels and rack through onConfigure, persist

--- a/console/src/platform/task/Form.tsx
+++ b/console/src/platform/task/Form.tsx
@@ -107,6 +107,9 @@ const Header = ({ isSnapshot }: HeaderProps) => (
 // The deploy pipeline saves once at the end; notifying would fire autosave first.
 const SKIP_AUTOSAVE: PForm.SetOptions = { notifyOnChange: false };
 
+// Numeric fields have drag handles that emit a change per pixel.
+const AUTO_SAVE_DEBOUNCE = TimeSpan.milliseconds(500);
+
 const issueVariant = (issue: z.core.$ZodIssue): status.Variant =>
   issue.code === "custom" && issue.params != null && "variant" in issue.params
     ? (issue.params.variant as status.Variant)
@@ -130,8 +133,7 @@ export const wrapForm = <S extends task.Schemas = task.Schemas>({
     const { form, saveAsync } = useForm({
       query: { key: taskKey },
       autoSave: true,
-      // Numeric fields have drag handles that emit a change per pixel.
-      autoSaveDebounce: TimeSpan.milliseconds(500),
+      autoSaveDebounce: AUTO_SAVE_DEBOUNCE,
     });
 
     // Deploy pipeline: resolve channels and rack through onConfigure, persist

--- a/console/src/platform/version/Updater.tsx
+++ b/console/src/platform/version/Updater.tsx
@@ -21,6 +21,7 @@ import { useInfoModal } from "@/platform/version/useInfoModal";
 import { Session } from "@/session";
 
 const STATUS_KEY_PREFIX = "versionUpdate";
+const CHECK_INTERVAL = TimeSpan.seconds(30);
 
 export const useCheckForUpdates = (): boolean => {
   const addStatus = Status.useAdder();
@@ -42,10 +43,7 @@ export const useCheckForUpdates = (): boolean => {
   useAsyncEffect(async (signal) => {
     await checkForUpdates();
     if (signal.aborted) return;
-    const i = setInterval(
-      () => void checkForUpdates(),
-      TimeSpan.seconds(30).milliseconds,
-    );
+    const i = setInterval(() => void checkForUpdates(), CHECK_INTERVAL.milliseconds);
     return () => clearInterval(i);
   }, []);
 

--- a/pluto/src/color/Swatch.spec.tsx
+++ b/pluto/src/color/Swatch.spec.tsx
@@ -1,0 +1,126 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { color } from "@synnaxlabs/x";
+import { fireEvent, render, type RenderResult } from "@testing-library/react";
+import { type PropsWithChildren, type ReactElement } from "react";
+import { describe, expect, it, vi } from "vitest";
+
+import { Color } from "@/color";
+import { CSS } from "@/css";
+import { Theming } from "@/theming";
+import { Triggers } from "@/triggers";
+
+const RED = "#ff0000";
+const GREEN = "00ff00";
+const BLUE = "0000ff";
+
+const SWATCH_VAR = CSS.var("swatch", "color");
+
+const Wrapper = ({ children }: PropsWithChildren): ReactElement => (
+  <Triggers.Provider>
+    <Theming.Provider>{children}</Theming.Provider>
+  </Triggers.Provider>
+);
+
+const swatchOf = (c: RenderResult): HTMLElement => {
+  const el = c.container.querySelector<HTMLElement>(`.${CSS.B("color-swatch")}`);
+  if (el == null) throw new Error("no swatch rendered");
+  return el;
+};
+
+const hexInputOf = (c: RenderResult): HTMLInputElement =>
+  c.getByLabelText("hex") as HTMLInputElement;
+
+const pick = (c: RenderResult, hex: string): void => {
+  fireEvent.change(hexInputOf(c), { target: { value: hex } });
+};
+
+const closePicker = (c: RenderResult): void => {
+  fireEvent.keyDown(c.container, { code: "Escape" });
+};
+
+describe("Swatch", () => {
+  describe("onChange", () => {
+    it("should call onChange on every picker change by default", () => {
+      const onChange = vi.fn();
+      const c = render(<Color.Swatch value={RED} onChange={onChange} />, {
+        wrapper: Wrapper,
+      });
+      fireEvent.click(swatchOf(c));
+      pick(c, GREEN);
+      pick(c, BLUE);
+      expect(onChange).toHaveBeenCalledTimes(2);
+      expect(color.hex(onChange.mock.calls[1][0])).toEqual(`#${BLUE}`);
+    });
+  });
+
+  describe("onlyChangeOnBlur", () => {
+    it("should not call onChange while the picker is open", () => {
+      const onChange = vi.fn();
+      const c = render(
+        <Color.Swatch value={RED} onChange={onChange} onlyChangeOnBlur />,
+        { wrapper: Wrapper },
+      );
+      fireEvent.click(swatchOf(c));
+      pick(c, GREEN);
+      pick(c, BLUE);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("should show the pending color on the swatch while the picker is open", () => {
+      const c = render(
+        <Color.Swatch value={RED} onChange={vi.fn()} onlyChangeOnBlur />,
+        { wrapper: Wrapper },
+      );
+      fireEvent.click(swatchOf(c));
+      pick(c, GREEN);
+      expect(swatchOf(c).style.getPropertyValue(SWATCH_VAR)).toEqual(
+        color.cssString(`#${GREEN}`),
+      );
+    });
+
+    it("should call onChange once with the last color when the picker closes", () => {
+      const onChange = vi.fn();
+      const c = render(
+        <Color.Swatch value={RED} onChange={onChange} onlyChangeOnBlur />,
+        { wrapper: Wrapper },
+      );
+      fireEvent.click(swatchOf(c));
+      pick(c, GREEN);
+      pick(c, BLUE);
+      closePicker(c);
+      expect(onChange).toHaveBeenCalledOnce();
+      expect(color.hex(onChange.mock.calls[0][0])).toEqual(`#${BLUE}`);
+    });
+
+    it("should not call onChange when the picker closes without a change", () => {
+      const onChange = vi.fn();
+      const c = render(
+        <Color.Swatch value={RED} onChange={onChange} onlyChangeOnBlur />,
+        { wrapper: Wrapper },
+      );
+      fireEvent.click(swatchOf(c));
+      closePicker(c);
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("should drop a pending change when the swatch unmounts", () => {
+      const onChange = vi.fn();
+      const c = render(
+        <Color.Swatch value={RED} onChange={onChange} onlyChangeOnBlur />,
+        { wrapper: Wrapper },
+      );
+      fireEvent.click(swatchOf(c));
+      pick(c, GREEN);
+      c.unmount();
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/pluto/src/color/Swatch.spec.tsx
+++ b/pluto/src/color/Swatch.spec.tsx
@@ -10,10 +10,11 @@
 import { color } from "@synnaxlabs/x";
 import { fireEvent, render, type RenderResult } from "@testing-library/react";
 import { type PropsWithChildren, type ReactElement } from "react";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Color } from "@/color";
 import { CSS } from "@/css";
+import { mockBoundingClientRect } from "@/testutil/dom";
 import { Theming } from "@/theming";
 import { Triggers } from "@/triggers";
 
@@ -121,6 +122,34 @@ describe("Swatch", () => {
       pick(c, GREEN);
       c.unmount();
       expect(onChange).not.toHaveBeenCalled();
+    });
+
+    // Dismissal reads the pointer against getBoundingClientRect, which jsdom reports
+    // as all zeros: the origin lands inside the picker and every other point lands
+    // outside the window. Give the document a size so the dismissal runs.
+    describe("dismissed by a click outside", () => {
+      beforeEach(() => {
+        vi.spyOn(document.documentElement, "getBoundingClientRect").mockImplementation(
+          mockBoundingClientRect(0, 0, 1000, 1000),
+        );
+      });
+      afterEach(() => {
+        vi.restoreAllMocks();
+      });
+
+      it("should call onChange once with the last color", () => {
+        const onChange = vi.fn();
+        const c = render(
+          <Color.Swatch value={RED} onChange={onChange} onlyChangeOnBlur />,
+          { wrapper: Wrapper },
+        );
+        fireEvent.click(swatchOf(c));
+        pick(c, GREEN);
+        pick(c, BLUE);
+        fireEvent.pointerDown(document.body, { clientX: 500, clientY: 500 });
+        expect(onChange).toHaveBeenCalledOnce();
+        expect(color.hex(onChange.mock.calls[0][0])).toEqual(`#${BLUE}`);
+      });
     });
   });
 });

--- a/pluto/src/color/Swatch.tsx
+++ b/pluto/src/color/Swatch.tsx
@@ -9,7 +9,8 @@
 
 import "@/color/Swatch.css";
 
-import { type ReactElement, useCallback, useMemo } from "react";
+import { type color, state as xstate } from "@synnaxlabs/x";
+import { type ReactElement, useCallback, useMemo, useState } from "react";
 
 import { BaseSwatch, type BaseSwatchProps } from "@/color/BaseSwatch";
 import { Picker, type PickerProps } from "@/color/Picker";
@@ -24,13 +25,28 @@ export interface SwatchProps
     Pick<Dialog.FrameProps, "visible" | "onVisibleChange" | "initialVisible">,
     Pick<PickerProps, "onDelete" | "position"> {
   allowChange?: boolean;
+  onlyChangeOnBlur?: boolean;
 }
 
+/**
+ * A color swatch that opens a picker when clicked.
+ *
+ * @param props - The props for the swatch. Unlisted props are passed to the underlying
+ * button.
+ * @param props.value - The color the swatch shows.
+ * @param props.onChange - A function to call when the color changes.
+ * @param props.allowChange - Whether clicking the swatch opens the picker.
+ * @param props.onlyChangeOnBlur - If true, the swatch holds picker changes locally and
+ * calls `onChange` once, when the picker closes. Set it where a live preview is not
+ * worth a change per pixel of drag through the gradient. A change pending when the
+ * swatch unmounts is dropped.
+ */
 export const Swatch = ({
   onChange,
   onVisibleChange,
   initialVisible = false,
   allowChange = true,
+  onlyChangeOnBlur = false,
   style,
   onClick,
   value,
@@ -42,22 +58,48 @@ export const Swatch = ({
     value: propsVisible,
     onChange: onVisibleChange,
   });
+  const [pending, setPending] = useState<color.Color | null>(null);
+  const handleVisibleChange = useCallback<xstate.Setter<boolean>>(
+    (arg) => {
+      if (pending != null && !xstate.executeSetter(arg, visible)) {
+        onChange?.(pending);
+        setPending(null);
+      }
+      setVisible(arg);
+    },
+    [visible, pending, onChange, setVisible],
+  );
+  const handleSwatchChange = useCallback<NonNullable<BaseSwatchProps["onChange"]>>(
+    (c) => {
+      setPending(null);
+      onChange?.(c);
+    },
+    [onChange],
+  );
+  const handlePickerChange = useCallback<PickerProps["onChange"]>(
+    (c) => {
+      if (onlyChangeOnBlur) setPending(c);
+      else onChange?.(c);
+    },
+    [onlyChangeOnBlur, onChange],
+  );
   const canPick = onChange != null && allowChange;
   const handleClick = useCallback<NonNullable<BaseSwatchProps["onClick"]>>(
-    (e) => (canPick ? setVisible(true) : onClick?.(e)),
-    [canPick, setVisible, onClick],
+    (e) => (canPick ? handleVisibleChange(true) : onClick?.(e)),
+    [canPick, handleVisibleChange, onClick],
   );
   const tooltip = useMemo(
     () =>
       canPick ? <Text.Text level="small">Click to change color</Text.Text> : undefined,
     [canPick],
   );
+  const shownValue = pending ?? value;
   const swatch = (
     <BaseSwatch
       disabled={!canPick && onClick == null}
       onClick={handleClick}
-      onChange={onChange}
-      value={value}
+      onChange={handleSwatchChange}
+      value={shownValue}
       style={style}
       tooltip={tooltip}
       {...rest}
@@ -68,13 +110,13 @@ export const Swatch = ({
     <Dialog.Frame
       visible={visible}
       initialVisible={initialVisible}
-      onVisibleChange={setVisible}
+      onVisibleChange={handleVisibleChange}
       className={CSS.BE("color-swatch", "dropdown")}
       variant="floating"
     >
       {swatch}
       <Dialog.Dialog rounded="small">
-        <Picker value={value} onChange={onChange} />
+        <Picker value={shownValue} onChange={handlePickerChange} />
       </Dialog.Dialog>
     </Dialog.Frame>
   );

--- a/pluto/src/flux/form.spec.tsx
+++ b/pluto/src/flux/form.spec.tsx
@@ -9,7 +9,7 @@
 
 import { query } from "@synnaxlabs/client";
 import { createTestClient } from "@synnaxlabs/client/testutil";
-import { color, testutil } from "@synnaxlabs/x";
+import { color, testutil, TimeSpan } from "@synnaxlabs/x";
 import { act, render, renderHook, waitFor } from "@testing-library/react";
 import { type ReactElement } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -32,6 +32,10 @@ type Params = {
 
 const client = createTestClient();
 const Wrapper = createSynnaxWrapper({ client });
+
+const DEBOUNCE = TimeSpan.milliseconds(100);
+// Long enough that a debounced save would have landed by now.
+const SETTLE = 500;
 
 describe("useForm", () => {
   let controller: AbortController;
@@ -530,16 +534,14 @@ describe("useForm", () => {
       });
     });
 
-    it("should collapse a burst of changes into a single update", async () => {
+    it("should update once per change when no debounce is set", async () => {
       const update = vi.fn();
-      const retrieve = vi.fn().mockReturnValue(null);
       const { result } = renderHook(
         () =>
           Flux.createForm<Params, typeof formSchema>({
             initialValues: { key: "", name: "John Doe", age: 25 },
             schema: formSchema,
             name: "test",
-            retrieve,
             update: ({ get }) => update(get("name").value),
           })({ query: null, autoSave: true }),
         { wrapper: Wrapper },
@@ -549,24 +551,44 @@ describe("useForm", () => {
         result.current.form.set("name", "Ja");
         result.current.form.set("name", "Jane");
       });
-      await waitFor(() => expect(update).toHaveBeenCalledTimes(1), { timeout: 2000 });
-      expect(update).toHaveBeenCalledWith("Jane");
+      await waitFor(() => expect(update).toHaveBeenCalledTimes(3));
+      expect(update).toHaveBeenLastCalledWith("Jane");
     });
+  });
 
-    it("should flush a pending update when the form unmounts", async () => {
+  describe("autoSaveDebounce", () => {
+    const renderDebouncedForm = () => {
       const update = vi.fn();
-      const retrieve = vi.fn().mockReturnValue(null);
-      const { result, unmount } = renderHook(
+      const rendered = renderHook(
         () =>
           Flux.createForm<Params, typeof formSchema>({
             initialValues: { key: "", name: "John Doe", age: 25 },
             schema: formSchema,
             name: "test",
-            retrieve,
             update: ({ get }) => update(get("name").value),
-          })({ query: null, autoSave: true }),
+          })({ query: null, autoSave: true, autoSaveDebounce: DEBOUNCE }),
         { wrapper: Wrapper },
       );
+      return { ...rendered, update };
+    };
+
+    it("should collapse a burst of changes into a single update", async () => {
+      const { result, update } = renderDebouncedForm();
+      act(() => {
+        result.current.form.set("name", "J");
+        result.current.form.set("name", "Ja");
+        result.current.form.set("name", "Jane");
+      });
+      await waitFor(() => expect(update).toHaveBeenCalledTimes(1));
+      expect(update).toHaveBeenCalledWith("Jane");
+      await testutil.expectAlways(
+        () => expect(update).toHaveBeenCalledTimes(1),
+        SETTLE,
+      );
+    });
+
+    it("should flush a pending update when the form unmounts", async () => {
+      const { result, update, unmount } = renderDebouncedForm();
       act(() => {
         result.current.form.set("name", "Jane Doe");
       });
@@ -594,10 +616,16 @@ describe("useForm", () => {
       return { update, useForm, abandon: () => abandon() };
     };
 
+    // Debounced so a save is genuinely queued when the record is abandoned.
     const renderAbandonableForm = () => {
       const { update, useForm, abandon } = createAbandonableForm();
       const rendered = renderHook(
-        () => useForm({ query: { key: "123" }, autoSave: true }),
+        () =>
+          useForm({
+            query: { key: "123" },
+            autoSave: true,
+            autoSaveDebounce: DEBOUNCE,
+          }),
         { wrapper: Wrapper },
       );
       return { ...rendered, update, abandon };
@@ -613,20 +641,21 @@ describe("useForm", () => {
       const { result, update, abandon } = renderAbandonableForm();
       act(() => result.current.form.set("name", "Jane Doe"));
       act(() => abandon());
-      await testutil.expectAlways(() => expect(update).not.toHaveBeenCalled(), 800);
+      await testutil.expectAlways(() => expect(update).not.toHaveBeenCalled(), SETTLE);
     });
 
     it("should ignore later changes once the record is abandoned", async () => {
       const { result, update, abandon } = renderAbandonableForm();
       act(() => abandon());
       act(() => result.current.form.set("name", "Jane Doe"));
-      await testutil.expectAlways(() => expect(update).not.toHaveBeenCalled(), 800);
+      await testutil.expectAlways(() => expect(update).not.toHaveBeenCalled(), SETTLE);
     });
 
     it("should autosave again once the form re-points at another record", async () => {
       const { update, useForm, abandon } = createAbandonableForm();
       const { result, rerender } = renderHook(
-        ({ key }: { key: string }) => useForm({ query: { key }, autoSave: true }),
+        ({ key }: { key: string }) =>
+          useForm({ query: { key }, autoSave: true, autoSaveDebounce: DEBOUNCE }),
         { wrapper: Wrapper, initialProps: { key: "123" } },
       );
       act(() => abandon());
@@ -640,7 +669,7 @@ describe("useForm", () => {
       act(() => result.current.form.set("name", "Jane Doe"));
       act(() => abandon());
       unmount();
-      await testutil.expectAlways(() => expect(update).not.toHaveBeenCalled(), 800);
+      await testutil.expectAlways(() => expect(update).not.toHaveBeenCalled(), SETTLE);
     });
   });
 

--- a/pluto/src/flux/form.spec.tsx
+++ b/pluto/src/flux/form.spec.tsx
@@ -671,6 +671,34 @@ describe("useForm", () => {
       unmount();
       await testutil.expectAlways(() => expect(update).not.toHaveBeenCalled(), SETTLE);
     });
+
+    it("should abort a save already running when the record is abandoned", async () => {
+      const { update, useForm, abandon } = createAbandonableForm();
+      let enter = (): void => {};
+      let release = (): void => {};
+      const entered = new Promise<void>((resolve) => (enter = resolve));
+      const held = new Promise<void>((resolve) => (release = resolve));
+      const { result } = renderHook(
+        () =>
+          useForm({
+            query: { key: "123" },
+            autoSave: true,
+            autoSaveDebounce: DEBOUNCE,
+            // Holds the save open past the delete, so abandon lands mid-flight.
+            beforeSave: async () => {
+              enter();
+              await held;
+              return true;
+            },
+          }),
+        { wrapper: Wrapper },
+      );
+      act(() => result.current.form.set("name", "Jane Doe"));
+      await entered;
+      act(() => abandon());
+      await act(async () => release());
+      await testutil.expectAlways(() => expect(update).not.toHaveBeenCalled(), SETTLE);
+    });
   });
 
   describe("listeners", () => {

--- a/pluto/src/flux/form.spec.tsx
+++ b/pluto/src/flux/form.spec.tsx
@@ -575,6 +575,75 @@ describe("useForm", () => {
     });
   });
 
+  describe("abandon", () => {
+    // Hands back the abandon handle the form passes to its listeners, so the
+    // tests can play the record being deleted out from under the form.
+    const createAbandonableForm = () => {
+      const update = vi.fn();
+      let abandon = (): void => {};
+      const useForm = Flux.createForm<Params, typeof formSchema>({
+        initialValues: { key: "", name: "John Doe", age: 25 },
+        schema: formSchema,
+        name: "test",
+        update: ({ get }) => update(get("name").value),
+        mountListeners: (params) => {
+          abandon = params.abandon;
+          return () => {};
+        },
+      });
+      return { update, useForm, abandon: () => abandon() };
+    };
+
+    const renderAbandonableForm = () => {
+      const { update, useForm, abandon } = createAbandonableForm();
+      const rendered = renderHook(
+        () => useForm({ query: { key: "123" }, autoSave: true }),
+        { wrapper: Wrapper },
+      );
+      return { ...rendered, update, abandon };
+    };
+
+    it("should autosave while the record still exists", async () => {
+      const { result, update } = renderAbandonableForm();
+      act(() => result.current.form.set("name", "Jane Doe"));
+      await waitFor(() => expect(update).toHaveBeenCalledWith("Jane Doe"));
+    });
+
+    it("should drop a pending autosave when the record is abandoned", async () => {
+      const { result, update, abandon } = renderAbandonableForm();
+      act(() => result.current.form.set("name", "Jane Doe"));
+      act(() => abandon());
+      await testutil.expectAlways(() => expect(update).not.toHaveBeenCalled(), 800);
+    });
+
+    it("should ignore later changes once the record is abandoned", async () => {
+      const { result, update, abandon } = renderAbandonableForm();
+      act(() => abandon());
+      act(() => result.current.form.set("name", "Jane Doe"));
+      await testutil.expectAlways(() => expect(update).not.toHaveBeenCalled(), 800);
+    });
+
+    it("should autosave again once the form re-points at another record", async () => {
+      const { update, useForm, abandon } = createAbandonableForm();
+      const { result, rerender } = renderHook(
+        ({ key }: { key: string }) => useForm({ query: { key }, autoSave: true }),
+        { wrapper: Wrapper, initialProps: { key: "123" } },
+      );
+      act(() => abandon());
+      rerender({ key: "456" });
+      act(() => result.current.form.set("name", "Jane Doe"));
+      await waitFor(() => expect(update).toHaveBeenCalledWith("Jane Doe"));
+    });
+
+    it("should not flush a pending autosave on unmount after abandoning", async () => {
+      const { result, update, abandon, unmount } = renderAbandonableForm();
+      act(() => result.current.form.set("name", "Jane Doe"));
+      act(() => abandon());
+      unmount();
+      await testutil.expectAlways(() => expect(update).not.toHaveBeenCalled(), 800);
+    });
+  });
+
   describe("listeners", () => {
     it("should correctly update the form data when the listener receives changes", async () => {
       const label = await client.labels.create({

--- a/pluto/src/flux/form.ts
+++ b/pluto/src/flux/form.ts
@@ -8,7 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { type query, type Synnax as Client } from "@synnaxlabs/client";
-import { type destructor, state, TimeSpan } from "@synnaxlabs/x";
+import { type CrudeTimeSpan, type destructor, state, TimeSpan } from "@synnaxlabs/x";
 import {
   useCallback,
   useEffect,
@@ -129,6 +129,12 @@ export interface UseFormParams<
 > extends Pick<Form.UseParams<Schema>, "sync" | "onHasTouched" | "mode"> {
   initialValues?: z.infer<Schema>;
   autoSave?: boolean;
+  /**
+   * How long to wait after a change before autosaving. Zero, the default, saves on
+   * every change. Set it only for a form with a continuous input, such as a drag
+   * handle or a color picker, where a single gesture emits a burst of changes.
+   */
+  autoSaveDebounce?: CrudeTimeSpan;
   /** The record to edit, or null for a form with nothing to read. */
   query: Query | null;
   beforeValidate?: (params: BeforeValidateParams<Query, Schema>) => boolean | void;
@@ -148,8 +154,6 @@ const DEFAULT_SET_OPTIONS: Form.SetOptions = {
   notifyOnChange: false,
 };
 
-const AUTO_SAVE_DEBOUNCE = TimeSpan.milliseconds(500);
-
 export const createForm = <
   Query extends query.Params,
   Schema extends z.ZodType<query.Data>,
@@ -168,6 +172,7 @@ export const createForm = <
     query,
     initialValues,
     autoSave = false,
+    autoSaveDebounce = TimeSpan.ZERO,
     afterSave,
     beforeSave,
     beforeValidate,
@@ -283,7 +288,7 @@ export const createForm = <
     const saveRef = useSyncedRef(save);
     const debouncedSave = useDebouncedCallback(
       () => saveRef.current(),
-      AUTO_SAVE_DEBOUNCE,
+      autoSaveDebounce,
       [],
     );
     useEffect(() => () => debouncedSave.flush(), [debouncedSave]);

--- a/pluto/src/flux/form.ts
+++ b/pluto/src/flux/form.ts
@@ -107,8 +107,9 @@ interface FormMountListenersParams<
   extends Form.UseReturn<Schema>, Omit<FormClientParams<Query>, "query"> {
   query: Query;
   /**
-   * Drops the pending autosave and stops further ones. Call when the record no
-   * longer exists: a save queued before a delete would otherwise write it back.
+   * Drops the pending autosave, aborts one already running, and stops further ones.
+   * Call when the record no longer exists: a save queued before a delete would
+   * otherwise write it back.
    */
   abandon: () => void;
 }
@@ -209,6 +210,8 @@ export const createForm = <
       );
 
     const abandonedRef = useRef(false);
+    const abortRef = useRef<AbortController>(null);
+    abortRef.current ??= new AbortController();
     const values = retrieved ?? initialValues ?? baseInitialValues;
     const form = Form.use<Schema>({
       schema,
@@ -236,12 +239,13 @@ export const createForm = <
       if (readQuery.current === memoQuery) return;
       readQuery.current = memoQuery;
       abandonedRef.current = false;
+      abortRef.current = new AbortController();
       form.reset(valuesRef.current);
     }, [memoQuery, form]);
 
     const saveAsync = useCallback(
       async (opts: query.FetchOptions = {}): Promise<boolean> => {
-        const { signal } = opts;
+        const { signal = abortRef.current?.signal } = opts;
         try {
           if (client == null) {
             setResult(nullClientResult<undefined>(`update ${name}`));
@@ -255,7 +259,10 @@ export const createForm = <
             setResult(successResult(`updated ${name}`, undefined));
             return false;
           }
-          if (signal?.aborted === true) return false;
+          if (signal?.aborted === true) {
+            setResult(successResult(`updated ${name}`, undefined));
+            return false;
+          }
           const setStatus = (setter: state.SetArg<ResultStatus<never>>) =>
             setResult((p) => {
               const nextStatus = state.executeSetter(setter, p.status);
@@ -296,6 +303,7 @@ export const createForm = <
     const abandon = useCallback(() => {
       abandonedRef.current = true;
       debouncedSave.cancel();
+      abortRef.current?.abort();
     }, [debouncedSave]);
 
     useEffect(() => {

--- a/pluto/src/flux/form.ts
+++ b/pluto/src/flux/form.ts
@@ -106,6 +106,11 @@ interface FormMountListenersParams<
 >
   extends Form.UseReturn<Schema>, Omit<FormClientParams<Query>, "query"> {
   query: Query;
+  /**
+   * Drops the pending autosave and stops further ones. Call when the record no
+   * longer exists: a save queued before a delete would otherwise write it back.
+   */
+  abandon: () => void;
 }
 
 export interface AfterSaveParams<
@@ -198,13 +203,14 @@ export const createForm = <
         pending,
       );
 
+    const abandonedRef = useRef(false);
     const values = retrieved ?? initialValues ?? baseInitialValues;
     const form = Form.use<Schema>({
       schema,
       values,
       onChange: ({ path }) => {
         // Don't save if the path is empty to prevent infinite save loops.
-        if (autoSave && path !== "") debouncedSave();
+        if (autoSave && path !== "" && !abandonedRef.current) debouncedSave();
       },
       sync,
       onHasTouched,
@@ -224,17 +230,9 @@ export const createForm = <
     useLayoutEffect(() => {
       if (readQuery.current === memoQuery) return;
       readQuery.current = memoQuery;
+      abandonedRef.current = false;
       form.reset(valuesRef.current);
     }, [memoQuery, form]);
-
-    useEffect(() => {
-      if (memoQuery == null || client == null || mountListeners == null) return;
-      listeners.cleanup();
-      listeners.set(
-        mountListeners({ client, query: memoQuery, ...form, set: noNotifySet }),
-      );
-      return () => listeners.cleanup();
-    }, [client, memoQuery, form, noNotifySet]);
 
     const saveAsync = useCallback(
       async (opts: query.FetchOptions = {}): Promise<boolean> => {
@@ -289,6 +287,26 @@ export const createForm = <
       [],
     );
     useEffect(() => () => debouncedSave.flush(), [debouncedSave]);
+
+    const abandon = useCallback(() => {
+      abandonedRef.current = true;
+      debouncedSave.cancel();
+    }, [debouncedSave]);
+
+    useEffect(() => {
+      if (memoQuery == null || client == null || mountListeners == null) return;
+      listeners.cleanup();
+      listeners.set(
+        mountListeners({
+          client,
+          query: memoQuery,
+          ...form,
+          set: noNotifySet,
+          abandon,
+        }),
+      );
+      return () => listeners.cleanup();
+    }, [client, memoQuery, form, noNotifySet, abandon]);
 
     return { form, save, saveAsync, ...result };
   };

--- a/pluto/src/hooks/ref.spec.ts
+++ b/pluto/src/hooks/ref.spec.ts
@@ -1,0 +1,72 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { act, renderHook } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { useCombinedStateAndRef } from "@/hooks/ref";
+
+describe("useCombinedStateAndRef", () => {
+  it("should seed both the state and the ref from the initial value", () => {
+    const { result } = renderHook(() => useCombinedStateAndRef<number>(1));
+    const [value, , ref] = result.current;
+    expect(value).toEqual(1);
+    expect(ref.current).toEqual(1);
+  });
+
+  it("should run a lazy initializer exactly once", () => {
+    const initializer = vi.fn(() => 1);
+    const { rerender } = renderHook(() => useCombinedStateAndRef<number>(initializer));
+    rerender();
+    expect(initializer).toHaveBeenCalledOnce();
+  });
+
+  it("should update the state", () => {
+    const { result } = renderHook(() => useCombinedStateAndRef<number>(1));
+    act(() => result.current[1](2));
+    expect(result.current[0]).toEqual(2);
+  });
+
+  // React computes the first update of a batch eagerly, so a ref assigned by the state
+  // updater rather than the setter reads correctly after a single call and only goes
+  // stale once an update is already pending. The pending cases below are the ones that
+  // hold the contract.
+  describe("ref currency", () => {
+    it("should update the ref before the setter returns", () => {
+      const { result } = renderHook(() => useCombinedStateAndRef<number>(1));
+      const [, setValue, ref] = result.current;
+      act(() => {
+        setValue(2);
+        expect(ref.current).toEqual(2);
+      });
+    });
+
+    it("should update the ref before the setter returns with an update pending", () => {
+      const { result } = renderHook(() => useCombinedStateAndRef<number>(1));
+      const [, setValue, ref] = result.current;
+      act(() => {
+        setValue(2);
+        setValue(3);
+        expect(ref.current).toEqual(3);
+      });
+      expect(result.current[0]).toEqual(3);
+    });
+
+    it("should compose sequential function updaters within one handler", () => {
+      const { result } = renderHook(() => useCombinedStateAndRef<number>(1));
+      const [, setValue, ref] = result.current;
+      act(() => {
+        setValue((prev) => prev + 1);
+        setValue((prev) => prev + 1);
+        expect(ref.current).toEqual(3);
+      });
+      expect(result.current[0]).toEqual(3);
+    });
+  });
+});

--- a/pluto/src/hooks/ref.ts
+++ b/pluto/src/hooks/ref.ts
@@ -80,24 +80,25 @@ export const useCombinedRefs = <T>(
     [],
   );
 
+/**
+ * Keeps a piece of state and a ref to it. The ref is assigned by the setter itself, so
+ * it is current as soon as the setter returns, before the re-render it triggers.
+ *
+ * @param initialState - The initial state, or a function that lazily computes it.
+ * @returns a tuple of the state, its setter, and a ref holding the latest value.
+ */
 export const useCombinedStateAndRef = <T extends primitive.Value | object>(
   initialState: state.Initial<T>,
-): [T, state.Setter<T>, React.RefObject<T>] => {
-  const ref = useRef<T | null>(null);
-  const [s, setS] = reactUseState<T>(() => {
-    const s = state.executeInitialSetter<T>(initialState);
-    ref.current = s;
-    return s;
-  });
+): [T, state.Setter<T>, RefObject<T>] => {
+  const ref = useInitializerRef<T>(() => state.executeInitialSetter<T>(initialState));
+  const [s, setS] = reactUseState<T>(() => ref.current);
 
   const setStateAndRef: state.Setter<T> = useCallback((nextState): void => {
-    setS((p) => {
-      ref.current = state.executeSetter<T>(nextState, p);
-      return ref.current;
-    });
+    ref.current = state.executeSetter<T>(nextState, ref.current);
+    setS(ref.current);
   }, []);
 
-  return [s, setStateAndRef, ref as React.RefObject<T>];
+  return [s, setStateAndRef, ref];
 };
 
 export const usePrevious = <T>(value: T): T | undefined => {

--- a/pluto/src/input/Numeric.spec.tsx
+++ b/pluto/src/input/Numeric.spec.tsx
@@ -1,0 +1,136 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { fireEvent, render, type RenderResult } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { CSS } from "@/css";
+import { Input } from "@/input";
+
+// The drag button ignores movement inside its threshold, then scales what is left, so a
+// drag to x carries a value of (x - THRESHOLD) at a unit scale.
+const THRESHOLD = 15;
+const UNIT_SCALE = { x: 1, y: 1 };
+
+const dragButtonOf = (c: RenderResult): HTMLElement => {
+  const el = c.container.querySelector<HTMLElement>(`.${CSS.BE("input", "drag-btn")}`);
+  if (el == null) throw new Error("no drag button rendered");
+  return el;
+};
+
+const pointer = (x: number) => ({
+  pointerId: 1,
+  button: 0,
+  isPrimary: true,
+  clientX: x,
+  clientY: 0,
+});
+
+const dragTo = (el: HTMLElement, ...xs: number[]): void => {
+  fireEvent.pointerDown(el, pointer(0));
+  xs.forEach((x) => fireEvent.pointerMove(el, pointer(x)));
+};
+
+const release = (el: HTMLElement, x: number): void => {
+  fireEvent.pointerUp(el, pointer(x));
+};
+
+describe("Input.Numeric", () => {
+  describe("drag handle", () => {
+    it("should emit a change per drag frame by default", () => {
+      const onChange = vi.fn();
+      const c = render(
+        <Input.Numeric value={0} onChange={onChange} dragScale={UNIT_SCALE} />,
+      );
+      dragTo(dragButtonOf(c), 100, 200);
+      expect(onChange.mock.calls.map(([v]) => v)).toEqual([
+        100 - THRESHOLD,
+        200 - THRESHOLD,
+      ]);
+    });
+
+    describe("onlyChangeOnBlur", () => {
+      it("should not emit while the drag is in progress", () => {
+        const onChange = vi.fn();
+        const c = render(
+          <Input.Numeric
+            value={0}
+            onChange={onChange}
+            dragScale={UNIT_SCALE}
+            onlyChangeOnBlur
+          />,
+        );
+        dragTo(dragButtonOf(c), 100, 200);
+        expect(onChange).not.toHaveBeenCalled();
+      });
+
+      it("should show the dragged value in the input while the drag is in progress", () => {
+        const c = render(
+          <Input.Numeric
+            value={0}
+            onChange={vi.fn()}
+            dragScale={UNIT_SCALE}
+            onlyChangeOnBlur
+          />,
+        );
+        dragTo(dragButtonOf(c), 100);
+        expect((c.getByRole("textbox") as HTMLInputElement).value).toEqual(
+          `${100 - THRESHOLD}`,
+        );
+      });
+
+      it("should emit once with the final value when the drag is released", () => {
+        const onChange = vi.fn();
+        const c = render(
+          <Input.Numeric
+            value={0}
+            onChange={onChange}
+            dragScale={UNIT_SCALE}
+            onlyChangeOnBlur
+          />,
+        );
+        const btn = dragButtonOf(c);
+        dragTo(btn, 100, 200);
+        release(btn, 200);
+        expect(onChange).toHaveBeenCalledOnce();
+        expect(onChange).toHaveBeenCalledWith(200 - THRESHOLD);
+      });
+
+      it("should clamp the released value to the bounds", () => {
+        const onChange = vi.fn();
+        const c = render(
+          <Input.Numeric
+            value={0}
+            onChange={onChange}
+            bounds={{ lower: 0, upper: 50 }}
+            dragScale={UNIT_SCALE}
+            onlyChangeOnBlur
+          />,
+        );
+        const btn = dragButtonOf(c);
+        dragTo(btn, 100, 200);
+        release(btn, 200);
+        expect(onChange).toHaveBeenCalledOnce();
+        expect(onChange).toHaveBeenCalledWith(50);
+      });
+
+      it("should emit the typed value on blur", () => {
+        const onChange = vi.fn();
+        const c = render(
+          <Input.Numeric value={0} onChange={onChange} onlyChangeOnBlur />,
+        );
+        const input = c.getByRole("textbox");
+        fireEvent.change(input, { target: { value: "42" } });
+        fireEvent.blur(input);
+        expect(onChange).toHaveBeenCalledOnce();
+        expect(onChange).toHaveBeenCalledWith(42);
+      });
+    });
+  });
+});

--- a/pluto/src/input/Numeric.tsx
+++ b/pluto/src/input/Numeric.tsx
@@ -52,6 +52,9 @@ export interface NumericProps
  * @default x: 1, y: 10
  * @param props.dragDirection - The direction of the drag handle.
  * @default undefined
+ * @param props.onlyChangeOnBlur - If true, a drag holds its value locally and calls
+ * `onChange` once, on release. Typed input always waits for blur or 'Enter'.
+ * @default false
  */
 export const Numeric = ({
   ref,
@@ -62,6 +65,7 @@ export const Numeric = ({
   dragScale,
   selectOnFocus = true,
   bounds: propsBounds = bounds.INFINITE,
+  onlyChangeOnBlur = false,
   resetValue,
   variant = "outlined",
   preview,
@@ -139,10 +143,18 @@ export const Numeric = ({
 
   const onDragChange = useCallback(
     (value: number) => {
+      const next = bounds.clamp(propsBounds, Math.round(value));
+      // A gated input parks the drag in the internal value, so the text tracks the
+      // pointer and the release commits through the same blur path typing uses.
+      if (onlyChangeOnBlur) {
+        setIsValueValid(false);
+        setInternalValue(next.toString());
+        return;
+      }
       setIsValueValid(true);
-      onChange?.(bounds.clamp(propsBounds, Math.round(value)));
+      onChange?.(next);
     },
-    [onChange, setIsValueValid],
+    [onChange, onlyChangeOnBlur, setInternalValue, setIsValueValid],
   );
 
   if (dragScale == null && bounds.isFinite(propsBounds))

--- a/pluto/src/label/queries.spec.ts
+++ b/pluto/src/label/queries.spec.ts
@@ -9,7 +9,7 @@
 
 import { label } from "@synnaxlabs/client";
 import { createTestClient } from "@synnaxlabs/client/testutil";
-import { color } from "@synnaxlabs/x";
+import { color, testutil, TimeSpan } from "@synnaxlabs/x";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { type FC, type PropsWithChildren } from "react";
 import { beforeAll, describe, expect, it } from "vitest";
@@ -469,6 +469,31 @@ describe("queries", () => {
       await waitFor(() => {
         expect(result.current.form.value().name).toEqual("externallyUpdated");
       });
+    });
+
+    it("should not write back a label deleted while an autosave was pending", async () => {
+      const toDelete = await client.labels.create({
+        name: "autosaveRace",
+        color: "#FF0000",
+      });
+      const { result } = renderHook(
+        () =>
+          Label.useForm({
+            query: { key: toDelete.key },
+            autoSave: true,
+            // Holds the save open long enough for the delete to overtake it.
+            autoSaveDebounce: TimeSpan.milliseconds(500),
+          }),
+        { wrapper },
+      );
+      await waitFor(() => expect(result.current.variant).toEqual("success"));
+      act(() => result.current.form.set("name", "edited"));
+      await act(async () => await client.labels.delete(toDelete.key));
+      await testutil.expectAlways(async () => {
+        await expect(
+          async () => await client.labels.retrieve(toDelete.key),
+        ).rejects.toThrow();
+      }, 800);
     });
 
     it("should handle form with default values", async () => {

--- a/pluto/src/label/queries.ts
+++ b/pluto/src/label/queries.ts
@@ -85,9 +85,10 @@ export const useForm = Flux.createForm<FormQuery, typeof formSchema>({
     const updated = await client.labels.create(value());
     reset(updated);
   },
-  mountListeners: ({ client, query: { key }, reset }) =>
+  mountListeners: ({ client, query: { key }, reset, abandon }) =>
     client.labels.onChange(key, (result) => {
       if (query.isLive(result)) reset(result);
+      else if (query.Deleted.matches(result)) abandon();
     }),
 });
 

--- a/pluto/src/lineplot/measure/aether/measure.ts
+++ b/pluto/src/lineplot/measure/aether/measure.ts
@@ -130,7 +130,7 @@ const LABEL_OVERLAP_Y_THRESHOLD = 30;
 const POINT_LABEL_OFFSET = 15;
 const POINT_LABEL_SPACING = 8;
 
-const TIME_FORMAT_THRESHOLD_MS = 10;
+const TIME_FORMAT_THRESHOLD = TimeSpan.milliseconds(10);
 
 export interface MeasureProps {
   findByXDecimal: (target: number) => FindResult[];
@@ -614,7 +614,7 @@ export class Measure extends aether.Leaf<typeof measureStateZ, InternalState> {
 
     // Now draw all labels on top
     const yValue = `${math.smartRound(yDist, bounds.construct(yDist))} ${oneValue.units ?? ""}`;
-    const trunc = xDist.lessThan(TimeSpan.milliseconds(TIME_FORMAT_THRESHOLD_MS))
+    const trunc = xDist.lessThan(TIME_FORMAT_THRESHOLD)
       ? TimeSpan.MICROSECOND
       : TimeSpan.MILLISECOND;
     const xValue = xDist.truncate(trunc).toString();

--- a/pluto/src/ranger/queries.spec.ts
+++ b/pluto/src/ranger/queries.spec.ts
@@ -9,7 +9,7 @@
 
 import { ranger } from "@synnaxlabs/client";
 import { createTestClient } from "@synnaxlabs/client/testutil";
-import { color, TimeSpan, TimeStamp } from "@synnaxlabs/x";
+import { color, testutil, TimeSpan, TimeStamp } from "@synnaxlabs/x";
 import { act, render, renderHook, waitFor } from "@testing-library/react";
 import {
   createElement,
@@ -1052,6 +1052,36 @@ describe("queries", () => {
       await waitFor(() => {
         expect(result.current.form.value().parent).toEqual(parent2.key);
       });
+    });
+  });
+
+  describe("useKVPairForm", () => {
+    it("should not write back a pair deleted while an autosave was pending", async () => {
+      const rng = await client.ranges.create({
+        name: "kv_delete_race",
+        timeRange: TimeStamp.now().spanRange(TimeSpan.seconds(1)),
+      });
+      await rng.kv.set("test_key", "initial");
+      // The metadata list warms this answer space in production.
+      await client.ranges.kv.retrieve(rng.key);
+      const { result } = renderHook(
+        () =>
+          Ranger.useKVPairForm({
+            query: { rangeKey: rng.key, key: "test_key" },
+            autoSave: true,
+            initialValues: { key: "test_key", value: "initial", range: rng.key },
+          }),
+        { wrapper },
+      );
+      act(() => {
+        result.current.form.set("value", "edited");
+      });
+      await act(async () => {
+        await rng.kv.delete("test_key");
+      });
+      await testutil.expectAlways(async () => {
+        expect(await rng.kv.list()).not.toHaveProperty("test_key");
+      }, 800);
     });
   });
 

--- a/pluto/src/ranger/queries.spec.ts
+++ b/pluto/src/ranger/queries.spec.ts
@@ -1069,6 +1069,8 @@ describe("queries", () => {
           Ranger.useKVPairForm({
             query: { rangeKey: rng.key, key: "test_key" },
             autoSave: true,
+            // Holds the save open long enough for the delete to overtake it.
+            autoSaveDebounce: TimeSpan.milliseconds(500),
             initialValues: { key: "test_key", value: "initial", range: rng.key },
           }),
         { wrapper },

--- a/pluto/src/ranger/queries.ts
+++ b/pluto/src/ranger/queries.ts
@@ -164,9 +164,10 @@ export const useForm = Flux.createForm<FormQuery, typeof formSchema>({
       parent: value.parent,
     });
   },
-  mountListeners: ({ client, query: { key }, reset }) =>
+  mountListeners: ({ client, query: { key }, reset, abandon }) =>
     client.ranges.onChange(key, (result) => {
       if (query.isLive(result)) reset(toFormValues(result));
+      else if (query.Deleted.matches(result)) abandon();
     }),
 });
 
@@ -209,7 +210,7 @@ export const useListMetaData = Flux.createList<
 
 export const kvPairFormSchema = ranger.kv.pairZ;
 
-export type KVFormQuery = ListMetaDataQuery;
+export type KVFormQuery = ListMetaDataQuery & { key: string };
 
 const ZERO_KV_PAIR_FORM_VALUES: z.infer<typeof kvPairFormSchema> = {
   key: "",
@@ -225,6 +226,13 @@ export const useKVPairForm = Flux.createForm<KVFormQuery, typeof kvPairFormSchem
     const { key, value, range } = getPair();
     await client.ranges.getKV(range).set(key, value);
   },
+  mountListeners: ({ client, query: { rangeKey, key }, abandon }) =>
+    client.ranges.kv.onChange(rangeKey, (result) => {
+      // An undefined answer is an invalidation, not a deletion.
+      if (result === undefined) return;
+      if (query.isLive(result) && result.some((pair) => pair.key === key)) return;
+      abandon();
+    }),
 });
 
 export interface DeleteKVParams extends ListMetaDataQuery {

--- a/pluto/src/status/queries.spec.ts
+++ b/pluto/src/status/queries.spec.ts
@@ -7,9 +7,9 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { group, ontology, query, status } from "@synnaxlabs/client";
+import { group, NotFoundError, ontology, query, status } from "@synnaxlabs/client";
 import { createTestClient } from "@synnaxlabs/client/testutil";
-import { id, TimeStamp, uuid } from "@synnaxlabs/x";
+import { id, testutil, TimeSpan, TimeStamp, uuid } from "@synnaxlabs/x";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { type FC, type PropsWithChildren } from "react";
 import { beforeAll, describe, expect, it } from "vitest";
@@ -688,6 +688,35 @@ describe("Status queries", () => {
         expect(result.current.retrieve?.variant).toEqual("success");
         expect(result.current.retrieve?.message).toEqual("Updated message");
       });
+    });
+
+    it("should not write back a status deleted while an autosave was pending", async () => {
+      const key = uuid.create();
+      await client.statuses.set({
+        name: "Autosave Race",
+        key,
+        variant: "info",
+        message: "Original",
+        time: TimeStamp.now(),
+      });
+      const { result } = await renderHookSuspended(
+        () =>
+          Status.useForm({
+            query: { key },
+            autoSave: true,
+            // Holds the save open long enough for the delete to overtake it.
+            autoSaveDebounce: TimeSpan.milliseconds(500),
+          }),
+        { wrapper },
+      );
+      await waitFor(() => expect(result.current.variant).toEqual("success"));
+      act(() => result.current.form.set("name", "Edited"));
+      await act(async () => await client.statuses.delete(key));
+      await testutil.expectAlways(async () => {
+        await expect(
+          async () => await client.statuses.retrieve({ keys: [key] }),
+        ).rejects.toThrow(NotFoundError);
+      }, 800);
     });
 
     it("should handle status with labels", async () => {

--- a/pluto/src/status/queries.ts
+++ b/pluto/src/status/queries.ts
@@ -150,11 +150,13 @@ export const useForm = Flux.createForm<RetrieveQuery, typeof formSchema>({
       });
     set("key", res.key);
   },
-  mountListeners: ({ client, query: { key }, reset }) =>
+  mountListeners: ({ client, query: { key }, reset, abandon }) =>
     client.statuses.onChange(key, (result) => {
-      if (!query.isLive(result)) return;
-      const { labels, ...rest } = result;
-      reset({ ...rest, labels: labels?.map((l) => l.key) ?? [] });
+      if (query.Deleted.matches(result)) abandon();
+      else if (query.isLive(result)) {
+        const { labels, ...rest } = result;
+        reset({ ...rest, labels: labels?.map((l) => l.key) ?? [] });
+      }
     }),
 });
 

--- a/pluto/src/tooltip/Config.tsx
+++ b/pluto/src/tooltip/Config.tsx
@@ -41,9 +41,12 @@ export interface ConfigProps extends PropsWithChildren {
   skipDelay?: CrudeTimeSpan;
 }
 
+const DEFAULT_DELAY = TimeSpan.milliseconds(700);
+const DEFAULT_SKIP_DELAY = TimeSpan.milliseconds(300);
+
 const [Context, useConfig] = context.create<ContextValue>({
   defaultValue: {
-    delay: TimeSpan.milliseconds(700),
+    delay: DEFAULT_DELAY,
     isWarm: () => false,
     markClosed: () => {},
     acquire: () => () => {},
@@ -63,8 +66,8 @@ export { useConfig };
  * @default 300ms.
  */
 export const Config = ({
-  delay = TimeSpan.milliseconds(700),
-  skipDelay = TimeSpan.milliseconds(300),
+  delay = DEFAULT_DELAY,
+  skipDelay = DEFAULT_SKIP_DELAY,
   children,
 }: ConfigProps): ReactElement => {
   const lastClosed = useRef<TimeStamp | null>(null);

--- a/pluto/src/triggers/Provider.tsx
+++ b/pluto/src/triggers/Provider.tsx
@@ -59,6 +59,7 @@ const ZERO_REF_STATE: RefState = {
 };
 
 const EXCLUDE_TRIGGERS = ["CapsLock"];
+const DOUBLE_PRESS_WINDOW = TimeSpan.milliseconds(300).valueOf();
 
 // Native text-editing shortcuts (select-all, copy, paste, cut) the browser owns inside
 // any text field. We drop them while a text-entry element is focused so app-level
@@ -140,7 +141,7 @@ export const Provider = ({
       // This is considered a double press.
       if (
         prev.prev.includes(key) &&
-        TimeStamp.since(prev.last).valueOf() < TimeSpan.milliseconds(300).valueOf()
+        TimeStamp.since(prev.last).valueOf() < DOUBLE_PRESS_WINDOW
       )
         next.push(key);
       const nextState: RefState = {

--- a/pluto/src/vis/axis/preciseTimeScale.ts
+++ b/pluto/src/vis/axis/preciseTimeScale.ts
@@ -44,6 +44,8 @@ export const TIME_SCALE_STEPS: TimeSpan[] = [
   TimeSpan.SECOND, // 1s
 ];
 
+const MICROSECOND_FORMAT_THRESHOLD = TimeSpan.microseconds(50);
+
 /**
  * Configuration properties for creating a PreciseTimeScale.
  */
@@ -180,7 +182,7 @@ export class PreciseTimeScale {
    * @returns Formatted string representation of the timestamp
    */
   formatTick(value: TimeStamp): string {
-    if (this._span.lessThan(TimeSpan.microseconds(50))) {
+    if (this._span.lessThan(MICROSECOND_FORMAT_THRESHOLD)) {
       const remainder = value.remainder(TimeSpan.MILLISECOND);
       return `${remainder.microseconds.toString()}µs`;
     }

--- a/pluto/src/vis/canvas/Canvas.tsx
+++ b/pluto/src/vis/canvas/Canvas.tsx
@@ -51,13 +51,15 @@ const ZERO_CANVASES: Canvases = {
   bootstrapped: false,
 };
 
+const DEFAULT_RESIZE_DEBOUNCE = TimeSpan.milliseconds(100);
+
 export interface CanvasProps extends Omit<HTMLDivProps, "ref"> {
   resizeDebounce?: CrudeTimeSpan;
 }
 
 export const Canvas = ({
   children,
-  resizeDebounce: debounce = TimeSpan.milliseconds(100),
+  resizeDebounce: debounce = DEFAULT_RESIZE_DEBOUNCE,
   className,
   ...rest
 }: CanvasProps): ReactElement => {

--- a/pluto/src/vis/diagram/Diagram.tsx
+++ b/pluto/src/vis/diagram/Diagram.tsx
@@ -186,6 +186,7 @@ export interface DiagramProps
 }
 
 const DELETE_KEY_CODES: Triggers.Trigger = ["Backspace", "Delete"];
+const FIT_VIEW_DEBOUNCE = TimeSpan.milliseconds(50);
 
 export const create = ({
   node: nodeRenderer,
@@ -312,7 +313,7 @@ export const create = ({
     const { fitView } = useReactFlow();
     const debouncedFitView = useDebouncedCallback(
       (args: diagram.FitViewOptions) => void fitView(args),
-      TimeSpan.milliseconds(50),
+      FIT_VIEW_DEBOUNCE,
       [fitView],
     );
 


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4606](https://linear.app/synnax/issue/SY-4606)

## Description

Deleting a range metadata pair right after editing its value brought the pair back. The integration suite caught it as a delete that did not stick; the network trace showed `/range/kv/delete` followed by `/range/kv/set`.

Every autosaving form carried a 500 ms debounce, and the form flushed any pending save on unmount. Deleting a list row unmounts its form, so the flush wrote the record back after the delete. Four components shared that shape, so the fix belongs in flux rather than at a call site.

`mountListeners` now receives `abandon`, which drops the pending autosave and stops further ones; the range, range metadata, label, and status forms call it when their record is deleted. The debounce becomes an optional `autoSaveDebounce` TimeSpan, defaulting to off. Only two forms have a continuous input that needs one: the task form, whose numeric fields have drag handles, and the label list, whose color picker fires on every drag through the gradient. With no debounce a save is issued on the change rather than sitting queued behind a delete.

Also removes the autosaving form wrapping the status list row. It had no editable fields, so it could never fire a change.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents queued form autosaves from restoring deleted records.
- Adds an `abandon` lifecycle operation that cancels pending autosaves and blocks later saves.
- Connects range metadata, label, and status deletion events to `abandon`.
- Makes autosave debounce optional and adds focused form and query regression tests.
- Removes the unused autosaving wrapper from status list items.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pluto/src/flux/form.ts | Adds autosave abandonment, per-form cancellation state, and configurable debounce behavior. |
| pluto/src/flux/form.spec.tsx | Covers queued saves, abandonment, later changes, query repointing, unmounting, and cancellation before update. |
| pluto/src/label/queries.ts | Abandons label autosaves when the listener receives a deletion event. |
| pluto/src/status/queries.ts | Abandons status autosaves when the listener receives a deletion event. |
| pluto/src/ranger/queries.ts | Abandons range and metadata autosaves when their records are deleted. |
| console/src/platform/label/useEditModal.tsx | Supplies the edited label query and commits color changes when the picker closes. |
| console/src/platform/range/overview/MetaData.tsx | Supplies each existing metadata pair query so deletion events reach its form listener. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant User
  participant Form
  participant Listener
  participant Core
  User->>Form: Edit record
  Form->>Form: Queue autosave
  User->>Core: Delete record
  Core-->>Listener: Deleted event
  Listener->>Form: abandon()
  Form->>Form: Cancel queued save
```

<sub>Reviews (2): Last reviewed commit: ["Shorten the task autosave debounce to 20..."](https://github.com/synnaxlabs/synnax/commit/54f7565f0e44a160a1c860f59d55dcdb2e6126e0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53800941)</sub>

**Context used:**

- Knowledge Base — [Pluto Component and Visualization Library](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/pluto-components.md)

<!-- /greptile_comment -->