### PR TITLE
SY-4608: Move PagerDuty onto the schema-carried config, and assorted fixes

### DIFF
--- a/console/src/feature/project/Splash.tsx
+++ b/console/src/feature/project/Splash.tsx
@@ -99,7 +99,12 @@ export const Splash = (): ReactElement => {
               Projects
             </Header.Title>
             <Header.Actions>
-              <PButton.Button variant="text" color={9} size="medium" onClick={logout}>
+              <PButton.Button
+                variant="text"
+                textColor={9}
+                size="medium"
+                onClick={logout}
+              >
                 <Icon.Logout />
                 Log Out
               </PButton.Button>

--- a/console/src/feature/shell/Nav.tsx
+++ b/console/src/feature/shell/Nav.tsx
@@ -31,7 +31,7 @@ export const Nav = ({ connection }: NavProps): ReactElement => {
     <Shell.Islands>
       <Flex.Box x align="center" gap="medium">
         {chrome && os === "macOS" && (
-          <Shell.Island>
+          <Shell.Island data-tauri-drag-region>
             <Window.Controls visibleIfOS="macOS" forceOS={os} />
           </Shell.Island>
         )}
@@ -44,7 +44,7 @@ export const Nav = ({ connection }: NavProps): ReactElement => {
       <Flex.Box x align="center" gap="medium">
         <Shell.Connection cluster={connection} />
         {chrome && os === "Windows" && (
-          <Shell.Island>
+          <Shell.Island data-tauri-drag-region>
             <Window.Controls visibleIfOS="Windows" forceOS={os} />
           </Shell.Island>
         )}

--- a/console/src/platform/button/CreateListItem.tsx
+++ b/console/src/platform/button/CreateListItem.tsx
@@ -28,7 +28,7 @@ export const CreateListItem = ({
 }: CreateListItemProps): ReactElement => (
   <Button.Button
     variant="text"
-    color={9}
+    textColor={9}
     justify="start"
     className={CSS(CSS.B("create-list-item"), CSS.M(size), className)}
     {...rest}

--- a/core/pkg/service/pagerduty/alert_task.go
+++ b/core/pkg/service/pagerduty/alert_task.go
@@ -11,7 +11,6 @@ package pagerduty
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"time"
 
@@ -20,7 +19,6 @@ import (
 	"github.com/synnaxlabs/synnax/pkg/service/status"
 	"github.com/synnaxlabs/synnax/pkg/service/task"
 	"github.com/synnaxlabs/x/change"
-	"github.com/synnaxlabs/x/encoding/msgpack"
 	"github.com/synnaxlabs/x/gorp"
 	"github.com/synnaxlabs/x/observe"
 	"github.com/synnaxlabs/x/validate"
@@ -30,43 +28,14 @@ import (
 // AlertTaskType is the type identifier for PagerDuty alert tasks.
 const AlertTaskType = "pagerduty_alert"
 
-// AlertConfig is the configuration for a single alert, mapping a Synnax status to a
-// PagerDuty alert.
-type AlertConfig struct {
-	// Status is the Synnax status key to alert on.
-	Status string `json:"status" msgpack:"status"`
-	// TreatErrorAsCritical controls whether error status variant maps to "critical"
-	// (true) or "error" (false) severity in PagerDuty.
-	TreatErrorAsCritical bool `json:"treat_error_as_critical" msgpack:"treat_error_as_critical"`
-	// Component of the source machine responsible for the event, for example "mysql" or
-	// "eth0".
-	Component string `json:"component" msgpack:"component"`
-	// Group is a logical grouping of components of a service, for example "app-stack".
-	Group string `json:"group" msgpack:"group"`
-	// Class is the class/type of the event, for example "ping failure" or "cpu load".
-	Class string `json:"class" msgpack:"class"`
-	// Enabled controls whether this specific alert is active.
-	Enabled bool `json:"enabled" msgpack:"enabled"`
-}
-
-// AlertTaskConfig is the configuration for a PagerDuty alert task.
-type AlertTaskConfig struct {
-	// RoutingKey is the 32-character Integration Key for an integration on a service
-	// or on a global ruleset.
-	RoutingKey string `json:"routing_key" msgpack:"routing_key"`
-	// AutoStart controls whether the task starts automatically when configured.
-	AutoStart bool `json:"auto_start" msgpack:"auto_start"`
-	// Alerts is the list of alert configurations to send.
-	Alerts []AlertConfig `json:"alerts" msgpack:"alerts"`
-}
-
-// Validate validates the alert task configuration.
-func (c AlertTaskConfig) Validate() error {
-	v := validate.New("pagerduty.alert_task_config")
+// validateConfig checks the deploy-time constraints on a task config: a real
+// routing key and at least one enabled alert.
+func validateConfig(c TaskConfig) error {
+	v := validate.New("pagerduty.task_config")
 	v.Ternary("routing_key", len(c.RoutingKey) != 32, "must be exactly 32 characters")
 	var hasEnabled bool
 	for _, a := range c.Alerts {
-		if a.Enabled {
+		if !a.Disabled {
 			hasEnabled = true
 			break
 		}
@@ -75,29 +44,15 @@ func (c AlertTaskConfig) Validate() error {
 	return v.Error()
 }
 
-// MsgpackEncodedJSON converts the config into a binary.MsgpackEncodedJSON suitable
-// for use as a task.Task.Config value.
-func (c AlertTaskConfig) MsgpackEncodedJSON() (msgpack.EncodedJSON, error) {
-	b, err := json.Marshal(c)
-	if err != nil {
-		return nil, err
-	}
-	var m msgpack.EncodedJSON
-	if err := json.Unmarshal(b, &m); err != nil {
-		return nil, err
-	}
-	return m, nil
-}
-
 type alertTask struct {
 	factoryCfg FactoryConfig
 	task       task.Task
-	cfg        AlertTaskConfig
+	cfg        TaskConfig
 	// status is the authority on this instance's current status.
 	status     *driver.StatusHandler
 	disconnect observe.Disconnect
-	// alertsByStatus maps status keys to their AlertConfig for O(1) lookup.
-	alertsByStatus map[string]AlertConfig
+	// alertsByStatus maps status keys to their enabled Alert for O(1) lookup.
+	alertsByStatus map[string]Alert
 }
 
 var _ driver.Task = (*alertTask)(nil)
@@ -120,9 +75,9 @@ func (t *alertTask) start(ctx context.Context, cmdKey string) error {
 		t.ackCurrent(ctx, cmdKey, true)
 		return nil
 	}
-	t.alertsByStatus = make(map[string]AlertConfig, len(t.cfg.Alerts))
+	t.alertsByStatus = make(map[string]Alert, len(t.cfg.Alerts))
 	for _, a := range t.cfg.Alerts {
-		if a.Enabled {
+		if !a.Disabled {
 			t.alertsByStatus[a.Status] = a
 		}
 	}
@@ -183,7 +138,7 @@ func (t *alertTask) handleStatusChange(
 			continue
 		}
 		alertCfg, ok := t.alertsByStatus[ch.Key]
-		if !ok || !alertCfg.Enabled {
+		if !ok {
 			continue
 		}
 		s := ch.Value
@@ -202,7 +157,7 @@ func (t *alertTask) handleStatusChange(
 
 func (t *alertTask) buildTriggerEvent(
 	s status.Status[any],
-	alertCfg AlertConfig,
+	alertCfg Alert,
 ) pagerduty.V2Event {
 	summary := s.Message
 	if s.Description != "" {

--- a/core/pkg/service/pagerduty/alert_task_test.go
+++ b/core/pkg/service/pagerduty/alert_task_test.go
@@ -27,95 +27,27 @@ import (
 )
 
 var _ = Describe("AlertTask", func() {
-	Describe("Config", func() {
-		Describe("Validate", func() {
-			It("Should return an error for invalid routing key length", func() {
-				cfg := pd.AlertTaskConfig{
-					RoutingKey: "tooshort",
-					Alerts: []pd.AlertConfig{
-						{Status: "test-status", Enabled: true},
-					},
-				}
-				Expect(cfg.Validate()).To(MatchError(ContainSubstring("routing_key")))
-			})
-
-			It("Should return an error when no alerts are enabled", func() {
-				cfg := pd.AlertTaskConfig{
-					RoutingKey: strings.Repeat("a", 32),
-					Alerts: []pd.AlertConfig{
-						{Status: "test-status", Enabled: false},
-					},
-				}
-				Expect(cfg.Validate()).To(MatchError(ContainSubstring("alerts")))
-			})
-
-			It("Should succeed with a valid config", func() {
-				cfg := pd.AlertTaskConfig{
-					RoutingKey: strings.Repeat("a", 32),
-					Alerts: []pd.AlertConfig{
-						{Status: "test-status", Enabled: true},
-					},
-				}
-				Expect(cfg.Validate()).To(Succeed())
-			})
-		})
-
-		Describe("MsgpackEncodedJSON", func() {
-			It("Should round-trip all fields correctly", func() {
-				cfg := pd.AlertTaskConfig{
-					RoutingKey: strings.Repeat("x", 32),
-					AutoStart:  true,
-					Alerts: []pd.AlertConfig{
-						{
-							Status:               "my-status",
-							TreatErrorAsCritical: true,
-							Component:            "sensor",
-							Group:                "hw",
-							Class:                "temp",
-							Enabled:              true,
-						},
-					},
-				}
-				m := MustSucceed(cfg.MsgpackEncodedJSON())
-				var decoded pd.AlertTaskConfig
-				Expect(m.Unmarshal(&decoded)).To(Succeed())
-				Expect(decoded).To(Equal(cfg))
-			})
-
-			It("Should produce a valid map with expected keys", func() {
-				cfg := pd.AlertTaskConfig{
-					RoutingKey: strings.Repeat("a", 32),
-					Alerts:     []pd.AlertConfig{{Status: "s1", Enabled: true}},
-				}
-				m := MustSucceed(cfg.MsgpackEncodedJSON())
-				Expect(m).To(HaveKey("routing_key"))
-				Expect(m).To(HaveKey("auto_start"))
-				Expect(m).To(HaveKey("alerts"))
-			})
-		})
-	})
 	var (
 		sender  *mockEventSender
 		factory driver.Factory
 	)
 
-	validConfig := func(alerts ...pd.AlertConfig) pd.AlertTaskConfig {
-		return pd.AlertTaskConfig{
+	validConfig := func(alerts ...pd.Alert) pd.TaskConfig {
+		return pd.TaskConfig{
 			RoutingKey: strings.Repeat("b", 32),
-			AutoStart:  false,
 			Alerts:     alerts,
 		}
 	}
 
 	configureAndStart := func(
 		ctx context.Context,
-		cfg pd.AlertTaskConfig,
+		cfg pd.TaskConfig,
 	) driver.Task {
 		t := task.Task{
 			Key:    uuid.New(),
 			Name:   "PagerDuty Test",
 			Type:   pd.AlertTaskType,
-			Config: MustSucceed(cfg.MsgpackEncodedJSON()),
+			Config: encodeConfig(cfg),
 		}
 		tsk := MustSucceed(factory.ConfigureTask(ctx, t, "cmd-1"))
 		Expect(tsk.Exec(ctx, task.Command{Type: "start"})).To(Succeed())
@@ -154,12 +86,12 @@ var _ = Describe("AlertTask", func() {
 	Describe("Exec", func() {
 		It("Should return ErrUnsupportedCommand for unknown commands",
 			func(ctx context.Context) {
-				cfg := validConfig(pd.AlertConfig{Status: "s1", Enabled: true})
+				cfg := validConfig(pd.Alert{Status: "s1"})
 				t := task.Task{
 					Key:    uuid.New(),
 					Name:   "test",
 					Type:   pd.AlertTaskType,
-					Config: MustSucceed(cfg.MsgpackEncodedJSON()),
+					Config: encodeConfig(cfg),
 				}
 				tsk := MustSucceed(factory.ConfigureTask(ctx, t, "cmd-1"))
 				defer func() { Expect(tsk.Stop(true)).To(Succeed()) }()
@@ -171,12 +103,10 @@ var _ = Describe("AlertTask", func() {
 		DescribeTable("Should acknowledge a command that needs no work",
 			func(ctx context.Context, cmdType string, running bool) {
 				t := task.Task{
-					Key:  uuid.New(),
-					Name: "PagerDuty Test",
-					Type: pd.AlertTaskType,
-					Config: MustSucceed(validConfig(
-						pd.AlertConfig{Status: "s1", Enabled: true},
-					).MsgpackEncodedJSON()),
+					Key:    uuid.New(),
+					Name:   "PagerDuty Test",
+					Type:   pd.AlertTaskType,
+					Config: encodeConfig(validConfig(pd.Alert{Status: "s1"})),
 				}
 				tsk := MustSucceed(factory.ConfigureTask(ctx, t, "cmd-1"))
 				defer func() { Expect(tsk.Stop(false)).To(Succeed()) }()
@@ -206,7 +136,7 @@ var _ = Describe("AlertTask", func() {
 		It("Should send a trigger event when a watched status changes to error",
 			func(ctx context.Context) {
 				tsk := configureAndStart(ctx, validConfig(
-					pd.AlertConfig{Status: "watched-error", Enabled: true},
+					pd.Alert{Status: "watched-error"},
 				))
 				defer func() { Expect(tsk.Stop(true)).To(Succeed()) }()
 
@@ -231,7 +161,7 @@ var _ = Describe("AlertTask", func() {
 		It("Should send a resolve event when a watched status changes to success",
 			func(ctx context.Context) {
 				tsk := configureAndStart(ctx, validConfig(
-					pd.AlertConfig{Status: "watched-resolve", Enabled: true},
+					pd.Alert{Status: "watched-resolve"},
 				))
 				defer func() { Expect(tsk.Stop(true)).To(Succeed()) }()
 
@@ -251,7 +181,7 @@ var _ = Describe("AlertTask", func() {
 		It("Should ignore status changes for unwatched keys",
 			func(ctx context.Context) {
 				tsk := configureAndStart(ctx, validConfig(
-					pd.AlertConfig{Status: "watched-only", Enabled: true},
+					pd.Alert{Status: "watched-only"},
 				))
 				defer func() { Expect(tsk.Stop(true)).To(Succeed()) }()
 
@@ -266,8 +196,8 @@ var _ = Describe("AlertTask", func() {
 
 		It("Should ignore disabled alerts", func(ctx context.Context) {
 			tsk := configureAndStart(ctx, validConfig(
-				pd.AlertConfig{Status: "disabled-alert", Enabled: false},
-				pd.AlertConfig{Status: "enabled-alert", Enabled: true},
+				pd.Alert{Status: "disabled-alert", Disabled: true},
+				pd.Alert{Status: "enabled-alert"},
 			))
 			defer func() { Expect(tsk.Stop(true)).To(Succeed()) }()
 
@@ -282,7 +212,7 @@ var _ = Describe("AlertTask", func() {
 		It("Should skip loading and disabled status variants",
 			func(ctx context.Context) {
 				tsk := configureAndStart(ctx, validConfig(
-					pd.AlertConfig{Status: "variant-skip", Enabled: true},
+					pd.Alert{Status: "variant-skip"},
 				))
 				defer func() { Expect(tsk.Stop(true)).To(Succeed()) }()
 
@@ -298,7 +228,7 @@ var _ = Describe("AlertTask", func() {
 		It("Should send a trigger event for warning status",
 			func(ctx context.Context) {
 				tsk := configureAndStart(ctx, validConfig(
-					pd.AlertConfig{Status: "watched-warning", Enabled: true},
+					pd.Alert{Status: "watched-warning"},
 				))
 				defer func() { Expect(tsk.Stop(true)).To(Succeed()) }()
 
@@ -316,7 +246,7 @@ var _ = Describe("AlertTask", func() {
 		It("Should send a trigger event for info status",
 			func(ctx context.Context) {
 				tsk := configureAndStart(ctx, validConfig(
-					pd.AlertConfig{Status: "watched-info", Enabled: true},
+					pd.Alert{Status: "watched-info"},
 				))
 				defer func() { Expect(tsk.Stop(true)).To(Succeed()) }()
 
@@ -335,9 +265,8 @@ var _ = Describe("AlertTask", func() {
 		It("Should map error to critical when TreatErrorAsCritical is true",
 			func(ctx context.Context) {
 				tsk := configureAndStart(ctx, validConfig(
-					pd.AlertConfig{
+					pd.Alert{
 						Status:               "critical-error",
-						Enabled:              true,
 						TreatErrorAsCritical: true,
 					},
 				))
@@ -357,9 +286,8 @@ var _ = Describe("AlertTask", func() {
 		It("Should map error to error when TreatErrorAsCritical is false",
 			func(ctx context.Context) {
 				tsk := configureAndStart(ctx, validConfig(
-					pd.AlertConfig{
+					pd.Alert{
 						Status:               "normal-error",
-						Enabled:              true,
 						TreatErrorAsCritical: false,
 					},
 				))
@@ -381,9 +309,8 @@ var _ = Describe("AlertTask", func() {
 		It("Should map status fields to PagerDuty event fields correctly",
 			func(ctx context.Context) {
 				tsk := configureAndStart(ctx, validConfig(
-					pd.AlertConfig{
+					pd.Alert{
 						Status:    "payload-test",
-						Enabled:   true,
 						Component: "sensor-array",
 						Group:     "hardware",
 						Class:     "temperature-warning",
@@ -429,7 +356,7 @@ var _ = Describe("AlertTask", func() {
 		It("Should use only message as summary when description is empty",
 			func(ctx context.Context) {
 				tsk := configureAndStart(ctx, validConfig(
-					pd.AlertConfig{Status: "no-desc", Enabled: true},
+					pd.Alert{Status: "no-desc"},
 				))
 				defer func() { Expect(tsk.Stop(true)).To(Succeed()) }()
 
@@ -450,7 +377,7 @@ var _ = Describe("AlertTask", func() {
 		It("Should stop observing status changes after stop",
 			func(ctx context.Context) {
 				tsk := configureAndStart(ctx, validConfig(
-					pd.AlertConfig{Status: "stop-test", Enabled: true},
+					pd.Alert{Status: "stop-test"},
 				))
 				Expect(tsk.Stop(true)).To(Succeed())
 
@@ -466,7 +393,7 @@ var _ = Describe("AlertTask", func() {
 			func(ctx context.Context) {
 				sender.setError(fmt.Errorf("simulated PagerDuty outage"))
 				tsk := configureAndStart(ctx, validConfig(
-					pd.AlertConfig{Status: "send-failure", Enabled: true},
+					pd.Alert{Status: "send-failure"},
 				))
 				defer func() { Expect(tsk.Stop(true)).To(Succeed()) }()
 

--- a/core/pkg/service/pagerduty/factory.go
+++ b/core/pkg/service/pagerduty/factory.go
@@ -75,7 +75,7 @@ func (f *factory) ConfigureTask(
 	if t.Type != AlertTaskType {
 		return nil, driver.ErrTaskNotHandled
 	}
-	var cfg AlertTaskConfig
+	var cfg TaskConfig
 	if err := t.Config.Unmarshal(&cfg); err != nil {
 		if cmdKey == driver.NoCommand {
 			f.cfg.L.Warn("failed to configure task",
@@ -87,7 +87,7 @@ func (f *factory) ConfigureTask(
 		}
 		return nil, err
 	}
-	if err := cfg.Validate(); err != nil {
+	if err := validateConfig(cfg); err != nil {
 		if cmdKey == driver.NoCommand && !cfg.AutoStart {
 			f.cfg.L.Warn("failed to configure task",
 				zap.Stringer("task", t),

--- a/core/pkg/service/pagerduty/factory_test.go
+++ b/core/pkg/service/pagerduty/factory_test.go
@@ -20,6 +20,7 @@ import (
 	pd "github.com/synnaxlabs/synnax/pkg/service/pagerduty"
 	"github.com/synnaxlabs/synnax/pkg/service/status"
 	"github.com/synnaxlabs/synnax/pkg/service/task"
+	taskconfig "github.com/synnaxlabs/synnax/pkg/service/task/config"
 	"github.com/synnaxlabs/x/encoding/msgpack"
 	"github.com/synnaxlabs/x/query"
 	. "github.com/synnaxlabs/x/testutil"
@@ -130,12 +131,10 @@ var _ = Describe("Factory", func() {
 
 			It("Should return a validation error for invalid task config",
 				func(ctx context.Context) {
-					cfg := MustSucceed(pd.AlertTaskConfig{
+					cfg := encodeConfig(pd.TaskConfig{
 						RoutingKey: "tooshort",
-						Alerts: []pd.AlertConfig{
-							{Status: "test-status", Enabled: true},
-						},
-					}.MsgpackEncodedJSON())
+						Alerts:     []pd.Alert{{Status: "test-status"}},
+					})
 					t := task.Task{
 						Key: uuid.New(), Name: "test", Type: pd.AlertTaskType,
 						Config: cfg,
@@ -145,14 +144,29 @@ var _ = Describe("Factory", func() {
 				},
 			)
 
+			It("Should return a validation error when every alert is disabled",
+				func(ctx context.Context) {
+					cfg := encodeConfig(pd.TaskConfig{
+						RoutingKey: strings.Repeat("a", 32),
+						Alerts: []pd.Alert{
+							{Status: "test-status", Disabled: true},
+						},
+					})
+					t := task.Task{
+						Key: uuid.New(), Name: "test", Type: pd.AlertTaskType,
+						Config: cfg,
+					}
+					Expect(factory.ConfigureTask(ctx, t, "cmd-1")).Error().
+						To(MatchError(ContainSubstring("alerts")))
+				},
+			)
+
 			It("Should attribute a failed configure to the start command",
 				func(ctx context.Context) {
-					cfg := MustSucceed(pd.AlertTaskConfig{
+					cfg := encodeConfig(pd.TaskConfig{
 						RoutingKey: "tooshort",
-						Alerts: []pd.AlertConfig{
-							{Status: "test-status", Enabled: true},
-						},
-					}.MsgpackEncodedJSON())
+						Alerts:     []pd.Alert{{Status: "test-status"}},
+					})
 					t := task.Task{
 						Key: uuid.New(), Name: "test", Type: pd.AlertTaskType,
 						Config: cfg,
@@ -172,13 +186,10 @@ var _ = Describe("Factory", func() {
 			DescribeTable("Should write no status for a successful configure "+
 				"without auto-start",
 				func(ctx context.Context, cmdKey string) {
-					cfg := MustSucceed(pd.AlertTaskConfig{
+					cfg := encodeConfig(pd.TaskConfig{
 						RoutingKey: strings.Repeat("a", 32),
-						AutoStart:  false,
-						Alerts: []pd.AlertConfig{
-							{Status: "test-status", Enabled: true},
-						},
-					}.MsgpackEncodedJSON())
+						Alerts:     []pd.Alert{{Status: "test-status"}},
+					})
 					t := task.Task{
 						Key: uuid.New(), Name: "PagerDuty Test",
 						Type: pd.AlertTaskType, Config: cfg,
@@ -196,13 +207,11 @@ var _ = Describe("Factory", func() {
 			)
 
 			It("Should configure and auto-start a task", func(ctx context.Context) {
-				cfg := MustSucceed(pd.AlertTaskConfig{
+				cfg := encodeConfig(pd.TaskConfig{
+					BaseStart:  taskconfig.BaseStart{AutoStart: true},
 					RoutingKey: strings.Repeat("a", 32),
-					AutoStart:  true,
-					Alerts: []pd.AlertConfig{
-						{Status: "test-status", Enabled: true},
-					},
-				}.MsgpackEncodedJSON())
+					Alerts:     []pd.Alert{{Status: "test-status"}},
+				})
 				t := task.Task{
 					Key: uuid.New(), Name: "PagerDuty Test",
 					Type: pd.AlertTaskType, Config: cfg,
@@ -221,12 +230,10 @@ var _ = Describe("Factory", func() {
 
 			It("Should not write a status for an invalid config at boot",
 				func(ctx context.Context) {
-					cfg := MustSucceed(pd.AlertTaskConfig{
+					cfg := encodeConfig(pd.TaskConfig{
 						RoutingKey: "tooshort",
-						Alerts: []pd.AlertConfig{
-							{Status: "test-status", Enabled: true},
-						},
-					}.MsgpackEncodedJSON())
+						Alerts:     []pd.Alert{{Status: "test-status"}},
+					})
 					t := task.Task{
 						Key: uuid.New(), Name: "test", Type: pd.AlertTaskType,
 						Config: cfg,
@@ -242,13 +249,11 @@ var _ = Describe("Factory", func() {
 
 			It("Should write an error status for an invalid auto-start config at boot",
 				func(ctx context.Context) {
-					cfg := MustSucceed(pd.AlertTaskConfig{
+					cfg := encodeConfig(pd.TaskConfig{
+						BaseStart:  taskconfig.BaseStart{AutoStart: true},
 						RoutingKey: "tooshort",
-						AutoStart:  true,
-						Alerts: []pd.AlertConfig{
-							{Status: "test-status", Enabled: true},
-						},
-					}.MsgpackEncodedJSON())
+						Alerts:     []pd.Alert{{Status: "test-status"}},
+					})
 					t := task.Task{
 						Key: uuid.New(), Name: "test", Type: pd.AlertTaskType,
 						Config: cfg,
@@ -266,13 +271,11 @@ var _ = Describe("Factory", func() {
 
 			It("Should auto-start at boot when auto_start is true",
 				func(ctx context.Context) {
-					cfg := MustSucceed(pd.AlertTaskConfig{
+					cfg := encodeConfig(pd.TaskConfig{
+						BaseStart:  taskconfig.BaseStart{AutoStart: true},
 						RoutingKey: strings.Repeat("a", 32),
-						AutoStart:  true,
-						Alerts: []pd.AlertConfig{
-							{Status: "test-status", Enabled: true},
-						},
-					}.MsgpackEncodedJSON())
+						Alerts:     []pd.Alert{{Status: "test-status"}},
+					})
 					t := task.Task{
 						Key: uuid.New(), Name: "PagerDuty Test",
 						Type: pd.AlertTaskType, Config: cfg,

--- a/core/pkg/service/pagerduty/pagerduty_suite_test.go
+++ b/core/pkg/service/pagerduty/pagerduty_suite_test.go
@@ -11,6 +11,7 @@ package pagerduty_test
 
 import (
 	"context"
+	"encoding/json"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -24,6 +25,7 @@ import (
 	pd "github.com/synnaxlabs/synnax/pkg/service/pagerduty"
 	"github.com/synnaxlabs/synnax/pkg/service/search"
 	"github.com/synnaxlabs/synnax/pkg/service/status"
+	"github.com/synnaxlabs/x/encoding/msgpack"
 	"github.com/synnaxlabs/x/gorp"
 	"github.com/synnaxlabs/x/kv/memkv"
 	. "github.com/synnaxlabs/x/testutil"
@@ -57,6 +59,16 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 	}))
 	Expect(searchIdx.Initialize(ctx)).To(Succeed())
 })
+
+// encodeConfig converts a config into the msgpack.EncodedJSON shape the driver
+// receives as task.Task.Config.
+func encodeConfig(cfg pd.TaskConfig) msgpack.EncodedJSON {
+	GinkgoHelper()
+	b := MustSucceed(json.Marshal(cfg))
+	var m msgpack.EncodedJSON
+	Expect(json.Unmarshal(b, &m)).To(Succeed())
+	return m
+}
 
 // mockEventSender records events sent through it for test assertions.
 type mockEventSender struct {

--- a/integration/console/notifications.py
+++ b/integration/console/notifications.py
@@ -100,10 +100,10 @@ class NotificationsClient:
                 return False
 
             notification = notifications.nth(notification_index)
-            close_button = notification.locator(".pluto-notification__silence")
+            close_button = notification.get_by_role("button", name="close")
 
             if close_button.count() > 0:
-                close_button.dispatch_event("click")
+                close_button.first.dispatch_event("click")
                 notification.wait_for(state="hidden", timeout=2000)
                 return True
             return False
@@ -150,11 +150,11 @@ class NotificationsClient:
         if notification.count() == 0:
             return False
 
-        close_btn = notification.locator(".pluto-notification__silence")
+        close_btn = notification.get_by_role("button", name="close")
         if close_btn.count() == 0:
             return False
         try:
-            close_btn.dispatch_event("click", timeout=2000)
+            close_btn.first.dispatch_event("click", timeout=2000)
             return True
         except PlaywrightTimeoutError:
             return False

--- a/integration/tests/client/pagerduty_alert.py
+++ b/integration/tests/client/pagerduty_alert.py
@@ -83,7 +83,6 @@ class PagerDutyAlert(TestCase):
                 alerts=[
                     sy.pagerduty.Alert(
                         status=self.status_key,
-                        enabled=True,
                         treat_error_as_critical=True,
                         component="integration-test",
                         group="ci",

--- a/integration/tests/client/pagerduty_alert.py
+++ b/integration/tests/client/pagerduty_alert.py
@@ -77,20 +77,20 @@ class PagerDutyAlert(TestCase):
             rack=go_rack.key,
             name=f"PD Integration Test {self.suffix}",
             type="pagerduty_alert",
-            config=sy.pagerduty.AlertTaskConfig(
+            config=sy.pagerduty.TaskConfig(
                 routing_key=ROUTING_KEY,
                 auto_start=True,
                 alerts=[
-                    sy.pagerduty.AlertConfig(
+                    sy.pagerduty.Alert(
                         status=self.status_key,
                         enabled=True,
                         treat_error_as_critical=True,
                         component="integration-test",
                         group="ci",
-                        alert_class="test_alert",
+                        class_="test_alert",
                     ),
                 ],
-            ).model_dump(by_alias=True, exclude_none=True),
+            ),
         )
         self.log(f"Alert task created: key={created.key}")
 

--- a/pluto/src/schematic/node/common/custom/Overrides.spec.tsx
+++ b/pluto/src/schematic/node/common/custom/Overrides.spec.tsx
@@ -1,0 +1,105 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { group, ontology, schematic } from "@synnaxlabs/client";
+import { createTestClient } from "@synnaxlabs/client/testutil";
+import { color } from "@synnaxlabs/x";
+import { act, fireEvent, render, waitFor } from "@testing-library/react";
+import { type FC, type PropsWithChildren, type ReactElement } from "react";
+import { beforeAll, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { Form } from "@/form";
+import { Custom } from "@/schematic/node/common/custom";
+import { createAsyncSynnaxWrapper } from "@/testutil/Synnax";
+
+const formSchema = z.object({
+  specKey: z.string(),
+  stateOverrides: schematic.symbol.stateZ.array(),
+});
+
+const createState = (key: string, name: string): schematic.symbol.State => ({
+  key,
+  name,
+  regions: [
+    {
+      key: "main",
+      name: `${name} Region`,
+      selectors: [".main"],
+      strokeColor: color.construct("#333333"),
+      fillColor: color.construct("#cccccc"),
+    },
+  ],
+});
+
+describe("StateOverrideForm", () => {
+  const client = createTestClient();
+  let wrapper: FC<PropsWithChildren>;
+
+  beforeAll(async () => {
+    wrapper = await createAsyncSynnaxWrapper({ client });
+  });
+
+  const createSymbol = async () => {
+    const parent = await client.groups.create({
+      parent: ontology.ROOT_ID,
+      name: "state-override-form-spec",
+    });
+    return await client.schematics.symbols.create({
+      name: "actuated",
+      parent: group.ontologyID(parent.key),
+      data: {
+        svg: '<svg viewBox="0 0 10 10"><rect class="main" /></svg>',
+        states: [createState("base", "Base"), createState("active", "Active")],
+        handles: [],
+        variant: "actuator",
+        scale: 1,
+        scaleStroke: false,
+        previewViewport: { zoom: 1, position: { x: 0, y: 0 } },
+      },
+    });
+  };
+
+  const renderForm = (specKey: string) => {
+    let form!: Form.UseReturn<typeof formSchema>;
+    const Container = (): ReactElement => {
+      form = Form.use<typeof formSchema>({
+        values: { specKey, stateOverrides: [] },
+        schema: formSchema,
+      });
+      return (
+        <Form.Form<typeof formSchema> {...form}>
+          <Custom.StateOverrideForm />
+        </Form.Form>
+      );
+    };
+    const utils = render(<Container />, { wrapper });
+    return { ...utils, form: () => form };
+  };
+
+  it("should render the resolved symbol's states and regions", async () => {
+    const symbol = await createSymbol();
+    const { getByText } = renderForm(symbol.key);
+    await waitFor(() => expect(getByText("Base Region")).toBeTruthy());
+    expect(getByText("Active")).toBeTruthy();
+  });
+
+  it("should fall back to the first state when the selected one disappears", async () => {
+    const symbol = await createSymbol();
+    const { getByText, queryByText, form } = renderForm(symbol.key);
+    await waitFor(() => expect(getByText("Active")).toBeTruthy());
+    fireEvent.click(getByText("Active"));
+    await waitFor(() => expect(getByText("Active Region")).toBeTruthy());
+    // Swapping the overrides beneath the held selection must not crash the
+    // region list; it falls back to the first remaining state.
+    act(() => form().set("stateOverrides", [createState("base", "Base")]));
+    await waitFor(() => expect(getByText("Base Region")).toBeTruthy());
+    expect(queryByText("Active Region")).toBeNull();
+  });
+});

--- a/pluto/src/schematic/node/common/custom/Overrides.tsx
+++ b/pluto/src/schematic/node/common/custom/Overrides.tsx
@@ -208,9 +208,7 @@ export const StateOverrideForm = (): ReactElement => {
   // The form can swap to a different symbol's overrides beneath the locally
   // held selection, so fall back to the first state when the key disappears.
   const shownState =
-    selectedState != null && states.includes(selectedState)
-      ? selectedState
-      : states[0];
+    selectedState != null && states.includes(selectedState) ? selectedState : states[0];
 
   return (
     <Flex.Box y align="stretch">

--- a/pluto/src/schematic/node/common/custom/Overrides.tsx
+++ b/pluto/src/schematic/node/common/custom/Overrides.tsx
@@ -205,12 +205,19 @@ export const StateOverrideForm = (): ReactElement => {
     [originalStates],
   );
 
+  // The form can swap to a different symbol's overrides beneath the locally
+  // held selection, so fall back to the first state when the key disappears.
+  const shownState =
+    selectedState != null && states.includes(selectedState)
+      ? selectedState
+      : states[0];
+
   return (
     <Flex.Box y align="stretch">
       {states.length > 1 && (
         <Select.Buttons
           keys={states}
-          value={selectedState}
+          value={shownState}
           onChange={setSelectedState}
           full="x"
         >
@@ -221,9 +228,9 @@ export const StateOverrideForm = (): ReactElement => {
           ))}
         </Select.Buttons>
       )}
-      {selectedState != null && (
+      {shownState != null && (
         <RegionList
-          selectedState={selectedState}
+          selectedState={shownState}
           onReset={resetRegion}
           getOriginalRegion={getOriginalRegion}
         />

--- a/pluto/src/theming/theme.css
+++ b/pluto/src/theming/theme.css
@@ -112,7 +112,8 @@
     --pluto-height-tiny: 3.5rem;
     --pluto-btn-transition:
         background 0.15s ease-in-out, border-color 0.15s ease-in-out,
-        fill 0.15s ease-in-out, opacity 0.15s ease-in-out, box-shadow 0.15s ease-in-out;
+        color 0.15s ease-in-out, fill 0.15s ease-in-out, opacity 0.15s ease-in-out,
+        box-shadow 0.15s ease-in-out;
     --pluto-modal-animation: fade-in-zoom 0.15s ease-in-out;
     --pluto-dialog-animation: fade-in-zoom 0.1s ease-in-out;
     --pluto-frost: blur(3.5rem) saturate(140%);

--- a/x/cpp/json/json.h
+++ b/x/cpp/json/json.h
@@ -385,12 +385,13 @@ public:
         return results;
     }
 
-    /// @brief binds a new error to the field at the given path, using the message from
-    /// a errors::Error.
+    /// @brief binds a new error to the field at the given path, using the data from
+    /// a errors::Error. The type prefix is omitted: error() re-wraps the accumulated
+    /// messages in a validation error, which would otherwise double the prefix.
     /// @param path The JSON path to the field.
-    /// @param err The error whose message will be used.
+    /// @param err The error whose data will be used.
     void field_err(const std::string &path, const errors::Error &err) const {
-        this->field_err(path, err.message());
+        this->field_err(path, err.data);
     }
 
     /// @brief binds a new error to the field at the given path.

--- a/x/ts/src/migrate/migrate.spec.ts
+++ b/x/ts/src/migrate/migrate.spec.ts
@@ -166,6 +166,21 @@ describe("compareSemVer", () => {
       ).toBeLessThan(0);
     });
   });
+  describe("patch unchecked", () => {
+    it("should ignore pre-release tags when patch checking is disabled", () => {
+      expect(
+        migrate.compareSemVer("0.56.2", "0.56.16-79dd4e2", { checkPatch: false }),
+      ).toBe(0);
+      expect(
+        migrate.versionsEqual("0.56.2", "0.56.16-79dd4e2", { checkPatch: false }),
+      ).toBe(true);
+    });
+    it("should still compare minor versions when only patch is unchecked", () => {
+      expect(
+        migrate.compareSemVer("0.57.0", "0.56.16-79dd4e2", { checkPatch: false }),
+      ).toBeGreaterThan(0);
+    });
+  });
   describe("only check patch", () => {
     it("should return equal when the patch versions are equal but the major and minor are different", () => {
       expect(

--- a/x/ts/src/migrate/migrate.ts
+++ b/x/ts/src/migrate/migrate.ts
@@ -123,6 +123,8 @@ export const compareSemVer = ((
 
   // When major.minor.patch are equal, compare pre-release versions
   // Version without pre-release > version with pre-release
+  // Pre-release qualifies the patch version, so skip it when patch is unchecked
+  if (!opts.checkPatch) return compare.EQUAL;
   if (aPreRelease === undefined && bPreRelease === undefined) return compare.EQUAL;
   if (aPreRelease === undefined) return compare.GREATER_THAN;
   if (bPreRelease === undefined) return compare.LESS_THAN;


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4608](https://linear.app/synnax/issue/SY-4608)

## Description

Small independent fixes that share no code with the other branches in this split.

- The PagerDuty alert task moves onto the schema-carried task config, dropping the hand-rolled parsing and the removed `enabled` flag.
- Semver comparison ignores pre-release tags when patch is unchecked, since a pre-release qualifies the patch version.
- `StateOverrideForm` crashed with `Path stateOverrides.<key>.regions does not exist` when the form swapped to another symbol's overrides beneath the held selection. It now falls back to the first state.
- The C++ JSON parser stores bare error data on field errors, so a message no longer carries a duplicated type prefix.
- Text buttons use `textColor`, with theme colors tuned to match, and the window control islands are draggable.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.