### PR TITLE
SY-4619: Scrub Arc test sequence and language reference examples

### DIFF
--- a/docs/site/src/pages/reference/control/arc/how-to/test-sequences.mdx
+++ b/docs/site/src/pages/reference/control/arc/how-to/test-sequences.mdx
@@ -21,16 +21,10 @@ monitoring for abort conditions.
 
 ## Basic Sequence
 
-A minimal sequence with idle, active, and complete states:
+A minimal sequence with active and complete states:
 
-```arc channels="press_vlv_cmd, ox_pt_1, start_cmd, op_cmd", bodies="main"
+```arc channels="press_vlv_cmd, ox_pt_1, start_cmd, log", bodies="main"
 sequence main {
-    stage idle {
-        // Wait for operator to start
-        false -> press_vlv_cmd
-        op_cmd => next
-    }
-
     stage active {
         true -> press_vlv_cmd
         ox_pt_1 > 500 => next
@@ -38,15 +32,15 @@ sequence main {
 
     stage complete {
         false -> press_vlv_cmd
+        "complete" -> log
     }
 }
 
 start_cmd => main
 ```
 
-Wire `start_cmd` to a button in Console. When clicked, the sequence moves from `idle` to
-`active`, opens the valve, waits for pressure to reach 500, then closes the valve and
-stops.
+Wire `start_cmd` to a button in the Console. When clicked, the sequence opens the valve,
+waits for pressure to reach 500, then closes the valve and stops.
 
 <Note.Note variant="info">
 The entry point `start_cmd => main` triggers the sequence when the channel
@@ -147,7 +141,7 @@ conditions and the `emergency_stop` channel can trigger it.
 <Note.Note variant="warning">
 Always put abort conditions before normal operation flows in each stage.
 When multiple conditional transitions (`=>`) are truthy in the same cycle, the
-first one listed wins. Safety conditions should always have priority.
+first one listed wins.
 </Note.Note>
 
 <Divider.Divider x />
@@ -204,13 +198,12 @@ sequence prime {
     false -> vent_vlv_cmd
     true -> press_vlv_cmd
 
-    // Inline gate:
-    // Group advacnement conditions
+    // Inline gate: group the exit conditions
     stage {
         tank_pressure > 700 => abort
         abort_btn => abort
         tank_pressure > 500 => next
-        time.wait{30s} => timeout
+        time.wait{duration=30s} => timeout
     }
 
     // Procedure resumes
@@ -249,44 +242,29 @@ a multi-exit gate.
 
 Control the pressurization rate to avoid thermal shock or mechanical stress:
 
-```arc channels="ox_pt_1, ox_rate_high, abort_btn", bodies="abort"
-import time
-
-func rate_monitor{dt_ms f64, max_rate f64} (value f64) bool {
-    prev $= 0.0
-    d := value - prev
-    prev = value
-
-    dt_s := dt_ms / 1000.0
-    if dt_s <= 0 {
-        return false
-    }
-
-    rate := d / dt_s
-    // Check magnitude
-    if rate < 0 {
-        rate = 0.0 - rate
-    }
-
-    return rate > max_rate
-}
+```arc channels="ox_pt_1, ox_rate, press_vlv_cmd, abort_btn", bodies="abort"
+import math
 
 sequence main {
     stage pressurize {
         // Abort conditions
         ox_pt_1 > 700 => abort
-        ox_pt_1 -> rate_monitor{dt_ms=50.0, max_rate=100.0} -> ox_rate_high
-        ox_rate_high => abort
+        ox_rate > 150 => abort
         abort_btn => abort
-        // Pressurize slowly by pulsing the valve
-        time.interval{period=100ms} -> press_valve_pulse{}
+
+        // Open the valve only while the rise rate is under 100 psi/s
+        ox_pt_1 -> math.derivative{} -> ox_rate
+        ox_rate < 100 -> press_vlv_cmd
+
         ox_pt_1 > 500 => next
     }
     // ... rest of sequence
 }
 ```
 
-The rate monitor triggers an abort if pressure rises faster than 100 psi/second.
+[`math.derivative`](/reference/control/arc/reference/standard-library/math#derivative)
+computes the rise rate in psi per second. The valve stays open while the rate is under
+100 psi/s, and a runaway rate over 150 psi/s aborts.
 
 <Divider.Divider x />
 
@@ -295,19 +273,8 @@ The rate monitor triggers an abort if pressure rises faster than 100 psi/second.
 A realistic rocket engine test sequence with all the patterns combined:
 
 ```arc channels="ox_pt_1, fuel_pt_1, abort_btn, ox_rate, ox_press_vlv_cmd, fuel_press_vlv_cmd, igniter_cmd, chamber_tc_1, ox_main_vlv_cmd, fuel_main_vlv_cmd, ox_vent_vlv_cmd, fuel_vent_vlv_cmd, start_cmd, emergency_stop",bodies="abort, ignition_fail, main"
+import math
 import time
-
-// Rate monitoring
-func pressure_rate{dt_ms f64} (value f64) f64 {
-    prev $= 0.0
-    d := value - prev
-    prev = value
-    dt_s := dt_ms / 1000.0
-    if dt_s <= 0 {
-        return 0.0
-    }
-    return d / dt_s
-}
 
 sequence main {
     // Stage 1: System checkout
@@ -321,7 +288,7 @@ sequence main {
     // Stage 2: Pressurize oxidizer
     stage press_ox {
         ox_pt_1 > 650 => abort
-        ox_pt_1 -> pressure_rate{dt_ms=50.0} -> ox_rate
+        ox_pt_1 -> math.derivative{} -> ox_rate
         ox_rate > 100 => abort
         abort_btn => abort
         true -> ox_press_vlv_cmd
@@ -422,20 +389,20 @@ emergency_stop => abort
 
 ## Sequence Design Tips
 
-**List abort conditions first.** Line order determines priority. Safety conditions
-should always win over normal operations.
+**List abort conditions first.** Line order determines priority, and safety conditions
+should always win.
 
 **Use multiple abort thresholds.** A pressure of 600 psi might be a warning, but 700 psi
 triggers an immediate abort.
 
-**Add timeouts.** Sequences that wait indefinitely for conditions can hang. Use
-`time.wait` to set maximum durations and transition to error stages.
+**Add timeouts.** A sequence waiting on a condition that never comes hangs forever.
+Bound each wait with `time.wait` and transition to an error stage.
 
-**Keep stages focused.** Each stage should have one primary purpose. Split complex
-operations into multiple stages for clarity and easier debugging.
+**Keep stages focused.** Give each stage one purpose. Split complex operations into
+multiple stages.
 
-**Monitor continuously.** While waiting for one condition, continue checking abort
-conditions. All flows in a stage run concurrently.
+**Monitor continuously.** All flows in a stage run concurrently, so abort checks stay
+armed while the stage waits.
 
 **Test abort paths.** Simulate abort conditions during development to verify the system
 reaches a safe state. The abort sequence is the most important part of your automation.

--- a/docs/site/src/pages/reference/control/arc/reference/errors.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/errors.mdx
@@ -170,25 +170,6 @@ if index < len(data) {
 }
 ```
 
-### Channel Errors
-
-| Error         | Cause                                                         |
-| ------------- | ------------------------------------------------------------- |
-| Type mismatch | Writing wrong type to channel (if not caught at compile time) |
-
-<Divider.Divider x />
-
-## Error Severity Levels
-
-| Level   | Description                             |
-| ------- | --------------------------------------- |
-| Error   | Prevents compilation or stops execution |
-| Warning | Potential problem, compiles anyway      |
-| Info    | Informational message                   |
-| Hint    | Suggested improvement                   |
-
-The text editor shows errors inline with severity indicators.
-
 <Divider.Divider x />
 
 ## Error Isolation
@@ -226,7 +207,7 @@ func debug_controller(value f64) f64 {
     error := value - setpoint
 
     // Write to channel for visibility
-    debug_log = f"Error is: {error}"
+    debug_error = f"Error is: {error}"
     return error * gain
 }
 ```

--- a/docs/site/src/pages/reference/control/arc/reference/flow.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/flow.mdx
@@ -182,9 +182,9 @@ function body, and route each output by name.
 
 ```arc channels="tank_pressure, open_vent" bodies="pressurize, safe_state"
 func decide_stage{low f64, high f64} (value f64) (vent bool, press bool, abort bool) {
-    if (value < low) {
+    if value < low {
         vent = true
-    } else if (value <= high) {
+    } else if value <= high {
         press = true
     } else {
         abort = true

--- a/docs/site/src/pages/reference/control/arc/reference/functions.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/functions.mdx
@@ -61,26 +61,27 @@ func log_value(value f64) {
   flow.
 - Parens `()` for the `func` side: inputs passed when you call the function.
 
-```arc
+Here `threshold` is set in the braces and `value` is the trigger:
+
+```arc channels="sensor, filtered"
 func filter{threshold f64} (value f64) f64 {
     if value > threshold {
         return value
     }
     return 0.0
 }
+sensor -> filter{threshold = 0.1} -> filtered
 ```
-
-Here `threshold` is set in the braces and `value` is the trigger.
 
 Input parameters can be literals or channel references:
 
-```arc channels="temp, cmd, setpoint_input, value"
+```arc channels="temp, cmd, enable_cmd, setpoint_input"
 func controller{
-    setpoint f64,      // literal or channel
-    sensor chan f64,   // channel reference
-    output chan f64,   // channel reference
+    setpoint f64,     // literal or channel
+    input chan f64,   // channel reference
+    output chan f64,  // channel reference
 } (enable bool) f64 {
-    value := sensor
+    value := input
     if enable {
         output = value - setpoint
     }
@@ -88,10 +89,10 @@ func controller{
 }
 
 // Static setpoint
-sensor -> controller{setpoint=100.0, sensor=temp, output=cmd}
+enable_cmd -> controller{setpoint=100.0, input=temp, output=cmd}
 
 // Setpoint driven by a channel
-sensor -> controller{setpoint=setpoint_input, sensor=temp, output=cmd}
+enable_cmd -> controller{setpoint=setpoint_input, input=temp, output=cmd}
 ```
 
 ### Optional Inputs
@@ -125,7 +126,7 @@ func double(value f64) f64 {
 ### Single Named Output
 
 ```arc
-func compute(x f64)result f64 {
+func compute(x f64) result f64 {
     result = x * 2
     return result
 }
@@ -213,7 +214,7 @@ time.interval{200ms} -> counter{} -> count2
 
 Functions can read from and write to channels:
 
-```arc channels="value"
+```arc
 func controller{input chan f64, output chan f64, threshold f64} () {
     value := input // read (non-blocking)
     if value > threshold {

--- a/docs/site/src/pages/reference/control/arc/reference/operators.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/operators.mdx
@@ -32,8 +32,8 @@ export const components = mdxOverrides;
 Integer division truncates toward zero:
 
 ```arc
-result := 10 / 3 // 3 (not 3.333)
-result := -10 / 3 // -3
+positive := 10 / 3 // 3 (not 3.333)
+negative := -10 / 3 // -3
 ```
 
 Float division produces a float:
@@ -188,3 +188,17 @@ msg := "Hello"
 greeting := msg + " World" // "Hello World"
 is_empty := msg == "" // false
 ```
+
+<Divider.Divider x />
+
+## Truthiness
+
+Contexts that test a value accept more than `bool`: the
+[`=>` conditional flow operator](/reference/control/arc/reference/flow), `if`
+conditions, and `for` conditions.
+
+| Type    | Truthy when |
+| ------- | ----------- |
+| `bool`  | `true`      |
+| numeric | Non-zero    |
+| `str`   | Non-empty   |

--- a/docs/site/src/pages/reference/control/arc/reference/sequences.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/sequences.mdx
@@ -45,25 +45,29 @@ sequence {
 
 A sequence item is one of:
 
-| Item            | Syntax                | Description                                   |
-| --------------- | --------------------- | --------------------------------------------- |
-| Write           | `expr -> chan`        | Write once, advance                           |
-| Wait            | `time.wait{duration}` | Pause for the duration, advance               |
-| Condition gate  | `expr`                | Pause until the expression is truthy, advance |
-| Stage           | `stage name? { ... }` | Enter stage; advance when a transition fires  |
-| Nested sequence | `sequence { ... }`    | Run nested items in order                     |
+| Item           | Syntax                | Description                                   |
+| -------------- | --------------------- | --------------------------------------------- |
+| Condition gate | `expr => next`        | Pause until the expression is truthy, advance |
+| Write          | `expr -> chan`        | Write once, advance                           |
+| Wait           | `time.wait{duration}` | Pause for the duration, advance               |
+| Sequence       | `sequence { ... }`    | Run nested items in order                     |
+| Stage          | `stage { ... }`       | Enter stage; advance when a transition fires  |
+
+Stages and sequences can be named. A named item is a valid `=> name` target for its
+siblings; an anonymous one can only be reached in order.
 
 ```arc channels="vent_vlv_cmd, press_vlv_cmd, tank_pressure", bodies="abort"
 sequence prime {
-    false -> vent_vlv_cmd          // write
-    true -> press_vlv_cmd          // write
-    time.wait{5s}                   // wait
-    tank_pressure > 500             // condition gate
-    stage hold {                    // stage
-        time.wait{30s} => next
+    true -> vent_vlv_cmd              // write
+    tank_pressure < 50 => next        // condition gate
+    false -> vent_vlv_cmd             // write
+    time.wait{5s}                     // wait
+    stage pressurize {                // stage
         tank_pressure > 700 => abort
+        true -> press_vlv_cmd
+        tank_pressure > 500 => next
     }
-    false -> press_vlv_cmd         // write
+    false -> press_vlv_cmd            // write
 }
 ```
 
@@ -132,7 +136,7 @@ An anonymous `stage { ... }` used as a sequence item acts as a multi-exit gate.
 [transition targets](/reference/control/arc/reference/flow#transition-targets) jump as
 usual.
 
-```arc channels="press_vlv_cmd, tank_pressure"
+```arc channels="press_vlv_cmd, tank_pressure", bodies="abort"
 sequence press {
     true -> press_vlv_cmd
     stage {
@@ -191,7 +195,6 @@ sequence main {
 sequence abort {
     stage safed {
         false -> press_vlv_cmd
-        false -> vent_vlv_cmd
         true -> vent_vlv_cmd
     }
 }

--- a/docs/site/src/pages/reference/control/arc/reference/stages.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/stages.mdx
@@ -39,7 +39,6 @@ stage pressurize {
     // Continuous flows (run every cycle)
     true -> press_vlv_cmd
     sensor -> controller{}
-
 }
 ```
 
@@ -98,16 +97,13 @@ All flow statements in a stage run concurrently:
 
 ```arc channels="sensor, ox_pt_1, fuel_pt_1, abort_btn, pressure", bodies="abort"
 stage pressurize {
-
     // ALL of these run simultaneously
-
     ox_pt_1 > 600 => abort   // monitor
     fuel_pt_1 > 400 => abort // monitor
     abort_btn => abort       // listen
     pressure > 500 => next   // advance
 
     sensor -> controller{target=500} // control loop
-
 }
 ```
 
@@ -118,7 +114,6 @@ listed wins:
 
 ```arc channels="ox_pt_1, fuel_pt_1, abort_btn, pressure", bodies="abort"
 stage pressurize {
-
     // Safety conditions first (higher priority)
     ox_pt_1 > 600 => abort   // 1st priority
     fuel_pt_1 > 400 => abort // 2nd priority

--- a/docs/site/src/pages/reference/control/arc/reference/standard-library/control.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/standard-library/control.mdx
@@ -78,8 +78,8 @@ and `0` releases control.
 // Sets every channel the program writes to
 trigger -> control.set_authority{value=255}
 
-// Sets one channel; value=0 releases control
-trigger -> control.set_authority{value=255, channel=press_vlv_cmd}
+// Releases control of single channel
+trigger -> control.set_authority{value=0, channel=press_vlv_cmd}
 
 // Sets each channel to a different authority
 stage emergency {
@@ -90,7 +90,9 @@ stage emergency {
 
 ## Relationship to Manual Control
 
-Default `authority` for a task when not declared is `255`
+<Note.Note variant="info">
+  The default `authority` for a task that declares none is `255`.
+</Note.Note>
 
 [Schematics](/reference/console/schematics) and other manual controls obey the same
 authority rules as an Arc task. Equal authority goes to whichever task, schematic, or

--- a/docs/site/src/pages/reference/control/arc/reference/standard-library/math.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/standard-library/math.mdx
@@ -46,7 +46,6 @@ the window periodically.
 />
 
 ```arc channels="sensor, output"
-// `flow` only
 sensor -> math.avg{} -> output
 
 // Reset by sample count or time window
@@ -71,7 +70,6 @@ Computes the rate of change of input values with respect to time. The output is 
 />
 
 ```arc channels="sensor, rate_output"
-// `flow` only
 sensor -> math.derivative{} -> rate_output
 ```
 
@@ -105,7 +103,6 @@ the window periodically.
 />
 
 ```arc channels="sensor, output"
-// `flow` only
 sensor -> math.max{} -> output
 
 // Reset by sample count or time window
@@ -143,7 +140,6 @@ the window periodically.
 />
 
 ```arc channels="sensor, output"
-// `flow` only
 sensor -> math.min{} -> output
 
 // Reset by sample count or time window

--- a/docs/site/src/pages/reference/control/arc/reference/standard-library/ranges.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/standard-library/ranges.mdx
@@ -53,7 +53,7 @@ shown as "In Progress". Outputs the new range key.
 
 ```arc channels="range_key"
 sequence ranges_create {
-  ranges.create{name="Terminal Count", color="#3bc454"} -> range_key
+    ranges.create{name="Terminal Count", color="#3bc454"} -> range_key
 }
 ```
 
@@ -63,7 +63,7 @@ sequence ranges_create {
 
 ```arc
 func ranges_create() {
-  range_key := ranges.create("Terminal Count", parent_key, "#3bc454")
+    range_key := ranges.create("Terminal Count", "", "#3bc454")
 }
 ```
 

--- a/docs/site/src/pages/reference/control/arc/reference/standard-library/time.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/standard-library/time.mdx
@@ -38,7 +38,6 @@ control loops, periodic sampling, and generating test data.
 />
 
 ```arc channels="tick"
-// `flow` only
 time.interval{period=1s} -> tick
 ```
 
@@ -98,7 +97,6 @@ Fires once after a fixed duration, then stops.
   output={{ type: "u8", description: "Emits `1` once the duration elapses." }}
 />
 
-```arc channels="done"
-// `flow` only
+```arc bodies="done"
 time.wait{duration=500ms} -> done
 ```

--- a/docs/site/src/pages/reference/control/arc/reference/statements.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/statements.mdx
@@ -74,7 +74,7 @@ Arc supports [`for` loops](/reference/control/arc/reference/loops) for iterating
 series, counting through ranges, and repeating until a condition is met.
 
 ```arc
-for x := data{
+for x := data {
 // iterate over a series
 }
 

--- a/docs/site/src/pages/reference/control/arc/reference/types.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/types.mdx
@@ -84,19 +84,19 @@ channel:
 <Arc.Tabs client:load>
 
 <Fragment slot="flow">
-```arc channels="value, ox_pt_1, ox_pt_cmd"
+```arc channels="source_ch, sink_ch"
 sequence {
-  value := ox_pt_1   // binds to ox_pt_1
-  value -> ox_pt_cmd // writes to ox_pt_cmd
+    value := source_ch  // binds to source_ch
+    value -> sink_ch    // writes to sink_ch
 }
 ```
 </Fragment>
 
 <Fragment slot="function">
-```arc channels="value, ox_pt_1, ox_pt_cmd"
-func example{}(){
-  value := ox_pt_1 // read from channel
-  ox_pt_cmd = value // write to channel
+```arc channels="source_ch, sink_ch"
+func example() {
+    value := source_ch  // read from source_ch
+    sink_ch = value     // write to sink_ch
 }
 ```
 </Fragment>
@@ -129,7 +129,7 @@ empty series f64 := [] // empty series (type required)
 ```arc
 length := len(data) // i64: number of elements
 first := data[0] // indexing (0-based)
-subset := data[1: 3] // slicing [start:end)
+subset := data[1:3] // slicing [start:end)
 ```
 
 ### Element-wise Operations
@@ -186,10 +186,10 @@ The compiler enforces dimensional compatibility:
 
 ```arc
 distance f64 m := 10.0
-time f64 s := 2.0
+elapsed f64 s := 2.0
 
 // Division produces a length/time quantity (a velocity)
-speed := distance / time
+speed := distance / elapsed
 
 // Exponentiation produces a squared-length quantity (an area)
 area := distance ^ 2
@@ -280,7 +280,7 @@ Strings support the following operations:
 msg := "Hello"
 greet := msg + " World"  // concatenation
 first := msg[0]          // indexing (returns u8)
-sub := msg[1: 4]         // slicing
+sub := msg[1:4]          // slicing
 length := len(msg)       // length in bytes
 equal := msg == "Hello"  // equality (returns bool)
 ```

--- a/docs/site/src/pages/reference/control/arc/reference/variables.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/variables.mdx
@@ -134,7 +134,7 @@ Track how many times a condition has occurred.
 <Arc.Tabs client:load>
 
 <Fragment slot="flow">
-```arc
+```arc channels="value, threshold"
 stage {
     count $= 0
     // Triggered on new `value`
@@ -169,7 +169,7 @@ Sum values over time.
 <Arc.Tabs client:load>
 
 <Fragment slot="flow">
-```arc
+```arc channels="value"
 stage accumulate {
     total $= 0.0
     // Triggered on new `value`
@@ -200,12 +200,12 @@ Compare the current value to the previous one.
 <Arc.Tabs client:load>
 
 <Fragment slot="flow">
-```arc
+```arc channels="value, delta"
 sequence phase_delta {
     prev $= 0.0
     // Triggered on new `value`
     value - prev -> delta
-    value -> previous
+    value -> prev
 }
 ```
 </Fragment>
@@ -233,7 +233,7 @@ Track the highest value seen.
 <Arc.Tabs client:load>
 
 <Fragment slot="flow">
-```arc
+```arc channels="value"
 stage running_max {
     max $= 0.0
     // Triggered on new `value`
@@ -269,7 +269,7 @@ Maintain an on/off state.
 
 <Fragment slot="flow">
 
-```arc
+```arc channels="trigger"
 stage toggle {
     state $= false
 
@@ -278,7 +278,6 @@ stage toggle {
         true: true -> state,
         false: false -> state
     }
-
 }
 ```
 


### PR DESCRIPTION
# Issue Pull Request

## Description

Scrubs the Arc Test Sequences guide and the Language Reference pages for conciseness and replaces examples that hand-rolled logic the standard library already provides. Rate monitoring now uses `math.derivative`, the `stable` module has its own reference page, and broken examples (the Previous Value flow tab, the debug channel write, the contradictory abort writes, the `operators#truthiness` links) are fixed.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR streamlines the Arc test-sequence guide and language reference while correcting several examples.
- Replaces hand-written rate calculations with `math.derivative`.
- Clarifies sequence gates, transitions, truthiness, function inputs, channel operations, and standard-library usage.
- Corrects malformed, contradictory, or misleading examples across the Arc reference.

<h3>Confidence Score: 5/5</h3>

The documentation-only PR appears safe to merge, with no concrete broken examples or reference regressions established.

The changed examples align with the Arc analyzer and standard-library contracts examined, and the remaining documentation concerns lack a reachable incorrect outcome.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| docs/site/src/pages/reference/control/arc/how-to/test-sequences.mdx | Simplifies sequence guidance and replaces custom pressure-rate functions with the standard `math.derivative` flow. |
| docs/site/src/pages/reference/control/arc/reference/sequences.mdx | Clarifies sequence-item syntax, direct condition gates, named-item transitions, and abort behavior. |
| docs/site/src/pages/reference/control/arc/reference/functions.mdx | Improves examples for configured inputs, trigger values, channel references, and named outputs. |
| docs/site/src/pages/reference/control/arc/reference/operators.mdx | Adds a centralized truthiness reference and fixes duplicate local declarations in arithmetic examples. |
| docs/site/src/pages/reference/control/arc/reference/variables.mdx | Repairs stateful-variable flow examples and supplies highlighting metadata for referenced channels. |
| docs/site/src/pages/reference/control/arc/reference/standard-library/math.mdx | Concisely documents the existing running aggregate and derivative functions without changing their stated signatures. |

<sub>Reviews (1): Last reviewed commit: ["\[docs\] Scrub Arc test sequence and langu..."](https://github.com/synnaxlabs/synnax/commit/a4e8968041ee778eed8311bb15eb98cc8621951e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55285271)</sub>

**Context used:**

- Knowledge Base — [Arc: Automation Language and Runtime Engine](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/arc-engine.md)

<!-- /greptile_comment -->