### PR TITLE
SY-4621: Change reset inputs to boolean instead of u8

### DIFF
--- a/arc/cpp/runtime/state/state_test.cpp
+++ b/arc/cpp/runtime/state/state_test.cpp
@@ -431,7 +431,7 @@ TEST(StateTest, InitInput_SeedsConnectedInput) {
 
     arc::types::Param reset_output;
     reset_output.name = "output";
-    reset_output.type = arc::types::Type{.kind = arc::types::Kind::U8};
+    reset_output.type = arc::types::Type{.kind = arc::types::Kind::Bool};
 
     arc::types::Param input_data;
     input_data.name = "data";
@@ -439,7 +439,7 @@ TEST(StateTest, InitInput_SeedsConnectedInput) {
 
     arc::types::Param input_reset;
     input_reset.name = "reset";
-    input_reset.type = arc::types::Type{.kind = arc::types::Kind::U8};
+    input_reset.type = arc::types::Type{.kind = arc::types::Kind::Bool};
 
     arc::ir::Node data_producer;
     data_producer.key = "data_producer";
@@ -494,7 +494,7 @@ TEST(StateTest, InitInput_SeedsConnectedInput) {
     // After init_input, the reset input has seed data so refresh_inputs succeeds.
     consumer_node.init_input(
         1,
-        x::mem::make_local_shared<x::telem::Series>(static_cast<uint8_t>(0)),
+        x::mem::make_local_shared<x::telem::Series>(false),
         x::mem::make_local_shared<x::telem::Series>(x::telem::TimeStamp(1))
     );
 
@@ -502,7 +502,7 @@ TEST(StateTest, InitInput_SeedsConnectedInput) {
     EXPECT_EQ(consumer_node.input(0)->size(), 2);
     EXPECT_EQ(consumer_node.input(0)->at<float>(0), 1.0f);
     EXPECT_EQ(consumer_node.input(1)->size(), 1);
-    EXPECT_EQ(consumer_node.input(1)->at<uint8_t>(0), 0);
+    EXPECT_EQ(consumer_node.input(1)->at<bool>(0), false);
 }
 
 /// @brief init_input data gets overwritten when the real source produces data.

--- a/arc/cpp/stl/math/math.h
+++ b/arc/cpp/stl/math/math.h
@@ -110,7 +110,7 @@ public:
             const auto &reset_time = this->state.input_time(*this->reset_idx);
             for (size_t i = 0; i < reset_data->size(); i++) {
                 auto ts = x::telem::TimeStamp(reset_time->at<int64_t>(i));
-                if (ts > this->last_reset_time && reset_data->at<uint8_t>(i) == 1)
+                if (ts > this->last_reset_time && reset_data->at<bool>(i))
                     should_reset = true;
             }
             if (reset_time->size() > 0)
@@ -683,7 +683,7 @@ public:
             reset_idx = ri;
             cfg.state.init_input(
                 ri,
-                x::mem::make_local_shared<x::telem::Series>(static_cast<uint8_t>(0)),
+                x::mem::make_local_shared<x::telem::Series>(false),
                 x::mem::make_local_shared<x::telem::Series>(x::telem::TimeStamp(1))
             );
         }

--- a/arc/cpp/stl/math/math_test.cpp
+++ b/arc/cpp/stl/math/math_test.cpp
@@ -114,7 +114,7 @@ private:
         if (with_reset) {
             types::Param reset_output;
             reset_output.name = ir::default_output_param;
-            reset_output.type = types::Type{.kind = types::Kind::U8};
+            reset_output.type = types::Type{.kind = types::Kind::Bool};
 
             ir::Node reset_node;
             reset_node.key = "reset_signal";
@@ -123,7 +123,7 @@ private:
 
             types::Param reset_input;
             reset_input.name = "reset";
-            reset_input.type = types::Type{.kind = types::Kind::U8};
+            reset_input.type = types::Type{.kind = types::Kind::Bool};
             target_node.inputs.push_back(reset_input);
             ir.nodes[1] = target_node;
 
@@ -163,7 +163,8 @@ void write_reset(
     const std::vector<uint8_t> &data,
     const std::vector<int64_t> &timestamps
 ) {
-    reset.output(0) = x::mem::make_local_shared<x::telem::Series>(data);
+    reset.output(0) =
+        x::mem::make_local_shared<x::telem::Series>(data, x::telem::BOOLEAN_T);
     reset.output_time(0) = x::mem::make_local_shared<x::telem::Series>(timestamps);
 }
 }
@@ -684,7 +685,7 @@ TEST(MathMaxTest, SumsAlignmentFromResetSignal) {
     );
 
     auto reset = setup.make_reset_node();
-    auto reset_series = x::telem::Series(static_cast<uint8_t>(0));
+    auto reset_series = x::telem::Series(false);
     reset_series.alignment = x::telem::Alignment(75);
     reset_series.time_range = x::telem::TimeRange(
         x::telem::TimeStamp(25 * sec),

--- a/arc/cpp/stl/math/math_test.cpp
+++ b/arc/cpp/stl/math/math_test.cpp
@@ -163,8 +163,9 @@ void write_reset(
     const std::vector<uint8_t> &data,
     const std::vector<int64_t> &timestamps
 ) {
-    reset.output(0) =
-        x::mem::make_local_shared<x::telem::Series>(data, x::telem::BOOLEAN_T);
+    reset.output(
+        0
+    ) = x::mem::make_local_shared<x::telem::Series>(data, x::telem::BOOLEAN_T);
     reset.output_time(0) = x::mem::make_local_shared<x::telem::Series>(timestamps);
 }
 }

--- a/arc/go/runtime/node/state_test.go
+++ b/arc/go/runtime/node/state_test.go
@@ -1778,7 +1778,7 @@ var _ = Describe("ProgramState", func() {
 								Type:  types.F32(),
 								Value: float32(0),
 							},
-							{Name: "reset", Type: types.U8(), Value: uint8(0)},
+							{Name: "reset", Type: types.Bool(), Value: false},
 						},
 						Outputs: types.Params{
 							{Name: ir.DefaultOutputParam, Type: types.F32()},

--- a/arc/go/stl/math/math.go
+++ b/arc/go/stl/math/math.go
@@ -66,7 +66,7 @@ func createBaseSymbol(name string, doc doc.Doc) *symbol.Symbol {
 					Value: telem.TimeSpanZero,
 				},
 				{Name: countInputParam, Type: types.I64(), Value: 0},
-				{Name: resetInputParam, Type: types.U8(), Value: 0},
+				{Name: resetInputParam, Type: types.Bool(), Value: false},
 			},
 			Outputs: types.Params{
 				{
@@ -286,7 +286,7 @@ func (h *Host) Create(_ context.Context, nodeCfg node.Config) (node.Node, error)
 		}
 		nodeCfg.State.InitInput(
 			resetIdx,
-			telem.NewSeriesV[uint8](0),
+			telem.NewSeriesV[bool](false),
 			telem.NewSeriesV[telem.TimeStamp](1),
 		)
 	}
@@ -354,7 +354,7 @@ func (r *avgNode) Next(ctx node.Context) {
 		resetTime := r.InputTime(r.resetIdx)
 		for i := int64(0); i < resetData.Len(); i++ {
 			ts := telem.ValueAt[telem.TimeStamp](resetTime, int(i))
-			if ts > r.lastResetTime && telem.ValueAt[uint8](resetData, int(i)) == 1 {
+			if ts > r.lastResetTime && telem.ValueAt[bool](resetData, int(i)) {
 				shouldReset = true
 				break
 			}

--- a/arc/go/stl/math/math_test.go
+++ b/arc/go/stl/math/math_test.go
@@ -79,7 +79,7 @@ func makeMathGraphWithReset(nodeType string, dt types.Type) graph.Graph {
 			},
 			{
 				Key:     "reset_signal",
-				Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.U8()}},
+				Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.Bool()}},
 			},
 		},
 	}
@@ -449,7 +449,7 @@ var _ = Describe("Avg", func() {
 		resetNode := s.state.Node("reset_signal")
 		*s.inputNode.Output(0) = telem.NewSeriesV(10.0, 20.0, 30.0)
 		*s.inputNode.OutputTime(0) = telem.NewSeriesSecondsTSV(1, 2, 3)
-		*resetNode.Output(0) = telem.NewSeriesV[uint8](0)
+		*resetNode.Output(0) = telem.NewSeriesV[bool](false)
 		*resetNode.OutputTime(0) = telem.NewSeriesSecondsTSV(1)
 		nextChanged(ctx, s.n)
 		expectOutput[float64](s.state, 20.0)
@@ -457,7 +457,7 @@ var _ = Describe("Avg", func() {
 
 		*s.inputNode.Output(0) = telem.NewSeriesV(100.0, 200.0)
 		*s.inputNode.OutputTime(0) = telem.NewSeriesSecondsTSV(4, 5)
-		*resetNode.Output(0) = telem.NewSeriesV[uint8](1)
+		*resetNode.Output(0) = telem.NewSeriesV[bool](true)
 		*resetNode.OutputTime(0) = telem.NewSeriesSecondsTSV(4)
 		nextChanged(ctx, s.n)
 		expectOutput[float64](s.state, 150.0)
@@ -557,7 +557,7 @@ var _ = Describe("Min", func() {
 		resetNode := s.state.Node("reset_signal")
 		*s.inputNode.Output(0) = telem.NewSeriesV[int32](50, 10, 70)
 		*s.inputNode.OutputTime(0) = telem.NewSeriesSecondsTSV(1, 2, 3)
-		*resetNode.Output(0) = telem.NewSeriesV[uint8](0)
+		*resetNode.Output(0) = telem.NewSeriesV[bool](false)
 		*resetNode.OutputTime(0) = telem.NewSeriesSecondsTSV(1)
 		nextChanged(ctx, s.n)
 		expectOutput[int32](s.state, 10)
@@ -565,7 +565,7 @@ var _ = Describe("Min", func() {
 
 		*s.inputNode.Output(0) = telem.NewSeriesV[int32](80, 40, 60)
 		*s.inputNode.OutputTime(0) = telem.NewSeriesSecondsTSV(4, 5, 6)
-		*resetNode.Output(0) = telem.NewSeriesV[uint8](1)
+		*resetNode.Output(0) = telem.NewSeriesV[bool](true)
 		*resetNode.OutputTime(0) = telem.NewSeriesSecondsTSV(4)
 		nextChanged(ctx, s.n)
 		expectOutput[int32](s.state, 40)
@@ -649,7 +649,7 @@ var _ = Describe("Max", func() {
 		resetNode := s.state.Node("reset_signal")
 		*s.inputNode.Output(0) = telem.NewSeriesV(10.0, 50.0, 30.0)
 		*s.inputNode.OutputTime(0) = telem.NewSeriesSecondsTSV(1, 2, 3)
-		*resetNode.Output(0) = telem.NewSeriesV[uint8](0)
+		*resetNode.Output(0) = telem.NewSeriesV[bool](false)
 		*resetNode.OutputTime(0) = telem.NewSeriesSecondsTSV(1)
 		nextChanged(ctx, s.n)
 		expectOutput[float64](s.state, 50.0)
@@ -657,7 +657,7 @@ var _ = Describe("Max", func() {
 
 		*s.inputNode.Output(0) = telem.NewSeriesV(25.0, 15.0, 70.0)
 		*s.inputNode.OutputTime(0) = telem.NewSeriesSecondsTSV(4, 5, 6)
-		*resetNode.Output(0) = telem.NewSeriesV[uint8](1)
+		*resetNode.Output(0) = telem.NewSeriesV[bool](true)
 		*resetNode.OutputTime(0) = telem.NewSeriesSecondsTSV(4)
 		nextChanged(ctx, s.n)
 		expectOutput[float64](s.state, 70.0)
@@ -686,7 +686,7 @@ var _ = Describe("Max", func() {
 
 		*s.inputNode.Output(0) = telem.NewSeriesV[int64](10, 20, 30)
 		*s.inputNode.OutputTime(0) = telem.NewSeriesSecondsTSV(1, 2, 3)
-		*resetNode.Output(0) = telem.NewSeriesV[uint8](0)
+		*resetNode.Output(0) = telem.NewSeriesV[bool](false)
 		*resetNode.OutputTime(0) = telem.NewSeriesSecondsTSV(1)
 		nextChanged(ctx, s.n)
 		expectOutput[int64](s.state, 20)
@@ -694,7 +694,7 @@ var _ = Describe("Max", func() {
 
 		*s.inputNode.Output(0) = telem.NewSeriesV[int64](40, 50, 60)
 		*s.inputNode.OutputTime(0) = telem.NewSeriesSecondsTSV(4, 5, 6)
-		*resetNode.Output(0) = telem.NewSeriesV[uint8](1, 0)
+		*resetNode.Output(0) = telem.NewSeriesV[bool](true, false)
 		*resetNode.OutputTime(0) = telem.NewSeriesSecondsTSV(4, 5)
 		nextChanged(ctx, s.n)
 		expectOutput[int64](s.state, 50)
@@ -737,7 +737,7 @@ var _ = Describe("Alignment", func() {
 		*s.inputNode.Output(0) = inputSeries
 		*s.inputNode.OutputTime(0) = telem.NewSeriesSecondsTSV(50, 100, 150)
 
-		resetSeries := telem.NewSeriesV[uint8](0)
+		resetSeries := telem.NewSeriesV[bool](false)
 		resetSeries.Alignment = 75
 		resetSeries.TimeRange = telem.TimeRange{
 			Start: 25 * telem.SecondTS,

--- a/arc/go/stl/math/math_test.go
+++ b/arc/go/stl/math/math_test.go
@@ -50,7 +50,7 @@ func makeMathGraph(nodeType string, dt types.Type) graph.Graph {
 	}
 }
 
-func makeMathGraphWithReset(nodeType string, dt types.Type) graph.Graph {
+func makeMathGraphWithReset(nodeType string, dt, resetDt types.Type) graph.Graph {
 	return graph.Graph{
 		Nodes: []graph.Node{
 			{Key: "input"},
@@ -79,7 +79,7 @@ func makeMathGraphWithReset(nodeType string, dt types.Type) graph.Graph {
 			},
 			{
 				Key:     "reset_signal",
-				Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.Bool()}},
+				Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: resetDt}},
 			},
 		},
 	}
@@ -117,7 +117,7 @@ func openMathWithReset(
 	dt types.Type,
 	inputs types.Params,
 ) mathSetup {
-	g := makeMathGraphWithReset(nodeType, dt)
+	g := makeMathGraphWithReset(nodeType, dt, types.Bool())
 	analyzed, diagnostics := graph.Analyze(ctx, g, NewGraphRoot(nil))
 	Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
 	s := node.New(analyzed)
@@ -699,6 +699,12 @@ var _ = Describe("Max", func() {
 		nextChanged(ctx, s.n)
 		expectOutput[int64](s.state, 50)
 		expectOutputTime(s.state, 6*telem.SecondTS)
+	})
+	It("Should reject a non-boolean reset signal", func(ctx SpecContext) {
+		g := makeMathGraphWithReset("max", types.I64(), types.U8())
+		_, diagnostics := graph.Analyze(ctx, g, NewGraphRoot(nil))
+		Expect(diagnostics.Ok()).To(BeFalse())
+		Expect(diagnostics.String()).To(ContainSubstring("type mismatch"))
 	})
 })
 

--- a/client/py/tests/test_frame_calculations.py
+++ b/client/py/tests/test_frame_calculations.py
@@ -893,7 +893,7 @@ class TestCalculationOperations:
             name=random_name(), data_type=sy.DataType.FLOAT32, index=idx.key
         )
         reset = client.channels.create(
-            name=random_name(), data_type=sy.DataType.UINT8, virtual=True
+            name=random_name(), data_type=sy.DataType.BOOLEAN, virtual=True
         )
         calc = client.channels.create(
             name=random_name(),
@@ -914,7 +914,7 @@ class TestCalculationOperations:
                             dtype=np.int64,
                         ),
                         data.key: np.array([10.0, 20.0, 30.0], dtype=np.float32),
-                        reset.key: np.array([0, 0, 0], dtype=np.uint8),
+                        reset.key: np.array([False, False, False], dtype=np.bool_),
                     }
                 )
                 frame = streamer.read(timeout=1)
@@ -931,7 +931,7 @@ class TestCalculationOperations:
                             dtype=np.int64,
                         ),
                         data.key: np.array([40.0, 50.0], dtype=np.float32),
-                        reset.key: np.array([1, 0], dtype=np.uint8),
+                        reset.key: np.array([True, False], dtype=np.bool_),
                     }
                 )
                 frame = streamer.read(timeout=1)
@@ -947,7 +947,7 @@ class TestCalculationOperations:
             name=random_name(), data_type=sy.DataType.FLOAT32, index=idx.key
         )
         reset = client.channels.create(
-            name=random_name(), data_type=sy.DataType.UINT8, virtual=True
+            name=random_name(), data_type=sy.DataType.BOOLEAN, virtual=True
         )
         calc = client.channels.create(
             name=random_name(),
@@ -968,7 +968,7 @@ class TestCalculationOperations:
                             dtype=np.int64,
                         ),
                         data.key: np.array([30.0, 10.0, 20.0], dtype=np.float32),
-                        reset.key: np.array([0, 0, 0], dtype=np.uint8),
+                        reset.key: np.array([False, False, False], dtype=np.bool_),
                     }
                 )
                 frame = streamer.read(timeout=1)
@@ -985,7 +985,7 @@ class TestCalculationOperations:
                             dtype=np.int64,
                         ),
                         data.key: np.array([50.0, 40.0], dtype=np.float32),
-                        reset.key: np.array([1, 0], dtype=np.uint8),
+                        reset.key: np.array([True, False], dtype=np.bool_),
                     }
                 )
                 frame = streamer.read(timeout=1)
@@ -1001,7 +1001,7 @@ class TestCalculationOperations:
             name=random_name(), data_type=sy.DataType.FLOAT32, index=idx.key
         )
         reset = client.channels.create(
-            name=random_name(), data_type=sy.DataType.UINT8, virtual=True
+            name=random_name(), data_type=sy.DataType.BOOLEAN, virtual=True
         )
         calc = client.channels.create(
             name=random_name(),
@@ -1022,7 +1022,7 @@ class TestCalculationOperations:
                             dtype=np.int64,
                         ),
                         data.key: np.array([10.0, 30.0, 20.0], dtype=np.float32),
-                        reset.key: np.array([0, 0, 0], dtype=np.uint8),
+                        reset.key: np.array([False, False, False], dtype=np.bool_),
                     }
                 )
                 frame = streamer.read(timeout=1)
@@ -1039,7 +1039,7 @@ class TestCalculationOperations:
                             dtype=np.int64,
                         ),
                         data.key: np.array([15.0, 25.0], dtype=np.float32),
-                        reset.key: np.array([1, 0], dtype=np.uint8),
+                        reset.key: np.array([True, False], dtype=np.bool_),
                     }
                 )
                 frame = streamer.read(timeout=1)
@@ -1147,7 +1147,7 @@ class TestCalculationOperations:
             name=random_name(), data_type=sy.DataType.FLOAT32, index=idx.key
         )
         reset = client.channels.create(
-            name=random_name(), data_type=sy.DataType.UINT8, virtual=True
+            name=random_name(), data_type=sy.DataType.BOOLEAN, virtual=True
         )
         calc = client.channels.create(
             name=random_name(),
@@ -1173,7 +1173,7 @@ class TestCalculationOperations:
                             dtype=np.int64,
                         ),
                         data.key: np.array([10.0, 20.0], dtype=np.float32),
-                        reset.key: np.array([0, 0], dtype=np.uint8),
+                        reset.key: np.array([False, False], dtype=np.bool_),
                     }
                 )
                 frame = streamer.read(timeout=1)
@@ -1185,7 +1185,7 @@ class TestCalculationOperations:
                             [start + 3 * sy.TimeSpan.SECOND], dtype=np.int64
                         ),
                         data.key: np.array([30.0], dtype=np.float32),
-                        reset.key: np.array([1], dtype=np.uint8),
+                        reset.key: np.array([True], dtype=np.bool_),
                     }
                 )
                 frame = streamer.read(timeout=1)
@@ -1197,7 +1197,7 @@ class TestCalculationOperations:
                             [start + 4 * sy.TimeSpan.SECOND], dtype=np.int64
                         ),
                         data.key: np.array([40.0], dtype=np.float32),
-                        reset.key: np.array([0], dtype=np.uint8),
+                        reset.key: np.array([False], dtype=np.bool_),
                     }
                 )
                 frame = streamer.read(timeout=1)
@@ -1259,7 +1259,7 @@ class TestCalculationOperations:
             name=random_name(), data_type=sy.DataType.FLOAT32, index=idx.key
         )
         reset = client.channels.create(
-            name=random_name(), data_type=sy.DataType.UINT8, virtual=True
+            name=random_name(), data_type=sy.DataType.BOOLEAN, virtual=True
         )
         calc = client.channels.create(
             name=random_name(),
@@ -1279,7 +1279,7 @@ class TestCalculationOperations:
                             dtype=np.int64,
                         ),
                         data.key: np.array([10.0, 20.0], dtype=np.float32),
-                        reset.key: np.array([0, 0], dtype=np.uint8),
+                        reset.key: np.array([False, False], dtype=np.bool_),
                     }
                 )
                 frame = streamer.read(timeout=1)
@@ -1296,7 +1296,7 @@ class TestCalculationOperations:
                             dtype=np.int64,
                         ),
                         data.key: np.array([30.0, 40.0, 50.0], dtype=np.float32),
-                        reset.key: np.array([1, 0, 1], dtype=np.uint8),
+                        reset.key: np.array([True, False, True], dtype=np.bool_),
                     }
                 )
                 frame = streamer.read(timeout=1)

--- a/console/src/platform/channel/useCalculatedModal.spec.ts
+++ b/console/src/platform/channel/useCalculatedModal.spec.ts
@@ -60,6 +60,32 @@ describe("useCalculatedModal", () => {
     });
   });
 
+  describe("reset channel picker", () => {
+    it("should list boolean channels and exclude other data types", async () => {
+      const base = uniqueChannelName("reset");
+      await client.channels.create({
+        name: `${base}_bool`,
+        dataType: DataType.BOOLEAN,
+        virtual: true,
+      });
+      await client.channels.create({
+        name: `${base}_u8`,
+        dataType: DataType.UINT8,
+        virtual: true,
+      });
+      await openModal();
+      await waitFor(() => expect(screen.getByText("Average")).toBeTruthy());
+      fireEvent.click(screen.getByText("Average"));
+      await waitFor(() => expect(screen.getByText("Reset channel")).toBeTruthy());
+      fireEvent.click(screen.getByText("Select channel"));
+      fireEvent.change(await screen.findByPlaceholderText("Search channels..."), {
+        target: { value: base },
+      });
+      await screen.findByText(`${base}_bool`);
+      expect(screen.queryByText(`${base}_u8`)).toBeNull();
+    });
+  });
+
   describe("validation", () => {
     it("should keep the modal open and show errors when the name and expression are empty", async () => {
       await openModal();

--- a/console/src/platform/channel/useCalculatedModal.tsx
+++ b/console/src/platform/channel/useCalculatedModal.tsx
@@ -9,7 +9,7 @@
 
 import "@/platform/channel/CalculatedModal.css";
 
-import { channel, status, TimeSpan } from "@synnaxlabs/client";
+import { channel, DataType, status, TimeSpan } from "@synnaxlabs/client";
 import {
   Arc,
   Button,
@@ -34,6 +34,10 @@ import { Triggers } from "@/platform/triggers";
 export interface CalculatedModalParams {
   channelKey?: channel.Key;
 }
+
+const BOOLEAN_QUERY: Partial<Channel.RetrieveMultipleQuery> = {
+  dataTypes: [DataType.BOOLEAN],
+};
 
 const NAME_INPUT_PROPS: Partial<Input.TextProps> = {
   autoFocus: true,
@@ -127,13 +131,14 @@ export const useCalculatedModal = Modals.create<CalculatedModalParams>(
                   <Form.Field<channel.Key>
                     path="operations.0.resetChannel"
                     label="Reset channel"
-                    helpText="Resets the calculation when this channel is triggered."
+                    helpText="Resets the calculation when this boolean channel is triggered."
                     grow
                   >
                     {({ value, onChange }) => (
                       <Channel.SelectSingle
                         value={value}
                         onChange={(v: channel.Key | undefined) => onChange(v ?? 0)}
+                        initialQuery={BOOLEAN_QUERY}
                         grow
                         allowNone
                       />

--- a/core/pkg/service/framer/calculation/calculator/calculator_test.go
+++ b/core/pkg/service/framer/calculation/calculator/calculator_test.go
@@ -786,6 +786,40 @@ var _ = Describe("Calculator", Ordered, func() {
 		Expect(o.Get(calc.Key()).Series[0]).To(telem.MatchSeriesDataV[int64](35))
 	})
 
+	Describe("Reset channel", func() {
+		It(
+			"Should fail to compile with a non-boolean reset channel",
+			func(ctx SpecContext) {
+				reset := channel.Channel{
+					Name:     UniqueChannelName(),
+					DataType: telem.Uint8T,
+					Virtual:  true,
+				}
+				Expect(channelWriter.Create(ctx, &reset)).To(Succeed())
+				base := []channel.Channel{{
+					Name:     UniqueChannelName(),
+					DataType: telem.Int64T,
+					Virtual:  true,
+				}}
+				Expect(channelWriter.CreateMany(ctx, &base)).To(Succeed())
+				calc := channel.Channel{
+					Name:       UniqueChannelName(),
+					DataType:   telem.Int64T,
+					Virtual:    true,
+					Expression: fmt.Sprintf("return %s", base[0].Name),
+					Operations: []channel.Operation{
+						{Type: "max", ResetChannel: reset.Key()},
+					},
+				}
+				Expect(channelWriter.Create(ctx, &calc)).To(Succeed())
+				Expect(compiler.Compile(ctx, compiler.Config{
+					ChannelService: channelSvc,
+					Channel:        calc,
+				})).Error().To(MatchError(ContainSubstring("type mismatch")))
+			},
+		)
+	})
+
 	It(
 		"Should compute derivative operation with type promotion",
 		func(ctx SpecContext) {

--- a/docs/site/src/pages/reference/console/calculated-channels.mdx
+++ b/docs/site/src/pages/reference/console/calculated-channels.mdx
@@ -90,9 +90,9 @@ Calculation" from the context menu:
       <td>Reset Channel (Optional)</td>
       {
         <td>
-          A <code>uint8</code>{" "}
+          A <code>boolean</code>{" "}
           <a href="#reset-channels">channel that triggers operation reset</a> when its
-          value equals 1. Only applies when an operation is selected.
+          value is <code>true</code>. Only applies when an operation is selected.
         </td>
       }
     </tr>
@@ -165,30 +165,31 @@ The operation keeps state across executions and outputs a single aggregated valu
 | Minimum, time or signal    | `min`        | `60s`  | `cycle_complete`   |
 | Rate of change             | `derivative` | n/a    | n/a                |
 
-A reset fires when the window expires or the reset channel receives `1`, whichever comes
-first. Set the window to `0` and omit the reset channel for an operation that never
-resets.
+A reset fires when the window expires or the reset channel receives `true`, whichever
+comes first. Set the window to `0` and omit the reset channel for an operation that
+never resets.
 
 <Divider.Divider x />
 
 ## Reset Channels
 
 A reset channel provides signal-based control over operation state and must have the
-data type `uint8`. When it receives `1`, the operation clears its state and restarts.
+data type `boolean`. When it receives `true`, the operation clears its state and
+restarts.
 
 {/* [VIDEO NEEDED] Demonstration of reset channel triggering and operation resetting */}
 
-- **Manual**: write to a virtual `uint8` channel from a schematic button or control
+- **Manual**: write to a virtual `boolean` channel from a schematic button or control
   panel.
 - **Periodic**: use a timer or sequence to generate reset pulses.
-- **Conditional**: use a calculated channel that outputs `1` when a condition is met.
+- **Conditional**: use a calculated channel that outputs `true` when a condition is met.
 
 ### Reset Example
 
 ```
-Time:           0s → 5s  → 10s → 10.1s (reset=1) → 15s → 20s
-Pressure:       50 → 100 → 75  → 75              → 90  → 110
-Max Operation:  50 → 100 → 100 → (reset to 75)   → 90  → 110
+Time:           0s → 5s  → 10s → 10.1s (reset=true) → 15s → 20s
+Pressure:       50 → 100 → 75  → 75                 → 90  → 110
+Max Operation:  50 → 100 → 100 → (reset to 75)      → 90  → 110
 ```
 
 At 10.1s, the reset channel triggers, clearing the max value. The operation restarts

--- a/integration/tests/migration/channels_calc_verify.py
+++ b/integration/tests/migration/channels_calc_verify.py
@@ -109,6 +109,8 @@ class CalcChannelsVerify(TestCase):
 
     def test_calc_operations(self) -> None:
         self.log("Testing: Calc channel operations metadata")
+        # Legacy uint8 reset configs survive migration but no longer compile (reset
+        # channels must be boolean), so only their stored metadata is asserted.
         reset = self.client.channels.retrieve(CALC_RESET)
         for name, expected_op, expected_dur, uses_reset in CALC_OP_CHANNELS:
             ch = self.client.channels.retrieve(name)
@@ -150,40 +152,6 @@ class CalcChannelsVerify(TestCase):
                 "mig_calc_expr_max": 65.0,
             }
         )
-
-        calc_avg_rst = self.client.channels.retrieve("mig_calc_op_avg_rst")
-        start = sy.TimeStamp.now()
-        with self.client.open_streamer(calc_avg_rst.key) as streamer:
-            with self.client.open_writer(
-                start, [self._calc_idx.key, self._src.key, reset.key]
-            ) as writer:
-                writer.write(
-                    {
-                        self._calc_idx.key: _timestamps(start, 3),
-                        self._src.key: VERIFY_SRC_DATA,
-                        reset.key: np.array([0, 0, 0], dtype=np.uint8),
-                    }
-                )
-                frame = streamer.read(timeout=5)
-                assert frame is not None
-                val = float(frame[calc_avg_rst.key][0])
-                assert abs(val - 20.0) < 0.01, (
-                    f"avg_rst batch1: expected 20.0, got {val}"
-                )
-
-                writer.write(
-                    {
-                        self._calc_idx.key: _timestamps(start, 2, offset=4),
-                        self._src.key: np.array([40.0, 50.0], dtype=np.float32),
-                        reset.key: np.array([1, 0], dtype=np.uint8),
-                    }
-                )
-                frame = streamer.read(timeout=5)
-                assert frame is not None
-                val = float(frame[calc_avg_rst.key][0])
-                assert abs(val - 45.0) < 0.01, (
-                    f"avg_rst after reset: expected 45.0, got {val}"
-                )
 
     def test_calc_type_handling(self) -> None:
         self.log("Testing: Calc type handling metadata")


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4621](<>)

## Description

Changes the `reset` input on `math.avg`, `math.min`, and `math.max` from `u8` to `boolean`, following Arc boolean support (SY-3482). The Go symbol definition, Go runtime reads, and C++ runtime mirror now use `boolean` series, and the reset fires on `true` instead of `1`.

This is a hard flip, as discussed offline. Calculated channels with a `uint8` reset channel fail Arc analysis on recompile, and reset channels must now be `boolean`. No compatibility shim is added. The migration tests that assert the old `uint8` behavior fail by design and will be reworked separately.

The Console calculated channel modal now filters the reset channel picker to `boolean` channels and notes the requirement in the help text. The calculated channel docs are updated to match.

New tests: an Arc analyzer case rejecting a non-`boolean` reset edge, a core case asserting compilation fails with a non-`boolean` reset channel, and a Console case asserting the picker excludes non-`boolean` channels. A pre-existing defect where a standalone reset signal re-aggregates the retained input batch was found while testing and is deferred to a separate issue.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes the `math.avg`, `math.min`, and `math.max` reset input from `uint8` to `boolean` across Arc analysis, Go and C++ runtimes, Console filtering, tests, and documentation.
- Updates reset defaults and runtime reads to use boolean telemetry.
- Restricts the calculated-channel reset picker to boolean channels.
- Adds analyzer, calculator, runtime, and Console coverage for the new type contract.
- Removes legacy migration assertions for the intentionally unsupported `uint8` reset configuration.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| arc/go/stl/math/math.go | Changes aggregate reset symbol definitions, seeded values, and runtime reads from `uint8` to boolean. |
| arc/cpp/stl/math/math.h | Mirrors the boolean reset behavior in the C++ Arc runtime. |
| console/src/platform/channel/useCalculatedModal.tsx | Filters reset-channel selection to boolean channels and updates contextual help. |
| core/pkg/service/framer/calculation/calculator/calculator_test.go | Adds coverage ensuring non-boolean reset channels fail calculated-channel compilation. |
| docs/site/src/pages/reference/console/calculated-channels.mdx | Updates calculated-channel documentation to describe boolean reset channels. |
| integration/tests/migration/channels_calc_verify.py | Removes legacy migration verification for the intentionally unsupported `uint8` reset contract. |

<sub>Reviews (2): Last reviewed commit: ["SY-4621: Fix CI fallout from boolean res..."](https://github.com/synnaxlabs/synnax/commit/f1dceaff576879717f8733d149a3a69d5e021f1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55092796)</sub>

**Context used:**

- Rule used - In MDX documentation files, wrap text content in t... ([source](https://app.greptile.com/synnax/-/custom-context?memory=216d1be9-1019-4dff-9e9b-93b67c01a4fc))

**Learned From**
[synnaxlabs/synnax#1556](https://github.com/synnaxlabs/synnax/pull/1556)
- Knowledge Base — [Arc: Automation Language and Runtime Engine](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/arc-engine.md)

<!-- /greptile_comment -->