### PR TITLE
SY-4675: Recover Windows Bazel builds from a deleted repo cache entry

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -11,6 +11,13 @@ build --action_env=PATH
 # Enable platform-specific configs
 build --enable_platform_specific_config
 
+# Each external repo is a symlink into the shared repo contents cache, and Bazel deletes
+# a cache entry that goes 14 days without a fetch. A repo that every build reuses is
+# never re-fetched, so the collector can delete the target of a live symlink and leave
+# the repo half-present. Build machines hold an output base for weeks, which is long
+# enough to hit this. Collect duplicate entries only.
+common --repo_contents_cache_gc_max_age=0
+
 # The remote cache can return an action-cache hit whose output blobs have been evicted
 # from the CAS, so a later action fails to fetch them ("Failed to fetch blobs because of
 # a remote cache error"). Retry the build when that happens, and download all outputs

--- a/.github/workflows/build.synnax.yaml
+++ b/.github/workflows/build.synnax.yaml
@@ -260,7 +260,7 @@ jobs:
         shell: bash
         run: |
           export MSYS_NO_PATHCONV=1
-          bazel --output_user_root=C:/tmp build $BAZEL_BUILD_FLAGS $BAZEL_REMOTE_CACHE_FLAGS \
+          scripts/run_bazel.sh build $BAZEL_BUILD_FLAGS $BAZEL_REMOTE_CACHE_FLAGS \
             ${{ !inputs.debug && '--config=opt-windows' || '--output_groups=+pdb_file' }} //driver
 
       - name: Upload Windows Debug Symbols

--- a/.github/workflows/test.arc.yaml
+++ b/.github/workflows/test.arc.yaml
@@ -26,6 +26,7 @@ on:
       - integration/scripts/kill_synnax_processes.sh
       - scripts/check_clang_format.sh
       - scripts/install_clang_format.sh
+      - scripts/run_bazel.sh
       - scripts/sanitizers/**
       - vendor/wasmtime/**
       - x/cpp/**
@@ -49,6 +50,7 @@ on:
       - integration/scripts/kill_synnax_processes.sh
       - scripts/check_clang_format.sh
       - scripts/install_clang_format.sh
+      - scripts/run_bazel.sh
       - scripts/sanitizers/**
       - vendor/wasmtime/**
       - x/cpp/**
@@ -180,7 +182,7 @@ jobs:
       - name: Test (Windows)
         if: matrix.os == 'windows-build-bot'
         run: |
-          bazel --output_user_root=C:/tmp test --test_output=all //arc/cpp/... \
+          scripts/run_bazel.sh test --test_output=all //arc/cpp/... \
             --remote_cache=${{ env.BAZEL_REMOTE_CACHE }} --remote_cache_compression=true \
             --test_tag_filters=-requires-core
         shell: bash

--- a/.github/workflows/test.freighter.cpp.yaml
+++ b/.github/workflows/test.freighter.cpp.yaml
@@ -21,6 +21,7 @@ on:
       - MODULE.bazel
       - MODULE.bazel.lock
       - scripts/check_clang_format.sh
+      - scripts/run_bazel.sh
       - scripts/sanitizers/**
       - x/cpp/**
       - x/go/**/*.pb.go
@@ -38,6 +39,7 @@ on:
       - MODULE.bazel
       - MODULE.bazel.lock
       - scripts/check_clang_format.sh
+      - scripts/run_bazel.sh
       - scripts/sanitizers/**
       - x/cpp/**
       - x/go/**/*.pb.go
@@ -107,5 +109,6 @@ jobs:
         if: matrix.os == 'windows-build-bot'
         run: |
           export MSYS_NO_PATHCONV=1
-          bazel --output_user_root=C:/tmp test $BAZEL_REMOTE_CACHE_FLAGS --test_output=all //freighter/cpp/...
+          scripts/run_bazel.sh test $BAZEL_REMOTE_CACHE_FLAGS --test_output=all \
+            //freighter/cpp/...
         shell: bash

--- a/.github/workflows/test.x.cpp.yaml
+++ b/.github/workflows/test.x.cpp.yaml
@@ -20,6 +20,7 @@ on:
       - MODULE.bazel
       - MODULE.bazel.lock
       - scripts/check_clang_format.sh
+      - scripts/run_bazel.sh
       - scripts/sanitizers/**
       - x/cpp/**
       - x/go/**/*.pb.go
@@ -36,6 +37,7 @@ on:
       - MODULE.bazel
       - MODULE.bazel.lock
       - scripts/check_clang_format.sh
+      - scripts/run_bazel.sh
       - scripts/sanitizers/**
       - x/cpp/**
       - x/go/**/*.pb.go
@@ -104,6 +106,6 @@ jobs:
       - name: Test (Windows)
         if: matrix.os == 'windows-build-bot'
         run: |
-          bazel --output_user_root=C:/tmp test --test_output=all //x/cpp/... \
+          scripts/run_bazel.sh test --test_output=all //x/cpp/... \
             --remote_cache=${{ env.BAZEL_REMOTE_CACHE }} --remote_cache_compression=true
         shell: bash

--- a/docs/claude/scripts.md
+++ b/docs/claude/scripts.md
@@ -57,6 +57,13 @@ Neither script touches `.oracle` schema files — no header comments there.
   per-runner keychain for macOS code signing. Requires runner-scoped env vars
   (`APPLE_CERTIFICATE*`, `KEYCHAIN_*`, `GITHUB_ENV`).
 
+## Bazel
+
+- `run_bazel.sh <bazel arguments...>` — runs Bazel, and recovers once from an external
+  repo that a repo contents cache deletion left unloadable. Only the Windows CI steps
+  use it, because those runners hold one output base for weeks. A compile error or a
+  failed test still fails on the first run.
+
 ## Toolchain Bootstrap
 
 - `install_antlr4.sh` — installs a pinned, checksum-verified antlr4 4.13.2 onto PATH,

--- a/scripts/run_bazel.sh
+++ b/scripts/run_bazel.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+
+# Copyright 2026 Synnax Labs, Inc.
+#
+# Use of this software is governed by the Business Source License included in the file
+# licenses/BSL.txt.
+#
+# As of the Change Date specified in that file, in accordance with the Business Source
+# License, use of this software will be governed by the Apache License, Version 2.0,
+# included in the file licenses/APL.txt.
+
+# Runs Bazel, and recovers once from an external repo that cannot be loaded.
+#
+# Self-hosted runners keep the Bazel output base warm between jobs. Each external repo
+# there is a symlink into the shared repo contents cache, so a deleted cache entry
+# leaves a repo that Bazel records as fetched but cannot load. Every later job on that
+# machine then fails in the same way. Wipe the output base and the contents cache, then
+# run the command again.
+#
+# Usage: run_bazel.sh test --test_output=all //x/cpp/...
+
+set -uo pipefail
+
+if [ "$#" -eq 0 ]; then
+    echo "Usage: $0 <bazel arguments...>"
+    exit 1
+fi
+
+log=$(mktemp)
+trap 'rm -f "$log"' EXIT
+
+bazel "$@" 2>&1 | tee "$log"
+status=${PIPESTATUS[0]}
+if [ "$status" -eq 0 ]; then
+    exit 0
+fi
+
+# Retry an unloadable repo only. A compile error or a failed test ends the job here.
+corrupt_repo="Error loading '@@|no such package '@@|@@[^']*' is invalid because"
+if ! grep -qE "$corrupt_repo" "$log"; then
+    exit "$status"
+fi
+
+echo "::warning::Bazel could not load an external repo. Wiping the output base."
+repository_cache=$(bazel info repository_cache 2> /dev/null || true)
+bazel clean --expunge
+if [ -n "$repository_cache" ]; then
+    rm -rf "${repository_cache:?}/contents"
+fi
+bazel "$@"


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4675](https://linear.app/synnax/issue/SY-4675)

## Description

Windows Bazel jobs failed during loading with<br>`Label '@@rules_rust+//crate_universe/private:crates_vendor.bzl' is invalid because 'crate_universe/private' is not a package`, while the same commit passed on Linux and<br>macOS.

Bazel symlinks each external repo in the output base into a shared repo contents cache<br>and collects entries that go 14 days without a fetch. A repo that every build reuses is<br>never re-fetched, so the collector can delete the target while the symlink and the fetch<br>marker survive. Bazel then treats the repo as fetched but cannot load parts of it. The<br>Windows bots hold one output base for weeks, so a hit machine stays broken: both<br>failures ran on `windows-build-bot-i-015d`, and every Windows run that passed in the<br>same window ran on `-0bd7` or `-0342`.

Two changes:

* `.bazelrc` sets `--repo_contents_cache_gc_max_age=0`. Duplicate entries are still<br>collected. Age-based deletion, which is what corrupts a warm output base, is off.
* `scripts/run_bazel.sh` runs Bazel and retries once, but only when the log shows an<br>unloadable external repo. It expunges the output base, removes the contents cache,<br>then repeats the command. A compile error or a failed test still fails on the first<br>run. The four Windows Bazel steps call it.

Those steps also passed `--output_user_root=C:/tmp`, which never took effect —<br>setup-bazel pins `--output_base=C:/_bazel` in the runner bazelrc. Removed.

Verified on a Windows machine: `//x/cpp/...` builds clean, so no C++ break exists.<br>`run_bazel.sh` returns 0 on success, exits 7 without retrying on a plain<br>`no such package` error, and its detection pattern matches the real CI error text but<br>not a compile error.

The poisoned runner still holds the bad cache entry. The wrapper heals it on the next<br>Windows job; expunging `C:/_bazel` on `windows-build-bot-i-015d` clears it now.

## Basic Readiness

- [X] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [X] I have updated documentation to reflect the changes.

### Greptile Summary

This PR makes Windows Bazel CI recover from stale external-repository cache links by disabling age-based repository-content collection and introducing a one-time cleanup-and-retry wrapper.

* Routes four Windows build and test steps through `scripts/run_bazel.sh`.
* Retries only after output matches an external-repository loading error.
* Removes ineffective `--output_user_root` arguments and documents the wrapper.

### Confidence Score: 4/5

The PR appears safe to merge, with the non-blocking concern that its destructive cache-recovery classification and retry behavior are not protected by automated tests.

The workflow and wrapper changes preserve Bazel arguments and failure propagation, and no current blocking failure was established; however, the regex-gated expunge and retry path could regress without test coverage.

**Files Needing Attention:** scripts/run_bazel.sh

### Important Files Changed

<!-- linear:table-colwidths:400,400 -->
| Filename | Overview |
| -- | -- |
| scripts/run_bazel.sh | Adds the external-repository failure detector and destructive one-time recovery path; the behavior lacks corresponding automated tests. |
| .bazelrc | Disables age-based repository-content cache collection while retaining duplicate-entry collection. |
| .github/workflows/build.synnax.yaml | Routes the Windows driver build through the new wrapper and removes the ineffective output-user-root option. |
| .github/workflows/test.arc.yaml | Routes Windows Arc tests through the wrapper and adds the script to workflow path filters. |
| .github/workflows/test.freighter.cpp.yaml | Routes Windows Freighter C++ tests through the wrapper and adds the script to workflow path filters. |
| .github/workflows/test.x.cpp.yaml | Routes Windows shared C++ tests through the wrapper and adds the script to workflow path filters. |
| docs/claude/scripts.md | Documents the wrapper's Windows-only recovery purpose and single-retry behavior. |

### Flowchart

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Run Bazel command] --> B{Command succeeded?}
    B -- Yes --> C[Exit successfully]
    B -- No --> D{External repository error matched?}
    D -- No --> E[Return original failure]
    D -- Yes --> F[Read repository cache path]
    F --> G[Expunge Bazel output base]
    G --> H[Remove repository contents cache]
    H --> I[Retry Bazel once]
    I --> J[Return retry result]
```

Reviews (1): Last reviewed commit: ["SY-4675: Recover Windows Bazel builds fr..."](<https://github.com/synnaxlabs/synnax/commit/213b224bed6a9f44568fe0758d1b5453bd9ad5bd>) | [Re-trigger Greptile](<https://app.greptile.com/api/retrigger?id=55297861>)

> Greptile also left **1 inline comment** on this PR.

**Context used:**

* Rule used - When making changes to functionality, add correspo... ([source](<https://app.greptile.com/synnax/-/custom-context?memory=8b39d83e-3d2b-4dd4-9e14-d0644d6bfe58>))

**Learned From**<br>[synnaxlabs/synnax#1550](<https://github.com/synnaxlabs/synnax/pull/1550>)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes Windows Bazel CI recover from stale external-repository cache links by disabling age-based repository-content collection and adding a one-time cleanup-and-retry wrapper.

- Routes four Windows Bazel build and test steps through `scripts/run_bazel.sh`.
- Removes ineffective `--output_user_root` arguments.
- Documents the Windows-specific recovery behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| scripts/run_bazel.sh | Adds a Bazel passthrough that detects unloadable external repositories, clears stale state, and retries once. |
| .bazelrc | Disables age-based repository-content cache collection while retaining duplicate-entry collection. |
| .github/workflows/build.synnax.yaml | Routes the Windows driver build through the recovery wrapper and removes the ineffective output-user-root option. |
| .github/workflows/test.arc.yaml | Routes Windows Arc tests through the wrapper and includes the script in workflow path filters. |
| .github/workflows/test.freighter.cpp.yaml | Routes Windows Freighter C++ tests through the wrapper and includes the script in workflow path filters. |
| .github/workflows/test.x.cpp.yaml | Routes Windows shared C++ tests through the wrapper and includes the script in workflow path filters. |
| docs/claude/scripts.md | Documents the wrapper’s Windows-only stale-repository recovery behavior. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Run Bazel command] --> B{Command succeeded?}
    B -- Yes --> C[Exit successfully]
    B -- No --> D{External repository error matched?}
    D -- No --> E[Return original failure]
    D -- Yes --> F[Read repository cache path]
    F --> G[Expunge Bazel output base]
    G --> H[Remove repository contents cache]
    H --> I[Retry Bazel once]
    I --> J[Return retry result]
```

<sub>Reviews (2): Last reviewed commit: ["Merge remote-tracking branch &#39;origin/rc&#39;..."](https://github.com/synnaxlabs/synnax/commit/7d633ad8a10de7f59530eafb6f465bea06f68726) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55297861)</sub>

<!-- /greptile_comment -->