### PR TITLE
SY-4673: Fix flaky x/go/signal RecvUnderContext Windows test

### DIFF
--- a/x/go/signal/signal_test.go
+++ b/x/go/signal/signal_test.go
@@ -268,19 +268,18 @@ var _ = Describe("Signal", func() {
 		It(
 			"Should return context error if context is cancelled before receive",
 			func(specCtx SpecContext) {
-				ctx, cancel := signal.WithTimeout(specCtx, 500*time.Microsecond)
+				ctx, cancel := signal.WithCancel(specCtx)
 				v := make(chan int)
 				cancel()
-				val, err := signal.RecvUnderContext(ctx, v)
-				Expect(err).To(MatchError(context.Canceled))
-				Expect(val).To(Equal(0))
+				Expect(signal.RecvUnderContext(ctx, v)).Error().
+					To(MatchError(context.Canceled))
 			},
 		)
 
 		It(
 			"Should receive value even if context is cancelled after value is available",
 			func(specCtx SpecContext) {
-				ctx, cancel := signal.WithTimeout(specCtx, 500*time.Microsecond)
+				ctx, cancel := signal.WithCancel(specCtx)
 				v := make(chan int, 1)
 				v <- 1
 				val := MustSucceed(signal.RecvUnderContext(ctx, v))


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4673](https://linear.app/synnax/issue/SY-4673)

## Description

`RecvUnderContext / Should return context error if context is cancelled before receive`
flaked on `windows-latest`. The spec built a context with a 500µs deadline via
`WithTimeout` and then cancelled it manually. On a loaded Windows runner the 500µs
deadline could fire before `cancel()` ran, so `ctx.Err()` returned
`context.DeadlineExceeded` instead of `context.Canceled` and the assertion failed.

The deadline served no purpose — the test cancels the context itself. Switched this spec
and its sibling ("receive value even if context is cancelled after value is available",
which had the same race in its `select`) to `WithCancel`, removing the competing timer.
Also folded the failing spec's two assertions into the inline `Expect(...).Error()`
form.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR removes competing 500µs deadlines from two cancellation tests to prevent timing-dependent Windows failures.
- Replaces `WithTimeout` with explicit `WithCancel` contexts.
- Rewrites the cancelled-receive assertion into Gomega's inline `Error()` form.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking test-coverage regression in the cancelled-receive assertion.

Explicit cancellation removes the competing deadline without introducing a hang, but the updated assertion no longer verifies that `RecvUnderContext` returns the required zero value with its cancellation error.

**Files Needing Attention:** x/go/signal/signal_test.go

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| x/go/signal/signal_test.go | The timeout removal addresses the reported race, but the rewritten assertion drops explicit coverage of the zero-value result on cancellation. |

<sub>Reviews (1): Last reviewed commit: ["SY-4673: Fix flaky x/go/signal RecvUnder..."](https://github.com/synnaxlabs/synnax/commit/38a5ea4beed02cbcb31cc45abb27958b06b0b3ee) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55232285)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - When returning errors in Go functions, the first r... ([source](https://app.greptile.com/synnax/-/custom-context?memory=53992e61-3091-4ecd-b93f-2cb98c4ddbd8))

**Learned From**
[synnaxlabs/synnax#1532](https://github.com/synnaxlabs/synnax/pull/1532)

<!-- /greptile_comment -->