### PR TITLE
SY-4617: Fix backward auto-span reads and the duplicated chunk boundary

### DIFF
--- a/cesium/internal/index/domain.go
+++ b/cesium/internal/index/domain.go
@@ -334,23 +334,17 @@ func (i *Domain) forwardStamp(
 	upperTSByteOffset := byteSize(endOffset)
 	lowerTSOffset := endOffset - startApprox.Span()
 	lowerTSByteOffset := byteSize(lowerTSOffset)
-	return i.approximateStamp(
-		ctx,
-		r,
-		iter,
-		endOffset,
-		effectiveDomainLen,
-		upperTSByteOffset,
-		lowerTSByteOffset,
-	)
+	return i.approximateStamp(ctx, r, iter, upperTSByteOffset, lowerTSByteOffset)
 }
 
+// approximateStamp brackets the stamp between the timestamps at upperTSByteOffset and
+// lowerTSByteOffset within the current domain. A negative lowerTSByteOffset places the
+// lower timestamp that many bytes before the domain, i.e. at the tail of the previous
+// one. approximateStamp leaves iter on that previous domain.
 func (i *Domain) approximateStamp(
 	ctx context.Context,
 	r *domain.Reader,
 	iter *domain.Iterator,
-	endOffset int64,
-	effectiveDomainLen int64,
 	upperTSByteOffset,
 	lowerTSByteOffset telem.Size,
 ) (TimeStampApproximation, error) {
@@ -360,26 +354,38 @@ func (i *Domain) approximateStamp(
 		return TimeStampApproximation{}, err
 	}
 	if lowerTSByteOffset >= 0 {
-		lowerTs, err := readStamp(r, lowerTSByteOffset)
-		return Between(lowerTs, upperTS), err
+		lowerTS, err := readStamp(r, lowerTSByteOffset)
+		return Between(lowerTS, upperTS), err
 	}
-	// Edge case: end timestamps are split between two different files, so we must go
-	// back to read the lower bound.
+	lowerTS, ok, err := i.previousDomainStamp(ctx, iter, -lowerTSByteOffset)
+	if err != nil {
+		return TimeStampApproximation{}, err
+	}
+	// Nothing precedes the first domain, so no sample bounds the stamp from below.
+	if !ok {
+		return Between(telem.TimeStampMin, upperTS), nil
+	}
+	return Between(lowerTS, upperTS), nil
+}
+
+// previousDomainStamp reads the timestamp sitting offset bytes before the end of the
+// domain preceding iter's current position, moving iter onto that domain. ok is false
+// when iter is already on the first domain.
+func (i *Domain) previousDomainStamp(
+	ctx context.Context,
+	iter *domain.Iterator,
+	offset telem.Size,
+) (ts telem.TimeStamp, ok bool, err error) {
 	if !iter.Prev() {
-		i.L.DPanic("iterator prev failed in stamp")
-		return TimeStampApproximation{}, NewDiscontinuousOffsetError(
-			endOffset,
-			effectiveDomainLen,
-		)
+		return 0, false, nil
 	}
-	if err = r.Close(); err != nil {
-		return TimeStampApproximation{}, err
+	r, err := iter.OpenReader(ctx)
+	if err != nil {
+		return 0, false, err
 	}
-	if r, err = iter.OpenReader(ctx); err != nil {
-		return TimeStampApproximation{}, err
-	}
-	lowerTS, err := readStamp(r, iter.Size()+lowerTSByteOffset)
-	return Between(lowerTS, upperTS), err
+	defer func() { err = errors.Combine(err, r.Close()) }()
+	ts, err = newStampReader()(r, iter.Size()-offset)
+	return ts, true, err
 }
 
 // BackwardStamp calculates an approximate starting timestamp for a range given a known
@@ -446,7 +452,9 @@ func (i *Domain) backwardStamp(
 	}
 
 	totalTraversed := domainLen
-	if endOffset >= domainLen {
+	// endOffset counts backwards from the end of the domain, so an offset of exactly
+	// domainLen still lands on the domain's first sample.
+	if endOffset > domainLen {
 		for {
 			if !iter.Prev() {
 				if continuous {
@@ -474,15 +482,7 @@ func (i *Domain) backwardStamp(
 
 	upperTSByteOffset := iter.Size() - byteSize(endOffset)
 	lowerTSByteOffset := iter.Size() - byteSize(endOffset+startApprox.Span())
-	return i.approximateStamp(
-		ctx,
-		r,
-		iter,
-		endOffset,
-		effectiveDomainLen,
-		upperTSByteOffset,
-		lowerTSByteOffset,
-	)
+	return i.approximateStamp(ctx, r, iter, upperTSByteOffset, lowerTSByteOffset)
 }
 
 // resolveForwardEffectiveDomainTR returns the TimeRange and length of the underlying

--- a/cesium/internal/index/domain_test.go
+++ b/cesium/internal/index/domain_test.go
@@ -1130,6 +1130,18 @@ var _ = Describe("Domain", func() {
 								index.Exactly(5*telem.SecondTS),
 								nil,
 							),
+							Entry("Landing on the first sample of a previous TimeRange",
+								31*telem.SecondTS+500*telem.MillisecondTS,
+								-2,
+								index.Between(20*telem.SecondTS, 30*telem.SecondTS),
+								nil,
+							),
+							Entry("Lower bound before the first sample",
+								31*telem.SecondTS+500*telem.MillisecondTS,
+								-11,
+								index.Between(telem.TimeStampMin, 1*telem.SecondTS),
+								nil,
+							),
 						)
 					})
 				})

--- a/cesium/internal/unary/iterator.go
+++ b/cesium/internal/unary/iterator.go
@@ -209,100 +209,90 @@ func (i *Iterator) Next(ctx context.Context, span telem.TimeSpan) (ok bool) {
 	return ok
 }
 
+// autoNext reads up to AutoChunkSize samples forward from the current view end. Each
+// domain resolves the chunk to a pair of sample positions, and both the samples read
+// and the time range reported come from that pair, so the two cannot disagree.
 func (i *Iterator) autoNext(ctx context.Context) bool {
-	i.view.Start = i.view.End
-	viewEnd, err := i.idx.Stamp(
-		ctx,
-		i.view.Start,
-		i.AutoChunkSize,
-		index.AllowDiscontinuous,
+	// The chunk provisionally covers everything left in bounds. The sample that closes
+	// it replaces the end once the read reaches it.
+	i.reset(i.view.End.Range(i.bounds.End))
+	var (
+		nRemaining = i.AutoChunkSize
+		end        = i.view.Start
+		closed     bool
 	)
-	if err != nil {
-		i.err = err
-		return false
-	}
-	if viewEnd.Lower.After(i.bounds.End) {
-		return i.Next(ctx, i.view.Start.Span(i.bounds.End))
-	}
-	// A view start between two samples brackets the chunk end. The upper bound is the
-	// first sample past the chunk, so a view ending there holds exactly AutoChunkSize
-	// samples. A stamp that runs out of data reports an unbounded upper instead.
-	i.view.End = viewEnd.Lower
-	if viewEnd.Upper != telem.TimeStampMax {
-		i.view.End = viewEnd.Upper
-	}
-	i.reset(i.view.BoundBy(i.bounds))
-
-	nRemaining := i.AutoChunkSize
 	for {
 		domainTR := i.internal.TimeRange()
-		// Domains are ordered, so one starting at or after the view end belongs to the
-		// next chunk. Leave the iterator on it and keep what this chunk already read.
-		if domainTR.Start.AfterEq(i.view.End) {
-			break
-		}
 		if !domainTR.OverlapsWith(i.view) {
 			if !i.internal.Next() {
 				break
 			}
 			continue
 		}
-		startApprox, dmn, err := i.approximateStart(ctx)
+		startApprox, alignment, err := i.approximateStart(ctx)
 		if err != nil {
 			i.err = err
 			return false
 		}
-		startSample := pickSampleOffset(startApprox)
+		endApprox, err := i.approximateEnd(ctx)
+		if err != nil {
+			i.err = err
+			return false
+		}
+		var (
+			startSample = pickSampleOffset(startApprox)
+			// limit is the sample after the last one this domain can give the chunk.
+			limit     = pickSampleOffset(endApprox)
+			endSample = min(startSample+nRemaining, limit)
+		)
+		end = domainTR.End
+		if closed = endSample < limit; closed {
+			// The chunk fills inside this domain, so it ends at the first sample it
+			// leaves behind.
+			end, err = i.stampSample(ctx, domainTR.Start, endSample)
+			if err != nil {
+				i.err = err
+				return false
+			}
+			i.view.End = end
+		}
 		startOffset, err := i.resolver.byteOffset(ctx, i.internal, startSample)
 		if err != nil {
 			i.err = err
 			return false
 		}
-		endOffset, err := i.resolver.byteOffset(ctx, i.internal, startSample+nRemaining)
+		endOffset, err := i.resolver.byteOffset(ctx, i.internal, endSample)
 		if err != nil {
 			i.err = err
 			return false
 		}
-		series, err := i.read(ctx, dmn, startOffset, endOffset-startOffset)
+		series, err := i.read(ctx, alignment, startOffset, endOffset-startOffset)
 		if err != nil && !errors.Is(err, io.EOF) {
 			i.err = err
 			return false
 		}
 		nRemaining -= series.Len()
 		i.insert(series)
-		if nRemaining <= 0 || !i.internal.Next() {
+		if closed || nRemaining <= 0 || !i.internal.Next() {
 			break
 		}
 	}
-
+	i.view.End = min(end, i.bounds.End)
 	return i.partiallySatisfied()
 }
 
+// autoPrev reads up to AutoChunkSize samples backward from the current view start. It
+// mirrors autoNext: the chunk resolves to sample positions first, and its time range
+// follows from them.
 func (i *Iterator) autoPrev(ctx context.Context) bool {
-	i.view.End = i.view.Start
-	viewStart, err := i.idx.Stamp(
-		ctx,
-		i.view.Start,
-		-i.AutoChunkSize,
-		index.AllowDiscontinuous,
+	i.reset(i.bounds.Start.Range(i.view.Start))
+	var (
+		nRemaining = i.AutoChunkSize
+		start      = i.view.End
+		closed     bool
 	)
-	if err != nil {
-		i.err = err
-		return false
-	}
-	if viewStart.Lower.Before(i.bounds.Start) {
-		return i.Prev(ctx, i.bounds.Start.Span(i.view.End))
-	}
-	i.view.Start = viewStart.Lower + 1
-	i.reset(i.view.BoundBy(i.bounds))
-	nRemaining := i.AutoChunkSize
 	for {
 		domainTR := i.internal.TimeRange()
-		// Domains are ordered, so one ending at or before the view start belongs to the
-		// previous chunk. Leave the iterator on it and keep this chunk's samples.
-		if domainTR.End.BeforeEq(i.view.Start) {
-			break
-		}
 		if !domainTR.OverlapsWith(i.view) {
 			if !i.internal.Prev() {
 				break
@@ -319,17 +309,32 @@ func (i *Iterator) autoPrev(ctx context.Context) bool {
 			i.err = err
 			return false
 		}
-		endSample := pickSampleOffset(endApprox)
-		endOffset, err := i.resolver.byteOffset(ctx, i.internal, endSample)
+		var (
+			// first is the earliest sample of this domain the chunk can reach.
+			first       = pickSampleOffset(startApprox)
+			endSample   = pickSampleOffset(endApprox)
+			startSample = max(endSample-nRemaining, first)
+		)
+		start = domainTR.Start
+		if closed = startSample > first; closed {
+			// The chunk fills inside this domain, so it starts at the earliest sample
+			// it holds.
+			start, err = i.stampSample(ctx, domainTR.Start, startSample)
+			if err != nil {
+				i.err = err
+				return false
+			}
+			i.view.Start = start
+		}
+		// approximateStart stamps the alignment at the view start. This chunk may begin
+		// earlier in the domain, so move the alignment back with it.
+		alignment -= telem.Alignment(first - startSample)
+		startOffset, err := i.resolver.byteOffset(ctx, i.internal, startSample)
 		if err != nil {
 			i.err = err
 			return false
 		}
-		startSample := max(endSample-nRemaining, 0)
-		// approximateStart stamps the alignment at the view start. This chunk may begin
-		// earlier in the domain, so move the alignment back with it.
-		alignment -= telem.Alignment(pickSampleOffset(startApprox) - startSample)
-		startOffset, err := i.resolver.byteOffset(ctx, i.internal, startSample)
+		endOffset, err := i.resolver.byteOffset(ctx, i.internal, endSample)
 		if err != nil {
 			i.err = err
 			return false
@@ -341,11 +346,23 @@ func (i *Iterator) autoPrev(ctx context.Context) bool {
 		}
 		nRemaining -= series.Len()
 		i.insert(series)
-		if nRemaining <= 0 || !i.internal.Prev() {
+		if closed || nRemaining <= 0 || !i.internal.Prev() {
 			break
 		}
 	}
+	i.view.Start = max(start, i.bounds.Start)
 	return i.partiallySatisfied()
+}
+
+// stampSample returns the timestamp of the sample at position offset within the domain
+// starting at start.
+func (i *Iterator) stampSample(
+	ctx context.Context,
+	start telem.TimeStamp,
+	offset int64,
+) (telem.TimeStamp, error) {
+	approx, err := i.idx.Stamp(ctx, start, offset, index.AllowDiscontinuous)
+	return approx.Upper, err
 }
 
 // Prev moves the iterator backward by span. More specifically, if the current view is
@@ -516,7 +533,9 @@ func pickSampleOffset(approx index.DistanceApproximation) int64 {
 	if approx.EndExact {
 		return approx.Lower
 	}
-	return (approx.Lower + approx.Upper) / 2
+	// Distance widens its bounds by one sample for each end it could not place, so with
+	// neither end exact the count sits one below the upper bound.
+	return approx.Upper - 1
 }
 
 // approximateStart approximates the number of samples between the start of the current

--- a/cesium/iterator.go
+++ b/cesium/iterator.go
@@ -15,9 +15,9 @@ import (
 	"github.com/synnaxlabs/cesium/internal/resource"
 	"github.com/synnaxlabs/cesium/internal/unary"
 	"github.com/synnaxlabs/x/confluence"
+	"github.com/synnaxlabs/x/errors"
 	"github.com/synnaxlabs/x/signal"
 	"github.com/synnaxlabs/x/telem"
-	"go.uber.org/zap"
 )
 
 const AutoSpan = unary.AutoSpan
@@ -29,7 +29,6 @@ type Iterator struct {
 	outlet   confluence.Outlet[IteratorResponse]
 	wg       signal.WaitGroup
 	shutdown context.CancelFunc
-	logger   *zap.Logger
 	frame    Frame
 	closed   bool
 }
@@ -37,7 +36,11 @@ type Iterator struct {
 func wrapStreamIterator(internal *streamIterator) *Iterator {
 	ctx, cancel := signal.Isolated()
 	req, res := confluence.Attach(internal, 1)
-	internal.Flow(ctx, confluence.RecoverWithErrOnPanic())
+	internal.Flow(
+		ctx,
+		confluence.CloseOutputInletsOnExit(),
+		confluence.RecoverWithErrOnPanic(),
+	)
 	return &Iterator{
 		inlet:    req,
 		outlet:   res,
@@ -131,6 +134,12 @@ func (i *Iterator) execErr(req IteratorRequest) (bool, error) {
 		}
 		i.frame = i.frame.Extend(res.Frame)
 	}
-	i.logger.DPanic("unexpected early closure of response stream")
-	return false, nil
+	// The response stream only closes when the iterator's routine exits, so an
+	// acknowledgement that never arrives means the routine stopped early. Wait reports
+	// what it stopped with.
+	err := i.wg.Wait()
+	if err == nil {
+		err = errors.New("cesium.iterator: stopped before acknowledging the request")
+	}
+	return false, err
 }

--- a/cesium/iterator_test.go
+++ b/cesium/iterator_test.go
@@ -443,13 +443,18 @@ var _ = Describe("Iterator Behavior", func() {
 				)
 
 				// A start between two samples makes every chunk end land between two
-				// samples as well, which is where a chunk can repeat or drop one.
+				// samples as well, which is where a chunk can repeat or drop one. An
+				// end that lands on a sample must leave that sample out.
 				DescribeTable(
 					"should return every sample once across auto-span chunks",
-					func(ctx SpecContext, chunk int64) {
+					func(
+						ctx SpecContext,
+						bounds telem.TimeRange,
+						chunk int64,
+						expected []int64,
+					) {
 						i := MustSucceed(db.OpenIterator(cesium.IteratorConfig{
-							Bounds: (4*telem.SecondTS + 1).
-								Range(telem.TimeStampMax),
+							Bounds:        bounds,
 							Channels:      []cesium.ChannelKey{dataKey},
 							AutoChunkSize: chunk,
 						}))
@@ -464,20 +469,46 @@ var _ = Describe("Iterator Behavior", func() {
 							}
 						}
 						Expect(i.Close()).To(Succeed())
-						Expect(got).To(Equal([]int64{1, 2, 3, 4}))
+						Expect(got).To(Equal(expected))
 					},
-					Entry("one sample per chunk", int64(1)),
-					Entry("two samples per chunk", int64(2)),
-					Entry("three samples per chunk", int64(3)),
+					Entry(
+						"one sample per chunk",
+						(4*telem.SecondTS+1).Range(telem.TimeStampMax),
+						int64(1),
+						[]int64{1, 2, 3, 4},
+					),
+					Entry(
+						"two samples per chunk",
+						(4*telem.SecondTS+1).Range(telem.TimeStampMax),
+						int64(2),
+						[]int64{1, 2, 3, 4},
+					),
+					Entry(
+						"three samples per chunk",
+						(4*telem.SecondTS+1).Range(telem.TimeStampMax),
+						int64(3),
+						[]int64{1, 2, 3, 4},
+					),
+					Entry(
+						"chunk reaching the upper bound",
+						telem.SecondTS.Range(8*telem.SecondTS),
+						int64(3),
+						[]int64{0, 1},
+					),
 				)
 
 				// Each value equals the index of the sample holding it, so a chunk is
 				// aligned correctly when its alignment equals its first value.
 				DescribeTable(
 					"should align a backward auto-span read with the samples it returns",
-					func(ctx SpecContext, chunk int64) {
+					func(
+						ctx SpecContext,
+						bounds telem.TimeRange,
+						chunk int64,
+						expected []int64,
+					) {
 						i := MustSucceed(db.OpenIterator(cesium.IteratorConfig{
-							Bounds:        telem.SecondTS.Range(telem.TimeStampMax),
+							Bounds:        bounds,
 							Channels:      []cesium.ChannelKey{dataKey},
 							AutoChunkSize: chunk,
 						}))
@@ -497,10 +528,79 @@ var _ = Describe("Iterator Behavior", func() {
 							got = append(batch, got...)
 						}
 						Expect(i.Close()).To(Succeed())
-						Expect(got).To(Equal([]int64{0, 1, 2, 3, 4}))
+						Expect(got).To(Equal(expected))
 					},
-					Entry("chunk smaller than the domain", int64(2)),
-					Entry("chunk larger than the domain", int64(10)),
+					Entry(
+						"chunk smaller than the domain",
+						telem.SecondTS.Range(telem.TimeStampMax),
+						int64(2),
+						[]int64{0, 1, 2, 3, 4},
+					),
+					Entry(
+						"chunk larger than the domain",
+						telem.SecondTS.Range(telem.TimeStampMax),
+						int64(10),
+						[]int64{0, 1, 2, 3, 4},
+					),
+					// A chunk start between two samples is where the same sample can
+					// reach two chunks.
+					Entry(
+						"chunk boundary between samples",
+						telem.SecondTS.Range(10*telem.SecondTS),
+						int64(1),
+						[]int64{0, 1, 2},
+					),
+					Entry(
+						"chunk reaching the lower bound",
+						(4*telem.SecondTS+1).Range(telem.TimeStampMax),
+						int64(2),
+						[]int64{1, 2, 3, 4},
+					),
+				)
+
+				// Both directions close a chunk on a sample: forward on the first
+				// sample it leaves out, backward on the first sample it holds. The
+				// chunks then tile the data without a gap or an overlap.
+				DescribeTable(
+					"should close every chunk on a sample",
+					func(ctx SpecContext, fwd bool, expected []telem.TimeRange) {
+						i := MustSucceed(db.OpenIterator(cesium.IteratorConfig{
+							Bounds:        telem.SecondTS.Range(telem.TimeStampMax),
+							Channels:      []cesium.ChannelKey{dataKey},
+							AutoChunkSize: 2,
+						}))
+						var got []telem.TimeRange
+						if fwd {
+							Expect(i.SeekFirst()).To(BeTrue())
+							for i.Next(cesium.AutoSpan) {
+								got = append(got, i.Value().SeriesAt(0).TimeRange)
+							}
+						} else {
+							Expect(i.SeekLast()).To(BeTrue())
+							for i.Prev(cesium.AutoSpan) {
+								got = append(
+									[]telem.TimeRange{
+										i.Value().SeriesAt(0).TimeRange,
+									},
+									got...,
+								)
+							}
+						}
+						// An exhausted auto-span read is not a failure.
+						Expect(i.Error()).To(Succeed())
+						Expect(i.Close()).To(Succeed())
+						Expect(got).To(Equal(expected))
+					},
+					Entry("forward", true, []telem.TimeRange{
+						telem.SecondTS.Range(8 * telem.SecondTS),
+						(8 * telem.SecondTS).Range(12 * telem.SecondTS),
+						(12 * telem.SecondTS).Range(12*telem.SecondTS + 1),
+					}),
+					Entry("backward", false, []telem.TimeRange{
+						telem.SecondTS.Range(6 * telem.SecondTS),
+						(6 * telem.SecondTS).Range(10 * telem.SecondTS),
+						(10 * telem.SecondTS).Range(12*telem.SecondTS + 1),
+					}),
 				)
 			})
 
@@ -590,6 +690,58 @@ var _ = Describe("Iterator Behavior", func() {
 						8*telem.SecondTS+1,
 						int64(3),
 						[]int64{3, 4, 5, 6, 7, 8},
+					),
+				)
+
+				// Reading backwards, a chunk that reaches past the start of a domain
+				// must stop there instead of consuming the one before it.
+				DescribeTable(
+					"should read every sample before the gap",
+					func(
+						ctx SpecContext,
+						start telem.TimeStamp,
+						chunk int64,
+						expected []int64,
+					) {
+						i := MustSucceed(db.OpenIterator(cesium.IteratorConfig{
+							Bounds:        start.Range(60 * telem.SecondTS),
+							Channels:      []cesium.ChannelKey{dataKey},
+							AutoChunkSize: chunk,
+						}))
+						Expect(i.SeekLast()).To(BeTrue())
+						var got []int64
+						// Chunks arrive newest first, so each one goes in front of the
+						// ones already read.
+						for i.Prev(cesium.AutoSpan) {
+							var batch []int64
+							for _, s := range i.Value().RawSeries() {
+								batch = append(
+									batch,
+									telem.UnmarshalSeries[int64](s)...,
+								)
+							}
+							got = append(batch, got...)
+						}
+						Expect(i.Close()).To(Succeed())
+						Expect(got).To(Equal(expected))
+					},
+					Entry(
+						"chunk smaller than the gap",
+						10*telem.SecondTS+1,
+						int64(2),
+						[]int64{4, 5, 6, 7, 8},
+					),
+					Entry(
+						"chunk spanning the gap",
+						8*telem.SecondTS+1,
+						int64(3),
+						[]int64{3, 4, 5, 6, 7, 8},
+					),
+					Entry(
+						"chunk wider than every domain",
+						telem.SecondTS,
+						int64(9),
+						[]int64{0, 1, 2, 3, 4, 5, 6, 7, 8},
 					),
 				)
 			})


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4617](https://linear.app/synnax/issue/SY-4617/fix-backward-auto-span-reads-and-the-duplicated-chunk-boundary)

## Description

A backward auto-span read near the first domain lost all its data. To place the<br>chunk start, the index asked for the sample before the first one. No such sample<br>exists, so the index logged a DPanic and returned an error, and the read came back<br>empty. The index now reports an unbounded lower stamp instead, which is what the<br>approximation type is for.

Two smaller index defects came out of the same path. A backward stamp landing<br>exactly on a domain's first sample took the walk-back branch and failed with EOF.<br>And the helper that reads the bounding timestamps closed the caller's reader, so<br>the caller's own close double-closed it and the replacement reader leaked. Reading<br>the previous domain now happens in its own function that owns and closes its<br>reader.

The chunk boundary was worked out twice. The index picked it as a timestamp, then<br>the unary iterator picked it again as a sample count. The two agreed only through<br>rounding conventions written down nowhere, and the two directions rounded<br>differently. Both auto-span paths now resolve the chunk to a pair of sample<br>positions first, and the reported time range comes from those positions, so the<br>samples returned and the range reported cannot disagree. A forward chunk ends on<br>the first sample it leaves out; a backward chunk starts on the first sample it<br>holds. Consecutive chunks tile the data with no gap and no overlap.

That rewrite fixes two further defects it exposed. Forward reads returned the<br>sample sitting exactly at the exclusive upper bound. Backward reads clamped the<br>chunk start at the domain start instead of the view start, so every chunk after<br>the first repeated samples the previous one had already returned.

The Cesium iterator no longer crashes when its worker dies. `wrapStreamIterator`<br>never asked the flow to close its output inlets on exit, so a dead worker left the<br>caller waiting forever. It now closes them, and a request that gets no<br>acknowledgement reports the error the routine stopped with rather than<br>dereferencing a logger that was never assigned.

Validation: an offline differential harness ran 20,930 auto-span reads (six domain<br>layouts, many bounds pairs, chunk sizes 1, 2, 3, 5 and 8, both directions), each<br>checked against an exact oracle for sample set, order and per-series alignment.<br>1,518 cases were wrong before and none after. The 3,956 cases that changed but were<br>already correct differ only in the reported range boundaries, which is the intended<br>convention change.

Reads are also cheaper. On a 2,000,000 sample read at the default chunk size, the<br>underlying file read count goes from 1218 to 1198 forward and from 2028 to 1198<br>backward.

## Basic Readiness

- [X] I have performed a self-review of my code.
- [X] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

### Greptile Summary

The PR resolves automatic read chunks from sample positions so forward and backward chunks have consistent, non-overlapping boundaries. It also fixes lower-bound timestamp approximation, reader ownership, and iterator worker-failure propagation.

* Uses an unbounded lower timestamp when no prior domain exists.
* Derives automatic chunk ranges from the samples that each chunk contains.
* Closes iterator output inlets when the worker exits and returns the worker error.
* Adds regression coverage for exact bounds, gaps, alignment, and chunk tiling.

### Confidence Score: 5/5

The PR appears safe to merge.

The changed sample-boundary calculations, reader lifecycle, and iterator shutdown path are consistent with their surrounding contracts, and no actionable failure remains.

### Important Files Changed

<!-- linear:table-colwidths:400,400 -->
| Filename | Overview |
| -- | -- |
| cesium/internal/index/domain.go | Fixes first-domain lower approximation, exact backward domain boundaries, and reader ownership. |
| cesium/internal/unary/iterator.go | Reworks automatic forward and backward chunks around sample positions and consistent range boundaries. |
| cesium/iterator.go | Closes response inlets on worker exit and returns worker termination errors without a nil logger access. |
| cesium/internal/index/domain_test.go | Adds regression cases for the first sample of a prior domain and an unbounded lower timestamp. |
| cesium/iterator_test.go | Adds coverage for exclusive bounds, backward alignment, gaps, and non-overlapping chunk ranges. |

### Flowchart

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Current iterator boundary] --> B[Resolve domain sample positions]
  B --> C{Chunk direction}
  C -->|Forward| D[End at first excluded sample]
  C -->|Backward| E[Start at first included sample]
  D --> F[Read sample offsets]
  E --> F
  F --> G[Report range from resolved positions]
```

Reviews (1): Last reviewed commit: ["SY-4617: Fix backward auto-span reads an..."](<https://github.com/synnaxlabs/synnax/commit/d087335014df45be39eb04bad629b66e3c8a366c>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=54067005>)

**Context used:**

* Knowledge Base — [Cesium Storage Engine](<https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/cesium-storage.md>)

<!-- greptile_comment -->

<!-- greptile_summary -->

<h2><a href="https://app.greptile.com/api/retrigger?id=54067005"><picture><source media="(prefers-color-scheme: dark)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/RetriggerDark.svg?v=2"><source media="(prefers-color-scheme: light)" srcset="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2"><img alt="Retrigger" src="https://greptile-static-assets.s3.amazonaws.com/badges/Retrigger.svg?v=2" align="right"></picture></a>Confidence Score: 5/5</h2>

The PR appears safe to merge.

<h3>Summary</h3>

The PR resolves automatic read chunks from sample positions so forward and backward chunks have consistent, non-overlapping boundaries. It also corrects lower-bound timestamp approximation, reader ownership, and iterator worker-failure propagation.

- Uses an unbounded lower timestamp when no prior domain exists.
- Derives automatic chunk ranges from the samples each chunk contains.
- Closes iterator output inlets when the worker exits and propagates worker errors.
- Adds regression coverage for exact bounds, gaps, alignment, and chunk tiling.

<h3>Diagram</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Current iterator boundary] --> B[Resolve domain sample positions]
  B --> C{Chunk direction}
  C -->|Forward| D[End at first excluded sample]
  C -->|Backward| E[Start at first included sample]
  D --> F[Read sample offsets]
  E --> F
  F --> G[Report range from resolved positions]
```

<sub>Reviews (2) · Last reviewed commit: ["SY-4617: Add unary-level auto-span itera..."](https://github.com/synnaxlabs/synnax/commit/bb247c5b84d4c14a919063ec9153b0add2125cd6)</sub>

<!-- /greptile_comment -->