### PR TITLE
[Docs] `stable.for` and scrub examples

### DIFF
--- a/docs/site/src/pages/reference/control/arc/how-to/alarms.mdx
+++ b/docs/site/src/pages/reference/control/arc/how-to/alarms.mdx
@@ -166,30 +166,13 @@ time.interval{period=50ms} -> combined_alarm{
 ## Time-Delayed Alarm
 
 A brief spike might be acceptable, but a sustained high value indicates a real problem.
-Use a counter to require the condition to persist:
+Debounce the condition with
+[`stable.for`](/reference/control/arc/reference/standard-library/stable) so the alarm
+fires only after it holds:
 
-```arc channels="tank_pressure, sustained_high"
-func sustained_alarm{
-    limit f64,
-    samples i64, // number of consecutive samples above limit
-} (value f64) bool {
-    count $= 0
-
-    if value > limit {
-        count = count + 1
-    } else {
-        count = 0
-    }
-
-    return count >= samples
-}
-
-// At 50ms intervals, 20 samples = 1 second
-tank_pressure -> sustained_alarm{limit=600.0, samples=20} -> sustained_high
+```arc channels="tank_pressure" bodies="alert_hq"
+tank_pressure > 600 -> stable.for{duration=1s} -> alert_hq
 ```
-
-For time-based delays, use the sample rate to calculate the count. At 50ms intervals, 20
-samples equals 1 second of sustained high readings.
 
 <Divider.Divider x />
 

--- a/docs/site/src/pages/reference/control/arc/how-to/alarms.mdx
+++ b/docs/site/src/pages/reference/control/arc/how-to/alarms.mdx
@@ -19,34 +19,34 @@ seconds should sound an alarm. Arc makes these patterns straightforward.
 
 <Divider.Divider x />
 
-## Basic Threshold Alarm
+## Basic Threshold
 
-The simplest alarm compares a value to a threshold:
+The simplest alarm compares a value to a threshold.
 
-```arc channels="tank_pressure, pressure_high"
-func threshold{limit f64} (value f64) bool {
-    return value > limit
-}
+```arc channels="tank_pressure, pressure_high, tank_level, tank_level_low"
+// Threshold low
+tank_level < 10.0 -> status.set{ ... }
 
-tank_pressure -> threshold{limit=600.0} -> pressure_high
-```
-
-When `tank_pressure` exceeds 600, `pressure_high` outputs `true`. Wire this to a warning
-indicator in your Console schematic.
-
-For low alarms, flip the comparison:
-
-```arc channels="tank_level, tank_level_low"
-func low_alarm{limit f64} (value f64) bool {
-    return value < limit
-}
-
-tank_level -> low_alarm{limit=10.0} -> tank_level_low
+// Threshold high
+tank_pressure > 9000.0 -> status.set{ ... }
 ```
 
 <Divider.Divider x />
 
-## Deadband Alarm
+## Time-Delayed
+
+A brief spike might be acceptable, but a sustained high value indicates a real problem.
+Debounce the condition with
+[`stable.for`](/reference/control/arc/reference/standard-library/stable) so the alarm
+fires only after it holds:
+
+```arc channels="tank_pressure" bodies="alert_hq"
+tank_pressure > 600 -> stable.for{duration=1s} => alert_hq
+```
+
+<Divider.Divider x />
+
+## Deadband
 
 Simple threshold alarms chatter when values oscillate near the limit. If pressure hovers
 around 600 psi, the alarm toggles on and off rapidly. A deadband prevents this by
@@ -87,7 +87,7 @@ below 580 psi. This 20 psi deadband eliminates chatter.
 
 <Divider.Divider x />
 
-## High and Low Alarm with Deadband
+## High and Low with Deadband
 
 Many sensors need both high and low alarms. Create separate functions for each:
 
@@ -117,7 +117,7 @@ tank_pressure -> low_deadband_alarm{low=100.0, clear=120.0} -> pressure_low
 
 <Divider.Divider x />
 
-## Multi-Condition Alarms
+## Multi-Condition
 
 Some alarms require multiple conditions. An abort alarm might trigger when both inlet
 and outlet pressures are elevated (potential runaway), or when any single pressure
@@ -136,19 +136,11 @@ func combined_alarm{
     p2 := outlet
 
     // Critical: either exceeds maximum
-    if p1 > inlet_crit {
-        return true
-    }
-    if p2 > outlet_crit {
-        return true
-    }
-
+    critical := p1 > inlet_crit or p2 > outlet_crit
     // Combined: both elevated (potential runaway)
-    if p1 > combined_inlet and p2 > combined_outlet {
-        return true
-    }
+    combined := p1 > combined_inlet and p2 > combined_outlet
 
-    return false
+    return critical or combined
 }
 
 time.interval{period=50ms} -> combined_alarm{
@@ -163,20 +155,7 @@ time.interval{period=50ms} -> combined_alarm{
 
 <Divider.Divider x />
 
-## Time-Delayed Alarm
-
-A brief spike might be acceptable, but a sustained high value indicates a real problem.
-Debounce the condition with
-[`stable.for`](/reference/control/arc/reference/standard-library/stable) so the alarm
-fires only after it holds:
-
-```arc channels="tank_pressure" bodies="alert_hq"
-tank_pressure > 600 -> stable.for{duration=1s} -> alert_hq
-```
-
-<Divider.Divider x />
-
-## Latching Alarm
+## Latching
 
 Some alarms should stay active until manually acknowledged, even if the condition
 clears:
@@ -210,52 +189,56 @@ operator acknowledges it by clicking the button.
 
 <Divider.Divider x />
 
-## Alarm Priority Levels
+## Priority Levels
 
-Different conditions warrant different responses:
+The simplest form maps a reading to a priority level and logs it:
 
-```arc channels="tank_pressure, pressure_warning, pressure_alarm, pressure_critical"
-func priority_alarm{warning f64, alarm f64, critical f64} (value f64) (level i64, warning bool, alarm bool, critical bool) {
-    // Priority levels: 0=normal, 1=warning, 2=alarm, 3=critical
-    level = 0
-    warning = false
-    alarm = false
-    critical = false
-
-    if value > critical {
-        level = 3
-        critical = true
-        alarm = true
-        warning = true
-    } else if value > alarm {
-        level = 2
-        alarm = true
-        warning = true
-    } else if value > warning {
-        level = 1
-        warning = true
+```arc channels="tank_pressure, log_channel"
+func classify{warn f64, critical f64} (value f64) str {
+    if value >= critical {
+        return "Critical"
     }
-}
-// Use separate functions for each priority level
-func warning_check{limit f64} (value f64) bool {
-    return value > limit
-}
-
-func alarm_check{limit f64} (value f64) bool {
-    return value > limit
+    if value >= warn {
+        return "Warning"
+    }
+    return ""
 }
 
-func critical_check{limit f64} (value f64) bool {
-    return value > limit
-}
-
-tank_pressure -> warning_check{limit=500.0} -> pressure_warning
-tank_pressure -> alarm_check{limit=600.0} -> pressure_alarm
-tank_pressure -> critical_check{limit=700.0} -> pressure_critical
+// "" is falsy, so => never fires for nominal readings
+tank_pressure -> classify{warn=600.0, critical=700.0} => log_channel
 ```
 
-Higher priority alarms include all lower levels. A critical condition is also an alarm
-and a warning.
+When each level warrants a different response, demux the value with a
+[custom routing table](/reference/control/arc/reference/flow#custom-routing). A warning
+sets the status, and a critical also triggers the abort stage:
+
+```arc channels="tank_pressure, log_channel" bodies="abort"
+import status
+
+func prioritize{
+    warn f64,
+    crit f64,
+} (value f64) (nominal bool, warning bool, critical bool) {
+    if value < warn {
+        nominal = true
+    } else if value < crit {
+        warning = true
+    } else {
+        critical = true
+    }
+}
+
+stage monitor {
+    tank_pressure -> prioritize{warn=600.0, crit=700.0} -> {
+        // nominal: no-op
+        warning:  "Warning" -> status.set{ ... },
+        critical: sequence {
+            "Critical" -> status.set{ ... },
+            true => abort
+        }
+    }
+}
+```
 
 <Divider.Divider x />
 

--- a/docs/site/src/pages/reference/control/arc/how-to/alarms.mdx
+++ b/docs/site/src/pages/reference/control/arc/how-to/alarms.mdx
@@ -24,10 +24,7 @@ seconds should sound an alarm. Arc makes these patterns straightforward.
 The simplest alarm compares a value to a threshold.
 
 ```arc channels="tank_pressure, pressure_high, tank_level, tank_level_low"
-// Threshold low
 tank_level < 10.0 -> status.set{ ... }
-
-// Threshold high
 tank_pressure > 9000.0 -> status.set{ ... }
 ```
 

--- a/docs/site/src/pages/reference/control/arc/how-to/bang-bang-control.mdx
+++ b/docs/site/src/pages/reference/control/arc/how-to/bang-bang-control.mdx
@@ -24,11 +24,7 @@ value is too low, off when it's too high. It's commonly used for temperature con
 Turn a heater on when temperature drops below a setpoint:
 
 ```arc channels="tank_temp, heater_cmd"
-func on_off{setpoint f64} (value f64) bool {
-    return value < setpoint
-}
-
-tank_temp -> on_off{setpoint=50.0} -> heater_cmd
+tank_temp < 50.0 -> heater_cmd
 ```
 
 This turns the heater on whenever temperature drops below 50°C and off when it rises

--- a/docs/site/src/pages/reference/control/arc/how-to/data-processing.mdx
+++ b/docs/site/src/pages/reference/control/arc/how-to/data-processing.mdx
@@ -181,36 +181,23 @@ that, `prev` retains whatever was assigned to it.
 
 ## Running Calculations
 
-Accumulators track totals or counts over time:
+Track running statistics with
+[`math.avg`](/reference/control/arc/reference/standard-library/math#avg) and
+[`math.max`](/reference/control/arc/reference/standard-library/math#max), which emit the
+updated statistic on each input:
+
+```arc channels="temperature, temperature_avg, temperature_max"
+temperature -> math.avg{} -> temperature_avg
+temperature -> math.max{} -> temperature_max
+```
+
+Both accumulate over every sample by default. Set `duration` or `count` to control the
+window:
 
 ```arc channels="temperature, temperature_avg"
-func running_avg(value f64) f64 {
-    total $= 0.0
-    count $= 0
-    total = total + value
-    count = count + 1
-    return total / f64(count)
-}
-
-temperature -> running_avg{} -> temperature_avg
+temperature -> math.avg{duration=5s} -> temperature_avg
+temperature -> math.avg{count=20} -> temperature_avg
 ```
-
-Each execution adds to `total` and increments `count`. The average includes all values
-seen so far.
-
-For a running maximum:
-
-```arc
-func running_max(value f64) f64 {
-    max $= value
-    if value > max {
-        max = value
-    }
-    return max
-}
-```
-
-Initializing `max $= value` means the first reading becomes the initial maximum.
 
 <Divider.Divider x />
 
@@ -240,25 +227,21 @@ The `alpha` parameter controls responsiveness:
 
 When a function needs multiple sensor values, pass the channels as input parameters:
 
-```arc channels="p1, p2"
+```arc channels="inlet_pressure, outlet_pressure, delta_p"
 func pressure_diff{inlet chan f64, outlet chan f64} () f64 {
     p1 := inlet
     p2 := outlet
     return p1 - p2
 }
+
+time.interval{period=5s} -> pressure_diff{
+    inlet = inlet_pressure,
+    outlet = outlet_pressure
+} -> delta_p
 ```
 
-Inside the function, `inlet` and `outlet` read the latest value from those channels.
-
-But what triggers this function? It has no trigger to receive flow data. Use
-`time.interval` to run it on a schedule:
-
-```arc channels="inlet_pressure, outlet_pressure, delta_p"
-time.interval{period=50ms} -> pressure_diff{inlet=inlet_pressure, outlet=outlet_pressure} -> delta_p
-```
-
-Every 50ms, Arc runs `pressure_diff`, which reads both pressure channels and outputs the
-difference.
+Inside the function, `inlet` and `outlet` read the latest values from those channels.
+The function has no flow input, so `time.interval` triggers it on a schedule.
 
 <Divider.Divider x />
 
@@ -345,22 +328,27 @@ func categorize(value f64) i64 {
 When you have redundant sensors, use voting to reject outliers. A median of three
 readings ignores a single faulty sensor:
 
-```arc channels="pressure_1, pressure_2, pressure_3, pressure_voted, va, vb, vc"
-func median3{a chan f64, b chan f64, c chan f64} () f64 {
-    va := a
-    vb := b
-    vc := c
+```arc channels="pressure_1, pressure_2, pressure_3, pressure_voted"
+func median3{sensor_a chan f64, sensor_b chan f64, sensor_c chan f64} () f64 {
+    a := sensor_a
+    b := sensor_b
+    c := sensor_c
+
     // Find the middle value
-    if (va >= vb and va <= vc) or (va >= vc and va <= vb) {
-        return va
+    if (a >= b and a <= c) or (a >= c and a <= b) {
+        return a
     }
-    if (vb >= va and vb <= vc) or (vb >= vc and vb <= va) {
-        return vb
+    if (b >= a and b <= c) or (b >= c and b <= a) {
+        return b
     }
-    return vc
+    return c
 }
 
-time.interval{period=50ms} -> median3{a=pressure_1, b=pressure_2, c=pressure_3} -> pressure_voted
+time.interval{period=50ms} -> median3{
+    sensor_a = pressure_1,
+    sensor_b = pressure_2,
+    sensor_c = pressure_3
+} -> pressure_voted
 ```
 
 If one sensor fails and reads 0 while the others read 500, the median is 500. The faulty
@@ -370,28 +358,14 @@ reading is ignored.
 
 ## Rate of Change
 
-Detecting how fast a value is changing requires tracking the previous value and dividing
-by time:
+[`math.derivative`](/reference/control/arc/reference/standard-library/math#derivative)
+computes how fast a value is changing from the samples' actual timestamps:
 
 ```arc channels="pressure, pressure_rate"
-func rate{dt_ms f64} (value f64) f64 {
-    prev $= value
-    d := value - prev
-    prev = value
-    dt_s := dt_ms / 1000.0
-    return d / dt_s
-}
-
-pressure -> rate{dt_ms=50.0} -> pressure_rate
+pressure -> math.derivative{} -> pressure_rate
 ```
 
-The `dt_ms` input parameter is the expected time between samples in milliseconds. The
-output is in units per second (e.g., psi/second if pressure is in psi).
-
-<Note.Note variant="info">
-  The `dt_ms` parameter should match your actual sample rate. If the sensor updates
-  every 50ms, use `dt_ms=50.0`. Mismatched timing gives incorrect rate values.
-</Note.Note>
+The output is in units per second (e.g., psi/second if pressure is in psi).
 
 <Divider.Divider x />
 
@@ -435,6 +409,8 @@ Here's a complete pipeline that reads a pressure sensor, converts units, smooths
 signal, computes rate of change, and outputs everything:
 
 ```arc channels="pressure_raw, pressure_psi, pressure_smooth, pressure_rate, pressure_high"
+import math
+
 // Unit conversion: voltage to psi
 func volts_to_psi{v_min f64, v_max f64, p_max f64} (v f64) f64 {
     ratio := (v - v_min) / (v_max - v_min)
@@ -446,17 +422,12 @@ func ema{alpha f64} (value f64) f64 {
     avg = alpha * value + (1.0 - alpha) * avg
     return avg
 }
-// Rate of change
-func rate{dt_ms f64} (value f64) f64 {
-    prev $= value
-    d := value - prev
-    prev = value
-    return d / (dt_ms / 1000.0)
-}
+
 // Pipeline: raw voltage -> psi -> smoothed -> rate
 pressure_raw -> volts_to_psi{v_min=0.5, v_max=4.5, p_max=1000.0} -> pressure_psi
 pressure_psi -> ema{alpha=0.3} -> pressure_smooth
-pressure_smooth -> rate{dt_ms=50.0} -> pressure_rate
+pressure_smooth -> math.derivative{} -> pressure_rate
+
 // Also output a high-pressure flag
 pressure_smooth > 800 -> pressure_high
 ```
@@ -465,7 +436,7 @@ Each stage feeds the next. When `pressure_raw` updates:
 
 1. `volts_to_psi` converts to psi
 2. `ema` smooths the result
-3. `rate` computes how fast the smoothed value is changing
+3. `math.derivative` computes how fast the smoothed value is changing
 4. The comparison outputs `true` if pressure exceeds 800
 
 The raw value flows through the entire pipeline automatically.

--- a/docs/site/src/pages/reference/control/arc/reference/standard-library.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/standard-library.mdx
@@ -1,9 +1,7 @@
 ---
 layout: "@/layouts/Reference.astro"
 title: "Standard Library"
-description:
-  "Overview of Arc's standard library modules: control, math, ranges, select, status,
-  and time"
+description: "Overview of Arc's standard library modules"
 prev: "Loops"
 prevURL: "/reference/control/arc/reference/loops"
 next: "`control`"
@@ -33,5 +31,6 @@ time.interval{period=1s} -> tick
 | [`math`](/reference/control/arc/reference/standard-library/math)       | Running averages, min/max, and derivatives |
 | [`ranges`](/reference/control/arc/reference/standard-library/ranges)   | Create and close ranges on the Core        |
 | [`select`](/reference/control/arc/reference/standard-library/select)   | Route a boolean to a true or false entry   |
+| [`stable`](/reference/control/arc/reference/standard-library/stable)   | Debounce values until they hold steady     |
 | [`status`](/reference/control/arc/reference/standard-library/status)   | Publish status notifications to the Core   |
 | [`time`](/reference/control/arc/reference/standard-library/time)       | Timestamps, periodic firing, and delays    |

--- a/docs/site/src/pages/reference/control/arc/reference/standard-library/_nav.ts
+++ b/docs/site/src/pages/reference/control/arc/reference/standard-library/_nav.ts
@@ -35,6 +35,11 @@ export const STANDARD_LIBRARY_NAV: PageNavNode = {
       name: "`select`",
     },
     {
+      key: "/reference/control/arc/reference/standard-library/stable",
+      href: "/reference/control/arc/reference/standard-library/stable",
+      name: "`stable`",
+    },
+    {
       key: "/reference/control/arc/reference/standard-library/status",
       href: "/reference/control/arc/reference/standard-library/status",
       name: "`status`",

--- a/docs/site/src/pages/reference/control/arc/reference/standard-library/select.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/standard-library/select.mdx
@@ -6,8 +6,8 @@ description:
   or false entry"
 prev: "`ranges`"
 prevURL: "/reference/control/arc/reference/standard-library/ranges"
-next: "`status`"
-nextURL: "/reference/control/arc/reference/standard-library/status"
+next: "`stable`"
+nextURL: "/reference/control/arc/reference/standard-library/stable"
 ---
 
 import { Divider, Note } from "@synnaxlabs/pluto";

--- a/docs/site/src/pages/reference/control/arc/reference/standard-library/stable.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/standard-library/stable.mdx
@@ -1,0 +1,53 @@
+---
+layout: "@/layouts/Reference.astro"
+title: "`stable`"
+description: "Arc standard library reference for the debounce module"
+prev: "`select`"
+prevURL: "/reference/control/arc/reference/standard-library/select"
+next: "`status`"
+nextURL: "/reference/control/arc/reference/standard-library/status"
+---
+
+import { Note } from "@synnaxlabs/pluto";
+import { mdxOverrides } from "@/components/mdxOverrides";
+import Params from "@/components/params/Params.astro";
+
+export const components = mdxOverrides;
+
+The `stable` module suppresses transient signal changes.
+
+## `for`
+
+`stable.for` is a debounce: it emits its input value only after the value has held
+unchanged for `duration`. Any change restarts the window, so fluctuations shorter than
+`duration` never propagate, and a newly stable value is emitted once.
+
+<Params
+  fn="stable.for"
+  input="numeric | bool"
+  params={[
+    {
+      name: "duration",
+      type: "i64 ns",
+      required: true,
+      description:
+        "How long the value must hold before it is emitted, as a duration literal (e.g. `500ms`).",
+    },
+  ]}
+  output={{
+    type: "numeric | bool",
+    description: "The debounced value, matching the input type.",
+  }}
+/>
+
+<Note.Note variant="warning">
+  Channels with variable-size data types, such as `str`, are not allowed.
+</Note.Note>
+
+```arc channels="input, output, press_pt, vent_cmd"
+// Debounce a value: write afterit holds for 5s
+input -> stable.for{ duration=5s } -> output
+
+// Debounce a condition: act only after it holds for 500ms
+press_pt > 100 -> stable.for{ duration=500ms } -> vent_cmd
+```

--- a/docs/site/src/pages/reference/control/arc/reference/standard-library/status.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/standard-library/status.mdx
@@ -2,8 +2,8 @@
 layout: "@/layouts/Reference.astro"
 title: "`status`"
 description: "Arc standard library reference for the status module"
-prev: "`select`"
-prevURL: "/reference/control/arc/reference/standard-library/select"
+prev: "`stable`"
+prevURL: "/reference/control/arc/reference/standard-library/stable"
 next: "`time`"
 nextURL: "/reference/control/arc/reference/standard-library/time"
 ---


### PR DESCRIPTION
[Docs] `stable.for` and scrub examples

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR expands and streamlines the Arc documentation.
- Adds a `stable` standard-library reference and integrates it into navigation.
- Reworks alarm, control, and data-processing examples around standard-library helpers and simpler Arc expressions.
- Updates neighboring reference-page links.

<h3>Confidence Score: 5/5</h3>

The documentation-only PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/site/src/pages/reference/control/arc/reference/standard-library/stable.mdx | Adds the `stable.for` API reference, parameter documentation, restrictions, and examples. |
| docs/site/src/pages/reference/control/arc/how-to/alarms.mdx | Simplifies alarm examples and introduces `stable.for`, routing-table, and status-based patterns. |
| docs/site/src/pages/reference/control/arc/how-to/data-processing.mdx | Replaces custom running-statistic and derivative implementations with standard-library examples. |
| docs/site/src/pages/reference/control/arc/reference/standard-library/_nav.ts | Adds the `stable` module to the standard-library navigation. |

<sub>Reviews (2): Last reviewed commit: ["\[docs\] nit"](https://github.com/synnaxlabs/synnax/commit/638e1208211d098067714c2cb553b0d9913d8008) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55073444)</sub>

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/synnaxlabs/synnax/blob/main/CLAUDE.md))

<!-- /greptile_comment -->