### PR TITLE
SY-4619: Require routing entries to be full flow statements

### DIFF
--- a/arc/cpp/runtime/wasm/node_test.cpp
+++ b/arc/cpp/runtime/wasm/node_test.cpp
@@ -1866,8 +1866,8 @@ func labeler(x i64) (label str, value i64) {
     value = x * 2
 }
 )arc" + input_name +
-        " -> labeler{} -> {label: " + label_out_name + ", value: " + value_out_name +
-        "}";
+        " -> labeler{} -> {label: \"ok\" -> " + label_out_name + ", value: 0 -> " +
+        value_out_name + "}";
 
     auto str_st = std::make_shared<stl::strings::State>();
     auto series_st = std::make_shared<stl::series::State>();

--- a/arc/cpp/stl/selector/selector.h
+++ b/arc/cpp/stl/selector/selector.h
@@ -32,12 +32,11 @@ inline const std::string false_param = "false";
 inline constexpr size_t TRUE_OUTPUT_IDX = 0;
 inline constexpr size_t FALSE_OUTPUT_IDX = 1;
 
-/// @brief Select routes a boolean input to its "true" or "false" outputs:
-/// true values produce samples on the "true" output; false values produce
-/// samples on the "false" output. Both outputs emit a value of 1 for each
-/// matched sample — the output value signals "this route fired" rather than
-/// echoing the input — so the output can drive a truthy-gated transition
-/// whether the matched route is true or false.
+/// @brief Select gates the "true" or "false" branch of a routing table: true
+/// input samples fire the true output, false samples fire the false output.
+/// Each fired output emits 1 so truthy-gated transitions fire on either
+/// branch. The value never reaches an entry; entries define their own
+/// sources.
 class Select : public runtime::node::Node {
     runtime::state::Node state;
     size_t input_idx;

--- a/arc/docs/spec.md
+++ b/arc/docs/spec.md
@@ -505,15 +505,22 @@ FlowOperator ::= '->'       // continuous flow
 
 RoutingTable ::= '{' RoutingEntry (',' RoutingEntry)* '}'
 
-RoutingEntry ::= RoutingKey ':' FlowNode ('->' FlowNode)* (':' Identifier)?
+RoutingEntry ::= RoutingKey ':' FlowNode (('->' | '=>') FlowNode)* (':' Identifier)?
 
 RoutingKey ::= Identifier | 'true' | 'false'
 
 FlowNode ::= Identifier           // channel, variable, stage, or sequence name
            | FunctionInvocation   // func{...}
            | Expression           // inline computation
+           | StageDeclaration     // inline stage body
+           | SequenceDeclaration  // inline sequence body
            | 'next'               // next stage (sequences only)
 ```
+
+An output routing entry's case body must be a full flow statement (at least two nodes)
+or an inline stage/sequence body. The routed output only decides that the entry runs; it
+feeds no value into it. A trailing `: Identifier` maps the entry's own result to an
+input of the function after the table.
 
 ### Simple Pipelines
 
@@ -523,12 +530,12 @@ sensor -> filter{threshold=50.0} -> controller{} -> actuator
 
 ### Output Routing Tables
 
-Route named outputs to different targets:
+Branch on named outputs; the output that fires runs its entry:
 
 ```arc
 sensor -> demux{} -> {
-    high: alarm{},
-    low: logger{}
+    high: true => alarm,
+    low: true => all_clear
 }
 ```
 
@@ -550,8 +557,8 @@ Map multiple sources to named input parameters:
     temp1: a,
     temp2: b
 } -> averager{} -> threshold{} -> {
-    above: alarm{},
-    below: logger{}
+    above: true => alarm,
+    below: true => all_clear
 }
 ```
 
@@ -569,13 +576,13 @@ pressure > 100 or emergency -> shutdown{} // logical (emergency is a chan bool)
 
 ### Selecting on a Boolean
 
-`select{}` routes a `bool` input by value using the `true` and `false` routing keys.
-Each output is `u8` and emits `1` when its branch fires.
+`select{}` runs the `true` or `false` entry for each `bool` input. No value flows into
+the entry; each case body is a full flow statement.
 
 ```arc
 pressure > 500.0 -> select{} -> {
-    true: alarm{},
-    false: all_clear{}
+    true: true => alarm,
+    false: true => all_clear
 }
 ```
 

--- a/arc/go/analyzer/flow/flow.go
+++ b/arc/go/analyzer/flow/flow.go
@@ -676,8 +676,7 @@ func analyzeOutputRoutingTable(
 	for _, entry := range ctx.AST.AllRoutingEntry() {
 		outputName := entry.RoutingKey().GetText()
 
-		outputType, exists := fnType.Type.Outputs.Get(outputName)
-		if !exists {
+		if _, exists := fnType.Type.Outputs.Get(outputName); !exists {
 			ctx.Diagnostics.Add(diagnostics.Errorf(
 				entry,
 				"func '%s' does not have output '%s'",
@@ -710,26 +709,88 @@ func analyzeOutputRoutingTable(
 			}
 		}
 
-		// First node's source is the select-output type; subsequent nodes
-		// chain from the previous node's output.
 		flowNodes := entry.AllFlowNode()
-		nodeSourceType := outputType.Type
+		if len(flowNodes) == 0 {
+			continue
+		}
+
+		// A routing key only gates its entry, so a bare target would never
+		// receive a value. The entry must define its own source. Output types
+		// stay unconstrained on purpose: a future syntax can still opt into
+		// passing the routed value along.
+		if len(flowNodes) == 1 && targetParamName == "" &&
+			!isInlineBody(flowNodes[0]) {
+			ctx.Diagnostics.Add(diagnostics.Errorf(
+				entry,
+				"routing entry '%s' must be a full statement (e.g. '%s: true => next')",
+				outputName,
+				outputName,
+			))
+			continue
+		}
+
+		// The first node is the head of the entry's flow statement: it is
+		// analyzed with no upstream and feeds the rest of the chain.
+		var nodeSourceType types.Type
 		for i, flowNode := range flowNodes {
 			isLastNode := i == len(flowNodes)-1
+			child := context.Child(ctx, flowNode)
+			if i == 0 {
+				analyzeNode(child, nil, false)
+				if isLastNode {
+					checkEntryHeadParamMapping(child, nextFuncType, targetParamName)
+				} else {
+					nodeSourceType = inferFlowNodeOutputType(child)
+				}
+				continue
+			}
 			var targetParam *string
 			if isLastNode && targetParamName != "" {
 				targetParam = &targetParamName
 			}
 			analyzeRoutingTargetWithParam(
-				context.Child(ctx, flowNode),
+				child,
 				nodeSourceType,
 				nextFuncType,
 				targetParam,
 			)
 			if !isLastNode {
-				nodeSourceType = inferFlowNodeOutputType(context.Child(ctx, flowNode))
+				nodeSourceType = inferFlowNodeOutputType(child)
 			}
 		}
+	}
+}
+
+// isInlineBody reports whether the flow node is an inline stage or sequence
+// declaration, which is a self-contained routing target.
+func isInlineBody(node parser.IFlowNodeContext) bool {
+	return node.StageDeclaration() != nil || node.SequenceDeclaration() != nil
+}
+
+// checkEntryHeadParamMapping type-checks a single-node routing entry's head
+// against the parameter it maps to on the func after the table.
+func checkEntryHeadParamMapping(
+	ctx context.Context[parser.IFlowNodeContext],
+	nextFuncType types.Type,
+	targetParamName string,
+) {
+	if targetParamName == "" {
+		return
+	}
+	param, exists := nextFuncType.Inputs.Get(targetParamName)
+	if !exists {
+		return
+	}
+	headType := inferFlowNodeOutputType(ctx)
+	if err := atypes.Check(ctx.Constraints, headType, param.Type, ctx.AST,
+		"routing table parameter mapping"); err != nil {
+		ctx.Diagnostics.Add(diagnostics.Errorf(
+			ctx.AST,
+			"type mismatch: output type %s does not match target parameter %s type %s",
+			headType,
+			targetParamName,
+			param.Type,
+		))
 	}
 }
 

--- a/arc/go/analyzer/flow/flow_test.go
+++ b/arc/go/analyzer/flow/flow_test.go
@@ -1007,7 +1007,7 @@ func demux(value f64) (high f64, low f64) {
     low = value
 }
 sensor_chan -> demux{} -> {
-    high: some_var
+    high: true -> some_var
 }`))
 					ctx := context.NewRoot(bCtx, ast, NewRoot(nil, localResolver...))
 					analyzer.AnalyzeProgram(ctx)
@@ -1033,7 +1033,7 @@ func router{} (value f64) (high u8, low u8) {
 sequence main {
     stage first {
         sensor_chan -> router{} -> {
-            high: opt_1,
+            high: true => opt_1,
         }
     }
     stage opt_1 {}
@@ -1094,8 +1094,8 @@ sequence main {
 			func logger{} (value f64) {}
 
 			sensor_chan -> demux{threshold=100.0} -> {
-			    high: alarm{},
-			    low: logger{}
+			    high: 1.0 -> alarm{},
+			    low: 1.0 -> logger{}
 			}`))
 			ctx := context.NewRoot(bCtx, ast, NewRoot(nil, resolver...))
 			analyzer.AnalyzeProgram(ctx)
@@ -1138,8 +1138,8 @@ sequence main {
 			func target{} (value f64) {}
 
 			sensor_chan -> demux{} -> {
-			    high: target{},
-			    medium: target{}
+			    high: 1.0 -> target{},
+			    medium: 1.0 -> target{}
 			}`))
 			ctx := context.NewRoot(bCtx, ast, NewRoot(nil, resolver...))
 			analyzer.AnalyzeProgram(ctx)
@@ -1163,7 +1163,7 @@ sequence main {
 			func u32_target{} (value u32) {}
 
 			sensor_chan -> demux{} -> {
-			    high: u32_target{}
+			    high: "nope" -> u32_target{}
 			}`))
 			ctx := context.NewRoot(bCtx, ast, NewRoot(nil, resolver...))
 			analyzer.AnalyzeProgram(ctx)
@@ -1190,8 +1190,8 @@ sequence main {
 			func logger{} (value f64) {}
 
 			sensor_chan -> demux{} -> {
-			    high: multiplier{} -> alarm{},
-			    low: logger{}
+			    high: 1.0 -> multiplier{} -> alarm{},
+			    low: 1.0 -> logger{}
 			}`))
 			ctx := context.NewRoot(bCtx, ast, NewRoot(nil, resolver...))
 			analyzer.AnalyzeProgram(ctx)
@@ -1218,8 +1218,8 @@ sequence main {
 			func logger{} (value f64) {}
 
 			sensor_chan -> demux{} -> {
-			    high: multiplier{} => alarm{},
-			    low: logger{}
+			    high: 1.0 -> multiplier{} => alarm{},
+			    low: 1.0 -> logger{}
 			}`))
 				ctx := context.NewRoot(bCtx, ast, NewRoot(nil, resolver...))
 				analyzer.AnalyzeProgram(ctx)
@@ -1402,7 +1402,7 @@ sequence main {
 			}
 
 			sensor_chan -> demux{} -> {
-			    high: demux{} -> log_num,
+			    high: 1.0 -> demux{} -> log_num,
 			    low: 1 -> log_num
 			}`))
 				ctx := context.NewRoot(bCtx, ast, NewRoot(customResolver))
@@ -2614,8 +2614,8 @@ sequence main {
 			}
 
 			sensor_chan -> demux{} -> {
-			    high: output_chan,
-			    low: temp_sensor
+			    high: 1.0 -> output_chan,
+			    low: 1.0 -> temp_sensor
 			}`))
 			ctx := context.NewRoot(bCtx, ast, NewRoot(nil, resolver...))
 			analyzer.AnalyzeProgram(ctx)
@@ -2656,8 +2656,8 @@ sequence main {
 			func configurable{threshold f64} (value f64) {}
 
 			sensor_chan -> demux{} -> {
-			    high: configurable{threshold=50.0},
-			    low: configurable{}
+			    high: 1.0 -> configurable{threshold=50.0},
+			    low: 1.0 -> configurable{}
 			}`))
 				ctx := context.NewRoot(bCtx, ast, NewRoot(nil, resolver...))
 				analyzer.AnalyzeProgram(ctx)
@@ -2744,7 +2744,7 @@ sequence main {
 			}
 
 			sensor_chan -> demux{} -> {
-			    high: multiplier{}: a
+			    high: 1.0 -> multiplier{}: a
 			} -> converter{}`))
 			ctx := context.NewRoot(bCtx, ast, NewRoot(nil, resolver...))
 			analyzer.AnalyzeProgram(ctx)
@@ -2778,7 +2778,7 @@ sequence main {
 			}
 
 			sensor_chan -> demux{} -> {
-			    high: filter{} -> amplifier{}: input,
+			    high: 1.0 -> filter{} -> amplifier{}: input,
 			    low: output_chan: scale
 			} -> scaler{}`))
 				ctx := context.NewRoot(bCtx, ast, NewRoot(nil, resolver...))
@@ -3208,8 +3208,8 @@ var _ = Describe("Trigger in select routing branches", func() {
 			ast := MustSucceed(parser.Parse(`
 		func setter{key_or_name str, message str, variant str} () {}
 		start_cmd -> select{} -> {
-			true: setter{key_or_name="a", message="up", variant="info"},
-			false: setter{key_or_name="b", message="down", variant="info"}
+			true: true -> setter{key_or_name="a", message="up", variant="info"},
+			false: true -> setter{key_or_name="b", message="down", variant="info"}
 		}`))
 			ctx := context.NewRoot(bCtx, ast, NewRoot(nil, resolver...))
 			analyzer.AnalyzeProgram(ctx)
@@ -3223,8 +3223,8 @@ var _ = Describe("Trigger in select routing branches", func() {
 			ast := MustSucceed(parser.Parse(`
 		func sink(v str) {}
 		start_cmd -> select{} -> {
-			true: sink{},
-			false: sink{}
+			true: true -> sink{},
+			false: true -> sink{}
 		}`))
 			ctx := context.NewRoot(bCtx, ast, NewRoot(nil, resolver...))
 			analyzer.AnalyzeProgram(ctx)
@@ -3257,6 +3257,162 @@ var _ = Describe("Trigger in select routing branches", func() {
 			ctx := context.NewRoot(bCtx, ast, NewRoot(customResolver))
 			analyzer.AnalyzeProgram(ctx)
 			Expect(ctx.Diagnostics.Ok()).To(BeTrue(), ctx.Diagnostics.String())
+		},
+	)
+})
+
+var _ = Describe("Routing entry strictness", func() {
+	routingResolver := StaticResolver{
+		{Name: "flag", Kind: symbol.KindChannel, Type: types.Chan(types.Bool())},
+		{Name: "vlv_cmd", Kind: symbol.KindChannel, Type: types.Chan(types.Bool())},
+		{Name: "log_str", Kind: symbol.KindChannel, Type: types.Chan(types.String())},
+		{Name: "sensor_chan", Kind: symbol.KindChannel, Type: types.Chan(types.F64())},
+	}
+
+	DescribeTable("Should reject a bare routing entry target",
+		func(bCtx SpecContext, source string) {
+			ast := MustSucceed(parser.Parse(source))
+			ctx := context.NewRoot(bCtx, ast, NewRoot(routingResolver))
+			analyzer.AnalyzeProgram(ctx)
+			Expect(ctx.Diagnostics.Ok()).To(BeFalse())
+			Expect(ctx.Diagnostics.String()).To(
+				ContainSubstring("must be a full statement"),
+			)
+		},
+		Entry("bare next", `
+			sequence main {
+			    stage first {
+			        flag -> select{} -> { true: next }
+			    }
+			    stage second {}
+			}`),
+		Entry("bare channel", `
+			flag -> select{} -> { false: vlv_cmd }`),
+		Entry("bare sequence", `
+			sequence alarm {
+			    stage active {}
+			}
+			flag -> select{} -> { true: alarm }`),
+		Entry("bare expression", `
+			flag -> select{} -> { true: 1 }`),
+		Entry("bare func invocation", `
+			func alarm{} (value f64) {}
+			flag -> select{} -> { true: alarm{} }`),
+		Entry("bare func invocations on a custom routing func", `
+			func demux{} (value f64) (high f64, low f64) {
+			    if (value > 100.0) {
+			        high = value
+			    } else {
+			        low = value
+			    }
+			}
+			func alarm{} (value f64) {}
+			func logger{} (value f64) {}
+			sensor_chan -> demux{} -> { high: alarm{}, low: logger{} }`),
+	)
+
+	It("Should not feed the routed value into an entry's head func",
+		func(bCtx SpecContext) {
+			ast := MustSucceed(parser.Parse(`
+			func amplify{} (value f64) f64 {
+			    return value * 2.0
+			}
+			flag -> select{} -> {
+			    true: amplify{} -> log_str
+			}`))
+			ctx := context.NewRoot(bCtx, ast, NewRoot(routingResolver))
+			analyzer.AnalyzeProgram(ctx)
+			Expect(ctx.Diagnostics.Ok()).To(BeFalse())
+			Expect(ctx.Diagnostics.String()).To(ContainSubstring(
+				"missing required argument for parameter 'value' of func 'amplify'"))
+		},
+	)
+
+	DescribeTable("Should accept a full flow statement entry",
+		func(bCtx SpecContext, source string) {
+			ast := MustSucceed(parser.Parse(source))
+			ctx := context.NewRoot(bCtx, ast, NewRoot(routingResolver))
+			analyzer.AnalyzeProgram(ctx)
+			Expect(ctx.Diagnostics.Ok()).To(BeTrue(), ctx.Diagnostics.String())
+		},
+		Entry("boolean transition to next", `
+			sequence main {
+			    stage first {
+			        flag -> select{} -> { true: true => next }
+			    }
+			    stage second {}
+			}`),
+		Entry("explicit value per branch", `
+			flag -> select{} -> {
+			    true: true -> vlv_cmd,
+			    false: false -> vlv_cmd
+			}`),
+		Entry("boolean transition to a sequence", `
+			sequence alarm {
+			    stage active {}
+			}
+			flag -> select{} -> { true: true => alarm }`),
+	)
+
+	// Inline bodies are the exception to the full-statement rule. They are
+	// self-contained, so they run without the entry providing an upstream flow.
+	DescribeTable("Should accept an inline body without an upstream flow",
+		func(bCtx SpecContext, source string) {
+			ast := MustSucceed(parser.Parse(source))
+			ctx := context.NewRoot(bCtx, ast, NewRoot(routingResolver))
+			analyzer.AnalyzeProgram(ctx)
+			Expect(ctx.Diagnostics.Ok()).To(BeTrue(), ctx.Diagnostics.String())
+		},
+		Entry("inline stage body", `
+			flag -> select{} -> {
+			    true: stage { true -> vlv_cmd }
+			}`),
+		Entry("inline sequence body", `
+			flag -> select{} -> {
+			    true: sequence { true -> vlv_cmd }
+			}`),
+		Entry("inline bodies on both branches", `
+			flag -> select{} -> {
+			    true: stage { true -> vlv_cmd },
+			    false: sequence { false -> vlv_cmd }
+			}`),
+	)
+
+	It("Should type-check a param-mapped entry head against the parameter",
+		func(bCtx SpecContext) {
+			ast := MustSucceed(parser.Parse(`
+			func demux{} (value f64) (high f64, low f64) {
+			    if (value > 100.0) {
+			        high = value
+			    } else {
+			        low = value
+			    }
+			}
+			func combiner{} (a f64, b f64) f64 {
+			    return a + b
+			}
+			sensor_chan -> demux{} -> {
+			    high: log_str: a,
+			    low: 1.0: b
+			} -> combiner{}`))
+			resolver := StaticResolver{
+				{
+					Name: "sensor_chan",
+					Kind: symbol.KindChannel,
+					Type: types.Chan(types.F64()),
+				},
+				{
+					Name: "log_str",
+					Kind: symbol.KindChannel,
+					Type: types.Chan(types.String()),
+				},
+			}
+			ctx := context.NewRoot(bCtx, ast, NewRoot(resolver))
+			analyzer.AnalyzeProgram(ctx)
+			Expect(ctx.Diagnostics.Ok()).To(BeFalse())
+			Expect(ctx.Diagnostics.String()).To(
+				ContainSubstring("does not match target parameter a"),
+			)
 		},
 	)
 })

--- a/arc/go/compiler/statement/variable.go
+++ b/arc/go/compiler/statement/variable.go
@@ -538,7 +538,7 @@ func compileOutputAssignment(
 
 	// Write the appropriate store instruction based on type
 	switch scope.Type.Kind {
-	case types.KindI8, types.KindU8:
+	case types.KindI8, types.KindU8, types.KindBool:
 		ctx.Writer.WriteMemoryOp(wasm.OpI32Store8, 0, 0)
 	case types.KindI16, types.KindU16:
 		ctx.Writer.WriteMemoryOp(wasm.OpI32Store16, 1, 0)

--- a/arc/go/lsp/hover_test.go
+++ b/arc/go/lsp/hover_test.go
@@ -223,7 +223,9 @@ var _ = Describe("Hover", func() {
 
 			Expect(hover).ToNot(BeNil())
 			Expect(HoverContents(hover)).To(ContainSubstring("#### select"))
-			Expect(HoverContents(hover)).To(ContainSubstring("Routes a boolean input"))
+			Expect(HoverContents(hover)).To(
+				ContainSubstring("Triggers the 'true' or 'false' routing entry"),
+			)
 		})
 
 		It("should provide hover for 'stable.for' function", func(ctx SpecContext) {

--- a/arc/go/routing_table_test.go
+++ b/arc/go/routing_table_test.go
@@ -39,8 +39,8 @@ var _ = Describe("Routing Table Runtime", func() {
 				})
 				h := newRuntimeHarness(ctx, demuxSource+`
 				sensor -> demux{threshold=50.0} -> {
-					high: high_out,
-					low: low_out
+					high: 1.0 -> high_out,
+					low: 2.0 -> low_out
 				}
 			`, resolver,
 					channels.Digest{Key: 100, DataType: telem.Float64T},
@@ -65,12 +65,14 @@ var _ = Describe("Routing Table Runtime", func() {
 				lowResult := h.Output("demux_0", 1)
 				Expect(lowResult.Len()).To(Equal(int64(0)))
 
+				// The branch only gates the entry: the write carries the entry's
+				// own constant, not the routed value.
 				out, changed := h.Flush()
 				Expect(changed).To(BeTrue())
 				Expect(out.Get(200).Series).To(HaveLen(1))
 				Expect(
 					telem.UnmarshalSeries[float64](out.Get(200).Series[0]),
-				).To(Equal([]float64{75.0}))
+				).To(Equal([]float64{1.0}))
 				Expect(out.Get(300).Series).To(BeEmpty())
 			},
 		)
@@ -85,8 +87,8 @@ var _ = Describe("Routing Table Runtime", func() {
 				})
 				h := newRuntimeHarness(ctx, demuxSource+`
 				sensor -> demux{threshold=50.0} -> {
-					high: high_out,
-					low: low_out
+					high: 1.0 -> high_out,
+					low: 2.0 -> low_out
 				}
 			`, resolver,
 					channels.Digest{Key: 100, DataType: telem.Float64T},
@@ -117,7 +119,7 @@ var _ = Describe("Routing Table Runtime", func() {
 				Expect(out.Get(300).Series).To(HaveLen(1))
 				Expect(
 					telem.UnmarshalSeries[float64](out.Get(300).Series[0]),
-				).To(Equal([]float64{25.0}))
+				).To(Equal([]float64{2.0}))
 			},
 		)
 
@@ -131,8 +133,8 @@ var _ = Describe("Routing Table Runtime", func() {
 				})
 				h := newRuntimeHarness(ctx, demuxSource+`
 				sensor -> demux{threshold=50.0} -> {
-					high: high_out,
-					low: low_out
+					high: 1.0 -> high_out,
+					low: 2.0 -> low_out
 				}
 			`, resolver,
 					channels.Digest{Key: 100, DataType: telem.Float64T},
@@ -157,14 +159,16 @@ var _ = Describe("Routing Table Runtime", func() {
 				).To(Equal([]float64{20.0, 10.0}))
 				Expect(h.OutputTime("demux_0", 1).Len()).To(Equal(int64(2)))
 
+				// Each entry's constant fires once per trigger batch, so the
+				// writes carry one sample regardless of the batch size.
 				out, changed := h.Flush()
 				Expect(changed).To(BeTrue())
 				Expect(
 					telem.UnmarshalSeries[float64](out.Get(200).Series[0]),
-				).To(Equal([]float64{80.0, 90.0}))
+				).To(Equal([]float64{1.0}))
 				Expect(
 					telem.UnmarshalSeries[float64](out.Get(300).Series[0]),
-				).To(Equal([]float64{20.0, 10.0}))
+				).To(Equal([]float64{2.0}))
 			},
 		)
 
@@ -189,9 +193,9 @@ var _ = Describe("Routing Table Runtime", func() {
 				}
 
 				sensor -> classify{} -> {
-				    negative: neg_out,
-				    zero: zero_out,
-				    positive: pos_out
+				    negative: -1 -> neg_out,
+				    zero: 0 -> zero_out,
+				    positive: 1 -> pos_out
 				}`, resolver,
 					channels.Digest{Key: 100, DataType: telem.Int64T},
 					channels.Digest{Key: 200, DataType: telem.Int64T},
@@ -217,13 +221,189 @@ var _ = Describe("Routing Table Runtime", func() {
 				Expect(changed).To(BeTrue())
 				Expect(
 					telem.UnmarshalSeries[int64](out.Get(200).Series[0]),
-				).To(Equal([]int64{-5}))
+				).To(Equal([]int64{-1}))
 				Expect(
 					telem.UnmarshalSeries[int64](out.Get(300).Series[0]),
 				).To(Equal([]int64{0}))
 				Expect(
 					telem.UnmarshalSeries[int64](out.Get(400).Series[0]),
-				).To(Equal([]int64{42}))
+				).To(Equal([]int64{1}))
+			},
+		)
+
+		It(
+			"Should fire entries for mixed bool and u8 outputs in the same tick",
+			func(ctx SpecContext) {
+				resolver := channelSymbols(map[string]channelDef{
+					"sensor":   {types.F64(), 100},
+					"flag_out": {types.U8(), 200},
+					"mode_out": {types.U8(), 300},
+				})
+				h := newRuntimeHarness(ctx, `
+				func split{} (value f64) (ok bool, mode u8) {
+				    mode = 2
+				    ok = value > 50.0
+				}
+
+				sensor -> split{} -> {
+				    ok: 1 -> flag_out,
+				    mode: 2 -> mode_out
+				}`, resolver,
+					channels.Digest{Key: 100, DataType: telem.Float64T},
+					channels.Digest{Key: 200, DataType: telem.Uint8T},
+					channels.Digest{Key: 300, DataType: telem.Uint8T},
+				)
+				defer h.Close(ctx)
+
+				// One input sets both outputs, so both entries run in the same
+				// tick regardless of their output types.
+				h.Ingest(100, telem.NewSeriesV(75.0))
+				h.Tick(ctx, telem.Millisecond)
+				h.channelState.ClearReads()
+
+				// mode is written first, so a too-wide bool store clobbers it.
+				Expect(
+					telem.UnmarshalSeries[bool](h.Output("split_0", 0)),
+				).To(Equal([]bool{true}))
+				Expect(
+					telem.UnmarshalSeries[uint8](h.Output("split_0", 1)),
+				).To(Equal([]uint8{2}))
+
+				out, changed := h.Flush()
+				Expect(changed).To(BeTrue())
+				Expect(out.Get(200).Series).To(HaveLen(1))
+				Expect(
+					telem.UnmarshalSeries[uint8](out.Get(200).Series[0]),
+				).To(Equal([]uint8{1}))
+				Expect(out.Get(300).Series).To(HaveLen(1))
+				Expect(
+					telem.UnmarshalSeries[uint8](out.Get(300).Series[0]),
+				).To(Equal([]uint8{2}))
+			},
+		)
+
+		It(
+			"Should fire entries for mixed numeric and string outputs in the same tick",
+			func(ctx SpecContext) {
+				resolver := channelSymbols(map[string]channelDef{
+					"sensor":    {types.F64(), 100},
+					"count_out": {types.U8(), 200},
+					"mode_out":  {types.U8(), 300},
+					"total_out": {types.U8(), 400},
+					"ratio_out": {types.U8(), 500},
+					"mean_out":  {types.U8(), 600},
+					"label_out": {types.U8(), 700},
+				})
+				h := newRuntimeHarness(ctx, `
+				func spread{} (value f64) (
+				    count u16,
+				    mode i32,
+				    total i64,
+				    ratio f32,
+				    mean f64,
+				    label str,
+				) {
+				    label = "ok"
+				    mean = value
+				    ratio = 1.5
+				    total = 5000000000
+				    mode = -3
+				    count = 300
+				}
+
+				sensor -> spread{} -> {
+				    count: 1 -> count_out,
+				    mode: 2 -> mode_out,
+				    total: 3 -> total_out,
+				    ratio: 4 -> ratio_out,
+				    mean: 5 -> mean_out,
+				    label: 6 -> label_out
+				}`, resolver,
+					channels.Digest{Key: 100, DataType: telem.Float64T},
+					channels.Digest{Key: 200, DataType: telem.Uint8T},
+					channels.Digest{Key: 300, DataType: telem.Uint8T},
+					channels.Digest{Key: 400, DataType: telem.Uint8T},
+					channels.Digest{Key: 500, DataType: telem.Uint8T},
+					channels.Digest{Key: 600, DataType: telem.Uint8T},
+					channels.Digest{Key: 700, DataType: telem.Uint8T},
+				)
+				defer h.Close(ctx)
+
+				// Values need every byte of their width and are written in reverse
+				// declaration order, so a wrong store width fails the readbacks.
+				h.Ingest(100, telem.NewSeriesV(75.0))
+				h.Tick(ctx, telem.Millisecond)
+				h.channelState.ClearReads()
+
+				Expect(
+					telem.UnmarshalSeries[uint16](h.Output("spread_0", 0)),
+				).To(Equal([]uint16{300}))
+				Expect(
+					telem.UnmarshalSeries[int32](h.Output("spread_0", 1)),
+				).To(Equal([]int32{-3}))
+				Expect(
+					telem.UnmarshalSeries[int64](h.Output("spread_0", 2)),
+				).To(Equal([]int64{5000000000}))
+				Expect(
+					telem.UnmarshalSeries[float32](h.Output("spread_0", 3)),
+				).To(Equal([]float32{1.5}))
+				Expect(
+					telem.UnmarshalSeries[float64](h.Output("spread_0", 4)),
+				).To(Equal([]float64{75.0}))
+				Expect(
+					telem.UnmarshalSeries[string](h.Output("spread_0", 5)),
+				).To(Equal([]string{"ok"}))
+
+				out, changed := h.Flush()
+				Expect(changed).To(BeTrue())
+				for i, key := range []uint32{200, 300, 400, 500, 600, 700} {
+					Expect(out.Get(key).Series).To(HaveLen(1))
+					Expect(
+						telem.UnmarshalSeries[uint8](out.Get(key).Series[0]),
+					).To(Equal([]uint8{uint8(i + 1)}))
+				}
+			},
+		)
+
+		It(
+			"Should fire a transition entry when the output is set to a falsy value",
+			func(ctx SpecContext) {
+				resolver := channelSymbols(map[string]channelDef{
+					"sensor":  {types.F64(), 100},
+					"vlv_cmd": {types.U8(), 200},
+				})
+				h := newRuntimeHarness(ctx, `
+				func gate{} (value f64) (level u8) {
+				    level = 0
+				}
+
+				sequence alarm {
+				    stage active {
+				        1 -> vlv_cmd
+				    }
+				}
+
+				sensor -> gate{} -> {
+				    level: true => alarm
+				}`, resolver,
+					channels.Digest{Key: 100, DataType: telem.Float64T},
+					channels.Digest{Key: 200, DataType: telem.Uint8T},
+				)
+				defer h.Close(ctx)
+
+				// gate sets level to 0. Setting the output fires the entry, and
+				// the transition gates on the entry's own constant, so the
+				// falsy output value still activates the sequence.
+				h.Ingest(100, telem.NewSeriesV(25.0))
+				h.Tick(ctx, telem.Millisecond)
+				h.channelState.ClearReads()
+
+				out, changed := h.Flush()
+				Expect(changed).To(BeTrue())
+				Expect(out.Get(200).Series).To(HaveLen(1))
+				Expect(
+					telem.UnmarshalSeries[uint8](out.Get(200).Series[0]),
+				).To(Equal([]uint8{1}))
 			},
 		)
 	})
@@ -242,7 +422,7 @@ var _ = Describe("Routing Table Runtime", func() {
 				}
 
 				sensor -> demux{threshold=50.0} -> {
-				    high: amplify{} -> alarm_out
+				    high: 2.0 -> amplify{} -> alarm_out
 				}`, resolver,
 					channels.Digest{Key: 100, DataType: telem.Float64T},
 					channels.Digest{Key: 200, DataType: telem.Float64T},
@@ -258,17 +438,19 @@ var _ = Describe("Routing Table Runtime", func() {
 					telem.UnmarshalSeries[float64](demuxHigh),
 				).To(Equal([]float64{80.0}))
 
+				// amplify computes from the entry's constant, not the routed
+				// value: 2.0 * 2.0.
 				amplifyResult := h.Output("amplify_0", 0)
 				Expect(
 					telem.UnmarshalSeries[float64](amplifyResult),
-				).To(Equal([]float64{160.0}))
+				).To(Equal([]float64{4.0}))
 				Expect(h.OutputTime("amplify_0", 0).Len()).To(Equal(int64(1)))
 
 				out, changed := h.Flush()
 				Expect(changed).To(BeTrue())
 				Expect(
 					telem.UnmarshalSeries[float64](out.Get(200).Series[0]),
-				).To(Equal([]float64{160.0}))
+				).To(Equal([]float64{4.0}))
 			},
 		)
 
@@ -285,7 +467,7 @@ var _ = Describe("Routing Table Runtime", func() {
 				}
 
 				sensor -> demux{threshold=50.0} -> {
-				    high: amplify{} -> alarm_out
+				    high: 2.0 -> amplify{} -> alarm_out
 				}`, resolver,
 					channels.Digest{Key: 100, DataType: telem.Float64T},
 					channels.Digest{Key: 200, DataType: telem.Float64T},
@@ -308,7 +490,7 @@ var _ = Describe("Routing Table Runtime", func() {
 		)
 
 		It(
-			"Should chain multiple samples through amplify preserving per-sample timestamps",
+			"Should fire the chained function once per multi-sample trigger batch",
 			func(ctx SpecContext) {
 				resolver := channelSymbols(map[string]channelDef{
 					"sensor":    {types.F64(), 100},
@@ -320,7 +502,7 @@ var _ = Describe("Routing Table Runtime", func() {
 				}
 
 				sensor -> demux{threshold=50.0} -> {
-				    high: amplify{} -> alarm_out
+				    high: 2.0 -> amplify{} -> alarm_out
 				}`, resolver,
 					channels.Digest{Key: 100, DataType: telem.Float64T},
 					channels.Digest{Key: 200, DataType: telem.Float64T},
@@ -337,17 +519,19 @@ var _ = Describe("Routing Table Runtime", func() {
 				).To(Equal([]float64{80.0, 90.0}))
 				Expect(h.OutputTime("demux_0", 0).Len()).To(Equal(int64(2)))
 
+				// The entry's constant fires once for the batch, so amplify
+				// emits a single sample.
 				amplifyResult := h.Output("amplify_0", 0)
 				Expect(
 					telem.UnmarshalSeries[float64](amplifyResult),
-				).To(Equal([]float64{160.0, 180.0}))
-				Expect(h.OutputTime("amplify_0", 0).Len()).To(Equal(int64(2)))
+				).To(Equal([]float64{4.0}))
+				Expect(h.OutputTime("amplify_0", 0).Len()).To(Equal(int64(1)))
 
 				out, changed := h.Flush()
 				Expect(changed).To(BeTrue())
 				Expect(
 					telem.UnmarshalSeries[float64](out.Get(200).Series[0]),
-				).To(Equal([]float64{160.0, 180.0}))
+				).To(Equal([]float64{4.0}))
 			},
 		)
 
@@ -408,7 +592,7 @@ var _ = Describe("Routing Table Runtime", func() {
 				}
 
 				sensor -> demux{threshold=50.0} -> {
-				    high: alarm
+				    high: true => alarm
 				}`, resolver,
 					channels.Digest{Key: 100, DataType: telem.Float64T},
 					channels.Digest{Key: 200, DataType: telem.Uint8T},
@@ -470,7 +654,7 @@ var _ = Describe("Routing Table Runtime", func() {
 				}
 
 				sensor -> demux{threshold=50.0} -> {
-				    high: alarm
+				    high: true => alarm
 				}`, resolver,
 					channels.Digest{Key: 100, DataType: telem.Float64T},
 					channels.Digest{Key: 200, DataType: telem.Uint8T},
@@ -520,8 +704,8 @@ var _ = Describe("Routing Table Runtime", func() {
 				}
 
 				sensor -> classify{threshold=100.0} -> {
-				    above: open_valve,
-				    below: log_event
+				    above: true => open_valve,
+				    below: true => log_event
 				}`, resolver,
 					channels.Digest{Key: 100, DataType: telem.Float64T},
 					channels.Digest{Key: 200, DataType: telem.Uint8T},
@@ -590,7 +774,7 @@ var _ = Describe("Routing Table Runtime", func() {
 				}
 
 				sensor -> demux{threshold=50.0} -> {
-				    high: pressurize
+				    high: true => pressurize
 				}`, resolver,
 					channels.Digest{Key: 100, DataType: telem.Float64T},
 					channels.Digest{Key: 101, DataType: telem.Float32T},
@@ -646,8 +830,8 @@ var _ = Describe("Routing Table Runtime", func() {
 				})
 				h := newRuntimeHarness(ctx, `
 				flag -> select{} -> {
-				    true: open_valve,
-				    false: shut_valve
+				    true: true => open_valve,
+				    false: true => shut_valve
 				}
 
 				sequence open_valve {
@@ -717,8 +901,8 @@ var _ = Describe("Routing Table Runtime", func() {
 			})
 			h := newRuntimeHarness(ctx, `
 				flag -> select{} -> {
-					true: open_valve,
-					false: shut_valve
+					true: true => open_valve,
+					false: true => shut_valve
 				}
 
 				sequence open_valve {
@@ -756,6 +940,97 @@ var _ = Describe("Routing Table Runtime", func() {
 			).To(Equal([]uint8{1}))
 			Expect(out.Get(300).Series).To(BeEmpty())
 		})
+
+		It("Should write the entry's explicit value per branch", func(ctx SpecContext) {
+			resolver := channelSymbols(map[string]channelDef{
+				"flag":    {types.Bool(), 100},
+				"vlv_cmd": {types.Bool(), 200},
+			})
+			h := newRuntimeHarness(ctx, `
+				flag -> select{} -> {
+					true: true -> vlv_cmd,
+					false: false -> vlv_cmd
+				}
+			`, resolver,
+				channels.Digest{Key: 100, DataType: telem.BooleanT},
+				channels.Digest{Key: 200, DataType: telem.BooleanT},
+			)
+			defer h.Close(ctx)
+
+			// True branch: the entry writes its own literal true.
+			h.Ingest(100, telem.NewSeriesV[bool](true))
+			h.Tick(ctx, telem.Millisecond)
+			h.channelState.ClearReads()
+
+			out, changed := h.Flush()
+			Expect(changed).To(BeTrue())
+			Expect(out.Get(200).Series).To(HaveLen(1))
+			Expect(
+				telem.UnmarshalSeries[bool](out.Get(200).Series[0]),
+			).To(Equal([]bool{true}))
+
+			// False branch: the entry writes literal false, not the 1-valued
+			// pulse the select node emits to gate the branch.
+			h.Ingest(100, telem.NewSeriesV[bool](false))
+			h.Tick(ctx, 2*telem.Millisecond)
+			h.channelState.ClearReads()
+
+			out2, changed2 := h.Flush()
+			Expect(changed2).To(BeTrue())
+			Expect(out2.Get(200).Series).To(HaveLen(1))
+			Expect(
+				telem.UnmarshalSeries[bool](out2.Get(200).Series[0]),
+			).To(Equal([]bool{false}))
+		})
+
+		It(
+			"Should run an inline body entry without an upstream flow",
+			func(ctx SpecContext) {
+				resolver := channelSymbols(map[string]channelDef{
+					"flag":      {types.Bool(), 100},
+					"stage_out": {types.U8(), 200},
+					"seq_out":   {types.U8(), 300},
+				})
+				h := newRuntimeHarness(ctx, `
+				flag -> select{} -> {
+				    true: stage { 1 -> stage_out },
+				    false: sequence { 1 -> seq_out }
+				}
+			`, resolver,
+					channels.Digest{Key: 100, DataType: telem.BooleanT},
+					channels.Digest{Key: 200, DataType: telem.Uint8T},
+					channels.Digest{Key: 300, DataType: telem.Uint8T},
+				)
+				defer h.Close(ctx)
+
+				// True branch activates the inline stage; its body fires on
+				// activation with no upstream flow in the entry.
+				h.Ingest(100, telem.NewSeriesV[bool](true))
+				h.Tick(ctx, telem.Millisecond)
+				h.channelState.ClearReads()
+
+				out, changed := h.Flush()
+				Expect(changed).To(BeTrue())
+				Expect(out.Get(200).Series).To(HaveLen(1))
+				Expect(
+					telem.UnmarshalSeries[uint8](out.Get(200).Series[0]),
+				).To(Equal([]uint8{1}))
+				Expect(out.Get(300).Series).To(BeEmpty())
+
+				// False branch activates the inline sequence the same way.
+				h.Ingest(100, telem.NewSeriesV[bool](false))
+				h.Tick(ctx, 2*telem.Millisecond)
+				h.channelState.ClearReads()
+
+				out2, changed2 := h.Flush()
+				Expect(changed2).To(BeTrue())
+				Expect(out2.Get(200).Series).To(BeEmpty())
+				Expect(out2.Get(300).Series).To(HaveLen(1))
+				Expect(
+					telem.UnmarshalSeries[uint8](out2.Get(300).Series[0]),
+				).To(Equal([]uint8{1}))
+			},
+		)
 	})
 
 	Describe("Routing to Stages", func() {
@@ -781,7 +1056,7 @@ var _ = Describe("Routing Table Runtime", func() {
 				sequence main {
 				    stage first {
 				        sensor -> demux{threshold=50.0} -> {
-				            high: pressurize,
+				            high: true => pressurize,
 				        }
 				    }
 				    stage pressurize {

--- a/arc/go/stl/selector/selector.go
+++ b/arc/go/stl/selector/selector.go
@@ -43,12 +43,12 @@ var (
 	symbolName = "select"
 	symbolDoc  = doc.New(
 		doc.Paragraph(
-			"Routes a boolean input to 'true' or 'false' outputs. `true` values are routed to the true output; `false` to the false output.",
+			"Triggers the 'true' or 'false' routing entry for each boolean input.",
 		),
 		doc.Divider(),
 		doc.Code(
 			"arc",
-			"flag -> select{} -> {\n    true: open_valve,\n    false: shut_valve\n}",
+			"flag -> select{} -> {\n    true: true -> open_valve,\n    false: true -> shut_valve\n}",
 		),
 	)
 )

--- a/arc/go/text/text_test.go
+++ b/arc/go/text/text_test.go
@@ -4354,8 +4354,8 @@ time.wait{duration=500ms} -> output`
 				func logger{} (value f64) {}
 
 				signal -> demux{threshold=100.0} -> {
-				    high: alarm{},
-				    low: logger{}
+				    high: 1.0 -> alarm{},
+				    low: 1.0 -> logger{}
 				}`
 					parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
 					inter, diagnostics := text.Analyze(
@@ -4365,8 +4365,8 @@ time.wait{duration=500ms} -> output`
 					)
 					Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
 
-					Expect(inter.Nodes).To(HaveLen(4))
-					Expect(inter.Edges).To(HaveLen(3))
+					Expect(inter.Nodes).To(HaveLen(6))
+					Expect(inter.Edges).To(HaveLen(5))
 
 					demuxNode := findNodeByKey(inter.Nodes, "demux_0")
 					alarmNode := findNodeByKey(inter.Nodes, "alarm_0")
@@ -4376,15 +4376,29 @@ time.wait{duration=500ms} -> output`
 					Expect(demuxNode.Outputs.Has("high")).To(BeTrue())
 					Expect(demuxNode.Outputs.Has("low")).To(BeTrue())
 
+					// The routed output only gates the entry's constant; the
+					// constant's own value feeds the target func.
 					highEdge := findEdgeBySourceParam(inter.Edges, "high")
 					Expect(highEdge.Source.Node).To(Equal("demux_0"))
-					Expect(highEdge.Target.Node).To(Equal(alarmNode.Key))
-					Expect(highEdge.Target.Param).To(Equal("value"))
+					highConst := findNodeByKey(inter.Nodes, highEdge.Target.Node)
+					Expect(highConst.Type).To(Equal("constant"))
+					alarmIn := MustBeOk(ir.Edges(inter.Edges).FindByTarget(
+						ir.Handle{Node: alarmNode.Key, Param: "value"},
+					))
+					Expect(alarmIn.Source).To(Equal(
+						ir.Handle{Node: highConst.Key, Param: ir.DefaultOutputParam},
+					))
 
 					lowEdge := findEdgeBySourceParam(inter.Edges, "low")
 					Expect(lowEdge.Source.Node).To(Equal("demux_0"))
-					Expect(lowEdge.Target.Node).To(Equal(loggerNode.Key))
-					Expect(lowEdge.Target.Param).To(Equal("value"))
+					lowConst := findNodeByKey(inter.Nodes, lowEdge.Target.Node)
+					Expect(lowConst.Type).To(Equal("constant"))
+					loggerIn := MustBeOk(ir.Edges(inter.Edges).FindByTarget(
+						ir.Handle{Node: loggerNode.Key, Param: "value"},
+					))
+					Expect(loggerIn.Source).To(Equal(
+						ir.Handle{Node: lowConst.Key, Param: ir.DefaultOutputParam},
+					))
 				},
 			)
 
@@ -4415,7 +4429,7 @@ time.wait{duration=500ms} -> output`
 				func mix{} (a f64, b f64) {}
 
 				signal -> demux{threshold=100.0} -> {
-				    high: doubler{}: b
+				    high: 1.0 -> doubler{}: b
 				} -> mix{}`
 					parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
 					_, diagnostics := text.Analyze(
@@ -4500,7 +4514,7 @@ time.wait{duration=500ms} -> output`
 				func display{} (value f64) {}
 
 				signal -> demux{threshold=100.0} -> {
-				    high: amplify{} -> display{}
+				    high: 1.0 -> amplify{} -> display{}
 				}`
 				parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
 				inter, diagnostics := text.Analyze(
@@ -4510,12 +4524,20 @@ time.wait{duration=500ms} -> output`
 				)
 				Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
 
-				Expect(inter.Nodes).To(HaveLen(4))
-				Expect(inter.Edges).To(HaveLen(3))
+				Expect(inter.Nodes).To(HaveLen(5))
+				Expect(inter.Edges).To(HaveLen(4))
 
-				demuxToAmplify := findEdgeBySourceParam(inter.Edges, "high")
-				Expect(demuxToAmplify.Source.Node).To(Equal("demux_0"))
-				Expect(demuxToAmplify.Target.Node).To(Equal("amplify_0"))
+				// The routed output gates the entry's constant, which feeds
+				// amplify.
+				highEdge := findEdgeBySourceParam(inter.Edges, "high")
+				Expect(highEdge.Source.Node).To(Equal("demux_0"))
+				highConst := findNodeByKey(inter.Nodes, highEdge.Target.Node)
+				Expect(highConst.Type).To(Equal("constant"))
+
+				constToAmplify := MustBeOk(ir.Edges(inter.Edges).FindByTarget(
+					ir.Handle{Node: "amplify_0", Param: "signal"},
+				))
+				Expect(constToAmplify.Source.Node).To(Equal(highConst.Key))
 
 				var amplifyToDisplay ir.Edge
 				for _, e := range inter.Edges {
@@ -4553,7 +4575,7 @@ time.wait{duration=500ms} -> output`
 				func display{} (value f64) {}
 
 				signal -> demux{threshold=100.0} -> {
-				    high: amplify{} => display{}
+				    high: 1.0 -> amplify{} => display{}
 				}`
 					parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
 					inter, diagnostics := text.Analyze(
@@ -4563,7 +4585,7 @@ time.wait{duration=500ms} -> output`
 					)
 					Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
 
-					// The routed output feeds the first node continuously...
+					// The routed output gates the entry's constant continuously...
 					Expect(findEdgeBySourceParam(inter.Edges, "high").Kind).
 						To(Equal(ir.EdgeKindContinuous))
 
@@ -4604,7 +4626,7 @@ time.wait{duration=500ms} -> output`
 				func sink{} (value f64) {}
 
 				signal -> demux{threshold=100.0} -> {
-				    high: filter{} -> amplify{} => sink{}
+				    high: 1.0 -> filter{} -> amplify{} => sink{}
 				}`
 					parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
 					inter, diagnostics := text.Analyze(
@@ -4623,7 +4645,7 @@ time.wait{duration=500ms} -> output`
 						return ir.Edge{}
 					}
 
-					// high -> filter: routed feed, continuous.
+					// high gates the entry's constant: continuous.
 					Expect(findEdgeBySourceParam(inter.Edges, "high").Kind).
 						To(Equal(ir.EdgeKindContinuous))
 					// filter -> amplify: continuous.
@@ -4666,7 +4688,7 @@ time.wait{duration=500ms} -> output`
 				}
 
 				signal -> demux{threshold=100.0} -> {
-				    high: increment{ch=counter}
+				    high: stage { increment{ch=counter} }
 				}`
 					parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
 					inter, diagnostics := text.Analyze(
@@ -4706,6 +4728,77 @@ time.wait{duration=500ms} -> output`
 					_, diagnostics := text.Analyze(ctx, parsedText, NewRoot(nil))
 					Expect(diagnostics.Ok()).To(BeFalse())
 					Expect(diagnostics.String()).To(ContainSubstring("nonexistent"))
+				},
+			)
+
+			It("Should reject a bare routing entry target", func(ctx SpecContext) {
+				resolver := []symbol.Symbol{
+					{
+						Name: "flag",
+						Kind: symbol.KindChannel,
+						Type: types.Chan(types.Bool()),
+						ID:   10107,
+					},
+					{
+						Name: "vlv_cmd",
+						Kind: symbol.KindChannel,
+						Type: types.Chan(types.Bool()),
+						ID:   10108,
+					},
+				}
+				source := `
+				flag -> select{} -> {
+				    false: vlv_cmd
+				}`
+				parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
+				_, diagnostics := text.Analyze(
+					ctx,
+					parsedText,
+					NewRoot(nil, resolver...),
+				)
+				Expect(diagnostics.Ok()).To(BeFalse())
+				Expect(diagnostics.String()).To(
+					ContainSubstring("must be a full statement"),
+				)
+			})
+
+			It(
+				"Should gate a select branch transition on the entry's constant",
+				func(ctx SpecContext) {
+					resolver := []symbol.Symbol{
+						{
+							Name: "flag",
+							Kind: symbol.KindChannel,
+							Type: types.Chan(types.Bool()),
+							ID:   10109,
+						},
+					}
+					source := `
+				sequence alarm {
+				    stage active {}
+				}
+
+				flag -> select{} -> {
+				    true: true => alarm
+				}`
+					parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
+					inter, diagnostics := text.Analyze(
+						ctx,
+						parsedText,
+						NewRoot(nil, resolver...),
+					)
+					Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
+
+					selectNode := findNodeByType(inter.Nodes, "select")
+					trueEdge := findEdgeBySourceParam(inter.Edges, "true")
+					Expect(trueEdge.Source.Node).To(Equal(selectNode.Key))
+					gate := findNodeByKey(inter.Nodes, trueEdge.Target.Node)
+					Expect(gate.Type).To(Equal("constant"))
+
+					alarm := findTopLevelScope(inter, "alarm")
+					Expect(alarm.Activation).ToNot(BeNil())
+					Expect(alarm.Activation.Node).To(Equal(gate.Key))
+					Expect(alarm.Activation.Param).To(Equal(ir.DefaultOutputParam))
 				},
 			)
 		})
@@ -4769,8 +4862,8 @@ time.wait{duration=500ms} -> output`
 				func logger{} (value f64) {}
 
 				signal => demux{threshold=100.0} -> {
-				    high: alarm{},
-				    low: logger{}
+				    high: 1.0 -> alarm{},
+				    low: 1.0 -> logger{}
 				}`
 					parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
 					inter, diagnostics := text.Analyze(
@@ -4780,11 +4873,18 @@ time.wait{duration=500ms} -> output`
 					)
 					Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
 
-					Expect(inter.Root.Strata).To(HaveLen(3))
+					Expect(inter.Root.Strata).To(HaveLen(4))
 					Expect(inter.Root.Strata[0][0].Key()).To(Equal("on_signal_0"))
 					Expect(inter.Root.Strata[1][0].Key()).To(Equal("demux_0"))
+					// Stratum 2 holds the per-entry constants that gate the
+					// targets in stratum 3.
+					for _, m := range inter.Root.Strata[2] {
+						Expect(
+							findNodeByKey(inter.Nodes, m.Key()).Type,
+						).To(Equal("constant"))
+					}
 					keys := lo.Map(
-						inter.Root.Strata[2],
+						inter.Root.Strata[3],
 						func(m ir.Member, _ int) string {
 							return m.Key()
 						},
@@ -4905,8 +5005,8 @@ time.wait{duration=500ms} -> output`
 				}
 
 				signal -> demux{threshold=100.0} -> {
-				    high: high_chan,
-				    low: low_chan
+				    high: 1.0 -> high_chan,
+				    low: 1.0 -> low_chan
 				}`
 				parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
 				inter, diagnostics := text.Analyze(
@@ -4916,7 +5016,7 @@ time.wait{duration=500ms} -> output`
 				)
 				Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
 
-				Expect(inter.Nodes).To(HaveLen(4))
+				Expect(inter.Nodes).To(HaveLen(6))
 
 				writeCount := countNodesByType(inter.Nodes, "write")
 				Expect(writeCount).To(Equal(2))
@@ -6158,8 +6258,8 @@ time.wait{duration=500ms} -> output`
 				}
 
 				signal -> demux{threshold=100.0} -> {
-				    high: alarm,
-				    low: high_chan
+				    high: true => alarm,
+				    low: 1.0 -> high_chan
 				}`
 					parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
 					inter, diagnostics := text.Analyze(
@@ -6169,22 +6269,25 @@ time.wait{duration=500ms} -> output`
 					)
 					Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
 
-					// on node for signal + demux node + write node for the `low`
-					// branch. The `high` branch is a scope reference that becomes
-					// an activation.
-					Expect(inter.Nodes).To(HaveLen(3))
+					// on node for signal + demux node + a constant per entry +
+					// write node for the `low` branch. The `high` branch's
+					// constant gates alarm's scope activation.
+					Expect(inter.Nodes).To(HaveLen(5))
 
 					demuxNode := findNodeByType(inter.Nodes, "demux")
 					writeNode := findNodeByType(inter.Nodes, "write")
 					Expect(writeNode.Channels.Write).To(HaveKey(uint32(10071)))
 
-					// The signal->demux edge and the write edge exist; the `high`
-					// branch lands on alarm's scope activation.
-					Expect(inter.Edges).To(HaveLen(2))
+					Expect(inter.Edges).To(HaveLen(4))
+					highEdge := findEdgeBySourceParam(inter.Edges, "high")
+					Expect(highEdge.Source.Node).To(Equal(demuxNode.Key))
+					highConst := findNodeByKey(inter.Nodes, highEdge.Target.Node)
+					Expect(highConst.Type).To(Equal("constant"))
+
 					alarm := findTopLevelScope(inter, "alarm")
 					Expect(alarm.Activation).ToNot(BeNil())
-					Expect(alarm.Activation.Node).To(Equal(demuxNode.Key))
-					Expect(alarm.Activation.Param).To(Equal("high"))
+					Expect(alarm.Activation.Node).To(Equal(highConst.Key))
+					Expect(alarm.Activation.Param).To(Equal(ir.DefaultOutputParam))
 				},
 			)
 		})

--- a/docs/site/src/pages/reference/control/arc/reference/flow.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/flow.mdx
@@ -161,48 +161,37 @@ variables from function bodies.
 ## Routing Tables
 
 A **routing table** is a brace-delimited map written on either end of a flow operator.
-It either gathers several sources into one function's inputs, or fans one function's
-outputs out to several destinations. Routing is how an Arc flow branches: a value is
-sent to one of several named destinations instead of running through an `if`/`else`.
+An input table gathers several sources into one function's inputs. An output table
+branches the flow: the output that fires decides which entry runs, instead of an
+`if`/`else`.
 
-```arc channels="sensor_1, sensor_2, sensor"
+```arc channels="sensor_1, sensor_2, sensor, log"
 // Input routing: many sources -> one function
 { sensor_1: a, sensor_2: b } -> average{}
 
-// Output routing: one function -> many destinations
-sensor -> demux{} -> { high: alarm{}, low: logger{} }
+// Output routing: the fired output picks the entry that runs
+sensor -> demux{} -> { high: "high" -> log, low: "low" -> log }
 ```
 
 ### Select
 
-`select` is the built-in boolean router. It takes a `bool` input and exposes two
-outputs, `true` and `false`.
+`select` is the built-in decision point: it takes a boolean input and runs the matching
+entry, `true` or `false`.
 
-```arc channels="flag" bodies="open_valve, shut_valve"
+```arc channels="flag, press_valve, vent_valve" bodies="shutdown_sequence"
 flag -> select{} -> {
-    true: open_valve,
-    false: shut_valve
+    true: true -> press_valve,
+    false: true -> vent_valve
+}
+
+// Omitting a branch is valid
+flag -> select{} -> {
+    true: true => shutdown_sequence
 }
 ```
 
-`select` is part of the ambient prelude, so it needs no `import`. It is also available
-under its qualified name `selector.select` if you prefer to be explicit.
-
-| Output  | Type | Fires when       |
-| ------- | ---- | ---------------- |
-| `true`  | `u8` | input is `true`  |
-| `false` | `u8` | input is `false` |
-
-Each output emits `1` when its branch fires; downstream nodes typically use the
-activation, not the value.
-
-A routing table may bind only the branches it cares about. Omitting `false` is valid:
-
-```arc channels="flag, alarm_cmd"
-flag -> select{} -> {
-    true: true -> alarm_cmd
-}
-```
+A branch only decides that its entry runs. No value flows from `select` into the entry:
+each entry is a full flow statement that defines its own source.
 
 ### Custom Routing
 
@@ -222,9 +211,9 @@ func decide_stage{low f64, high f64} (value f64) (vent bool, press bool, abort b
 }
 
 tank_pressure -> decide_stage{low=10.0, high=80.0} -> {
-    vent:  open_vent,   // channel: receives the routed value
-    press: pressurize,  // activate sequence: `pressurize`
-    abort: safe_state   // activate sequence: `safe_state`
+    vent:  true -> open_vent,  // write a channel
+    press: true => pressurize, // activate sequence: `pressurize`
+    abort: true => safe_state  // activate sequence: `safe_state`
 }
 ```
 
@@ -232,26 +221,10 @@ Output names are arbitrary identifiers declared with the function's
 [named outputs](/reference/control/arc/reference/functions#multiple-named-outputs), and
 the routing table keys must match them exactly.
 
-### Case Body Forms
+### Case Bodies
 
-The right side of an output routing entry, the **case body**, is not limited to a single
-channel. It accepts any of the following.
-
-#### Single Target
-
-A channel, stage, or sequence name:
-
-```arc channels="flag, shut_cmd" bodies="open_valves"
-flag -> select{} -> {
-    true: open_valves,     // sequence name: activates the sequence
-    false: shut_cmd        // channel: receives the routed value
-}
-```
-
-#### Flow-Node Chains
-
-A case body can be a chain of flow nodes joined with `->`, exactly like a top-level
-flow. The routed output feeds the first node, and types are threaded through the chain:
+The right side of an output routing entry, the **case body**, is a full flow statement
+or an inline body. A bare target (`true: next`, `false: shut_cmd`) is an error.
 
 ```arc channels="flag, log_str, sensor, log_num"
 flag -> select{} -> {
@@ -301,8 +274,8 @@ A single routing table may freely mix all of the above:
 
 ```arc channels="sensor, log, cooler_cmd, open_vent"
 sensor -> decide_stage{low=30.0, high=80.0} -> {
-    vent:  open_vent,                            // single target
-    press: "nominal" -> log,                     // chain
+    vent:  true -> open_vent,                    // flow statement
+    press: "nominal" -> log,                     // flow statement
     abort: stage { true -> cooler_cmd }          // inline body
 }
 ```
@@ -349,15 +322,14 @@ func demux{threshold f64} (value f64) (high f64, low f64) {
 }
 
 sensor -> demux{threshold=50.0} -> {
-    high: high_out,
-    low: low_out
+    high: true => high_out,
+    low: true => low_out
 }
 ```
 
-Each entry is `output: destination`. The key on the left is one of the function's named
-outputs; the right side is where that output is routed. Only the outputs the function
-actually writes on a given cycle propagate. In the example above, a reading of `75.0`
-writes `high_out` and leaves `low_out` untouched.
+Each entry is `output: flow statement`. The key is one of the function's named outputs;
+the body runs when the function sets that output. A reading of `75.0` runs the `high`
+entry and leaves `low` untouched.
 
 <Divider.Divider x />
 

--- a/docs/site/src/pages/reference/control/arc/reference/flow.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/flow.mdx
@@ -3,7 +3,7 @@ layout: "@/layouts/Reference.astro"
 title: "Flow"
 description:
   "Arc flow reference: continuous and conditional flow operators, transitions,
-  expressions in flows, routing tables, the select built-in, and inline case bodies"
+  expressions in flows, routing tables, and inline case bodies"
 prev: "Operators"
 prevURL: "/reference/control/arc/reference/operators"
 next: "Sequences"
@@ -173,31 +173,12 @@ branches the flow: the output that fires decides which entry runs, instead of an
 sensor -> demux{} -> { high: "high" -> log, low: "low" -> log }
 ```
 
-### Select
-
-`select` is the built-in decision point: it takes a boolean input and runs the matching
-entry, `true` or `false`.
-
-```arc channels="flag, press_valve, vent_valve" bodies="shutdown_sequence"
-flag -> select{} -> {
-    true: true -> press_valve,
-    false: true -> vent_valve
-}
-
-// Omitting a branch is valid
-flag -> select{} -> {
-    true: true => shutdown_sequence
-}
-```
-
-A branch only decides that its entry runs. No value flows from `select` into the entry:
-each entry is a full flow statement that defines its own source.
-
 ### Custom Routing
 
-`select` is just a function with two named outputs. Any function with multiple named
-outputs can drive a routing table: declare the branches your logic needs as outputs, set
-the matching one in the function body, and route each output by name.
+[`select`](/reference/control/arc/reference/standard-library/select) is just a function
+with two named outputs. Any function with multiple named outputs can drive a routing
+table: declare the branches your logic needs as outputs, set the matching one in the
+function body, and route each output by name.
 
 ```arc channels="tank_pressure, open_vent" bodies="pressurize, safe_state"
 func decide_stage{low f64, high f64} (value f64) (vent bool, press bool, abort bool) {
@@ -243,7 +224,7 @@ sensor -> demux{} -> {
 An anonymous `stage { ... }` written directly as a case body. Its flows run in parallel
 while the branch is active:
 
-```arc channels="flag, vent_cmd, log"
+```arc channels="flag, vent_cmd, log, pressure" bodies="shutdown"
 flag -> select{} -> {
     true:  stage {
         "venting" -> log,
@@ -312,7 +293,7 @@ is an error.
 An output routing table follows a function invocation and maps each named output to a
 destination:
 
-```arc bodies="high_out, low_out"
+```arc channels="sensor" bodies="high_out, low_out"
 func demux{threshold f64} (value f64) (high f64, low f64) {
     if value > threshold {
         high = value

--- a/docs/site/src/pages/reference/control/arc/reference/functions.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/functions.mdx
@@ -133,12 +133,11 @@ func compute(x f64)result f64 {
 
 ### Multiple Named Outputs
 
-A function may declare more than one named output. Each output is set in the body and
-routed to its own destination at the call site. Use
-[routing tables](/reference/control/arc/reference/flow#output-routing) to connect
-multiple outputs:
+A function may declare more than one named output. Each output keys a branch at the call
+site: setting an output runs its
+[routing table](/reference/control/arc/reference/flow#output-routing) entry.
 
-```arc channels="sensor"
+```arc channels="sensor, log"
 func split(value f64) (high f64, low f64) {
     if value > 50.0 {
         high = value
@@ -148,8 +147,8 @@ func split(value f64) (high f64, low f64) {
 }
 
 sensor -> split{} -> {
-    high: alarm{},
-    low: logger{}
+    high: "high" -> log,
+    low: "low" -> log
 }
 ```
 

--- a/docs/site/src/pages/reference/control/arc/reference/standard-library.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/standard-library.mdx
@@ -2,7 +2,8 @@
 layout: "@/layouts/Reference.astro"
 title: "Standard Library"
 description:
-  "Overview of Arc's standard library modules: control, math, ranges, status, and time"
+  "Overview of Arc's standard library modules: control, math, ranges, select, status,
+  and time"
 prev: "Loops"
 prevURL: "/reference/control/arc/reference/loops"
 next: "`control`"
@@ -31,5 +32,6 @@ time.interval{period=1s} -> tick
 | [`control`](/reference/control/arc/reference/standard-library/control) | Runtime control over write authority       |
 | [`math`](/reference/control/arc/reference/standard-library/math)       | Running averages, min/max, and derivatives |
 | [`ranges`](/reference/control/arc/reference/standard-library/ranges)   | Create and close ranges on the Core        |
+| [`select`](/reference/control/arc/reference/standard-library/select)   | Route a boolean to a true or false entry   |
 | [`status`](/reference/control/arc/reference/standard-library/status)   | Publish status notifications to the Core   |
 | [`time`](/reference/control/arc/reference/standard-library/time)       | Timestamps, periodic firing, and delays    |

--- a/docs/site/src/pages/reference/control/arc/reference/standard-library/_nav.ts
+++ b/docs/site/src/pages/reference/control/arc/reference/standard-library/_nav.ts
@@ -30,6 +30,11 @@ export const STANDARD_LIBRARY_NAV: PageNavNode = {
       name: "`ranges`",
     },
     {
+      key: "/reference/control/arc/reference/standard-library/select",
+      href: "/reference/control/arc/reference/standard-library/select",
+      name: "`select`",
+    },
+    {
       key: "/reference/control/arc/reference/standard-library/status",
       href: "/reference/control/arc/reference/standard-library/status",
       name: "`status`",

--- a/docs/site/src/pages/reference/control/arc/reference/standard-library/ranges.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/standard-library/ranges.mdx
@@ -4,8 +4,8 @@ title: "`ranges`"
 description: "Arc standard library reference for the ranges module: create and end"
 prev: "`math`"
 prevURL: "/reference/control/arc/reference/standard-library/math"
-next: "`status`"
-nextURL: "/reference/control/arc/reference/standard-library/status"
+next: "`select`"
+nextURL: "/reference/control/arc/reference/standard-library/select"
 ---
 
 import { Divider } from "@synnaxlabs/pluto";

--- a/docs/site/src/pages/reference/control/arc/reference/standard-library/select.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/standard-library/select.mdx
@@ -1,0 +1,54 @@
+---
+layout: "@/layouts/Reference.astro"
+title: "`select`"
+description:
+  "Arc standard library reference for the select built-in: routing a boolean to a true
+  or false entry"
+prev: "`ranges`"
+prevURL: "/reference/control/arc/reference/standard-library/ranges"
+next: "`status`"
+nextURL: "/reference/control/arc/reference/standard-library/status"
+---
+
+import { Divider, Note } from "@synnaxlabs/pluto";
+import { mdxOverrides } from "@/components/mdxOverrides";
+import Params from "@/components/params/Params.astro";
+
+export const components = mdxOverrides;
+
+<Note.Note variant="info">
+  `select` is a built-in, not a module member: it is available in the global namespace
+  and needs no `import`.
+</Note.Note>
+
+<Params
+  fn="select"
+  input="bool"
+  output={{
+    description:
+      "Two named outputs, `true` and `false`. The matching output triggers its routing entry.",
+  }}
+/>
+
+```arc channels="flag, press_valve, vent_valve" bodies="shutdown_sequence"
+flag -> select{} -> {
+    true: true -> press_valve,
+    false: true -> vent_valve
+}
+
+// Omitting a branch is valid:
+flag -> select{} -> {
+    true: true => shutdown_sequence
+}
+```
+
+An [output routing](/reference/control/arc/reference/flow#output-routing) entry can also
+hold an [inline body](/reference/control/arc/reference/flow#case-bodies).
+
+<Divider.Divider x />
+
+## Custom Routing
+
+For more than two branches, a
+[custom routing table](/reference/control/arc/reference/flow#custom-routing) can be
+defined using a function with multiple named outputs.

--- a/docs/site/src/pages/reference/control/arc/reference/standard-library/status.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/standard-library/status.mdx
@@ -2,8 +2,8 @@
 layout: "@/layouts/Reference.astro"
 title: "`status`"
 description: "Arc standard library reference for the status module"
-prev: "`ranges`"
-prevURL: "/reference/control/arc/reference/standard-library/ranges"
+prev: "`select`"
+prevURL: "/reference/control/arc/reference/standard-library/select"
 next: "`time`"
 nextURL: "/reference/control/arc/reference/standard-library/time"
 ---

--- a/docs/site/src/pages/reference/control/arc/reference/variables.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/variables.mdx
@@ -172,7 +172,7 @@ Sum values over time.
 ```arc
 stage accumulate {
     total $= 0.0
-    // Triggred on new `value`
+    // Triggered on new `value`
     value + total -> total
 }
 ```
@@ -273,7 +273,7 @@ Maintain an on/off state.
 stage toggle {
     state $= false
 
-    // Blocked on new `trigger`
+    // Triggered on new `trigger`
     trigger -> not state -> select{} -> {
         true: true -> state,
         false: false -> state

--- a/integration/tests/arc/lifecycle.py
+++ b/integration/tests/arc/lifecycle.py
@@ -30,12 +30,12 @@ func check_high_pressure(p f32) bool {
 }
 
 press_pt -> check_high_pressure{} -> stable.for{500ms} -> select{} -> {
-    true: status.set{
+    true: true -> status.set{
         key_or_name="lifecycle_press_alarm",
         variant="warning",
         message="Pressure stable above 25 PSI"
     },
-    false: status.set{
+    false: true -> status.set{
         key_or_name="lifecycle_press_normal",
         variant="warning",
         message="Pressure below 25 PSI"

--- a/integration/tests/arc/stage_routing.py
+++ b/integration/tests/arc/stage_routing.py
@@ -29,8 +29,8 @@ sequence main {
     stage select_hold {
         "select_hold" -> routing_stage_log
         routing_flag -> select{} -> {
-            true: select_on,
-            false: select_off
+            true: true => select_on,
+            false: true => select_off
         }
     }
     stage select_on {
@@ -45,9 +45,9 @@ sequence main {
     stage decide_stage_hold {
         "decide_stage_hold" -> routing_stage_log
         routing_sensor -> decide_stage{low=30.0, high=80.0} -> {
-            vent: decide_stage_vent,
-            press: decide_stage_press,
-            abort: decide_stage_abort
+            vent: true => decide_stage_vent,
+            press: true => decide_stage_press,
+            abort: true => decide_stage_abort
         }
     }
     stage decide_stage_vent {
@@ -75,8 +75,8 @@ sequence main {
     stage arrow_body_hold {
         "arrow_body_hold" -> routing_stage_log
         routing_flag -> select{} -> {
-            true: 1 => arrow_on,
-            false: 1 => arrow_off
+            true: true => arrow_on,
+            false: true => arrow_off
         }
     }
     stage arrow_on {

--- a/integration/tests/arc/stage_routing.py
+++ b/integration/tests/arc/stage_routing.py
@@ -8,7 +8,11 @@
 #  included in the file licenses/APL.txt.
 
 import synnax as sy
-from framework.utils import create_indexed_pair, create_virtual_channel
+from framework.utils import (
+    create_indexed_pair,
+    create_virtual_channel,
+    create_virtual_channels,
+)
 from tests.arc.arc import ArcCase
 
 ARC_STAGE_ROUTING = """
@@ -20,6 +24,16 @@ func decide_stage{low f64, high f64} (value f64) (vent u8, press u8, abort u8) {
         press = 1
     } else {
         abort = 1
+    }
+}
+
+func multi_route{} (value f64) (first u8, second u8, third u8, fourth u8) {
+    if (value > 50.0) {
+        first = 1
+        third = 1
+    } else {
+        second = 1
+        fourth = 1
     }
 }
 
@@ -85,6 +99,17 @@ sequence main {
     }
     stage arrow_off {
         "arrow_off" -> routing_stage_log
+        next_cmd => multi_hold
+    }
+
+    stage multi_hold {
+        "multi_hold" -> routing_stage_log
+        routing_sensor -> multi_route{} -> {
+            first: "multi_1" -> routing_multi_log_1,
+            second: "multi_2" -> routing_multi_log_2,
+            third: "multi_3" -> routing_multi_log_3,
+            fourth: "multi_4" -> routing_multi_log_4
+        }
         next_cmd => done
     }
 
@@ -106,17 +131,29 @@ class StageRouting(ArcCase):
     to a channel, verifying that case-body chains type-check via chain semantics
     rather than against the select's discriminator output.
     Phase 4 (SY-4460) uses select with `=>` transition case bodies, verifying that
-    the transition operator drives stage jumps from inside a routing table."""
+    the transition operator drives stage jumps from inside a routing table.
+    Phase 5 sets two of four outputs in one invocation, verifying that every set
+    output fires its entry in the same tick."""
 
     arc_source = ARC_STAGE_ROUTING
     arc_name_prefix = "StageRouting"
     start_cmd_channel = "start_stage_routing_cmd"
-    subscribe_channels = ["routing_stage_log"]
+    subscribe_channels = [
+        "routing_stage_log",
+        "routing_multi_log_1",
+        "routing_multi_log_2",
+        "routing_multi_log_3",
+        "routing_multi_log_4",
+    ]
 
     def setup(self) -> None:
         create_indexed_pair(self.client, "routing_flag", sy.DataType.BOOLEAN)
         create_indexed_pair(self.client, "routing_sensor", sy.DataType.FLOAT64)
         create_virtual_channel(self.client, "routing_stage_log", sy.DataType.STRING)
+        create_virtual_channels(
+            self.client,
+            [(f"routing_multi_log_{i}", sy.DataType.STRING) for i in range(1, 5)],
+        )
         create_virtual_channel(self.client, "next_cmd", sy.DataType.UINT8)
         super().setup()
 
@@ -205,6 +242,30 @@ class StageRouting(ArcCase):
         self._write_flag(0)
         self.wait_for_eq("routing_stage_log", "arrow_off")
 
-        self.log("[arrow_body] Advancing arrow_off -> done")
+        self.log("[arrow_body] Advancing arrow_off -> multi_hold")
+        self._advance()
+        self.wait_for_eq("routing_stage_log", "multi_hold")
+
+        # Phase 5: one invocation sets two of four outputs; both entries fire.
+        # Sentinel writes keep a wait_for_eq from passing on a stale value.
+        for i in range(1, 5):
+            self.writer.write(f"routing_multi_log_{i}", "zero_value")
+            self.wait_for_eq(f"routing_multi_log_{i}", "zero_value")
+
+        self.log("[multi] sensor=75.0 sets first+third")
+        self._write_sensor(75.0)
+        self.wait_for_eq("routing_multi_log_1", "multi_1")
+        self.wait_for_eq("routing_multi_log_3", "multi_3")
+
+        for i in range(1, 5):
+            self.writer.write(f"routing_multi_log_{i}", "zero_value")
+            self.wait_for_eq(f"routing_multi_log_{i}", "zero_value")
+
+        self.log("[multi] sensor=10.0 sets second+fourth")
+        self._write_sensor(10.0)
+        self.wait_for_eq("routing_multi_log_2", "multi_2")
+        self.wait_for_eq("routing_multi_log_4", "multi_4")
+
+        self.log("[multi] Advancing multi_hold -> done")
         self._advance()
         self.wait_for_eq("routing_stage_log", "done")

--- a/integration/tests/arc/tpc_cold_flow.py
+++ b/integration/tests/arc/tpc_cold_flow.py
@@ -69,9 +69,9 @@ func on_critical{} (value f32) {
 }
 // Dataflow: OX pressure -> classifier -> status handlers
 ox_pt_1 -> classify_pressure{15, 40} -> {
-    safe_out: on_safe{},
-    warning_out: on_warning{},
-    critical_out: on_critical{}
+    safe_out: 1 -> on_safe{},
+    warning_out: 1 -> on_warning{},
+    critical_out: 1 -> on_critical{}
 }
 
 start_tpc_cmd => main


### PR DESCRIPTION
## Linear Issue

[SY-4619](https://linear.app/synnax/issue/SY-4619)

## Description

Removes an ambiguity in output routing tables. `select{} -> { false: next }` read like the routed value flowed into the entry, but both select outputs are u8 pulses, so what actually ran was `1 -> next`. What fed the entry depended on the routing function's output types, invisibly at the call site.

The fix: everything to the right of a routing key must be a full flow statement. A routing key only gates its entry; no value flows from the router into it, and the entry defines its own source (`true: true => next`, `high: "high" -> log`). Bare targets are now compile errors. Inline `stage {}`/`sequence {}` bodies are the only bare exception, and param-mapped entries (`high: chan: a`) are unchanged.

Output types stay unconstrained on purpose rather than being forced to `bool`:

- Enforcing `bool` outputs would be a lot of extra plumbing for no behavior change.
- The root issue was ambiguity about what runs, and the strictness rule resolves it.
- It keeps the door open for the originally intended feature: a future, more thought-out syntax can still pass the routed value along.
- Truthiness is already a documented concept, so any-typed outputs behave intuitively.

Behavior change: the old passthrough form forwarded per-sample values; an entry's own constant fires once per trigger batch. Migration is loud since the old form no longer compiles.

Also fixes a gap this exposed: the WASM named-output store was missing the `bool` case, so a `bool` named output failed to compile. New runtime specs read every output type back and cover the remaining store widths.

Docs (`flow.mdx`, `functions.mdx`, `spec.md`, hover docs) are reframed around flow routing and decision making instead of output types and values.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR removes output-routing ambiguity by requiring each routing entry to define a complete flow statement, while retaining inline stage and sequence bodies and parameter-mapped entries as supported forms. It also completes boolean named-output storage and updates the Arc documentation and tests to describe the new gating semantics.
- Output routing keys now gate independently sourced entry flows instead of forwarding routed values.
- Bare routing targets are rejected during flow analysis.
- Boolean named outputs use byte-width WASM stores consistent with their memory representation.
- Runtime, analyzer, integration, hover, specification, and reference documentation coverage is updated.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| arc/go/analyzer/flow/flow.go | Enforces full routing statements, analyzes entry heads without routed input, and preserves type checking for parameter-mapped entries. |
| arc/go/compiler/statement/variable.go | Adds boolean named outputs to the one-byte WASM store path, matching boolean allocation density. |
| arc/go/routing_table_test.go | Exercises explicit branch values, mixed named-output widths, falsy routed outputs, inline bodies, transitions, and batch-level routing behavior. |
| arc/go/text/text_test.go | Updates expected IR topology and stratification so routing outputs gate entry-owned source nodes. |
| docs/site/src/pages/reference/control/arc/reference/flow.mdx | Reframes output routing around branch gating and complete entry flows rather than routed-value forwarding. |
| arc/docs/spec.md | Documents full-statement routing entries, inline-body exceptions, and the absence of routed-value passthrough. |

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Upstream value] --> B[Function with named outputs]
    B -->|Output fires| C{Routing key}
    C -->|Gates| D[Entry-owned source]
    D --> E[Entry flow target]
    C -. No routed value forwarded .-> D
```

<sub>Reviews (2): Last reviewed commit: ["SY-4619: Updated integration test"](https://github.com/synnaxlabs/synnax/commit/a3218760ecc5d83a587a7c24a70648cc15ba88b5) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55033091)</sub>

<!-- /greptile_comment -->