### PR TITLE
SY-4624: Minor UI improvements

### DIFF
--- a/client/py/synnax/access/role/client.py
+++ b/client/py/synnax/access/role/client.py
@@ -27,6 +27,7 @@ _CreateResponse = _CreateRequest
 
 class _RetrieveRequest(BaseModel):
     keys: list[UUID] | None = None
+    search_term: str | None = None
     limit: int | None = None
     offset: int | None = None
     internal: bool | None = None
@@ -91,6 +92,7 @@ class Client:
         self,
         *,
         keys: list[UUID] | None = None,
+        search_term: str | None = None,
         limit: int | None = None,
         offset: int | None = None,
         internal: bool | None = None,
@@ -100,6 +102,7 @@ class Client:
         self,
         key: UUID | None = None,
         keys: list[UUID] | None = None,
+        search_term: str | None = None,
         limit: int | None = None,
         offset: int | None = None,
         internal: bool | None = None,
@@ -107,7 +110,13 @@ class Client:
         is_single = key is not None
         if is_single and key is not None:
             keys = [key]
-        req = _RetrieveRequest(keys=keys, limit=limit, offset=offset, internal=internal)
+        req = _RetrieveRequest(
+            keys=keys,
+            search_term=search_term,
+            limit=limit,
+            offset=offset,
+            internal=internal,
+        )
         res = self._client.send("/access/role/retrieve", req, _RetrieveResponse)
         return res.roles[0] if is_single else res.roles
 

--- a/client/ts/src/access/role/client.ts
+++ b/client/ts/src/access/role/client.ts
@@ -28,6 +28,7 @@ export const DELETE_CHANNEL_NAME = "sy_role_delete";
 
 const retrieveRequestZ = z.object({
   keys: keyZ.array().optional(),
+  searchTerm: z.string().optional(),
   limit: z.number().optional(),
   offset: z.number().optional(),
   internal: z.boolean().optional(),
@@ -80,13 +81,10 @@ export type UnassignParams = z.input<typeof unassignReqZ>;
 
 const unassignResZ = z.object({});
 
-/** Query fields only the server can evaluate. */
-const SERVER_FIELDS = ["limit", "offset"] as const;
-
 /**
  * Client-side matching for a request: key sets and the internal flag.
- * Server-computed shapes (pagination) never reach this filter; they refetch
- * instead.
+ * Server-computed shapes (search, limit/offset) never reach this filter; they
+ * refetch instead.
  */
 const requestFilter = (req: RetrieveRequest): ((r: Role) => boolean) => {
   const keySet = primitive.isNonZero(req.keys) ? new Set(req.keys) : undefined;
@@ -130,7 +128,6 @@ export class Client extends query.Retriever<typeof retrieveMultiParamsZ, Key, Ro
         schema: retrieveMultiParamsZ,
         fetch: async (req) => await this.execRetrieve(req),
         matches: (role, req) => requestFilter(req)(role),
-        serverFields: SERVER_FIELDS,
       },
     });
     this.cfg = cfg;

--- a/client/ts/src/access/role/role.spec.ts
+++ b/client/ts/src/access/role/role.spec.ts
@@ -60,6 +60,18 @@ describe("role", () => {
       expect(nonInternalRoles.every((r) => r.internal !== true)).toBe(true);
       expect(nonInternalRoles.find((r) => r.key === created.key)).toBeDefined();
     });
+
+    it("should retrieve roles by search term", async () => {
+      const prefix = `searchable-role-${id.create()}`;
+      const names = [`${prefix}-1`, `${prefix}-2`];
+      await client.access.roles.create(names.map((name) => ({ name })));
+      await expect
+        .poll(async () => {
+          const results = await client.access.roles.retrieve({ searchTerm: prefix });
+          return results.map((r) => r.name).sort();
+        })
+        .toEqual(names);
+    });
   });
 
   describe("delete", () => {

--- a/console/src/app/nav/bar/testutil.ts
+++ b/console/src/app/nav/bar/testutil.ts
@@ -11,8 +11,11 @@ import { createTestClient } from "@synnaxlabs/client/testutil";
 import { act, render, type RenderResult } from "@testing-library/react";
 import { type ReactElement } from "react";
 
-import { Session } from "@/session";
-import { type ConsolePreloadedState, createConsoleWrapper } from "@/testutil";
+import {
+  type ConsolePreloadedState,
+  createConsoleWrapper,
+  withSelectedProject,
+} from "@/testutil";
 
 export const client = createTestClient();
 
@@ -25,13 +28,7 @@ export const ACTIVE_PROJECT = await client.projects.create({
 // production they mount inside the project guard).
 export const withActiveProject = (
   state: ConsolePreloadedState = {},
-): ConsolePreloadedState => ({
-  ...state,
-  [Session.Project.SLICE_NAME]: {
-    ...Session.Project.ZERO_SLICE_STATE,
-    selected: ACTIVE_PROJECT.key,
-  },
-});
+): ConsolePreloadedState => withSelectedProject(ACTIVE_PROJECT.key, state);
 
 // renderBar mounts ui against a real client so access-gated nav items and the user/
 // connection badges resolve through the production query path, and returns the render

--- a/console/src/feature/panel/ContextMenu.tsx
+++ b/console/src/feature/panel/ContextMenu.tsx
@@ -66,6 +66,12 @@ const useOrigin = (): (() => TabOrigin | undefined) => {
   }, [key, tabKey, client]);
 };
 
+const SplitItems = (): ReactElement | null => {
+  const isOverlaid = Session.Panel.useSelectIsTabOverlaid();
+  if (isOverlaid) return null;
+  return <Panel.SplitTabMenuItems />;
+};
+
 const MoveToPanelItem = (): ReactElement => {
   const getOrigin = useOrigin();
   const openPicker = useMovePicker();
@@ -106,7 +112,7 @@ export const TabMenuItems = ({ keys }: Menu.ContextMenuMenuProps): ReactElement 
       <RenameItem />
       <FocusItem />
       <Menu.Divider />
-      <Panel.SplitTabMenuItems />
+      <SplitItems />
       <MoveToPanelItem />
       <MoveToNewWindowItem />
       <Menu.Divider />

--- a/console/src/feature/panel/Mosaic.spec.tsx
+++ b/console/src/feature/panel/Mosaic.spec.tsx
@@ -39,6 +39,7 @@ import {
   getBySelector,
   type TestStore,
   uniqueName,
+  withSelectedProject,
 } from "@/testutil";
 
 // The shape a reload hydrates: the persisted selection with the keep-alive set
@@ -365,6 +366,44 @@ describe("Panel.Mosaic overlay", () => {
     expect(tabMountCount(tabA.key)).toBe(1);
     expect(tabMountCount(tabB.key)).toBe(1);
     expect(tabUnmounts).toHaveLength(0);
+  });
+
+  it("should hide the split items while the tab is focused", async () => {
+    const tabA = tabProbeTab();
+    const tabB = tabProbeTab();
+    const pan = await createServerPanel(client, {
+      variant: "leaf",
+      tabs: [tabA, tabB],
+    });
+    const proj = await client.projects.create({ name: uniqueName("proj"), layout: {} });
+    const { wrapper, store } = await setup(withSelectedProject(proj.key));
+    render(<Mosaic onCreateTab={createTab} />, { wrapper });
+
+    act(() => {
+      store.dispatch(Session.Panel.select({ key: pan.key }));
+    });
+    await waitFor(() => expect(screen.getAllByText("probe")).toHaveLength(2));
+
+    fireEvent.contextMenu(screen.getAllByText("probe")[0]);
+    await screen.findByText("Split horizontally");
+    fireEvent.keyDown(document.body, { code: "Escape" });
+
+    act(() => {
+      store.dispatch(
+        Session.Panel.internalSelectTab({
+          key: pan.key,
+          tabKey: tabA.key,
+          otherTabKeys: [tabA.key, tabB.key],
+        }),
+      );
+      store.dispatch(Session.Panel.startOverlaying({}));
+    });
+    await waitFor(() => expect(screen.getByText("Exit focus")).toBeTruthy());
+
+    fireEvent.contextMenu(screen.getAllByText("probe")[0]);
+    await screen.findByText("Close");
+    expect(screen.queryByText("Split horizontally")).toBeNull();
+    expect(screen.queryByText("Split vertically")).toBeNull();
   });
 
   it("should carry overlay mode to the newly selected panel on switch", async () => {

--- a/console/src/feature/project/Splash.spec.tsx
+++ b/console/src/feature/project/Splash.spec.tsx
@@ -9,8 +9,9 @@
 
 import { type Synnax } from "@synnaxlabs/client";
 import { createTestClient } from "@synnaxlabs/client/testutil";
+import { Triggers } from "@synnaxlabs/pluto";
 import { id } from "@synnaxlabs/x";
-import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { Project } from "@/feature/project";
@@ -90,6 +91,82 @@ describe("project/Splash", () => {
 
       await screen.findByText("No matching projects");
       expect(screen.queryByText("No projects")).toBeNull();
+    });
+  });
+
+  describe("keyboard navigation", () => {
+    it("should select the hovered project when Enter is pressed", async () => {
+      const name = uniqueName("kb_enter");
+      const proj = await client.projects.create({ name, layout: {} });
+      const { wrapper, store } = await createConsoleWrapper({ client });
+      render(
+        <Triggers.Provider>
+          <Project.Splash />
+        </Triggers.Provider>,
+        { wrapper },
+      );
+
+      const search = await screen.findByPlaceholderText("Search projects...");
+      fireEvent.change(search, { target: { value: name } });
+      await screen.findByText(name);
+
+      fireEvent.keyDown(search, { code: "Enter" });
+      await waitFor(() => {
+        const active = Session.Project.selectOptionalSelected(store.getState());
+        expect(active).toEqual(proj.key);
+      });
+    });
+
+    it("should move the hover with the arrow keys before selecting", async () => {
+      const prefix = uniqueName("kb_arrows");
+      const a = await client.projects.create({ name: `${prefix}_a`, layout: {} });
+      const b = await client.projects.create({ name: `${prefix}_b`, layout: {} });
+      const { wrapper, store } = await createConsoleWrapper({ client });
+      render(
+        <Triggers.Provider>
+          <Project.Splash />
+        </Triggers.Provider>,
+        { wrapper },
+      );
+
+      const search = await screen.findByPlaceholderText("Search projects...");
+      fireEvent.change(search, { target: { value: prefix } });
+      const elA = await screen.findByText(a.name);
+      const elB = await screen.findByText(b.name);
+      const aIsFirst =
+        (elA.compareDocumentPosition(elB) & Node.DOCUMENT_POSITION_FOLLOWING) !== 0;
+      const second = aIsFirst ? b : a;
+
+      fireEvent.keyDown(search, { code: "ArrowDown" });
+      fireEvent.keyUp(search, { code: "ArrowDown" });
+      fireEvent.keyDown(search, { code: "Enter" });
+      await waitFor(() => {
+        const active = Session.Project.selectOptionalSelected(store.getState());
+        expect(active).toEqual(second.key);
+      });
+    });
+
+    it("should not select a project while a modal is open", async () => {
+      const name = uniqueName("kb_modal");
+      await client.projects.create({ name, layout: {} });
+      const { wrapper, store } = await createConsoleWrapper({ client });
+      render(
+        <Triggers.Provider>
+          <Project.Splash />
+          <Modals.Stack />
+        </Triggers.Provider>,
+        { wrapper },
+      );
+
+      const search = await screen.findByPlaceholderText("Search projects...");
+      fireEvent.change(search, { target: { value: name } });
+      await screen.findByText(name);
+
+      fireEvent.click(screen.getByText("New project"));
+      await screen.findByPlaceholderText("Name");
+      fireEvent.keyDown(document.body, { code: "Enter" });
+      await act(async () => {});
+      expect(Session.Project.selectOptionalSelected(store.getState())).toBeUndefined();
     });
   });
 

--- a/console/src/feature/project/Splash.tsx
+++ b/console/src/feature/project/Splash.tsx
@@ -76,6 +76,7 @@ export const Splash = (): ReactElement => {
     [getItem],
   );
   const menuProps = Menu.useContextMenu();
+  const getIsAnyModalOpen = Session.Modals.useGetIsAnyOpen();
 
   return (
     <Shell.Frame className={CSS.B("project-splash")} connection={activeCluster}>
@@ -86,6 +87,8 @@ export const Splash = (): ReactElement => {
         getItem={getItem}
         subscribe={subscribe}
         onFetchMore={fetchMore}
+        initialHover={0}
+        enableTriggers={() => !getIsAnyModalOpen()}
       >
         <Flex.Box
           y

--- a/console/src/feature/shell/Nav.tsx
+++ b/console/src/feature/shell/Nav.tsx
@@ -11,6 +11,7 @@ import { Flex, OS } from "@synnaxlabs/pluto";
 import { type ReactElement } from "react";
 
 import { Shell } from "@/platform/shell";
+import { Theme } from "@/platform/theme";
 import { Version } from "@/platform/version";
 import { Window } from "@/platform/window";
 import { Session } from "@/session";
@@ -42,6 +43,9 @@ export const Nav = ({ connection }: NavProps): ReactElement => {
         )}
       </Flex.Box>
       <Flex.Box x align="center" gap="medium">
+        <Shell.Island square>
+          <Theme.Toggle size="medium" textColor={9} />
+        </Shell.Island>
         <Shell.Connection cluster={connection} />
         {chrome && os === "Windows" && (
           <Shell.Island data-tauri-drag-region>

--- a/console/src/platform/shell/Shell.css
+++ b/console/src/platform/shell/Shell.css
@@ -42,6 +42,11 @@
     min-height: 6rem;
     padding: 0 2rem;
     border-radius: var(--pluto-border-radius-medium);
+
+    &.pluto--square {
+        width: 6rem;
+        padding: 0;
+    }
 }
 
 .console-shell__island:empty {

--- a/console/src/platform/theme/Toggle.spec.tsx
+++ b/console/src/platform/theme/Toggle.spec.tsx
@@ -1,0 +1,43 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { Theming } from "@synnaxlabs/pluto";
+import { fireEvent, waitFor } from "@testing-library/react";
+import { type ReactElement } from "react";
+import { describe, expect, it } from "vitest";
+
+import { Theme } from "@/platform/theme";
+import { Session } from "@/session";
+import { getIconButton, renderWithConsole } from "@/testutil";
+
+// Wires the app's real theming provider so a press flips the rendered icon.
+const ThemedToggle = (): ReactElement => (
+  <Theming.Provider {...Session.Theme.useProviderProps()}>
+    <Theme.Toggle />
+  </Theming.Provider>
+);
+ThemedToggle.displayName = "ThemedToggle";
+
+describe("Theme.Toggle", () => {
+  it("should flip the theme and its icon on each press", async () => {
+    const { container, store } = await renderWithConsole(<ThemedToggle />);
+
+    fireEvent.click(getIconButton(container, "dark-mode"));
+    await waitFor(() => {
+      expect(store.getState()[Session.Theme.SLICE_NAME].mode).toEqual("dark");
+      getIconButton(container, "light-mode");
+    });
+
+    fireEvent.click(getIconButton(container, "light-mode"));
+    await waitFor(() => {
+      expect(store.getState()[Session.Theme.SLICE_NAME].mode).toEqual("light");
+      getIconButton(container, "dark-mode");
+    });
+  });
+});

--- a/console/src/platform/theme/Toggle.tsx
+++ b/console/src/platform/theme/Toggle.tsx
@@ -1,0 +1,34 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { type Dispatch } from "@reduxjs/toolkit";
+import { Button, Icon, Theming } from "@synnaxlabs/pluto";
+import { type ReactElement } from "react";
+import { useDispatch } from "react-redux";
+
+import { Theme } from "@/session/theme";
+
+export interface ToggleProps extends Omit<Button.ButtonProps, "onClick" | "children"> {}
+
+/** Icon-only button that flips the color theme opposite the effective one. */
+export const Toggle = (props: ToggleProps): ReactElement => {
+  const dark = Theming.use().key === Theming.SYNNAX_DARK.key;
+  const dispatch = useDispatch<Dispatch<Theme.Action>>();
+  const next = dark ? "light" : "dark";
+  return (
+    <Button.Button
+      variant="text"
+      tooltip={`Switch to ${next} theme`}
+      onClick={() => dispatch(Theme.set(next))}
+      {...props}
+    >
+      {dark ? <Icon.LightMode /> : <Icon.DarkMode />}
+    </Button.Button>
+  );
+};

--- a/console/src/platform/theme/external.ts
+++ b/console/src/platform/theme/external.ts
@@ -1,0 +1,10 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+export * from "@/platform/theme/Toggle";

--- a/console/src/platform/theme/index.ts
+++ b/console/src/platform/theme/index.ts
@@ -1,0 +1,10 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+export * as Theme from "@/platform/theme/external";

--- a/console/src/session/modals/Context.spec.tsx
+++ b/console/src/session/modals/Context.spec.tsx
@@ -168,6 +168,26 @@ describe("Provider", () => {
   });
 });
 
+describe("useGetIsAnyOpen", () => {
+  it("should reflect the live stack through a stable getter", () => {
+    const { result, rerender } = renderHook(
+      () => ({
+        getIsAnyOpen: Modals.useGetIsAnyOpen(),
+        store: Modals.useStore("test"),
+      }),
+      { wrapper },
+    );
+    const first = result.current.getIsAnyOpen;
+    expect(first()).toBe(false);
+    act(() => result.current.store.push(Noop, undefined, () => {}));
+    expect(first()).toBe(true);
+    act(() => result.current.store.closeTop());
+    expect(first()).toBe(false);
+    rerender();
+    expect(result.current.getIsAnyOpen).toBe(first);
+  });
+});
+
 describe("useStack", () => {
   it("should reactively reflect pushes and dismissals", () => {
     const { result } = renderHook(

--- a/console/src/session/modals/Context.tsx
+++ b/console/src/session/modals/Context.tsx
@@ -150,3 +150,7 @@ export const useStack = (): readonly Entry[] => {
   const store = useStore("useStack");
   return useSyncExternalStore(store.subscribe, store.getState);
 };
+
+/** @returns a stable getter for whether any modal is open in this window. */
+export const useGetIsAnyOpen = (): (() => boolean) =>
+  useStore("useGetIsAnyOpen").isAnyOpen;

--- a/console/src/session/panel/triggers.ts
+++ b/console/src/session/panel/triggers.ts
@@ -22,9 +22,9 @@ import { useGetTabIsFocused } from "@/session/panel/selectors";
  */
 export const useGetTabTriggersActive = (): (() => boolean) => {
   const getIsFocused = useGetTabIsFocused();
-  const modals = Modals.useStore("useGetTabTriggersActive");
+  const getIsAnyModalOpen = Modals.useGetIsAnyOpen();
   return useCallback(
-    () => getIsFocused() && !modals.isAnyOpen(),
-    [getIsFocused, modals],
+    () => getIsFocused() && !getIsAnyModalOpen(),
+    [getIsFocused, getIsAnyModalOpen],
   );
 };

--- a/console/src/testutil/testutil.tsx
+++ b/console/src/testutil/testutil.tsx
@@ -12,6 +12,7 @@ import {
   type access,
   type ontology,
   panel,
+  type project,
   type Synnax as Client,
   type SynnaxParams,
 } from "@synnaxlabs/client";
@@ -154,6 +155,19 @@ export const CaptureStatuses = ({ onStatuses }: CaptureStatusesProps): null => {
 };
 
 export type ConsolePreloadedState = Partial<Session.State>;
+
+// withSelectedProject seeds the selected project for surfaces that production mounts
+// inside Project.Guard.
+export const withSelectedProject = (
+  key: project.Key,
+  state: ConsolePreloadedState = {},
+): ConsolePreloadedState => ({
+  ...state,
+  [Session.Project.SLICE_NAME]: {
+    ...Session.Project.ZERO_SLICE_STATE,
+    selected: key,
+  },
+});
 
 export interface ConsoleTestProviderOptions {
   preloadedState?: ConsolePreloadedState;

--- a/core/pkg/api/access/access.go
+++ b/core/pkg/api/access/access.go
@@ -166,10 +166,11 @@ func (s *Service) CreateRole(
 
 type (
 	RetrieveRoleRequest struct {
-		Internal *bool      `json:"internal" msgpack:"internal"`
-		Keys     []role.Key `json:"keys"     msgpack:"keys"`
-		Limit    int        `json:"limit"    msgpack:"limit"`
-		Offset   int        `json:"offset"   msgpack:"offset"`
+		Internal   *bool      `json:"internal"    msgpack:"internal"`
+		Keys       []role.Key `json:"keys"        msgpack:"keys"`
+		SearchTerm string     `json:"search_term" msgpack:"search_term"`
+		Limit      int        `json:"limit"       msgpack:"limit"`
+		Offset     int        `json:"offset"      msgpack:"offset"`
 	}
 	RetrieveRoleResponse struct {
 		Roles []role.Role `json:"roles,omitzero" msgpack:"roles,omitzero"`
@@ -181,6 +182,9 @@ func (s *Service) RetrieveRole(
 	req RetrieveRoleRequest,
 ) (RetrieveRoleResponse, error) {
 	q := s.internal.Role.NewRetrieve()
+	if req.SearchTerm != "" {
+		q = q.Search(req.SearchTerm)
+	}
 	if len(req.Keys) > 0 {
 		q = q.Where(role.MatchKeys(req.Keys...))
 	}

--- a/core/pkg/service/access/rbac/role/ontology.go
+++ b/core/pkg/service/access/rbac/role/ontology.go
@@ -34,6 +34,17 @@ func OntologyIDsFromRoles(roles []Role) []ontology.ID {
 	return lo.Map(roles, func(r Role, _ int) ontology.ID { return r.OntologyID() })
 }
 
+// KeyFromOntologyID parses the role key from the given ontology.ID.
+func KeyFromOntologyID(id ontology.ID) (Key, error) { return uuid.Parse(id.Key) }
+
+// KeysFromOntologyIDs converts a slice of ontology IDs to a slice of keys, returning an
+// error if any of the IDs are invalid.
+func KeysFromOntologyIDs(ids []ontology.ID) ([]Key, error) {
+	return lo.MapErr(ids, func(id ontology.ID, _ int) (Key, error) {
+		return KeyFromOntologyID(id)
+	})
+}
+
 var schema = zyn.Object(map[string]zyn.Schema{
 	"key":      zyn.UUID(),
 	"name":     zyn.String(),

--- a/core/pkg/service/access/rbac/role/retrieve.gen.go
+++ b/core/pkg/service/access/rbac/role/retrieve.gen.go
@@ -14,14 +14,18 @@ package role
 import (
 	"context"
 	"github.com/samber/lo"
+	"github.com/synnaxlabs/synnax/pkg/service/ontology"
+	"github.com/synnaxlabs/synnax/pkg/service/search"
 	"github.com/synnaxlabs/x/gorp"
 )
 
 // Retrieve is used to retrieve Role records from the database using a
 // builder pattern for constructing queries.
 type Retrieve struct {
-	baseTX gorp.Tx
-	gorp   gorp.Retrieve[Key, Role]
+	baseTX     gorp.Tx
+	gorp       gorp.Retrieve[Key, Role]
+	search     *search.Index
+	searchTerm string
 }
 
 // Filter is a per-service filter that is bound to the Retrieve when passed to
@@ -55,6 +59,9 @@ func Or(fs ...Filter) Filter {
 func Not(f Filter) Filter {
 	return gorp.NotBound[Retrieve, Key, Role](f)
 }
+
+// Search sets a fuzzy search term that Retrieve will use to filter results.
+func (r Retrieve) Search(term string) Retrieve { r.searchTerm = term; return r }
 
 // MatchKeys returns a filter that restricts results to
 // roles whose key matches any of the provided
@@ -122,17 +129,47 @@ func (r Retrieve) Offset(offset int) Retrieve {
 	return r
 }
 
+func (r Retrieve) execSearch(ctx context.Context) (Retrieve, error) {
+	if r.searchTerm == "" {
+		return r, nil
+	}
+	ids, err := r.search.Search(ctx, search.Request{
+		Type: ontology.ResourceTypeRole,
+		Term: r.searchTerm,
+	})
+	if err != nil {
+		return Retrieve{}, err
+	}
+	keys, err := KeysFromOntologyIDs(ids)
+	if err != nil {
+		return Retrieve{}, err
+	}
+	return r.Where(MatchKeys(keys...)), nil
+}
+
 // Exec executes the query against the provided transaction.
 func (r Retrieve) Exec(ctx context.Context, tx gorp.Tx) error {
+	var err error
+	if r, err = r.execSearch(ctx); err != nil {
+		return err
+	}
 	return r.gorp.Exec(ctx, gorp.OverrideTx(r.baseTX, tx))
 }
 
 // Count returns the number of roles matching the query.
 func (r Retrieve) Count(ctx context.Context, tx gorp.Tx) (int, error) {
+	var err error
+	if r, err = r.execSearch(ctx); err != nil {
+		return 0, err
+	}
 	return r.gorp.Count(ctx, gorp.OverrideTx(r.baseTX, tx))
 }
 
 // Exists checks whether any roles match the query.
 func (r Retrieve) Exists(ctx context.Context, tx gorp.Tx) (bool, error) {
+	var err error
+	if r, err = r.execSearch(ctx); err != nil {
+		return false, err
+	}
 	return r.gorp.Exists(ctx, gorp.OverrideTx(r.baseTX, tx))
 }

--- a/core/pkg/service/access/rbac/role/role_suite_test.go
+++ b/core/pkg/service/access/rbac/role/role_suite_test.go
@@ -32,13 +32,14 @@ var (
 	svc       *role.Service
 	policySvc *policy.Service
 	userSvc   *user.Service
+	searchIdx *search.Index
 )
 
 var _ = BeforeSuite(func(ctx SpecContext) {
 	ShouldNotLeakGoroutines()
 	db = DeferClose(gorp.Wrap(memkv.New()))
 	otg = MustOpen(ontology.Open(ctx, ontology.Config{DB: db}))
-	searchIdx := MustOpen(search.OpenIndex())
+	searchIdx = MustOpen(search.OpenIndex())
 	g = MustOpen(group.OpenService(ctx, group.ServiceConfig{
 		DB:       db,
 		Ontology: otg,
@@ -61,6 +62,7 @@ var _ = BeforeSuite(func(ctx SpecContext) {
 		Group:    g,
 		Search:   searchIdx,
 	}))
+	Expect(searchIdx.Initialize(ctx)).To(Succeed())
 })
 
 func TestRole(t *testing.T) {

--- a/core/pkg/service/access/rbac/role/role_test.go
+++ b/core/pkg/service/access/rbac/role/role_test.go
@@ -436,6 +436,33 @@ var _ = Describe("Retrieve", func() {
 	})
 })
 
+var _ = Describe("Search", func() {
+	// Writes commit directly so the search index observes them; indexing is
+	// asynchronous, hence the Eventually.
+	It("Should retrieve roles matching the search term", func(ctx SpecContext) {
+		w := svc.NewWriter(nil, true)
+		r := role.Role{Name: "quasar-operator", Description: "Quasar operator"}
+		Expect(w.Create(ctx, &r)).To(Succeed())
+		Eventually(func(g Gomega) {
+			var rs []role.Role
+			g.Expect(svc.NewRetrieve().
+				Search("quasar").
+				Entries(&rs).
+				Exec(ctx, nil)).To(Succeed())
+			g.Expect(rs).To(ContainElement(HaveField("Key", r.Key)))
+		}).Should(Succeed())
+	})
+
+	It("Should return no roles when nothing matches", func(ctx SpecContext) {
+		var rs []role.Role
+		Expect(svc.NewRetrieve().
+			Search("zzz-no-such-role").
+			Entries(&rs).
+			Exec(ctx, nil)).To(Succeed())
+		Expect(rs).To(BeEmpty())
+	})
+})
+
 var _ = Describe("Ontology Integration", func() {
 	var tx gorp.Tx
 	BeforeEach(func(ctx SpecContext) { tx = db.OpenTx() })

--- a/core/pkg/service/access/rbac/role/service.go
+++ b/core/pkg/service/access/rbac/role/service.go
@@ -126,5 +126,5 @@ func (s *Service) NewWriter(tx gorp.Tx, allowInternal bool) Writer {
 }
 
 func (s *Service) NewRetrieve() Retrieve {
-	return Retrieve{baseTX: s.cfg.DB, gorp: s.table.NewRetrieve()}
+	return Retrieve{baseTX: s.cfg.DB, gorp: s.table.NewRetrieve(), search: s.cfg.Search}
 }

--- a/pluto/src/schematic/node/general/setpoint/Primitive.tsx
+++ b/pluto/src/schematic/node/general/setpoint/Primitive.tsx
@@ -44,12 +44,7 @@ export const Setpoint = ({
   );
   return (
     <Primitive.Div
-      className={CSS(
-        CSS.B("setpoint"),
-        CSS.B("symbol-colored"),
-        symbolColor != null && CSS.M("colored"),
-        className,
-      )}
+      className={CSS(CSS.B("setpoint"), CSS.B("symbol-colored"), className)}
       orientation={orientation}
       style={mergedStyle}
     >

--- a/pluto/src/schematic/node/general/setpoint/setpoint.css
+++ b/pluto/src/schematic/node/general/setpoint/setpoint.css
@@ -10,74 +10,14 @@
  */
 
 .pluto-setpoint {
-    /* The input chrome is an outlined Button that assigns border/bg vars on
-       itself, so overrides must land on the element, not an ancestor. */
-    .pluto-input.pluto-btn {
+    --pluto-border-color: var(--pluto-symbol-display);
+
+    .pluto-input {
         width: min-content;
-        background: var(--pluto-gray-l1);
-        --pluto-border-color: var(--pluto-gray-l6);
-        --pluto-hover-border-color: var(--pluto-gray-l6);
-        --pluto-active-border-color: var(--pluto-gray-l6);
     }
 
     input {
         min-width: 12rem;
-        font-family: var(--pluto-code-font-family);
-        font-variant-numeric: tabular-nums;
-    }
-
-    .pluto-btn.pluto-btn--filled.pluto-symbol-button {
-        border-width: 1px;
-        --pluto-bg: var(--pluto-gray-l3);
-        --pluto-hover-bg: var(--pluto-gray-l4);
-        --pluto-active-bg: var(--pluto-gray-l5);
-        --pluto-border-color: var(--pluto-gray-l6);
-        --pluto-hover-border-color: var(--pluto-gray-l6);
-        --pluto-active-border-color: var(--pluto-gray-l6);
-        --pluto-btn-text-color: var(--pluto-gray-l10);
-    }
-
-    &.pluto--colored {
-        .pluto-input.pluto-btn:focus-within {
-            background: color-mix(
-                in oklab,
-                var(--pluto-symbol-display) 16%,
-                var(--pluto-gray-l1)
-            );
-        }
-
-        .pluto-input.pluto-btn {
-            background: color-mix(
-                in oklab,
-                var(--pluto-symbol-display) 8%,
-                var(--pluto-gray-l1)
-            );
-            --pluto-border-color: var(--pluto-symbol-display);
-            --pluto-hover-border-color: var(--pluto-symbol-display);
-            --pluto-active-border-color: var(--pluto-symbol-display);
-        }
-
-        .pluto-btn.pluto-btn--filled.pluto-symbol-button {
-            --pluto-bg: color-mix(
-                in oklab,
-                var(--pluto-symbol-display) 20%,
-                var(--pluto-gray-l1)
-            );
-            --pluto-hover-bg: color-mix(
-                in oklab,
-                var(--pluto-symbol-display) 30%,
-                var(--pluto-gray-l1)
-            );
-            --pluto-active-bg: color-mix(
-                in oklab,
-                var(--pluto-symbol-display) 40%,
-                var(--pluto-gray-l1)
-            );
-            --pluto-border-color: var(--pluto-symbol-display);
-            --pluto-hover-border-color: var(--pluto-symbol-display);
-            --pluto-active-border-color: var(--pluto-symbol-display);
-            --pluto-btn-text-color: var(--pluto-gray-l11);
-        }
     }
 
     .pluto-handle__2 {
@@ -93,14 +33,4 @@
         width: 120px;
         transform: scale(0.95);
     }
-}
-
-/* Editing focus on a colored setpoint keeps the symbol's hue instead of
-   swapping to primary; the input's own focus rule (six class units of
-   specificity) would repaint the border blue, so this doubles classes to
-   outrank it. The inset focus shadow reads the same var, so the thickened
-   ring stays in-hue too. */
-.pluto-setpoint.pluto-setpoint.pluto--colored
-    .pluto-input.pluto-input.pluto-btn:focus-within {
-    --pluto-border-color: var(--pluto-symbol-display);
 }

--- a/pluto/src/schematic/node/general/stateIndicator/Primitive.tsx
+++ b/pluto/src/schematic/node/general/stateIndicator/Primitive.tsx
@@ -18,6 +18,7 @@ import { Primitive } from "@/schematic/node/common/primitive";
 import { type Config } from "@/schematic/node/general/stateIndicator/config";
 import { symbolColorVar } from "@/schematic/symbolColor";
 import { Text } from "@/text";
+import { Theming } from "@/theming";
 
 interface RenderProps extends Omit<Config, "variant"> {
   className?: string;
@@ -36,25 +37,33 @@ export const StateIndicator = ({
   staleColor,
 }: RenderProps): ReactElement => {
   const matched = options.find((o) => o.key === matchedOptionKey);
-  // The matched state's color drives the chassis; the symbol color is the
-  // fallback so an unmatched indicator still reads as its symbol.
-  const symbolColor = symbolColorVar(matched?.color) ?? symbolColorVar(colorVal);
+  const stateColor = matched?.color;
+  const backgroundColor = stateColor != null ? color.cssString(stateColor) : undefined;
+  const theme = Theming.use();
+  const textColor =
+    staleColor != null
+      ? color.cssString(staleColor)
+      : stateColor != null
+        ? color.cssString(
+            color.pickByContrast(
+              stateColor,
+              theme.colors.gray.l0,
+              theme.colors.gray.l11,
+            ),
+          )
+        : undefined;
   const label = matched != null ? matched.name || `Option ${matched.value}` : "Unknown";
   const style = useMemo<CSSProperties>(
     () => ({
-      [CSS.var("symbol-color")]: symbolColor,
+      [CSS.var("symbol-color")]: symbolColorVar(colorVal),
+      backgroundColor,
       minWidth: inlineSize,
     }),
-    [symbolColor, inlineSize],
+    [colorVal, backgroundColor, inlineSize],
   );
   return (
     <Primitive.Div
-      className={CSS(
-        CSS.B("state-indicator"),
-        CSS.B("symbol-colored"),
-        symbolColor != null && CSS.M("colored"),
-        className,
-      )}
+      className={CSS(CSS.B("state-indicator"), CSS.B("symbol-colored"), className)}
       style={style}
     >
       <Handle.Rectangle
@@ -65,7 +74,7 @@ export const StateIndicator = ({
         bottom={102}
       />
       <div className={CSS.BE("state-indicator", "content")}>
-        <Text.Text level="p" color={color.cssString(staleColor)} variant="code">
+        <Text.Text level="p" color={textColor} variant="code">
           {label}
         </Text.Text>
       </div>

--- a/pluto/src/schematic/node/general/stateIndicator/stateIndicator.css
+++ b/pluto/src/schematic/node/general/stateIndicator/stateIndicator.css
@@ -12,24 +12,13 @@
 .pluto-state-indicator {
     display: flex;
     flex-direction: row;
-    border: 1px solid var(--pluto-gray-l6);
+    border: var(--pluto-border);
+    border-color: var(--pluto-symbol-display);
     border-radius: var(--pluto-border-radius);
-    background: var(--pluto-gray-l1);
+    border-width: 2px;
     padding: 0;
     align-items: center;
     justify-content: center;
-    transition:
-        border-color 0.15s ease-in-out,
-        background 0.15s ease-in-out;
-
-    &.pluto--colored {
-        border-color: var(--pluto-symbol-display);
-        background: color-mix(
-            in oklab,
-            var(--pluto-symbol-display) 8%,
-            var(--pluto-gray-l1)
-        );
-    }
 
     & .pluto-state-indicator__content {
         padding: 0.5rem 1.5rem;

--- a/pluto/src/schematic/node/general/value/Primitive.tsx
+++ b/pluto/src/schematic/node/general/value/Primitive.tsx
@@ -58,12 +58,7 @@ export const Value = ({
   );
   return (
     <Primitive.Div
-      className={CSS(
-        CSS.B("value"),
-        CSS.B("symbol-colored"),
-        symbolColor != null && CSS.M("colored"),
-        className,
-      )}
+      className={CSS(CSS.B("value"), CSS.B("symbol-colored"), className)}
       style={style}
     >
       <div className={CSS.BE("value", "content")} style={contentStyle}>

--- a/pluto/src/schematic/node/general/value/value.css
+++ b/pluto/src/schematic/node/general/value/value.css
@@ -12,26 +12,14 @@
 .pluto-value {
     display: flex;
     flex-direction: row;
-    border: 1px solid var(--pluto-gray-l6);
+    border: var(--pluto-border);
+    border-color: var(--pluto-symbol-display);
     border-radius: var(--pluto-border-radius);
-    background: var(--pluto-gray-l1);
+    border-width: 2px;
     padding: 0;
     flex-grow: 0;
     align-items: center;
-    transition:
-        border-color 0.15s ease-in-out,
-        background 0.15s ease-in-out;
-
-    /* Opaque mix instead of an alpha tint: alpha over the dark canvas muddies
-       saturated hues and renders differently per backdrop. */
-    &.pluto--colored {
-        border-color: var(--pluto-symbol-display);
-        background: color-mix(
-            in oklab,
-            var(--pluto-symbol-display) 8%,
-            var(--pluto-gray-l1)
-        );
-    }
+    justify-content: center;
 
     & .pluto-value__content {
         padding-left: 1.5rem;
@@ -41,12 +29,25 @@
     & .pluto-value__units {
         display: flex;
         align-items: center;
+        height: calc(100% + 2px);
         padding: 0 1rem;
+        background: var(--pluto-symbol-display);
+        color: var(--pluto-symbol-contrast);
+        padding-top: 1px;
+        margin-right: -1px;
         text-align: center;
 
+        &.pluto--h4 {
+            padding: 0 1.5rem;
+        }
+
+        &.pluto--h3 {
+            padding: 0 2rem;
+        }
+
         & .pluto-text {
-            color: var(--pluto-gray-l9);
-            font-weight: 400;
+            color: var(--pluto-symbol-contrast);
+            font-weight: 500;
         }
     }
 }

--- a/pluto/src/select/use.ts
+++ b/pluto/src/select/use.ts
@@ -49,11 +49,11 @@ export type UseSingleProps<K extends record.Key> = optional.Optional<
   UseSingleInternalProps<K>,
   "allowNone"
 > &
-  Pick<UseHoverProps<K>, "initialHover">;
+  Pick<UseHoverProps<K>, "initialHover" | "enableTriggers">;
 
 export interface UseMultipleProps<K extends record.Key> extends Pick<
   UseHoverProps<K>,
-  "initialHover"
+  "initialHover" | "enableTriggers"
 > {
   allowNone?: boolean;
   value: K[];
@@ -88,6 +88,7 @@ export const useSingle = <K extends record.Key>({
   value,
   closeDialogOnSelect = false,
   initialHover,
+  enableTriggers,
   autoSelectOnNone = false,
 }: UseSingleProps<K>): UseReturn<K> => {
   const valueRef = useSyncedRef(value);
@@ -123,7 +124,12 @@ export const useSingle = <K extends record.Key>({
     [onChange],
   );
 
-  const hover = useHover({ data, onSelect: handleSelect, initialHover });
+  const hover = useHover({
+    data,
+    onSelect: handleSelect,
+    initialHover,
+    enableTriggers,
+  });
   return { onSelect: handleSelect, setSelected, clear, ...hover };
 };
 
@@ -132,6 +138,7 @@ export const useMultiple = <K extends record.Key>({
   replaceOnSingle = false,
   onChange,
   initialHover,
+  enableTriggers,
   allowNone = true,
   closeDialogOnSelect = false,
   autoSelectOnNone = false,
@@ -204,6 +211,6 @@ export const useMultiple = <K extends record.Key>({
     (keys: K[]): void => onChange(keys, { clicked: null, clickedIndex: 0 }),
     [onChange],
   );
-  const hover = useHover({ data, onSelect, initialHover });
+  const hover = useHover({ data, onSelect, initialHover, enableTriggers });
   return { onSelect, setSelected, clear, ...hover };
 };

--- a/pluto/src/select/useHover.spec.tsx
+++ b/pluto/src/select/useHover.spec.tsx
@@ -16,28 +16,34 @@ import { Select } from "@/select";
 import { Triggers } from "@/triggers";
 
 describe("useHover", () => {
+  interface RenderHoverOptions {
+    initialHover?: number;
+    enableTriggers?: Triggers.Condition;
+    dialog?: boolean;
+  }
+
   const renderHover = (
     data: string[],
     onSelect: (key: string) => void,
-    initialHover?: number,
+    { initialHover, enableTriggers, dialog = true }: RenderHoverOptions = {},
   ) => {
     const C = () => {
       const { hover } = Select.useHover({
         data,
         onSelect,
         initialHover,
+        enableTriggers,
       });
       return <div>{hover}</div>;
     };
-    return render(
-      <Dialog.Frame visible>
-        <List.Frame data={data}>
-          <Triggers.Provider>
-            <C />
-          </Triggers.Provider>
-        </List.Frame>
-      </Dialog.Frame>,
+    const content = (
+      <List.Frame data={data}>
+        <Triggers.Provider>
+          <C />
+        </Triggers.Provider>
+      </List.Frame>
     );
+    return render(dialog ? <Dialog.Frame visible>{content}</Dialog.Frame> : content);
   };
 
   it("should shift the hover position of the list when the down arrow is pressed", () => {
@@ -52,7 +58,7 @@ describe("useHover", () => {
   it("should accept an initial hover value", () => {
     const onSelect = vi.fn();
     const data = ["1", "2", "3"];
-    const c = renderHover(data, onSelect, 1);
+    const c = renderHover(data, onSelect, { initialHover: 1 });
 
     expect(c.getByText("2")).toBeTruthy();
   });
@@ -60,7 +66,7 @@ describe("useHover", () => {
   it("should shift the hover position of the list when the up arrow is pressed", () => {
     const onSelect = vi.fn();
     const data = ["1", "2", "3"];
-    const c = renderHover(data, onSelect, 1);
+    const c = renderHover(data, onSelect, { initialHover: 1 });
     fireEvent.keyDown(c.container, { code: "ArrowUp" });
     expect(c.getByText("1")).toBeTruthy();
   });
@@ -68,7 +74,7 @@ describe("useHover", () => {
   it("should select the item when the enter key is pressed", () => {
     const onSelect = vi.fn();
     const data = ["1", "2", "3"];
-    const c = renderHover(data, onSelect, 1);
+    const c = renderHover(data, onSelect, { initialHover: 1 });
     fireEvent.keyDown(c.container, { code: "Enter" });
     expect(onSelect).toHaveBeenCalledWith("2");
   });
@@ -76,7 +82,51 @@ describe("useHover", () => {
   it("should move the hover index to 0 when the initial hover is beyond the length of the list", () => {
     const onSelect = vi.fn();
     const data = ["1", "2", "3"];
-    const c = renderHover(data, onSelect, 10);
+    const c = renderHover(data, onSelect, { initialHover: 10 });
     expect(c.getByText("1")).toBeTruthy();
+  });
+
+  describe("enableTriggers", () => {
+    it("should ignore keyboard triggers outside a dialog by default", () => {
+      const onSelect = vi.fn();
+      const data = ["1", "2", "3"];
+      const c = renderHover(data, onSelect, { initialHover: 0, dialog: false });
+      fireEvent.keyDown(c.container, { code: "ArrowDown" });
+      expect(c.getByText("1")).toBeTruthy();
+      fireEvent.keyDown(c.container, { code: "Enter" });
+      expect(onSelect).not.toHaveBeenCalled();
+    });
+
+    it("should answer keyboard triggers outside a dialog when enabled", () => {
+      const onSelect = vi.fn();
+      const data = ["1", "2", "3"];
+      const c = renderHover(data, onSelect, {
+        initialHover: 0,
+        dialog: false,
+        enableTriggers: true,
+      });
+      fireEvent.keyDown(c.container, { code: "ArrowDown" });
+      fireEvent.keyUp(c.container, { code: "ArrowDown" });
+      expect(c.getByText("2")).toBeTruthy();
+      fireEvent.keyDown(c.container, { code: "Enter" });
+      expect(onSelect).toHaveBeenCalledWith("2");
+    });
+
+    it("should resolve a condition getter when the trigger fires", () => {
+      const onSelect = vi.fn();
+      const data = ["1", "2", "3"];
+      let enabled = false;
+      const c = renderHover(data, onSelect, {
+        initialHover: 0,
+        dialog: false,
+        enableTriggers: () => enabled,
+      });
+      fireEvent.keyDown(c.container, { code: "ArrowDown" });
+      fireEvent.keyUp(c.container, { code: "ArrowDown" });
+      expect(c.getByText("1")).toBeTruthy();
+      enabled = true;
+      fireEvent.keyDown(c.container, { code: "ArrowDown" });
+      expect(c.getByText("2")).toBeTruthy();
+    });
   });
 });

--- a/pluto/src/select/useHover.ts
+++ b/pluto/src/select/useHover.ts
@@ -19,6 +19,10 @@ export interface UseHoverProps<K extends record.Key> {
   initialHover?: number;
   data: K[];
   onSelect: (key: K) => void;
+  /**
+   * When to answer keyboard triggers. Defaults to the enclosing dialog's visibility.
+   */
+  enableTriggers?: Triggers.Condition;
 }
 
 const UP_TRIGGER: Triggers.Trigger = ["ArrowUp"];
@@ -37,11 +41,12 @@ export const useHover = <K extends record.Key>({
   data,
   initialHover = -1,
   onSelect,
+  enableTriggers,
 }: UseHoverProps<K>): UseHoverReturn<K> => {
   const dataRef = useSyncedRef(data);
   const [hover, setHover, hoverRef] = useCombinedStateAndRef<number>(initialHover);
   const { visible } = Dialog.useContext();
-  const visibleRef = useSyncedRef(visible);
+  const enabledRef = useSyncedRef<Triggers.Condition>(enableTriggers ?? visible);
   const { scrollToIndex } = List.useScroller();
   const updateHover = useCallback(
     (setArg: state.SetArg<number>) => {
@@ -60,7 +65,7 @@ export const useHover = <K extends record.Key>({
 
   const handleTrigger = useCallback(
     ({ triggers, stage }: Triggers.UseEvent) => {
-      if (!visibleRef.current) return;
+      if (!Triggers.resolveCondition(enabledRef.current)) return;
       if (intervalRef.current != null) {
         clearInterval(intervalRef.current);
         intervalRef.current = null;

--- a/schemas/synnax/role.oracle
+++ b/schemas/synnax/role.oracle
@@ -46,4 +46,5 @@ Role struct {
     @go migrate
     @ontology type "role"
     @retrieve
+    @search
 }


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4624](https://linear.app/synnax/issue/SY-4624/minor-ui-improvements)

## Description

A batch of small UI fixes for the Console login flow and panels:

- Keyboard navigation now works on the project selection splash. Pluto's select hover hook gains an `enableTriggers` condition so a list outside a dialog can own arrow/Enter keys; the splash enables it whenever no modal is open, with the first project hovered by default. Adds `Session.Modals.useGetIsAnyOpen` for trigger gating.
- The login flow shell gains a square icon-only theme toggle island (`platform/theme` `Theme.Toggle`) that flips the color theme opposite the effective one.
- Role search now filters. The search term the role select dialog already sent was dropped by both the TS client schema and the Core; `role.oracle` opts into `@search`, the API handler and clients carry `search_term`, and the role test suite now initializes its search index.
- The split horizontally/vertically items hide from the tab context menu while the tab is in focus mode, since splitting would rearrange the mosaic invisibly behind the overlay.
- Reverts the schematic value, setpoint, and state indicator restyles to their released look. Symbol restyling is deferred to 0.58.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR improves project selection, theme controls, role search, and focused-panel menus.

- Adds keyboard project navigation with modal-aware trigger gating.
- Propagates role search terms through the SDKs, Core API, and search-backed role retrieval.
- Adds a login-shell theme toggle and hides split actions during panel focus mode.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The changed query routing, role search pipeline, trigger gating, theme control, and panel menu behavior preserve their relevant contracts, and no actionable failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| client/ts/src/access/role/client.ts | Adds `searchTerm` to role retrieval and correctly relies on default server-computed query fields. |
| core/pkg/service/access/rbac/role/retrieve.gen.go | Adds search-index filtering consistently across role execution, count, and existence queries. |
| console/src/feature/project/Splash.tsx | Enables project-list keyboard triggers only while no Console modal is open. |
| pluto/src/select/useHover.ts | Adds a live trigger condition while retaining dialog visibility as the default. |
| console/src/platform/theme/Toggle.tsx | Adds an icon-only control that switches to the opposite effective theme. |
| console/src/feature/panel/ContextMenu.tsx | Removes split actions while the selected tab is displayed as an overlay. |
| schemas/synnax/role.oracle | Enables Oracle-generated search support for roles. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Console["Role selector"] --> TS["TypeScript client"]
  Python["Python client"] --> API["Core access API"]
  TS --> API
  API --> Retrieve["Role Retrieve.Search"]
  Retrieve --> Index["Search index"]
  Index --> Keys["Role ontology keys"]
  Keys --> DB["Filtered role query"]
```

<sub>Reviews (1): Last reviewed commit: ["SY-4624: Minor UI improvements"](https://github.com/synnaxlabs/synnax/commit/6a9fb5e231896f6517a44bab12bf263c3a50e282) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54486403)</sub>

<details><summary><h4>Context used (5)</h4></summary>

- Knowledge Base — [Client SDKs](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/client-sdks.md)
- Knowledge Base — [Console App](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/console-app.md)
- Knowledge Base — [Core Server](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/core-server.md)
- Knowledge Base — [Oracle Codegen](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/oracle-codegen.md)
- Knowledge Base — [Pluto Component and Visualization Library](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/pluto-components.md)
</details>

<!-- /greptile_comment -->
