### PR TITLE
SY-4611: Pass the schema through Series.parseJSON and cap unary retries at the breaker limit

### DIFF
--- a/client/ts/src/channel/channel.spec.ts
+++ b/client/ts/src/channel/channel.spec.ts
@@ -18,6 +18,7 @@ import {
   createTestClient,
   expectDeleted,
   expectLive,
+  FAST_RETRY,
   TEST_CLIENT_PARAMS,
 } from "@/testutil";
 
@@ -488,7 +489,11 @@ describe("cached reads", () => {
   describe("name resolution", () => {
     it("serves literal names from the record store without reaching the cluster", async () => {
       const proxy = await createSeverableProxy();
-      const local = createTestClient({ ...TEST_CLIENT_PARAMS, port: proxy.port });
+      const local = createTestClient({
+        ...TEST_CLIENT_PARAMS,
+        port: proxy.port,
+        retry: FAST_RETRY,
+      });
       try {
         const ch = await createVirtual(local);
         await proxy.sever();
@@ -501,7 +506,11 @@ describe("cached reads", () => {
 
     it("fetches only the names the store cannot resolve", async () => {
       const proxy = await createSeverableProxy();
-      const local = createTestClient({ ...TEST_CLIENT_PARAMS, port: proxy.port });
+      const local = createTestClient({
+        ...TEST_CLIENT_PARAMS,
+        port: proxy.port,
+        retry: FAST_RETRY,
+      });
       try {
         const known = await createVirtual(local);
         // Created by another client, so `local` has never seen it. Severing
@@ -526,7 +535,11 @@ describe("cached reads", () => {
 
     it("goes to the cluster for a name holding regex characters", async () => {
       const proxy = await createSeverableProxy();
-      const local = createTestClient({ ...TEST_CLIENT_PARAMS, port: proxy.port });
+      const local = createTestClient({
+        ...TEST_CLIENT_PARAMS,
+        port: proxy.port,
+        retry: FAST_RETRY,
+      });
       try {
         const ch = await createVirtual(local);
         await proxy.sever();
@@ -540,7 +553,11 @@ describe("cached reads", () => {
 
     it("goes to the cluster when a name matches two stored channels", async () => {
       const proxy = await createSeverableProxy();
-      const local = createTestClient({ ...TEST_CLIENT_PARAMS, port: proxy.port });
+      const local = createTestClient({
+        ...TEST_CLIENT_PARAMS,
+        port: proxy.port,
+        retry: FAST_RETRY,
+      });
       try {
         const ch = await createVirtual(local);
         const other = await createVirtual(local);
@@ -564,7 +581,11 @@ describe("cached reads", () => {
 
     it("goes to the cluster for a request narrowed beyond names", async () => {
       const proxy = await createSeverableProxy();
-      const local = createTestClient({ ...TEST_CLIENT_PARAMS, port: proxy.port });
+      const local = createTestClient({
+        ...TEST_CLIENT_PARAMS,
+        port: proxy.port,
+        retry: FAST_RETRY,
+      });
       try {
         const ch = await createVirtual(local);
         await proxy.sever();

--- a/client/ts/src/connection/client.ts
+++ b/client/ts/src/connection/client.ts
@@ -20,7 +20,6 @@ import {
   TimeSpan,
   TimeStamp,
   url,
-  zod,
 } from "@synnaxlabs/x";
 import { z } from "zod";
 
@@ -74,7 +73,6 @@ export interface CheckParams {
   secure?: boolean;
   /** Human-readable cluster name for status messages. */
   name?: string;
-  retry?: breaker.Config;
 }
 
 /**
@@ -83,10 +81,9 @@ export interface CheckParams {
  * returned status.
  */
 export const check = async (params: CheckParams): Promise<Status> => {
-  const { host, port, secure = false, name, retry } = params;
-  const retryConfig = zod.parse(breaker.breakerConfigZ.optional(), retry);
+  const { host, port, secure = false, name } = params;
   const endpoint = new url.URL({ host, port: Number(port) });
-  const transport = new Transport(endpoint, retryConfig, secure);
+  const transport = new Transport(endpoint, {}, secure);
   transport.use(errorsMiddleware);
   const cfg: Config = {
     clientVersion: __VERSION__,
@@ -97,7 +94,7 @@ export const check = async (params: CheckParams): Promise<Status> => {
   };
   const initial = createInitialStatus(cfg);
   try {
-    const info = await sendCheck(transport.unary);
+    const info = await sendCheck(transport.unaryNoRetry);
     return reduce(initial, { type: "check.success", info }, cfg);
   } catch (err) {
     const error = errors.fromUnknown(err);

--- a/client/ts/src/connection/connection.spec.ts
+++ b/client/ts/src/connection/connection.spec.ts
@@ -195,7 +195,6 @@ describe("connection", () => {
       const status = await connection.check({
         host: "invalid-host-that-does-not-exist",
         port: 9999,
-        retry: { maxRetries: 0 },
       });
       expect(status.variant).toEqual("error");
       expect(reasonOf(status)).toEqual("unreachable");
@@ -205,7 +204,6 @@ describe("connection", () => {
       const status = await connection.check({
         host: TEST_CLIENT_PARAMS.host,
         port: 9999,
-        retry: { maxRetries: 0 },
       });
       expect(status.variant).toEqual("error");
     });

--- a/client/ts/src/connection/downtime.spec.ts
+++ b/client/ts/src/connection/downtime.spec.ts
@@ -14,16 +14,11 @@ import Synnax from "@/client";
 import { DisconnectedError, isConnectionError } from "@/errors";
 import {
   createSeverableProxy,
+  FAST_RETRY,
   type SeverableProxy,
   TEST_CLIENT_PARAMS,
   waitForStatus,
 } from "@/testutil";
-
-const FAST_RETRY: breaker.Config = {
-  baseInterval: TimeSpan.milliseconds(10),
-  maxInterval: TimeSpan.milliseconds(50),
-  scale: 1.5,
-};
 
 interface ProxiedClient {
   proxy: SeverableProxy;

--- a/client/ts/src/ontology/client.ts
+++ b/client/ts/src/ontology/client.ts
@@ -19,6 +19,7 @@ import {
   idZ,
   oppositeRelationshipDirection,
   PARENT_OF_RELATIONSHIP_TYPE,
+  parseID,
   parseIDs,
   type Relationship,
   type RelationshipDirection,
@@ -357,7 +358,7 @@ export class Client extends query.Retriever<
   /** Subscribes to every resource delete delivered to the cache. */
   onResourceDelete(handler: (id: ID) => void): destructor.Destructor {
     return this.cache.resources.subscribe((event) => {
-      if (event.variant === "delete") handler(idZ.parse(event.key));
+      if (event.variant === "delete") handler(parseID(event.key));
     });
   }
 
@@ -389,7 +390,9 @@ export class Client extends query.Retriever<
   // never reaches the resource store, so fetches always hit the network
   // rather than serving a possibly stale cached entry.
   private async fetchSingle(q: string): Promise<Resource> {
-    const resources = await this.execRetrieve({ ids: [idZ.parse(q)] });
+    const resources = await this.execRetrieve({
+      ids: [parseID(q)],
+    });
     if (resources.length === 0)
       throw new NotFoundError(`No resource found with ID ${q}`);
     this.writeResources(resources);
@@ -419,7 +422,7 @@ export class Client extends query.Retriever<
     // Multi-anchor answers can't attribute members to an anchor, so only
     // single-anchor queries write relationships through.
     if (ids.length === 1) {
-      const anchor = idZ.parse(ids[0]);
+      const anchor = parseID(ids[0]);
       resources.forEach(({ id }) => {
         const rel = direction === "to" ? parentRel(anchor, id) : parentRel(id, anchor);
         this.cache.relationships.set(relationshipToString(rel), rel);

--- a/client/ts/src/ontology/payload.ts
+++ b/client/ts/src/ontology/payload.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { array, type change, primitive, record } from "@synnaxlabs/x";
+import { array, type change, primitive, record, zod } from "@synnaxlabs/x";
 import { z } from "zod";
 
 import { RESOURCE_TYPES, type ResourceType, resourceTypeZ } from "@/ontology/types.gen";
@@ -61,12 +61,19 @@ export interface IDToString {
 }
 
 export const idToString = ((id: ID | string | (ID | string)[]) => {
-  if (typeof id === "string") id = stringIDZ.parse(id);
+  if (typeof id === "string") id = zod.parse(stringIDZ, id, { label: "ontology ID" });
   if (Array.isArray(id)) return id.map((id) => idToString(id));
   return `${id.type}:${id.key}`;
 }) as IDToString;
 
 export const idsEqual = (a: ID, b: ID) => a.type === b.type && a.key === b.key;
+
+/**
+ * Parses a crude ID (an object or a "type:key" string) into an ID.
+ * @throws {zod.ParseError} if the value is not a valid ontology ID.
+ */
+export const parseID = (id: unknown): ID =>
+  zod.parse(idZ, id, { label: "ontology ID" });
 
 export const parseIDs = (
   ids: ID | string | Resource | (ID | string | Resource)[],
@@ -75,7 +82,7 @@ export const parseIDs = (
   if (arr.length === 0) return [];
   if (typeof arr[0] === "object" && "id" in arr[0])
     return (arr as Resource[]).map(({ id }) => id);
-  return arr.map((id) => idZ.parse(id));
+  return arr.map(parseID);
 };
 
 export const resourceZ = z

--- a/client/ts/src/table/actions.spec.ts
+++ b/client/ts/src/table/actions.spec.ts
@@ -1,0 +1,54 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { DataType, Series } from "@synnaxlabs/x";
+import { describe, expect, test } from "vitest";
+
+import { scopedActionZ } from "@/table/actions.gen";
+
+describe("table action wire decode", () => {
+  test("preserves cell keys through the set-channel schema", () => {
+    const wire = {
+      key: "c211c9f3-0b3c-4f5a-9185-e9cabc09a091",
+      dispatch_key: "abc",
+      seq: 1,
+      actions: [
+        {
+          type: "create",
+          create: {
+            table: {
+              key: "c211c9f3-0b3c-4f5a-9185-e9cabc09a091",
+              name: "Metrics Table",
+              rows: [{ size: 36, cells: ["UnSv19BHjPB", "SMm7XhRkCJM"] }],
+              columns: [{ size: 72 }, { size: 72 }],
+              cells: {
+                UnSv19BHjPB: { key: "UnSv19BHjPB", variant: "value", props: {} },
+                SMm7XhRkCJM: { key: "SMm7XhRkCJM", variant: "value", props: {} },
+              },
+            },
+          },
+        },
+      ],
+    };
+    const raw = new TextEncoder().encode(JSON.stringify(wire));
+    const buf = new ArrayBuffer(4 + raw.byteLength);
+    new DataView(buf).setUint32(0, raw.byteLength, true);
+    new Uint8Array(buf).set(raw, 4);
+    const s = new Series({ data: buf, dataType: DataType.JSON });
+    const [parsed] = s.parseJSON(scopedActionZ);
+    const action = parsed.actions[0];
+    expect(action.type).toEqual("create");
+    if (action.type !== "create") return;
+    expect(Object.keys(action.create.table.cells)).toEqual([
+      "UnSv19BHjPB",
+      "SMm7XhRkCJM",
+    ]);
+    expect(action.create.table.cells.UnSv19BHjPB.key).toEqual("UnSv19BHjPB");
+  });
+});

--- a/client/ts/src/testutil/proxy.ts
+++ b/client/ts/src/testutil/proxy.ts
@@ -9,7 +9,21 @@
 
 import { connect, createServer, type Socket } from "node:net";
 
+import { type breaker, TimeSpan } from "@synnaxlabs/x";
+
 const DEFAULT_TARGET = { host: "localhost", port: 9090 };
+
+/**
+ * Retry policy for a client pointed at a severable proxy. A spec drives its own
+ * retries, so the client's must finish well inside one assertion budget: the
+ * default policy waits seconds per request and outlasts a single `expect.poll`
+ * attempt, which reports as a timeout rather than the real answer.
+ */
+export const FAST_RETRY: breaker.Config = {
+  baseInterval: TimeSpan.milliseconds(10),
+  maxInterval: TimeSpan.milliseconds(50),
+  scale: 1.5,
+};
 
 export interface SeverableProxyTarget {
   host?: string;

--- a/console/src/platform/cluster/list/Item.tsx
+++ b/console/src/platform/cluster/list/Item.tsx
@@ -47,7 +47,6 @@ const Base = ({
     host: item.host,
     port: item.port,
     secure: item.secure,
-    retry: { maxRetries: 0 },
   });
   let statusVariant = status?.variant ?? "disabled";
   let statusMessage = LABELS[statusVariant];

--- a/console/src/platform/shell/Connection.tsx
+++ b/console/src/platform/shell/Connection.tsx
@@ -60,12 +60,7 @@ export const Connection = ({ cluster }: ConnectionProps): ReactElement | null =>
   const checked = Synnax.useCheckConnection(
     isActive || cluster == null
       ? null
-      : {
-          host: cluster.host,
-          port: cluster.port,
-          secure: cluster.secure,
-          retry: { maxRetries: 0 },
-        },
+      : { host: cluster.host, port: cluster.port, secure: cluster.secure },
   );
   if (cluster == null) return null;
   const variant = variantOf(isActive ? live : checked);

--- a/console/src/platform/tree/Tree.tsx
+++ b/console/src/platform/tree/Tree.tsx
@@ -82,7 +82,7 @@ const FallbackContextMenu = (): ReactElement => (
 const itemRenderProp = Component.renderProp(
   ({ onDrop: _, ...rest }: Base.ItemProps<string>) => {
     const { itemKey } = rest;
-    const id = ontology.idZ.parse(itemKey);
+    const id = ontology.parseID(itemKey);
     const resource = List.useItem<string, ontology.Resource>(itemKey);
     const Item = useItems()[id.type] ?? DefaultItem;
     const { onDrop, useLoading, onDragStart, onDragEnd } =
@@ -326,7 +326,7 @@ const Internal = ({ root, emptyContent }: InternalProps): ReactElement => {
         return;
       }
       setLoading(clicked);
-      watchChildren(ontology.idZ.parse(clicked));
+      watchChildren(ontology.parseID(clicked));
     },
     [watchChildren, releaseChildren, setLoading, nodesRef],
   );
@@ -419,7 +419,7 @@ const Internal = ({ root, emptyContent }: InternalProps): ReactElement => {
       const dropped = Base.filterHaulItems(items);
       const isValidDrop = dropped.length > 0 && source.type === Base.HAUL_TYPE;
       if (!isValidDrop) return [];
-      const destination = ontology.idZ.parse(key);
+      const destination = ontology.parseID(key);
       const svc = resolveItem(destination.type);
       if (!svc.canDrop({ source, items })) return [];
 
@@ -436,13 +436,13 @@ const Internal = ({ root, emptyContent }: InternalProps): ReactElement => {
         const parent = Base.findNodeParent({ tree: nodesSnapshot, key });
         const sourceKey = parent?.key ?? ontology.idToString(root);
         const ids = bySource.get(sourceKey) ?? [];
-        ids.push(ontology.idZ.parse(key));
+        ids.push(ontology.parseID(key));
         bySource.set(sourceKey, ids);
       });
       contract(...moved.map(({ key }) => key));
       bySource.forEach((ids, sourceKey) =>
         moveChildren.update({
-          source: ontology.idZ.parse(sourceKey),
+          source: ontology.parseID(sourceKey),
           destination,
           ids,
         }),
@@ -465,7 +465,7 @@ const Internal = ({ root, emptyContent }: InternalProps): ReactElement => {
         });
         return startDrag(selectedHaulItems);
       }
-      const haulItems = resolveItem(ontology.idZ.parse(itemKey).type).haulItems(
+      const haulItems = resolveItem(ontology.parseID(itemKey).type).haulItems(
         getResource(itemKey),
       );
       startDrag([Base.createHaulItem(itemKey), ...haulItems]);
@@ -490,7 +490,7 @@ const Internal = ({ root, emptyContent }: InternalProps): ReactElement => {
       else keys = selectedRef.current;
       const nodeSnapshot = nodesRef.current;
 
-      const ids = keys.map((key) => ontology.idZ.parse(key));
+      const ids = keys.map((key) => ontology.parseID(key));
 
       // TODO: we might be selecting two nodes that are not ascendants or
       // descendants of the other ones. We need to change this function to
@@ -502,9 +502,9 @@ const Internal = ({ root, emptyContent }: InternalProps): ReactElement => {
         key: keys.sort(Base.compareDepth(shapeRef.current))[0],
       });
 
-      const parentID = parent == null ? root : ontology.idZ.parse(parent.key);
+      const parentID = parent == null ? root : ontology.parseID(parent.key);
 
-      const firstID = ontology.idZ.parse(keys[0]);
+      const firstID = ontology.parseID(keys[0]);
 
       const props: ContextMenuProps = {
         selection: {

--- a/freighter/ts/src/unary.spec.ts
+++ b/freighter/ts/src/unary.spec.ts
@@ -1,0 +1,61 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { type breaker } from "@synnaxlabs/x";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { z } from "zod";
+
+import { Unreachable } from "@/errors";
+import { type UnaryClient, unaryWithBreaker } from "@/unary";
+
+const NO_SLEEP: breaker.Config = { sleepFn: async () => {} };
+const UNREACHABLE_MESSAGE = "server down";
+const FATAL_MESSAGE = "malformed request";
+
+const failingUnary = (error: Error): UnaryClient => ({
+  send: vi.fn().mockRejectedValue(error),
+  use: vi.fn(),
+});
+
+const send = async (client: UnaryClient): Promise<void> =>
+  await client.send("check", undefined, z.void(), z.void());
+
+describe("unaryWithBreaker", () => {
+  let warn: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => warn.mockRestore());
+
+  it("should retry an unreachable target until the retries run out", async () => {
+    const unary = failingUnary(new Unreachable({ message: UNREACHABLE_MESSAGE }));
+    const client = unaryWithBreaker(unary, { ...NO_SLEEP, maxRetries: 2 });
+    await expect(send(client)).rejects.toThrow(UNREACHABLE_MESSAGE);
+    expect(unary.send).toHaveBeenCalledTimes(3);
+    expect(warn).toHaveBeenCalledTimes(2);
+  });
+
+  it("should not announce a retry it will not make", async () => {
+    const unary = failingUnary(new Unreachable({ message: UNREACHABLE_MESSAGE }));
+    const client = unaryWithBreaker(unary, { ...NO_SLEEP, maxRetries: 0 });
+    await expect(send(client)).rejects.toThrow(UNREACHABLE_MESSAGE);
+    expect(unary.send).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it("should rethrow an error that is not an unreachable target", async () => {
+    const unary = failingUnary(new Error(FATAL_MESSAGE));
+    const client = unaryWithBreaker(unary, { ...NO_SLEEP, maxRetries: 2 });
+    await expect(send(client)).rejects.toThrow(FATAL_MESSAGE);
+    expect(unary.send).toHaveBeenCalledTimes(1);
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/freighter/ts/src/unary.ts
+++ b/freighter/ts/src/unary.ts
@@ -62,9 +62,9 @@ export const unaryWithBreaker = (
           return await this.wrapped.send(target, req, reqSchema, resSchema);
         } catch (err) {
           const e = errors.fromUnknown(err);
-          if (!Unreachable.matches(e)) throw e;
+          if (!Unreachable.matches(e) || !brk.canRetry) throw e;
           console.warn(`[freighter] ${brk.retryMessage}`, e);
-          if (!(await brk.wait())) throw e;
+          await brk.wait();
         }
       while (true);
     }

--- a/pluto/src/ontology/queries.ts
+++ b/pluto/src/ontology/queries.ts
@@ -65,7 +65,7 @@ export const createDependentsListHook = (
       return await dependentSpace(client, direction).retrieve({ ids: id });
     },
     retrieveByKey: async ({ client, key }) =>
-      await client.ontology.retrieve(ontology.idZ.parse(key)),
+      await client.ontology.retrieve(ontology.parseID(key)),
     onChange: ({ client, query: { id } }, handler) => {
       if (id == null) return () => {};
       return dependentSpace(client, direction).onChange({ ids: id }, handler);
@@ -75,7 +75,7 @@ export const createDependentsListHook = (
       return dependentSpace(client, direction).getCached({ ids: id });
     },
     onChangeByKey: ({ client, key }, handler) =>
-      client.ontology.onChange(ontology.idZ.parse(key), handler),
+      client.ontology.onChange(ontology.parseID(key), handler),
   });
 
 export const useListChildren = createDependentsListHook(
@@ -89,11 +89,11 @@ export const useResourceList = Flux.createList<ListQuery, string, ontology.Resou
   name: PLURAL_RESOURCE_RESOURCE_NAME,
   retrieve: async ({ client, query }) => await client.ontology.retrieve(query),
   retrieveByKey: async ({ client, key }) =>
-    await client.ontology.retrieve(ontology.idZ.parse(key)),
+    await client.ontology.retrieve(ontology.parseID(key)),
   onChange: ({ client, query }, handler) => client.ontology.onChange(query, handler),
   getCached: ({ client, query }) => client.ontology.getCached(query),
   onChangeByKey: ({ client, key }, handler) =>
-    client.ontology.onChange(ontology.idZ.parse(key), handler),
+    client.ontology.onChange(ontology.parseID(key), handler),
 });
 
 export interface MoveChildrenParams {

--- a/pluto/src/synnax/useCheckConnection.spec.ts
+++ b/pluto/src/synnax/useCheckConnection.spec.ts
@@ -34,11 +34,7 @@ describe("useCheckConnection", () => {
 
   it("should resolve an error status against a dead port", async () => {
     const { result } = renderHook(() =>
-      Synnax.useCheckConnection({
-        host: TEST_CLIENT_PARAMS.host,
-        port: 9999,
-        retry: { maxRetries: 0 },
-      }),
+      Synnax.useCheckConnection({ host: TEST_CLIENT_PARAMS.host, port: 9999 }),
     );
     await waitFor(() => expect(result.current?.variant).toEqual("error"));
   });
@@ -75,7 +71,7 @@ describe("useCheckConnection", () => {
     );
     await waitFor(() => expect(result.current?.variant).toEqual("success"));
     rerender({
-      params: { host: TEST_CLIENT_PARAMS.host, port: 9999, retry: { maxRetries: 0 } },
+      params: { host: TEST_CLIENT_PARAMS.host, port: 9999 },
     });
     await waitFor(() => expect(result.current?.variant).toEqual("error"));
   });

--- a/x/ts/src/breaker/breaker.spec.ts
+++ b/x/ts/src/breaker/breaker.spec.ts
@@ -16,9 +16,9 @@ describe("breaker", () => {
   it("should allow first attempt without sleeping", async () => {
     const mockSleep = vi.fn();
     const brk = new breaker.Breaker({ sleepFn: mockSleep });
-    const canRetry = await brk.wait();
+    const waited = await brk.wait();
 
-    expect(canRetry).toBe(true);
+    expect(waited).toBe(true);
     expect(mockSleep).toHaveBeenCalled();
   });
 
@@ -119,5 +119,35 @@ describe("breaker", () => {
     });
 
     for (let i = 0; i < 50; i++) expect(await brk.wait()).toBe(true);
+  });
+
+  describe("canRetry", () => {
+    it("should be false when the breaker is configured for no retries", () => {
+      expect(new breaker.Breaker({ maxRetries: 0 }).canRetry).toBe(false);
+    });
+
+    it("should turn false once the waits are exhausted", async () => {
+      const brk = new breaker.Breaker({ maxRetries: 2, sleepFn: vi.fn() });
+      expect(brk.canRetry).toBe(true);
+      expect(await brk.wait()).toBe(true);
+      expect(brk.canRetry).toBe(true);
+      expect(await brk.wait()).toBe(true);
+      expect(brk.canRetry).toBe(false);
+      expect(await brk.wait()).toBe(false);
+    });
+
+    it("should stay true for unbounded retries", async () => {
+      const brk = new breaker.Breaker({ maxRetries: Infinity, sleepFn: vi.fn() });
+      for (let i = 0; i < 50; i++) await brk.wait();
+      expect(brk.canRetry).toBe(true);
+    });
+
+    it("should be restored by reset", async () => {
+      const brk = new breaker.Breaker({ maxRetries: 1, sleepFn: vi.fn() });
+      await brk.wait();
+      expect(brk.canRetry).toBe(false);
+      brk.reset();
+      expect(brk.canRetry).toBe(true);
+    });
   });
 });

--- a/x/ts/src/breaker/breaker.ts
+++ b/x/ts/src/breaker/breaker.ts
@@ -52,6 +52,11 @@ export class Breaker {
     return true;
   }
 
+  /** Whether {@link wait} has retries left. */
+  get canRetry(): boolean {
+    return this.retries < this.config.maxRetries;
+  }
+
   /** A log-ready summary of the retry count and the next interval. */
   get retryMessage(): string {
     return `breaker triggered ${this.retries + 1}/${this.config.maxRetries} times, retrying in ${this.interval.toString()}`;

--- a/x/ts/src/telem/series.spec.ts
+++ b/x/ts/src/telem/series.spec.ts
@@ -10,6 +10,7 @@
 import { describe, expect, it, test } from "vitest";
 import { z } from "zod";
 
+import { caseconv } from "@/caseconv";
 import { MockGLBufferController } from "@/mock/MockGLBufferController";
 import { type CrudeSeries, isCrudeSeries, MultiSeries, Series } from "@/telem/series";
 import {
@@ -1019,6 +1020,22 @@ describe("Series", () => {
       const s = new Series({ data: new ArrayBuffer(0), dataType: DataType.JSON });
       expect(s.length).toEqual(0);
       expect(Array.from(s)).toEqual([]);
+    });
+
+    it("should preserve record keys marked with preserveCase", () => {
+      const schema = z.object({
+        cells: caseconv.preserveCase(z.record(z.string(), z.number())),
+      });
+      // Build the buffer as the server would: raw JSON with semantic keys.
+      const raw = new TextEncoder().encode(
+        JSON.stringify({ cells: { UnSv19BHjPB: 1, x5kWGi0DZha: 2 } }),
+      );
+      const buf = new ArrayBuffer(4 + raw.byteLength);
+      new DataView(buf).setUint32(0, raw.byteLength, true);
+      new Uint8Array(buf).set(raw, 4);
+      const s = new Series({ data: buf, dataType: DataType.JSON });
+      const out = s.parseJSON(schema);
+      expect(Object.keys(out[0].cells)).toEqual(["UnSv19BHjPB", "x5kWGi0DZha"]);
     });
   });
 

--- a/x/ts/src/telem/series.spec.ts
+++ b/x/ts/src/telem/series.spec.ts
@@ -1026,7 +1026,6 @@ describe("Series", () => {
       const schema = z.object({
         cells: caseconv.preserveCase(z.record(z.string(), z.number())),
       });
-      // Build the buffer as the server would: raw JSON with semantic keys.
       const raw = new TextEncoder().encode(
         JSON.stringify({ cells: { UnSv19BHjPB: 1, x5kWGi0DZha: 2 } }),
       );

--- a/x/ts/src/telem/series.ts
+++ b/x/ts/src/telem/series.ts
@@ -623,7 +623,9 @@ export class Series<T extends TelemValue = TelemValue>
   parseJSON<Z extends z.ZodType>(schema: Z): Array<z.infer<Z>> {
     if (!this.dataType.equals(DataType.JSON))
       throw new Error("cannot parse non-JSON series as JSON");
-    return this.toStrings().map((s) => schema.parse(binary.JSON_CODEC.decodeString(s)));
+    // The schema must reach the codec so its case conversion honors preserveCase
+    // markers; a schema-blind conversion mangles semantic record keys.
+    return this.toStrings().map((s) => binary.JSON_CODEC.decodeString(s, schema));
   }
 
   /**

--- a/x/ts/src/telem/series.ts
+++ b/x/ts/src/telem/series.ts
@@ -623,8 +623,6 @@ export class Series<T extends TelemValue = TelemValue>
   parseJSON<Z extends z.ZodType>(schema: Z): Array<z.infer<Z>> {
     if (!this.dataType.equals(DataType.JSON))
       throw new Error("cannot parse non-JSON series as JSON");
-    // The schema must reach the codec so its case conversion honors preserveCase
-    // markers; a schema-blind conversion mangles semantic record keys.
     return this.toStrings().map((s) => binary.JSON_CODEC.decodeString(s, schema));
   }
 


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4611](https://linear.app/synnax/issue/SY-4611/pass-the-schema-through-seriesparsejson-and-cap-unary-retries-at-the)

## Description

Three small parse and transport fixes carved out of #2725 so the error-diagnostics work reviews on its own.

`Series.parseJSON` decoded without handing the schema to the codec, so `caseconv.snakeToCamel` ran schema-blind and mangled semantic record keys. This is user visible: an imported table renders only three of its four cells, which is what fails `console/project/project` in the integration suite.

Unary requests retried forever instead of stopping at the breaker limit, so an unreachable Core never surfaced a failure.

`ontology.parseID` replaces the hand-rolled ID parsing at every call site.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR preserves semantic JSON record keys during `Series.parseJSON`, caps unary retries at the breaker limit, makes connection checks use the no-retry transport, and centralizes ontology ID parsing.

- Passes schemas into JSON decoding before Zod validation.
- Adds a per-request retry-cap check and focused breaker tests.
- Replaces direct ontology schema parsing with `parseID`.
- Updates connection and proxy tests for the new retry behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The schema-aware decode retains Zod validation, retry limits are isolated per request with correct attempt counts, and no changed path produces a concrete failure.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| x/ts/src/telem/series.ts | Passes the schema into JSON decoding so case conversion honors preserved record keys before validation. |
| freighter/ts/src/unary.ts | Stops retrying unreachable unary requests after the per-request breaker exhausts its configured retries. |
| x/ts/src/breaker/breaker.ts | Exposes whether the breaker has retries remaining without consuming a retry. |
| client/ts/src/connection/client.ts | Uses the no-retry unary path for connection probes and removes caller-controlled retry configuration. |
| client/ts/src/ontology/payload.ts | Adds a labeled ontology ID parser and uses it consistently for ID normalization. |

<sub>Reviews (1): Last reviewed commit: ["Stop proxy-backed specs nesting a slow b..."](https://github.com/synnaxlabs/synnax/commit/0fffae720ed10872396b95dc21b349a0f2248009) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=53996461)</sub>

<details><summary><h4>Context used (4)</h4></summary>

- Knowledge Base — [Client SDKs](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/client-sdks.md)
- Knowledge Base — [Console App](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/console-app.md)
- Knowledge Base — [Freighter Transport Library](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/freighter-transport.md)
- Knowledge Base — [x: Shared Cross-Language Utilities](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/x-shared-utils.md)
</details>

<!-- /greptile_comment -->