### PR TITLE
[docs] Bypass GitHub CDN cache when resolving latest release

### DIFF
--- a/docs/site/src/util/fetchVersion.ts
+++ b/docs/site/src/util/fetchVersion.ts
@@ -17,12 +17,16 @@ interface Release {
 const STABLE = /^synnax-v(\d+\.\d+\.\d+)$/;
 
 const resolveVersion = async (): Promise<string> => {
-  const releases = (await (await fetch(RELEASES)).json()) as Release[];
-  for (const { tag_name, draft } of releases) {
-    const match = STABLE.exec(tag_name);
-    if (!draft && match != null) return match[1];
-  }
-  throw new Error("no published Synnax release found");
+  // GitHub's CDN can pin a stale empty response to a fixed URL; a timestamp param
+  // forces a cache miss so each build sees current releases.
+  const response = await fetch(`${RELEASES}&t=${Date.now()}`);
+  const releases = (await response.json()) as Release[];
+  if (Array.isArray(releases))
+    for (const { tag_name, draft } of releases) {
+      const match = STABLE.exec(tag_name);
+      if (!draft && match != null) return match[1];
+    }
+  throw new Error("GitHub releases API outage: no published Synnax releases returned");
 };
 
 // Memoized to one API call per build; the components below render across many pages.


### PR DESCRIPTION
[docs] Bypass GitHub CDN cache when resolving latest release

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The change bypasses stale GitHub CDN responses when resolving the latest published Synnax release.
- Adds a timestamp query parameter to the releases API request.
- Validates that the returned payload is an array and improves the outage error message.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/site/src/util/fetchVersion.ts | Adds cache busting and response-shape validation while preserving the existing module-level promise memoization. |

<sub>Reviews (2): Last reviewed commit: ["\[docs\] Bypass GitHub CDN cache when reso..."](https://github.com/synnaxlabs/synnax/commit/c27c3ecce47cd4a24acee5110f86b68f041c5d94) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54019576)</sub>

<!-- /greptile_comment -->