### PR TITLE
SY-4639: Fix flakey Cesium slow-consumer streamer spec

### DIFF
--- a/cesium/open.go
+++ b/cesium/open.go
@@ -77,7 +77,7 @@ func Open(ctx context.Context, dirname string, opts ...Option) (*DB, error) {
 	}
 
 	sCtx, cancel := signal.Isolated(signal.WithInstrumentation(o.Instrumentation))
-	db.relay = openRelay(sCtx, o.Instrumentation, o.relayBufferSize, o.streamBufferSize)
+	db.relay = openRelay(sCtx, o)
 	db.startGC(sCtx, o)
 	db.shutdown = signal.NewHardShutdown(sCtx, cancel)
 	return db, nil

--- a/cesium/open_test.go
+++ b/cesium/open_test.go
@@ -22,6 +22,19 @@ import (
 	. "github.com/synnaxlabs/x/testutil"
 )
 
+var _ = Describe("Options", func() {
+	It("Should reject a non-positive slow consumer timeout", func(ctx SpecContext) {
+		Expect(cesium.Open(
+			ctx,
+			"",
+			cesium.WithFS(fs.NewMem()),
+			cesium.WithSlowConsumerTimeout(0),
+		)).Error().To(MatchError(
+			ContainSubstring("slow_consumer_timeout: must be positive"),
+		))
+	})
+})
+
 var _ = Describe("Open", func() {
 	for fsName, openFS := range FileSystems {
 		Context("FS: "+fsName, Ordered, func() {

--- a/cesium/options.go
+++ b/cesium/options.go
@@ -32,15 +32,19 @@ type options struct {
 	fileSize         telem.Size
 	relayBufferSize  int
 	streamBufferSize int
+	// slowConsumerTimeout bounds how long the relay waits for a streamer to receive a
+	// frame before dropping it.
+	slowConsumerTimeout time.Duration
 }
 
 func (o *options) Report() alamos.Report { return alamos.Report{"dirname": o.dirname} }
 
 func newOptions(dirname string, opts ...Option) (*options, error) {
 	o := &options{
-		dirname:          dirname,
-		relayBufferSize:  defaultRelayBufferSize,
-		streamBufferSize: defaultStreamBufferSize,
+		dirname:             dirname,
+		relayBufferSize:     defaultRelayBufferSize,
+		streamBufferSize:    defaultStreamBufferSize,
+		slowConsumerTimeout: defaultSlowConsumerTimeout,
 	}
 	for _, opt := range opts {
 		opt(o)
@@ -67,6 +71,7 @@ func mergeAndValidateOptions(o *options) error {
 	v := validate.New("cesium.options")
 	validate.Positive(v, "relay_buffer_size", o.relayBufferSize)
 	validate.Positive(v, "stream_buffer_size", o.streamBufferSize)
+	validate.Positive(v, "slow_consumer_timeout", o.slowConsumerTimeout)
 	return v.Error()
 }
 
@@ -103,4 +108,10 @@ func WithRelayBufferSize(size int) Option {
 // to the relay pipe. Defaults to 100 frames.
 func WithStreamBufferSize(size int) Option {
 	return func(o *options) { o.streamBufferSize = size }
+}
+
+// WithSlowConsumerTimeout sets the maximum amount of time the relay will wait for a
+// streamer to receive a frame before dropping it. Defaults to 20ms.
+func WithSlowConsumerTimeout(timeout time.Duration) Option {
+	return func(o *options) { o.slowConsumerTimeout = timeout }
 }

--- a/cesium/relay.go
+++ b/cesium/relay.go
@@ -13,7 +13,6 @@ import (
 	"sync"
 	"time"
 
-	"github.com/synnaxlabs/alamos"
 	"github.com/synnaxlabs/x/address"
 	"github.com/synnaxlabs/x/confluence"
 	"github.com/synnaxlabs/x/signal"
@@ -40,21 +39,17 @@ const (
 	// connection to the relay. A smaller buffer absorbs a brief consumer stall while
 	// bounding how stale buffered frames can get.
 	defaultStreamBufferSize = 100
-	// slowConsumerTimeout is the maximum amount of time the relay will wait for a
-	// consumer to receive a frame before dropping the frame.
-	slowConsumerTimeout = 20 * time.Millisecond
+	// defaultSlowConsumerTimeout is the default maximum amount of time the relay will
+	// wait for a consumer to receive a frame before dropping the frame.
+	defaultSlowConsumerTimeout = 20 * time.Millisecond
 )
 
-func openRelay(
-	sCtx signal.Context,
-	ins alamos.Instrumentation,
-	bufferSize, streamBufferSize int,
-) *relay {
+func openRelay(sCtx signal.Context, o *options) *relay {
 	delta := confluence.NewDynamicDeltaMultiplier[relayResponse](
-		slowConsumerTimeout,
-		ins,
+		o.slowConsumerTimeout,
+		o.Instrumentation,
 	)
-	writes := confluence.NewStream[relayResponse](bufferSize)
+	writes := confluence.NewStream[relayResponse](o.relayBufferSize)
 	delta.InFrom(writes)
 	delta.Flow(
 		sCtx,
@@ -62,7 +57,7 @@ func openRelay(
 		confluence.WithRetryOnPanic(),
 		confluence.WithAddress("relay"),
 	)
-	return &relay{delta: delta, inlet: writes, streamBufferSize: streamBufferSize}
+	return &relay{delta: delta, inlet: writes, streamBufferSize: o.streamBufferSize}
 }
 
 func (r *relay) connect() (confluence.Outlet[relayResponse], func()) {

--- a/cesium/streamer_test.go
+++ b/cesium/streamer_test.go
@@ -12,6 +12,7 @@ package cesium_test
 import (
 	"context"
 	"io"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -487,8 +488,9 @@ var _ = Describe("Streamer Behavior", func() {
 						// Writing past the relay's total buffered capacity would force
 						// the writer to block until the relay times out and drops
 						// frames for the stalled consumer, so undersized buffering
-						// surfaces as missing
-						// frames in the drain below.
+						// surfaces as missing frames in the drain below. The long
+						// slow-consumer timeout keeps the relay from dropping a frame
+						// when a scheduling stall delays the drain.
 						const frameCount int64 = 2 * bufferSize
 						subFS := MustSucceed(fs.Sub("slow-consumer"))
 						subDB := mustOpenDBOnFS(
@@ -496,6 +498,7 @@ var _ = Describe("Streamer Behavior", func() {
 							subFS,
 							cesium.WithRelayBufferSize(bufferSize),
 							cesium.WithStreamBufferSize(bufferSize),
+							cesium.WithSlowConsumerTimeout(10*time.Second),
 						)
 						key := GenerateChannelKey()
 						Expect(subDB.CreateChannel(


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4639](https://linear.app/synnax/issue/SY-4639/fix-flakey-cesium-test)

## Description

The `Slow Consumers` streamer spec raced the relay's hard-coded 20ms slow-consumer timeout: if a CI scheduling stall delayed the drain loop past 20ms, the relay dropped an in-flight frame and the spec failed. The timeout is now an injected DB option (`WithSlowConsumerTimeout`, 20ms default), and the spec sets it to 10 seconds so the drain always wins. A new spec covers validation of the option.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes the Cesium relay slow-consumer timeout configurable while retaining the 20 ms default.
- Validates that configured timeouts are positive.
- Sets a longer timeout in the buffering spec to prevent scheduling stalls from dropping frames.
- Passes the validated Cesium options directly to relay construction.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The new option preserves the previous default, is validated before relay construction, and is applied through the only relay initialization path.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| cesium/options.go | Adds the timeout option, default, validation, and public configuration function. |
| cesium/relay.go | Replaces the fixed timeout with the validated option while preserving other relay settings. |
| cesium/open.go | Passes the validated options object to relay construction. |
| cesium/open_test.go | Verifies that Cesium rejects a non-positive slow-consumer timeout. |
| cesium/streamer_test.go | Uses a long timeout to isolate the buffering behavior from CI scheduling stalls. |

<sub>Reviews (1): Last reviewed commit: ["SY-4639: Fix flakey Cesium slow-consumer..."](https://github.com/synnaxlabs/synnax/commit/6f79efb92ef26e8c61d8a12499eff39da80f8d8d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54864711)</sub>

<!-- /greptile_comment -->