### PR TITLE
Reclaim leaked CI runner disk in cache-cleanup scripts

### DIFF
--- a/integration/scripts/CleanBuildCaches.ps1
+++ b/integration/scripts/CleanBuildCaches.ps1
@@ -14,15 +14,10 @@
 # - Otherwise: `bazel clean` first (largest consumer), then oldest Go/binary files
 #   until MinFreeGB is available.
 #
-# Usage: CleanBuildCaches.ps1 [-MinFreeGB 35] [-BazelOutputRoot C:/tmp]
-#
-# BazelOutputRoot is the build's --output_user_root override. Both it and the default
-# root are cleaned; if this did not match the build, its output tree would never be
-# cleaned and would grow unbounded.
+# Usage: CleanBuildCaches.ps1 [-MinFreeGB 35]
 
 param(
-    [int]$MinFreeGB = 35,
-    [string]$BazelOutputRoot = "C:/tmp"
+    [int]$MinFreeGB = 35
 )
 
 # Best-effort cleanup — must never fail the build
@@ -77,42 +72,46 @@ if (Test-EnoughSpace) {
 }
 
 # --- Below threshold: Bazel is the largest consumer, so clean it first ---
-# The driver build overrides the output root to C:/tmp; other bazel calls use the
-# default root. Clean both so neither leaks.
+# The runner bazelrc pins --output_base=C:/_bazel, so `bazel clean` frees it.
 Write-Output "Bazel clean:"
 $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
-$bazelRoots = @($BazelOutputRoot)
 if (Test-Path $repoRoot) {
     Push-Location $repoRoot
-    $defaultRoot = (bazel info output_user_root 2>$null)
-    Pop-Location
-    if ($defaultRoot) { $bazelRoots += $defaultRoot }
-}
-$bazelRoots = $bazelRoots | Where-Object { $_ } | Select-Object -Unique
-if (Test-Path $repoRoot) {
-    foreach ($root in $bazelRoots) {
-        if (-not (Test-Path $root)) {
-            Write-Output ("  {0,-35} skipped (not found)" -f $root)
-            continue
-        }
+    $outputBase = (bazel info output_base 2>$null)
+    $before = 0
+    if ($outputBase -and (Test-Path $outputBase)) {
         $before = [math]::Round(
-            ((Get-ChildItem -Recurse -File $root -ErrorAction SilentlyContinue |
+            ((Get-ChildItem -Recurse -File $outputBase -ErrorAction SilentlyContinue |
                 Measure-Object -Property Length -Sum).Sum / 1MB), 0)
-        Push-Location $repoRoot
-        $out = bazel --output_user_root=$root clean 2>&1
-        if ($LASTEXITCODE -ne 0) {
-            Write-Output "  clean failed for $root (exit $LASTEXITCODE): $out"
-        }
-        Pop-Location
-        $after = [math]::Round(
-            ((Get-ChildItem -Recurse -File $root -ErrorAction SilentlyContinue |
-                Measure-Object -Property Length -Sum).Sum / 1MB), 0)
-        $script:totalFreed += ($before - $after)
-        Write-Output ("  {0,-35} {1,6}MB -> {2,6}MB  (freed {3}MB)" -f `
-            $root, $before, $after, ($before - $after))
     }
+    $out = bazel clean 2>&1
+    if ($LASTEXITCODE -ne 0) {
+        Write-Output "  clean failed (exit $LASTEXITCODE): $out"
+    }
+    Pop-Location
+    $after = 0
+    if ($outputBase -and (Test-Path $outputBase)) {
+        $after = [math]::Round(
+            ((Get-ChildItem -Recurse -File $outputBase -ErrorAction SilentlyContinue |
+                Measure-Object -Property Length -Sum).Sum / 1MB), 0)
+    }
+    $label = if ($outputBase) { $outputBase } else { "output_base" }
+    $script:totalFreed += ($before - $after)
+    Write-Output ("  {0,-35} {1,6}MB -> {2,6}MB  (freed {3}MB)" -f `
+        $label, $before, $after, ($before - $after))
 } else {
     Write-Output ("  {0,-35} skipped (repo not found)" -f "bazel clean")
+}
+Write-Output ""
+
+# --- C:/tmp: Bazel install/server files that `bazel clean` leaves behind ---
+if (Test-Path "C:/tmp") {
+    $tmpBefore = [math]::Round(
+        ((Get-ChildItem -Recurse -File "C:/tmp" -ErrorAction SilentlyContinue |
+            Measure-Object -Property Length -Sum).Sum / 1MB), 0)
+    Remove-Item -Recurse -Force "C:/tmp" -ErrorAction SilentlyContinue
+    $script:totalFreed += $tmpBefore
+    Write-Output ("  {0,-35} freed {1}MB" -f "C:/tmp", $tmpBefore)
 }
 Write-Output ""
 

--- a/integration/scripts/CleanBuildCaches.ps1
+++ b/integration/scripts/CleanBuildCaches.ps1
@@ -14,10 +14,15 @@
 # - Otherwise: `bazel clean` first (largest consumer), then oldest Go/binary files
 #   until MinFreeGB is available.
 #
-# Usage: CleanBuildCaches.ps1 [-MinFreeGB 35]
+# Usage: CleanBuildCaches.ps1 [-MinFreeGB 35] [-BazelOutputRoot C:/tmp]
+#
+# BazelOutputRoot is the build's --output_user_root override. Both it and the default
+# root are cleaned; if this did not match the build, its output tree would never be
+# cleaned and would grow unbounded.
 
 param(
-    [int]$MinFreeGB = 35
+    [int]$MinFreeGB = 35,
+    [string]$BazelOutputRoot = "C:/tmp"
 )
 
 # Best-effort cleanup — must never fail the build
@@ -72,36 +77,42 @@ if (Test-EnoughSpace) {
 }
 
 # --- Below threshold: Bazel is the largest consumer, so clean it first ---
+# The driver build overrides the output root to C:/tmp; other bazel calls use the
+# default root. Clean both so neither leaks.
 Write-Output "Bazel clean:"
 $repoRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
-$bazelBase = $null
+$bazelRoots = @($BazelOutputRoot)
 if (Test-Path $repoRoot) {
-    try {
-        Push-Location $repoRoot
-        $bazelBase = (bazel info output_user_root 2>$null)
-        Pop-Location
-    } catch { Pop-Location }
-}
-if (-not $bazelBase) { $bazelBase = "C:\_bazel" }
-if ((Test-Path $bazelBase) -and (Test-Path $repoRoot)) {
-    $beforeBazel = [math]::Round(
-        ((Get-ChildItem -Recurse -File $bazelBase -ErrorAction SilentlyContinue |
-            Measure-Object -Property Length -Sum).Sum / 1MB), 0)
     Push-Location $repoRoot
-    $bazelOutput = bazel clean 2>&1
-    if ($LASTEXITCODE -ne 0) {
-        Write-Output "  bazel clean failed (exit $LASTEXITCODE): $bazelOutput"
-    }
+    $defaultRoot = (bazel info output_user_root 2>$null)
     Pop-Location
-    $afterBazel = [math]::Round(
-        ((Get-ChildItem -Recurse -File $bazelBase -ErrorAction SilentlyContinue |
-            Measure-Object -Property Length -Sum).Sum / 1MB), 0)
-    $freedBazel = $beforeBazel - $afterBazel
-    $script:totalFreed += $freedBazel
-    Write-Output ("  {0,-35} {1,6}MB -> {2,6}MB  (freed {3}MB)" -f `
-        "bazel clean", $beforeBazel, $afterBazel, $freedBazel)
+    if ($defaultRoot) { $bazelRoots += $defaultRoot }
+}
+$bazelRoots = $bazelRoots | Where-Object { $_ } | Select-Object -Unique
+if (Test-Path $repoRoot) {
+    foreach ($root in $bazelRoots) {
+        if (-not (Test-Path $root)) {
+            Write-Output ("  {0,-35} skipped (not found)" -f $root)
+            continue
+        }
+        $before = [math]::Round(
+            ((Get-ChildItem -Recurse -File $root -ErrorAction SilentlyContinue |
+                Measure-Object -Property Length -Sum).Sum / 1MB), 0)
+        Push-Location $repoRoot
+        $out = bazel --output_user_root=$root clean 2>&1
+        if ($LASTEXITCODE -ne 0) {
+            Write-Output "  clean failed for $root (exit $LASTEXITCODE): $out"
+        }
+        Pop-Location
+        $after = [math]::Round(
+            ((Get-ChildItem -Recurse -File $root -ErrorAction SilentlyContinue |
+                Measure-Object -Property Length -Sum).Sum / 1MB), 0)
+        $script:totalFreed += ($before - $after)
+        Write-Output ("  {0,-35} {1,6}MB -> {2,6}MB  (freed {3}MB)" -f `
+            $root, $before, $after, ($before - $after))
+    }
 } else {
-    Write-Output ("  {0,-35} skipped (not found)" -f "bazel clean")
+    Write-Output ("  {0,-35} skipped (repo not found)" -f "bazel clean")
 }
 Write-Output ""
 

--- a/integration/scripts/CleanBuildCaches.ps1
+++ b/integration/scripts/CleanBuildCaches.ps1
@@ -116,6 +116,16 @@ if (Test-Path $repoRoot) {
 }
 Write-Output ""
 
+# --- Docker (unbounded image/layer growth, largest consumer on some bots) ---
+Write-Output "Docker prune:"
+if (Get-Command docker -ErrorAction SilentlyContinue) {
+    docker system prune -af 2>&1 | Out-Null
+    Write-Output "  done"
+} else {
+    Write-Output "  skipped (docker not found)"
+}
+Write-Output ""
+
 # --- Check if we already have enough space after bazel clean ---
 if (Test-EnoughSpace) {
     $freeMB = Get-DiskFreeMB

--- a/integration/scripts/KillSynnaxProcesses.cmd
+++ b/integration/scripts/KillSynnaxProcesses.cmd
@@ -29,18 +29,18 @@ if exist "%LOCALAPPDATA%\synnax" (
 
 rem Clean up any existing binaries directory (current working directory)
 if exist ".\binaries" (
-    echo 🧹 Cleaning existing binaries directory...
+    echo Cleaning existing binaries directory...
     rmdir /s /q ".\binaries"
 ) else (
-    echo 🧹 No existing binaries directory to clean
+    echo No existing binaries directory to clean
 )
 
 rem Also clean up synnax-binaries if it exists (for consistency with other OS patterns)
 if exist "%USERPROFILE%\synnax-binaries" (
-    echo 🧹 Cleaning synnax-binaries directory from %USERPROFILE%...
+    echo Cleaning synnax-binaries directory from %USERPROFILE%...
     rmdir /s /q "%USERPROFILE%\synnax-binaries"
 ) else (
-    echo 🧹 No synnax-binaries directory found in %USERPROFILE%
+    echo No synnax-binaries directory found in %USERPROFILE%
 )
 
 rem Clean up any existing desktop binaries
@@ -53,34 +53,34 @@ echo Verifying cleanup...
 set "cleanup_failed=false"
 
 if exist ".\binaries" (
-    echo ❌ ERROR: binaries directory still exists after cleanup
+    echo ERROR: binaries directory still exists after cleanup
     set "cleanup_failed=true"
 )
 
 if exist "%USERPROFILE%\synnax-binaries" (
-    echo ❌ ERROR: synnax-binaries directory still exists in %USERPROFILE% after cleanup
+    echo ERROR: synnax-binaries directory still exists in %USERPROFILE% after cleanup
     set "cleanup_failed=true"
 )
 
 if exist "%USERPROFILE%\synnax-data" (
-    echo ❌ ERROR: synnax-data directory still exists in %USERPROFILE% after cleanup
+    echo ERROR: synnax-data directory still exists in %USERPROFILE% after cleanup
     set "cleanup_failed=true"
 )
 
 rem Check if any desktop synnax executables still exist
 dir "%USERPROFILE%\Desktop\synnax*.exe" >nul 2>nul
 if %errorlevel% equ 0 (
-    echo ❌ ERROR: synnax executables still exist on desktop after cleanup:
+    echo ERROR: synnax executables still exist on desktop after cleanup:
     dir "%USERPROFILE%\Desktop\synnax*.exe"
     set "cleanup_failed=true"
 )
 
 if "%cleanup_failed%"=="true" (
-    echo ❌ Cleanup verification failed
+    echo Cleanup verification failed
     exit /b 1
 ) else (
-    echo ✅ Cleanup verification passed - all directories and files removed
+    echo Cleanup verification passed - all directories and files removed
 )
 
-echo ✅ Synnax process cleanup completed
+echo Synnax process cleanup completed
 exit /b 0

--- a/integration/scripts/KillSynnaxProcesses.cmd
+++ b/integration/scripts/KillSynnaxProcesses.cmd
@@ -18,6 +18,10 @@ echo Cleaning up synnax directories...
 if exist "%USERPROFILE%\synnax-binaries" rmdir /s /q "%USERPROFILE%\synnax-binaries" && echo Removed synnax-binaries directory from %USERPROFILE% || echo No synnax-binaries directory found in %USERPROFILE%
 if exist "%USERPROFILE%\synnax-data" rmdir /s /q "%USERPROFILE%\synnax-data" && echo Removed synnax-data directory from %USERPROFILE% || echo No synnax-data directory found in %USERPROFILE%
 
+rem A force-killed Core never removes its cache workdir (UserCacheDir\synnax), so one
+rem orphaned dir per run leaks here. Clear it to stop unbounded disk growth.
+if exist "%LOCALAPPDATA%\synnax" rmdir /s /q "%LOCALAPPDATA%\synnax" && echo Removed synnax cache directory from %LOCALAPPDATA% || echo No synnax cache directory found in %LOCALAPPDATA%
+
 rem Clean up any existing binaries directory (current working directory)
 if exist ".\binaries" (
     echo 🧹 Cleaning existing binaries directory...

--- a/integration/scripts/KillSynnaxProcesses.cmd
+++ b/integration/scripts/KillSynnaxProcesses.cmd
@@ -20,7 +20,12 @@ if exist "%USERPROFILE%\synnax-data" rmdir /s /q "%USERPROFILE%\synnax-data" && 
 
 rem A force-killed Core never removes its cache workdir (UserCacheDir\synnax), so one
 rem orphaned dir per run leaks here. Clear it to stop unbounded disk growth.
-if exist "%LOCALAPPDATA%\synnax" rmdir /s /q "%LOCALAPPDATA%\synnax" && echo Removed synnax cache directory from %LOCALAPPDATA% || echo No synnax cache directory found in %LOCALAPPDATA%
+if exist "%LOCALAPPDATA%\synnax" (
+    rmdir /s /q "%LOCALAPPDATA%\synnax"
+    echo Removed synnax cache directory from %LOCALAPPDATA%
+) else (
+    echo No synnax cache directory found in %LOCALAPPDATA%
+)
 
 rem Clean up any existing binaries directory (current working directory)
 if exist ".\binaries" (

--- a/integration/scripts/clean_build_caches.sh
+++ b/integration/scripts/clean_build_caches.sh
@@ -59,6 +59,15 @@ else
 fi
 echo ""
 
+# --- Docker (unbounded image/layer growth, largest consumer on some bots) ---
+echo "Docker prune:"
+if command -v docker > /dev/null 2>&1; then
+    docker system prune -af > /dev/null 2>&1 && echo "  done" || echo "  failed"
+else
+    echo "  skipped (docker not found)"
+fi
+echo ""
+
 # --- Check if we already have enough space after bazel clean ---
 if has_enough_space; then
     echo "Free space $(get_free_mb)MB >= target ${MIN_FREE_MB}MB — skipping cache cleanup."

--- a/integration/scripts/kill_synnax_processes.sh
+++ b/integration/scripts/kill_synnax_processes.sh
@@ -56,6 +56,11 @@ echo "Cleaning up synnax directories..."
 [ -d "$HOME/synnax-binaries" ] && rm -rf "$HOME/synnax-binaries" && echo "Removed synnax-binaries directory from $HOME" || echo "No synnax-binaries directory found in $HOME"
 [ -d "$HOME/synnax-data" ] && rm -rf "$HOME/synnax-data" && echo "Removed synnax-data directory from $HOME" || echo "No synnax-data directory found in $HOME"
 
+# A force-killed Core never removes its cache workdir (UserCacheDir/synnax), so one
+# orphaned dir per run leaks here. Clear it to stop unbounded disk growth.
+SYNNAX_CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/synnax"
+[ -d "$SYNNAX_CACHE_DIR" ] && rm -rf "$SYNNAX_CACHE_DIR" && echo "Removed synnax cache directory: $SYNNAX_CACHE_DIR" || echo "No synnax cache directory found at $SYNNAX_CACHE_DIR"
+
 # Check if directories still exist after cleanup
 echo "Verifying directory cleanup..."
 if [ -d "$HOME/synnax-binaries" ] || [ -d "$HOME/synnax-data" ]; then

--- a/integration/scripts/kill_synnax_processes.sh
+++ b/integration/scripts/kill_synnax_processes.sh
@@ -59,7 +59,12 @@ echo "Cleaning up synnax directories..."
 # A force-killed Core never removes its cache workdir (UserCacheDir/synnax), so one
 # orphaned dir per run leaks here. Clear it to stop unbounded disk growth.
 SYNNAX_CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/synnax"
-[ -d "$SYNNAX_CACHE_DIR" ] && rm -rf "$SYNNAX_CACHE_DIR" && echo "Removed synnax cache directory: $SYNNAX_CACHE_DIR" || echo "No synnax cache directory found at $SYNNAX_CACHE_DIR"
+if [ -d "$SYNNAX_CACHE_DIR" ]; then
+    rm -rf "$SYNNAX_CACHE_DIR"
+    echo "Removed synnax cache directory: $SYNNAX_CACHE_DIR"
+else
+    echo "No synnax cache directory found at $SYNNAX_CACHE_DIR"
+fi
 
 # Check if directories still exist after cleanup
 echo "Verifying directory cleanup..."


### PR DESCRIPTION
## Description

The self-hosted CI runners kept filling their disks because two cleanup paths missed the caches that actually grow.

Build bots: CleanBuildCaches.ps1 ran `bazel clean` against only the default output root, but the Windows driver build passes `--output_user_root=C:/tmp`. That tree was never cleaned and grew until the disk filled. The script now cleans both roots.

Integration testers: the kill scripts remove `synnax-data` at the start of each run but never touched the Core's cache workdir (`UserCacheDir/synnax`). The Core only deletes that workdir on graceful shutdown, and the test job force-kills the Core, so every run orphaned a 40 MB Driver binary there. Over thousands of runs this reached 48 GB. The kill scripts now clear it before each job, on Windows and Unix.

Both changes are best-effort and cannot fail a job.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR reclaims disk space on self-hosted CI runners by cleaning both Bazel output roots, pruning unused Docker resources, and removing orphaned Core cache workdirs.
- Cleans the overridden and default Bazel output roots on Windows.
- Adds best-effort Docker pruning to Windows and Unix build-cache cleanup.
- Clears orphaned Synnax cache workdirs in Windows and Unix process cleanup.
- Wraps the previously overlong cache-cleanup commands into readable blocks.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| integration/scripts/CleanBuildCaches.ps1 | Cleans configured and default Bazel roots and adds Docker resource pruning. |
| integration/scripts/KillSynnaxProcesses.cmd | Removes the Windows Synnax cache directory using an 88-column-compliant command block. |
| integration/scripts/clean_build_caches.sh | Adds best-effort Docker pruning to Unix build-cache cleanup. |
| integration/scripts/kill_synnax_processes.sh | Removes the Unix Synnax cache directory using an 88-column-compliant command block. |

<sub>Reviews (2): Last reviewed commit: ["Prune Docker in build cleanup, wrap cach..."](https://github.com/synnaxlabs/synnax/commit/53f1f1c06e916abf2700ab4eaf0df952d7f60aad) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55343211)</sub>

<!-- /greptile_comment -->