### PR TITLE
SY-4657: Fix two stale console toolbar specs

### DIFF
--- a/console/src/feature/schematic/toolbar/Toolbar.spec.ts
+++ b/console/src/feature/schematic/toolbar/Toolbar.spec.ts
@@ -108,7 +108,7 @@ describe("Schematic.Toolbar", () => {
       );
       // The Core serializes the schematic into the flat imex envelope: numeric version,
       // and the resource key is dropped.
-      expect(contents).toMatchObject({ name, type: "schematic", version: 7 });
+      expect(contents).toMatchObject({ name, type: "schematic", version: 8 });
     });
   });
 });

--- a/console/src/feature/task/Toolbar.spec.tsx
+++ b/console/src/feature/task/Toolbar.spec.tsx
@@ -142,7 +142,10 @@ describe("task/Toolbar", () => {
 
   it("withholds the empty message until the task list answers", async () => {
     const t = await createTask();
-    await renderToolbar();
+    // The task cache hangs off the client, so a client an earlier test left holding a
+    // live empty list would answer the toolbar before the fetch. A fresh client is
+    // cold, which is the cold-start state this guard exists for.
+    await renderToolbar(createTestClient());
     expect(screen.queryByText("No tasks")).toBeNull();
     await screen.findByText(t.name);
   });


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4657](https://linear.app/synnax/issue/SY-4657/fix-two-stale-console-toolbar-specs)

## Description

Two console specs fail against the current Core and test layout.

`Schematic.Toolbar > export > downloads the schematic as a typed JSON export` pinned the exported envelope at version 7. The Core writes 8 (`core/pkg/service/schematic/versions/v8/imex.gen.go`), so the expectation is bumped.

`task/Toolbar > withholds the empty message until the task list answers` asserts the empty message is held back until the list answers. The task cache hangs off the client, which is shared across the whole spec file, so an earlier test left it holding a live empty list that answered the toolbar before its own fetch — the guard never saw the cold start it exists for. It now renders with a fresh client.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates two stale Console toolbar tests.
- Updates the schematic export expectation to Core envelope version 8.
- Uses a fresh client to test the task toolbar’s cold-cache state.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The changes align the tests with the current Core export format and isolate client-owned cache state without changing production behavior.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| console/src/feature/schematic/toolbar/Toolbar.spec.ts | Updates the expected schematic export version to match the current Core format. |
| console/src/feature/task/Toolbar.spec.tsx | Isolates the cold-cache assertion with a fresh test client. |

<sub>Reviews (1): Last reviewed commit: ["SY-4657: Fix two stale console toolbar s..."](https://github.com/synnaxlabs/synnax/commit/d404c89a2617d8ac5da689074c0ab53d61034beb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55016492)</sub>

<!-- /greptile_comment -->