### PR TITLE
SY-4554: Add manual entry of tables for NI task scaling

### DIFF
--- a/console/src/feature/ni/task/AnalogRead.spec.ts
+++ b/console/src/feature/ni/task/AnalogRead.spec.ts
@@ -17,8 +17,6 @@ import { NI } from "@/feature/ni";
 import {
   awaitStatusDescription,
   createNIDevice,
-  getCoefficientInput,
-  getCoefficientsField,
   renderNITaskForm,
 } from "@/feature/ni/task/testutil";
 import {
@@ -29,7 +27,7 @@ import {
   getLabeledInput,
   selectFromDropdown,
 } from "@/platform/task/testutil";
-import { getIconButton, uniqueName } from "@/testutil";
+import { getIconButton, getInputTable, uniqueName } from "@/testutil";
 
 const client = createTestClient();
 
@@ -256,18 +254,17 @@ describe("AnalogRead", () => {
         ],
       });
       await screen.findByText("Forward coefficients");
-      const forward = getCoefficientsField("Forward coefficients");
+      const forward = getInputTable("Forward coefficients");
       expect(forward.rows).toHaveLength(3);
       fireEvent.click(getIconButton(forward.rows[1], "close"));
       await waitFor(() =>
-        expect(getCoefficientsField("Forward coefficients").rows).toHaveLength(2),
+        expect(getInputTable("Forward coefficients").rows).toHaveLength(2),
       );
-      fireEvent.click(getCoefficientsField("Reverse coefficients").add);
+      fireEvent.click(getInputTable("Reverse coefficients").add);
       await waitFor(() =>
-        expect(getCoefficientsField("Reverse coefficients").rows).toHaveLength(1),
+        expect(getInputTable("Reverse coefficients").rows).toHaveLength(1),
       );
-      const [reverseRow] = getCoefficientsField("Reverse coefficients").rows;
-      commitFieldInput(getCoefficientInput(reverseRow), "7.5");
+      commitFieldInput(getInputTable("Reverse coefficients").cell(0), "7.5");
 
       await deployAndAwaitTask(client, container, draft.key);
       const created = await client.tasks.retrieve({

--- a/console/src/feature/ni/task/CoefficientsField.tsx
+++ b/console/src/feature/ni/task/CoefficientsField.tsx
@@ -7,11 +7,13 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { Button, CSS as PCSS, Flex, Form, Icon, Input, Text } from "@synnaxlabs/pluto";
+import { Form, Input } from "@synnaxlabs/pluto";
+import { type ReactElement, useMemo } from "react";
 
-import { CSS } from "@/platform/css";
+// The row gutter names each coefficient, so the lone column needs no heading.
+const COLUMNS: Input.TableColumn[] = [{}];
 
-export interface CoefficientsFieldProps extends Omit<Flex.BoxProps, "children"> {
+export interface CoefficientsFieldProps {
   path: string;
   label: string;
 }
@@ -25,60 +27,23 @@ export interface CoefficientsFieldProps extends Omit<Flex.BoxProps, "children"> 
 export const CoefficientsField = ({
   path,
   label,
-  ...rest
-}: CoefficientsFieldProps): React.ReactElement => {
-  const { value, onChange, preview } = Form.useField<number[]>(path);
-  const handleChange = (index: number, next: number) =>
-    onChange(value.map((coeff, i) => (i === index ? next : coeff)));
+}: CoefficientsFieldProps): ReactElement => {
+  const { value, onChange, preview, status } = Form.useField<number[]>(path);
+  const rows = useMemo(() => value.map((coeff) => [coeff]), [value]);
   return (
-    <Flex.Box y gap="small" className={CSS.B("coefficients")} {...rest}>
-      <Text.Text level="small" justify="between" color={9}>
-        {label}
-        {!preview && (
-          <Button.Button
-            onClick={() => onChange([...value, 0])}
-            variant="filled"
-            tooltip={`Add ${label.toLowerCase()}`}
-            size="small"
-          >
-            <Icon.Add />
-          </Button.Button>
-        )}
-      </Text.Text>
-      <Flex.Box y gap="small">
-        {value.map((coeff, i) => (
-          <Flex.Box
-            x
-            key={i}
-            align="center"
-            gap="small"
-            className={CSS.cls(CSS.B("coefficient-row"), PCSS.M("reveals"))}
-          >
-            <Input.Numeric
-              value={coeff}
-              onChange={(next) => handleChange(i, next)}
-              preview={preview}
-              startContent={
-                <Text.Text level="small" color={9}>
-                  c{i}
-                </Text.Text>
-              }
-              grow
-            />
-            {!preview && (
-              <Button.Button
-                variant="text"
-                reveal
-                size="small"
-                tooltip={`Remove c${i}`}
-                onClick={() => onChange(value.filter((_, j) => j !== i))}
-              >
-                <Icon.Close />
-              </Button.Button>
-            )}
-          </Flex.Box>
-        ))}
-      </Flex.Box>
-    </Flex.Box>
+    <Input.Item
+      label={label}
+      helpText={status.message}
+      status={status.variant}
+      padHelpText
+    >
+      <Input.Table
+        columns={COLUMNS}
+        value={rows}
+        onChange={(next) => onChange(next.map(([coeff]) => coeff))}
+        rowLabel={(index) => `c${index}`}
+        preview={preview}
+      />
+    </Input.Item>
   );
 };

--- a/console/src/feature/ni/task/CoefficientsField.tsx
+++ b/console/src/feature/ni/task/CoefficientsField.tsx
@@ -10,9 +10,6 @@
 import { Form, Input } from "@synnaxlabs/pluto";
 import { type ReactElement, useMemo } from "react";
 
-// The row gutter names each coefficient, so the lone column needs no heading.
-const COLUMNS: Input.TableColumn[] = [{}];
-
 export interface CoefficientsFieldProps {
   path: string;
   label: string;
@@ -38,12 +35,13 @@ export const CoefficientsField = ({
       padHelpText
     >
       <Input.Table
-        columns={COLUMNS}
         value={rows}
-        onChange={(next) => onChange(next.map(([coeff]) => coeff))}
+        onChange={(next) => onChange(next.map(([coeff]) => Number(coeff)))}
         rowLabel={(index) => `c${index}`}
         preview={preview}
-      />
+      >
+        <Input.TableColumn />
+      </Input.Table>
     </Input.Item>
   );
 };

--- a/console/src/feature/ni/task/CustomScaleForm.spec.ts
+++ b/console/src/feature/ni/task/CustomScaleForm.spec.ts
@@ -215,6 +215,19 @@ describe("CustomScaleForm", () => {
       expect(table.cell(2, 1).value).toBe("30");
     });
 
+    it("should reject a CSV whose columns hold a different number of values", async () => {
+      const csvPath = join(dir, "ragged.csv");
+      await writeFile(csvPath, "raw_col,scaled_col\n1,10\n2,\n3,30\n");
+      openMock.mockResolvedValue(csvPath);
+      await renderWithScale(NI.Task.createScale("table"));
+      await screen.findByText("Table CSV");
+      fireEvent.click(screen.getByText("Select file"));
+      await screen.findByText(
+        "Pre-scaled 3 values and scaled 2 values must be the same length",
+      );
+      expect(getInputTable("Values").rows).toHaveLength(0);
+    });
+
     it("should show the values loaded from a CSV", async () => {
       const csvPath = join(dir, "table3.csv");
       await writeFile(csvPath, "raw_col,scaled_col\n1,10\n2,20\n3,30\n");

--- a/console/src/feature/ni/task/CustomScaleForm.spec.ts
+++ b/console/src/feature/ni/task/CustomScaleForm.spec.ts
@@ -43,8 +43,17 @@ import { open } from "@tauri-apps/plugin-dialog";
 
 import { NI } from "@/feature/ni";
 import { renderNITaskForm } from "@/feature/ni/task/testutil";
-import { findDialogTriggerByText, selectFromDropdown } from "@/platform/task/testutil";
-import { fakePickedFile, interceptFilePicker } from "@/testutil";
+import {
+  commitFieldInput,
+  findDialogTriggerByText,
+  selectFromDropdown,
+} from "@/platform/task/testutil";
+import {
+  fakePickedFile,
+  getIconButton,
+  getInputTable,
+  interceptFilePicker,
+} from "@/testutil";
 
 const openMock = vi.mocked(open);
 
@@ -148,5 +157,75 @@ describe("CustomScaleForm", () => {
     await findDialogTriggerByText("web_scaled");
     expect(screen.getByText(/browser\.csv/)).toBeTruthy();
     expect(openMock).not.toHaveBeenCalled();
+  });
+
+  describe("manual entry", () => {
+    it("should append rows with an increasing pre-scaled value", async () => {
+      await renderWithScale(NI.Task.createScale("table"));
+      await screen.findByText("Values");
+      expect(getInputTable("Values").rows).toHaveLength(0);
+      fireEvent.click(getInputTable("Values").add);
+      await waitFor(() => expect(getInputTable("Values").rows).toHaveLength(1));
+      fireEvent.click(getInputTable("Values").add);
+      await waitFor(() => expect(getInputTable("Values").rows).toHaveLength(2));
+      const table = getInputTable("Values");
+      expect(table.cell(0, 0).value).toBe("0");
+      expect(table.cell(1, 0).value).toBe("1");
+    });
+
+    it("should keep an edited pair in the table", async () => {
+      await renderWithScale({
+        ...(NI.Task.createScale("table") as Extract<NI.Task.Scale, { type: "table" }>),
+        preScaledVals: [1, 2],
+        scaledVals: [10, 20],
+      });
+      await screen.findByText("Values");
+      commitFieldInput(getInputTable("Values").cell(1, 1), "25");
+      await waitFor(() => expect(getInputTable("Values").cell(1, 1).value).toBe("25"));
+      expect(getInputTable("Values").cell(0, 1).value).toBe("10");
+    });
+
+    it("should remove the row whose button is clicked", async () => {
+      await renderWithScale({
+        ...(NI.Task.createScale("table") as Extract<NI.Task.Scale, { type: "table" }>),
+        preScaledVals: [1, 2, 3],
+        scaledVals: [10, 20, 30],
+      });
+      await screen.findByText("Values");
+      fireEvent.click(getIconButton(getInputTable("Values").rows[1], "close"));
+      await waitFor(() => expect(getInputTable("Values").rows).toHaveLength(2));
+      const table = getInputTable("Values");
+      expect(table.cell(0, 0).value).toBe("1");
+      expect(table.cell(1, 0).value).toBe("3");
+    });
+
+    it("should fill the table from a pasted block", async () => {
+      await renderWithScale(NI.Task.createScale("table"));
+      await screen.findByText("Values");
+      fireEvent.click(getInputTable("Values").add);
+      await waitFor(() => expect(getInputTable("Values").rows).toHaveLength(1));
+      const cell = getInputTable("Values").cell(0, 0);
+      fireEvent.focus(cell);
+      fireEvent.paste(cell, {
+        clipboardData: { getData: () => "1\t10\n2\t20\n3\t30" },
+      });
+      await waitFor(() => expect(getInputTable("Values").rows).toHaveLength(3));
+      const table = getInputTable("Values");
+      expect(table.cell(2, 0).value).toBe("3");
+      expect(table.cell(2, 1).value).toBe("30");
+    });
+
+    it("should show the values loaded from a CSV", async () => {
+      const csvPath = join(dir, "table3.csv");
+      await writeFile(csvPath, "raw_col,scaled_col\n1,10\n2,20\n3,30\n");
+      openMock.mockResolvedValue(csvPath);
+      await renderWithScale(NI.Task.createScale("table"));
+      await screen.findByText("Table CSV");
+      fireEvent.click(screen.getByText("Select file"));
+      await waitFor(() => expect(getInputTable("Values").rows).toHaveLength(3));
+      const table = getInputTable("Values");
+      expect(table.cell(0, 0).value).toBe("1");
+      expect(table.cell(2, 1).value).toBe("30");
+    });
   });
 });

--- a/console/src/feature/ni/task/CustomScaleForm.spec.ts
+++ b/console/src/feature/ni/task/CustomScaleForm.spec.ts
@@ -228,6 +228,18 @@ describe("CustomScaleForm", () => {
       expect(getInputTable("Values").rows).toHaveLength(0);
     });
 
+    it("should flag a stored scale whose columns are unpaired", async () => {
+      await renderWithScale({
+        ...(NI.Task.createScale("table") as Extract<NI.Task.Scale, { type: "table" }>),
+        preScaledVals: [1, 2, 3],
+        scaledVals: [10, 20],
+      });
+      await screen.findByText(
+        "Pre-scaled 3 values and scaled 2 values must be the same length",
+      );
+      expect(getInputTable("Values").rows).toHaveLength(3);
+    });
+
     it("should show the values loaded from a CSV", async () => {
       const csvPath = join(dir, "table3.csv");
       await writeFile(csvPath, "raw_col,scaled_col\n1,10\n2,20\n3,30\n");

--- a/console/src/feature/ni/task/CustomScaleForm.tsx
+++ b/console/src/feature/ni/task/CustomScaleForm.tsx
@@ -7,12 +7,12 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { Flex, Form, Icon, Input, Select, state } from "@synnaxlabs/pluto";
-import { binary, deep, record } from "@synnaxlabs/x";
+import { Flex, Form, Icon, type Select } from "@synnaxlabs/pluto";
+import { deep, record } from "@synnaxlabs/x";
 import { type FC } from "react";
-import { z } from "zod";
 
 import { CoefficientsField } from "@/feature/ni/task/CoefficientsField";
+import { TableScaleForm } from "@/feature/ni/task/TableScaleForm";
 import {
   createScale,
   type Scale,
@@ -20,7 +20,6 @@ import {
   type ScaleType,
   type Units,
 } from "@/feature/ni/task/types";
-import { FS } from "@/platform/fs";
 
 const SelectCustomScaleTypeField = Form.buildSelectField<
   ScaleType,
@@ -96,8 +95,6 @@ const UnitsField = Form.buildSelectField<Units, record.KeyedNamed<Units>>({
   },
 });
 
-const tableSchema = z.record(z.string(), z.array(z.unknown()));
-
 export interface CustomScaleFormProps {
   prefix: string;
 }
@@ -159,106 +156,12 @@ const SCALE_FORMS: Record<ScaleType, FC<CustomScaleFormProps>> = {
       />
     </>
   ),
-  table: ({ prefix }) => {
-    const [rawCol, setRawCol] = state.usePersisted<string>("Raw", `${prefix}.rawCol`);
-    const [scaledCol, setScaledCol] = state.usePersisted<string>(
-      "Scaled",
-      `${prefix}.scaledCol`,
-    );
-    const [colOptions, setColOptions] = state.usePersisted<record.KeyedNamed<string>[]>(
-      [],
-      `${prefix}.colOptions`,
-    );
-    const [fileName, setFileName] = state.usePersisted<string>("", `${prefix}.path`);
-    // The parsed table persists beside the form state, so a column change after a
-    // remount recomputes the values without re-reading the file.
-    const [table, setTable] = state.usePersisted<Record<string, unknown[]>>(
-      {},
-      `${prefix}.table`,
-    );
-    const preScaledField = Form.useField<number[]>(`${prefix}.preScaledVals`);
-    const scaledField = Form.useField<number[]>(`${prefix}.scaledVals`);
-
-    const applyColumns = (
-      value: Record<string, unknown[]>,
-      raw: string,
-      scaled: string,
-    ) => {
-      const preScaledValues = value[raw] as number[] | undefined;
-      const scaledValues = value[scaled] as number[] | undefined;
-      const hasScaled = scaledValues != null;
-      const hasPreScaled = preScaledValues != null;
-      if (hasScaled && hasPreScaled)
-        if (preScaledValues.length !== scaledValues.length)
-          preScaledField.setStatus({
-            variant: "error",
-            message: `Pre-scaled ${preScaledValues.length} values and scaled ${scaledValues.length} values must be the same length`,
-          });
-      if (hasPreScaled) preScaledField.onChange(preScaledValues);
-      if (hasScaled) scaledField.onChange(scaledValues);
-    };
-
-    const handleFileChange = (value: z.infer<typeof tableSchema>, name: string) => {
-      setFileName(name);
-      setTable(value);
-      const keys = Object.keys(value).filter(
-        (key) =>
-          Array.isArray(value[key]) && value[key].every((v) => isFinite(Number(v))),
-      );
-      setColOptions(keys.map((key) => ({ key, name: key })));
-      const raw = keys.length > 0 ? keys[0] : rawCol;
-      const scaled = keys.length > 1 ? keys[1] : scaledCol;
-      if (keys.length > 0) setRawCol(raw);
-      if (keys.length > 1) setScaledCol(scaled);
-      applyColumns(value, raw, scaled);
-    };
-
-    const handleRawColChange = (value: string) => {
-      setRawCol(value);
-      applyColumns(table, value, scaledCol);
-    };
-
-    const handleScaledColChange = (value: string) => {
-      setScaledCol(value);
-      applyColumns(table, rawCol, value);
-    };
-
-    if (preScaledField.preview) return <CustomScaleUnitsFields prefix={prefix} />;
-
-    return (
-      <>
-        <CustomScaleUnitsFields prefix={prefix} />
-        <Input.Item label="Table CSV" padHelpText>
-          <FS.InputFile<typeof tableSchema>
-            value={fileName}
-            onChange={handleFileChange}
-            title="Select a table CSV"
-            extension="csv"
-            schema={tableSchema}
-            decoder={binary.CSV_CODEC}
-          />
-        </Input.Item>
-        <Flex.Box x>
-          <Input.Item label="Raw column" padHelpText grow>
-            <Select.Static
-              resourceName="raw column"
-              value={rawCol}
-              onChange={handleRawColChange}
-              data={colOptions}
-            />
-          </Input.Item>
-          <Input.Item label="Scaled column" padHelpText grow>
-            <Select.Static
-              resourceName="scaled column"
-              value={scaledCol}
-              onChange={handleScaledColChange}
-              data={colOptions}
-            />
-          </Input.Item>
-        </Flex.Box>
-      </>
-    );
-  },
+  table: ({ prefix }) => (
+    <>
+      <CustomScaleUnitsFields prefix={prefix} />
+      <TableScaleForm prefix={prefix} />
+    </>
+  ),
   none: () => null,
 };
 

--- a/console/src/feature/ni/task/TableScaleForm.tsx
+++ b/console/src/feature/ni/task/TableScaleForm.tsx
@@ -16,12 +16,10 @@ import { FS } from "@/platform/fs";
 
 const tableSchema = z.record(z.string(), z.array(z.unknown()));
 
-const COLUMNS = [{ name: "Pre-scaled" }, { name: "Scaled" }];
-
 /** Keeps the appended row's pre-scaled value above the one before it. */
-const createRow = (rows: number[][]): number[] => {
+const createRow = (rows: Input.TableCell[][]): Input.TableCell[] => {
   const last = rows.at(-1);
-  return [last == null ? 0 : last[0] + 1, 0];
+  return [last == null ? 0 : Number(last[0]) + 1, 0];
 };
 
 /**
@@ -115,9 +113,9 @@ export const TableScaleForm = ({ prefix }: TableScaleFormProps): ReactElement =>
     applyColumns(table, rawCol, value);
   };
 
-  const handleRowsChange = (next: number[][]) => {
-    preScaled.onChange(next.map(([raw]) => raw));
-    scaled.onChange(next.map(([, value]) => value));
+  const handleRowsChange = (next: Input.TableCell[][]) => {
+    preScaled.onChange(next.map(([raw]) => Number(raw)));
+    scaled.onChange(next.map(([, value]) => Number(value)));
   };
 
   const { preview } = preScaled;
@@ -169,12 +167,14 @@ export const TableScaleForm = ({ prefix }: TableScaleFormProps): ReactElement =>
         status={mismatch != null ? "error" : status.variant}
       >
         <Input.Table
-          columns={COLUMNS}
           value={rows}
           onChange={handleRowsChange}
           createRow={createRow}
           preview={preview}
-        />
+        >
+          <Input.TableColumn name="Pre-scaled" />
+          <Input.TableColumn name="Scaled" />
+        </Input.Table>
       </Input.Item>
     </>
   );

--- a/console/src/feature/ni/task/TableScaleForm.tsx
+++ b/console/src/feature/ni/task/TableScaleForm.tsx
@@ -68,16 +68,21 @@ export const TableScaleForm = ({ prefix }: TableScaleFormProps): ReactElement =>
   ) => {
     const preScaledValues = value[raw] as number[] | undefined;
     const scaledValues = value[scaledKey] as number[] | undefined;
-    const hasScaled = scaledValues != null;
-    const hasPreScaled = preScaledValues != null;
-    if (hasScaled && hasPreScaled)
-      if (preScaledValues.length !== scaledValues.length)
-        preScaled.setStatus({
-          variant: "error",
-          message: `Pre-scaled ${preScaledValues.length} values and scaled ${scaledValues.length} values must be the same length`,
-        });
-    if (hasPreScaled) preScaled.onChange(preScaledValues);
-    if (hasScaled) scaled.onChange(scaledValues);
+    if (
+      preScaledValues != null &&
+      scaledValues != null &&
+      preScaledValues.length !== scaledValues.length
+    ) {
+      // Loading the pair would pad the shorter column with zeros, giving the scale
+      // points the CSV never held.
+      preScaled.setStatus({
+        variant: "error",
+        message: `Pre-scaled ${preScaledValues.length} values and scaled ${scaledValues.length} values must be the same length`,
+      });
+      return;
+    }
+    if (preScaledValues != null) preScaled.onChange(preScaledValues);
+    if (scaledValues != null) scaled.onChange(scaledValues);
   };
 
   const handleFileChange = (value: z.infer<typeof tableSchema>, name: string) => {

--- a/console/src/feature/ni/task/TableScaleForm.tsx
+++ b/console/src/feature/ni/task/TableScaleForm.tsx
@@ -1,0 +1,168 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { Flex, Form, Input, Select, state } from "@synnaxlabs/pluto";
+import { binary, type record } from "@synnaxlabs/x";
+import { type ReactElement, useMemo } from "react";
+import { z } from "zod";
+
+import { FS } from "@/platform/fs";
+
+const tableSchema = z.record(z.string(), z.array(z.unknown()));
+
+const COLUMNS = [{ name: "Pre-scaled" }, { name: "Scaled" }];
+
+/** Keeps the appended row's pre-scaled value above the one before it. */
+const createRow = (rows: number[][]): number[] => {
+  const last = rows.at(-1);
+  return [last == null ? 0 : last[0] + 1, 0];
+};
+
+export interface TableScaleFormProps {
+  /** The form path of the table scale. */
+  prefix: string;
+}
+
+/**
+ * Edits the pre-scaled and scaled value pairs of a table scale. The pairs are typed in
+ * directly or loaded from two columns of a CSV.
+ */
+export const TableScaleForm = ({ prefix }: TableScaleFormProps): ReactElement => {
+  const [rawCol, setRawCol] = state.usePersisted<string>("Raw", `${prefix}.rawCol`);
+  const [scaledCol, setScaledCol] = state.usePersisted<string>(
+    "Scaled",
+    `${prefix}.scaledCol`,
+  );
+  const [colOptions, setColOptions] = state.usePersisted<record.KeyedNamed<string>[]>(
+    [],
+    `${prefix}.colOptions`,
+  );
+  const [fileName, setFileName] = state.usePersisted<string>("", `${prefix}.path`);
+  // The parsed table persists beside the form state, so a column change after a
+  // remount recomputes the values without re-reading the file.
+  const [table, setTable] = state.usePersisted<Record<string, unknown[]>>(
+    {},
+    `${prefix}.table`,
+  );
+  const preScaled = Form.useField<number[]>(`${prefix}.preScaledVals`);
+  const scaled = Form.useField<number[]>(`${prefix}.scaledVals`);
+
+  const rows = useMemo(() => {
+    const length = Math.max(preScaled.value.length, scaled.value.length);
+    return Array.from({ length }, (_, i) => [
+      preScaled.value[i] ?? 0,
+      scaled.value[i] ?? 0,
+    ]);
+  }, [preScaled.value, scaled.value]);
+
+  const applyColumns = (
+    value: Record<string, unknown[]>,
+    raw: string,
+    scaledKey: string,
+  ) => {
+    const preScaledValues = value[raw] as number[] | undefined;
+    const scaledValues = value[scaledKey] as number[] | undefined;
+    const hasScaled = scaledValues != null;
+    const hasPreScaled = preScaledValues != null;
+    if (hasScaled && hasPreScaled)
+      if (preScaledValues.length !== scaledValues.length)
+        preScaled.setStatus({
+          variant: "error",
+          message: `Pre-scaled ${preScaledValues.length} values and scaled ${scaledValues.length} values must be the same length`,
+        });
+    if (hasPreScaled) preScaled.onChange(preScaledValues);
+    if (hasScaled) scaled.onChange(scaledValues);
+  };
+
+  const handleFileChange = (value: z.infer<typeof tableSchema>, name: string) => {
+    setFileName(name);
+    setTable(value);
+    const keys = Object.keys(value).filter(
+      (key) =>
+        Array.isArray(value[key]) && value[key].every((v) => isFinite(Number(v))),
+    );
+    setColOptions(keys.map((key) => ({ key, name: key })));
+    const raw = keys.length > 0 ? keys[0] : rawCol;
+    const scaledKey = keys.length > 1 ? keys[1] : scaledCol;
+    if (keys.length > 0) setRawCol(raw);
+    if (keys.length > 1) setScaledCol(scaledKey);
+    applyColumns(value, raw, scaledKey);
+  };
+
+  const handleRawColChange = (value: string) => {
+    setRawCol(value);
+    applyColumns(table, value, scaledCol);
+  };
+
+  const handleScaledColChange = (value: string) => {
+    setScaledCol(value);
+    applyColumns(table, rawCol, value);
+  };
+
+  const handleRowsChange = (next: number[][]) => {
+    preScaled.onChange(next.map(([raw]) => raw));
+    scaled.onChange(next.map(([, value]) => value));
+  };
+
+  const { preview } = preScaled;
+  const status =
+    preScaled.status.variant !== "success" ? preScaled.status : scaled.status;
+  return (
+    <>
+      {preview !== true && (
+        <>
+          <Input.Item label="Table CSV" padHelpText>
+            <FS.InputFile<typeof tableSchema>
+              value={fileName}
+              onChange={handleFileChange}
+              title="Select a table CSV"
+              extension="csv"
+              schema={tableSchema}
+              decoder={binary.CSV_CODEC}
+            />
+          </Input.Item>
+          {colOptions.length > 0 && (
+            <Flex.Box x>
+              <Input.Item label="Raw column" padHelpText grow>
+                <Select.Static
+                  resourceName="raw column"
+                  value={rawCol}
+                  onChange={handleRawColChange}
+                  data={colOptions}
+                />
+              </Input.Item>
+              <Input.Item label="Scaled column" padHelpText grow>
+                <Select.Static
+                  resourceName="scaled column"
+                  value={scaledCol}
+                  onChange={handleScaledColChange}
+                  data={colOptions}
+                />
+              </Input.Item>
+            </Flex.Box>
+          )}
+        </>
+      )}
+      <Input.Item
+        label="Values"
+        padHelpText
+        helpText={status.message}
+        status={status.variant}
+      >
+        <Input.Table
+          columns={COLUMNS}
+          value={rows}
+          onChange={handleRowsChange}
+          createRow={createRow}
+          preview={preview}
+        />
+      </Input.Item>
+    </>
+  );
+};

--- a/console/src/feature/ni/task/TableScaleForm.tsx
+++ b/console/src/feature/ni/task/TableScaleForm.tsx
@@ -24,6 +24,15 @@ const createRow = (rows: number[][]): number[] => {
   return [last == null ? 0 : last[0] + 1, 0];
 };
 
+/**
+ * @returns The error to show when the two columns hold a different number of values, or
+ * null when they pair up.
+ */
+const lengthMismatch = (preScaled: number[], scaled: number[]): string | null =>
+  preScaled.length === scaled.length
+    ? null
+    : `Pre-scaled ${preScaled.length} values and scaled ${scaled.length} values must be the same length`;
+
 export interface TableScaleFormProps {
   /** The form path of the table scale. */
   prefix: string;
@@ -68,18 +77,14 @@ export const TableScaleForm = ({ prefix }: TableScaleFormProps): ReactElement =>
   ) => {
     const preScaledValues = value[raw] as number[] | undefined;
     const scaledValues = value[scaledKey] as number[] | undefined;
-    if (
-      preScaledValues != null &&
-      scaledValues != null &&
-      preScaledValues.length !== scaledValues.length
-    ) {
-      // Loading the pair would pad the shorter column with zeros, giving the scale
-      // points the CSV never held.
-      preScaled.setStatus({
-        variant: "error",
-        message: `Pre-scaled ${preScaledValues.length} values and scaled ${scaledValues.length} values must be the same length`,
-      });
-      return;
+    if (preScaledValues != null && scaledValues != null) {
+      const message = lengthMismatch(preScaledValues, scaledValues);
+      if (message != null) {
+        // Loading the pair would pad the shorter column with zeros, giving the scale
+        // points the CSV never held.
+        preScaled.setStatus({ variant: "error", message });
+        return;
+      }
     }
     if (preScaledValues != null) preScaled.onChange(preScaledValues);
     if (scaledValues != null) scaled.onChange(scaledValues);
@@ -118,6 +123,9 @@ export const TableScaleForm = ({ prefix }: TableScaleFormProps): ReactElement =>
   const { preview } = preScaled;
   const status =
     preScaled.status.variant !== "success" ? preScaled.status : scaled.status;
+  // A scale stored with unpaired columns renders zeros for the values it never held, so
+  // name the problem before an edit commits them.
+  const mismatch = lengthMismatch(preScaled.value, scaled.value);
   return (
     <>
       {preview !== true && (
@@ -157,8 +165,8 @@ export const TableScaleForm = ({ prefix }: TableScaleFormProps): ReactElement =>
       <Input.Item
         label="Values"
         padHelpText
-        helpText={status.message}
-        status={status.variant}
+        helpText={mismatch ?? status.message}
+        status={mismatch != null ? "error" : status.variant}
       >
         <Input.Table
           columns={COLUMNS}

--- a/console/src/feature/ni/task/testutil.ts
+++ b/console/src/feature/ni/task/testutil.ts
@@ -10,7 +10,7 @@
 import { type Synnax } from "@synnaxlabs/client";
 import { type Status } from "@synnaxlabs/pluto";
 import { id } from "@synnaxlabs/x";
-import { screen, waitFor, within } from "@testing-library/react";
+import { waitFor } from "@testing-library/react";
 import { type FC } from "react";
 import { expect } from "vitest";
 
@@ -21,7 +21,7 @@ import {
   type RenderTaskFormTabOptions,
   type RenderTaskFormTabResult,
 } from "@/platform/task/testutil";
-import { assertDefined, getIconButton, uniqueName } from "@/testutil";
+import { uniqueName } from "@/testutil";
 
 export interface CreateNIDeviceOptions extends Partial<Omit<Device.New, "properties">> {
   properties?: Partial<Device.Properties>;
@@ -82,32 +82,6 @@ export const renderNITaskForm = async (
   });
   return { ...result, statuses };
 };
-
-export interface CoefficientsField {
-  /** The button that appends a coefficient. */
-  add: HTMLButtonElement;
-  /** The coefficient rows, lowest order first. */
-  rows: HTMLElement[];
-}
-
-/**
- * Returns the add button and rows of the coefficients field under the given heading.
- * Rows carry no accessible handle of their own, so the structural class selector lives
- * here.
- * @throws if no coefficients field renders under the heading.
- */
-export const getCoefficientsField = (label: string): CoefficientsField => {
-  const field = screen.getByText(label).closest(".console-coefficients");
-  assertDefined(field, `no coefficients field for "${label}"`);
-  return {
-    add: getIconButton(field, "add"),
-    rows: Array.from(field.querySelectorAll<HTMLElement>(".console-coefficient-row")),
-  };
-};
-
-/** Returns the numeric input of a coefficient row returned by getCoefficientsField. */
-export const getCoefficientInput = (row: HTMLElement): HTMLInputElement =>
-  within(row).getByRole("textbox");
 
 /**
  * Polls the captured statuses until one's message or description matches. Uses

--- a/console/src/platform/form/KeyValueEditor.spec.tsx
+++ b/console/src/platform/form/KeyValueEditor.spec.tsx
@@ -181,6 +181,24 @@ describe("KeyValueEditor", () => {
     expect(inputs[1].getAttribute("placeholder")).toBe("Key");
   });
 
+  it("should bind each valueFirst input to its own field", async () => {
+    const onChange = vi.fn();
+    await renderWithConsole(
+      <Harness
+        onChange={onChange}
+        initialHeaders={[{ name: "the-key", value: "the-value" }]}
+        valueFirst
+      />,
+    );
+    const valueInput = await screen.findByPlaceholderText("Value");
+    expect((valueInput as HTMLInputElement).value).toBe("the-value");
+    expect(screen.getByPlaceholderText("Key").getAttribute("value")).toBe("the-key");
+    fireEvent.change(valueInput, { target: { value: "changed" } });
+    await waitFor(() =>
+      expect(lastHeaders(onChange)).toEqual([{ name: "the-key", value: "changed" }]),
+    );
+  });
+
   it("should reset a non-array (legacy) value to an empty array on mount", async () => {
     const onChange = vi.fn();
     await renderWithConsole(

--- a/console/src/platform/form/KeyValueEditor.tsx
+++ b/console/src/platform/form/KeyValueEditor.tsx
@@ -7,10 +7,9 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { Button, CSS as PCSS, Flex, Form, Icon, Input, Text } from "@synnaxlabs/pluto";
-import { useEffect } from "react";
-
-import { CSS } from "@/platform/css";
+import { Flex, Form, Input, Text } from "@synnaxlabs/pluto";
+import { caseconv } from "@synnaxlabs/x";
+import { useEffect, useMemo } from "react";
 
 export type Entry<K extends string, V extends string | number> = {
   [k in K]: string;
@@ -38,7 +37,6 @@ export const KeyValueEditor = <K extends string, V extends string | number>({
   ...rest
 }: KeyValueEditorProps<K, V>): React.ReactElement => {
   const vt = valueType ?? "string";
-  const defaultValue: V = (vt === "number" ? 0 : "") as V;
   const { set, mode } = Form.useContext();
   const preview = mode === "preview" ? true : undefined;
   const value = Form.useFieldValue<Entry<K, V>[]>(path, { defaultValue: [] });
@@ -55,90 +53,59 @@ export const KeyValueEditor = <K extends string, V extends string | number>({
   }, []);
   const entries = Array.isArray(value) ? value : [];
 
-  const setFormValue = (arr: Entry<K, V>[]) =>
-    set(path, arr.length > 0 ? arr : undefined);
+  // Both directions and the column order read off these, so valueFirst cannot leave a
+  // cell bound to the other field.
+  const keyIndex = valueFirst ? 1 : 0;
+  const valueIndex = valueFirst ? 0 : 1;
 
-  const addRow = () =>
-    setFormValue([...entries, { [keyField]: "", value: defaultValue } as Entry<K, V>]);
+  const rows = useMemo(
+    () =>
+      entries.map((entry) => {
+        const row: Input.TableCell[] = [];
+        row[keyIndex] = entry[keyField];
+        row[valueIndex] = entry.value;
+        return row;
+      }),
+    [entries, keyField, keyIndex, valueIndex],
+  );
 
-  const updateRowKey = (i: number, k: string) => {
-    const updated = [...entries];
-    updated[i] = { ...updated[i], [keyField]: k };
-    setFormValue(updated);
-  };
+  const handleRowsChange = (next: Input.TableCell[][]) =>
+    set(
+      path,
+      next.length > 0
+        ? next.map(
+            (row) =>
+              ({ [keyField]: row[keyIndex], value: row[valueIndex] }) as Entry<K, V>,
+          )
+        : undefined,
+    );
 
-  const updateRowValue = (i: number, v: V) => {
-    const updated = [...entries];
-    updated[i] = { ...updated[i], value: v };
-    setFormValue(updated);
-  };
+  const keyColumn = (
+    <Input.TableColumn key="key" name={caseconv.capitalize(keyField)} type="string">
+      {(p) => <Input.Text {...p} placeholder={keyPlaceholder} />}
+    </Input.TableColumn>
+  );
+  const valueColumn =
+    vt === "number" ? (
+      <Input.TableColumn key="value" name="Value" />
+    ) : (
+      <Input.TableColumn key="value" name="Value" type="string">
+        {(p) => <Input.Text {...p} placeholder={valuePlaceholder} />}
+      </Input.TableColumn>
+    );
 
-  const removeRow = (i: number) => setFormValue(entries.filter((_, j) => j !== i));
+  const columns = [];
+  columns[keyIndex] = keyColumn;
+  columns[valueIndex] = valueColumn;
 
   return (
     <Flex.Box y gap="small" {...rest}>
-      <Text.Text level="small" justify="between" size="small" color={9}>
+      <Text.Text level="small" size="small" color={9}>
         {label}
-        {!preview && (
-          <Button.Button
-            onClick={addRow}
-            variant="filled"
-            tooltip={`Add ${label.toLowerCase()}`}
-            size="small"
-          >
-            <Icon.Add />
-          </Button.Button>
-        )}
       </Text.Text>
-      <Flex.Box y gap="small">
-        {entries.map((entry, i) => {
-          const keyInput = (
-            <Input.Text
-              placeholder={keyPlaceholder}
-              value={entry[keyField]}
-              onChange={(v) => updateRowKey(i, v)}
-              preview={preview}
-            />
-          );
-          const valueInput =
-            vt === "number" ? (
-              <Input.Numeric
-                value={entry.value as number}
-                onChange={(v) => updateRowValue(i, v as V)}
-                preview={preview}
-              />
-            ) : (
-              <Input.Text
-                placeholder={valuePlaceholder}
-                value={entry.value as string}
-                onChange={(v) => updateRowValue(i, v as V)}
-                preview={preview}
-              />
-            );
-          return (
-            <Flex.Box
-              x
-              key={i}
-              align="center"
-              gap="small"
-              className={CSS.cls(CSS.B("kv-row"), PCSS.M("reveals"))}
-            >
-              {valueFirst ? valueInput : keyInput}
-              {valueFirst ? keyInput : valueInput}
-              {!preview && (
-                <Button.Button
-                  variant="text"
-                  reveal
-                  size="small"
-                  onClick={() => removeRow(i)}
-                >
-                  <Icon.Close />
-                </Button.Button>
-              )}
-            </Flex.Box>
-          );
-        })}
-      </Flex.Box>
+      <Input.Table value={rows} onChange={handleRowsChange} preview={preview}>
+        {columns}
+      </Input.Table>
     </Flex.Box>
   );
 };

--- a/console/src/platform/form/testutil.ts
+++ b/console/src/platform/form/testutil.ts
@@ -7,9 +7,8 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-/**
- * Returns the rendered KeyValueEditor rows in document order. Rows carry no
- * accessible handle of their own, so the structural class selector lives here.
- */
+import { within } from "@testing-library/react";
+
+/** Returns the KeyValueEditor's entry rows, without the heading row. */
 export const getKVRows = (container: HTMLElement): HTMLElement[] =>
-  Array.from(container.querySelectorAll<HTMLElement>(".console-kv-row"));
+  within(container).getAllByRole("row").slice(1);

--- a/console/src/testutil/dom.ts
+++ b/console/src/testutil/dom.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { act, fireEvent, screen, waitFor } from "@testing-library/react";
+import { act, fireEvent, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach } from "vitest";
 
 /**
@@ -196,6 +196,31 @@ export const getCompositeIconButtons = (
   Array.from(container.querySelectorAll("button")).filter((b) =>
     icons.every((i) => b.querySelector(`.pluto-icon--${i}`) != null),
   );
+
+/** A handle on the pluto input table inside an input item. */
+export interface InputTable {
+  /** The button that appends a row. */
+  add: HTMLButtonElement;
+  /** The body rows, top to bottom. */
+  rows: HTMLElement[];
+  /** The numeric input of the given row and column. */
+  cell: (row: number, col?: number) => HTMLInputElement;
+}
+
+/** Finds the pluto input table inside the input item labeled with labelText. */
+export const getInputTable = (labelText: string): InputTable => {
+  const table = getBySelector<HTMLElement>(
+    getInputItem(labelText),
+    ".pluto-input__table",
+  );
+  const [header, ...rows] = Array.from(table.querySelectorAll<HTMLElement>("tr"));
+  return {
+    add: getIconButton(header, "add"),
+    rows,
+    cell: (row, col = 0) =>
+      within(rows[row]).getAllByRole<HTMLInputElement>("textbox")[col],
+  };
+};
 
 /**
  * Finds the checkbox input of the pluto switch field labeled with labelText. Pluto

--- a/pluto/src/input/Table.css
+++ b/pluto/src/input/Table.css
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2026 Synnax Labs, Inc.
+ *
+ * Use of this software is governed by the Business Source License included in the file
+ * licenses/BSL.txt.
+ *
+ * As of the Change Date specified in that file, in accordance with the Business Source
+ * License, use of this software will be governed by the Apache License, Version 2.0,
+ * included in the file licenses/APL.txt.
+ */
+
+.pluto-input__table {
+    width: 100%;
+    table-layout: fixed;
+    border-collapse: collapse;
+
+    & th,
+    & td {
+        vertical-align: middle;
+        font-weight: unset;
+    }
+
+    & thead th {
+        text-align: left;
+        padding-bottom: 0.5rem;
+    }
+
+    & tbody td {
+        padding-block: 0.5rem;
+    }
+
+    /* The gutter holds the row's label, the action column its remove button. */
+    & th:first-child {
+        width: 5rem;
+        text-align: right;
+        padding-right: 1rem;
+    }
+
+    & th:last-child,
+    & td:last-child {
+        width: 6rem;
+        text-align: right;
+    }
+
+    & td:not(:last-child) {
+        padding-right: 1rem;
+    }
+}

--- a/pluto/src/input/Table.spec.tsx
+++ b/pluto/src/input/Table.spec.tsx
@@ -174,6 +174,12 @@ describe("Input.Table", () => {
       expect(document.activeElement).toBe(cell("Raw", "1"));
     });
 
+    it("should leave a key pressed outside a cell alone", () => {
+      renderTable({ value: VALUE });
+      expect(fireEvent.keyDown(addButton(), { key: "Enter" })).toBe(true);
+      expect(fireEvent.keyDown(cell("Raw", "1"), { key: "Enter" })).toBe(false);
+    });
+
     it("should hold focus at the last cell", () => {
       renderTable({ value: VALUE });
       const from = cell("Scaled", "2");

--- a/pluto/src/input/Table.spec.tsx
+++ b/pluto/src/input/Table.spec.tsx
@@ -1,0 +1,267 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { fireEvent, render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { Input } from "@/input";
+
+const COLUMNS = [{ name: "Raw" }, { name: "Scaled" }];
+
+interface RenderOptions {
+  value?: number[][];
+  preview?: boolean;
+  createRow?: (value: number[][]) => number[];
+  rowLabel?: (index: number) => string;
+}
+
+const renderTable = ({ value = [[1, 10]], ...rest }: RenderOptions = {}) => {
+  const onChange = vi.fn();
+  render(<Input.Table columns={COLUMNS} value={value} onChange={onChange} {...rest} />);
+  return onChange;
+};
+
+const cell = (column: string, row: string): HTMLInputElement =>
+  screen.getByLabelText(`${column} ${row}`);
+
+const commit = (input: HTMLInputElement, value: string): void => {
+  fireEvent.change(input, { target: { value } });
+  fireEvent.blur(input);
+};
+
+const paste = (input: HTMLInputElement, text: string): void => {
+  fireEvent.focus(input);
+  fireEvent.paste(input, { clipboardData: { getData: () => text } });
+};
+
+const addButton = (): HTMLElement => screen.getAllByRole("button")[0];
+
+const removeButton = (row: number): HTMLElement =>
+  screen.getAllByRole("row")[row + 1].querySelectorAll("button")[0];
+
+describe("Input.Table", () => {
+  it("should render a row per entry and a cell per column", () => {
+    renderTable({
+      value: [
+        [1, 10],
+        [2, 20],
+      ],
+    });
+    expect(screen.getAllByRole("row")).toHaveLength(3);
+    expect(cell("Raw", "2").value).toBe("2");
+    expect(cell("Scaled", "1").value).toBe("10");
+  });
+
+  it("should label rows by their one-based index", () => {
+    renderTable({
+      value: [
+        [1, 10],
+        [2, 20],
+      ],
+    });
+    expect(screen.getByRole("rowheader", { name: "1" })).toBeTruthy();
+    expect(screen.getByRole("rowheader", { name: "2" })).toBeTruthy();
+  });
+
+  it("should label rows with the given labeler", () => {
+    renderTable({ rowLabel: (i) => `c${i}` });
+    expect(screen.getByRole("rowheader", { name: "c0" })).toBeTruthy();
+  });
+
+  it("should commit an edited cell without touching the rest of the row", () => {
+    const onChange = renderTable({
+      value: [
+        [1, 10],
+        [2, 20],
+      ],
+    });
+    commit(cell("Scaled", "1"), "15");
+    expect(onChange).toHaveBeenCalledWith([
+      [1, 15],
+      [2, 20],
+    ]);
+  });
+
+  it("should append a row of zeros", () => {
+    const onChange = renderTable();
+    fireEvent.click(addButton());
+    expect(onChange).toHaveBeenCalledWith([
+      [1, 10],
+      [0, 0],
+    ]);
+  });
+
+  it("should append the row built by createRow", () => {
+    const onChange = renderTable({
+      createRow: (value) => [(value.at(-1)?.[0] ?? 0) + 1, 0],
+    });
+    fireEvent.click(addButton());
+    expect(onChange).toHaveBeenCalledWith([
+      [1, 10],
+      [2, 0],
+    ]);
+  });
+
+  it("should remove the row whose button is clicked", () => {
+    const onChange = renderTable({
+      value: [
+        [1, 10],
+        [2, 20],
+        [3, 30],
+      ],
+    });
+    fireEvent.click(removeButton(1));
+    expect(onChange).toHaveBeenCalledWith([
+      [1, 10],
+      [3, 30],
+    ]);
+  });
+
+  it("should hide the add and remove buttons in preview", () => {
+    renderTable({ preview: true });
+    expect(screen.queryAllByRole("button")).toHaveLength(0);
+  });
+
+  describe("keyboard", () => {
+    const VALUE = [
+      [1, 10],
+      [2, 20],
+    ];
+
+    it("should move Enter to the next cell in row-major order", () => {
+      renderTable({ value: VALUE });
+      const from = cell("Raw", "1");
+      from.focus();
+      fireEvent.keyDown(from, { key: "Enter" });
+      expect(document.activeElement).toBe(cell("Scaled", "1"));
+    });
+
+    it("should wrap Enter onto the next row", () => {
+      renderTable({ value: VALUE });
+      const from = cell("Scaled", "1");
+      from.focus();
+      fireEvent.keyDown(from, { key: "Enter" });
+      expect(document.activeElement).toBe(cell("Raw", "2"));
+    });
+
+    it("should move shift+Enter backwards", () => {
+      renderTable({ value: VALUE });
+      const from = cell("Raw", "2");
+      from.focus();
+      fireEvent.keyDown(from, { key: "Enter", shiftKey: true });
+      expect(document.activeElement).toBe(cell("Scaled", "1"));
+    });
+
+    it("should move the down arrow to the row below", () => {
+      renderTable({ value: VALUE });
+      const from = cell("Scaled", "1");
+      from.focus();
+      fireEvent.keyDown(from, { key: "ArrowDown" });
+      expect(document.activeElement).toBe(cell("Scaled", "2"));
+    });
+
+    it("should move the up arrow to the row above", () => {
+      renderTable({ value: VALUE });
+      const from = cell("Raw", "2");
+      from.focus();
+      fireEvent.keyDown(from, { key: "ArrowUp" });
+      expect(document.activeElement).toBe(cell("Raw", "1"));
+    });
+
+    it("should hold focus at the last cell", () => {
+      renderTable({ value: VALUE });
+      const from = cell("Scaled", "2");
+      from.focus();
+      fireEvent.keyDown(from, { key: "Enter" });
+      expect(document.activeElement).toBe(from);
+    });
+  });
+
+  describe("paste", () => {
+    it("should fill the grid from the focused cell, adding rows", () => {
+      const onChange = renderTable();
+      paste(cell("Raw", "1"), "1\t10\n2\t20\n3\t30");
+      expect(onChange).toHaveBeenCalledWith([
+        [1, 10],
+        [2, 20],
+        [3, 30],
+      ]);
+    });
+
+    it("should anchor the paste on the focused cell", () => {
+      const onChange = renderTable();
+      paste(cell("Scaled", "1"), "11\n21");
+      expect(onChange).toHaveBeenCalledWith([
+        [1, 11],
+        [0, 21],
+      ]);
+    });
+
+    it("should accept a comma delimited block", () => {
+      const onChange = renderTable();
+      paste(cell("Raw", "1"), "1,10\n2,20");
+      expect(onChange).toHaveBeenCalledWith([
+        [1, 10],
+        [2, 20],
+      ]);
+    });
+
+    it("should drop a heading row", () => {
+      const onChange = renderTable();
+      paste(cell("Raw", "1"), "raw\tscaled\n1\t10\n2\t20");
+      expect(onChange).toHaveBeenCalledWith([
+        [1, 10],
+        [2, 20],
+      ]);
+    });
+
+    it("should ignore columns past the last one", () => {
+      const onChange = renderTable();
+      paste(cell("Raw", "1"), "1\t10\t100");
+      expect(onChange).toHaveBeenCalledWith([[1, 10]]);
+    });
+
+    it("should stay contiguous when the anchored row is gone", () => {
+      const onChange = vi.fn();
+      const { rerender } = render(
+        <Input.Table
+          columns={COLUMNS}
+          value={[
+            [1, 10],
+            [2, 20],
+            [3, 30],
+          ]}
+          onChange={onChange}
+        />,
+      );
+      fireEvent.focus(cell("Raw", "3"));
+      rerender(<Input.Table columns={COLUMNS} value={[[1, 10]]} onChange={onChange} />);
+      fireEvent.paste(cell("Raw", "1"), {
+        clipboardData: { getData: () => "9\t90\n8\t80" },
+      });
+      expect(onChange).toHaveBeenCalledWith([
+        [1, 10],
+        [9, 90],
+        [8, 80],
+      ]);
+    });
+
+    it("should leave a single value to the cell", () => {
+      const onChange = renderTable();
+      paste(cell("Raw", "1"), "5");
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("should leave a block holding a non-numeric row to the cell", () => {
+      const onChange = renderTable();
+      paste(cell("Raw", "1"), "1\t10\n2\tnot a number");
+      expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/pluto/src/input/Table.spec.tsx
+++ b/pluto/src/input/Table.spec.tsx
@@ -12,18 +12,25 @@ import { describe, expect, it, vi } from "vitest";
 
 import { Input } from "@/input";
 
-const COLUMNS = [{ name: "Raw" }, { name: "Scaled" }];
+const COLUMNS = [
+  <Input.TableColumn key="raw" name="Raw" />,
+  <Input.TableColumn key="scaled" name="Scaled" />,
+];
 
 interface RenderOptions {
-  value?: number[][];
+  value?: Input.TableCell[][];
   preview?: boolean;
-  createRow?: (value: number[][]) => number[];
+  createRow?: (value: Input.TableCell[][]) => Input.TableCell[];
   rowLabel?: (index: number) => string;
 }
 
 const renderTable = ({ value = [[1, 10]], ...rest }: RenderOptions = {}) => {
   const onChange = vi.fn();
-  render(<Input.Table columns={COLUMNS} value={value} onChange={onChange} {...rest} />);
+  render(
+    <Input.Table value={value} onChange={onChange} {...rest}>
+      {COLUMNS}
+    </Input.Table>,
+  );
   return onChange;
 };
 
@@ -99,7 +106,7 @@ describe("Input.Table", () => {
 
   it("should append the row built by createRow", () => {
     const onChange = renderTable({
-      createRow: (value) => [(value.at(-1)?.[0] ?? 0) + 1, 0],
+      createRow: (value) => [Number(value.at(-1)?.[0] ?? 0) + 1, 0],
     });
     fireEvent.click(addButton());
     expect(onChange).toHaveBeenCalledWith([
@@ -237,17 +244,22 @@ describe("Input.Table", () => {
       const onChange = vi.fn();
       const { rerender } = render(
         <Input.Table
-          columns={COLUMNS}
           value={[
             [1, 10],
             [2, 20],
             [3, 30],
           ]}
           onChange={onChange}
-        />,
+        >
+          {COLUMNS}
+        </Input.Table>,
       );
       fireEvent.focus(cell("Raw", "3"));
-      rerender(<Input.Table columns={COLUMNS} value={[[1, 10]]} onChange={onChange} />);
+      rerender(
+        <Input.Table value={[[1, 10]]} onChange={onChange}>
+          {COLUMNS}
+        </Input.Table>,
+      );
       fireEvent.paste(cell("Raw", "1"), {
         clipboardData: { getData: () => "9\t90\n8\t80" },
       });
@@ -268,6 +280,88 @@ describe("Input.Table", () => {
       const onChange = renderTable();
       paste(cell("Raw", "1"), "1\t10\n2\tnot a number");
       expect(onChange).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("columns", () => {
+    const renderMixed = (value: Input.TableCell[][] = [["on", 1]]) => {
+      const onChange = vi.fn();
+      render(
+        <Input.Table value={value} onChange={onChange}>
+          <Input.TableColumn name="Label" type="string" />
+          <Input.TableColumn name="Value" />
+        </Input.Table>,
+      );
+      return onChange;
+    };
+
+    it("should default a text column to a text input", () => {
+      renderMixed();
+      expect(cell("Label", "1").getAttribute("type")).not.toBe("number");
+      expect(cell("Label", "1").value).toBe("on");
+    });
+
+    it("should render the cell a column's children build", () => {
+      const onChange = vi.fn();
+      render(
+        <Input.Table value={[["on", 1]]} onChange={onChange}>
+          <Input.TableColumn name="Label" type="string">
+            {(p) => <Input.Text {...p} placeholder="the label" />}
+          </Input.TableColumn>
+          <Input.TableColumn name="Value" />
+        </Input.Table>,
+      );
+      expect(screen.getByPlaceholderText("the label")).toBe(cell("Label", "1"));
+    });
+
+    it("should commit a text cell's edit into its column", () => {
+      const onChange = renderMixed();
+      commit(cell("Label", "1"), "off");
+      expect(onChange).toHaveBeenCalledWith([["off", 1]]);
+    });
+
+    it("should append a row of the column default values", () => {
+      const onChange = renderMixed();
+      fireEvent.click(addButton());
+      expect(onChange).toHaveBeenCalledWith([
+        ["on", 1],
+        ["", 0],
+      ]);
+    });
+
+    it("should paste text into a column that accepts it", () => {
+      const onChange = renderMixed();
+      paste(cell("Label", "1"), "off\t2\nidle\t3");
+      expect(onChange).toHaveBeenCalledWith([
+        ["off", 2],
+        ["idle", 3],
+      ]);
+    });
+
+    it("should reject a block whose text lands on a numeric column", () => {
+      const onChange = renderMixed();
+      paste(cell("Label", "1"), "off\tnot a number");
+      expect(onChange).not.toHaveBeenCalled();
+    });
+
+    it("should drop a heading row a text column would otherwise accept", () => {
+      const onChange = renderMixed();
+      paste(cell("Label", "1"), "Label\tValue\nON\t1\nOFF\t2");
+      expect(onChange).toHaveBeenCalledWith([
+        ["ON", 1],
+        ["OFF", 2],
+      ]);
+    });
+
+    it("should move focus into a text cell", () => {
+      renderMixed([
+        ["on", 1],
+        ["off", 2],
+      ]);
+      const from = cell("Label", "1");
+      from.focus();
+      fireEvent.keyDown(from, { key: "ArrowDown" });
+      expect(document.activeElement).toBe(cell("Label", "2"));
     });
   });
 });

--- a/pluto/src/input/Table.tsx
+++ b/pluto/src/input/Table.tsx
@@ -9,7 +9,7 @@
 
 import "@/input/Table.css";
 
-import { csv, grid } from "@synnaxlabs/x";
+import { csv, type dimensions, grid, xy } from "@synnaxlabs/x";
 import {
   type ClipboardEvent,
   type ComponentPropsWithRef,
@@ -63,19 +63,15 @@ const parseBlock = (text: string): number[][] | null => {
   return block;
 };
 
-const cellID = ({ row, col }: grid.Position): string => `${row}:${col}`;
+const cellID = ({ x, y }: xy.XY): string => `${y}:${x}`;
 
-type Move = (
-  dims: grid.Dimensions,
-  from: grid.Position,
-  back: boolean,
-) => grid.Position | null;
+type Move = (dims: dimensions.Dimensions, from: xy.XY, back: boolean) => xy.XY | null;
 
 /** The cell each navigation key moves focus to. */
 const MOVES: Partial<Record<string, Move>> = {
   Enter: (dims, from, back) => grid.next(dims, from, back ? -1 : 1),
-  ArrowDown: (dims, from) => grid.move(dims, from, { row: 1 }),
-  ArrowUp: (dims, from) => grid.move(dims, from, { row: -1 }),
+  ArrowDown: (dims, from) => grid.move(dims, from, { x: 0, y: 1 }),
+  ArrowUp: (dims, from) => grid.move(dims, from, { x: 0, y: -1 }),
 };
 
 /**
@@ -102,14 +98,14 @@ export const Table = ({
   ...rest
 }: TableProps): ReactElement => {
   // Paste and keyboard moves land on the focused cell, so the last focus is the anchor.
-  const anchor = useRef<grid.Position>({ row: 0, col: 0 });
+  const anchor = useRef<xy.XY>(xy.ZERO);
   const cells = useRef(new Map<string, HTMLInputElement | null>());
-  const dims: grid.Dimensions = { rows: value.length, cols: columns.length };
+  const dims: dimensions.Dimensions = { width: columns.length, height: value.length };
 
-  const handleCellChange = (at: grid.Position, next: number) =>
+  const handleCellChange = (at: xy.XY, next: number) =>
     onChange(
       value.map((row, i) =>
-        i === at.row ? row.map((cell, j) => (j === at.col ? next : cell)) : row,
+        i === at.y ? row.map((cell, j) => (j === at.x ? next : cell)) : row,
       ),
     );
 
@@ -118,13 +114,13 @@ export const Table = ({
     const block = parseBlock(e.clipboardData.getData("text/plain"));
     if (block == null) return;
     e.preventDefault();
-    const { dimensions, writes } = grid.plan(dims, anchor.current, block);
+    const plan = grid.plan(dims, anchor.current, block);
     const next = value.map((row) => [...row]);
-    for (let row = dims.rows; row < dimensions.rows; row++)
+    for (let row = dims.height; row < plan.dimensions.height; row++)
       next.push(new Array<number>(columns.length).fill(0));
     // The column count is fixed, so a block wider than the table loses its tail.
-    writes.forEach(({ position: { row, col }, value }) => {
-      if (col < columns.length) next[row][col] = value;
+    plan.writes.forEach(({ position: { x, y }, value }) => {
+      if (x < columns.length) next[y][x] = value;
     });
     onChange(next);
   };
@@ -182,11 +178,11 @@ export const Table = ({
               <td key={j}>
                 <Numeric
                   ref={(el) => {
-                    cells.current.set(cellID({ row: i, col: j }), el);
+                    cells.current.set(cellID({ x: j, y: i }), el);
                   }}
                   value={row[j] ?? 0}
-                  onChange={(next) => handleCellChange({ row: i, col: j }, next)}
-                  onFocus={() => (anchor.current = { row: i, col: j })}
+                  onChange={(next) => handleCellChange({ x: j, y: i }, next)}
+                  onFocus={() => (anchor.current = { x: j, y: i })}
                   preview={preview}
                   showDragHandle={false}
                   aria-label={name == null ? rowLabel(i) : `${name} ${rowLabel(i)}`}

--- a/pluto/src/input/Table.tsx
+++ b/pluto/src/input/Table.tsx
@@ -130,6 +130,8 @@ export const Table = ({
   };
 
   const handleKeyDown = (e: KeyboardEvent) => {
+    // Enter on the add and remove buttons must reach their native activation.
+    if (!(e.target instanceof HTMLInputElement)) return;
     const move = MOVES[e.key];
     if (move == null) return;
     e.preventDefault();

--- a/pluto/src/input/Table.tsx
+++ b/pluto/src/input/Table.tsx
@@ -15,55 +15,120 @@ import {
   type ComponentPropsWithRef,
   type KeyboardEvent,
   type ReactElement,
+  type ReactNode,
   useRef,
 } from "react";
 
 import { Button } from "@/button";
+import { type RenderProp } from "@/component/renderProp";
 import { CSS } from "@/css";
 import { Icon } from "@/icon";
 import { Numeric } from "@/input/Numeric";
+import { Text as InputText } from "@/input/Text";
 import { type Control } from "@/input/types";
 import { Text } from "@/text";
+import { reactElementToArray } from "@/util/children";
 
-/** A column of a {@link Table}. */
-export interface TableColumn {
+/** The value one {@link Table} cell holds. */
+export type TableCell = string | number;
+
+/** The props a {@link TableColumn} cell renderer receives. */
+export interface TableCellProps<V extends TableCell = TableCell> extends Control<V> {
+  /** Whether the cell is read-only. */
+  preview?: boolean;
+  "aria-label": string;
+}
+
+interface BaseTableColumnProps {
   /** The heading rendered above the column. Omitted for a lone unlabeled column. */
   name?: string;
 }
 
-export interface TableProps
-  extends
-    Omit<ComponentPropsWithRef<"table">, "onChange" | "children">,
-    Control<number[][]> {
-  /** The columns in render order. Every row holds one value per column. */
-  columns: TableColumn[];
-  /** Hides the add and remove buttons and makes every cell read-only. */
-  preview?: boolean;
-  /** Labels a row's gutter cell. Defaults to the one-based row index. */
-  rowLabel?: (index: number) => string;
-  /** Builds the row the add button appends. Defaults to zeros. */
-  createRow?: (value: number[][]) => number[];
-}
+/**
+ * The column's type decides what a new row holds, how pasted text is read, and which
+ * input a cell defaults to.
+ */
+export type TableColumnProps =
+  | (BaseTableColumnProps & {
+      type?: "number";
+      /** Renders the cell. Defaults to a numeric input. */
+      children?: RenderProp<TableCellProps<number>>;
+    })
+  | (BaseTableColumnProps & {
+      type: "string";
+      /** Renders the cell. Defaults to a text input. */
+      children?: RenderProp<TableCellProps<string>>;
+    });
 
 /**
- * Reads clipboard text as a grid of numbers.
- * @returns null when the text is a single cell or holds a value that is not a number,
- * leaving the paste to the focused cell.
+ * Declares one column of a {@link Table}. It renders nothing itself: the table reads
+ * its props to build the header and every row's cell.
+ *
+ * @example <Input.TableColumn name="Pre-scaled" />
+ * @example <Input.TableColumn name="Label" type="string" />
  */
-const parseBlock = (text: string): number[][] | null => {
-  const block = csv
-    .parseBlock(text)
-    .map((row) => row.map(Number))
-    // A spreadsheet selection often carries a heading row, so drop the rows holding no
-    // numbers at all. A row that mixes text into numbers rejects the whole paste.
-    .filter((row) => row.some((cell) => isFinite(cell)));
-  if (block.length === 0) return null;
-  if (block.length === 1 && block[0].length === 1) return null;
-  if (block.some((row) => row.some((cell) => !isFinite(cell)))) return null;
-  return block;
+export const TableColumn = (_: TableColumnProps): null => null;
+
+const renderCell = (column: TableColumnProps, props: TableCellProps): ReactNode => {
+  if (column.type === "string") {
+    const cell = { ...props, value: String(props.value) };
+    if (column.children != null) return column.children(cell);
+    return <InputText {...cell} />;
+  }
+  const cell = { ...props, value: Number(props.value) };
+  if (column.children != null) return column.children(cell);
+  return <Numeric {...cell} showDragHandle={false} />;
 };
 
-const cellID = ({ x, y }: xy.XY): string => `${y}:${x}`;
+/** The value a new row holds in this column. */
+const emptyCell = (column: TableColumnProps): TableCell =>
+  column.type === "string" ? "" : 0;
+
+/**
+ * Reads a pasted cell as the type its column holds.
+ * @returns null when a numeric column is given text that is not a number. A text
+ * column takes anything.
+ */
+const parseCell = (text: string, column: TableColumnProps): TableCell | null => {
+  if (column.type === "string") return text;
+  const value = Number(text);
+  return isFinite(value) ? value : null;
+};
+
+const isComplete = (row: (TableCell | null)[]): row is TableCell[] =>
+  row.every((cell) => cell != null);
+
+/**
+ * Reads clipboard text as a grid of cell values, parsing each against the column it
+ * lands on.
+ * @returns null when the text is a single cell or holds a value its column rejects,
+ * leaving the paste to the focused cell.
+ */
+const parseBlock = (
+  text: string,
+  columns: TableColumnProps[],
+  from: number,
+): TableCell[][] | null => {
+  if (from >= columns.length) return null;
+  const block: TableCell[][] = [];
+  for (const [i, cells] of csv.parseBlock(text).entries()) {
+    // The column count is fixed, so a block wider than the table loses its tail before
+    // it can reject anything.
+    const row = cells
+      .slice(0, columns.length - from)
+      .map((cell, j) => parseCell(cell, columns[from + j]));
+    if (!isComplete(row)) {
+      // A spreadsheet selection often carries a heading row, so a first row that does
+      // not parse is dropped. A later one rejects the whole paste.
+      if (i === 0) continue;
+      return null;
+    }
+    block.push(row);
+  }
+  if (block.length === 0) return null;
+  if (block.length === 1 && block[0].length === 1) return null;
+  return block;
+};
 
 type Move = (dims: dimensions.Dimensions, from: xy.XY, back: boolean) => xy.XY | null;
 
@@ -74,35 +139,54 @@ const MOVES: Partial<Record<string, Move>> = {
   ArrowUp: (dims, from) => grid.move(dims, from, { x: 0, y: -1 }),
 };
 
+type ColumnElement = ReactElement<TableColumnProps>;
+
+export interface TableProps
+  extends
+    Omit<ComponentPropsWithRef<"table">, "onChange" | "children">,
+    Control<TableCell[][]> {
+  /** The {@link TableColumn} children in render order. */
+  children: ColumnElement | ColumnElement[];
+  /** Hides the add and remove buttons and makes every cell read-only. */
+  preview?: boolean;
+  /** Labels a row's gutter cell. Defaults to the one-based row index. */
+  rowLabel?: (index: number) => string;
+  /** Builds the row the add button appends. Defaults to the column default values. */
+  createRow?: (value: TableCell[][]) => TableCell[];
+}
+
 /**
- * An editable grid of numbers. The value is row-major: one entry per row, holding one
- * number per column. Enter and the up and down arrows move between cells. Pasting a tab
- * or comma delimited block into a focused cell fills the grid from that cell, adding
- * rows as needed.
+ * An editable grid. The value is row-major: one entry per row, holding one value per
+ * column. Enter and the up and down arrows move between cells. Pasting a tab or comma
+ * delimited block into a focused cell fills the grid from that cell, adding rows as
+ * needed.
  *
  * @example
- * <Input.Table
- *   columns={[{ name: "Pre-scaled" }, { name: "Scaled" }]}
- *   value={rows}
- *   onChange={setRows}
- * />
+ * <Input.Table value={rows} onChange={setRows}>
+ *   <Input.TableColumn name="Pre-scaled" />
+ *   <Input.TableColumn name="Scaled" />
+ * </Input.Table>
  */
 export const Table = ({
   value,
   onChange,
-  columns,
+  children,
   preview = false,
   rowLabel = (index) => (index + 1).toString(),
-  createRow = () => new Array<number>(columns.length).fill(0),
+  createRow,
   className,
   ...rest
 }: TableProps): ReactElement => {
   // Paste and keyboard moves land on the focused cell, so the last focus is the anchor.
   const anchor = useRef<xy.XY>(xy.ZERO);
-  const cells = useRef(new Map<string, HTMLInputElement | null>());
+  const table = useRef<HTMLTableElement>(null);
+  const columns = reactElementToArray<TableColumnProps>(children).map(
+    ({ props }) => props,
+  );
   const dims: dimensions.Dimensions = { width: columns.length, height: value.length };
+  const emptyRow = (): TableCell[] => columns.map(emptyCell);
 
-  const handleCellChange = (at: xy.XY, next: number) =>
+  const handleCellChange = (at: xy.XY, next: TableCell) =>
     onChange(
       value.map((row, i) =>
         i === at.y ? row.map((cell, j) => (j === at.x ? next : cell)) : row,
@@ -111,19 +195,26 @@ export const Table = ({
 
   const handlePaste = (e: ClipboardEvent) => {
     if (preview) return;
-    const block = parseBlock(e.clipboardData.getData("text/plain"));
+    const block = parseBlock(
+      e.clipboardData.getData("text/plain"),
+      columns,
+      anchor.current.x,
+    );
     if (block == null) return;
     e.preventDefault();
     const plan = grid.plan(dims, anchor.current, block);
     const next = value.map((row) => [...row]);
     for (let row = dims.height; row < plan.dimensions.height; row++)
-      next.push(new Array<number>(columns.length).fill(0));
-    // The column count is fixed, so a block wider than the table loses its tail.
-    plan.writes.forEach(({ position: { x, y }, value }) => {
-      if (x < columns.length) next[y][x] = value;
-    });
+      next.push(emptyRow());
+    plan.writes.forEach(({ position: { x, y }, value }) => (next[y][x] = value));
     onChange(next);
   };
+
+  // The row's first cell is its gutter header, so the data columns start at one.
+  const cellAt = ({ x, y }: xy.XY): HTMLInputElement | null =>
+    table.current?.tBodies[0]?.rows[y]?.cells[x + 1]?.querySelector<HTMLInputElement>(
+      "input",
+    ) ?? null;
 
   const handleKeyDown = (e: KeyboardEvent) => {
     // Enter on the add and remove buttons must reach their native activation.
@@ -132,11 +223,12 @@ export const Table = ({
     if (move == null) return;
     e.preventDefault();
     const to = move(dims, anchor.current, e.shiftKey);
-    if (to != null) cells.current.get(cellID(to))?.focus();
+    if (to != null) cellAt(to)?.focus();
   };
 
   return (
     <table
+      ref={table}
       className={CSS.cls(CSS.BE("input", "table"), className)}
       onPaste={handlePaste}
       onKeyDown={handleKeyDown}
@@ -158,7 +250,7 @@ export const Table = ({
                 variant="filled"
                 size="small"
                 tooltip="Add row"
-                onClick={() => onChange([...value, createRow(value)])}
+                onClick={() => onChange([...value, createRow?.(value) ?? emptyRow()])}
               >
                 <Icon.Add />
               </Button.Button>
@@ -174,19 +266,15 @@ export const Table = ({
                 {rowLabel(i)}
               </Text.Text>
             </th>
-            {columns.map(({ name }, j) => (
-              <td key={j}>
-                <Numeric
-                  ref={(el) => {
-                    cells.current.set(cellID({ x: j, y: i }), el);
-                  }}
-                  value={row[j] ?? 0}
-                  onChange={(next) => handleCellChange({ x: j, y: i }, next)}
-                  onFocus={() => (anchor.current = { x: j, y: i })}
-                  preview={preview}
-                  showDragHandle={false}
-                  aria-label={name == null ? rowLabel(i) : `${name} ${rowLabel(i)}`}
-                />
+            {columns.map((column, j) => (
+              <td key={j} onFocus={() => (anchor.current = { x: j, y: i })}>
+                {renderCell(column, {
+                  value: row[j] ?? emptyCell(column),
+                  onChange: (next) => handleCellChange({ x: j, y: i }, next),
+                  preview,
+                  "aria-label":
+                    column.name == null ? rowLabel(i) : `${column.name} ${rowLabel(i)}`,
+                })}
               </td>
             ))}
             <td>

--- a/pluto/src/input/Table.tsx
+++ b/pluto/src/input/Table.tsx
@@ -1,0 +1,212 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import "@/input/Table.css";
+
+import { csv, grid } from "@synnaxlabs/x";
+import {
+  type ClipboardEvent,
+  type ComponentPropsWithRef,
+  type KeyboardEvent,
+  type ReactElement,
+  useRef,
+} from "react";
+
+import { Button } from "@/button";
+import { CSS } from "@/css";
+import { Icon } from "@/icon";
+import { Numeric } from "@/input/Numeric";
+import { type Control } from "@/input/types";
+import { Text } from "@/text";
+
+/** A column of a {@link Table}. */
+export interface TableColumn {
+  /** The heading rendered above the column. Omitted for a lone unlabeled column. */
+  name?: string;
+}
+
+export interface TableProps
+  extends
+    Omit<ComponentPropsWithRef<"table">, "onChange" | "children">,
+    Control<number[][]> {
+  /** The columns in render order. Every row holds one value per column. */
+  columns: TableColumn[];
+  /** Hides the add and remove buttons and makes every cell read-only. */
+  preview?: boolean;
+  /** Labels a row's gutter cell. Defaults to the one-based row index. */
+  rowLabel?: (index: number) => string;
+  /** Builds the row the add button appends. Defaults to zeros. */
+  createRow?: (value: number[][]) => number[];
+}
+
+/**
+ * Reads clipboard text as a grid of numbers.
+ * @returns null when the text is a single cell or holds a value that is not a number,
+ * leaving the paste to the focused cell.
+ */
+const parseBlock = (text: string): number[][] | null => {
+  const block = csv
+    .parseBlock(text)
+    .map((row) => row.map(Number))
+    // A spreadsheet selection often carries a heading row, so drop the rows holding no
+    // numbers at all. A row that mixes text into numbers rejects the whole paste.
+    .filter((row) => row.some((cell) => isFinite(cell)));
+  if (block.length === 0) return null;
+  if (block.length === 1 && block[0].length === 1) return null;
+  if (block.some((row) => row.some((cell) => !isFinite(cell)))) return null;
+  return block;
+};
+
+const cellID = ({ row, col }: grid.Position): string => `${row}:${col}`;
+
+type Move = (
+  dims: grid.Dimensions,
+  from: grid.Position,
+  back: boolean,
+) => grid.Position | null;
+
+/** The cell each navigation key moves focus to. */
+const MOVES: Partial<Record<string, Move>> = {
+  Enter: (dims, from, back) => grid.next(dims, from, back ? -1 : 1),
+  ArrowDown: (dims, from) => grid.move(dims, from, { row: 1 }),
+  ArrowUp: (dims, from) => grid.move(dims, from, { row: -1 }),
+};
+
+/**
+ * An editable grid of numbers. The value is row-major: one entry per row, holding one
+ * number per column. Enter and the up and down arrows move between cells. Pasting a tab
+ * or comma delimited block into a focused cell fills the grid from that cell, adding
+ * rows as needed.
+ *
+ * @example
+ * <Input.Table
+ *   columns={[{ name: "Pre-scaled" }, { name: "Scaled" }]}
+ *   value={rows}
+ *   onChange={setRows}
+ * />
+ */
+export const Table = ({
+  value,
+  onChange,
+  columns,
+  preview = false,
+  rowLabel = (index) => (index + 1).toString(),
+  createRow = () => new Array<number>(columns.length).fill(0),
+  className,
+  ...rest
+}: TableProps): ReactElement => {
+  // Paste and keyboard moves land on the focused cell, so the last focus is the anchor.
+  const anchor = useRef<grid.Position>({ row: 0, col: 0 });
+  const cells = useRef(new Map<string, HTMLInputElement | null>());
+  const dims: grid.Dimensions = { rows: value.length, cols: columns.length };
+
+  const handleCellChange = (at: grid.Position, next: number) =>
+    onChange(
+      value.map((row, i) =>
+        i === at.row ? row.map((cell, j) => (j === at.col ? next : cell)) : row,
+      ),
+    );
+
+  const handlePaste = (e: ClipboardEvent) => {
+    if (preview) return;
+    const block = parseBlock(e.clipboardData.getData("text/plain"));
+    if (block == null) return;
+    e.preventDefault();
+    const { dimensions, writes } = grid.plan(dims, anchor.current, block);
+    const next = value.map((row) => [...row]);
+    for (let row = dims.rows; row < dimensions.rows; row++)
+      next.push(new Array<number>(columns.length).fill(0));
+    // The column count is fixed, so a block wider than the table loses its tail.
+    writes.forEach(({ position: { row, col }, value }) => {
+      if (col < columns.length) next[row][col] = value;
+    });
+    onChange(next);
+  };
+
+  const handleKeyDown = (e: KeyboardEvent) => {
+    const move = MOVES[e.key];
+    if (move == null) return;
+    e.preventDefault();
+    const to = move(dims, anchor.current, e.shiftKey);
+    if (to != null) cells.current.get(cellID(to))?.focus();
+  };
+
+  return (
+    <table
+      className={CSS.cls(CSS.BE("input", "table"), className)}
+      onPaste={handlePaste}
+      onKeyDown={handleKeyDown}
+      {...rest}
+    >
+      <thead>
+        <tr>
+          <th />
+          {columns.map(({ name }, i) => (
+            <th key={i} scope="col">
+              <Text.Text level="small" color={9}>
+                {name}
+              </Text.Text>
+            </th>
+          ))}
+          <th>
+            {!preview && (
+              <Button.Button
+                variant="filled"
+                size="small"
+                tooltip="Add row"
+                onClick={() => onChange([...value, createRow(value)])}
+              >
+                <Icon.Add />
+              </Button.Button>
+            )}
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        {value.map((row, i) => (
+          <tr key={i} className={CSS.M("reveals")}>
+            <th scope="row">
+              <Text.Text level="small" color={9}>
+                {rowLabel(i)}
+              </Text.Text>
+            </th>
+            {columns.map(({ name }, j) => (
+              <td key={j}>
+                <Numeric
+                  ref={(el) => {
+                    cells.current.set(cellID({ row: i, col: j }), el);
+                  }}
+                  value={row[j] ?? 0}
+                  onChange={(next) => handleCellChange({ row: i, col: j }, next)}
+                  onFocus={() => (anchor.current = { row: i, col: j })}
+                  preview={preview}
+                  showDragHandle={false}
+                  aria-label={name == null ? rowLabel(i) : `${name} ${rowLabel(i)}`}
+                />
+              </td>
+            ))}
+            <td>
+              {!preview && (
+                <Button.Button
+                  variant="text"
+                  size="small"
+                  reveal
+                  tooltip={`Remove row ${rowLabel(i)}`}
+                  onClick={() => onChange(value.filter((_, j) => j !== i))}
+                >
+                  <Icon.Close />
+                </Button.Button>
+              )}
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  );
+};

--- a/pluto/src/input/external.ts
+++ b/pluto/src/input/external.ts
@@ -16,6 +16,7 @@ export * from "@/input/Item";
 export * from "@/input/Label";
 export * from "@/input/Numeric";
 export * from "@/input/Switch";
+export * from "@/input/Table";
 export * from "@/input/Text";
 export * from "@/input/Time";
 export * from "@/input/types";

--- a/pluto/src/table/queries.ts
+++ b/pluto/src/table/queries.ts
@@ -206,8 +206,8 @@ export const nextCellPosition = (
 // are skipped silently; ragged rows produce a sparse region.
 export const cellsInRegion = (rows: table.Row[], start: xy.XY, end: xy.XY): string[] =>
   grid
-    .region({ row: start.y, col: start.x }, { row: end.y, col: end.x })
-    .map(({ row, col }) => rows[row]?.cells[col])
+    .region(start, end)
+    .map(({ x, y }) => rows[y]?.cells[x])
     .filter((cellKey) => cellKey != null);
 
 export const useCellPosition = Scope.bindHook(

--- a/pluto/src/table/queries.ts
+++ b/pluto/src/table/queries.ts
@@ -8,7 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { type project, type table } from "@synnaxlabs/client";
-import { compare, id, uuid, verbs, type xy } from "@synnaxlabs/x";
+import { compare, grid, id, uuid, verbs, type xy } from "@synnaxlabs/x";
 import { useCallback, useMemo } from "react";
 
 import { Flux } from "@/flux";
@@ -204,23 +204,11 @@ export const nextCellPosition = (
 // cellsInRegion returns the cell keys inside the inclusive axis-aligned
 // rectangle defined by start and end. Rows or row slots outside the rectangle
 // are skipped silently; ragged rows produce a sparse region.
-export const cellsInRegion = (
-  rows: table.Row[],
-  start: xy.XY,
-  end: xy.XY,
-): string[] => {
-  const minX = Math.min(start.x, end.x);
-  const maxX = Math.max(start.x, end.x);
-  const minY = Math.min(start.y, end.y);
-  const maxY = Math.max(start.y, end.y);
-  const out: string[] = [];
-  for (let y = minY; y <= maxY; y++) {
-    const row = rows[y];
-    if (row == null) continue;
-    for (let x = minX; x <= maxX; x++) if (row.cells[x] != null) out.push(row.cells[x]);
-  }
-  return out;
-};
+export const cellsInRegion = (rows: table.Row[], start: xy.XY, end: xy.XY): string[] =>
+  grid
+    .region({ row: start.y, col: start.x }, { row: end.y, col: end.x })
+    .map(({ row, col }) => rows[row]?.cells[col])
+    .filter((cellKey) => cellKey != null);
 
 export const useCellPosition = Scope.bindHook(
   ({ key, cellKey }: CellParams): xy.XY | null => {

--- a/x/ts/src/csv/csv.spec.ts
+++ b/x/ts/src/csv/csv.spec.ts
@@ -122,6 +122,14 @@ describe("csv", () => {
       expect(csv.parseBlock("1,10,100\n2")).toEqual([["1", "10", "100"], ["2"]]);
     });
 
+    it("should keep a newline inside a quoted field", () => {
+      expect(csv.parseBlock('"a\nb",c')).toEqual([["a\nb", "c"]]);
+    });
+
+    it("should split on commas when the only tab is inside a quoted field", () => {
+      expect(csv.parseBlock('"a\tb",c')).toEqual([["a\tb", "c"]]);
+    });
+
     it("should return no rows for empty text", () => {
       expect(csv.parseBlock("")).toEqual([]);
     });
@@ -146,6 +154,11 @@ describe("csv", () => {
         ["a,b", 'say "hi"'],
         ["1", "2"],
       ];
+      expect(csv.parseBlock(csv.formatBlock(rows))).toEqual(rows);
+    });
+
+    it("should round-trip a field holding a newline", () => {
+      const rows = [["a\nb", "c"]];
       expect(csv.parseBlock(csv.formatBlock(rows))).toEqual(rows);
     });
   });

--- a/x/ts/src/csv/csv.spec.ts
+++ b/x/ts/src/csv/csv.spec.ts
@@ -73,4 +73,80 @@ describe("csv", () => {
       });
     });
   });
+  describe("parseBlock", () => {
+    it("should split a tab delimited block into rows of fields", () => {
+      expect(csv.parseBlock("1\t10\n2\t20")).toEqual([
+        ["1", "10"],
+        ["2", "20"],
+      ]);
+    });
+
+    it("should split a comma delimited block", () => {
+      expect(csv.parseBlock("1,10\n2,20")).toEqual([
+        ["1", "10"],
+        ["2", "20"],
+      ]);
+    });
+
+    it("should keep commas inside a tab delimited field", () => {
+      expect(csv.parseBlock("1,000\t2,000")).toEqual([["1,000", "2,000"]]);
+    });
+
+    it("should keep a delimiter inside a quoted field", () => {
+      expect(csv.parseBlock('"a,b",c')).toEqual([["a,b", "c"]]);
+    });
+
+    it("should unescape doubled quotes", () => {
+      expect(csv.parseBlock('"say ""hi""",b')).toEqual([['say "hi"', "b"]]);
+    });
+
+    it("should trim the fields", () => {
+      expect(csv.parseBlock(" 1 , 10 ")).toEqual([["1", "10"]]);
+    });
+
+    it("should drop empty lines", () => {
+      expect(csv.parseBlock("1,10\n\n2,20\n")).toEqual([
+        ["1", "10"],
+        ["2", "20"],
+      ]);
+    });
+
+    it("should handle carriage returns", () => {
+      expect(csv.parseBlock("1,10\r\n2,20")).toEqual([
+        ["1", "10"],
+        ["2", "20"],
+      ]);
+    });
+
+    it("should leave ragged rows ragged", () => {
+      expect(csv.parseBlock("1,10,100\n2")).toEqual([["1", "10", "100"], ["2"]]);
+    });
+
+    it("should return no rows for empty text", () => {
+      expect(csv.parseBlock("")).toEqual([]);
+    });
+  });
+
+  describe("formatBlock", () => {
+    it("should join rows into a tab delimited block", () => {
+      expect(
+        csv.formatBlock([
+          [1, 10],
+          [2, 20],
+        ]),
+      ).toBe("1\t10\n2\t20");
+    });
+
+    it("should quote a field holding a delimiter", () => {
+      expect(csv.formatBlock([["a\tb", "c,d"]])).toBe('"a\tb"\t"c,d"');
+    });
+
+    it("should round-trip through parseBlock", () => {
+      const rows = [
+        ["a,b", 'say "hi"'],
+        ["1", "2"],
+      ];
+      expect(csv.parseBlock(csv.formatBlock(rows))).toEqual(rows);
+    });
+  });
 });

--- a/x/ts/src/csv/csv.ts
+++ b/x/ts/src/csv/csv.ts
@@ -31,10 +31,52 @@ export const formatValue = (value: unknown): string => {
   }
 };
 
-const QUOTE_REGEX = /[",\n]/;
+const QUOTE_REGEX = /["\t,\n]/;
 
 const maybeEscapeField = (field: string): string => {
   if (!QUOTE_REGEX.test(field)) return field;
   const escaped = field.replace(/"/g, '""');
   return `"${escaped}"`;
 };
+
+const TAB = "\t";
+
+/**
+ * Parses a headerless delimited block, the form a spreadsheet puts on the clipboard,
+ * into rows of fields. A line holding a tab splits on tabs, otherwise on commas, so a
+ * spreadsheet's tab-delimited fields survive the commas inside them. Quoted fields keep
+ * their delimiters and unescape doubled quotes.
+ * @returns One entry per line, each holding the line's fields. Ragged lines stay
+ * ragged; empty lines are dropped.
+ */
+export const parseBlock = (data: string): string[][] =>
+  data
+    .split(/\r?\n/)
+    .filter((line) => line.trim().length > 0)
+    .map((line) => parseLine(line, line.includes(TAB) ? TAB : ","));
+
+const parseLine = (line: string, delimiter: string): string[] => {
+  const fields: string[] = [];
+  let field = "";
+  let quoted = false;
+  for (let i = 0; i < line.length; i++) {
+    const char = line[i];
+    if (quoted && char === '"' && line[i + 1] === '"') {
+      field += '"';
+      i++;
+    } else if (char === '"') quoted = !quoted;
+    else if (char === delimiter && !quoted) {
+      fields.push(field.trim());
+      field = "";
+    } else field += char;
+  }
+  fields.push(field.trim());
+  return fields;
+};
+
+/**
+ * Formats rows of values into a tab delimited block, the form a spreadsheet reads from
+ * the clipboard. Fields holding a delimiter, a quote, or a newline are quoted.
+ */
+export const formatBlock = (rows: unknown[][]): string =>
+  rows.map((row) => row.map(formatValue).join(TAB)).join("\n");

--- a/x/ts/src/csv/csv.ts
+++ b/x/ts/src/csv/csv.ts
@@ -41,37 +41,51 @@ const maybeEscapeField = (field: string): string => {
 
 const TAB = "\t";
 
+const delimiterOf = (data: string): string => {
+  let quoted = false;
+  for (const char of data)
+    if (char === '"') quoted = !quoted;
+    else if (char === TAB && !quoted) return TAB;
+  return ",";
+};
+
 /**
  * Parses a headerless delimited block, the form a spreadsheet puts on the clipboard,
- * into rows of fields. A line holding a tab splits on tabs, otherwise on commas, so a
- * spreadsheet's tab-delimited fields survive the commas inside them. Quoted fields keep
- * their delimiters and unescape doubled quotes.
- * @returns One entry per line, each holding the line's fields. Ragged lines stay
- * ragged; empty lines are dropped.
+ * into rows of fields. The block splits on tabs when it holds one outside a quoted
+ * field, otherwise on commas, so a spreadsheet's tab-delimited fields survive the
+ * commas inside them. A quoted field keeps its delimiters and its newlines, and
+ * doubled quotes unescape.
+ * @returns One entry per row, each holding the row's fields. Ragged rows stay ragged;
+ * rows holding nothing but empty fields are dropped.
  */
-export const parseBlock = (data: string): string[][] =>
-  data
-    .split(/\r?\n/)
-    .filter((line) => line.trim().length > 0)
-    .map((line) => parseLine(line, line.includes(TAB) ? TAB : ","));
-
-const parseLine = (line: string, delimiter: string): string[] => {
-  const fields: string[] = [];
+export const parseBlock = (data: string): string[][] => {
+  const delimiter = delimiterOf(data);
+  const rows: string[][] = [];
+  let fields: string[] = [];
   let field = "";
   let quoted = false;
-  for (let i = 0; i < line.length; i++) {
-    const char = line[i];
-    if (quoted && char === '"' && line[i + 1] === '"') {
+  const endField = () => {
+    fields.push(field.trim());
+    field = "";
+  };
+  const endRow = () => {
+    endField();
+    if (fields.some((f) => f.length > 0)) rows.push(fields);
+    fields = [];
+  };
+  for (let i = 0; i < data.length; i++) {
+    const char = data[i];
+    if (quoted && char === '"' && data[i + 1] === '"') {
       field += '"';
       i++;
     } else if (char === '"') quoted = !quoted;
-    else if (char === delimiter && !quoted) {
-      fields.push(field.trim());
-      field = "";
-    } else field += char;
+    else if (quoted) field += char;
+    else if (char === delimiter) endField();
+    else if (char === "\n") endRow();
+    else if (char !== "\r") field += char;
   }
-  fields.push(field.trim());
-  return fields;
+  endRow();
+  return rows;
 };
 
 /**

--- a/x/ts/src/grid/grid.spec.ts
+++ b/x/ts/src/grid/grid.spec.ts
@@ -11,125 +11,120 @@ import { describe, expect, it } from "vitest";
 
 import { grid } from "@/grid";
 
-const DIMS = { rows: 3, cols: 2 };
+const DIMS = { width: 2, height: 3 };
 
 describe("grid", () => {
   describe("contains", () => {
-    it("should accept a position inside the grid", () => {
-      expect(grid.contains(DIMS, { row: 2, col: 1 })).toBe(true);
+    it("should accept a cell inside the grid", () => {
+      expect(grid.contains(DIMS, { x: 1, y: 2 })).toBe(true);
     });
 
-    it("should reject a position past an edge", () => {
-      expect(grid.contains(DIMS, { row: 3, col: 0 })).toBe(false);
-      expect(grid.contains(DIMS, { row: 0, col: -1 })).toBe(false);
+    it("should reject a cell past an edge", () => {
+      expect(grid.contains(DIMS, { x: 0, y: 3 })).toBe(false);
+      expect(grid.contains(DIMS, { x: -1, y: 0 })).toBe(false);
     });
   });
 
   describe("move", () => {
     it("should step a single axis", () => {
-      expect(grid.move(DIMS, { row: 0, col: 0 }, { row: 1 })).toEqual({
-        row: 1,
-        col: 0,
-      });
+      expect(grid.move(DIMS, { x: 0, y: 0 }, { x: 0, y: 1 })).toEqual({ x: 0, y: 1 });
     });
 
     it("should return null when the step leaves the grid", () => {
-      expect(grid.move(DIMS, { row: 2, col: 0 }, { row: 1 })).toBeNull();
-      expect(grid.move(DIMS, { row: 0, col: 1 }, { col: 1 })).toBeNull();
+      expect(grid.move(DIMS, { x: 0, y: 2 }, { x: 0, y: 1 })).toBeNull();
+      expect(grid.move(DIMS, { x: 1, y: 0 }, { x: 1, y: 0 })).toBeNull();
     });
   });
 
   describe("next", () => {
     it("should step forward inside a row", () => {
-      expect(grid.next(DIMS, { row: 0, col: 0 }, 1)).toEqual({ row: 0, col: 1 });
+      expect(grid.next(DIMS, { x: 0, y: 0 }, 1)).toEqual({ x: 1, y: 0 });
     });
 
     it("should wrap onto the next row", () => {
-      expect(grid.next(DIMS, { row: 0, col: 1 }, 1)).toEqual({ row: 1, col: 0 });
+      expect(grid.next(DIMS, { x: 1, y: 0 }, 1)).toEqual({ x: 0, y: 1 });
     });
 
     it("should wrap onto the end of the previous row", () => {
-      expect(grid.next(DIMS, { row: 1, col: 0 }, -1)).toEqual({ row: 0, col: 1 });
+      expect(grid.next(DIMS, { x: 0, y: 1 }, -1)).toEqual({ x: 1, y: 0 });
     });
 
     it("should return null at the last cell", () => {
-      expect(grid.next(DIMS, { row: 2, col: 1 }, 1)).toBeNull();
+      expect(grid.next(DIMS, { x: 1, y: 2 }, 1)).toBeNull();
     });
 
     it("should return null at the first cell", () => {
-      expect(grid.next(DIMS, { row: 0, col: 0 }, -1)).toBeNull();
+      expect(grid.next(DIMS, { x: 0, y: 0 }, -1)).toBeNull();
     });
 
-    it("should return null for a position outside the grid", () => {
-      expect(grid.next(DIMS, { row: 9, col: 0 }, 1)).toBeNull();
+    it("should return null for a cell outside the grid", () => {
+      expect(grid.next(DIMS, { x: 0, y: 9 }, 1)).toBeNull();
     });
   });
 
   describe("region", () => {
     it("should list the rectangle in row-major order", () => {
-      expect(grid.region({ row: 0, col: 0 }, { row: 1, col: 1 })).toEqual([
-        { row: 0, col: 0 },
-        { row: 0, col: 1 },
-        { row: 1, col: 0 },
-        { row: 1, col: 1 },
+      expect(grid.region({ x: 0, y: 0 }, { x: 1, y: 1 })).toEqual([
+        { x: 0, y: 0 },
+        { x: 1, y: 0 },
+        { x: 0, y: 1 },
+        { x: 1, y: 1 },
       ]);
     });
 
     it("should accept the corners in any order", () => {
-      expect(grid.region({ row: 1, col: 1 }, { row: 0, col: 0 })).toEqual(
-        grid.region({ row: 0, col: 0 }, { row: 1, col: 1 }),
+      expect(grid.region({ x: 1, y: 1 }, { x: 0, y: 0 })).toEqual(
+        grid.region({ x: 0, y: 0 }, { x: 1, y: 1 }),
       );
     });
 
-    it("should list a single position for one cell", () => {
-      expect(grid.region({ row: 2, col: 1 }, { row: 2, col: 1 })).toEqual([
-        { row: 2, col: 1 },
-      ]);
+    it("should list a single cell for one cell", () => {
+      expect(grid.region({ x: 1, y: 2 }, { x: 1, y: 2 })).toEqual([{ x: 1, y: 2 }]);
     });
   });
 
   describe("plan", () => {
     it("should place a block at the anchor", () => {
-      const { dimensions, writes } = grid.plan(DIMS, { row: 1, col: 0 }, [[7, 8]]);
+      const { dimensions, writes } = grid.plan(DIMS, { x: 0, y: 1 }, [[7, 8]]);
       expect(dimensions).toEqual(DIMS);
       expect(writes).toEqual([
-        { position: { row: 1, col: 0 }, value: 7 },
-        { position: { row: 1, col: 1 }, value: 8 },
+        { position: { x: 0, y: 1 }, value: 7 },
+        { position: { x: 1, y: 1 }, value: 8 },
       ]);
     });
 
     it("should grow the dimensions to hold the block", () => {
-      const { dimensions } = grid.plan({ rows: 1, cols: 1 }, { row: 0, col: 0 }, [
+      const { dimensions } = grid.plan({ width: 1, height: 1 }, { x: 0, y: 0 }, [
         [1, 2],
         [3, 4],
       ]);
-      expect(dimensions).toEqual({ rows: 2, cols: 2 });
+      expect(dimensions).toEqual({ width: 2, height: 2 });
     });
 
     it("should keep the plan contiguous when the anchor is past the last row", () => {
       const { dimensions, writes } = grid.plan(
-        { rows: 1, cols: 2 },
-        { row: 5, col: 0 },
+        { width: 2, height: 1 },
+        { x: 0, y: 5 },
         [[9, 90]],
       );
-      expect(dimensions).toEqual({ rows: 2, cols: 2 });
-      expect(writes[0].position).toEqual({ row: 1, col: 0 });
+      expect(dimensions).toEqual({ width: 2, height: 2 });
+      expect(writes[0].position).toEqual({ x: 0, y: 1 });
     });
 
     it("should clamp a negative anchor", () => {
-      const { writes } = grid.plan(DIMS, { row: -2, col: -1 }, [[1]]);
-      expect(writes[0].position).toEqual({ row: 0, col: 0 });
+      const { writes } = grid.plan(DIMS, { x: -1, y: -2 }, [[1]]);
+      expect(writes[0].position).toEqual({ x: 0, y: 0 });
     });
 
     it("should plan nothing for an empty block", () => {
-      expect(grid.plan(DIMS, { row: 0, col: 0 }, [])).toEqual({
+      expect(grid.plan(DIMS, { x: 0, y: 0 }, [])).toEqual({
         dimensions: DIMS,
         writes: [],
       });
     });
 
     it("should carry any value type", () => {
-      const { writes } = grid.plan({ rows: 1, cols: 1 }, { row: 0, col: 0 }, [["a"]]);
+      const { writes } = grid.plan({ width: 1, height: 1 }, { x: 0, y: 0 }, [["a"]]);
       expect(writes[0].value).toBe("a");
     });
   });

--- a/x/ts/src/grid/grid.spec.ts
+++ b/x/ts/src/grid/grid.spec.ts
@@ -1,0 +1,136 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { describe, expect, it } from "vitest";
+
+import { grid } from "@/grid";
+
+const DIMS = { rows: 3, cols: 2 };
+
+describe("grid", () => {
+  describe("contains", () => {
+    it("should accept a position inside the grid", () => {
+      expect(grid.contains(DIMS, { row: 2, col: 1 })).toBe(true);
+    });
+
+    it("should reject a position past an edge", () => {
+      expect(grid.contains(DIMS, { row: 3, col: 0 })).toBe(false);
+      expect(grid.contains(DIMS, { row: 0, col: -1 })).toBe(false);
+    });
+  });
+
+  describe("move", () => {
+    it("should step a single axis", () => {
+      expect(grid.move(DIMS, { row: 0, col: 0 }, { row: 1 })).toEqual({
+        row: 1,
+        col: 0,
+      });
+    });
+
+    it("should return null when the step leaves the grid", () => {
+      expect(grid.move(DIMS, { row: 2, col: 0 }, { row: 1 })).toBeNull();
+      expect(grid.move(DIMS, { row: 0, col: 1 }, { col: 1 })).toBeNull();
+    });
+  });
+
+  describe("next", () => {
+    it("should step forward inside a row", () => {
+      expect(grid.next(DIMS, { row: 0, col: 0 }, 1)).toEqual({ row: 0, col: 1 });
+    });
+
+    it("should wrap onto the next row", () => {
+      expect(grid.next(DIMS, { row: 0, col: 1 }, 1)).toEqual({ row: 1, col: 0 });
+    });
+
+    it("should wrap onto the end of the previous row", () => {
+      expect(grid.next(DIMS, { row: 1, col: 0 }, -1)).toEqual({ row: 0, col: 1 });
+    });
+
+    it("should return null at the last cell", () => {
+      expect(grid.next(DIMS, { row: 2, col: 1 }, 1)).toBeNull();
+    });
+
+    it("should return null at the first cell", () => {
+      expect(grid.next(DIMS, { row: 0, col: 0 }, -1)).toBeNull();
+    });
+
+    it("should return null for a position outside the grid", () => {
+      expect(grid.next(DIMS, { row: 9, col: 0 }, 1)).toBeNull();
+    });
+  });
+
+  describe("region", () => {
+    it("should list the rectangle in row-major order", () => {
+      expect(grid.region({ row: 0, col: 0 }, { row: 1, col: 1 })).toEqual([
+        { row: 0, col: 0 },
+        { row: 0, col: 1 },
+        { row: 1, col: 0 },
+        { row: 1, col: 1 },
+      ]);
+    });
+
+    it("should accept the corners in any order", () => {
+      expect(grid.region({ row: 1, col: 1 }, { row: 0, col: 0 })).toEqual(
+        grid.region({ row: 0, col: 0 }, { row: 1, col: 1 }),
+      );
+    });
+
+    it("should list a single position for one cell", () => {
+      expect(grid.region({ row: 2, col: 1 }, { row: 2, col: 1 })).toEqual([
+        { row: 2, col: 1 },
+      ]);
+    });
+  });
+
+  describe("plan", () => {
+    it("should place a block at the anchor", () => {
+      const { dimensions, writes } = grid.plan(DIMS, { row: 1, col: 0 }, [[7, 8]]);
+      expect(dimensions).toEqual(DIMS);
+      expect(writes).toEqual([
+        { position: { row: 1, col: 0 }, value: 7 },
+        { position: { row: 1, col: 1 }, value: 8 },
+      ]);
+    });
+
+    it("should grow the dimensions to hold the block", () => {
+      const { dimensions } = grid.plan({ rows: 1, cols: 1 }, { row: 0, col: 0 }, [
+        [1, 2],
+        [3, 4],
+      ]);
+      expect(dimensions).toEqual({ rows: 2, cols: 2 });
+    });
+
+    it("should keep the plan contiguous when the anchor is past the last row", () => {
+      const { dimensions, writes } = grid.plan(
+        { rows: 1, cols: 2 },
+        { row: 5, col: 0 },
+        [[9, 90]],
+      );
+      expect(dimensions).toEqual({ rows: 2, cols: 2 });
+      expect(writes[0].position).toEqual({ row: 1, col: 0 });
+    });
+
+    it("should clamp a negative anchor", () => {
+      const { writes } = grid.plan(DIMS, { row: -2, col: -1 }, [[1]]);
+      expect(writes[0].position).toEqual({ row: 0, col: 0 });
+    });
+
+    it("should plan nothing for an empty block", () => {
+      expect(grid.plan(DIMS, { row: 0, col: 0 }, [])).toEqual({
+        dimensions: DIMS,
+        writes: [],
+      });
+    });
+
+    it("should carry any value type", () => {
+      const { writes } = grid.plan({ rows: 1, cols: 1 }, { row: 0, col: 0 }, [["a"]]);
+      expect(writes[0].value).toBe("a");
+    });
+  });
+});

--- a/x/ts/src/grid/grid.ts
+++ b/x/ts/src/grid/grid.ts
@@ -7,73 +7,68 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-/** A cell's coordinates in a grid, both zero-based. */
-export interface Position {
-  row: number;
-  col: number;
-}
+import { bounds, type dimensions, xy } from "@/spatial";
 
-/** A grid's extent. */
-export interface Dimensions {
-  rows: number;
-  cols: number;
-}
-
-export const contains = ({ rows, cols }: Dimensions, { row, col }: Position): boolean =>
-  row >= 0 && row < rows && col >= 0 && col < cols;
+/** Reports whether a cell lies inside a grid of the given dimensions. */
+export const contains = (dims: dimensions.Dimensions, cell: xy.XY): boolean =>
+  cell.x >= 0 && cell.x < dims.width && cell.y >= 0 && cell.y < dims.height;
 
 /**
- * Steps one cell in a direction.
- * @returns The moved position, or null when the step leaves the grid.
+ * Steps a cell by a delta.
+ * @returns The moved cell, or null when the step leaves the grid.
  */
 export const move = (
-  dims: Dimensions,
-  { row, col }: Position,
-  delta: Partial<Position>,
-): Position | null => {
-  const next = { row: row + (delta.row ?? 0), col: col + (delta.col ?? 0) };
+  dims: dimensions.Dimensions,
+  cell: xy.XY,
+  delta: xy.XY,
+): xy.XY | null => {
+  const next = xy.translate(cell, delta);
   return contains(dims, next) ? next : null;
 };
 
 /**
  * Steps one cell forward (dir 1) or backward (dir -1) in row-major order, wrapping at a
  * row's end onto the next row.
- * @returns The next position, or null at the grid's first or last cell.
+ * @returns The next cell, or null at the grid's first or last cell.
  */
-export const next = (dims: Dimensions, pos: Position, dir: 1 | -1): Position | null => {
-  if (!contains(dims, pos)) return null;
-  const col = pos.col + dir;
-  if (col >= 0 && col < dims.cols) return { row: pos.row, col };
-  const row = pos.row + dir;
-  if (row < 0 || row >= dims.rows) return null;
-  return { row, col: dir === 1 ? 0 : dims.cols - 1 };
+export const next = (
+  dims: dimensions.Dimensions,
+  cell: xy.XY,
+  dir: 1 | -1,
+): xy.XY | null => {
+  if (!contains(dims, cell)) return null;
+  const x = cell.x + dir;
+  if (x >= 0 && x < dims.width) return { x, y: cell.y };
+  const y = cell.y + dir;
+  if (y < 0 || y >= dims.height) return null;
+  return { x: dir === 1 ? 0 : dims.width - 1, y };
 };
 
 /**
- * Lists the positions inside the inclusive rectangle the two corners define, in
- * row-major order.
+ * Lists the cells inside the inclusive rectangle the two corners define, in row-major
+ * order.
  */
-export const region = (start: Position, end: Position): Position[] => {
-  const positions: Position[] = [];
-  const minRow = Math.min(start.row, end.row);
-  const maxRow = Math.max(start.row, end.row);
-  const minCol = Math.min(start.col, end.col);
-  const maxCol = Math.max(start.col, end.col);
-  for (let row = minRow; row <= maxRow; row++)
-    for (let col = minCol; col <= maxCol; col++) positions.push({ row, col });
-  return positions;
+export const region = (start: xy.XY, end: xy.XY): xy.XY[] => {
+  const cells: xy.XY[] = [];
+  const minX = Math.min(start.x, end.x);
+  const maxX = Math.max(start.x, end.x);
+  const minY = Math.min(start.y, end.y);
+  const maxY = Math.max(start.y, end.y);
+  for (let y = minY; y <= maxY; y++)
+    for (let x = minX; x <= maxX; x++) cells.push({ x, y });
+  return cells;
 };
 
-/** One value bound for a position by a {@link Plan}. */
+/** One value bound for a cell by a {@link Plan}. */
 export interface Write<V> {
-  position: Position;
+  position: xy.XY;
   value: V;
 }
 
 /** The result of {@link plan}: where a block lands and how big the grid must become. */
 export interface Plan<V> {
   /** The extent the grid needs to hold every write. Never smaller than the current. */
-  dimensions: Dimensions;
+  dimensions: dimensions.Dimensions;
   writes: Write<V>[];
 }
 
@@ -86,21 +81,24 @@ export interface Plan<V> {
  * array grows it and assigns, a caller backed by a document adds rows and columns first
  * and then writes each position.
  */
-export const plan = <V>(dims: Dimensions, anchor: Position, block: V[][]): Plan<V> => {
-  const start = {
-    row: Math.min(Math.max(anchor.row, 0), dims.rows),
-    col: Math.min(Math.max(anchor.col, 0), dims.cols),
+export const plan = <V>(
+  dims: dimensions.Dimensions,
+  anchor: xy.XY,
+  block: V[][],
+): Plan<V> => {
+  const start: xy.XY = {
+    x: bounds.clamp({ lower: 0, upper: dims.width }, anchor.x),
+    y: bounds.clamp({ lower: 0, upper: dims.height }, anchor.y),
   };
   const writes: Write<V>[] = [];
-  let rows = dims.rows;
-  let cols = dims.cols;
-  block.forEach((blockRow, i) =>
-    blockRow.forEach((value, j) => {
-      const position = { row: start.row + i, col: start.col + j };
-      rows = Math.max(rows, position.row + 1);
-      cols = Math.max(cols, position.col + 1);
+  let { width, height } = dims;
+  block.forEach((row, i) =>
+    row.forEach((value, j) => {
+      const position = { x: start.x + j, y: start.y + i };
+      width = Math.max(width, position.x + 1);
+      height = Math.max(height, position.y + 1);
       writes.push({ position, value });
     }),
   );
-  return { dimensions: { rows, cols }, writes };
+  return { dimensions: { width, height }, writes };
 };

--- a/x/ts/src/grid/grid.ts
+++ b/x/ts/src/grid/grid.ts
@@ -1,0 +1,106 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+/** A cell's coordinates in a grid, both zero-based. */
+export interface Position {
+  row: number;
+  col: number;
+}
+
+/** A grid's extent. */
+export interface Dimensions {
+  rows: number;
+  cols: number;
+}
+
+export const contains = ({ rows, cols }: Dimensions, { row, col }: Position): boolean =>
+  row >= 0 && row < rows && col >= 0 && col < cols;
+
+/**
+ * Steps one cell in a direction.
+ * @returns The moved position, or null when the step leaves the grid.
+ */
+export const move = (
+  dims: Dimensions,
+  { row, col }: Position,
+  delta: Partial<Position>,
+): Position | null => {
+  const next = { row: row + (delta.row ?? 0), col: col + (delta.col ?? 0) };
+  return contains(dims, next) ? next : null;
+};
+
+/**
+ * Steps one cell forward (dir 1) or backward (dir -1) in row-major order, wrapping at a
+ * row's end onto the next row.
+ * @returns The next position, or null at the grid's first or last cell.
+ */
+export const next = (dims: Dimensions, pos: Position, dir: 1 | -1): Position | null => {
+  if (!contains(dims, pos)) return null;
+  const col = pos.col + dir;
+  if (col >= 0 && col < dims.cols) return { row: pos.row, col };
+  const row = pos.row + dir;
+  if (row < 0 || row >= dims.rows) return null;
+  return { row, col: dir === 1 ? 0 : dims.cols - 1 };
+};
+
+/**
+ * Lists the positions inside the inclusive rectangle the two corners define, in
+ * row-major order.
+ */
+export const region = (start: Position, end: Position): Position[] => {
+  const positions: Position[] = [];
+  const minRow = Math.min(start.row, end.row);
+  const maxRow = Math.max(start.row, end.row);
+  const minCol = Math.min(start.col, end.col);
+  const maxCol = Math.max(start.col, end.col);
+  for (let row = minRow; row <= maxRow; row++)
+    for (let col = minCol; col <= maxCol; col++) positions.push({ row, col });
+  return positions;
+};
+
+/** One value bound for a position by a {@link Plan}. */
+export interface Write<V> {
+  position: Position;
+  value: V;
+}
+
+/** The result of {@link plan}: where a block lands and how big the grid must become. */
+export interface Plan<V> {
+  /** The extent the grid needs to hold every write. Never smaller than the current. */
+  dimensions: Dimensions;
+  writes: Write<V>[];
+}
+
+/**
+ * Plans the paste of a block of values with its top left corner at an anchor. The anchor
+ * clamps into the current grid, so a stale anchor cannot leave a gap between the last
+ * row and the block.
+ *
+ * The plan says what the result holds, never how to get there: a caller backed by an
+ * array grows it and assigns, a caller backed by a document adds rows and columns first
+ * and then writes each position.
+ */
+export const plan = <V>(dims: Dimensions, anchor: Position, block: V[][]): Plan<V> => {
+  const start = {
+    row: Math.min(Math.max(anchor.row, 0), dims.rows),
+    col: Math.min(Math.max(anchor.col, 0), dims.cols),
+  };
+  const writes: Write<V>[] = [];
+  let rows = dims.rows;
+  let cols = dims.cols;
+  block.forEach((blockRow, i) =>
+    blockRow.forEach((value, j) => {
+      const position = { row: start.row + i, col: start.col + j };
+      rows = Math.max(rows, position.row + 1);
+      cols = Math.max(cols, position.col + 1);
+      writes.push({ position, value });
+    }),
+  );
+  return { dimensions: { rows, cols }, writes };
+};

--- a/x/ts/src/grid/index.ts
+++ b/x/ts/src/grid/index.ts
@@ -1,0 +1,10 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+export * as grid from "@/grid/grid";

--- a/x/ts/src/index.ts
+++ b/x/ts/src/index.ts
@@ -23,6 +23,7 @@ export * from "@/destructor";
 export * from "@/errors";
 export * from "@/filename";
 export * from "@/fmt";
+export * from "@/grid";
 export * from "@/id";
 export * from "@/instance";
 export * from "@/json";


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4554](https://linear.app/synnax/issue/SY-4554/add-manual-entry-of-tables-for-ni-task-scaling)

## Description

The NI custom `Table` scaling only accepted a CSV upload, so an engineer holding<br>breakpoints in a spreadsheet or a document had to export a file first, then upload it<br>blind: the loaded values never appeared in the form. The table scale now shows an<br>editable grid. Values are typed in directly, pasted as a block from a spreadsheet, or<br>loaded from a CSV as before, and every path lands in the same visible, editable grid.<br>Enter and the up and down arrows move between cells.

The grid is a new Pluto primitive, `Input.Table`: a controlled numeric grid over<br>`number[][]` with column headings, a row gutter, and add and remove row controls. The<br>polynomial `CoefficientsField` is rebuilt on it as a single unlabeled column, which<br>deletes its hand-rolled row list and gains it the validation help text it never showed.<br>Test access goes through one `getInputTable(label)` helper in the Console testutil,<br>replacing NI's class-selector helpers.

Two pure seams move into `x` so the table visualization can reuse them rather than grow<br>a second copy:

* `csv.parseBlock` / `csv.formatBlock` read and write the headerless tab-or-comma block<br>spreadsheets put on the clipboard. `binary.CSVCodec` cannot serve: it demands a header<br>line and returns column-keyed arrays.
* `grid` holds `{row, col}` coordinate math and a paste plan: target dimensions plus the<br>writes a block produces at an anchor. `Input.Table` applies the plan to an array;<br>`table.cellsInRegion` already reads its region helper.

I looked at making the table visualization a managed mode over shared base table<br>components first, and rejected it. Its body is CRDT action batches with undo and redo,<br>variant cells resolved per key from Flux where the `value` variant draws into the Aether<br>canvas and emits no DOM, stored pixel row and column sizes with drag resize, and<br>cell-key selection with shift and control regions. The overlap with a form grid is the<br>`<table>` skeleton and keyboard navigation, so a base parameterized by cell renderer,<br>optional pixel geometry, selection model, and mutation strategy would be as complex as<br>the implementation it hides. The pure seams carry the reuse instead.

One thing the research turned up, left for its own issue since it changes table<br>behavior: spreadsheet copy and paste does not work in the table visualization. Paste<br>returns early unless its private MIME type is present, and copy writes a description<br>such as `4 cells` to `text/plain`. Wiring that clipboard onto `csv.parseBlock` and<br>`grid.plan` is a follow-up.

## Basic Readiness

- [X] I have performed a self-review of my code.
- [X] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

### Greptile Summary

The PR adds an editable numeric table for NI scaling and shared CSV and grid utilities. The CSV import fix rejects newly loaded ragged columns, but existing mismatched form values can still become zero-filled scaling points.

* Adds direct entry, spreadsheet paste, and CSV loading for NI table scales.
* Rebuilds coefficient entry with the shared `Input.Table` component.
* Adds headerless CSV-block parsing and reusable grid coordinate helpers.

### Confidence Score: 4/5

The PR is not safe to merge until mismatched table-scale arrays can no longer become persisted zero-filled scaling points.

Existing mismatched arrays are still padded for display, and any grid mutation writes those synthesized zeros back into deployable form state.

**Files Needing Attention:** console/src/feature/ni/task/TableScaleForm.tsx

### Important Files Changed

<!-- linear:table-colwidths:400,400 -->
| Filename | Overview |
| -- | -- |
| console/src/feature/ni/task/TableScaleForm.tsx | Adds unified CSV and manual table editing, but grid mutations can persist zeros synthesized from mismatched source arrays. |
| pluto/src/input/Table.tsx | Adds the controlled numeric grid with row operations, navigation, and block paste handling. |
| x/ts/src/csv/csv.ts | Replaces physical-line parsing with a character scanner that handles quoted multiline fields. |
| x/ts/src/grid/grid.ts | Adds reusable grid bounds, movement, region, and paste-planning helpers. |

### Flowchart

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Mismatched scale arrays] --> B[Build rows to maximum length]
  B --> C[Substitute zero for missing values]
  C --> D[User changes the grid]
  D --> E[Write all rows to both arrays]
  E --> F[Deploy synthesized scaling points]
```

Reviews (2): Last reviewed commit: ["Address grid cells as xy.XY and dimensio..."](<https://github.com/synnaxlabs/synnax/commit/154769dbac2dee21bc76dc2b1e30dd06d2b4c07f>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=54943254>)

> Greptile also left **1 inline comment** on this PR.