### PR TITLE
SY-4610: Match driver reads to the flattened schema for RTDs, array mode, and sample counts

### DIFF
--- a/driver/ni/channel/channels.h
+++ b/driver/ni/channel/channels.h
@@ -108,11 +108,11 @@ static int32_t get_shunt_resistor_loc(const std::string &loc) {
 
 static int32_t get_rtd_type(const std::string &type) {
     if (type == "Pt3750") return DAQmx_Val_Pt3750;
-    if (type == "PT3851") return DAQmx_Val_Pt3851;
-    if (type == "PT3911") return DAQmx_Val_Pt3911;
-    if (type == "PT3916") return DAQmx_Val_Pt3916;
-    if (type == "PT3920") return DAQmx_Val_Pt3920;
-    if (type == "PT3928") return DAQmx_Val_Pt3928;
+    if (type == "Pt3851") return DAQmx_Val_Pt3851;
+    if (type == "Pt3911") return DAQmx_Val_Pt3911;
+    if (type == "Pt3916") return DAQmx_Val_Pt3916;
+    if (type == "Pt3920") return DAQmx_Val_Pt3920;
+    if (type == "Pt3928") return DAQmx_Val_Pt3928;
     if (type == "Custom") return DAQmx_Val_Custom;
     return DAQmx_Val_Pt3750;
 }

--- a/driver/ni/channel/channels_tests.cpp
+++ b/driver/ni/channel/channels_tests.cpp
@@ -373,7 +373,7 @@ TEST(ChannelsTest, ParseAIRTDChan) {
         {"resistance_config", "2Wire"},
         {"current_excit_source", "Internal"},
         {"current_excit_val", 0},
-        {"rtd_type", "Pt3750"},
+        {"rtd_type", "Pt3851"},
         {"r0", 0},
         {"units", "DegC"},
         {"device", "cdaq1Mod2"}
@@ -393,7 +393,7 @@ TEST(ChannelsTest, ParseAIRTDChan) {
     EXPECT_EQ(call["args"]["resistanceConfig"], DAQmx_Val_2Wire);
     EXPECT_EQ(call["args"]["minVal"], 0);
     EXPECT_EQ(call["args"]["maxVal"], 1);
-    EXPECT_EQ(call["args"]["rtdType"], DAQmx_Val_Pt3750);
+    EXPECT_EQ(call["args"]["rtdType"], DAQmx_Val_Pt3851);
     EXPECT_EQ(call["args"]["r0"], 0);
 }
 

--- a/driver/opcua/factory.cpp
+++ b/driver/opcua/factory.cpp
@@ -27,7 +27,7 @@ std::pair<common::ConfigureResult, x::errors::Error> configure_read(
     auto [cfg, err] = ReadTaskConfig::parse(ctx->client, task);
     if (err) return {std::move(result), err};
     std::unique_ptr<common::Source> s;
-    if (cfg.array_size > 1)
+    if (cfg.array_mode)
         s = std::make_unique<ArrayReadTaskSource>(pool, std::move(cfg));
     else
         s = std::make_unique<UnaryReadTaskSource>(pool, std::move(cfg));

--- a/driver/opcua/read_task.h
+++ b/driver/opcua/read_task.h
@@ -116,7 +116,8 @@ struct ReadTaskConfig : common::BaseReadTaskConfig {
         device_key(parser.field<std::string>("device")),
         array_mode(parser.field<bool>("array_mode", false)),
         array_size(parser.field<std::size_t>("array_size", 1)),
-        samples_per_chan(this->sample_rate / this->stream_rate) {
+        // Array mode never uses samples_per_chan and its stream rate may be zero.
+        samples_per_chan(this->array_mode ? 0 : this->sample_rate / this->stream_rate) {
         parser.iter("channels", [&](x::json::Parser &cp) {
             const auto parsed = ::synnax::opcua::ReadChannel::parse(cp);
             if (parsed.disabled) return;

--- a/driver/opcua/read_task.h
+++ b/driver/opcua/read_task.h
@@ -72,7 +72,9 @@ struct InputChan {
 struct ReadTaskConfig : common::BaseReadTaskConfig {
     /// @brief the device representing the OPC UA server to read from.
     const std::string device_key;
-    /// @brief array_size;
+    /// @brief whether each read returns an array of samples per node.
+    const bool array_mode;
+    /// @brief the number of samples in each array when array_mode is true.
     const size_t array_size;
     /// @brief the config for connecting to the OPC UA server.
     /// Dynamically populated from device properties.
@@ -89,6 +91,7 @@ struct ReadTaskConfig : common::BaseReadTaskConfig {
     ReadTaskConfig(ReadTaskConfig &&other) noexcept:
         common::BaseReadTaskConfig(std::move(other)),
         device_key(other.device_key),
+        array_mode(other.array_mode),
         array_size(other.array_size),
         connection(std::move(other.connection)),
         index_keys(std::move(other.index_keys)),
@@ -108,9 +111,10 @@ struct ReadTaskConfig : common::BaseReadTaskConfig {
         common::BaseReadTaskConfig(
             parser,
             common::TimingConfig(),
-            parser.field<std::size_t>("array_size", 1) <= 1
+            !parser.field<bool>("array_mode", false)
         ),
         device_key(parser.field<std::string>("device")),
+        array_mode(parser.field<bool>("array_mode", false)),
         array_size(parser.field<std::size_t>("array_size", 1)),
         samples_per_chan(this->sample_rate / this->stream_rate) {
         parser.iter("channels", [&](x::json::Parser &cp) {

--- a/driver/opcua/read_task_test.cpp
+++ b/driver/opcua/read_task_test.cpp
@@ -456,6 +456,37 @@ TEST_F(TestReadTask, testUnboundDisabledChannel) {
     EXPECT_EQ(parsed->channels[0]->synnax_key, this->float_channel.key);
 }
 
+/// @brief it should stay out of array mode when array_mode is false, even when
+/// the config carries an array_size greater than one.
+TEST_F(TestReadTask, testArraySizeIgnoredWhenArrayModeDisabled) {
+    task_cfg_json["array_size"] = 5;
+    auto p = x::json::Parser(task_cfg_json);
+    const ReadTaskConfig cfg(ctx->client, p);
+    ASSERT_NIL(p.error());
+    EXPECT_FALSE(cfg.array_mode);
+
+    task_cfg_json["stream_rate"] = 0;
+    auto strict_p = x::json::Parser(task_cfg_json);
+    const ReadTaskConfig strict_cfg(ctx->client, strict_p);
+    ASSERT_OCCURRED_AS(strict_p.error(), x::errors::VALIDATION);
+}
+
+/// @brief it should require a stream rate only when array_mode is false.
+TEST_F(TestReadTask, testStreamRateOptionalInArrayMode) {
+    task_cfg_json["stream_rate"] = 0;
+    auto p = x::json::Parser(task_cfg_json);
+    const ReadTaskConfig unary_cfg(ctx->client, p);
+    ASSERT_OCCURRED_AS(p.error(), x::errors::VALIDATION);
+
+    task_cfg_json["array_mode"] = true;
+    task_cfg_json["array_size"] = 5;
+    auto array_p = x::json::Parser(task_cfg_json);
+    const ReadTaskConfig array_cfg(ctx->client, array_p);
+    ASSERT_NIL(array_p.error());
+    EXPECT_TRUE(array_cfg.array_mode);
+    EXPECT_EQ(array_cfg.array_size, 5);
+}
+
 /// @brief it should handle rapid start and stop cycles.
 TEST_F(TestReadTask, testRapidStartStop) {
     const auto rt = create_task();

--- a/driver/opcua/read_task_test.cpp
+++ b/driver/opcua/read_task_test.cpp
@@ -485,6 +485,7 @@ TEST_F(TestReadTask, testStreamRateOptionalInArrayMode) {
     ASSERT_NIL(array_p.error());
     EXPECT_TRUE(array_cfg.array_mode);
     EXPECT_EQ(array_cfg.array_size, 5);
+    EXPECT_EQ(array_cfg.samples_per_chan, 0);
 }
 
 /// @brief it should handle rapid start and stop cycles.

--- a/integration/tests/driver/ni_read.py
+++ b/integration/tests/driver/ni_read.py
@@ -281,7 +281,7 @@ class NIReadTemperature(NIAnalogReadTaskCase):
     E101Mod8 (NI 9219) — RTD:
         Port 0: Pt3920, 3-wire, DegR
         Port 1: Pt3928, 3-wire, DegC
-        Port 2: Pt3850, 4-wire, DegF
+        Port 2: Pt3851, 4-wire, DegF
     """
 
     task_name = "NI Temperature + Resistance Read"
@@ -609,12 +609,12 @@ class NIReadTemperature(NIAnalogReadTaskCase):
                 port=2,
                 channel=create_channel(
                     client,
-                    name="ni_rtd_pt3850_4w",
+                    name="ni_rtd_pt3851_4w",
                     data_type=sy.DataType.FLOAT32,
                     index=idx.key,
                 ),
                 units="DegF",
-                rtd_type="Pt3850",
+                rtd_type="Pt3851",
                 resistance_config="4Wire",
                 current_excit_source="Internal",
                 current_excit_val=0.001,


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4610](https://linear.app/synnax/issue/SY-4610/match-driver-reads-to-the-flattened-schema-for-rtds-array-mode-and)

## Description

Three driver read-path defects the flattened rc schema exposed. Carved out of #2723 so the acquire-on-start change reviews on its own.

OPC UA read tasks branched on `array_size > 1` instead of honoring `array_mode`. The flattened schema made `array_mode: false, array_size: 5` representable for the first time, so the driver read scalar tasks as array tasks: nothing streamed, and every read logged a validation warning.

`samples_per_chan` is now guarded against a zero stream rate in array mode.

NI RTD type parsing matches the schema casing, and the Pt3850 entry that no schema produces is gone.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR aligns OPC UA read-source selection with the flattened `array_mode` field and aligns NI RTD strings with the schema.

- Selects unary or array OPC UA sources from `array_mode`.
- Avoids division by a zero stream rate in array mode.
- Corrects NI RTD casing and replaces the unsupported `Pt3850` test value.
- Adds focused unit and integration coverage.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The changed mode selection, timing validation, and RTD mapping match the schema contracts, and no reachable blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| driver/opcua/read_task.h | Adds explicit array-mode parsing and prevents a zero-stream-rate division in array mode. |
| driver/opcua/factory.cpp | Selects the OPC UA read source from the schema mode instead of the array size. |
| driver/opcua/read_task_test.cpp | Covers scalar configurations with large array sizes and zero stream rates in array mode. |
| driver/ni/channel/channels.h | Aligns RTD type matching with the exact schema casing. |
| driver/ni/channel/channels_tests.cpp | Verifies that `Pt3851` maps to the correct DAQmx RTD type. |
| integration/tests/driver/ni_read.py | Replaces the unsupported `Pt3850` fixture with the schema-supported `Pt3851` value. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  C[Parse OPC UA read config] --> M{array_mode}
  M -- false --> V[Require valid stream rate]
  V --> U[Construct UnaryReadTaskSource]
  M -- true --> A[Allow zero stream rate]
  A --> Z[Set samples_per_chan to zero]
  Z --> R[Construct ArrayReadTaskSource]
```

<sub>Reviews (1): Last reviewed commit: ["Match NI RTD type parsing to schema casi..."](https://github.com/synnaxlabs/synnax/commit/36cbb659691796c653ce238e62646afd1e1ba6c7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54000658)</sub>

**Context used:**

- Knowledge Base — [Driver: Connecting Physical Devices to Synnax](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/driver-devices.md)

<!-- /greptile_comment -->