### PR TITLE
SY-4625: Merge legacy table cell props over variant defaults

### DIFF
--- a/pluto/src/table/Row.tsx
+++ b/pluto/src/table/Row.tsx
@@ -129,11 +129,7 @@ const VariantCell = memo(
     const props = useMemo(() => {
       if (cell == null) return null;
       const spec = Cell.REGISTRY[cell.variant];
-      return deep.overrideValidItems(
-        spec.defaultProps(theme),
-        cell.props,
-        spec.schema,
-      );
+      return deep.overrideValidItems(spec.defaultProps(theme), cell.props, spec.schema);
     }, [cell, theme]);
     const handleChange = useCallback(
       (props: record.Unknown) => {

--- a/pluto/src/table/Row.tsx
+++ b/pluto/src/table/Row.tsx
@@ -8,7 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { table } from "@synnaxlabs/client";
-import { box, dimensions, type record, xy } from "@synnaxlabs/x";
+import { box, deep, dimensions, type record, xy } from "@synnaxlabs/x";
 import { memo, type ReactElement, useCallback, useMemo } from "react";
 
 import { CSS } from "@/css";
@@ -16,6 +16,7 @@ import { Cell } from "@/table/cells";
 import { Indicator } from "@/table/Indicator";
 import { useCell, useDispatch } from "@/table/queries";
 import { Selection } from "@/table/selection";
+import { Theming } from "@/theming";
 
 export interface RowProps {
   index: number;
@@ -118,10 +119,22 @@ const VariantCell = memo(
     const cell = useCell({ key: resourceKey, cellKey });
     const selected = Selection.useIsMember(cellKey);
     const { dispatch } = useDispatch();
+    const theme = Theming.use();
     const b = useMemo(
       () => box.construct(xy.construct({ x, y }), dimensions.construct(width, height)),
       [x, y, width, height],
     );
+    // Imported legacy states can carry sparse cell props, so valid wire fields
+    // are merged over the variant's defaults instead of spread directly.
+    const props = useMemo(() => {
+      if (cell == null) return null;
+      const spec = Cell.REGISTRY[cell.variant];
+      return deep.overrideValidItems(
+        spec.defaultProps(theme),
+        cell.props,
+        spec.schema,
+      );
+    }, [cell, theme]);
     const handleChange = useCallback(
       (props: record.Unknown) => {
         if (cell == null) return;
@@ -134,7 +147,7 @@ const VariantCell = memo(
       },
       [dispatch, resourceKey, cellKey, cell],
     );
-    if (cell == null) return null;
+    if (cell == null || props == null) return null;
     const Spec = Cell.REGISTRY[cell.variant];
     return (
       <Spec.Cell
@@ -144,7 +157,7 @@ const VariantCell = memo(
         editable={editable}
         onSelect={onSelect}
         onChange={handleChange}
-        {...cell.props}
+        {...props}
       />
     );
   },

--- a/pluto/src/table/Table.spec.tsx
+++ b/pluto/src/table/Table.spec.tsx
@@ -299,7 +299,7 @@ describe("Table", () => {
       const { container } = render(<Wrapped />, { wrapper });
       await waitFor(() => {
         expect(container.querySelector(".pluto-table-frame")).not.toBeNull();
-        expect(container.querySelector(".pluto-table__row")).not.toBeNull();
+        expect(container.querySelector(".pluto-table__cell--value")).not.toBeNull();
       });
     });
   });

--- a/pluto/src/table/Table.spec.tsx
+++ b/pluto/src/table/Table.spec.tsx
@@ -46,9 +46,10 @@ const loadTable = async (
   wrapper: React.FC<PropsWithChildren>,
   key: table.Key,
 ): Promise<void> => {
+  const testID = `loaded-${key}`;
   const Bootstrap = (): ReactElement => {
     Table.useEnsure({ key });
-    return <div data-testid="loaded" />;
+    return <div data-testid={testID} />;
   };
   let utils!: ReturnType<typeof render>;
   await act(async () => {
@@ -59,7 +60,7 @@ const loadTable = async (
       { wrapper },
     );
   });
-  await utils.findByTestId("loaded");
+  await utils.findByTestId(testID);
 };
 
 // The @juggle polyfill reads computed styles, which jsdom leaves empty, so it
@@ -274,6 +275,32 @@ describe("Table", () => {
       await expectDrawnAt(ORIGIN);
       scrollTo(scroller, { x: 10, y: 20 });
       await expectDrawnAt({ x: ORIGIN.x - 10, y: ORIGIN.y - 20 });
+    });
+  });
+
+  describe("sparse cell props", () => {
+    // An imported legacy state can carry a value cell with empty props. The
+    // renderer merges wire props over the variant's defaults, so the cell
+    // renders instead of crashing on the missing fields.
+    it("renders a value cell whose wire props are empty", async () => {
+      const project = await client.projects.create({ name: "sparse", layout: {} });
+      const created = await client.tables.create(project.key, {
+        name: "sparse_table",
+        rows: [{ size: ROW_SIZE, cells: ["a"] }],
+        columns: [{ size: COL_SIZE }],
+        cells: { a: { key: "a", variant: "value", props: {} } },
+      });
+      await loadTable(wrapper, created.key);
+      const Wrapped = (): ReactElement => (
+        <Table.Suspended tableKey={created.key}>
+          <Table.Table visible />
+        </Table.Suspended>
+      );
+      const { container } = render(<Wrapped />, { wrapper });
+      await waitFor(() => {
+        expect(container.querySelector(".pluto-table-frame")).not.toBeNull();
+        expect(container.querySelector(".pluto-table__row")).not.toBeNull();
+      });
     });
   });
 });


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4625](https://linear.app/synnax/issue/SY-4625/imported-legacy-tables-crash-on-sparse-cell-props)

## Description

Importing a table exported by a released Console can crash the Console when a cell carries sparse props (for example a value cell with `props: {}`). `VariantCell` spread the wire props directly into the cell component, so fields the variant expects were missing at render time.

The renderer now merges the wire props over the variant's defaults with `deep.overrideValidItems` against the variant schema, so sparse legacy states render with defaults instead of crashing. Found by the integration suite's golden-file import coverage against `core/pkg/service/table/versions/testdata`; a spec covers the empty-props value cell.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR merges persisted table-cell props over theme-aware variant defaults to support sparse legacy cells.
- Adds schema-gated default merging in `VariantCell`.
- Adds regression coverage for an empty value-cell props object.
- Makes the table-loading test ID specific to each table key.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, but the regression test should assert that the value cell itself renders.

The implementation supplies full variant defaults for empty persisted props, while the only accepted concern is non-blocking test coverage that can pass without the target cell.

**Files Needing Attention:** pluto/src/table/Table.spec.tsx

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pluto/src/table/Row.tsx | Merges valid persisted cell fields over variant defaults before rendering. |
| pluto/src/table/Table.spec.tsx | Adds sparse-props coverage, but the assertion does not confirm that the value cell renders. |

<sub>Reviews (1): Last reviewed commit: ["SY-4625: Merge legacy table cell props o..."](https://github.com/synnaxlabs/synnax/commit/91d46e89e29f881c2564baaffef4bf69d8600ca0) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54558136)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - When making changes to functionality, add correspo... ([source](https://app.greptile.com/synnax/-/custom-context?memory=8b39d83e-3d2b-4dd4-9e14-d0644d6bfe58))

**Learned From**
[synnaxlabs/synnax#1550](https://github.com/synnaxlabs/synnax/pull/1550)

<!-- /greptile_comment -->