### PR TITLE
SY-4640: Fix failing Windows Oracle tests

### DIFF
--- a/oracle/cmd/root_test.go
+++ b/oracle/cmd/root_test.go
@@ -14,7 +14,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -22,6 +21,7 @@ import (
 	"github.com/synnaxlabs/oracle/format"
 	"github.com/synnaxlabs/oracle/pipeline"
 	"github.com/synnaxlabs/oracle/plugin"
+	. "github.com/synnaxlabs/oracle/testutil"
 	. "github.com/synnaxlabs/x/testutil"
 )
 
@@ -243,26 +243,13 @@ var _ = Describe("fmt command with explicit file arguments", Ordered, func() {
 var _ = Describe("fmt command discovery error", Ordered, func() {
 	BeforeAll(func() {
 		ShouldNotLeakGoroutines()
-		if os.Geteuid() == 0 {
-			Skip("filesystem permissions are bypassed when running as root")
-		}
-		if runtime.GOOS == "windows" {
-			Skip("chmod cannot remove directory read permission on Windows")
-		}
 		repoDir, cleanup := setupMiniRepo("0.53.4", map[string]string{
 			"synnax/user.oracle": "User struct {\n    key uuid\n}\n",
 		})
+		DeferCleanup(cleanup)
 		locked := filepath.Join(repoDir, "schemas", "locked")
 		Expect(os.MkdirAll(locked, 0o755)).To(Succeed())
-		Expect(os.Chmod(locked, 0o000)).To(Succeed())
-		DeferCleanup(func() {
-			if locked != "" {
-				Expect(os.Chmod(locked, 0o755)).To(Succeed())
-			}
-			if cleanup != nil {
-				cleanup()
-			}
-		})
+		DenyDirRead(locked)
 	})
 
 	It("propagates the recursive-discovery error when no arguments are given", func() {

--- a/oracle/cmd/root_test.go
+++ b/oracle/cmd/root_test.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -244,6 +245,9 @@ var _ = Describe("fmt command discovery error", Ordered, func() {
 		ShouldNotLeakGoroutines()
 		if os.Geteuid() == 0 {
 			Skip("filesystem permissions are bypassed when running as root")
+		}
+		if runtime.GOOS == "windows" {
+			Skip("chmod cannot remove directory read permission on Windows")
 		}
 		repoDir, cleanup := setupMiniRepo("0.53.4", map[string]string{
 			"synnax/user.oracle": "User struct {\n    key uuid\n}\n",

--- a/oracle/paths/paths_test.go
+++ b/oracle/paths/paths_test.go
@@ -42,9 +42,12 @@ var _ = Describe("Paths", func() {
 		It("Should fall back to walking up for a .git entry", func() {
 			// An empty .git directory is not a valid repository, so `git rev-parse`
 			// fails and RepoRoot falls back to the directory walk.
+			// TempDir must be created before the chdir-back cleanup is registered:
+			// cleanups run LIFO, and Windows cannot delete the temp dir while it is
+			// still the working directory.
+			dir := GinkgoT().TempDir()
 			origWd := MustSucceed(os.Getwd())
 			DeferCleanup(func() { Expect(os.Chdir(origWd)).To(Succeed()) })
-			dir := GinkgoT().TempDir()
 			Expect(os.MkdirAll(filepath.Join(dir, ".git"), 0o755)).To(Succeed())
 			nested := filepath.Join(dir, "a", "b")
 			Expect(os.MkdirAll(nested, 0o755)).To(Succeed())
@@ -54,9 +57,11 @@ var _ = Describe("Paths", func() {
 		})
 
 		It("Should error outside any git repository", func() {
+			// TempDir before the chdir-back cleanup, for the same LIFO reason as above.
+			dir := GinkgoT().TempDir()
 			origWd := MustSucceed(os.Getwd())
 			DeferCleanup(func() { Expect(os.Chdir(origWd)).To(Succeed()) })
-			Expect(os.Chdir(GinkgoT().TempDir())).To(Succeed())
+			Expect(os.Chdir(dir)).To(Succeed())
 			Expect(paths.RepoRoot()).Error().
 				To(MatchError(ContainSubstring("no .git entry found")))
 		})

--- a/oracle/paths/paths_test.go
+++ b/oracle/paths/paths_test.go
@@ -42,9 +42,6 @@ var _ = Describe("Paths", func() {
 		It("Should fall back to walking up for a .git entry", func() {
 			// An empty .git directory is not a valid repository, so `git rev-parse`
 			// fails and RepoRoot falls back to the directory walk.
-			// TempDir must be created before the chdir-back cleanup is registered:
-			// cleanups run LIFO, and Windows cannot delete the temp dir while it is
-			// still the working directory.
 			dir := GinkgoT().TempDir()
 			origWd := MustSucceed(os.Getwd())
 			DeferCleanup(func() { Expect(os.Chdir(origWd)).To(Succeed()) })
@@ -57,7 +54,6 @@ var _ = Describe("Paths", func() {
 		})
 
 		It("Should error outside any git repository", func() {
-			// TempDir before the chdir-back cleanup, for the same LIFO reason as above.
 			dir := GinkgoT().TempDir()
 			origWd := MustSucceed(os.Getwd())
 			DeferCleanup(func() { Expect(os.Chdir(origWd)).To(Succeed()) })

--- a/oracle/pipeline/pipeline_test.go
+++ b/oracle/pipeline/pipeline_test.go
@@ -12,6 +12,7 @@ package pipeline_test
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"sync"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -504,6 +505,9 @@ var _ = Describe("pipeline.DiscoverSchemas", func() {
 	It("returns a wrapped error when a schema subdirectory cannot be read", func() {
 		if os.Geteuid() == 0 {
 			Skip("filesystem permissions are bypassed when running as root")
+		}
+		if runtime.GOOS == "windows" {
+			Skip("chmod cannot remove directory read permission on Windows")
 		}
 		repoRoot := MustSucceed(os.MkdirTemp("", "discover"))
 		locked := filepath.Join(repoRoot, "schemas", "locked")

--- a/oracle/pipeline/pipeline_test.go
+++ b/oracle/pipeline/pipeline_test.go
@@ -12,13 +12,13 @@ package pipeline_test
 import (
 	"os"
 	"path/filepath"
-	"runtime"
 	"sync"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/synnaxlabs/oracle/pipeline"
 	"github.com/synnaxlabs/oracle/plugin"
+	. "github.com/synnaxlabs/oracle/testutil"
 	"github.com/synnaxlabs/x/errors"
 	"github.com/synnaxlabs/x/set"
 	. "github.com/synnaxlabs/x/testutil"
@@ -503,20 +503,13 @@ var _ = Describe("pipeline.DiscoverSchemas", func() {
 	})
 
 	It("returns a wrapped error when a schema subdirectory cannot be read", func() {
-		if os.Geteuid() == 0 {
-			Skip("filesystem permissions are bypassed when running as root")
-		}
-		if runtime.GOOS == "windows" {
-			Skip("chmod cannot remove directory read permission on Windows")
-		}
 		repoRoot := MustSucceed(os.MkdirTemp("", "discover"))
-		locked := filepath.Join(repoRoot, "schemas", "locked")
-		Expect(os.MkdirAll(locked, 0o755)).To(Succeed())
-		Expect(os.Chmod(locked, 0o000)).To(Succeed())
 		DeferCleanup(func() {
-			Expect(os.Chmod(locked, 0o755)).To(Succeed())
 			Expect(os.RemoveAll(repoRoot)).To(Succeed())
 		})
+		locked := filepath.Join(repoRoot, "schemas", "locked")
+		Expect(os.MkdirAll(locked, 0o755)).To(Succeed())
+		DenyDirRead(locked)
 
 		Expect(pipeline.DiscoverSchemas(repoRoot)).Error().
 			To(MatchError(ContainSubstring("walk schema directory")))

--- a/oracle/plugin/go/imex/imex_test.go
+++ b/oracle/plugin/go/imex/imex_test.go
@@ -401,7 +401,7 @@ Symbol struct {
 					3: logChain(true),
 				})
 				Expect(p.Generate(req)).Error().To(MatchError(
-					ContainSubstring("versions/v3/migrate.go"),
+					ContainSubstring(filepath.FromSlash("versions/v3/migrate.go")),
 				))
 			},
 		)

--- a/oracle/testutil/helpers.go
+++ b/oracle/testutil/helpers.go
@@ -13,6 +13,9 @@ import (
 	"context"
 	"go/parser"
 	"go/token"
+	"os"
+	"os/exec"
+	"runtime"
 	"strings"
 
 	"github.com/onsi/ginkgo/v2"
@@ -114,6 +117,33 @@ func MustContentOf(resp *plugin.Response, pathSuffix string) string {
 	gomega.Expect(content).
 		NotTo(gomega.BeEmpty(), "no file found with suffix: %s", pathSuffix)
 	return content
+}
+
+// DenyDirRead revokes read permission on dir so directory listings fail, and
+// registers a DeferCleanup that restores access. It skips the calling spec when
+// running as root on Unix, where permission checks are bypassed.
+func DenyDirRead(dir string) {
+	ginkgo.GinkgoHelper()
+	if runtime.GOOS == "windows" {
+		// chmod cannot remove read permission on Windows; deny the Everyone SID
+		// (S-1-1-0) list-directory access via an ACL entry instead.
+		gomega.Expect(
+			exec.Command("icacls", dir, "/deny", "*S-1-1-0:(RD)").Run(),
+		).To(gomega.Succeed())
+		ginkgo.DeferCleanup(func() {
+			gomega.Expect(
+				exec.Command("icacls", dir, "/remove:d", "*S-1-1-0").Run(),
+			).To(gomega.Succeed())
+		})
+		return
+	}
+	if os.Geteuid() == 0 {
+		ginkgo.Skip("filesystem permissions are bypassed when running as root")
+	}
+	gomega.Expect(os.Chmod(dir, 0o000)).To(gomega.Succeed())
+	ginkgo.DeferCleanup(func() {
+		gomega.Expect(os.Chmod(dir, 0o755)).To(gomega.Succeed())
+	})
 }
 
 // ContentExpectation provides fluent assertions for generated content.

--- a/oracle/testutil/helpers.go
+++ b/oracle/testutil/helpers.go
@@ -119,9 +119,9 @@ func MustContentOf(resp *plugin.Response, pathSuffix string) string {
 	return content
 }
 
-// DenyDirRead revokes read permission on dir so directory listings fail, and
-// registers a DeferCleanup that restores access. It skips the calling spec when
-// running as root on Unix, where permission checks are bypassed.
+// DenyDirRead revokes read permission on dir so directory listings fail, and registers
+// a DeferCleanup that restores access. It skips the calling spec when running as root
+// on Unix, where permission checks are bypassed.
 func DenyDirRead(dir string) {
 	ginkgo.GinkgoHelper()
 	if runtime.GOOS == "windows" {

--- a/oracle/testutil/helpers_test.go
+++ b/oracle/testutil/helpers_test.go
@@ -11,6 +11,8 @@ package testutil_test
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -392,6 +394,15 @@ var _ = Describe("MustGenerate", func() {
 		source := fmt.Sprintf(multipleStructsTemplate, domainDirectives["go"])
 		resp := MustGenerate(ctx, source, "multi", loader, p)
 		Expect(resp.Files).To(HaveLen(2))
+	})
+})
+
+var _ = Describe("DenyDirRead", func() {
+	It("should make directory listings fail", func() {
+		locked := filepath.Join(GinkgoT().TempDir(), "locked")
+		Expect(os.Mkdir(locked, 0o755)).To(Succeed())
+		DenyDirRead(locked)
+		Expect(os.ReadDir(locked)).Error().To(MatchError(os.ErrPermission))
 	})
 })
 


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4640](https://linear.app/synnax/issue/SY-4640)

## Description

Fixes the five Oracle specs that fail on the Windows CI runner. All changes are in test code:

- `paths_test.go`: the chdir-back cleanup was registered before `GinkgoT().TempDir()`, so LIFO cleanup deleted the temp dir while it was still the working directory. Windows refuses to delete the working directory, so both `RepoRoot` specs failed in `DeferCleanup`. The temp dir is now created first.
- `pipeline_test.go` and `cmd/root_test.go`: both made a directory unreadable with `Chmod(0o000)`, which Windows ignores for reads, so the expected discovery error never occurred. A new `testutil.DenyDirRead` helper now revokes list access portably: `chmod` on Unix, an `icacls` deny ACE for the Everyone SID on Windows. It also folds in the run-as-root skip and restores access in cleanup.
- `imex_test.go`: the parse-error assertion matched `versions/v3/migrate.go`, but the Windows error message carries backslashes. The substring now goes through `filepath.FromSlash`.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes Oracle tests portable across Windows and Unix.
- Adds a cross-platform helper that denies directory listing access and restores it during cleanup.
- Corrects temporary-directory cleanup ordering.
- Normalizes a path-based error assertion for the host platform.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| oracle/testutil/helpers.go | Adds the cross-platform directory-access helper with LIFO permission restoration. |
| oracle/testutil/helpers_test.go | Verifies that the helper prevents directory listings. |
| oracle/cmd/root_test.go | Replaces Unix-specific permission setup with the shared portable helper. |
| oracle/pipeline/pipeline_test.go | Uses the portable helper while preserving cleanup order. |
| oracle/paths/paths_test.go | Registers working-directory restoration after temporary-directory cleanup creation. |
| oracle/plugin/go/imex/imex_test.go | Converts the expected migration path to native separators. |

<sub>Reviews (2): Last reviewed commit: ["SY-4640: Reflow DenyDirRead doc comment"](https://github.com/synnaxlabs/synnax/commit/eda37bc45043be46235b7202db21637e103624ac) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=54886077)</sub>

<!-- /greptile_comment -->