### PR TITLE
SY-4674: Fix flaky core/pkg/distribution/control tests

### DIFF
--- a/core/pkg/distribution/control/control_test.go
+++ b/core/pkg/distribution/control/control_test.go
@@ -314,7 +314,7 @@ var _ = Describe("Control", func() {
 			// The service has been retrying against an unbound address since it opened.
 			// Binding the peer lets the next attempt through.
 			net.New(peerAddr, 1).SubscribeServer().BindHandler(func(
-				_ context.Context,
+				streamCtx context.Context,
 				stream control.SubscribeStream,
 			) error {
 				if err := stream.Send(control.SubscribeResponse{
@@ -322,7 +322,7 @@ var _ = Describe("Control", func() {
 				}); err != nil {
 					return err
 				}
-				<-ctx.Done()
+				<-streamCtx.Done()
 				return nil
 			})
 			Eventually(updates).Should(Receive(WithTransform(
@@ -341,7 +341,7 @@ var _ = Describe("Control", func() {
 			updates := collect(svc)
 			var opens atomic.Int32
 			net.New(peerAddr, 1).SubscribeServer().BindHandler(func(
-				_ context.Context,
+				streamCtx context.Context,
 				stream control.SubscribeStream,
 			) error {
 				// The first open sends one state and ends, dropping the stream. The
@@ -358,7 +358,7 @@ var _ = Describe("Control", func() {
 				if opens.Load() == 1 {
 					return nil
 				}
-				<-ctx.Done()
+				<-streamCtx.Done()
 				return nil
 			})
 			Eventually(updates).Should(Receive(WithTransform(

--- a/core/pkg/distribution/control/service.go
+++ b/core/pkg/distribution/control/service.go
@@ -116,6 +116,8 @@ type Service struct {
 		sync.Mutex
 		// peers holds one entry per remote Core the host currently subscribes to.
 		peers map[node.Key]*peer
+		// closed stops a sync racing Close from opening another subscription.
+		closed bool
 	}
 }
 
@@ -195,6 +197,7 @@ func (s *Service) Close() error {
 	s.disconnectCluster()
 	s.disconnectStorage()
 	s.mu.Lock()
+	s.mu.closed = true
 	for _, p := range s.mu.peers {
 		p.stop()
 	}
@@ -296,34 +299,30 @@ func (s *Service) handleSubscribe(
 func (s *Service) syncPeers(ctx context.Context, sCtx signal.Context) {
 	host := s.cfg.Cluster.HostKey()
 	for _, n := range s.cfg.Cluster.Nodes() {
-		if n.Key == host {
-			continue
-		}
-		s.mu.Lock()
-		_, ok := s.mu.peers[n.Key]
-		s.mu.Unlock()
-		if !ok {
+		if n.Key != host {
 			s.addPeer(ctx, sCtx, n.Key)
 		}
 	}
 }
 
-// addPeer opens a subscription to target and starts reading it. The stream is opened
-// here rather than inside the reader so that the subscription is live before addPeer
+// addPeer opens a subscription to target and starts reading it, doing nothing if the
+// host already subscribes to target or the service is closed. The stream is opened here
+// rather than inside the reader so that the subscription is live before addPeer
 // returns, leaving no window in which a joining peer's transfers go unseen.
 func (s *Service) addPeer(ctx context.Context, sCtx signal.Context, target node.Key) {
 	peerCtx, stop := context.WithCancel(context.WithoutCancel(ctx))
-	stream, err := s.openPeerStream(peerCtx, target)
 	s.mu.Lock()
-	if _, ok := s.mu.peers[target]; ok {
+	_, subscribed := s.mu.peers[target]
+	if subscribed || s.mu.closed {
 		s.mu.Unlock()
-		// A concurrent sync won the race. Cancelling the context tears down the stream
-		// this call opened.
 		stop()
 		return
 	}
+	// The entry is claimed before the stream opens so that a concurrent sync cannot
+	// open a second subscription to the same peer.
 	s.mu.peers[target] = &peer{states: make(map[channel.Key]State), stop: stop}
 	s.mu.Unlock()
+	stream, err := s.openPeerStream(peerCtx, target)
 	sCtx.Go(
 		func(context.Context) error {
 			return s.subscribeToPeer(peerCtx, target, stream, err)

--- a/freighter/go/mock/stream.go
+++ b/freighter/go/mock/stream.go
@@ -252,7 +252,12 @@ func (s *ServerStream[RQ, RS]) exec(
 		errPayload = errors.Encode(ctx, freighter.EOF, true)
 	}
 	close(s.serverClosed)
-	s.responses <- message[RS]{error: errPayload}
+	// A client that abandons the stream stops receiving, so the final error can have
+	// nowhere to go. Drop it rather than parking this goroutine for good.
+	select {
+	case s.responses <- message[RS]{error: errPayload}:
+	case <-s.ctx.Done():
+	}
 }
 
 type ClientStream[RQ, RS freighter.Payload] struct {

--- a/freighter/go/mock/stream_test.go
+++ b/freighter/go/mock/stream_test.go
@@ -10,7 +10,10 @@
 package mock_test
 
 import (
+	"context"
+
 	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
 	"github.com/synnaxlabs/freighter"
 	"github.com/synnaxlabs/freighter/mock"
 	"github.com/synnaxlabs/freighter/test"
@@ -35,5 +38,26 @@ var _ = Describe("Stream", Ordered, Serial, func() {
 		address.Address,
 	) {
 		return server, client, "localhost:0"
+	})
+
+	It("Should release the handler when the client stops receiving", func(
+		ctx SpecContext,
+	) {
+		ShouldNotLeakGoroutines()
+		abandoned, dialer := mock.NewStreamPair[test.Request, test.Response](1, 1)
+		returned := make(chan struct{})
+		abandoned.BindHandler(func(
+			_ context.Context,
+			stream freighter.ServerStream[test.Request, test.Response],
+		) error {
+			defer close(returned)
+			return stream.Send(test.Response{ID: 1})
+		})
+		streamCtx, cancel := context.WithCancel(ctx)
+		// The response fills the buffer, so the closing error the handler emits on
+		// return has nowhere to go until the client cancels.
+		MustSucceed(dialer.Stream(streamCtx, "localhost:0"))
+		Eventually(returned).Should(BeClosed())
+		cancel()
 	})
 })

--- a/freighter/go/mock/stream_test.go
+++ b/freighter/go/mock/stream_test.go
@@ -51,12 +51,16 @@ var _ = Describe("Stream", Ordered, Serial, func() {
 			stream freighter.ServerStream[test.Request, test.Response],
 		) error {
 			defer close(returned)
-			return stream.Send(test.Response{ID: 1})
+			if err := stream.Send(test.Response{ID: 1}); err != nil {
+				return err
+			}
+			return stream.Send(test.Response{ID: 2})
 		})
 		streamCtx, cancel := context.WithCancel(ctx)
-		// The response fills the buffer, so the closing error the handler emits on
-		// return has nowhere to go until the client cancels.
-		MustSucceed(dialer.Stream(streamCtx, "localhost:0"))
+		stream := MustSucceed(dialer.Stream(streamCtx, "localhost:0"))
+		Expect(stream.Receive()).To(Equal(test.Response{ID: 1}))
+		// The client leaves the second response in the buffer, so the closing error
+		// the handler emits on return has nowhere to go until the client cancels.
 		Eventually(returned).Should(BeClosed())
 		cancel()
 	})

--- a/freighter/go/mock/stream_test.go
+++ b/freighter/go/mock/stream_test.go
@@ -59,8 +59,8 @@ var _ = Describe("Stream", Ordered, Serial, func() {
 		streamCtx, cancel := context.WithCancel(ctx)
 		stream := MustSucceed(dialer.Stream(streamCtx, "localhost:0"))
 		Expect(stream.Receive()).To(Equal(test.Response{ID: 1}))
-		// The client leaves the second response in the buffer, so the closing error
-		// the handler emits on return has nowhere to go until the client cancels.
+		// The client leaves the second response in the buffer, so the closing error the
+		// handler emits on return has nowhere to go until the client cancels.
 		Eventually(returned).Should(BeClosed())
 		cancel()
 	})

--- a/x/go/store/store.go
+++ b/x/go/store/store.go
@@ -144,6 +144,9 @@ func WrapObservable[S, O any](
 func (o *observable[S, O]) SetState(ctx context.Context, state S) {
 	prev := o.CopyState()
 	notify, shouldNotify := o.Transform(prev, state)
+	// The state is committed before observers run so that a handler that reads the
+	// store sees the change it was notified of.
+	o.Store.SetState(ctx, state)
 	if shouldNotify {
 		lo.Ternary(
 			*o.ObservableConfig.GoNotify,
@@ -151,7 +154,6 @@ func (o *observable[S, O]) SetState(ctx context.Context, state S) {
 			o.Notify,
 		)(ctx, notify)
 	}
-	o.Store.SetState(ctx, state)
 }
 
 type Flushable[S any] interface {

--- a/x/go/store/store_test.go
+++ b/x/go/store/store_test.go
@@ -42,5 +42,19 @@ var _ = Describe("Store", func() {
 			s.SetState(ctx, state{value: 2})
 			Expect(changedState.value).To(Equal(2))
 		})
+
+		It("Should commit the state before notifying observers", func(
+			ctx SpecContext,
+		) {
+			s := MustSucceed(store.WrapObservable(store.ObservableConfig[state, state]{
+				Store:     store.New(copyState),
+				Transform: func(_, next state) (state, bool) { return next, true },
+				GoNotify:  new(false),
+			}))
+			var observed state
+			s.OnChange(func(context.Context, state) { observed = s.CopyState() })
+			s.SetState(ctx, state{value: 2})
+			Expect(observed.value).To(Equal(2))
+		})
 	})
 })


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4674](https://linear.app/synnax/issue/SY-4674)

## Description

Two defects behind the two CI failures in the Distribution Control Suite, plus<br>a latent race found alongside them.

The observable store in `x/go/store` notified observers before it committed the<br>new state. The control service reads `Cluster.Nodes()` from its cluster<br>observer, so it could see a view without the joining peer, skip the sync, and<br>never subscribe. No later change arrives, so the spec waits out its timeout.<br>The store now commits before it notifies.

The Freighter mock parked its server handler forever on the closing error when<br>a client abandoned a stream whose response buffer was full, which is the leaked<br>goroutine CI reported. The send now drops the payload when the stream context<br>ends.

The latent race: `syncPeers` released the lock between reading the peer map and<br>claiming the entry, so two concurrent syncs could open two subscriptions to one<br>peer. `addPeer` now claims the entry under the lock and refuses after `Close`.

The two stub peer handlers in the control specs parked on the spec context<br>rather than their own stream context, so the service reopened the subscription<br>in a tight loop between the end of the spec and the close of the service. They<br>now park on the stream context.

## Basic Readiness

- [X] I have performed a self-review of my code.
- [X] I have added relevant, automated tests to cover the changes.
- [X] I have updated documentation to reflect the changes.

### Greptile Summary

The PR addresses flaky distribution-control tests by committing observable-store state before notifying observers, atomically claiming peer subscriptions, and allowing abandoned mock streams to stop waiting on terminal-error delivery.

* Updates control-service peer synchronization and shutdown coordination.
* Changes observable-store notification ordering and adds regression coverage.
* Improves mock-stream cleanup and aligns control test handlers with stream lifetimes.

### Confidence Score: 5/5

The PR appears safe to merge.

No blocking failure remains.

### Important Files Changed

<!-- linear:table-colwidths:400,400 -->
| Filename | Overview |
| -- | -- |
| x/go/store/store.go | Commits observable state before dispatching notifications so synchronous observers can read the state associated with the change. |
| core/pkg/distribution/control/service.go | Serializes peer claims and blocks subscription creation after service closure to prevent duplicate subscriptions. |
| freighter/go/mock/stream.go | Allows terminal stream delivery to stop waiting when the stream context is canceled. |
| core/pkg/distribution/control/control_test.go | Makes stub subscription handlers follow their stream contexts rather than the broader specification context. |
| freighter/go/mock/stream_test.go | Adds regression coverage for releasing a handler after a receiving client abandons a buffered stream. |
| x/go/store/store_test.go | Adds regression coverage proving observers can read committed state during synchronous notification. |

### Sequence Diagram

```mermaid
sequenceDiagram
    participant Store as Observable Store
    participant Observer as Cluster Observer
    participant Control as Control Service
    participant Peer as Remote Peer
    Store->>Store: Commit new cluster state
    Store->>Observer: Notify change
    Observer->>Control: Synchronize peers
    Control->>Control: Claim peer under lock
    Control->>Peer: Open control subscription
    Peer-->>Control: Stream control states
```

Reviews (2): Last reviewed commit: ["Merge branch < />rc< /> into sy-4674-fix-flake..."](<https://github.com/synnaxlabs/synnax/commit/191c3e0f80417572bebf1a871482606d6a96398e>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=55287099>)