### PR TITLE
SY-4634: Make sure RFC numbers don't conflict

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,9 +110,11 @@ reply is prose: it gets the same rules as a doc. Always write in sentence case i
 of title case for headings, titles, and menu options unless explicitly directed
 otherwise. Capitalize proper nouns and acronyms, including Synnax component names: Arc,
 Cesium, Aspen, Oracle, Pluto, Aether, Flux, Freighter, Alamos, Gorp, Drift, X, the
-Driver, the Core, and the Console. Third-party names are proper nouns too: Git, Go,
-gRPC, HashiCorp, Zod. Prefer referencing the Core as "the Core" / "a Core", instead of
-"server", "node", or "cluster", unless you are specifically writing about behavior of
+Driver, the Core, and the Console. Aether is always capitalized in prose, compounds
+included (the Aether binding, Aether-cached); only backticked identifiers and paths
+(`aether`, `flux.aether`) stay lowercase. Third-party names are proper nouns too: Git,
+Go, gRPC, HashiCorp, Zod. Prefer referencing the Core as "the Core" / "a Core", instead
+of "server", "node", or "cluster", unless you are specifically writing about behavior of
 multi-node clusters. If you are referring to code paths, then put those in backticks
 `x/go/gorp`.
 

--- a/docs/tech/rfc/0040-arc-function-call-unification.md
+++ b/docs/tech/rfc/0040-arc-function-call-unification.md
@@ -69,11 +69,10 @@ mirrored to `Config` in every `ExecBoth` symbol. Replace both with a single
 
 **Collapse the two analyzer hook surfaces.** A symbol that wants to validate its
 arguments (e.g. `status.set` constraining the `variant` literal; see
-[RFC 0037 §5.0.1](0037-arc-status-updates.md#501-literal-value-constraints)) registers
-`AnalyzeCall` for the parens form AND `AnalyzeFlowConfig` for the brace form. The two
-hooks walk different AST shapes to find the same argument and run the same literal
-check. Replace both with a single `AnalyzeArguments` hook that receives a unified
-`[]Argument` view.
+[RFC 0037](0037-arc-status-updates.md) §5.0.1) registers `AnalyzeCall` for the parens
+form AND `AnalyzeFlowConfig` for the brace form. The two hooks walk different AST shapes
+to find the same argument and run the same literal check. Replace both with a single
+`AnalyzeArguments` hook that receives a unified `[]Argument` view.
 
 ## 2 Non-goals
 

--- a/docs/tech/rfc/0051-pluto-visual-language.md
+++ b/docs/tech/rfc/0051-pluto-visual-language.md
@@ -1,9 +1,9 @@
-# 50 - Pluto Visual Language
+# 51 Pluto visual language
 
-**Feature Name**: Pluto Visual Language <br /> **Status**: Implemented <br /> **Start
-Date**: 2026-07-29 <br /> **Authors**: Emiliano Bonilla <br />
+- **Author**: Emiliano Bonilla
+- **Date**: 2026-07-29
 
-# 0 - Summary
+## 0 Summary
 
 This RFC re-architects the three systems that decide how every surface, control, and
 corner in Pluto and Console looks.
@@ -26,9 +26,9 @@ generated from the theme spec: `tiny`, `small`, `medium`, `large`, and `huge`, r
 Channel values, tier colors, and step sizes are tunable. The band roles, state rules,
 axes, tiers, and the ladder are the contract.
 
-# 1 - Motivation
+## 1 Motivation
 
-## 1.1 - The gray ramp
+### 1.1 The gray ramp
 
 A census of the pre-redesign ramp found structural problems, not value problems:
 
@@ -50,7 +50,7 @@ A census of the pre-redesign ramp found structural problems, not value problems:
 6. **Known bugs.** `theming/css.ts` generates the l9 alpha variants from l11, and
    `telem/control/Chip.tsx` references a nonexistent `--pluto-gray-l12`.
 
-## 1.2 - Clickables
+### 1.2 Clickables
 
 1. **The variant enum mixes three unrelated kinds of thing.** `filled | outlined | text`
    are an emphasis ladder; `preview` is an interactivity mode never written literally
@@ -58,7 +58,7 @@ A census of the pre-redesign ramp found structural problems, not value problems:
    eight edit-in-place Input sites whose CSS already half-lives in `input/Input.css`.
 2. **Four selection languages plus six strays.** A control tier, a subtle tier for tabs,
    a list-row tier inlined in `list/Item.css`, and then raw one-offs: `menu/Item.css`,
-   the console nav rail, the arc create modal, table alphas, DateTime day cells
+   the Console nav rail, the Arc create modal, table alphas, DateTime day cells
    selecting by variant swap, and Steps expressing progress via `disabled`.
 3. **`ghost` is a naming collision with the entire industry.** Everywhere else, ghost
    names a transparent low-emphasis variant (our `text`), and reveal-on-hover is a row
@@ -66,10 +66,11 @@ A census of the pre-redesign ramp found structural problems, not value problems:
    `KeyValueEditor.css` without the focus-visible reveal (keyboard-invisible delete
    buttons), and a third way in `label/Edit.css`.
 4. **Nested interactives work by eight unnamed mechanisms**, re-derived per site:
-   default stopPropagation, `propagateClick`, `preventClick`, per-site stopPropagation,
-   dblclick shields, a CSS `:active:not(:has())` exclusion, pointer-events, and
-   preventDefault-keep-drag. The pack z-index rules are `button`-tag-qualified, so
-   div-chassis Buttons silently miss them and have no built-in keyboard activation.
+   default `stopPropagation`, `propagateClick`, `preventClick`, per-site
+   `stopPropagation`, dblclick shields, a CSS `:active:not(:has())` exclusion,
+   `pointer-events`, and `preventDefault`-keep-drag. The pack z-index rules are
+   `button`-tag-qualified, so div-chassis Buttons silently miss them and have no
+   built-in keyboard activation.
 5. **Console re-derives house styles in CSS.** The quiet l9-to-l11 button four times,
    the pinned create-row three times, three competing toolbar-button definitions with
    one class declared in two files, filter chips byte-identical in three files, and a
@@ -79,7 +80,7 @@ A census of the pre-redesign ramp found structural problems, not value problems:
    zero CSS), and `Button.Toggle`'s `checkedVariant`/`uncheckedVariant` pair (both
    default outlined; paint comes from the checked class).
 
-## 1.3 - Corner radii
+### 1.3 Corner radii
 
 An audit found roughly 13 distinct corner sizes reached through two parallel unit
 systems: the px-emitted `--pluto-border-radius` token (frozen at 4px) and rem literals
@@ -94,27 +95,27 @@ Tailwind, Material 3, Radix Themes, Fluent 2, and Primer all use a small named l
 with roughly 1.5x steps. We align with Primer's shape, extended by the steps the audit
 showed in real use.
 
-# 2 - Vocabulary
+## 2 Vocabulary
 
-- **Slot**: one of the 12 ramp positions. **Band**: a contiguous group of slots sharing
+- **Slot**: One of the 12 ramp positions. **Band**: A contiguous group of slots sharing
   a role family.
-- **Surface**: a background something sits on (canvas, pane, dialog, chrome). **Fill**:
-  the background of an interactive component itself.
-- **Variant-var protocol**: the Button convention where variants set `--pluto-bg`,
+- **Surface**: A background something sits on (canvas, pane, dialog, chrome). **Fill**:
+  The background of an interactive component itself.
+- **Variant-var protocol**: The Button convention where variants set `--pluto-bg`,
   `--pluto-hover-bg`, `--pluto-active-bg` (and border equivalents) and shared rules swap
   them on hover and press.
-- **Variant**: the rest-state emphasis of a control's chassis, chosen statically at the
-  call site. **Tier**: the token set that paints the `selected` state for one family of
+- **Variant**: The rest-state emphasis of a control's chassis, chosen statically at the
+  call site. **Tier**: The token set that paints the `selected` state for one family of
   controls.
-- **Chassis**: the Button-rendered shell of a composite control (an input's frame, a
+- **Chassis**: The Button-rendered shell of a composite control (an input's frame, a
   tab, a tag, a list row), possibly rendered as a non-`button` element. An **interactive
   container** is a chassis that contains other interactive elements.
-- **Reveal**: the container-owned behavior that hides marked child actions until the
+- **Reveal**: The container-owned behavior that hides marked child actions until the
   container is hovered or the action is keyboard-focused.
 
-# 3 - Principles
+## 3 Principles
 
-## 3.1 - The gray ramp
+### 3.1 The gray ramp
 
 1. **One slot, one role.** A consumer that wants a different look moves to the slot
    whose role matches, never bends a slot's value.
@@ -132,7 +133,7 @@ showed in real use.
    legally sit on, placeholders included. Disabled text is exempt and becomes an alpha
    token rather than a slot.
 
-## 3.2 - Clickables
+### 3.2 Clickables
 
 1. **Two axes, never conflated.** Variant answers "how loud is this control at rest, as
    an action." A tier answers "what does on look like for this family." Every selectable
@@ -144,11 +145,11 @@ showed in real use.
    tier is a token set plus one rule mapping tokens onto the protocol.
 4. **The container owns nesting.** Conflict handling and keyboard contracts are
    properties of the container pattern, not per-call-site inventions.
-5. **Console composes; Pluto defines.** Console-only idioms get one named console
+5. **Console composes; Pluto defines.** Console-only idioms get one named Console
    definition built from Pluto parts. Pluto's vocabulary grows only for general-purpose
    needs.
 
-## 3.3 - Corner radii
+### 3.3 Corner radii
 
 1. **One ladder.** Every chrome corner speaks a named step or derives from one via
    `calc`.
@@ -160,9 +161,9 @@ showed in real use.
    (checkbox indicators, stadium pills, 50% circles, the schematic vessel percent
    system) are not ladder steps.
 
-# 4 - The gray ramp
+## 4 The gray ramp
 
-## 4.0 - The band table
+### 4.0 The band table
 
 | Slot | Band    | Role                                           |
 | ---- | ------- | ---------------------------------------------- |
@@ -179,10 +180,10 @@ showed in real use.
 | l10  | Text    | Primary body text                              |
 | l11  | Text    | Emphatic text (headings, selected rows)        |
 
-Selection lives off the gray ramp entirely; see 5.2. Disabled text is
+Selection lives off the gray ramp entirely; see §5.2. Disabled text is
 `--pluto-text-disabled` (l9 at 45% alpha), not a slot.
 
-## 4.1 - Value model
+### 4.1 Value model
 
 Values are generated in OKLCH from four sliders: floor lightness, per-slot chroma, band
 step sizes, and text anchors. Even perceptual steps inside a band, deliberate jumps
@@ -200,7 +201,7 @@ Dark surface and fill steps run 3.6 to 4.0 OKLab points, light steps 1.9 to 2.7,
 clears 4.5:1 against every surface in both themes, and the 22-point text chasms
 redistribute to steps that all land above AA.
 
-## 4.2 - Deleting the `contrast` prop
+### 4.2 Deleting the `contrast` prop
 
 With non-overlapping bands, a component's fixed slots work on every legal surface, so
 per-surface indexing machinery is unnecessary. The `contrast` prop, the `contrast-1/2/3`
@@ -208,7 +209,7 @@ CSS blocks, and the dead emitted classes are deleted; call sites migrate to noth
 escape hatch survives: the `Menu.background`-style context, kept for chrome that must
 know it sits on elevated l2.
 
-## 4.3 - Press policy
+### 4.3 Press policy
 
 Press is one ramp step past hover on the fill. The fill band is exposed as three tokens
 (`--pluto-fill-rest`, `--pluto-fill-hover`, `--pluto-fill-press`, mapping l3, l4, l5)
@@ -217,46 +218,46 @@ chrome steps it toward the canvas so its controls recess instead of lighten. Tex
 shadow variants rest transparent and join the band at hover. All seven old press
 vocabularies collapse into this rule; components with no press feedback gain it.
 
-## 4.4 - Focus model
+### 4.4 Focus model
 
 Two treatments, one geometry each:
 
-1. **Editing focus** (text fields, `:focus-within`, always on): the existing border swap
+1. **Editing focus** (text fields, `:focus-within`, always on): The existing border swap
    to primary plus the inset 0.5px shadow. `flush` inputs keep suppressing it.
-2. **Keyboard focus** (everything else, `:focus-visible` only): one rule,
+2. **Keyboard focus** (everything else, `:focus-visible` only): One rule,
    `outline: 1px solid var(--pluto-primary-z); outline-offset: 2px`. The gap is
    transparent, so the painted-gap halos die along with their guessed gap colors.
 
-## 4.5 - Migration map
+### 4.5 Migration map
 
 Old slots map to new slots by the role the site was actually using:
 
-| Old slot (role as used)       | New slot            |
-| ----------------------------- | ------------------- |
-| l0, l1, l2 as surfaces        | same                |
-| l1, l2 as component rest fill | l3                  |
-| l2, l3 as hover fill          | l4                  |
-| l3, l4 as pressed fill        | l5                  |
-| any slot as selected fill     | 5.2 selection tiers |
-| l4, l5 as border              | l6 or l7            |
-| l6, l7 as border              | l7 or l8            |
-| l7, l8 as text or icon        | l9                  |
-| l9 as secondary text          | l9                  |
-| l10, l11 as text              | same                |
+| Old slot (role as used)       | New slot             |
+| ----------------------------- | -------------------- |
+| l0, l1, l2 as surfaces        | same                 |
+| l1, l2 as component rest fill | l3                   |
+| l2, l3 as hover fill          | l4                   |
+| l3, l4 as pressed fill        | l5                   |
+| any slot as selected fill     | §5.2 selection tiers |
+| l4, l5 as border              | l6 or l7             |
+| l6, l7 as border              | l7 or l8             |
+| l7, l8 as text or icon        | l9                   |
+| l9 as secondary text          | l9                   |
+| l10, l11 as text              | same                 |
 
 Alpha variants follow their base slot.
 
-# 5 - Clickable vocabulary
+## 5 Clickable vocabulary
 
-## 5.1 - The emphasis ladder
+### 5.1 The emphasis ladder
 
 `Button.Variant = "filled" | "outlined" | "text"`. Default stays `outlined`.
 
-- `filled`: the primary action. Keeps its custom-color machinery and the press-and-hold
+- `filled`: The primary action. Keeps its custom-color machinery and the press-and-hold
   delay overlay.
-- `outlined`: the standard control. The only variant whose rest fill reads the theme
+- `outlined`: The standard control. The only variant whose rest fill reads the theme
   fill band.
-- `text`: the quiet action, transparent at rest. This is what the industry calls ghost;
+- `text`: The quiet action, transparent at rest. This is what the industry calls ghost;
   we keep the name `text` (roughly 130 call sites, Material precedent).
 
 `preview` becomes a boolean modifier on Button and Input, implying today's behavior:
@@ -272,7 +273,7 @@ chassis whose checked state speaks the control tier; the variant never swaps. Da
 day cells migrate from variant-swap selection to a real selected state, and Steps stops
 expressing progress through `disabled`.
 
-## 5.2 - Selection tiers
+### 5.2 Selection tiers
 
 Selection is a dedicated token family, not a gray slot. Three token sets live in
 `theming/theme.css` beside the fill band, each with `bg`, `hover-bg`, `active-bg`,
@@ -296,11 +297,11 @@ One shared rule per tier re-points the six protocol vars. `select/Button.css` an
 per-widget. Context overrides re-point tier tokens only; `panel/Mosaic.css`'s monochrome
 re-point of the overlaid leaf is the sanctioned example.
 
-Strays migrate: `menu/Item.css` and the console nav rail fill speak the list tier (the
-rail keeps its primary indicator ornament), and the arc create modal speaks the control
+Strays migrate: `menu/Item.css` and the Console nav rail fill speak the list tier (the
+rail keeps its primary indicator ornament), and the Arc create modal speaks the control
 tier. Table cells are an exception and keep their own selection paint.
 
-## 5.3 - Reveal
+### 5.3 Reveal
 
 The `ghost` prop and class are retired; the name is not reused. Reveal replaces them as
 a two-sided contract. The child action carries a marker, a `reveal` boolean on Button
@@ -311,7 +312,7 @@ trigger: hidden at rest, revealed on container hover and on the marked child's o
 Sites: list-row delete and favorite actions, KeyValueEditor rows, label editor rows, and
 the row-selection checkboxes previously using `ghost={!selected}`.
 
-## 5.4 - The interactive container pattern
+### 5.4 The interactive container pattern
 
 The div-chassis Button with manually restored semantics is the named pattern. No DOM
 restructure: ARIA has no legal nested-button DOM, and the alternatives (sibling plus
@@ -319,29 +320,29 @@ draft `aria-actions`, grid-role rework) either lack support or live on the defer
 list.
 
 The conflict zoo shrinks to three sanctioned mechanisms. **Child wins by default**:
-every Button stops propagation, so manual `stopPropagation` on Buttons migrates to
+Every Button stops propagation, so manual `stopPropagation` on Buttons migrates to
 nothing. **Parent yields or child shares, deliberately**: `preventClick` dead-zones a
 container that must yield to its children (selected tab, Boolean label), and
 `propagateClick` lets a child share its click with the row (menu items, metadata rows).
-**Non-Button nested controls shield themselves**: native inputs, drag handles, and
-editables keep explicit stopPropagation.
+**Non-Button nested controls shield themselves**: Native inputs, drag handles, and
+editables keep explicit `stopPropagation`.
 
 The chassis owns keyboard activation: a focusable Button rendered as a non-`button`
 element activates on Enter/Space from the component, and Tabs' hand-rolled handler
-migrates onto it. Each archetype declares a focus contract: tab (roving tabIndex, Delete
-closes), row (container focusable, revealed actions reachable via focus-visible), tag
-and input-shell (shell not focusable, inner control is). `el="div"` is Pluto-internal;
-console reaches the pattern only through named components. The pack z-index rules drop
-their `button` tag qualification so div-chassis members participate.
+migrates onto it. Each archetype declares a focus contract: tab (roving `tabIndex`,
+Delete closes), row (container focusable, revealed actions reachable via focus-visible),
+tag and input-shell (shell not focusable, inner control is). `el="div"` is
+Pluto-internal; the Console reaches the pattern only through named components. The pack
+z-index rules drop their `button` tag qualification so div-chassis members participate.
 
 **Inline glyph actions.** The micro-buttons nested inside chassis (tab close, tag close,
 the legend visibility toggle) are a named sub-pattern: a small square `text` Button with
 fill feedback suppressed and all feedback on the glyph (l9 rest, l11 hover, `error-z`
-press when destructive), `tabIndex -1`, revealed via 5.3, keyboard path on the parent.
+press when destructive), `tabIndex -1`, revealed via §5.3, keyboard path on the parent.
 Not a variant and not a tier. One shared definition replaces the chromeless `!important`
 blocks in `tabs/Tabs.css` and `tag/Tag.css`.
 
-## 5.5 - Checkbox and switch
+### 5.5 Checkbox and switch
 
 Checked paint stays their own primary-fill language, outside the tiers: a checked
 checkbox is form data, not selection. The label-chassis DOM share (`el="label"` +
@@ -349,24 +350,24 @@ checkbox is form data, not selection. The label-chassis DOM share (`el="label"` 
 contract. In selectable rows the row speaks the list tier while the checkbox speaks
 checkbox language; there is no double-painting.
 
-## 5.6 - Console consolidation
+### 5.6 Console consolidation
 
-One named definition per idiom, at the console platform layer:
+One named definition per idiom, at the Console platform layer:
 
-- **Quiet button** (l9 text, l11 on hover): the four CSS copies die.
-- **Pinned create-row** (button dressed as the terminal list row): the three geometry
+- **Quiet button** (l9 text, l11 on hover): The four CSS copies die.
+- **Pinned create-row** (button dressed as the terminal list row): The three geometry
   copies die.
-- **Toolbar button**: the `ToolbarButton` / `CopyLinkToolbarButton` twins collapse into
+- **Toolbar button**: The `ToolbarButton` / `CopyLinkToolbarButton` twins collapse into
   the `Toolbar.Action` family; the double-declared `.console-toolbar-button` class dies.
-- **Filter chips**: one class replaces three byte-identical copies.
-- The arc toolbar adopts `Empty.Action` instead of its hand-rolled copy.
+- **Filter chips**: One class replaces three byte-identical copies.
+- The Arc toolbar adopts `Empty.Action` instead of its hand-rolled copy.
 
-Feature wrappers with real logic (TareButton, EnableDisableButton, StartStopButton,
-ConfigureButton) stay where they are.
+Feature wrappers with real logic (`TareButton`, `EnableDisableButton`,
+`StartStopButton`, `ConfigureButton`) stay where they are.
 
-# 6 - Radius scale
+## 6 Radius scale
 
-## 6.1 - Tokens
+### 6.1 Tokens
 
 `theme.sizes.border.radius` is a five-field object of rem multiples emitted by
 `toCSSVars` as:
@@ -384,14 +385,14 @@ The bare token remains the theme default, so `pluto--rounded`, the roughly 50 ex
 `var()` sites, and the canvas renderer keep reading "the default" without naming a step.
 The canvas mirror computes `Math.round(radius.tiny * base)` px.
 
-## 6.2 - API
+### 6.2 API
 
 `rounded?: boolean | number | Component.Size` on `Flex.Box`. `true` applies the default
 class and a size name applies `pluto--rounded-<size>`. Both are class-based, so pack
 corner inheritance and seam-squaring rules can still override them; the number form
 stays an inline `${n}rem` escape hatch for derived one-offs.
 
-## 6.3 - Role assignment
+### 6.3 Role assignment
 
 | Step   | Roles                                                                    |
 | ------ | ------------------------------------------------------------------------ |
@@ -405,7 +406,7 @@ Filled buttons deliberately sit one step above other button variants; the fill c
 enough visual mass that the rounder corner reads as character rather than inconsistency.
 This is the only shape distinction between variants of one control.
 
-# 7 - Implementation
+## 7 Implementation
 
 Landed as a single-branch cutover, no coexistence. The ramps and token families are
 generated into `theming/base/theme.ts` and `theming/theme.css`; every CSS literal and
@@ -413,17 +414,17 @@ numeric `rounded` prop migrates to a step. The keyboard-focus rule is declared b
 adopting component rather than one global selector, so opting a component in stays a
 local change. The propagation and activation matrix gains spec coverage.
 
-The kill list is everything named dead in 1.2, plus the three reveal CSS copies,
+The kill list is everything named dead in §1.2, plus the three reveal CSS copies,
 Button's `--shadow` block, the six stray selection rules, the duplicated quiet-button,
 create-row, toolbar-button, and filter-chip definitions, `--pluto-pack-br`, the
 `CSS.rounded` and `CSS.sharp` helpers, and the `0.66666rem` hack.
 
 Deliberate pixel changes beyond the token swap: tooltip and Monaco hover 8px to 6px,
-mosaic create button 9px to 6px, arc type chip and gradient-stop marker 3px to 4px, nav
+mosaic create button 9px to 6px, Arc type chip and gradient-stop marker 3px to 4px, nav
 connection badge 4px to 6px. All changes are internal to the monorepo; no persisted
 data, wire format, or external API is touched.
 
-# 8 - What This RFC Does Not Cover
+## 8 What this RFC does not cover
 
 - Where color returns to the UI, and a possible warmer light theme.
 - The deferred a11y program: listbox and tree ARIA, roving rows, dialog focus traps,
@@ -433,56 +434,56 @@ data, wire format, or external API is touched.
   symbol, macOS traffic lights).
 - Dialog, menu-frame, and list behavior; only their selection paint is in scope.
 
-# 9 - Resolved Decisions
+## 9 Resolved decisions
 
-## 9.1 - The gray ramp
+### 9.1 The gray ramp
 
-- **Deep re-architecture over values-only retune.** A retune inherits the role
+- **Deep re-architecture over values-only retune**: A retune inherits the role
   conflicts; every slot keeps colliding consumers. The cost is a large one-time
   migration.
-- **Selection left the gray ramp.** The interview locked pressed and selected merged at
+- **Selection left the gray ramp**: The interview locked pressed and selected merged at
   l5. On real controls a selected toggle in gray l5 was indistinguishable from a pressed
   one and read as disabled beside its unselected siblings. Selection became the tinted
   tier family, at the price of one more token family to maintain.
-- **Contrast prop deleted, not fixed.** Fixing it means maintaining a Spectrum-style
+- **Contrast prop deleted, not fixed**: Fixing it means maintaining a Spectrum-style
   contrast-indexed token matrix nobody else in our reference set carries.
-- **Floor stays below the industry cluster.** Linear sits at OKLab L 0.139 and Radix
+- **Floor stays below the industry cluster**: Linear sits at OKLab L 0.139 and Radix
   slate at 0.179; we float l0 at ~0.115. Lifting to their levels reads brighter but
   sacrifices the dark-cockpit character and viz color pop.
-- **Whisper tint over assertive tint.** Primer's chroma 0.014+ visibly colors the UI and
+- **Whisper tint over assertive tint**: Primer's chroma 0.014+ visibly colors the UI and
   competes with schematic and channel colors, which need neutral backdrops to pop.
-- **No transform on press.** Linear ships `scale(0.97)`; fractional scaling shimmers
+- **No transform on press**: Linear ships `scale(0.97)`; fractional scaling shimmers
   0.5px hairline borders, and press stays purely in the color system.
 
-## 9.2 - Clickables
+### 9.2 Clickables
 
 - **Growing the fused variant enum** (rungs for selected-tab, quiet, and so on):
-  rejected. Encoding a runtime state as a variant forces variant-swapping (the DateTime
+  Rejected. Encoding a runtime state as a variant forces variant-swapping (the DateTime
   fossil) and cannot express selected-hover and selected-press without a cross-product
   leak (Carbon's `danger--tertiary`). The cost is that a selected tab visually sits
   between filled and outlined, so readers hold two loudness scales.
-- **Collapsing to fewer selection tiers** (tabs adopt the control tier): rejected. It
+- **Collapsing to fewer selection tiers** (tabs adopt the control tier): Rejected. It
   would re-litigate two approved looks to fix the one unapproved tier, and the industry
   deliberately keeps toggle, tab, and list selection as distinct languages.
-- **Renaming `text` to `ghost`** for industry alignment: rejected. Roughly 130 call
+- **Renaming `text` to `ghost`** for industry alignment: Rejected. Roughly 130 call
   sites of churn, and reusing a name that meant something else here for years plants a
   second confusion.
-- **Reveal as a Button prop under a new name**: rejected as the defining mechanism.
+- **Reveal as a Button prop under a new name**: Rejected as the defining mechanism.
   Ownership had to move to the container to make the keyboard reveal structural.
-- **DOM restructure for nested interactives**: rejected for now. `aria-actions` is a
+- **DOM restructure for nested interactives**: Rejected for now. `aria-actions` is a
   draft and the grid rework lives on the deferred a11y list. By strict ARIA the div
   chassis is a workaround, and we are hardening it rather than replacing it.
-- **Table selection as a fourth tier**: rejected. Migrating table cells would force the
+- **Table selection as a fourth tier**: Rejected. Migrating table cells would force the
   Button chassis onto a grid whose focus, spanning, and edit semantics it does not
   model.
 
-## 9.3 - Corner radii
+### 9.3 Corner radii
 
-- **Rem over px.** A px ladder preserved 4px on a clean grid but froze corners while
+- **Rem over px**: A px ladder preserved 4px on a clean grid but froze corners while
   every other dimension scales, and the codebase already contained a hand-rolled scaling
   4px. The cost is one off-grid fraction (2/3rem), confined to the theme spec.
-- **4px kept.** A pure 0.5rem-grid ladder (3/6/9/12) was rejected: 4px is the
+- **4px kept**: A pure 0.5rem-grid ladder (3/6/9/12) was rejected: 4px is the
   established control radius, and keeping it is worth the fractional rem step.
-- **Size names over role names.** Role-named tokens (control/chip/card/panel) would
+- **Size names over role names**: Role-named tokens (control/chip/card/panel) would
   self-document but would be the only role-named size tokens in the system and would
-  fight the `Component.Size` vocabulary. The role map lives in 6.3 instead.
+  fight the `Component.Size` vocabulary. The role map lives in §6.3 instead.

--- a/docs/tech/rfc/0053-oracle-explicit-schema-versioning.md
+++ b/docs/tech/rfc/0053-oracle-explicit-schema-versioning.md
@@ -2,9 +2,9 @@
 
 - **Author**: Patrick Dotson
 - **Date**: 2026-08-11
-- **Related**: [RFC 0033 - Oracle migrations](0033-oracle-migrations.md),
+- **Related**: [RFC 0033 - Oracle migration system](0033-oracle-migrations.md),
   [RFC 0042 - Core structure refactor](0042-core-structure-refactor.md),
-  [RFC 0048 - Oracle predecessor-chain versioning](0048-oracle-predecessor-chain-versioning.md)
+  [RFC 0048 - Oracle predecessor-chain type versioning](0048-oracle-predecessor-chain-versioning.md)
 
 ## 0 Summary
 
@@ -169,7 +169,7 @@ field-marshal injection, and the analyzer ban on marshal tags in live schemas.
   files and the §2.4 gates.
 - **RFC 0042**: §5.6 is superseded. Cross-resource compatibility is written into each
   version file as explicit pins, propagated by the pin-currency gate.
-- **RFC 0048**: §4.0's two-tier baseline collapses into the chain, and §6.2a's rejection
+- **RFC 0048**: §4.0's two-tier baseline collapses into the chain, and §6.3's rejection
   of transcribed history is superseded by §2.6. Everything else stands.
 
 ## 3 Implementation phases

--- a/docs/tech/rfc/0054-flux-read-unification.md
+++ b/docs/tech/rfc/0054-flux-read-unification.md
@@ -340,7 +340,8 @@ client-and-pluto internal, so no migration or compatibility window is needed.
 - **The ordered-retrieval Core program**: Exposing `OrderBy` and after-cursor pagination
   through the service layer, API, schemas, and clients, backed by Gorp's sorted indexes
   (RFC 0034). Deferred; the fill primitive is designed for it to slot into.
-- **Cache parity in the Python, Go, or C++ clients**:
+- **Cache parity in the Python, Go, or C++ clients**: The cache and both read idioms
+  ship in `client/ts` only.
 - **Telemetry reads**: The telem client, its frame cache, and its streamer are out of
   scope.
 - **Multiplayer presence and conflict resolution** (RFC 0041 remains the seam).

--- a/docs/tech/rfc/0054-flux-read-unification.md
+++ b/docs/tech/rfc/0054-flux-read-unification.md
@@ -19,7 +19,7 @@ remaining program. This RFC completes that cutover and amends it in three places
    classification then applies unchanged: enumerable lists patch membership locally on
    change events, search lists stay refetch-maintained with cancellation.
 3. **Domain query definitions become worker-safe and are bound twice**: `Flux` (React)
-   mints suspense hooks and selectors from them. A lowercase `flux` aether binding mints
+   mints suspense hooks and selectors from them. A lowercase `flux` Aether binding mints
    reactive reads for worker components, killing the hand-rolled lifecycle code that
    currently leaves worker visuals blind to deletes and renames.
 
@@ -44,7 +44,7 @@ cancellation, so a stale response can overwrite a newer one, and a virtualizer
 fetch-more can swallow a pending search inside the shared debounce. These defects are
 the visible flashing in remote selection dialogs.
 
-On the aether side, the worker constructs its own full client, but nothing on the worker
+On the Aether side, the worker constructs its own full client, but nothing on the worker
 uses `onChange` or `getCached`. Every read is retrieve-once, guarded by per-source
 `valid` flags and generation counters that re-implement query lifecycle by hand. Channel
 metadata is fetched on both threads through both caches for the same component, and a
@@ -102,7 +102,7 @@ strategy can later replace.
    encodes pagination.
 5. **Freshness classification is universal**: The three rules of RFC 0047 §5.1 govern
    lists exactly as they govern every other read.
-6. **Definitions are written once and bound twice**: React and aether consume the same
+6. **Definitions are written once and bound twice**: React and Aether consume the same
    per-domain definition through thin, lifecycle-native bindings.
 7. **The client surface is the only cache API** (RFC 0047 P1, P4, reaffirmed): Flux on
    either thread holds no cache and no lifecycle.
@@ -271,17 +271,17 @@ status keys, search and fetch-more stop sharing one debounce, the virtualizer's
 measurement gap is bridged, and a reopened dialog reconciles its input with the query it
 left behind.
 
-### 5.5 The aether binding
+### 5.5 The Aether binding
 
 **The definition split.** Each domain's definition moves to a worker-safe module
 (lowercase namespace, no React imports), following the existing casing law that
 lowercase means worker-legal. The React `queries.ts` files mint hooks from the
 definition; the worker imports the definition itself.
 
-**The binding.** A lowercase `flux` module gives aether components the same
+**The binding.** A lowercase `flux` module gives Aether components the same
 boilerplate-kill React gets: subscribe on mount, unsubscribe on teardown, dedupe by
 deep-equal query, initial value from `getCached` with a fetch on miss, and a change push
-the component answers with `requestRender`. No suspense and no `Result`: aether's
+the component answers with `requestRender`. No suspense and no `Result`: Aether's
 lifecycle is `afterUpdate`/`afterDelete`, and its degradation paths are its own. The
 three consumers with hand-rolled lifecycles migrate onto it: the control controller's
 bare channel retrieves, the telem remote sources' `valid`/generation bookkeeping, and
@@ -315,7 +315,7 @@ query cache by design.
 
 ## 6 Implementation phases
 
-- **Phase 1: The definition split and the aether binding.** Mechanical relocation of
+- **Phase 1: The definition split and the Aether binding.** Mechanical relocation of
   definitions to worker-safe modules with React hooks re-minted on top, then the
   lowercase binding and the three worker migrations. Additive and green throughout;
   isolates the only wire-adjacent risk (worker bundle composition) from behavior
@@ -359,7 +359,7 @@ client-and-pluto internal, so no migration or compatibility window is needed.
    document truth; deletion is a pushed state so a hold can never mask it, and RFC 0047
    §5.3 already serves the cache during gaps. The trade is one refetch window of
    possible staleness.
-4. **Raw client reads on aether, rejected**: It pushed subscription lifecycle onto every
+4. **Raw client reads on Aether, rejected**: It pushed subscription lifecycle onto every
    worker component, which is exactly the boilerplate the `valid`-flag code proves
    nobody writes correctly by hand.
 5. **A shared cross-thread cache, rejected**: `getCached` is synchronous; sharing forces

--- a/docs/tech/rfc/0054-flux-read-unification.md
+++ b/docs/tech/rfc/0054-flux-read-unification.md
@@ -1,41 +1,40 @@
-# 55 - Flux Read Unification
+# 54 Flux read unification
 
-**Feature Name**: Suspense-Primary Reads, Ordered List Sets, and the Aether Flux Binding
-<br /> **Status**: Draft <br /> **Start Date**: 2026-08-05 <br /> **Authors**: Emiliano
-Bonilla <br />
+- **Author**: Emiliano Bonilla
+- **Date**: 2026-08-05
 
-# 0 - Summary
+## 0 Summary
 
-RFC 0046 moved caching into `client/ts` and left the read-surface cutover as its
+RFC 0047 moved caching into `client/ts` and left the read-surface cutover as its
 remaining program. This RFC completes that cutover and amends it in three places:
 
-1. **Two read idioms, chosen by where the read happens.** Render-path reads suspend: one
+1. **Two read idioms, chosen by where the read happens**: Render-path reads suspend: one
    primary `use(query): Data` plus named selectors minted from the same definition.
    Event and callback reads use the domain client directly. The `Result`-shaped primary
    and its stateful, effect, and observable variants are deleted; a non-suspending
    `useResult` remains for decoration reads (§5.1). The planned non-reactive `useGet`
    never ships: the client cache is the non-reactive read API.
-2. **A list answer is one ordered set of keys per base query.** Offset and limit stop
+2. **A list answer is one ordered set of keys per base query**: Offset and limit stop
    being cache identity and become fetch hints that fill a window of the set. Freshness
    classification then applies unchanged: enumerable lists patch membership locally on
    change events, search lists stay refetch-maintained with cancellation.
-3. **Domain query definitions become worker-safe and are bound twice.** `Flux` (React)
+3. **Domain query definitions become worker-safe and are bound twice**: `Flux` (React)
    mints suspense hooks and selectors from them. A lowercase `flux` aether binding mints
    reactive reads for worker components, killing the hand-rolled lifecycle code that
    currently leaves worker visuals blind to deletes and renames.
 
-# 1 - Motivation
+## 1 Motivation
 
 Both read idioms have coexisted since the SY-4493 chain landed, and the split is
 lopsided in the wrong direction. The `Result`-shaped `useRetrieve` has ~45 call sites
 while the suspended read it was meant to yield to has 3. The suspense machinery that
-actually carries the console is `useEnsureRetrieved` (13 sites, six identical
+actually carries the Console is `useEnsureRetrieved` (13 sites, six identical
 `Suspended.tsx` wrappers) feeding 60 `createSelector` definitions, each of which
 hand-writes a `subscribe` closure restating what the domain's `createRetrieve` config
 already knows. A selector read cold returns nothing usable, so cache warming is an
 undocumented correctness requirement enforced by convention.
 
-Lists never joined the 0046 freshness model. `List.usePager` defaults `searchTerm` to
+Lists never joined the 0047 freshness model. `List.usePager` defaults `searchTerm` to
 `""`, which classifies every paged list as server-computed, so each loaded page is its
 own cache entry with a whole-table subscription and a debounced wholesale refetch. One
 mutation anywhere in a table refetches every loaded page. Offset is cache identity, so
@@ -52,28 +51,28 @@ metadata is fetched on both threads through both caches for the same component, 
 rename or delete observed by the worker cache never reaches a rendered value, line, or
 log.
 
-# 2 - Vocabulary
+## 2 Vocabulary
 
-- **Render-path read**: a read whose result is returned from a component's render.
-- **Event read**: a read performed inside a callback, effect, or utility, off the render
+- **Render-path read**: A read whose result is returned from a component's render.
+- **Event read**: A read performed inside a callback, effect, or utility, off the render
   path.
-- **Definition**: a domain's `{ retrieve, subscribe, getCached }` closures over the
+- **Definition**: A domain's `{ retrieve, subscribe, getCached }` closures over the
   domain client. React-free by construction.
-- **Selector**: a named, projected render-path read minted from a definition.
-- **Decoration read**: a render-path read that decorates another domain's record (a
+- **Selector**: A named, projected render-path read minted from a definition.
+- **Decoration read**: A render-path read that decorates another domain's record (a
   channel name on a graph node, a tick type on an axis) where suspension is illegal and
   no boundary can enumerate the keys. Serves the cache, fetches in the background, and
   reads absence as a loading or error `Result`.
-- **Base query**: a list query stripped of `offset` and `limit`.
-- **Window**: the slice of an ordered set a consumer currently renders. Filled by
+- **Base query**: A list query stripped of `offset` and `limit`.
+- **Window**: The slice of an ordered set a consumer currently renders. Filled by
   fetches; never part of cache identity.
-- **Enumerable list**: a base query whose membership and order the client can compute
+- **Enumerable list**: A base query whose membership and order the client can compute
   (`matches` plus a replicable sort). Rule 2.
-- **Search list**: a base query whose order is server-ranked (`searchTerm` set). Rule 3.
+- **Search list**: A base query whose order is server-ranked (`searchTerm` set). Rule 3.
 
-# 3 - Prior Art
+## 3 Prior art
 
-**Reads.** RFC 0036 introduced the suspended path; RFC 0046 rebased both idioms on the
+**Reads.** RFC 0036 introduced the suspended path; RFC 0047 rebased both idioms on the
 client cache and scheduled this cutover. React's own direction (`use()`,
 render-as-you-fetch) treats suspension as the default read posture with boundaries
 owning degradation, which is the posture adopted here.
@@ -87,30 +86,30 @@ take on. We adopt Firestore's shape with the maintenance client-side, where the 
 stream already delivers every event, and keep rule 3's refetch as the seam a server-push
 strategy can later replace.
 
-# 4 - Principles
+## 4 Principles
 
-1. **Two idioms and one sanctioned middle.** A read either suspends on the render path
+1. **Two idioms and one sanctioned middle**: A read either suspends on the render path
    or calls the client in an event. The decoration read is the single exception (RD11),
    and no other shape survives.
-2. **Suspension is a boundary concern.** Only boundary-level components suspend.
+2. **Suspension is a boundary concern**: Only boundary-level components suspend.
    Fine-grained render loops (React Flow nodes, list rows) read warm caches and never
    suspend. Where no boundary can enumerate the keys a loop will reference, the
    decoration read (`useResult`) fetches from the leaf without suspending.
-3. **A mounted selector always returns `Selected`.** Deletion throws typed. A cold miss
+3. **A mounted selector always returns `Selected`**: Deletion throws typed. A cold miss
    is a composition bug and throws loud. A transient invalidation holds the last live
    value until the maintained repair lands.
-4. **A list answer is an ordered set; windows are fetch hints.** Cache identity never
+4. **A list answer is an ordered set; windows are fetch hints**: Cache identity never
    encodes pagination.
-5. **Freshness classification is universal.** The three rules of RFC 0046 §5.1 govern
+5. **Freshness classification is universal**: The three rules of RFC 0047 §5.1 govern
    lists exactly as they govern every other read.
-6. **Definitions are written once and bound twice.** React and aether consume the same
+6. **Definitions are written once and bound twice**: React and aether consume the same
    per-domain definition through thin, lifecycle-native bindings.
-7. **The client surface is the only cache API** (RFC 0046 P1, P4, reaffirmed). Flux on
+7. **The client surface is the only cache API** (RFC 0047 P1, P4, reaffirmed): Flux on
    either thread holds no cache and no lifecycle.
 
-# 5 - Design
+## 5 Design
 
-## 5.0 - The read model
+### 5.0 The read model
 
 Every current read maps onto one idiom:
 
@@ -128,20 +127,20 @@ Every current read maps onto one idiom:
 `Result` survives on the write path, where pending state is genuinely inline
 (`createUpdate`, `createDispatch`, the form save leg), and on the decoration read, where
 a leaf renders its own loading and error. The form retrieve leg suspends (carried from
-RFC 0046). Lists stay imperative (RFC 0046 RD13, reaffirmed).
+RFC 0047). Lists stay imperative (RFC 0047 RD13, reaffirmed).
 
-## 5.1 - The suspended primary
+### 5.1 The suspended primary
 
 `createRetrieve` takes a definition and returns the read surface:
 
-- **`use(query): Data`**: serves a cached answer synchronously, otherwise suspends on
+- **`use(query): Data`**: Serves a cached answer synchronously, otherwise suspends on
   the fetch; subscribes and re-renders on change; throws `DeletedError` on a tombstone
   and `DisconnectedError` when a client-requiring read has none. Today's `useSuspended`
   semantics under the primary name. Named for the call site: `Channel.use({ key })`.
-- **`useEnsure(query): void`**: warms the cache without subscribing. It is a correctness
+- **`useEnsure(query): void`**: Warms the cache without subscribing. It is a correctness
   requirement for selector-reading subtrees (Principle 2) and a batching tool that
   collapses N child suspensions into one fetch.
-- **`useResult(query): Result<Data>`**: the decoration read. Serves the cached answer,
+- **`useResult(query): Result<Data>`**: The decoration read. Serves the cached answer,
   subscribes for changes, and starts a deduped background fetch on a cold miss, sharing
   the suspended path's in-flight and settled bookkeeping. Never suspends and never
   throws. A miss reads as loading, a deleted record and a failed fetch as an error, and
@@ -156,21 +155,21 @@ RFC 0046). Lists stay imperative (RFC 0046 RD13, reaffirmed).
   member it delegates to.
 
 The create-broadcast wait (a cached not-found briefly awaiting its create event) and the
-typed-error contract carry over from RFC 0046 §5.5 unchanged.
+typed-error contract carry over from RFC 0047 §5.5 unchanged.
 
 Three rules the implementation forced:
 
-- **The decoration read carries a `Result`, not `Data | undefined`.** A bare `undefined`
+- **The decoration read carries a `Result`, not `Data | undefined`**: A bare `undefined`
   collapses four states a leaf must tell apart: not fetched yet, deleted, fetch failed,
   and no client. Every other flux hook already returned a `Result`, so the decoration
   read adopting one closes the gap instead of widening it. The data inside is still
   `Data | undefined`, so this is a widening of the read surface, not an escape from one:
   the earlier rejection of `undefined`-returning selectors does not survive it.
-- **Settled answers.** A definition whose `retrieve` result never lands in the cache
+- **Settled answers**: A definition whose `retrieve` result never lands in the cache
   (the current user, a group's ID) is kept in the per-client settled map and served from
   there. `useResult` re-renders itself on settle, since no subscription announces an
   answer the cache never saw. Such an answer is served once and never updated.
-- **Answers built per call need `equal`.** A `getCached` that allocates a fresh array or
+- **Answers built per call need `equal`**: A `getCached` that allocates a fresh array or
   object every call breaks `useSyncExternalStore`; the definition supplies `equal` so
   the previous answer is held when the next compares equal. The same pressure applies to
   the client: a filter query it cannot prove complete must return undefined rather than
@@ -184,7 +183,7 @@ Three rules the implementation forced:
 `renderHookSuspended`, which renders inside an awaited `act` and returns the same result
 object.
 
-## 5.2 - Selectors
+### 5.2 Selectors
 
 The `createRetrieve` return gains a selector factory. A selector shares the definition's
 wiring and projects the answer:
@@ -196,7 +195,7 @@ export const useName = retrieve.createSelector((panel) => panel.name);
 - Same subscription and cache access as `use`; re-renders only when the selected slice
   changes, gated by an optional equality function. The transform memoization and
   `Scope.bindSelector` sugar survive as they are.
-- **Selectors never suspend.** Suspension inside React Flow rendering causes
+- **Selectors never suspend**: Suspension inside React Flow rendering causes
   concurrent-rendering errors, so selectors are warm-cache reads and the parent boundary
   owns the fetch (Principle 2).
 - The contract (Principle 3): cold miss throws typed (`NotFoundError` class), a
@@ -216,7 +215,7 @@ The 60 standalone `createSelector` definitions migrate onto minted selectors and
 `Flux.createSelector`'s hand-supplied `subscribe`/`select` form is deleted along with
 the `useGet` pair element.
 
-## 5.3 - Event reads
+### 5.3 Event reads
 
 The domain client is the whole event-read API. `client.<domain>.retrieve` is cached,
 deduped, and instant on a maintained hit; `client.<domain>.getCached` is the synchronous
@@ -226,15 +225,15 @@ effect, selector `useGet`) migrate to it. No `useGet` hook ships anywhere: a wra
 adding nothing over `Synnax.use()` plus a client call is a pass-through with no boundary
 to enforce.
 
-## 5.4 - Lists
+### 5.4 Lists
 
 **The ordered set.** The query package gains list spaces keyed by base query. An entry
-holds an ordered key array; content stays in tables (RFC 0046 P5). `offset` and `limit`
+holds an ordered key array; content stays in tables (RFC 0047 P5). `offset` and `limit`
 are stripped from the hash and become fetch hints: a window fill retrieves a slice,
 writes records through the table, and merges keys into the set at their sorted
 positions.
 
-**Freshness.** Classification is unchanged from RFC 0046 §5.1:
+**Freshness.** Classification is unchanged from RFC 0047 §5.1:
 
 - **Enumerable lists** declare `matches` and a sort comparator. Set and delete events
   insert, move, or remove keys exactly. No refetch, no page entries, no drift: page
@@ -245,13 +244,13 @@ positions.
   newer answer.
 
 **Window fills.** Offset fills cannot be the end state for enumerable lists. The API
-exposes no ordering contract: with no `OrderBy` set, gorp walks keyspace order
+exposes no ordering contract: with no `OrderBy` set, Gorp walks keyspace order
 (`x/go/gorp/retrieve.go`), which is UUID byte order for ranges, and no service retrieve
 sets one. An offset into an order the client does not display fetches the wrong slice,
 and an unanchored offset silently skips records that shift under concurrent mutation.
 The designed fill contract is a **cursor fill**: order by a declared sorted index, after
 a cursor key, limit N. Gorp already implements this (`SortedIndex.Ordered(dir)` with
-`.After(cursor)`, RFC 0034); the core program exposing it through the service layer,
+`.After(cursor)`, RFC 0034); the Core program exposing it through the service layer,
 API, and schemas is deferred (§7). Until it lands, enumerable lists hydrate wholesale:
 the base query is fetched once and windowed client-side, which is correct for the small
 domains dialogs actually enumerate (panels, ranges, devices, racks). Domains too large
@@ -272,7 +271,7 @@ status keys, search and fetch-more stop sharing one debounce, the virtualizer's
 measurement gap is bridged, and a reopened dialog reconciles its input with the query it
 left behind.
 
-## 5.5 - The aether binding
+### 5.5 The aether binding
 
 **The definition split.** Each domain's definition moves to a worker-safe module
 (lowercase namespace, no React imports), following the existing casing law that
@@ -295,9 +294,9 @@ caches fed by the same change stream are that replication, already built. The te
 frame cache is untouched: it caches series buffers, not documents, and stays beside the
 query cache by design.
 
-## 5.6 - The kill list
+### 5.6 The kill list
 
-- `useRetrieve` (Result form), `useRetrieveStateful`, `useRetrieveEffect`,
+- `useRetrieve` (`Result` form), `useRetrieveStateful`, `useRetrieveEffect`,
   `useRetrieveObservable`, `useObservableRetrieve`, and the observable read plumbing in
   `retrieve.ts` (`useObservableBase`, result mapping on the old read path). The
   decoration read keeps a `Result`; what dies is the observable machinery under it.
@@ -314,72 +313,73 @@ query cache by design.
   unused surface, `useListItem`'s standalone export, and the parameter/return types
   nothing imports.
 
-# 6 - Implementation Phases
+## 6 Implementation phases
 
-1. **The definition split and the aether binding.** Mechanical relocation of definitions
-   to worker-safe modules with React hooks re-minted on top, then the lowercase binding
-   and the three worker migrations. Additive and green throughout; isolates the only
-   wire-adjacent risk (worker bundle composition) from behavior changes.
-2. **The React read cutover.** Suspended semantics under the primary name, variants and
-   standalone selectors deleted, selector factory in, `useGet` dead, and the ~120 call
-   sites migrated. Atomic, zero coexistence: no site is left on a legacy idiom and no
-   compatibility alias ships. This program ships the two phases above: the query-model
-   cutover is the whole scope. The list set model (§5.4) is locked design but lands as
-   its own follow-on program: list spaces in the query package, the flux list rebind,
-   and the pager and dialog repairs. It follows the cutover so the new read substrate
-   soaks first, and the ordered-retrieval core program (§5.4) is sequenced after that,
-   swapping in behind the fill primitive.
+- **Phase 1: The definition split and the aether binding.** Mechanical relocation of
+  definitions to worker-safe modules with React hooks re-minted on top, then the
+  lowercase binding and the three worker migrations. Additive and green throughout;
+  isolates the only wire-adjacent risk (worker bundle composition) from behavior
+  changes.
+- **Phase 2: The React read cutover.** Suspended semantics under the primary name,
+  variants and standalone selectors deleted, selector factory in, `useGet` dead, and the
+  ~120 call sites migrated. Atomic, zero coexistence: no site is left on a legacy idiom
+  and no compatibility alias ships. This program ships the two phases above: the
+  query-model cutover is the whole scope. The list set model (§5.4) is locked design but
+  lands as its own follow-on program: list spaces in the query package, the flux list
+  rebind, and the pager and dialog repairs. It follows the cutover so the new read
+  substrate soaks first, and the ordered-retrieval Core program (§5.4) is sequenced
+  after that, swapping in behind the fill primitive.
 
 No wire formats, persisted schemas, or server behavior change; every phase is
 client-and-pluto internal, so no migration or compatibility window is needed.
 
-# 7 - What This RFC Does Not Cover
+## 7 What this RFC does not cover
 
-- **Server-side query subscriptions.** Rule 3's refetch remains the seam a server-push
+- **Server-side query subscriptions**: Rule 3's refetch remains the seam a server-push
   membership strategy swaps in behind.
-- **The ordered-retrieval core program.** Exposing `OrderBy` and after-cursor pagination
-  through the service layer, API, schemas, and clients, backed by gorp's sorted indexes
+- **The ordered-retrieval Core program**: Exposing `OrderBy` and after-cursor pagination
+  through the service layer, API, schemas, and clients, backed by Gorp's sorted indexes
   (RFC 0034). Deferred; the fill primitive is designed for it to slot into.
-- **Cache parity in the Python, Go, or C++ clients.**
-- **Telemetry reads.** The telem client, its frame cache, and its streamer are out of
+- **Cache parity in the Python, Go, or C++ clients**:
+- **Telemetry reads**: The telem client, its frame cache, and its streamer are out of
   scope.
-- **Multiplayer presence and conflict resolution** (RFC 0040 remains the seam).
+- **Multiplayer presence and conflict resolution** (RFC 0041 remains the seam).
 
-# 8 - Resolved Decisions
+## 8 Resolved decisions
 
-1. **Suspending selectors, rejected.** Suspension inside React Flow rendering causes
+1. **Suspending selectors, rejected**: Suspension inside React Flow rendering causes
    concurrent-rendering errors. The cost is that `useEnsure` stays a correctness
    requirement for selector subtrees rather than an optimization; boundaries own every
    fetch.
-2. **The non-reactive `useGet`, planned in RFC 0046 and removed.** It was conceived when
+2. **The non-reactive `useGet`, planned in RFC 0047 and removed**: It was conceived when
    the cache lived in flux. With the client owning the cache, a hook wrapping
    `Synnax.use()` plus one client call enforces no boundary; the sites it was meant to
    absorb already call the client.
-3. **Throwing on transient invalidation, rejected.** The gap is cache bookkeeping, not
-   document truth; deletion is a pushed state so a hold can never mask it, and RFC 0046
+3. **Throwing on transient invalidation, rejected**: The gap is cache bookkeeping, not
+   document truth; deletion is a pushed state so a hold can never mask it, and RFC 0047
    §5.3 already serves the cache during gaps. The trade is one refetch window of
    possible staleness.
-4. **Raw client reads on aether, rejected.** It pushed subscription lifecycle onto every
+4. **Raw client reads on aether, rejected**: It pushed subscription lifecycle onto every
    worker component, which is exactly the boilerplate the `valid`-flag code proves
    nobody writes correctly by hand.
-5. **A shared cross-thread cache, rejected.** `getCached` is synchronous; sharing forces
+5. **A shared cross-thread cache, rejected**: `getCached` is synchronous; sharing forces
    async messaging or replication, and two lazy caches over one change stream are the
    cheapest correct replication.
-6. **Two parallel list models, rejected as framing.** One model (ordered set plus
+6. **Two parallel list models, rejected as framing**: One model (ordered set plus
    windows) under the existing three-rule classification; "enumerable versus search" is
    rule 2 versus rule 3, not new machinery.
-7. **Per-page cache identity, rejected.** Offset-keyed entries are why drift, refetch
+7. **Per-page cache identity, rejected**: Offset-keyed entries are why drift, refetch
    storms, and the filter-versus-offset hole exist. Pagination is a fetch concern.
-8. **Suspense for lists, rejection reaffirmed** (RFC 0046 RD13): a requery under a
+8. **Suspense for lists, rejection reaffirmed** (RFC 0047 RD13): A requery under a
    boundary would blow away rendered rows on every keystroke.
-9. **Inline select args on `use`, rejection carried** from the SY-4494 interview: render
+9. **Inline select args on `use`, rejection carried** from the SY-4494 interview: Render
    granularity lives in named selectors only.
-10. **Offset fills for enumerable lists, rejected as the end state.** The core has no
+10. **Offset fills for enumerable lists, rejected as the end state**: The Core has no
     API-level ordering contract, and an unanchored offset skips shifted records
     silently. Cursor fills over server-declared sorted indexes are the contract; the
-    core exposure is deferred, so wholesale hydration (small domains) and hardened rule
+    Core exposure is deferred, so wholesale hydration (small domains) and hardened rule
     3 (channels) bridge until it lands.
-11. **Boundary key enumeration for decoration reads, rejected.** The selector-plus-
+11. **Boundary key enumeration for decoration reads, rejected**: The selector-plus-
     `useEnsure` shape requires the plot or graph boundary to enumerate every channel key
     its loop references, and the ensure re-suspends the whole subtree each time the set
     grows (picking a channel on a node blanks the editor). Hand-rolled per-site
@@ -387,16 +387,16 @@ client-and-pluto internal, so no migration or compatibility window is needed.
     `useResult` is the sanctioned middle Principle 1 names: minted once from the
     definition, stateless over the client cache, non-suspending, `Result`-reading.
 
-# 9 - Open Questions
+## 9 Open questions
 
-1. **Cancellation mechanics** for hardened rule-3 refetch: an `AbortSignal` threaded
+1. **Cancellation mechanics** for hardened rule-3 refetch: An `AbortSignal` threaded
    through the fetch primitive versus space-level generation counters.
-2. **The window-fill contract**: how `hasMore` and totals are expressed once fills are
+2. **The window-fill contract**: How `hasMore` and totals are expressed once fills are
    cursor-based, and what a fill returns when the set already covers it.
-3. **Sorted-index coverage**: which domains declare which server-side sorted indexes
+3. **Sorted-index coverage**: Which domains declare which server-side sorted indexes
    when the ordered-retrieval program lands, and how a client comparator is checked
    against the index it mirrors.
-4. **Cache memory bounds** (RFC 0046 OQ1, carried): ordered sets add key arrays to the
+4. **Cache memory bounds** (RFC 0047 OQ1, carried): Ordered sets add key arrays to the
    tables and tombstones already retained for the session.
-5. **Stale-window presentation**: whether rows held during a search flight render
+5. **Stale-window presentation**: Whether rows held during a search flight render
    plainly or visibly dimmed.

--- a/docs/tech/rfc/0055-client-telemetry-layer.md
+++ b/docs/tech/rfc/0055-client-telemetry-layer.md
@@ -256,12 +256,12 @@ in flight instead of starting a second one.
 
 ### 4.6 The Pluto side: Bindings replace the wrapper client
 
-`pluto/src/telem/client/` is deleted: `Core`, `NoopClient`, the telem aether provider's
-wrapper, and the frame cache all go. The telem aether provider opens a Feed from the
+`pluto/src/telem/client/` is deleted: `Core`, `NoopClient`, the telem Aether provider's
+wrapper, and the frame cache all go. The telem Aether provider opens a Feed from the
 current client with the GL series transform and closes it when the client identity
 changes, so the transform lives with the thread that renders. The `prevCore` deadlock
 and the NoopClient that throws `NotFoundError` into every symbol mounting during login
-both disappear structurally. The close stays fire-and-forget, because the aether
+both disappear structurally. The close stays fire-and-forget, because the Aether
 lifecycle hooks are synchronous, and reports its failures to the status aggregator.
 
 What Pluto keeps is a lowercase, worker-safe lifecycle binding in the `flux.Retrieve`
@@ -400,7 +400,7 @@ leaves the lie on screen: the customer's frozen valve would render identically. 
 data" treatment is the smallest scope at which the redesign reaches the operator.
 
 **A main-thread GL transform, rejected**: Only the worker-side Feed carries the GL
-transform: aether-cached series arrive render-ready, main-thread Feeds serve full
+transform: Aether-cached series arrive render-ready, main-thread Feeds serve full
 fidelity. Applying it on both threads would lossily downcast `float64` for exactly the
 consumers (export, analysis) that need raw values, and the two caches share no memory
 regardless.

--- a/docs/tech/rfc/0055-client-telemetry-layer.md
+++ b/docs/tech/rfc/0055-client-telemetry-layer.md
@@ -1,4 +1,4 @@
-# 56 Client telemetry layer
+# 55 Client telemetry layer
 
 - **Author**: Emiliano Bonilla
 - **Date**: 2026-08-06
@@ -57,22 +57,22 @@ The audit showed this is not one bug but the layer's character:
    (`pluto/src/vis/line/aether/line.ts:285-289`). Every other symbol drops telemetry
    errors and keeps drawing.
 
-No RFC governs this layer: RFC 0013 sketched its ancestor, RFC 0055 fenced telemetry
+No RFC governs this layer: RFC 0013 sketched its ancestor, RFC 0054 fenced telemetry
 reads out of scope, and the package README's Caching, Batching, and Concurrency sections
 are empty. The query cache (RFC 0047) has since matured beneath it, duplicating
 everything the batcher does except cross-call coalescing.
 
 ## 2 Vocabulary
 
-- **Feed**: the stateful frame consumer a caller opens over the framer transport: cached
+- **Feed**: The stateful frame consumer a caller opens over the framer transport: cached
   historical reads plus durable multiplexed subscriptions.
-- **Frame cache**: per-channel rolling buffers of `Series`, split into a dynamic leading
+- **Frame cache**: Per-channel rolling buffers of `Series`, split into a dynamic leading
   buffer receiving live writes and static historical buffers.
-- **MultiplexedStreamer**: maps N subscriptions onto one shared hardened streamer
+- **MultiplexedStreamer**: Maps N subscriptions onto one shared hardened streamer
   carrying the union of all demand.
-- **Demand set**: the union of keys across live subscriptions; the client-side intent
+- **Demand set**: The union of keys across live subscriptions; the client-side intent
   the socket key set must converge to.
-- **Data-plane status**: per-key state describing the flow of data (resolving, live,
+- **Data-plane status**: Per-key state describing the flow of data (resolving, live,
   stalled, erroring), never document truths like "channel does not exist".
 
 ## 3 Principles
@@ -86,7 +86,7 @@ everything the batcher does except cross-call coalescing.
    becomes that key's status, not an exception unwinding a batch or a loop.
 3. **The frame cache serves data, not metadata**: It may read channel records
    internally, but its public surface is key-addressed and data-plane only. Consumers
-   get metadata from the query cache through `client.channels` and flux, the one live,
+   get metadata from the query cache through `client.channels` and Flux, the one live,
    signal-invalidated copy of every channel record (RFC 0047).
 4. **Anomalies are loud**: Alignment regressions, data-type changes, and dropped frames
    reset buffers and log; they never silently discard samples. Failed lookups are never
@@ -254,7 +254,7 @@ re-enters the demand that triggered it. The `demand` returned by `createStreamer
 memoizes the open before the opener body runs, so the re-entrant demand joins the open
 in flight instead of starting a second one.
 
-### 4.6 The pluto side: bindings replace the wrapper client
+### 4.6 The Pluto side: Bindings replace the wrapper client
 
 `pluto/src/telem/client/` is deleted: `Core`, `NoopClient`, the telem aether provider's
 wrapper, and the frame cache all go. The telem aether provider opens a Feed from the
@@ -264,14 +264,14 @@ and the NoopClient that throws `NotFoundError` into every symbol mounting during
 both disappear structurally. The close stays fire-and-forget, because the aether
 lifecycle hooks are synchronous, and reports its failures to the status aggregator.
 
-What pluto keeps is a lowercase, worker-safe lifecycle binding in the `flux.Retrieve`
+What Pluto keeps is a lowercase, worker-safe lifecycle binding in the `flux.Retrieve`
 shape: created in `afterUpdate`, deduped when props are unchanged, torn down in
 `afterDelete`, calling `requestRender` on delivery. Telem sources become thin
 compositions of two such bindings: a `flux.Retrieve` over the channel query definition
-for metadata (the RFC 0055 §5.5 migration, killing the hand-rolled `valid` flags) and a
+for metadata (the RFC 0054 §5.5 migration, killing the hand-rolled `valid` flags) and a
 Feed subscription for data. A null client renders as disconnected status through the
-binding. The metadata half waits on the binding itself, which the RFC 0055 read
-unification introduces; until then the sources keep the hand-rolled flags (phase 4).
+binding. The metadata half waits on the binding itself, which the RFC 0054 read
+unification introduces; until then the sources keep the hand-rolled flags (Phase 4).
 
 ### 4.7 Status surface
 
@@ -282,7 +282,7 @@ merge this with the metadata query's verdict (missing, deleted, disconnected) an
 one status to the component layer.
 
 The `Subscription` status surface ships with the module and stays unconsumed until
-phase 5. A source's only sink today is an adder that appends to the notification list,
+Phase 5. A source's only sink today is an adder that appends to the notification list,
 and the transitions above are normal operation, so a twenty-channel plot would raise
 forty notifications on mount and twenty more on every reconnect. The plumbing lands with
 its destination: one new visual treatment on schematic symbols, a "no data" state
@@ -296,25 +296,25 @@ module.
 
 ## 5 Implementation phases
 
-- **Phase 1: additive substrate.** The subscription, cache, and reader machinery in
-  `client/ts` with full spec coverage against a live core, and cross-call coalescing at
+- **Phase 1: Additive substrate.** The subscription, cache, and reader machinery in
+  `client/ts` with full spec coverage against a live Core, and cross-call coalescing at
   the query table fetch seam. Nothing consumes the new module yet; the tree stays green
   and the machinery reviews as one unit.
-- **Phase 2: atomic pluto cutover.** Telem sources and log sources rewritten onto the
+- **Phase 2: Atomic Pluto cutover.** Telem sources and log sources rewritten onto the
   new module; deletion of `pluto/src/telem/client/`, `NoopClient`,
   `DebouncedBatchRetriever`, and `createDebouncedBatchRetriever`; spec migration. No
-  coexistence window. The sources keep their hand-rolled `valid` flags until phase 4.
-- **Phase 3: the framer merge and the cycle severing.** The module moves into `framer`
+  coexistence window. The sources keep their hand-rolled `valid` flags until Phase 4.
+- **Phase 3: The framer merge and the cycle severing.** The module moves into `framer`
   as the `Feed` with `openFeed` on `framer.Client`; `Synnax` drops its auto-built
-  instance and the construction-site transform option; the pluto telem provider opens
+  instance and the construction-site transform option; the Pluto telem provider opens
   its own Feed with the GL transform; `channel.Retriever`, `ClusterRetriever`, and the
   query cache's structural stream interfaces are deleted per §4.5.
-- **Phase 4: flux metadata bindings.** Telem sources resolve channels through the
+- **Phase 4: Flux metadata bindings.** Telem sources resolve channels through the
   `flux.Retrieve` binding instead of a direct `channels.retrieve` call, which deletes
   the hand-rolled `valid` flags and closes the §1 no-retry defect. Blocked on the
-  worker-safe `flux.Retrieve` binding, which lands with the RFC 0055 read unification.
-- **Phase 5: symbol status treatment.** The "no data" visual state and status plumbing
-  into schematic symbols. Split from phase 3 so rendering regressions bisect separately.
+  worker-safe `flux.Retrieve` binding, which lands with the RFC 0054 read unification.
+- **Phase 5: Symbol status treatment.** The "no data" visual state and status plumbing
+  into schematic symbols. Split from Phase 3 so rendering regressions bisect separately.
 
 **Compatibility.** No schema or persisted format changes, but one payload semantic does:
 a streamed series now carries the time range the index established for its write group,
@@ -353,8 +353,8 @@ These exports leave the public client surface: `channel.Retriever`,
 
 ## 7 Resolved decisions
 
-**Redesign in place inside pluto, rejected**: Metadata caching and connection lifecycle
-are now client-owned, so keeping the machinery in pluto means re-duplicating both or
+**Redesign in place inside Pluto, rejected**: Metadata caching and connection lifecycle
+are now client-owned, so keeping the machinery in Pluto means re-duplicating both or
 reaching down through the boundary. The trade is real (`client/ts` grows a stateful
 subsystem), but the machinery belongs beside the transport it consumes.
 

--- a/docs/tech/rfc/0056-task-autosave-deploy-on-start.md
+++ b/docs/tech/rfc/0056-task-autosave-deploy-on-start.md
@@ -395,7 +395,7 @@ The controls themselves become:
 
 ### 6.2 State matrix
 
-| running | drifted | visible controls         | action sent            |
+| Running | Drifted | Visible controls         | Action sent            |
 | ------- | ------- | ------------------------ | ---------------------- |
 | no      | n/a     | play                     | start (Driver syncs)   |
 | yes     | no      | pause                    | stop                   |

--- a/docs/tech/rfc/0056-task-autosave-deploy-on-start.md
+++ b/docs/tech/rfc/0056-task-autosave-deploy-on-start.md
@@ -1,4 +1,4 @@
-# 57 Task autosave with deploy-on-start
+# 56 Task autosave with deploy-on-start
 
 - **Author**: Emiliano Bonilla
 - **Date**: 2026-07-13

--- a/docs/tech/rfc/0057-control-state-service.md
+++ b/docs/tech/rfc/0057-control-state-service.md
@@ -233,7 +233,7 @@ Python gets the retrieve and nothing else. A live mirror on `Controller`, stream
 sequential assignment from the visualization palette and the user's legend overrides
 (`pluto/src/telem/control/aether/state.ts:186,125`), and it drops the tracker, the
 client, the transfer observer, and the `get` accessors. It is renamed `Control.Colors`
-in React and `control.Colors` in aether, since the namespace already carries "control".
+in React and `control.Colors` in Aether, since the namespace already carries "control".
 
 Assignment stays sequential rather than hashing the subject key. The palette holds 14
 colors, so a hash collides between two subjects with about even odds by the fifth

--- a/docs/tech/rfc/0057-control-state-service.md
+++ b/docs/tech/rfc/0057-control-state-service.md
@@ -1,10 +1,10 @@
-# 58 Control state service
+# 57 Control state service
 
 - **Author**: Emiliano Bonilla
 - **Date**: 2026-08-14
 - **Related**: [RFC 0032 - Telemetry bypass](0032-telemetry-bypass.md),
   [RFC 0047 - Client cache, unified reads, and Console session state](0047-client-cache-unified-reads-session-state.md),
-  [RFC 0056 - Client telemetry layer](0056-client-telemetry-layer.md)
+  [RFC 0055 - Client telemetry layer](0055-client-telemetry-layer.md)
 
 ## 0 Summary
 
@@ -54,7 +54,7 @@ Three consequences follow.
   (`cesium/control.go:70-73`, `cesium/writer_stream.go:444`, `:961`). All three exist
   only because the reporter is also a writer.
 
-RFC 0056 §6 deferred "migrating the control controller, control state, and lineplot
+RFC 0055 §6 deferred "migrating the control controller, control state, and lineplot
 range provider off their raw `Synnax` streamers". This RFC is the control-state half of
 that follow-on.
 
@@ -286,12 +286,12 @@ Core.
   the need for republication in §4.2 and fix every signals channel at once, and it is
   probably the right long-term fix, but it changes the semantics of every metadata
   channel in the system.
-- Moving control state onto the RFC 0056 `framer.Feed`. Control state is metadata and
+- Moving control state onto the RFC 0055 `framer.Feed`. Control state is metadata and
   belongs on the query cache's socket, not the telemetry feed.
 - A live control-state mirror in Python. The retrieve ships (§4.5); streaming
   `sy_control` through the `Controller`'s receiver has no caller today.
 - The control controller and the lineplot range provider, the other two migrations RFC
-  0056 §6 deferred.
+  0055 §6 deferred.
 
 ## 7 Resolved decisions
 


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4634](https://linear.app/synnax/issue/SY-4634/make-sure-rfc-numbers-dont-conflict)

## Description

Two RFCs merged in the old dated format and broke the number sequence: the Pluto visual
language RFC collided with 0050 (Console multi-window), and the Flux read unification
RFC sat at 0055 over a gap at 0054. 0051 was free because the PR that claimed it closed
unmerged.

- Renumber: Pluto visual language → 0051, Flux read unification → 0054, and shift the
  tail down one (client telemetry 0055, task autosave 0056, control state 0057). The
  corpus is now gapless through 0057.
- Restyle both movers to the `docs/tech/rfc/CLAUDE.md` conventions: bullet front
  matter, numbered `## N Title` headings, colon-form definition lists, § citations.
  Section numbers are preserved, and stale cross-RFC citations are corrected.
- Fix convention violations in the RFCs merged after the standardization pass: wrong
  Related-link titles and a dead §6.2a citation in 0053, casing in 0055, a missed
  renumber reference in 0057, an anchor-linked § citation in 0040, and lowercase table
  headers in 0056.

Note: open PR #2274 still carries old-format `0038-260425-*` files that will collide
with 0038 on merge.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR resolves conflicting RFC identifiers and makes the numbered corpus gapless through RFC 0057. It also restyles the two moved RFCs and corrects cross-references, titles, section citations, and casing across the affected documents.
- Renumbers the Pluto visual-language RFC to 0051 and Flux read unification to 0054.
- Shifts client telemetry, task autosave, and control state to 0055–0057.
- Aligns affected RFCs with repository formatting and citation conventions.
- Corrects stale RFC numbers, section references, related-link titles, and table-header casing.

<h3>Confidence Score: 5/5</h3>

The documentation-only PR appears safe to merge, with the renumbered files, inbound references, and corrected section citations remaining consistent.

No concrete broken link, incorrect citation, formatting-rule violation, security issue, or runtime-impacting defect remains in the accepted review findings.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/tech/rfc/0051-pluto-visual-language.md | Renumbers and comprehensively restyles the Pluto visual-language RFC without leaving identified stale inbound references. |
| docs/tech/rfc/0054-flux-read-unification.md | Renumbers and restyles the Flux read-unification RFC while correcting its citations to the cache and multiplayer RFCs. |
| docs/tech/rfc/0053-oracle-explicit-schema-versioning.md | Corrects related RFC titles and updates the superseded-history citation to the existing RFC 0048 §6.3. |
| docs/tech/rfc/0055-client-telemetry-layer.md | Moves the client telemetry RFC into the corrected sequence and applies terminology casing fixes. |
| docs/tech/rfc/0056-task-autosave-deploy-on-start.md | Moves the task autosave RFC into the corrected sequence and normalizes changed table headers. |
| docs/tech/rfc/0057-control-state-service.md | Moves the control-state RFC into the corrected sequence and updates its telemetry RFC reference. |
| docs/tech/rfc/0040-arc-function-call-unification.md | Converts an anchor-linked section reference to the repository’s plain-text section-citation convention. |

<sub>Reviews (1): Last reviewed commit: ["SY-4634: Capitalize the state-matrix tab..."](https://github.com/synnaxlabs/synnax/commit/0bc995ab1be0bd1ed3aa8b440176b30c9482d3ea) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54864787)</sub>

<!-- /greptile_comment -->