### PR TITLE
SY-4607: Never let streamed telemetry claim historical read coverage

### DIFF
--- a/cesium/internal/unary/iterator.go
+++ b/cesium/internal/unary/iterator.go
@@ -229,9 +229,15 @@ func (i *Iterator) autoNext(ctx context.Context) bool {
 
 	nRemaining := i.AutoChunkSize
 	for {
-		if !i.internal.TimeRange().OverlapsWith(i.view) {
+		domainTR := i.internal.TimeRange()
+		// Domains are ordered, so one starting at or after the view end belongs to the
+		// next chunk. Leave the iterator on it and keep what this chunk already read.
+		if domainTR.Start.AfterEq(i.view.End) {
+			break
+		}
+		if !domainTR.OverlapsWith(i.view) {
 			if !i.internal.Next() {
-				return false
+				break
 			}
 			continue
 		}
@@ -240,10 +246,7 @@ func (i *Iterator) autoNext(ctx context.Context) bool {
 			i.err = err
 			return false
 		}
-		startSample := startApprox.Upper
-		if !startApprox.Exact() && !startApprox.StartExact {
-			startSample = startApprox.Lower
-		}
+		startSample := pickSampleOffset(startApprox)
 		startOffset, err := i.resolver.byteOffset(ctx, i.internal, startSample)
 		if err != nil {
 			i.err = err
@@ -299,10 +302,7 @@ func (i *Iterator) autoPrev(ctx context.Context) bool {
 			i.err = err
 			return false
 		}
-		endSample := endApprox.Upper
-		if !startApprox.Exact() && !endApprox.StartExact {
-			endSample = endApprox.Lower
-		}
+		endSample := pickSampleOffset(endApprox)
 		endOffset, err := i.resolver.byteOffset(ctx, i.internal, endSample)
 		if err != nil {
 			i.err = err

--- a/cesium/internal/unary/iterator.go
+++ b/cesium/internal/unary/iterator.go
@@ -274,7 +274,7 @@ func (i *Iterator) autoNext(ctx context.Context) bool {
 
 func (i *Iterator) autoPrev(ctx context.Context) bool {
 	i.view.End = i.view.Start
-	startApprox, err := i.idx.Stamp(
+	viewStart, err := i.idx.Stamp(
 		ctx,
 		i.view.Start,
 		-i.AutoChunkSize,
@@ -284,18 +284,29 @@ func (i *Iterator) autoPrev(ctx context.Context) bool {
 		i.err = err
 		return false
 	}
-	if startApprox.Lower.Before(i.bounds.Start) {
+	if viewStart.Lower.Before(i.bounds.Start) {
 		return i.Prev(ctx, i.bounds.Start.Span(i.view.End))
 	}
-	i.view.Start = startApprox.Lower + 1
+	i.view.Start = viewStart.Lower + 1
 	i.reset(i.view.BoundBy(i.bounds))
 	nRemaining := i.AutoChunkSize
 	for {
-		if !i.internal.TimeRange().OverlapsWith(i.view) {
+		domainTR := i.internal.TimeRange()
+		// Domains are ordered, so one ending at or before the view start belongs to the
+		// previous chunk. Leave the iterator on it and keep this chunk's samples.
+		if domainTR.End.BeforeEq(i.view.Start) {
+			break
+		}
+		if !domainTR.OverlapsWith(i.view) {
 			if !i.internal.Prev() {
-				return false
+				break
 			}
 			continue
+		}
+		startApprox, alignment, err := i.approximateStart(ctx)
+		if err != nil {
+			i.err = err
+			return false
 		}
 		endApprox, err := i.approximateEnd(ctx)
 		if err != nil {
@@ -309,12 +320,15 @@ func (i *Iterator) autoPrev(ctx context.Context) bool {
 			return false
 		}
 		startSample := max(endSample-nRemaining, 0)
+		// approximateStart stamps the alignment at the view start. This chunk may begin
+		// earlier in the domain, so move the alignment back with it.
+		alignment -= telem.Alignment(pickSampleOffset(startApprox) - startSample)
 		startOffset, err := i.resolver.byteOffset(ctx, i.internal, startSample)
 		if err != nil {
 			i.err = err
 			return false
 		}
-		series, err := i.read(ctx, 0, startOffset, endOffset-startOffset)
+		series, err := i.read(ctx, alignment, startOffset, endOffset-startOffset)
 		if err != nil && !errors.Is(err, io.EOF) {
 			i.err = err
 			return false

--- a/cesium/internal/unary/iterator.go
+++ b/cesium/internal/unary/iterator.go
@@ -211,7 +211,7 @@ func (i *Iterator) Next(ctx context.Context, span telem.TimeSpan) (ok bool) {
 
 func (i *Iterator) autoNext(ctx context.Context) bool {
 	i.view.Start = i.view.End
-	endApprox, err := i.idx.Stamp(
+	viewEnd, err := i.idx.Stamp(
 		ctx,
 		i.view.Start,
 		i.AutoChunkSize,
@@ -221,10 +221,16 @@ func (i *Iterator) autoNext(ctx context.Context) bool {
 		i.err = err
 		return false
 	}
-	if endApprox.Lower.After(i.bounds.End) {
+	if viewEnd.Lower.After(i.bounds.End) {
 		return i.Next(ctx, i.view.Start.Span(i.bounds.End))
 	}
-	i.view.End = endApprox.Lower
+	// A view start between two samples brackets the chunk end. The upper bound is the
+	// first sample past the chunk, so a view ending there holds exactly AutoChunkSize
+	// samples. A stamp that runs out of data reports an unbounded upper instead.
+	i.view.End = viewEnd.Lower
+	if viewEnd.Upper != telem.TimeStampMax {
+		i.view.End = viewEnd.Upper
+	}
 	i.reset(i.view.BoundBy(i.bounds))
 
 	nRemaining := i.AutoChunkSize

--- a/cesium/internal/unary/iterator_test.go
+++ b/cesium/internal/unary/iterator_test.go
@@ -448,6 +448,39 @@ var _ = Describe("Iterator Behavior", Ordered, func() {
 					})
 					Describe("Auto Span", func() {
 						Specify(
+							"Single Domain - Last chunk view ends at the data",
+							func(ctx SpecContext) {
+								Expect(unary.Write(
+									ctx,
+									indexDB,
+									10*telem.SecondTS,
+									telem.NewSeriesSecondsTSV(10, 11, 12),
+								)).To(Succeed())
+								Expect(unary.Write(
+									ctx,
+									db,
+									10*telem.SecondTS,
+									telem.NewSeriesV[int64](1, 2, 3),
+								)).To(Succeed())
+								iter := MustSucceed(
+									db.OpenIterator(unary.IteratorConfig{
+										Bounds: telem.TimeStamp(0).
+											Range(telem.TimeStampMax),
+										AutoChunkSize: 2,
+									}),
+								)
+								Expect(iter.SeekFirst(ctx)).To(BeTrue())
+								Expect(iter.Next(ctx, unary.AutoSpan)).To(BeTrue())
+								Expect(iter.Next(ctx, unary.AutoSpan)).To(BeTrue())
+								Expect(iter.View()).To(Equal(
+									(12 * telem.SecondTS).Range(
+										12*telem.SecondTS + 1,
+									),
+								))
+								Expect(iter.Close()).To(Succeed())
+							},
+						)
+						Specify(
 							"Single Domain - Leftover chunk",
 							func(ctx SpecContext) {
 								Expect(

--- a/cesium/iterator_test.go
+++ b/cesium/iterator_test.go
@@ -442,6 +442,35 @@ var _ = Describe("Iterator Behavior", func() {
 					),
 				)
 
+				// A start between two samples makes every chunk end land between two
+				// samples as well, which is where a chunk can repeat or drop one.
+				DescribeTable(
+					"should return every sample once across auto-span chunks",
+					func(ctx SpecContext, chunk int64) {
+						i := MustSucceed(db.OpenIterator(cesium.IteratorConfig{
+							Bounds: (4*telem.SecondTS + 1).
+								Range(telem.TimeStampMax),
+							Channels:      []cesium.ChannelKey{dataKey},
+							AutoChunkSize: chunk,
+						}))
+						Expect(i.SeekFirst()).To(BeTrue())
+						var got []int64
+						for i.Next(cesium.AutoSpan) {
+							for _, s := range i.Value().RawSeries() {
+								got = append(
+									got,
+									telem.UnmarshalSeries[int64](s)...,
+								)
+							}
+						}
+						Expect(i.Close()).To(Succeed())
+						Expect(got).To(Equal([]int64{1, 2, 3, 4}))
+					},
+					Entry("one sample per chunk", int64(1)),
+					Entry("two samples per chunk", int64(2)),
+					Entry("three samples per chunk", int64(3)),
+				)
+
 				// Each value equals the index of the sample holding it, so a chunk is
 				// aligned correctly when its alignment equals its first value.
 				DescribeTable(
@@ -454,19 +483,21 @@ var _ = Describe("Iterator Behavior", func() {
 						}))
 						Expect(i.SeekLast()).To(BeTrue())
 						var got []int64
+						// Chunks arrive newest first, so each one goes in front of the
+						// ones already read.
 						for i.Prev(cesium.AutoSpan) {
+							var batch []int64
 							for _, s := range i.Value().RawSeries() {
 								vals := telem.UnmarshalSeries[int64](s)
 								Expect(s.Alignment).To(Equal(
 									telem.NewAlignment(0, uint32(vals[0])),
 								))
-								got = append(got, vals...)
+								batch = append(batch, vals...)
 							}
+							got = append(batch, got...)
 						}
 						Expect(i.Close()).To(Succeed())
-						Expect(got).To(ContainElements(
-							int64(0), int64(1), int64(2), int64(3), int64(4),
-						))
+						Expect(got).To(Equal([]int64{0, 1, 2, 3, 4}))
 					},
 					Entry("chunk smaller than the domain", int64(2)),
 					Entry("chunk larger than the domain", int64(10)),
@@ -527,7 +558,12 @@ var _ = Describe("Iterator Behavior", func() {
 
 				DescribeTable(
 					"should read every sample after the gap",
-					func(ctx SpecContext, start telem.TimeStamp, chunk int64) {
+					func(
+						ctx SpecContext,
+						start telem.TimeStamp,
+						chunk int64,
+						expected []int64,
+					) {
 						i := MustSucceed(db.OpenIterator(cesium.IteratorConfig{
 							Bounds:        start.Range(60 * telem.SecondTS),
 							Channels:      []cesium.ChannelKey{dataKey},
@@ -541,12 +577,96 @@ var _ = Describe("Iterator Behavior", func() {
 							}
 						}
 						Expect(i.Close()).To(Succeed())
-						Expect(got).To(ContainElements(
-							int64(4), int64(5), int64(6), int64(7), int64(8),
-						))
+						Expect(got).To(Equal(expected))
 					},
-					Entry("chunk smaller than the gap", 10*telem.SecondTS+1, int64(2)),
-					Entry("chunk spanning the gap", 8*telem.SecondTS+1, int64(3)),
+					Entry(
+						"chunk smaller than the gap",
+						10*telem.SecondTS+1,
+						int64(2),
+						[]int64{4, 5, 6, 7, 8},
+					),
+					Entry(
+						"chunk spanning the gap",
+						8*telem.SecondTS+1,
+						int64(3),
+						[]int64{3, 4, 5, 6, 7, 8},
+					),
+				)
+			})
+
+			// Chunk ends land between samples here too, but the read must also carry
+			// its count across the gap between the two domains.
+			Describe("Auto-span chunks inside a domain", func() {
+				var dataKey cesium.ChannelKey
+				BeforeAll(func(ctx SpecContext) {
+					ShouldNotLeakGoroutines()
+					idxKey := GenerateChannelKey()
+					dataKey = GenerateChannelKey()
+					Expect(db.CreateChannel(
+						ctx,
+						cesium.Channel{
+							Key:      idxKey,
+							Name:     "Nansen",
+							IsIndex:  true,
+							DataType: telem.TimeStampT,
+						},
+						cesium.Channel{
+							Key:      dataKey,
+							Name:     "Johansen",
+							Index:    idxKey,
+							DataType: telem.Int64T,
+						},
+					)).To(Succeed())
+					write := func(start telem.TimeStamp, ts, vals telem.Series) {
+						GinkgoHelper()
+						w := MustSucceed(db.OpenWriter(ctx, cesium.WriterConfig{
+							Channels: []cesium.ChannelKey{idxKey, dataKey},
+							Start:    start,
+						}))
+						MustSucceed(w.Write(telem.MultiFrame(
+							[]cesium.ChannelKey{idxKey, dataKey},
+							[]telem.Series{ts, vals},
+						)))
+						MustSucceed(w.Commit())
+						Expect(w.Close()).To(Succeed())
+					}
+					write(
+						telem.SecondTS,
+						telem.NewSeriesSecondsTSV(4, 6, 8, 10, 12, 14, 16),
+						telem.NewSeriesV[int64](0, 1, 2, 3, 4, 5, 6),
+					)
+					write(
+						100*telem.SecondTS,
+						telem.NewSeriesSecondsTSV(100, 102),
+						telem.NewSeriesV[int64](7, 8),
+					)
+				})
+
+				DescribeTable(
+					"should return every sample once across two domains",
+					func(ctx SpecContext, chunk int64) {
+						i := MustSucceed(db.OpenIterator(cesium.IteratorConfig{
+							Bounds: (4*telem.SecondTS + 1).
+								Range(200 * telem.SecondTS),
+							Channels:      []cesium.ChannelKey{dataKey},
+							AutoChunkSize: chunk,
+						}))
+						Expect(i.SeekFirst()).To(BeTrue())
+						var got []int64
+						for i.Next(cesium.AutoSpan) {
+							for _, s := range i.Value().RawSeries() {
+								got = append(
+									got,
+									telem.UnmarshalSeries[int64](s)...,
+								)
+							}
+						}
+						Expect(i.Close()).To(Succeed())
+						Expect(got).To(Equal([]int64{1, 2, 3, 4, 5, 6, 7, 8}))
+					},
+					Entry("one sample per chunk", int64(1)),
+					Entry("three samples per chunk", int64(3)),
+					Entry("a chunk wider than the first domain", int64(8)),
 				)
 			})
 

--- a/cesium/iterator_test.go
+++ b/cesium/iterator_test.go
@@ -368,6 +368,158 @@ var _ = Describe("Iterator Behavior", func() {
 				})
 			})
 
+			Describe("Alignment", func() {
+				var idxKey, dataKey cesium.ChannelKey
+				// A writer opens its domain at the requested start, which is normally
+				// earlier than the first sample it goes on to write.
+				BeforeAll(func(ctx SpecContext) {
+					ShouldNotLeakGoroutines()
+					idxKey, dataKey = GenerateChannelKey(), GenerateChannelKey()
+					Expect(db.CreateChannel(
+						ctx,
+						cesium.Channel{
+							Key:      idxKey,
+							Name:     "Amundsen",
+							IsIndex:  true,
+							DataType: telem.TimeStampT,
+						},
+						cesium.Channel{
+							Key:      dataKey,
+							Name:     "Scott",
+							Index:    idxKey,
+							DataType: telem.Int64T,
+						},
+					)).To(Succeed())
+					w := MustSucceed(db.OpenWriter(ctx, cesium.WriterConfig{
+						Channels: []cesium.ChannelKey{idxKey, dataKey},
+						Start:    1 * telem.SecondTS,
+					}))
+					MustSucceed(w.Write(telem.MultiFrame(
+						[]cesium.ChannelKey{idxKey, dataKey},
+						[]telem.Series{
+							telem.NewSeriesSecondsTSV(4, 6, 8, 10, 12),
+							telem.NewSeriesV[int64](0, 1, 2, 3, 4),
+						},
+					)))
+					MustSucceed(w.Commit())
+					Expect(w.Close()).To(Succeed())
+				})
+
+				DescribeTable(
+					"should align an auto-span read with the samples it returns",
+					func(ctx SpecContext, start telem.TimeStamp, expected []int64, alignment uint32) {
+						i := MustSucceed(db.OpenIterator(cesium.IteratorConfig{
+							Bounds:        start.Range(telem.TimeStampMax),
+							Channels:      []cesium.ChannelKey{dataKey},
+							AutoChunkSize: 10,
+						}))
+						Expect(i.SeekFirst()).To(BeTrue())
+						Expect(i.Next(cesium.AutoSpan)).To(BeTrue())
+						s := i.Value().SeriesAt(0)
+						Expect(s).To(telem.MatchSeriesData(telem.NewSeries(expected)))
+						Expect(s.Alignment).To(Equal(telem.NewAlignment(0, alignment)))
+						Expect(i.Close()).To(Succeed())
+					},
+					Entry(
+						"start on a sample",
+						8*telem.SecondTS,
+						[]int64{2, 3, 4},
+						uint32(2),
+					),
+					// A start between two samples must skip the earlier one rather than
+					// return it under the later one's alignment.
+					Entry(
+						"start between samples",
+						8*telem.SecondTS+1,
+						[]int64{3, 4},
+						uint32(3),
+					),
+					Entry(
+						"start before every sample",
+						telem.SecondTS,
+						[]int64{0, 1, 2, 3, 4},
+						uint32(0),
+					),
+				)
+			})
+
+			// A chunk that runs out of samples before it is full must stop at the next
+			// domain rather than consume it, or the samples it holds are lost.
+			Describe("Auto-span across a domain gap", func() {
+				var idxKey, dataKey cesium.ChannelKey
+				BeforeAll(func(ctx SpecContext) {
+					ShouldNotLeakGoroutines()
+					idxKey, dataKey = GenerateChannelKey(), GenerateChannelKey()
+					Expect(db.CreateChannel(
+						ctx,
+						cesium.Channel{
+							Key:      idxKey,
+							Name:     "Shackleton",
+							IsIndex:  true,
+							DataType: telem.TimeStampT,
+						},
+						cesium.Channel{
+							Key:      dataKey,
+							Name:     "Crean",
+							Index:    idxKey,
+							DataType: telem.Int64T,
+						},
+					)).To(Succeed())
+					write := func(start telem.TimeStamp, ts, vals telem.Series) {
+						GinkgoHelper()
+						w := MustSucceed(db.OpenWriter(ctx, cesium.WriterConfig{
+							Channels: []cesium.ChannelKey{idxKey, dataKey},
+							Start:    start,
+						}))
+						MustSucceed(w.Write(telem.MultiFrame(
+							[]cesium.ChannelKey{idxKey, dataKey},
+							[]telem.Series{ts, vals},
+						)))
+						MustSucceed(w.Commit())
+						Expect(w.Close()).To(Succeed())
+					}
+					write(
+						telem.SecondTS,
+						telem.NewSeriesSecondsTSV(4, 6, 8, 10, 12),
+						telem.NewSeriesV[int64](0, 1, 2, 3, 4),
+					)
+					write(
+						30*telem.SecondTS,
+						telem.NewSeriesSecondsTSV(30, 32, 34),
+						telem.NewSeriesV[int64](5, 6, 7),
+					)
+					write(
+						50*telem.SecondTS,
+						telem.NewSeriesSecondsTSV(52),
+						telem.NewSeriesV[int64](8),
+					)
+				})
+
+				DescribeTable(
+					"should read every sample after the gap",
+					func(ctx SpecContext, start telem.TimeStamp, chunk int64) {
+						i := MustSucceed(db.OpenIterator(cesium.IteratorConfig{
+							Bounds:        start.Range(60 * telem.SecondTS),
+							Channels:      []cesium.ChannelKey{dataKey},
+							AutoChunkSize: chunk,
+						}))
+						Expect(i.SeekFirst()).To(BeTrue())
+						var got []int64
+						for i.Next(cesium.AutoSpan) {
+							for _, s := range i.Value().RawSeries() {
+								got = append(got, telem.UnmarshalSeries[int64](s)...)
+							}
+						}
+						Expect(i.Close()).To(Succeed())
+						Expect(got).To(ContainElements(
+							int64(4), int64(5), int64(6), int64(7), int64(8),
+						))
+					},
+					Entry("chunk smaller than the gap", 10*telem.SecondTS+1, int64(2)),
+					Entry("chunk spanning the gap", 8*telem.SecondTS+1, int64(3)),
+				)
+			})
+
 			Describe("Variable Channels", func() {
 				var (
 					varIdxKey  cesium.ChannelKey

--- a/cesium/iterator_test.go
+++ b/cesium/iterator_test.go
@@ -441,6 +441,36 @@ var _ = Describe("Iterator Behavior", func() {
 						uint32(0),
 					),
 				)
+
+				// Each value equals the index of the sample holding it, so a chunk is
+				// aligned correctly when its alignment equals its first value.
+				DescribeTable(
+					"should align a backward auto-span read with the samples it returns",
+					func(ctx SpecContext, chunk int64) {
+						i := MustSucceed(db.OpenIterator(cesium.IteratorConfig{
+							Bounds:        telem.SecondTS.Range(telem.TimeStampMax),
+							Channels:      []cesium.ChannelKey{dataKey},
+							AutoChunkSize: chunk,
+						}))
+						Expect(i.SeekLast()).To(BeTrue())
+						var got []int64
+						for i.Prev(cesium.AutoSpan) {
+							for _, s := range i.Value().RawSeries() {
+								vals := telem.UnmarshalSeries[int64](s)
+								Expect(s.Alignment).To(Equal(
+									telem.NewAlignment(0, uint32(vals[0])),
+								))
+								got = append(got, vals...)
+							}
+						}
+						Expect(i.Close()).To(Succeed())
+						Expect(got).To(ContainElements(
+							int64(0), int64(1), int64(2), int64(3), int64(4),
+						))
+					},
+					Entry("chunk smaller than the domain", int64(2)),
+					Entry("chunk larger than the domain", int64(10)),
+				)
 			})
 
 			// A chunk that runs out of samples before it is full must stop at the next

--- a/client/py/examples/simulators/tpc.py
+++ b/client/py/examples/simulators/tpc.py
@@ -47,6 +47,33 @@ from examples.control.tpc.common import (
 )
 from examples.simulators.simdaq import SimDAQ
 
+INITIAL_DAQ_STATE: dict[str, float] = {
+    OX_VENT_CMD: 0,
+    OX_TPC_CMD: 0,
+    OX_MPV_CMD: 0,
+    OX_PRESS_CMD: 0,
+    FUEL_VENT_CMD: 0,
+    FUEL_TPC_CMD: 0,
+    FUEL_MPV_CMD: 0,
+    FUEL_PRESS_CMD: 0,
+    PRESS_ISO_CMD: 0,
+    GAS_BOOSTER_ISO_CMD: 0,
+    OX_TC_1: -190,
+    OX_TC_2: -190,
+    OX_PT_1: 1.75,
+    OX_PT_2: 1,
+    FUEL_TC_1: -190,
+    FUEL_TC_2: -190,
+    FUEL_PT_1: 2.25,
+    FUEL_PT_2: 3.25,
+    PRES_TC_1: -190,
+    PRES_TC_2: -190,
+    PRESS_PT_1: 0,
+    PRESS_PT_2: 1.3,
+    SUPPLY_PT: 4000,
+    PNEUMATICS_PT: 300,
+}
+
 
 class TPCSimDAQ(SimDAQ):
     """Simulates multi-system rocket engine with OX/FUEL tanks."""
@@ -89,11 +116,13 @@ class TPCSimDAQ(SimDAQ):
         )
 
         now = sy.TimeStamp.now()
+        # Sensors start at the simulation's real initial values: a 0.0 seed would
+        # write a spurious spike that pollutes plot auto-bounds.
         initial_state: dict[str, list] = {DAQ_TIME: [now]}
         for state_ch in VALVES.values():
             initial_state[state_ch] = [0]
         for sensor in SENSORS:
-            initial_state[sensor] = [0.0]
+            initial_state[sensor] = [INITIAL_DAQ_STATE[sensor]]
         client.write(now, initial_state)
         self.log("Channels created successfully")
 
@@ -102,32 +131,7 @@ class TPCSimDAQ(SimDAQ):
         loop = sy.Loop(sy.Rate.HZ * 50, precise=False)
         loop_count = 0
 
-        daq_state = {
-            OX_VENT_CMD: 0,
-            OX_TPC_CMD: 0,
-            OX_MPV_CMD: 0,
-            OX_PRESS_CMD: 0,
-            FUEL_VENT_CMD: 0,
-            FUEL_TPC_CMD: 0,
-            FUEL_MPV_CMD: 0,
-            FUEL_PRESS_CMD: 0,
-            PRESS_ISO_CMD: 0,
-            GAS_BOOSTER_ISO_CMD: 0,
-            OX_TC_1: -190,
-            OX_TC_2: -190,
-            OX_PT_1: 1.75,
-            OX_PT_2: 1,
-            FUEL_TC_1: -190,
-            FUEL_TC_2: -190,
-            FUEL_PT_1: 2.25,
-            FUEL_PT_2: 3.25,
-            PRES_TC_1: -190,
-            PRES_TC_2: -190,
-            PRESS_PT_1: 0,
-            PRESS_PT_2: 1.3,
-            SUPPLY_PT: 4000,
-            PNEUMATICS_PT: 300,
-        }
+        daq_state = dict(INITIAL_DAQ_STATE)
 
         ox_mpv_last_open = None
         fuel_mpv_last_open = None

--- a/client/ts/src/framer/cache/reader.spec.ts
+++ b/client/ts/src/framer/cache/reader.spec.ts
@@ -209,7 +209,9 @@ describe("read", () => {
     cache.close();
   });
 
-  it("should not fetch when the live leading buffer covers the requested range", async () => {
+  // The leading buffer holds provisional leading alignments, so its span still
+  // fetches: the fetched form is what pairs with other channels' fetched data.
+  it("should fetch the range the live leading buffer covers", async () => {
     const cache = new Cache();
     const remoteReadF = vi.fn();
     const reader = new Reader({ cache, readRemote: basicRemoteReadFunc(remoteReadF) });
@@ -226,12 +228,17 @@ describe("read", () => {
       new TimeRange(TimeSpan.seconds(10), TimeSpan.seconds(20)),
       1,
     );
-    expect(remoteReadF).not.toHaveBeenCalled();
-    expect(res).toHaveLength(3);
+    expect(remoteReadF).toHaveBeenCalledTimes(1);
+    expect(remoteReadF).toHaveBeenCalledWith(
+      new TimeRange(TimeSpan.seconds(10), TimeSpan.seconds(20)),
+      [1],
+    );
+    // Both representations return: 3 buffer samples plus the 3 fetched ones.
+    expect(res.length).toEqual(6);
     cache.close();
   });
 
-  it("should fetch only the portion of the range before the leading buffer", async () => {
+  it("should fetch the full range across the leading buffer start", async () => {
     const cache = new Cache();
     const remoteReadF = vi.fn();
     const reader = new Reader({ cache, readRemote: basicRemoteReadFunc(remoteReadF) });
@@ -247,7 +254,7 @@ describe("read", () => {
     await reader.read(new TimeRange(TimeSpan.seconds(5), TimeSpan.seconds(20)), 1);
     expect(remoteReadF).toHaveBeenCalledTimes(1);
     expect(remoteReadF).toHaveBeenCalledWith(
-      new TimeRange(TimeSpan.seconds(5), TimeSpan.seconds(10)),
+      new TimeRange(TimeSpan.seconds(5), TimeSpan.seconds(20)),
       [1],
     );
     cache.close();

--- a/client/ts/src/framer/cache/static.spec.ts
+++ b/client/ts/src/framer/cache/static.spec.ts
@@ -12,6 +12,7 @@ import {
   DataType,
   MultiSeries,
   Series,
+  sleep,
   type TimeRange,
   TimeSpan,
   TimeStamp,
@@ -360,6 +361,21 @@ describe("StaticReadCache", () => {
         TimeStamp.seconds(10).range(TimeStamp.seconds(40)),
       );
       expect(series.series).toHaveLength(2);
+    });
+
+    // Streamed entries arrive continuously, so a collector that misses them leaks.
+    it("should garbage collect streamed entries alongside fetched ones", async () => {
+      const c = new Static({ staleEntryThreshold: TimeSpan.milliseconds(5) });
+      const streamedTR = TimeStamp.seconds(30).range(TimeStamp.seconds(40));
+      const fetchedTR = TimeStamp.seconds(10).range(TimeStamp.seconds(20));
+      c.write(streamed(streamedTR, [3, 4]), true);
+      c.write(fetched(fetchedTR, [1, 2]));
+      const read = () =>
+        c.dirtyRead(TimeStamp.seconds(10).range(TimeStamp.seconds(40))).series.series;
+      expect(read()).toHaveLength(2);
+      await sleep.sleep(TimeSpan.milliseconds(10));
+      expect(c.gc().purgedSeries).toEqual(2);
+      expect(read()).toHaveLength(0);
     });
   });
 

--- a/client/ts/src/framer/cache/static.spec.ts
+++ b/client/ts/src/framer/cache/static.spec.ts
@@ -269,6 +269,33 @@ describe("StaticReadCache", () => {
         }),
       ]);
 
+    it("should return streamed entries without letting them claim coverage", () => {
+      const c = new Static({});
+      const tr = TimeStamp.seconds(10).range(TimeStamp.seconds(20));
+      c.write(streamed(tr, [1, 2]), true);
+      const { series, gaps } = c.dirtyRead(tr);
+      expect(series.series).toHaveLength(1);
+      expect(gaps).toHaveLength(1);
+      expect(gaps[0].equals(tr)).toBe(true);
+    });
+
+    it("should compute gaps from fetched entries around a streamed one", () => {
+      const c = new Static({});
+      c.write(
+        streamed(TimeStamp.seconds(12).range(TimeStamp.seconds(16)), [1, 2]),
+        true,
+      );
+      c.write(fetched(TimeStamp.seconds(10).range(TimeStamp.seconds(12)), [1, 2]));
+      const { series, gaps } = c.dirtyRead(
+        TimeStamp.seconds(10).range(TimeStamp.seconds(20)),
+      );
+      expect(series.series).toHaveLength(2);
+      expect(gaps).toHaveLength(1);
+      expect(gaps[0].equals(TimeStamp.seconds(12).range(TimeStamp.seconds(20)))).toBe(
+        true,
+      );
+    });
+
     it("should evict a streamed entry when a fetched write overlaps it", () => {
       const c = new Static({});
       const tr = TimeStamp.seconds(10).range(TimeStamp.seconds(20));
@@ -280,7 +307,9 @@ describe("StaticReadCache", () => {
       expect(gaps).toHaveLength(0);
     });
 
-    it("should evict a streamed entry on partial time overlap", () => {
+    it("should keep a streamed entry a fetched write only partially covers", () => {
+      // The fetch may be stamped wider than the committed data it returned, so a
+      // partial cover must not drop the streamed samples it did not replace.
       const c = new Static({});
       c.write(
         streamed(TimeStamp.seconds(12).range(TimeStamp.seconds(20)), [1, 2]),
@@ -290,8 +319,7 @@ describe("StaticReadCache", () => {
       const { series } = c.dirtyRead(
         TimeStamp.seconds(10).range(TimeStamp.seconds(20)),
       );
-      expect(series.series).toHaveLength(1);
-      expect(series.series[0].alignment).toEqual(0n);
+      expect(series.series).toHaveLength(2);
     });
 
     it("should keep streamed entries that do not overlap the write", () => {

--- a/client/ts/src/framer/cache/static.ts
+++ b/client/ts/src/framer/cache/static.ts
@@ -85,7 +85,7 @@ export class Static {
    *
    * @param series - The series to write.
    * @param streamed - Marks the series as live-streamed data. A fetched write
-   * evicts every streamed entry that overlaps its time range.
+   * evicts every streamed entry whose time range it fully covers.
    */
   write(series: MultiSeries, streamed: boolean = false): void {
     if (series.length === 0) return;
@@ -96,11 +96,17 @@ export class Static {
     this.repairIntegrity(series);
   }
 
+  // Containment, not overlap: a fetch stamped wider than the data it returned
+  // (an uncommitted tail) must not evict streamed samples it did not replace.
   private evictStreamed(written: MultiSeries): void {
     this.data = this.data.filter(
       (e) =>
         !e.streamed ||
-        !written.series.some((s) => s.timeRange.overlapsWith(e.data.timeRange)),
+        !written.series.some(
+          (s) =>
+            s.timeRange.start.beforeEq(e.data.timeRange.start) &&
+            s.timeRange.end.afterEq(e.data.timeRange.end),
+        ),
     );
   }
 
@@ -109,25 +115,32 @@ export class Static {
    * overlap with the given time range. The series may extend before or after the
    * range.
    *
+   * Gaps are computed against fetched entries only. Streamed entries carry
+   * provisional leading alignments that cannot pair with fetched data on another
+   * channel, so they never claim coverage; the fetch they provoke evicts them.
+   *
    * @param tr - The time range to read from the cache.
    * @returns A list of series that overlap with the given time range and a list of
-   * gaps, representing the missing regions of time between the series and before and
-   * after the first and last series.
+   * gaps, representing the regions of time the fetched series do not cover.
    */
   dirtyRead(tr: TimeRange): DirtyReadResult {
     const series: Series[] = [];
-    for (const { data } of this.data)
-      if (data.timeRange.overlapsWith(tr)) series.push(data);
-    if (series.length === 0) return { series: new MultiSeries([]), gaps: [tr] };
+    const fetched: Series[] = [];
+    for (const { data, streamed } of this.data)
+      if (data.timeRange.overlapsWith(tr)) {
+        series.push(data);
+        if (!streamed) fetched.push(data);
+      }
+    if (fetched.length === 0) return { series: new MultiSeries(series), gaps: [tr] };
     const gaps: TimeRange[] = [];
     const pushGap = (start: TimeStamp, end: TimeStamp): void => {
       const gap = new TimeRange(start, end);
       if (gap.isValid && !gap.span.isZero) gaps.push(gap);
     };
-    pushGap(tr.start, series[0].timeRange.start);
-    for (let i = 1; i < series.length; i++)
-      pushGap(series[i - 1].timeRange.end, series[i].timeRange.start);
-    pushGap(series[series.length - 1].timeRange.end, tr.end);
+    pushGap(tr.start, fetched[0].timeRange.start);
+    for (let i = 1; i < fetched.length; i++)
+      pushGap(fetched[i - 1].timeRange.end, fetched[i].timeRange.start);
+    pushGap(fetched[fetched.length - 1].timeRange.end, tr.end);
     return { series: new MultiSeries(series), gaps };
   }
 

--- a/client/ts/src/framer/cache/static.ts
+++ b/client/ts/src/framer/cache/static.ts
@@ -59,15 +59,19 @@ interface CacheEntry {
   data: Series;
   /** When the entry entered the cache, for garbage collection staleness. */
   addedAt: TimeStamp;
-  /** True when the entry came from the live stream instead of a fetch. */
-  streamed: boolean;
 }
 
 /**
  * A cache for historical channel data that will not be modified after it is written.
+ *
+ * Fetched and streamed entries are held apart because they measure position in
+ * different spaces: a fetched sample carries its committed alignment, the same sample
+ * streamed carries a provisional leading one. Insertion and gap computation both
+ * assume a single space, so each kind gets its own list.
  */
 export class Static {
-  private data: CacheEntry[] = [];
+  private fetched: CacheEntry[] = [];
+  private streamed: CacheEntry[] = [];
   private readonly props: Required<StaticProps>;
 
   constructor(props: StaticProps) {
@@ -90,18 +94,18 @@ export class Static {
   write(series: MultiSeries, streamed: boolean = false): void {
     if (series.length === 0) return;
     if (!streamed) this.evictStreamed(series);
+    const entries = streamed ? this.streamed : this.fetched;
     series.series.forEach((s) =>
-      this.writeOne(this.props.transform.convert(s), streamed),
+      this.writeOne(this.props.transform.convert(s), entries),
     );
-    this.repairIntegrity(series);
+    this.repairIntegrity(series, entries);
   }
 
   // Containment, not overlap: a fetch stamped wider than the data it returned
   // (an uncommitted tail) must not evict streamed samples it did not replace.
   private evictStreamed(written: MultiSeries): void {
-    this.data = this.data.filter(
+    this.streamed = this.streamed.filter(
       (e) =>
-        !e.streamed ||
         !written.series.some(
           (s) =>
             s.timeRange.start.beforeEq(e.data.timeRange.start) &&
@@ -124,13 +128,10 @@ export class Static {
    * gaps, representing the regions of time the fetched series do not cover.
    */
   dirtyRead(tr: TimeRange): DirtyReadResult {
-    const series: Series[] = [];
-    const fetched: Series[] = [];
-    for (const { data, streamed } of this.data)
-      if (data.timeRange.overlapsWith(tr)) {
-        series.push(data);
-        if (!streamed) fetched.push(data);
-      }
+    const overlapping = (entries: CacheEntry[]): Series[] =>
+      entries.filter((e) => e.data.timeRange.overlapsWith(tr)).map((e) => e.data);
+    const fetched = overlapping(this.fetched);
+    const series = [...fetched, ...overlapping(this.streamed)];
     if (fetched.length === 0) return { series: new MultiSeries(series), gaps: [tr] };
     const gaps: TimeRange[] = [];
     const pushGap = (start: TimeStamp, end: TimeStamp): void => {
@@ -152,61 +153,66 @@ export class Static {
   gc(): GCMetrics {
     const { staleEntryThreshold } = this.props;
     const res = zeroGCMetrics();
-    const newData = this.data.filter((s) => {
-      const shouldKeep =
-        s.data.refCount > 0 || TimeStamp.since(s.addedAt).lessThan(staleEntryThreshold);
-      if (!shouldKeep) res.purgedBytes = res.purgedBytes.add(s.data.byteCapacity);
-      return shouldKeep;
-    });
-    res.purgedSeries = this.data.length - newData.length;
-    this.data = newData;
+    const collect = (entries: CacheEntry[]): CacheEntry[] =>
+      entries.filter((s) => {
+        const shouldKeep =
+          s.data.refCount > 0 ||
+          TimeStamp.since(s.addedAt).lessThan(staleEntryThreshold);
+        if (!shouldKeep) {
+          res.purgedBytes = res.purgedBytes.add(s.data.byteCapacity);
+          res.purgedSeries++;
+        }
+        return shouldKeep;
+      });
+    this.fetched = collect(this.fetched);
+    this.streamed = collect(this.streamed);
     return res;
   }
 
   /** Closes the cache, freeing all of its resources. */
   close(): void {
-    this.data = [];
+    this.fetched = [];
+    this.streamed = [];
   }
 
-  private writeOne(series: Series, streamed: boolean): void {
+  private writeOne(series: Series, entries: CacheEntry[]): void {
     const {
       instrumentation: { L },
     } = this.props;
     if (series.length === 0) return;
     const insertionPlan = bounds.buildInsertionPlan(
-      this.data.map((s) => s.data.alignmentBounds),
+      entries.map((s) => s.data.alignmentBounds),
       series.alignmentBounds,
     );
     if (insertionPlan === null)
       return L.debug("Found no viable insertion plan", () => ({
         inserting: series.digest,
-        cacheContents: this.data.map((s) => s.data.digest),
+        cacheContents: entries.map((s) => s.data.digest),
       }));
     const { removeBefore, removeAfter, insertInto, deleteInBetween } = insertionPlan;
     series = series.slice(removeBefore, series.length - removeAfter);
     if (series.length === 0) return;
-    this.data.splice(insertInto, deleteInBetween, {
+    entries.splice(insertInto, deleteInBetween, {
       data: series,
       addedAt: TimeStamp.now(),
-      streamed,
     });
   }
 
-  private repairIntegrity(write: MultiSeries): void {
+  private repairIntegrity(write: MultiSeries, entries: CacheEntry[]): void {
     const {
       instrumentation: { L },
     } = this.props;
     // Entries are ordered and non-overlapping, so neighbor comparison suffices. An
     // overlap is an insertion bug: evict both entries and let a refetch heal the gap.
-    for (let i = 1; i < this.data.length; i++) {
+    for (let i = 1; i < entries.length; i++) {
       if (
         !bounds.overlapsWith(
-          this.data[i - 1].data.alignmentBounds,
-          this.data[i].data.alignmentBounds,
+          entries[i - 1].data.alignmentBounds,
+          entries[i].data.alignmentBounds,
         )
       )
         continue;
-      const [prev, curr] = this.data.splice(i - 1, 2);
+      const [prev, curr] = entries.splice(i - 1, 2);
       L.error("cache integrity violation - evicting overlapping entries", () => ({
         write: write.series.map((s) => s.digest),
         evicted: [prev.data.digest, curr.data.digest],

--- a/client/ts/src/framer/cache/streamer.spec.ts
+++ b/client/ts/src/framer/cache/streamer.spec.ts
@@ -635,13 +635,14 @@ describe("MultiplexedStreamer", () => {
       await vi.advanceTimersByTimeAsync(300);
 
       expect(cache.get(1).leadingBuffer).toBeNull();
-      // The flushed samples stay readable, with a true gap after their end.
+      // The flushed samples stay readable but claim no coverage, so the whole
+      // range remains a gap to fetch.
       const { series, gaps } = cache
         .get(1)
         .read(TimeStamp.seconds(10).range(TimeStamp.seconds(20)));
       expect(Array.from(series)).toEqual([1, 2, 3]);
       expect(gaps).toHaveLength(1);
-      expect(gaps[0].equals(TimeStamp.seconds(13).range(TimeStamp.seconds(20)))).toBe(
+      expect(gaps[0].equals(TimeStamp.seconds(10).range(TimeStamp.seconds(20)))).toBe(
         true,
       );
       await streamer.close();

--- a/client/ts/src/framer/cache/unary.spec.ts
+++ b/client/ts/src/framer/cache/unary.spec.ts
@@ -33,7 +33,9 @@ const newUnary = (): Unary => new Unary({ dynamicBufferSize: 100 });
 
 describe("Unary", () => {
   describe("read with a live leading buffer", () => {
-    it("should include the buffer and clip the trailing gap at its start", () => {
+    // The buffer's samples carry provisional leading alignments that cannot pair
+    // with fetched data on another channel, so it never claims coverage.
+    it("should include the buffer and still report the full gap", () => {
       const u = newUnary();
       u.writeDynamic(stamped(10, 13, [1, 2, 3], LEADING_ALIGNMENT));
       const { series, gaps } = u.read(
@@ -42,18 +44,22 @@ describe("Unary", () => {
       expect(series.series).toHaveLength(1);
       expect(series.series[0]).toBe(u.leadingBuffer);
       expect(gaps).toHaveLength(1);
-      expect(gaps[0].start).toEqual(TimeStamp.seconds(5));
-      expect(gaps[0].end).toEqual(TimeStamp.seconds(10));
+      expect(gaps[0].equals(TimeStamp.seconds(5).range(TimeStamp.seconds(15)))).toBe(
+        true,
+      );
     });
 
-    it("should drop gaps that start at or after the buffer start", () => {
+    it("should report a gap over the buffer's own span", () => {
       const u = newUnary();
       u.writeDynamic(stamped(10, 13, [1, 2, 3], LEADING_ALIGNMENT));
       const { series, gaps } = u.read(
         TimeStamp.seconds(12).range(TimeStamp.seconds(20)),
       );
       expect(series.series).toHaveLength(1);
-      expect(gaps).toHaveLength(0);
+      expect(gaps).toHaveLength(1);
+      expect(gaps[0].equals(TimeStamp.seconds(12).range(TimeStamp.seconds(20)))).toBe(
+        true,
+      );
     });
 
     it("should exclude the buffer when the read ends before it starts", () => {
@@ -67,7 +73,7 @@ describe("Unary", () => {
       );
     });
 
-    it("should truncate a gap that straddles the buffer start", () => {
+    it("should compute gaps from fetched entries alone", () => {
       const u = newUnary();
       u.writeStatic(stamped(0, 4, [1, 2, 3, 4], 0n));
       u.writeDynamic(stamped(10, 13, [5, 6, 7], LEADING_ALIGNMENT));
@@ -78,7 +84,7 @@ describe("Unary", () => {
       expect(series.series[1]).toBe(u.leadingBuffer);
       expect(gaps).toHaveLength(1);
       expect(gaps[0].start).toEqual(TimeStamp.seconds(4));
-      expect(gaps[0].end).toEqual(TimeStamp.seconds(10));
+      expect(gaps[0].end).toEqual(TimeStamp.seconds(20));
     });
   });
 
@@ -108,7 +114,7 @@ describe("Unary", () => {
   });
 
   describe("flushDynamic", () => {
-    it("should move the leading buffer to static and expose the trailing gap", () => {
+    it("should move the leading buffer to static without claiming coverage", () => {
       const u = newUnary();
       u.writeDynamic(stamped(10, 13, [1, 2, 3], LEADING_ALIGNMENT));
       u.flushDynamic();
@@ -118,11 +124,8 @@ describe("Unary", () => {
       );
       expect(series.series).toHaveLength(1);
       expect(Array.from(series.series[0])).toEqual([1, 2, 3]);
-      expect(gaps).toHaveLength(2);
-      expect(gaps[0].equals(TimeStamp.seconds(5).range(TimeStamp.seconds(10)))).toBe(
-        true,
-      );
-      expect(gaps[1].equals(TimeStamp.seconds(13).range(TimeStamp.seconds(20)))).toBe(
+      expect(gaps).toHaveLength(1);
+      expect(gaps[0].equals(TimeStamp.seconds(5).range(TimeStamp.seconds(20)))).toBe(
         true,
       );
     });

--- a/client/ts/src/framer/cache/unary.ts
+++ b/client/ts/src/framer/cache/unary.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { MultiSeries, type Series, TimeRange } from "@synnaxlabs/x";
+import { MultiSeries, type Series, type TimeRange } from "@synnaxlabs/x";
 
 import { UnexpectedError } from "@/errors";
 import { Dynamic, type DynamicProps } from "@/framer/cache/dynamic";
@@ -72,8 +72,10 @@ export class Unary {
 
   /**
    * Reads cached data overlapping the given time range. The result includes the
-   * live leading buffer when it overlaps, and its gaps are clipped at the buffer's
-   * start so a fetch never re-reads data the stream already delivered.
+   * live leading buffer when it overlaps, but the buffer never claims coverage:
+   * its samples carry provisional leading alignments that cannot pair with fetched
+   * data on another channel, so its span is still reported as a gap to fetch. A
+   * span may therefore return in both its streamed and fetched representation.
    */
   read(tr: TimeRange): DirtyReadResult {
     this.checkOpen("read");
@@ -81,12 +83,6 @@ export class Unary {
     const buf = this.dynamic.leadingBuffer;
     if (buf == null || buf.length === 0 || !buf.timeRange.overlapsWith(tr)) return res;
     res.series.push(buf);
-    const bufStart = buf.timeRange.start;
-    res.gaps = res.gaps.flatMap((gap) => {
-      if (gap.start.afterEq(bufStart)) return [];
-      if (gap.end.after(bufStart)) return [new TimeRange(gap.start, bufStart)];
-      return [gap];
-    });
     return res;
   }
 

--- a/client/ts/src/framer/feed.spec.ts
+++ b/client/ts/src/framer/feed.spec.ts
@@ -110,7 +110,7 @@ describe("feed", () => {
     sub.close();
   });
 
-  it("should return every sample exactly once across the live boundary", async () => {
+  it("should return every streamed sample across the live boundary", async () => {
     const { time, data } = await createChannels();
     const received: number[] = [];
     const sub = feed.stream(
@@ -143,13 +143,14 @@ describe("feed", () => {
     } finally {
       await w1.close();
     }
-    // A read that spans the live leading buffer returns it directly instead of
-    // re-fetching the persisted form of the same samples.
+    // A read that spans the live leading buffer includes it, and may also return
+    // the fetched form of the same samples: the two representations carry
+    // different alignments and both stay visible until the fetched form wins.
     const tr = new TimeRange(start, TimeStamp.now().add(TimeSpan.seconds(1)));
     const res = await feed.read(tr, data.key);
-    const values = Array.from(res) as number[];
-    expect(values.length).toBeGreaterThan(0);
-    expect(new Set(values).size).toEqual(values.length);
+    const values = new Set(Array.from(res) as number[]);
+    expect(values.size).toBeGreaterThan(0);
+    for (const v of received) expect(values).toContain(v);
     // A second writer opens a new alignment domain, which flushes the old leading
     // buffer into the static cache as a streamed entry.
     const w2 = await client.openWriter({
@@ -163,9 +164,8 @@ describe("feed", () => {
     }
     const tr2 = new TimeRange(start, TimeStamp.now().add(TimeSpan.seconds(1)));
     const res2 = await feed.read(tr2, data.key);
-    const values2 = Array.from(res2) as number[];
-    expect(values2.length).toBeGreaterThanOrEqual(values.length);
-    expect(new Set(values2).size).toEqual(values2.length);
+    const values2 = new Set(Array.from(res2) as number[]);
+    for (const v of received) expect(values2).toContain(v);
     sub.close();
   });
 
@@ -201,6 +201,109 @@ describe("feed", () => {
     // live buffer.
     expect(received.some((s) => res.series.includes(s))).toBe(true);
     sub.close();
+  });
+
+  it("should backload history that pairs with a warm index by alignment", async () => {
+    const { time, data } = await createChannels();
+    const short = client.openFeed({ removalDelay: TimeSpan.milliseconds(100) });
+    try {
+      const start = TimeStamp.now();
+      const w = await client.openWriter({
+        start,
+        channels: [time.key, data.key],
+        enableAutoCommit: true,
+      });
+      let value = 0;
+      try {
+        // Another consumer streams the index while history accumulates, so the
+        // index cache covers the window with leading-alignment data only.
+        const sub = short.stream(() => {}, [time.key]);
+        for (let i = 0; i < 40; i++) {
+          await w.write({ [time.key]: [TimeStamp.now()], [data.key]: [value++] });
+          await sleep.sleep(TimeSpan.milliseconds(5));
+        }
+        // A plot opens on the never-streamed channel: it reads the channel and its
+        // index over the same window.
+        const tr = new TimeRange(start, TimeStamp.now());
+        const yRes = await short.read(tr, data.key);
+        const xRes = await short.read(tr, time.key);
+        // The line renderer pairs x and y series by alignment overlap, so every
+        // backloaded y series must sit inside the union of x alignment spans.
+        const xSpans = xRes.series
+          .map((s) => s.alignmentBounds)
+          .sort((a, b) => Number(a.lower - b.lower));
+        const merged: Array<{ lower: bigint; upper: bigint }> = [];
+        for (const s of xSpans) {
+          const last = merged.at(-1);
+          if (last != null && s.lower <= last.upper) {
+            if (s.upper > last.upper) last.upper = s.upper;
+          } else merged.push({ lower: s.lower, upper: s.upper });
+        }
+        const uncovered = yRes.series.filter(
+          (y) =>
+            !merged.some(
+              (m) =>
+                y.alignmentBounds.lower >= m.lower &&
+                y.alignmentBounds.upper <= m.upper,
+            ),
+        );
+        expect(
+          uncovered.map((s) => ({
+            alignment: s.alignment.toString(16),
+            length: s.length,
+          })),
+        ).toHaveLength(0);
+        sub.close();
+      } finally {
+        await w.close();
+      }
+    } finally {
+      await short.close();
+    }
+  });
+
+  it("should keep reads complete across leading buffer rollovers", async () => {
+    const { time, data } = await createChannels();
+    // A small buffer forces frequent flush and realloc cycles.
+    const small = client.openFeed({ dynamicBufferSize: 50 });
+    try {
+      const start = TimeStamp.now();
+      const w = await client.openWriter({
+        start,
+        channels: [time.key, data.key],
+        enableAutoCommit: true,
+      });
+      try {
+        const sub = small.stream(() => {}, [time.key, data.key]);
+        let value = 0;
+        for (let i = 0; i < 10; i++) {
+          for (let j = 0; j < 30; j++) {
+            const now = TimeStamp.now();
+            await w.write({
+              [time.key]: [now, now.add(TimeSpan.microseconds(1))],
+              [data.key]: [value++, value++],
+            });
+          }
+          const tr = new TimeRange(start, TimeStamp.now());
+          // The fresh baseline reads first: anything committed by now must also
+          // reach the later cached read, so autocommit lag cannot flake this.
+          const fresh = client.openFeed();
+          try {
+            const all = Array.from(await fresh.read(tr, data.key)) as number[];
+            const got = new Set(Array.from(await small.read(tr, data.key)) as number[]);
+            const missing = all.filter((v) => !got.has(v));
+            expect(missing).toHaveLength(0);
+          } finally {
+            await fresh.close();
+          }
+        }
+        sub.close();
+      } finally {
+        await w.close();
+      }
+    } finally {
+      await small.close();
+    }
   });
 
   it("should refetch samples written while a channel was unstreamed", async () => {

--- a/client/ts/src/framer/feed.spec.ts
+++ b/client/ts/src/framer/feed.spec.ts
@@ -40,6 +40,20 @@ const createClock = (): (() => TimeStamp) => {
   };
 };
 
+/**
+ * Asserts a read returned every value written so far and nothing else. A span crossing
+ * the live boundary can come back in both its streamed and its fetched representation,
+ * so a value may appear twice, but never more.
+ */
+const expectWrittenValues = (values: number[], writeCount: number): void => {
+  const counts = new Map<number, number>();
+  values.forEach((v) => counts.set(v, (counts.get(v) ?? 0) + 1));
+  expect([...counts.keys()].sort((a, b) => a - b)).toEqual(
+    Array.from({ length: writeCount }, (_, i) => i),
+  );
+  expect([...counts.entries()].filter(([, count]) => count > 2)).toEqual([]);
+};
+
 const createChannels = async () => {
   const time = await client.channels.create({
     name: id.create(),
@@ -124,7 +138,7 @@ describe("feed", () => {
     sub.close();
   });
 
-  it("should return every streamed sample across the live boundary", async () => {
+  it("should return every written sample across the live boundary", async () => {
     const { time, data } = await createChannels();
     const received: number[] = [];
     const sub = feed.stream(
@@ -162,9 +176,7 @@ describe("feed", () => {
     // different alignments and both stay visible until the fetched form wins.
     const tr = new TimeRange(start, TimeStamp.now().add(TimeSpan.seconds(1)));
     const res = await feed.read(tr, data.key);
-    const values = new Set(Array.from(res) as number[]);
-    expect(values.size).toBeGreaterThan(0);
-    for (const v of received) expect(values).toContain(v);
+    expectWrittenValues(Array.from(res) as number[], value);
     // A second writer opens a new alignment domain, which flushes the old leading
     // buffer into the static cache as a streamed entry.
     const w2 = await client.openWriter({
@@ -178,8 +190,7 @@ describe("feed", () => {
     }
     const tr2 = new TimeRange(start, TimeStamp.now().add(TimeSpan.seconds(1)));
     const res2 = await feed.read(tr2, data.key);
-    const values2 = new Set(Array.from(res2) as number[]);
-    for (const v of received) expect(values2).toContain(v);
+    expectWrittenValues(Array.from(res2) as number[], value);
     sub.close();
   });
 

--- a/client/ts/src/framer/feed.spec.ts
+++ b/client/ts/src/framer/feed.spec.ts
@@ -26,6 +26,20 @@ const client = createTestClient();
 const feed = client.openFeed();
 afterAll(async () => await feed.close());
 
+/**
+ * Returns a source of strictly increasing timestamps. `TimeStamp.now()` resolves to the
+ * millisecond, so a tight write loop repeats one, and an index channel must never
+ * repeat a timestamp.
+ */
+const createClock = (): (() => TimeStamp) => {
+  let last = TimeStamp.now();
+  return () => {
+    const now = TimeStamp.now();
+    last = now.after(last) ? now : last.add(TimeSpan.microseconds(1));
+    return last;
+  };
+};
+
 const createChannels = async () => {
   const time = await client.channels.create({
     name: id.create(),
@@ -86,6 +100,7 @@ describe("feed", () => {
     );
     // The writer must stream as well as persist: the plain write convenience is
     // persist-only and the relay never broadcasts it.
+    const next = createClock();
     const writer = await client.openWriter({
       start: TimeStamp.now(),
       channels: [time.key, data.key],
@@ -96,8 +111,7 @@ describe("feed", () => {
       await expect
         .poll(
           async () => {
-            const now = TimeStamp.now();
-            await writer.write({ [time.key]: [now], [data.key]: [42] });
+            await writer.write({ [time.key]: [next()], [data.key]: [42] });
             return received.length > 0;
           },
           { timeout: 10000, interval: 250 },
@@ -121,6 +135,7 @@ describe("feed", () => {
       [data.key],
     );
     const start = TimeStamp.now();
+    const next = createClock();
     let value = 0;
     const writeUntilStreamed = async (
       w: Awaited<ReturnType<typeof client.openWriter>>,
@@ -129,8 +144,7 @@ describe("feed", () => {
       await expect
         .poll(
           async () => {
-            const now = TimeStamp.now();
-            await w.write({ [time.key]: [now], [data.key]: [value++] });
+            await w.write({ [time.key]: [next()], [data.key]: [value++] });
             return received.length > before;
           },
           { timeout: 10000, interval: 250 },
@@ -180,13 +194,13 @@ describe("feed", () => {
       [data.key],
     );
     const start = TimeStamp.now();
+    const next = createClock();
     const writer = await client.openWriter({ start, channels: [time.key, data.key] });
     try {
       await expect
         .poll(
           async () => {
-            const now = TimeStamp.now();
-            await writer.write({ [time.key]: [now], [data.key]: [1] });
+            await writer.write({ [time.key]: [next()], [data.key]: [1] });
             return received.length > 0;
           },
           { timeout: 10000, interval: 250 },
@@ -208,6 +222,7 @@ describe("feed", () => {
     const short = client.openFeed({ removalDelay: TimeSpan.milliseconds(100) });
     try {
       const start = TimeStamp.now();
+      const next = createClock();
       const w = await client.openWriter({
         start,
         channels: [time.key, data.key],
@@ -219,7 +234,7 @@ describe("feed", () => {
         // index cache covers the window with leading-alignment data only.
         const sub = short.stream(() => {}, [time.key]);
         for (let i = 0; i < 40; i++) {
-          await w.write({ [time.key]: [TimeStamp.now()], [data.key]: [value++] });
+          await w.write({ [time.key]: [next()], [data.key]: [value++] });
           await sleep.sleep(TimeSpan.milliseconds(5));
         }
         // A plot opens on the never-streamed channel: it reads the channel and its
@@ -268,6 +283,7 @@ describe("feed", () => {
     const small = client.openFeed({ dynamicBufferSize: 50 });
     try {
       const start = TimeStamp.now();
+      const next = createClock();
       const w = await client.openWriter({
         start,
         channels: [time.key, data.key],
@@ -277,13 +293,11 @@ describe("feed", () => {
         const sub = small.stream(() => {}, [time.key, data.key]);
         let value = 0;
         for (let i = 0; i < 10; i++) {
-          for (let j = 0; j < 30; j++) {
-            const now = TimeStamp.now();
+          for (let j = 0; j < 30; j++)
             await w.write({
-              [time.key]: [now, now.add(TimeSpan.microseconds(1))],
+              [time.key]: [next(), next()],
               [data.key]: [value++, value++],
             });
-          }
           const tr = new TimeRange(start, TimeStamp.now());
           // The fresh baseline reads first: anything committed by now must also
           // reach the later cached read, so autocommit lag cannot flake this.
@@ -311,6 +325,7 @@ describe("feed", () => {
     const short = client.openFeed({ removalDelay: TimeSpan.milliseconds(100) });
     try {
       const start = TimeStamp.now();
+      const next = createClock();
       const w = await client.openWriter({ start, channels: [time.key, data.key] });
       let value = 0;
       try {
@@ -325,7 +340,7 @@ describe("feed", () => {
         await expect
           .poll(
             async () => {
-              await w.write({ [time.key]: [TimeStamp.now()], [data.key]: [value++] });
+              await w.write({ [time.key]: [next()], [data.key]: [value++] });
               return received.length > 0;
             },
             { timeout: 10000, interval: 100 },
@@ -336,7 +351,7 @@ describe("feed", () => {
         sub.close();
         await sleep.sleep(TimeSpan.milliseconds(500));
         for (let i = 0; i < 10; i++)
-          await w.write({ [time.key]: [TimeStamp.now()], [data.key]: [value++] });
+          await w.write({ [time.key]: [next()], [data.key]: [value++] });
         await w.commit();
       } finally {
         await w.close();


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4607](https://linear.app/synnax/issue/SY-4607)

## Description

The same sample carries a provisional leading alignment when streamed and a committed alignment when fetched, and the line renderer pairs x and y series by alignment overlap. Serving a span from streamed data while the paired channel held fetched data made the pair undrawable: missing backloads, permanent gaps, zero-floored auto bounds, and dead tooltips at the seam.

Reads now fetch every span not covered by fetched entries, converging both channels to committed alignments. A span may briefly return in both forms.

Also: the TPC simulator seeded every sensor with 0.0 one sample before the loop's first real write, which spiked plot auto bounds on task start.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents streamed telemetry from claiming historical cache coverage so reads converge on committed alignments, while allowing both representations briefly.
- Separates fetched and streamed cache entries and derives gaps only from fetched data.
- Corrects Cesium auto-span sample boundaries and backward-read alignments.
- Seeds the TPC simulator with realistic initial sensor values.
- Adds cache, feed, iterator, alignment, rollover, and garbage-collection coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| client/ts/src/framer/cache/static.ts | Separates fetched and streamed entries, computes historical coverage exclusively from fetched data, and garbage-collects both lists. |
| client/ts/src/framer/cache/unary.ts | Preserves overlapping live-buffer data without allowing it to suppress historical gap fetching. |
| cesium/internal/unary/iterator.go | Corrects auto-span boundary selection, domain transitions, sample offsets, and backward alignment calculation. |
| client/py/examples/simulators/tpc.py | Reuses a complete initial-state map to seed sensors consistently with the simulation loop. |
| client/ts/src/framer/feed.spec.ts | Adds end-to-end coverage for alignment-compatible backloads and reads across leading-buffer rollovers. |

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Stream as Live stream
  participant Cache as Telemetry cache
  participant Reader as Historical reader
  participant Store as Cesium
  Stream->>Cache: Provisional-alignment series
  Reader->>Cache: Read requested span
  Cache-->>Reader: Streamed series + uncovered gap
  Reader->>Store: Fetch uncovered span
  Store-->>Reader: Committed-alignment series
  Reader->>Cache: Store fetched series
  Cache-->>Reader: Fetched and temporary streamed representations
```

<sub>Reviews (2): Last reviewed commit: ["Assert exact sample sets in the client c..."](https://github.com/synnaxlabs/synnax/commit/afb9040611b83bc9327f49c66661fb73ee367e5f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53800946)</sub>

**Context used:**

- Knowledge Base — [Cesium Storage Engine](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/cesium-storage.md)
- Knowledge Base — [Client SDKs](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/client-sdks.md)

<!-- /greptile_comment -->