### PR TITLE
SY-3877: Add "Views" integration test

### DIFF
--- a/docs/claude/testing.md
+++ b/docs/claude/testing.md
@@ -59,7 +59,8 @@ The `-tags=console` build tag activates `core/pkg/console/enabled.go`
 - `tc console/label` — cases matching "label" (2-part: file + case filter)
 - `tc console/channel/calc` — file + sequence + case filter (3-part)
 - `tc -f modbus` — global filter across all test files
-- Options: `--headed` (Playwright headed mode), `-d <rack>` (driver rack name)
+- Options: `--headed` (Playwright headed mode), `--slow-mo <ms>` (delay per Playwright
+  action), `-d <rack>` (driver rack name)
 
 ### Organization
 

--- a/integration/console/case.py
+++ b/integration/console/case.py
@@ -33,8 +33,12 @@ class ConsoleCase(TestCase):
     Console TestCase implementation using Playwright
 
     Environment Variables:
-    - PLAYWRIGHT_CONSOLE_HEADED: Run in headed mode (default: False)
-      Can be set via command line: --console-headed or -ch
+    - PLAYWRIGHT_CONSOLE_HEADED: Run in headed mode (default: False).
+      Set by the ``--headed`` flag.
+    - PLAYWRIGHT_CONSOLE_SLOW_MO: Delay between Playwright actions in ms (default: 0).
+      Set by the ``--slow-mo MS`` flag.
+
+    Per-case ``headed`` and ``slow_mo`` parameters override the environment.
     """
 
     browser: Browser
@@ -65,7 +69,8 @@ class ConsoleCase(TestCase):
     def _launch_browser(self) -> None:
         env_headed = os.environ.get("PLAYWRIGHT_CONSOLE_HEADED", "0") == "1"
         headed = self.params.get("headed", env_headed)
-        slow_mo = self.params.get("slow_mo", 0)
+        env_slow_mo = int(os.environ.get("PLAYWRIGHT_CONSOLE_SLOW_MO", "0"))
+        slow_mo = self.params.get("slow_mo", env_slow_mo)
         default_timeout = self.params.get("default_timeout", 15000)  # 15s
         default_nav_timeout = self.params.get("default_nav_timeout", 15000)  # 15s
 

--- a/integration/console/range/explorer.py
+++ b/integration/console/range/explorer.py
@@ -18,6 +18,7 @@ from console.range.surface import (
     Surface,
 )
 from console.range.toolbar import Toolbar
+from console.views import ViewsClient
 
 
 class Explorer(Surface):
@@ -30,6 +31,7 @@ class Explorer(Surface):
         ".console-range-explorer .pluto-list__items:not(.console-view__views)"
     )
     SEARCH_INPUT_PLACEHOLDER = "Search ranges..."
+    STATIC_VIEW_NAME = "All ranges"
     # The explorer list must stay the same height at the bottom for longer than a page
     # fetch before it counts as fully paged in.
     SCROLL_SETTLE = 1500 * sy.TimeSpan.MILLISECOND
@@ -37,13 +39,14 @@ class Explorer(Surface):
     def __init__(self, layout: LayoutClient, toolbar: Toolbar):
         super().__init__(layout)
         self.toolbar = toolbar
+        self.views = ViewsClient(
+            layout, self.SEARCH_INPUT_PLACEHOLDER, self.STATIC_VIEW_NAME
+        )
 
     def open(self) -> None:
         """Open the Range Explorer page (shows all ranges)."""
         self.layout.command_palette("Open range explorer")
-        self.layout.page.get_by_text("All ranges").wait_for(
-            state="visible", timeout=5000
-        )
+        self.views.wait_for_static_view()
 
     def get_item(self, name: str) -> Locator:
         """Get a range item locator from the explorer by name."""
@@ -210,72 +213,23 @@ class Explorer(Surface):
         modal.wait_for(state="visible", timeout=5000)
         self.fill_create_modal(child_name)
 
-    def enable_editing(self) -> None:
-        """Enable editing mode in the explorer to show search/filter
-        controls."""
-        search_input = self.layout.page.locator(
-            f"input[placeholder='{self.SEARCH_INPUT_PLACEHOLDER}']"
-        )
-        if search_input.is_visible():
-            return
-        edit_button = self.layout.page.get_by_role(
-            "button", name="Enable editing", exact=True
-        ).first
-        edit_button.click()
-        search_input.wait_for(state="visible", timeout=5000)
-
     def search(self, term: str) -> None:
         """Type a search term in the explorer search input.
 
         :param term: The search string to type.
         """
-        self.enable_editing()
-        search_input = self.layout.page.get_by_placeholder(
-            self.SEARCH_INPUT_PLACEHOLDER
-        )
-        search_input.fill(term)
-        search_input.dispatch_event(
-            "input",
-            {"bubbles": True, "data": term, "inputType": "insertText"},
-        )
+        self.views.search(term)
 
     def clear_search(self) -> None:
         """Clear the explorer search input."""
-        self.search("")
-
-    def open_label_filter(self) -> Locator:
-        """Open the label filter dropdown in the explorer.
-
-        :returns: Locator for the visible filter dialog.
-        """
-        self.enable_editing()
-        filter_button = self.layout.page.get_by_role(
-            "button", name="Filter", exact=True
-        ).first
-        filter_button.click()
-        dialog = self.layout.dialog
-        dialog.wait_for(state="visible", timeout=5000)
-        return dialog
+        self.views.clear_search()
 
     def select_label_filter(self, label_name: str) -> None:
         """Select a label in the explorer's label filter dropdown.
 
-        The filter is a two-level dialog:
-        1. Filter button → first dialog with "Select labels" trigger
-        2. "Select labels" → second dialog with label list
-
         :param label_name: The name of the label to select.
         """
-        filter_dialog = self.open_label_filter()
-        select_labels_trigger = filter_dialog.get_by_text("Select labels")
-        select_labels_trigger.click()
-        item = (
-            self.layout.dialog.get_by_role("option").filter(has_text=label_name).first
-        )
-        item.wait_for(state="visible", timeout=5000)
-        item.click()
-        self.layout.press_escape()
-        self.layout.press_escape()
+        self.views.select_filter("Select labels", label_name)
 
     def clear_label_filter(self, label_name: str) -> None:
         """Remove a label from the active filter by clicking its chip close
@@ -283,9 +237,4 @@ class Explorer(Surface):
 
         :param label_name: The name of the label chip to remove.
         """
-        remove_btn = self.layout.page.get_by_role(
-            "button", name=f"Remove {label_name}", exact=True
-        ).first
-        remove_btn.wait_for(state="visible", timeout=5000)
-        remove_btn.dispatch_event("click")
-        remove_btn.wait_for(state="hidden", timeout=5000)
+        self.views.clear_filter(label_name)

--- a/integration/console/range/overview.py
+++ b/integration/console/range/overview.py
@@ -216,9 +216,13 @@ class Overview(Surface):
         """Open the labels dropdown in the range overview and return the
         dialog."""
         labels_row = self.layout.page.get_by_text("Labels", exact=True).locator("..")
+        # The add button only renders once a label is set. Before that, the
+        # placeholder is the trigger.
         add_button = labels_row.locator("button").last
-        add_button.wait_for(state="visible", timeout=2000)
-        add_button.click()
+        placeholder = labels_row.locator(".pluto-select-multiple-trigger-placeholder")
+        trigger = add_button.or_(placeholder).first
+        trigger.wait_for(state="visible", timeout=2000)
+        trigger.click()
         dropdown = self.layout.dialog
         dropdown.wait_for(state="visible", timeout=5000)
         return dropdown

--- a/integration/console/statuses.py
+++ b/integration/console/statuses.py
@@ -11,6 +11,7 @@ from playwright.sync_api import Locator
 
 from console.base import ResourceClient
 from console.layout import LayoutClient
+from console.views import ViewsClient
 
 
 class StatusesClient(ResourceClient):
@@ -19,6 +20,13 @@ class StatusesClient(ResourceClient):
     TOOLBAR_ITEM_SELECTOR = ".console-status-list-item"
     EXPLORER_ITEM_SELECTOR = ".console-status__list-item"
     SEARCH_INPUT_PLACEHOLDER = "Search statuses..."
+    STATIC_VIEW_NAME = "All statuses"
+
+    def __init__(self, layout: LayoutClient):
+        super().__init__(layout)
+        self.views = ViewsClient(
+            layout, self.SEARCH_INPUT_PLACEHOLDER, self.STATIC_VIEW_NAME
+        )
 
     # ── Private Helpers ──────────────────────────────────────────────────
 
@@ -67,9 +75,7 @@ class StatusesClient(ResourceClient):
         """Open the Status Explorer via the command palette."""
         self.layout.hide_visualization_toolbar()
         self.layout.command_palette("Open status explorer")
-        self.layout.page.get_by_text("All statuses").wait_for(
-            state="visible", timeout=5000
-        )
+        self.views.wait_for_static_view()
         self.layout.page.locator(self.EXPLORER_ITEM_SELECTOR).first.wait_for(
             state="visible", timeout=5000
         )
@@ -144,50 +150,13 @@ class StatusesClient(ResourceClient):
 
     # ── Explorer Search & Filter ──────────────────────────────────────────
 
-    def enable_explorer_editing(self) -> None:
-        """Enable editing mode in the explorer to show search/filter controls."""
-        search_input = self.layout.page.locator(
-            f"input[placeholder='{self.SEARCH_INPUT_PLACEHOLDER}']"
-        )
-        if search_input.is_visible():
-            return
-        edit_button = self.layout.page.get_by_role(
-            "button", name="Enable editing", exact=True
-        ).first
-        edit_button.click()
-        search_input.wait_for(state="visible", timeout=5000)
-
-    def open_explorer_filter(self) -> Locator:
-        """Open the label filter dropdown in the explorer.
-
-        Returns:
-            Locator for the visible filter dialog.
-        """
-        self.enable_explorer_editing()
-        filter_button = self.layout.page.get_by_role(
-            "button", name="Filter", exact=True
-        ).first
-        filter_button.click()
-        dialog = self.layout.dialog
-        dialog.wait_for(state="visible", timeout=5000)
-        return dialog
-
     def select_explorer_variant_filter(self, variant_name: str) -> None:
         """Select a variant in the explorer's variant filter dropdown.
 
         Args:
             variant_name: The display name of the variant (e.g. "Error", "Success").
         """
-        filter_dialog = self.open_explorer_filter()
-        select_variants_trigger = filter_dialog.get_by_text("Select variants")
-        select_variants_trigger.click()
-        item = (
-            self.layout.dialog.get_by_role("option").filter(has_text=variant_name).first
-        )
-        item.wait_for(state="visible", timeout=5000)
-        item.click()
-        self.layout.press_escape()
-        self.layout.press_escape()
+        self.views.select_filter("Select variants", variant_name)
 
     def clear_explorer_variant_filter(self, variant_name: str) -> None:
         """Remove a variant from the active filter by clicking its chip close button.
@@ -195,12 +164,7 @@ class StatusesClient(ResourceClient):
         Args:
             variant_name: The display name of the variant to remove.
         """
-        remove_btn = self.layout.page.get_by_role(
-            "button", name=f"Remove {variant_name}", exact=True
-        ).first
-        remove_btn.wait_for(state="visible", timeout=5000)
-        remove_btn.dispatch_event("click")
-        remove_btn.wait_for(state="hidden", timeout=5000)
+        self.views.clear_filter(variant_name)
 
     def select_explorer_label_filter(self, label_name: str) -> None:
         """Select a label in the explorer's label filter dropdown.
@@ -208,25 +172,11 @@ class StatusesClient(ResourceClient):
         Args:
             label_name: The name of the label to filter by.
         """
-        filter_dialog = self.open_explorer_filter()
-        select_labels_trigger = filter_dialog.get_by_text("Select labels")
-        select_labels_trigger.click()
-        item = (
-            self.layout.dialog.get_by_role("option").filter(has_text=label_name).first
-        )
-        item.wait_for(state="visible", timeout=5000)
-        item.click()
-        self.layout.press_escape()
-        self.layout.press_escape()
+        self.views.select_filter("Select labels", label_name)
 
     def clear_explorer_label_filter(self, label_name: str) -> None:
         """Remove a label from the active filter by clicking its chip close button."""
-        remove_btn = self.layout.page.get_by_role(
-            "button", name=f"Remove {label_name}", exact=True
-        ).first
-        remove_btn.wait_for(state="visible", timeout=5000)
-        remove_btn.dispatch_event("click")
-        remove_btn.wait_for(state="hidden", timeout=5000)
+        self.views.clear_filter(label_name)
 
     # ── Toolbar ───────────────────────────────────────────────────────────
 

--- a/integration/console/views.py
+++ b/integration/console/views.py
@@ -1,0 +1,251 @@
+#  Copyright 2026 Synnax Labs, Inc.
+#
+#  Use of this software is governed by the Business Source License included in the file
+#  licenses/BSL.txt.
+#
+#  As of the Change Date specified in that file, in accordance with the Business Source
+#  License, use of this software will be governed by the Apache License, Version 2.0,
+#  included in the file licenses/APL.txt.
+
+"""View strip helper for Console UI automation."""
+
+import re
+
+from playwright.sync_api import Locator, expect
+
+from console.base import ResourceClient
+from console.layout import LayoutClient
+
+STRIP_SELECTOR = ".console-view__views"
+ITEM_SELECTOR = ".pluto-select-btn"
+ITEM_LABEL_SELECTOR = ".console-view__view-item"
+SELECTED_CLASS = "pluto--selected"
+EDITING_SELECTOR = "p.pluto-text--editable[contenteditable='true']"
+
+
+class ViewsClient(ResourceClient):
+    """Views client for the saved-search strip at the top of an explorer.
+
+    Views are saved searches scoped to one resource type. The strip holds a static
+    "All <resources>" view plus every saved view. Search, filters, and the create
+    button are hidden until edit mode is enabled.
+    """
+
+    search_placeholder: str
+    static_view_name: str
+
+    def __init__(
+        self,
+        layout: LayoutClient,
+        search_placeholder: str,
+        static_view_name: str,
+    ):
+        """Initialize the views client.
+
+        :param layout: The layout client for the console under test.
+        :param search_placeholder: Placeholder of the explorer search input, used to
+            detect edit mode (e.g. "Search ranges...").
+        :param static_view_name: Name of the built-in view the explorer opens on
+            (e.g. "All ranges").
+        """
+        super().__init__(layout)
+        self.search_placeholder = search_placeholder
+        self.static_view_name = static_view_name
+
+    # ── Private Helpers ───────────────────────────────────────────────────
+
+    def _strip(self) -> Locator:
+        """Return the view strip locator."""
+        return self.page.locator(STRIP_SELECTOR).first
+
+    def _search_input(self) -> Locator:
+        """Return the explorer search input locator."""
+        return self.page.get_by_placeholder(self.search_placeholder)
+
+    def _item_label(self, name: str) -> Locator:
+        """Return an exact-name label filter, relative to whatever it is nested in."""
+        pattern = re.compile(rf"^{re.escape(name)}$")
+        return self.page.locator(ITEM_LABEL_SELECTOR).filter(has_text=pattern)
+
+    # ── View Items ────────────────────────────────────────────────────────
+
+    def get_view_item(self, name: str) -> Locator:
+        """Return the clickable view item with the given name.
+
+        :param name: Exact name of the view.
+        """
+        return self._strip().locator(ITEM_SELECTOR).filter(has=self._item_label(name))
+
+    def get_view_items(self) -> list[str]:
+        """Return the names of every view in the strip, in display order."""
+        return self._strip().locator(ITEM_LABEL_SELECTOR).all_inner_texts()
+
+    def wait_for_static_view(self) -> None:
+        """Wait for the built-in view to show, marking the explorer as loaded."""
+        self.page.get_by_text(self.static_view_name).wait_for(
+            state="visible", timeout=5000
+        )
+
+    def exists(self, name: str) -> bool:
+        """Check whether a view with the given name is in the strip."""
+        return self.layout.locator_exists(self.get_view_item(name))
+
+    def wait_for(self, name: str) -> None:
+        """Wait for a view to appear in the strip."""
+        self.get_view_item(name).wait_for(state="visible", timeout=5000)
+
+    def wait_for_removed(self, name: str) -> None:
+        """Wait for a view to leave the strip."""
+        self.layout.wait_for_hidden(self.get_view_item(name))
+
+    # ── Select ────────────────────────────────────────────────────────────
+
+    def select(self, name: str) -> None:
+        """Switch to a view by clicking its item.
+
+        :param name: Exact name of the view.
+        """
+        item = self.get_view_item(name)
+        item.wait_for(state="visible", timeout=5000)
+        item.click()
+        expect(item).to_have_class(re.compile(SELECTED_CLASS), timeout=5000)
+
+    def get_selected(self) -> str:
+        """Return the name of the currently selected view."""
+        selected = self._strip().locator(f"{ITEM_SELECTOR}.{SELECTED_CLASS}").first
+        selected.wait_for(state="visible", timeout=5000)
+        return selected.locator(ITEM_LABEL_SELECTOR).inner_text()
+
+    def is_selected(self, name: str) -> bool:
+        """Check whether the named view is the selected one."""
+        return self.get_selected() == name
+
+    # ── Create / Rename / Delete ──────────────────────────────────────────
+
+    def create(self, name: str) -> None:
+        """Create a view from the current search and filters.
+
+        The create button pops a rename modal prefilled with a default name.
+
+        :param name: Name to give the new view.
+        """
+        self.enable_editing()
+        self.page.get_by_role("button", name="Create view", exact=True).first.click()
+        modal = self.page.locator(LayoutClient.MODAL_SELECTOR)
+        modal.wait_for(state="visible", timeout=5000)
+        modal.locator("input[placeholder='Name']").fill(name)
+        modal.get_by_role("button", name="Save", exact=True).click(timeout=5000)
+        modal.wait_for(state="hidden", timeout=5000)
+        self.wait_for(name)
+
+    def rename(self, old_name: str, new_name: str) -> None:
+        """Rename a view via its context menu. The name edits in place.
+
+        :param old_name: Current name of the view.
+        :param new_name: Name to set.
+        """
+        item = self.get_view_item(old_name)
+        item.wait_for(state="visible", timeout=5000)
+        self.ctx_menu.action(item, "Rename")
+        self.page.locator(EDITING_SELECTOR).first.wait_for(
+            state="visible", timeout=5000
+        )
+        self.layout.select_all_and_type(new_name)
+        self.layout.press_enter()
+        self.wait_for(new_name)
+
+    def delete(self, name: str) -> None:
+        """Delete a view via its context menu and confirm.
+
+        :param name: Exact name of the view.
+        """
+        item = self.get_view_item(name)
+        item.wait_for(state="visible", timeout=5000)
+        self.layout.delete_with_confirmation(item)
+        self.wait_for_removed(name)
+
+    # ── Edit Mode ─────────────────────────────────────────────────────────
+
+    def is_editable(self) -> bool:
+        """Check whether edit mode is on.
+
+        :returns: True if the search and filter controls are showing.
+        """
+        return self._search_input().is_visible()
+
+    def enable_editing(self) -> None:
+        """Turn on edit mode to show the search, filter, and create controls."""
+        if self.is_editable():
+            return
+        self.page.get_by_role("button", name="Enable editing", exact=True).first.click()
+        self._search_input().wait_for(state="visible", timeout=5000)
+
+    def disable_editing(self) -> None:
+        """Turn off edit mode, hiding the search, filter, and create controls."""
+        if not self.is_editable():
+            return
+        self.page.get_by_role(
+            "button", name="Disable editing", exact=True
+        ).first.click()
+        self._search_input().wait_for(state="hidden", timeout=5000)
+
+    # ── Search ────────────────────────────────────────────────────────────
+
+    def search(self, term: str) -> None:
+        """Type a search term into the explorer search input.
+
+        :param term: The search string to type.
+        """
+        self.enable_editing()
+        search_input = self._search_input()
+        search_input.fill(term)
+        search_input.dispatch_event(
+            "input",
+            {"bubbles": True, "data": term, "inputType": "insertText"},
+        )
+
+    def clear_search(self) -> None:
+        """Clear the explorer search input."""
+        self.search("")
+
+    # ── Filters ───────────────────────────────────────────────────────────
+
+    def open_filter(self) -> Locator:
+        """Open the filter dropdown in the explorer.
+
+        :returns: Locator for the visible filter dialog.
+        """
+        self.enable_editing()
+        self.page.get_by_role("button", name="Filter", exact=True).first.click()
+        dialog = self.layout.dialog
+        dialog.wait_for(state="visible", timeout=5000)
+        return dialog
+
+    def select_filter(self, trigger: str, option: str) -> None:
+        """Select an option in one of the explorer's filter dropdowns.
+
+        The filter is a two-level dialog: the filter button opens the first dialog,
+        the trigger opens the second dialog holding the option list.
+
+        :param trigger: Text of the dropdown trigger, e.g. "Select labels".
+        :param option: Display name of the option to select.
+        """
+        filter_dialog = self.open_filter()
+        filter_dialog.get_by_text(trigger).click()
+        item = self.layout.dialog.get_by_role("option").filter(has_text=option).first
+        item.wait_for(state="visible", timeout=5000)
+        item.click()
+        self.layout.press_escape()
+        self.layout.press_escape()
+
+    def clear_filter(self, option: str) -> None:
+        """Remove an option from the active filter by clicking its chip close button.
+
+        :param option: Display name of the option to remove.
+        """
+        remove_btn = self.page.get_by_role(
+            "button", name=f"Remove {option}", exact=True
+        ).first
+        remove_btn.wait_for(state="visible", timeout=5000)
+        remove_btn.dispatch_event("click")
+        remove_btn.wait_for(state="hidden", timeout=5000)

--- a/integration/framework/test_conductor.py
+++ b/integration/framework/test_conductor.py
@@ -449,6 +449,13 @@ All matching is case-insensitive substring.
         help="Run Playwright Console tests in headed mode (sets PLAYWRIGHT_CONSOLE_HEADED environment variable)",
     )
     parser.add_argument(
+        "--slow-mo",
+        type=int,
+        default=0,
+        metavar="MS",
+        help="Delay each Playwright action by MS milliseconds (sets PLAYWRIGHT_CONSOLE_SLOW_MO environment variable)",
+    )
+    parser.add_argument(
         "--driver",
         "-d",
         help="Driver rack name to use for driver tests (sets SYNNAX_DRIVER_RACK environment variable)",
@@ -457,6 +464,7 @@ All matching is case-insensitive substring.
     args = parser.parse_args()
 
     os.environ["PLAYWRIGHT_CONSOLE_HEADED"] = "1" if args.headed else "0"
+    os.environ["PLAYWRIGHT_CONSOLE_SLOW_MO"] = str(args.slow_mo)
     if args.driver:
         os.environ["SYNNAX_DRIVER_RACK"] = args.driver
 

--- a/integration/framework/test_conductor.py
+++ b/integration/framework/test_conductor.py
@@ -453,7 +453,10 @@ All matching is case-insensitive substring.
         type=int,
         default=0,
         metavar="MS",
-        help="Delay each Playwright action by MS milliseconds (sets PLAYWRIGHT_CONSOLE_SLOW_MO environment variable)",
+        help=(
+            "Delay each Playwright action by MS milliseconds "
+            "(sets PLAYWRIGHT_CONSOLE_SLOW_MO environment variable)"
+        ),
     )
     parser.add_argument(
         "--driver",

--- a/integration/tests/console/range/range_lifecycle.py
+++ b/integration/tests/console/range/range_lifecycle.py
@@ -183,8 +183,9 @@ class RangeLifecycle(ConsoleCase):
         """Test opening the Range Explorer."""
         self.log("Testing: Open Range Explorer")
         self.console.ranges.explorer.open()
-        all_ranges_header = self.page.get_by_text("All ranges")
-        assert all_ranges_header.is_visible(), "Range Explorer should show 'All Ranges'"
+        static_view_name = self.console.ranges.explorer.views.static_view_name
+        header = self.page.get_by_text(static_view_name)
+        assert header.is_visible(), f"Range Explorer should show '{static_view_name}'"
 
     def test_range_exists_in_explorer(self) -> None:
         """Test that created range exists in the explorer."""

--- a/integration/tests/console/view/view_lifecycle.py
+++ b/integration/tests/console/view/view_lifecycle.py
@@ -49,7 +49,6 @@ class ViewLifecycle(ConsoleCase):
     view_names: list[str]
 
     def setup(self) -> None:
-        super().setup()
         self.suffix = random_name()
         self.label_a_name = f"ViewLabelA_{self.suffix}"
         self.label_b_name = f"ViewLabelB_{self.suffix}"
@@ -60,6 +59,7 @@ class ViewLifecycle(ConsoleCase):
         self.status_b_name = f"ViewStatusB_{self.suffix}"
         self.status_n_name = f"ViewStatusN_{self.suffix}"
         self.view_names = []
+        super().setup()
 
         # The Python client has no label client, so the labels and the labeled
         # resources go through the Console. Unlabeled ones take the fast path.

--- a/integration/tests/console/view/view_lifecycle.py
+++ b/integration/tests/console/view/view_lifecycle.py
@@ -97,8 +97,11 @@ class ViewLifecycle(ConsoleCase):
                 self._delete_status(name)
             # Labels need the browser, which a failed setup may never have launched.
             if hasattr(self, "console"):
-                self.console.labels.delete(self.label_a_name)
-                self.console.labels.delete(self.label_b_name)
+                for name in [self.label_a_name, self.label_b_name]:
+                    try:
+                        self.console.labels.delete(name)
+                    except Exception as e:
+                        self.log(f"Failed to delete label '{name}': {e}")
         finally:
             super().teardown()
 

--- a/integration/tests/console/view/view_lifecycle.py
+++ b/integration/tests/console/view/view_lifecycle.py
@@ -1,0 +1,313 @@
+#  Copyright 2026 Synnax Labs, Inc.
+#
+#  Use of this software is governed by the Business Source License included in the file
+#  licenses/BSL.txt.
+#
+#  As of the Change Date specified in that file, in accordance with the Business Source
+#  License, use of this software will be governed by the Apache License, Version 2.0,
+#  included in the file licenses/APL.txt.
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import synnax as sy
+from console.case import ConsoleCase
+from console.views import ViewsClient
+from x import random_name
+
+
+@dataclass(frozen=True)
+class _Explorer:
+    """One explorer under test, with the item operations the suite needs."""
+
+    name: str
+    plural: str
+    views: ViewsClient
+    open: Callable[[], None]
+    exists: Callable[[str], bool]
+    wait_for_removed: Callable[[str], None]
+    delete_item: Callable[[str], None]
+    relabel: Callable[[str, str], None] | None
+    labeled_a: str
+    labeled_b: str
+    unlabeled: str
+
+
+class ViewLifecycle(ConsoleCase):
+    """Test views in the Range and Status Explorers. Two views with disjoint label
+    filters prove each holds its own query; the same suite runs once per explorer."""
+
+    suffix: str
+    label_a_name: str
+    label_b_name: str
+    range_a_name: str
+    range_b_name: str
+    range_n_name: str
+    status_a_name: str
+    status_b_name: str
+    status_n_name: str
+    view_names: list[str]
+
+    def setup(self) -> None:
+        super().setup()
+        self.suffix = random_name()
+        self.label_a_name = f"ViewLabelA_{self.suffix}"
+        self.label_b_name = f"ViewLabelB_{self.suffix}"
+        self.range_a_name = f"ViewRangeA_{self.suffix}"
+        self.range_b_name = f"ViewRangeB_{self.suffix}"
+        self.range_n_name = f"ViewRangeN_{self.suffix}"
+        self.status_a_name = f"ViewStatusA_{self.suffix}"
+        self.status_b_name = f"ViewStatusB_{self.suffix}"
+        self.status_n_name = f"ViewStatusN_{self.suffix}"
+        self.view_names = []
+
+        # The Python client has no label client, so the labels and the labeled
+        # resources go through the Console. Unlabeled ones take the fast path.
+        now = sy.TimeStamp.now()
+        tr = sy.TimeRange(now - sy.TimeSpan.HOUR, now + sy.TimeSpan.HOUR)
+        self.client.ranges.create(name=self.range_n_name, time_range=tr)
+        self.client.statuses.set(
+            sy.Status(
+                variant=sy.status.VARIANT_INFO,
+                message="Unlabeled status for view test",
+                name=self.status_n_name,
+            )
+        )
+        self.console.labels.create(name=self.label_a_name)
+        self.console.labels.create(name=self.label_b_name)
+        self.console.ranges.create(
+            self.range_a_name, persisted=True, labels=[self.label_a_name]
+        )
+        self.console.ranges.create(
+            self.range_b_name, persisted=True, labels=[self.label_b_name]
+        )
+        self.console.statuses.create(self.status_a_name, labels=[self.label_a_name])
+        self.console.statuses.create(self.status_b_name, labels=[self.label_b_name])
+
+    def teardown(self) -> None:
+        for name in self.view_names:
+            views = self.client.views.retrieve(search_term=name)
+            keys = [v.key for v in views if v.name == name]
+            if len(keys) > 0:
+                self.client.views.delete(keys)
+        for name in [self.range_a_name, self.range_b_name, self.range_n_name]:
+            self._delete_range(name)
+        for name in [self.status_a_name, self.status_b_name, self.status_n_name]:
+            self._delete_status(name)
+        self.console.labels.delete(self.label_a_name)
+        self.console.labels.delete(self.label_b_name)
+        super().teardown()
+
+    def _delete_range(self, name: str) -> None:
+        keys = [r.key for r in self.client.ranges.search(name) if r.name == name]
+        if len(keys) > 0:
+            self.client.ranges.delete(keys)
+
+    def _delete_status(self, name: str) -> None:
+        statuses = self.client.statuses.retrieve(search_term=name)
+        keys = [s.key for s in statuses if s.name == name]
+        if len(keys) > 0:
+            self.client.statuses.delete(keys)
+
+    def _range_removed(self, name: str) -> None:
+        """Wait for a range row to leave the list without the explorer's scroll
+        sweep. Filtered views are small, fully mounted lists."""
+        ranges = self.console.ranges.explorer
+        self.console.layout.wait_for_hidden(
+            self.console.layout.get_list_item(ranges.ITEM_SELECTOR, name)
+        )
+
+    def _relabel_range(self, name: str, label_name: str) -> None:
+        """Add a label to a range via its overview, then return to the explorer."""
+        self.console.ranges.overview.open(name)
+        self.console.ranges.overview.add_label(label_name)
+        self.console.layout.close_tab(name)
+        self.console.ranges.explorer.open()
+
+    def run(self) -> None:
+        """Run the view suite against each explorer."""
+        ranges = self.console.ranges.explorer
+        self._run_suite(
+            _Explorer(
+                name="Range",
+                plural="ranges",
+                views=ranges.views,
+                open=ranges.open,
+                exists=ranges.exists,
+                wait_for_removed=self._range_removed,
+                delete_item=self._delete_range,
+                relabel=self._relabel_range,
+                labeled_a=self.range_a_name,
+                labeled_b=self.range_b_name,
+                unlabeled=self.range_n_name,
+            )
+        )
+        self.console.layout.close_tab("Range explorer")
+
+        # Statuses have no label-edit path: the Console has no UI for it and the
+        # Python client has no label client. Relabel is skipped for them.
+        statuses = self.console.statuses
+        self._run_suite(
+            _Explorer(
+                name="Status",
+                plural="statuses",
+                views=statuses.views,
+                open=statuses.open_explorer,
+                exists=statuses.exists_in_explorer,
+                wait_for_removed=statuses.wait_for_removed_from_explorer,
+                delete_item=self._delete_status,
+                relabel=None,
+                labeled_a=self.status_a_name,
+                labeled_b=self.status_b_name,
+                unlabeled=self.status_n_name,
+            )
+        )
+
+    def _run_suite(self, explorer: _Explorer) -> None:
+        view_a = f"{explorer.name}ViewA_{self.suffix}"
+        view_b = f"{explorer.name}ViewB_{self.suffix}"
+        renamed = f"{explorer.name}ViewARenamed_{self.suffix}"
+        self.view_names.extend([view_a, view_b, renamed])
+
+        explorer.open()
+        self.test_create_views(explorer, view_a, view_b)
+        self.test_switch_between_views(explorer, view_a, view_b)
+        self.test_relabel_moves_item(explorer, view_a, view_b)
+        self.test_delete_item_leaves_view(explorer, view_a, view_b)
+        self.test_rename_view(explorer, view_a, renamed)
+        self.test_delete_view(explorer, renamed, view_b)
+
+    def _assert_only(
+        self, explorer: _Explorer, shown: list[str], hidden: list[str]
+    ) -> None:
+        for name in shown:
+            assert explorer.exists(name), (
+                f"'{name}' should be visible in the {explorer.name} Explorer"
+            )
+        for name in hidden:
+            explorer.wait_for_removed(name)
+
+    def test_create_views(self, explorer: _Explorer, view_a: str, view_b: str) -> None:
+        """Test creating two views, each filtered to a different label."""
+        self.log(f"Testing: Create views in {explorer.name} Explorer")
+        views = explorer.views
+        views.create(view_a)
+        assert views.is_selected(view_a), f"'{view_a}' should be selected on create"
+        views.select_filter("Select labels", self.label_a_name)
+        self._assert_only(
+            explorer,
+            shown=[explorer.labeled_a],
+            hidden=[explorer.labeled_b, explorer.unlabeled],
+        )
+
+        views.create(view_b)
+        assert views.is_selected(view_b), f"'{view_b}' should be selected on create"
+        assert explorer.exists(explorer.labeled_b), (
+            f"New view '{view_b}' should start unfiltered"
+        )
+        views.select_filter("Select labels", self.label_b_name)
+        self._assert_only(
+            explorer,
+            shown=[explorer.labeled_b],
+            hidden=[explorer.labeled_a, explorer.unlabeled],
+        )
+
+        saved = [
+            v
+            for v in self.client.views.retrieve(search_term=view_b)
+            if v.name == view_b
+        ]
+        assert len(saved) == 1 and len(saved[0].query) > 0, (
+            f"'{view_b}' should be saved to the server with its label filter"
+        )
+
+    def test_switch_between_views(
+        self, explorer: _Explorer, view_a: str, view_b: str
+    ) -> None:
+        """Test each view keeps its own filter when switching between them."""
+        self.log(f"Testing: Switch between views in {explorer.name} Explorer")
+        views = explorer.views
+        views.select(view_a)
+        self._assert_only(
+            explorer,
+            shown=[explorer.labeled_a],
+            hidden=[explorer.labeled_b, explorer.unlabeled],
+        )
+        views.select(view_b)
+        self._assert_only(
+            explorer, shown=[explorer.labeled_b], hidden=[explorer.labeled_a]
+        )
+        views.select(views.static_view_name)
+        self._assert_only(
+            explorer,
+            shown=[explorer.labeled_a, explorer.labeled_b, explorer.unlabeled],
+            hidden=[],
+        )
+
+    def test_relabel_moves_item(
+        self, explorer: _Explorer, view_a: str, view_b: str
+    ) -> None:
+        """Test adding a label to an item makes it appear in that label's view."""
+        if explorer.relabel is None:
+            self.log(f"Skipping: Relabel in {explorer.name} Explorer (no label edit)")
+            return
+        self.log(f"Testing: Relabel moves item in {explorer.name} Explorer")
+        views = explorer.views
+        views.select(views.static_view_name)
+        explorer.relabel(explorer.unlabeled, self.label_a_name)
+        views.select(view_a)
+        self._assert_only(
+            explorer,
+            shown=[explorer.labeled_a, explorer.unlabeled],
+            hidden=[explorer.labeled_b],
+        )
+        views.select(view_b)
+        self._assert_only(
+            explorer, shown=[explorer.labeled_b], hidden=[explorer.unlabeled]
+        )
+
+    def test_delete_item_leaves_view(
+        self, explorer: _Explorer, view_a: str, view_b: str
+    ) -> None:
+        """Test deleting an item removes it from its view, leaving other views alone."""
+        self.log(f"Testing: Delete item leaves view in {explorer.name} Explorer")
+        views = explorer.views
+        views.select(view_b)
+        explorer.delete_item(explorer.labeled_b)
+        explorer.wait_for_removed(explorer.labeled_b)
+        empty = self.page.get_by_text(f"No {explorer.plural} found")
+        assert empty.is_visible(), f"'{view_b}' should show the empty state"
+        views.select(view_a)
+        assert explorer.exists(explorer.labeled_a), (
+            f"'{explorer.labeled_a}' should still be visible in '{view_a}'"
+        )
+
+    def test_rename_view(
+        self, explorer: _Explorer, view_name: str, renamed: str
+    ) -> None:
+        """Test renaming a view in place via its context menu."""
+        self.log(f"Testing: Rename view in {explorer.name} Explorer")
+        explorer.views.rename(view_name, renamed)
+        assert explorer.views.exists(renamed), (
+            f"View '{renamed}' should appear after rename"
+        )
+        explorer.views.wait_for_removed(view_name)
+
+    def test_delete_view(self, explorer: _Explorer, view_name: str, other: str) -> None:
+        """Test deleting the selected view snaps back to the static view and leaves
+        other views intact."""
+        self.log(f"Testing: Delete view in {explorer.name} Explorer")
+        views = explorer.views
+        views.select(view_name)
+        views.delete(view_name)
+        static = views.static_view_name
+        assert views.is_selected(static), (
+            f"'{static}' should be selected after deleting '{view_name}'"
+        )
+        assert views.exists(other), f"'{other}' should survive deleting '{view_name}'"
+        remaining = [
+            v
+            for v in self.client.views.retrieve(search_term=view_name)
+            if v.name == view_name
+        ]
+        assert len(remaining) == 0, f"View '{view_name}' should be deleted from server"

--- a/integration/tests/console/view/view_lifecycle.py
+++ b/integration/tests/console/view/view_lifecycle.py
@@ -85,18 +85,22 @@ class ViewLifecycle(ConsoleCase):
         self.console.statuses.create(self.status_b_name, labels=[self.label_b_name])
 
     def teardown(self) -> None:
-        for name in self.view_names:
-            views = self.client.views.retrieve(search_term=name)
-            keys = [v.key for v in views if v.name == name]
-            if len(keys) > 0:
-                self.client.views.delete(keys)
-        for name in [self.range_a_name, self.range_b_name, self.range_n_name]:
-            self._delete_range(name)
-        for name in [self.status_a_name, self.status_b_name, self.status_n_name]:
-            self._delete_status(name)
-        self.console.labels.delete(self.label_a_name)
-        self.console.labels.delete(self.label_b_name)
-        super().teardown()
+        try:
+            for name in self.view_names:
+                views = self.client.views.retrieve(search_term=name)
+                keys = [v.key for v in views if v.name == name]
+                if len(keys) > 0:
+                    self.client.views.delete(keys)
+            for name in [self.range_a_name, self.range_b_name, self.range_n_name]:
+                self._delete_range(name)
+            for name in [self.status_a_name, self.status_b_name, self.status_n_name]:
+                self._delete_status(name)
+            # Labels need the browser, which a failed setup may never have launched.
+            if hasattr(self, "console"):
+                self.console.labels.delete(self.label_a_name)
+                self.console.labels.delete(self.label_b_name)
+        finally:
+            super().teardown()
 
     def _delete_range(self, name: str) -> None:
         keys = [r.key for r in self.client.ranges.search(name) if r.name == name]

--- a/integration/tests/console_tests.json
+++ b/integration/tests/console_tests.json
@@ -47,7 +47,8 @@
         { "case": "console/task/ni_analog_read_forms" },
         { "case": "console/task/ni_analog_write_forms" },
         { "case": "console/task/ni_counter_read_forms" },
-        { "case": "console/task/no_device" }
+        { "case": "console/task/no_device" },
+        { "case": "console/view/view_lifecycle" }
       ]
     },
     {


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-3877](https://linear.app/synnax/issue/SY-3877)

## Description

Adds `view_lifecycle`, covering the saved-view strip in the Range and Status Explorers: create, filter by label, switch, relabel, delete item, rename, delete. The same suite runs once per explorer.

Adds `ViewsClient`, a shared page object for the strip, and moves the duplicated search and filter helpers out of `range/explorer.py` and `statuses.py` into it.

Fixes `overview.add_label` for ranges with no labels, where the placeholder is the trigger and the add button does not render.

Adds a `--slow-mo MS` flag to `tc`, mirroring `--headed`, to delay each Playwright action for watching a case run.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds shared Console page-object support and an integration suite for saved views across the Range and Status explorers, along with a configurable Playwright action delay.
- Adds saved-view lifecycle coverage for creation, filtering, switching, relabeling, deletion, and renaming.
- Consolidates explorer search and filter operations in `ViewsClient`.
- Fixes adding the first label to a range with no existing labels.
- Adds the `--slow-mo MS` test-conductor option and documents it.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| integration/tests/console/view/view_lifecycle.py | Adds the cross-explorer saved-view lifecycle suite and now safely initializes teardown state, guards partial Console setup, and continues label cleanup after individual failures. |
| integration/console/views.py | Introduces the shared page object for saved-view selection, editing, search, filtering, creation, renaming, and deletion. |
| integration/framework/test_conductor.py | Adds the Playwright slow-motion CLI option and keeps its help declaration within the repository line-length standard. |
| integration/console/range/overview.py | Supports opening the label selector through the placeholder when a range has no labels. |
| integration/console/range/explorer.py | Delegates Range Explorer view, search, and label-filter interactions to the shared views client. |
| integration/console/statuses.py | Delegates Status Explorer view and filter interactions to the shared views client. |

<sub>Reviews (4): Last reviewed commit: ["SY-3877: Make teardown resilient to part..."](https://github.com/synnaxlabs/synnax/commit/209a35c8c89da0d27eb7c9f0b654e2fa30fc640c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55320031)</sub>

<!-- /greptile_comment -->