### PR TITLE
SY-4680: Minor UI tweaks

### DIFF
--- a/console/src/feature/http/task/ContextMenu.tsx
+++ b/console/src/feature/http/task/ContextMenu.tsx
@@ -14,7 +14,7 @@ import { Task } from "@/platform/task";
 
 export interface ContextMenuProps {
   keys: string[];
-  onDelete: (keys: string[]) => void;
+  onRemove: (keys: string[]) => void;
   onDuplicate?: (keys: string[]) => void;
   onRename?: (key: string) => void;
 }
@@ -22,7 +22,7 @@ export interface ContextMenuProps {
 export const ContextMenu = ({
   keys,
   onDuplicate,
-  onDelete,
+  onRemove,
   onRename,
 }: ContextMenuProps) => {
   const isPreview = Task.useIsPreview();
@@ -41,7 +41,7 @@ export const ContextMenu = ({
             </Menu.Item>
           )}
           <Menu.Divider />
-          <Base.DeleteItem onClick={() => onDelete(keys)} />
+          <Base.RemoveItem onClick={() => onRemove(keys)} />
           <Menu.Divider />
         </>
       )}

--- a/console/src/feature/http/task/Form.css
+++ b/console/src/feature/http/task/Form.css
@@ -11,8 +11,15 @@
 
 .console-task-configure--http_read,
 .console-task-configure--http_write {
+    /* Both halves are load-bearing: the list must refuse to shrink, and the detail
+       column must be allowed to, or the list absorbs everything it will not give up. */
     .console-endpoint-list {
         width: 250px;
+        flex-shrink: 0;
+    }
+
+    .console-endpoint-details-pane {
+        min-width: 0;
     }
 
     .console-endpoint-details {

--- a/console/src/feature/http/task/Form.css
+++ b/console/src/feature/http/task/Form.css
@@ -37,8 +37,19 @@
             padding: 2rem 0 0;
         }
 
-        .console-channel-list {
+        /* This pane is the only scroller. Its lists grow with their content and
+           hand the overflow up; pluto's paint containment would clip it instead. */
+        .console-channel-list,
+        .console-additional-fields {
             overflow: visible;
+            flex-shrink: 0;
+        }
+
+        .console-field-list-items,
+        .console-channel-list .pluto-list__items {
+            overflow: visible;
+            contain: layout;
+            height: auto;
         }
 
         .pluto-header__actions {
@@ -82,9 +93,5 @@
 
     .console-static-field-value {
         width: 120px;
-    }
-
-    .console-field-list-items {
-        overflow: visible;
     }
 }

--- a/console/src/feature/http/task/Form.css
+++ b/console/src/feature/http/task/Form.css
@@ -76,6 +76,10 @@
         max-width: 25rem;
     }
 
+    .console-field-data-type {
+        width: 22rem;
+    }
+
     .console-static-field-value {
         width: 120px;
     }

--- a/console/src/feature/http/task/Form.css
+++ b/console/src/feature/http/task/Form.css
@@ -45,11 +45,23 @@
             flex-shrink: 0;
         }
 
+        /* The shared rule sizes this list beside a detail column; stacked here, its
+           225px basis becomes a height that strands the enum mapping below the fold.
+           The :not() mirrors that rule so this one outweighs it. */
+        .console-channel-list:not(:only-child) {
+            flex-basis: auto;
+        }
+
         .console-field-list-items,
         .console-channel-list .pluto-list__items {
             overflow: visible;
             contain: layout;
             height: auto;
+        }
+
+        /* Content height alone puts the placeholder right under the header. */
+        .pluto-list__items--empty {
+            min-height: 15rem;
         }
 
         .pluto-header__actions {

--- a/console/src/feature/http/task/Read.spec.ts
+++ b/console/src/feature/http/task/Read.spec.ts
@@ -127,7 +127,7 @@ describe("HTTP Read form", () => {
     fireEvent.click(await screen.findByText("Duplicate"));
     await waitFor(() => expect(screen.getAllByText(/\/api\/v1/)).toHaveLength(2));
     fireEvent.contextMenu(screen.getAllByText(/\/api\/v1/)[0]);
-    fireEvent.click(await screen.findByText("Delete"));
+    fireEvent.click(await screen.findByText("Remove"));
     await waitFor(() => expect(screen.getAllByText(/\/api\/v1/)).toHaveLength(1));
   });
 

--- a/console/src/feature/http/task/Read.tsx
+++ b/console/src/feature/http/task/Read.tsx
@@ -520,7 +520,7 @@ const Form: FC = () => {
         </Menu.ContextMenu>
       </Flex.Box>
       <Divider.Divider y />
-      <Flex.Box y grow empty>
+      <Flex.Box y grow empty className={CSS.B("endpoint-details-pane")}>
         <Task.Views.DetailsHeader
           path={
             selectedEndpoints.length > 0

--- a/console/src/feature/http/task/Read.tsx
+++ b/console/src/feature/http/task/Read.tsx
@@ -436,7 +436,7 @@ const Form: FC = () => {
     setSelectedEndpoints([ep.key]);
   }, [push]);
 
-  const handleDeleteEndpoints = useCallback(
+  const handleRemoveEndpoints = useCallback(
     (keys: string[]) => {
       remove(keys);
       setSelectedEndpoints([]);
@@ -470,11 +470,11 @@ const Form: FC = () => {
     (p: Menu.ContextMenuMenuProps) => (
       <ContextMenu
         keys={p.keys}
-        onDelete={handleDeleteEndpoints}
+        onRemove={handleRemoveEndpoints}
         onDuplicate={handleDuplicateEndpoints}
       />
     ),
-    [handleDeleteEndpoints, handleDuplicateEndpoints],
+    [handleRemoveEndpoints, handleDuplicateEndpoints],
   );
 
   return (

--- a/console/src/feature/http/task/Read.tsx
+++ b/console/src/feature/http/task/Read.tsx
@@ -154,7 +154,12 @@ const HIDDEN_DATA_TYPES = [
 
 const renderTelemSelectDataType = Component.renderProp(
   (p: Telem.SelectDataTypeProps) => (
-    <Telem.SelectDataType {...p} hideDataTypes={HIDDEN_DATA_TYPES} location="bottom" />
+    <Telem.SelectDataType
+      {...p}
+      className={CSS.B("field-data-type")}
+      hideDataTypes={HIDDEN_DATA_TYPES}
+      location="bottom"
+    />
   ),
 );
 

--- a/console/src/feature/http/task/Write.spec.ts
+++ b/console/src/feature/http/task/Write.spec.ts
@@ -109,15 +109,15 @@ describe("HTTP Write form", () => {
     await findDialogTriggerByText("Timestamp (s)");
   });
 
-  it("should delete additional fields through a context menu without a duplicate option", async () => {
+  it("should remove additional fields through a context menu without a duplicate option", async () => {
     await renderWrite();
     await addEndpoint();
     fireEvent.click(getHeaderIconButton("Additional fields", "add"));
     const pointer = await screen.findByPlaceholderText("field");
     fireEvent.contextMenu(pointer);
-    await screen.findByText("Delete");
+    await screen.findByText("Remove");
     expect(screen.queryByText("Duplicate")).toBeNull();
-    fireEvent.click(screen.getByText("Delete"));
+    fireEvent.click(screen.getByText("Remove"));
     await waitFor(() => expect(screen.queryByText("static")).toBeNull());
   });
 

--- a/console/src/feature/http/task/Write.tsx
+++ b/console/src/feature/http/task/Write.tsx
@@ -355,7 +355,7 @@ const AdditionalFields: FC<{ epKey: string }> = ({ epKey }) => {
     setSelected([field.key]);
   }, [push]);
 
-  const handleDelete = useCallback(
+  const handleRemove = useCallback(
     (keys: string[]) => {
       remove(keys);
       setSelected([]);
@@ -373,13 +373,13 @@ const AdditionalFields: FC<{ epKey: string }> = ({ epKey }) => {
   const menuProps = Menu.useContextMenu();
   const menuRenderProp = useCallback(
     (p: Menu.ContextMenuMenuProps) => (
-      <ContextMenu keys={p.keys} onDelete={handleDelete} />
+      <ContextMenu keys={p.keys} onRemove={handleRemove} />
     ),
-    [handleDelete],
+    [handleRemove],
   );
 
   return (
-    <Flex.Box y grow empty>
+    <Flex.Box y grow empty className={CSS.B("additional-fields")}>
       <Header.Header>
         <Header.Title weight={500} color={9}>
           Additional fields
@@ -487,7 +487,7 @@ const Form: FC = () => {
     setSelectedEndpoints([ep.key]);
   }, [push]);
 
-  const handleDeleteEndpoints = useCallback(
+  const handleRemoveEndpoints = useCallback(
     (keys: string[]) => {
       remove(keys);
       setSelectedEndpoints([]);
@@ -522,12 +522,12 @@ const Form: FC = () => {
     (p: Menu.ContextMenuMenuProps) => (
       <ContextMenu
         keys={p.keys}
-        onDelete={handleDeleteEndpoints}
+        onRemove={handleRemoveEndpoints}
         onDuplicate={handleDuplicateEndpoints}
         onRename={handleRenameChannel}
       />
     ),
-    [handleDeleteEndpoints, handleDuplicateEndpoints, handleRenameChannel],
+    [handleRemoveEndpoints, handleDuplicateEndpoints, handleRenameChannel],
   );
 
   return (

--- a/console/src/feature/http/task/Write.tsx
+++ b/console/src/feature/http/task/Write.tsx
@@ -576,7 +576,7 @@ const Form: FC = () => {
         </Menu.ContextMenu>
       </Flex.Box>
       <Divider.Divider y />
-      <Flex.Box y grow empty>
+      <Flex.Box y grow empty className={CSS.B("endpoint-details-pane")}>
         <Task.Views.DetailsHeader
           path={
             selectedEndpoints.length > 0

--- a/console/src/feature/http/task/Write.tsx
+++ b/console/src/feature/http/task/Write.tsx
@@ -276,6 +276,7 @@ const FieldListItem = (props: List.ItemProps<string> & { epKey: string }) => {
           onChange={handleJSONTypeChange}
           data={JSON_TYPE_DATA}
           resourceName="type"
+          className={CSS.B("field-data-type")}
         />
       )}
       {fieldType === "static" && jsonType === "string" && (
@@ -311,6 +312,7 @@ const FieldListItem = (props: List.ItemProps<string> & { epKey: string }) => {
           onChange={handleGeneratorChange}
           data={GENERATOR_DATA}
           resourceName="generator"
+          variant="floating"
         />
       )}
       <Text.Text level="small" color={9}>

--- a/console/src/feature/lineplot/Controls.tsx
+++ b/console/src/feature/lineplot/Controls.tsx
@@ -72,13 +72,7 @@ export const Controls = memo(({ hasAnnotations }: ControlsProps): ReactElement =
   const triggers = useMemo(() => Viewport.DEFAULT_TRIGGERS[mode], [mode]);
 
   return (
-    <Vis.Controls
-      className={CSS.cls(
-        annotationsVisible &&
-          hasAnnotations &&
-          CSS.BM("controls", "annotations-visible"),
-      )}
-    >
+    <Vis.Controls>
       <Flex.Box x gap="small">
         <Viewport.SelectMode
           value={mode}

--- a/console/src/feature/lineplot/LinePlot.css
+++ b/console/src/feature/lineplot/LinePlot.css
@@ -14,12 +14,15 @@
     margin-right: 3rem;
 }
 
-.console-controls--annotations-visible {
-    top: 0rem;
-}
-
 .console-line-plot__container {
     height: 100%;
     width: 100%;
     padding: 2rem;
+
+    /* The wrapper's padding already supplies the inset that the other
+       visualizations get from the controls' own offset. */
+    .console-controls {
+        top: 0;
+        right: 0;
+    }
 }

--- a/console/src/feature/lineplot/toolbar/Lines.tsx
+++ b/console/src/feature/lineplot/toolbar/Lines.tsx
@@ -92,7 +92,7 @@ const Line = ({ itemKey, index }: LineProps): ReactElement | null => {
     dispatch(lineplot.setLineColor({ key: itemKey, color }));
 
   return (
-    <List.Item itemKey={itemKey} index={index} key={itemKey} gap="large">
+    <List.Item itemKey={itemKey} index={index} key={itemKey} gap="large" preventClick>
       <Channel.AliasInput
         channel={line.yChannel}
         variant="shadow"

--- a/console/src/feature/log/toolbar/Channels.tsx
+++ b/console/src/feature/log/toolbar/Channels.tsx
@@ -112,6 +112,7 @@ const ChannelRow = ({
       justify="between"
       gap="large"
       className={CSS.BE("log", "channel-row")}
+      preventClick
     >
       <Flex.Box x align="center" grow>
         <Channel.SelectSingle

--- a/console/src/feature/log/toolbar/Toolbar.css
+++ b/console/src/feature/log/toolbar/Toolbar.css
@@ -28,9 +28,6 @@
         .console-log__channel-row {
             padding: 0.25rem 3rem 0.25rem 1rem;
             min-height: unset;
-            cursor: default;
-
-            --pluto-hover-bg: transparent;
 
             .console-log__channel-select {
                 flex: 4;

--- a/console/src/feature/pagerduty/task/Alert.tsx
+++ b/console/src/feature/pagerduty/task/Alert.tsx
@@ -195,12 +195,7 @@ const AlertContextMenu = ({ keys, onRemove, onSetEnabled }: AlertContextMenuProp
             </PMenu.Item>
           )}
           <PMenu.Divider />
-          {canRemove && (
-            <PMenu.Item itemKey="remove" onClick={() => onRemove(keys)}>
-              <Icon.Close />
-              Remove
-            </PMenu.Item>
-          )}
+          {canRemove && <ContextMenu.RemoveItem onClick={() => onRemove(keys)} />}
           <PMenu.Divider />
         </>
       )}

--- a/console/src/platform/context-menu/RemoveItem.spec.tsx
+++ b/console/src/platform/context-menu/RemoveItem.spec.tsx
@@ -1,0 +1,26 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { Menu } from "@synnaxlabs/pluto";
+import { screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { ContextMenu } from "@/platform/context-menu";
+import { renderWithConsole } from "@/testutil";
+
+describe("ContextMenu.RemoveItem", () => {
+  it("renders the Remove label", async () => {
+    await renderWithConsole(
+      <Menu.Menu>
+        <ContextMenu.RemoveItem />
+      </Menu.Menu>,
+    );
+    expect(screen.getByText("Remove")).toBeTruthy();
+  });
+});

--- a/console/src/platform/context-menu/RemoveItem.tsx
+++ b/console/src/platform/context-menu/RemoveItem.tsx
@@ -1,0 +1,22 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { Icon, Menu } from "@synnaxlabs/pluto";
+import { type ReactElement } from "react";
+
+export interface RemoveItemProps extends Omit<Menu.ItemProps, "itemKey"> {}
+
+/** Takes an entry out of the list being edited. For destroying a cluster resource,
+ * use {@link DeleteItem} instead. */
+export const RemoveItem = (props: RemoveItemProps): ReactElement => (
+  <Menu.Item itemKey="remove" {...props}>
+    <Icon.Close />
+    Remove
+  </Menu.Item>
+);

--- a/console/src/platform/context-menu/external.ts
+++ b/console/src/platform/context-menu/external.ts
@@ -11,4 +11,5 @@ export * from "@/platform/context-menu/DeleteItem";
 export * from "@/platform/context-menu/FavoriteItems";
 export * from "@/platform/context-menu/Menu";
 export * from "@/platform/context-menu/ReloadConsoleItem";
+export * from "@/platform/context-menu/RemoveItem";
 export * from "@/platform/context-menu/RenameItem";

--- a/console/src/platform/task/ChannelList.tsx
+++ b/console/src/platform/task/ChannelList.tsx
@@ -111,12 +111,7 @@ const ContextMenu = <C extends Channel>({
       {!isPreview && (
         <>
           <Menu.Divider />
-          {canRemove && (
-            <Menu.Item itemKey="remove" onClick={handleRemove}>
-              <Icon.Close />
-              Remove
-            </Menu.Item>
-          )}
+          {canRemove && <PlatformContextMenu.RemoveItem onClick={handleRemove} />}
           <Menu.Divider />
         </>
       )}

--- a/console/src/platform/vis/Controls.css
+++ b/console/src/platform/vis/Controls.css
@@ -19,7 +19,7 @@
 }
 
 .pluto-tabs__content:hover .console-controls,
-.console-controls:focus-within,
+.console-controls:has(:focus-visible),
 .console-controls:has(.console-controls--pinned) {
     opacity: 1;
 }
@@ -37,7 +37,7 @@
 }
 
 .pluto-tabs__content:not(:hover)
-    .console-controls:has(.console-controls--pinned):not(:focus-within) {
+    .console-controls:has(.console-controls--pinned):not(:has(:focus-visible)) {
     & > *,
     & :has(.console-controls--pinned) > * {
         opacity: 0;

--- a/console/src/platform/vis/Controls.spec.tsx
+++ b/console/src/platform/vis/Controls.spec.tsx
@@ -7,8 +7,8 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { screen } from "@testing-library/react";
-import { describe, expect, it } from "vitest";
+import { fireEvent, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
 
 import { Vis } from "@/platform/vis";
 import { renderWithConsole } from "@/testutil";
@@ -24,5 +24,29 @@ describe("Vis.Controls", () => {
     const box = child.parentElement;
     expect(box?.className).toContain("console-controls");
     expect(box?.className).toContain("extra");
+  });
+
+  it("keeps a double click off the visualization behind it", async () => {
+    const onDoubleClick = vi.fn();
+    await renderWithConsole(
+      <div onDoubleClick={onDoubleClick}>
+        <Vis.Controls>
+          <button>Pause</button>
+        </Vis.Controls>
+      </div>,
+    );
+    fireEvent.doubleClick(screen.getByRole("button", { name: "Pause" }));
+    expect(onDoubleClick).not.toHaveBeenCalled();
+  });
+
+  it("lets a caller override the double click handler", async () => {
+    const onDoubleClick = vi.fn();
+    await renderWithConsole(
+      <Vis.Controls onDoubleClick={onDoubleClick}>
+        <button>Pause</button>
+      </Vis.Controls>,
+    );
+    fireEvent.doubleClick(screen.getByRole("button", { name: "Pause" }));
+    expect(onDoubleClick).toHaveBeenCalledOnce();
   });
 });

--- a/console/src/platform/vis/Controls.tsx
+++ b/console/src/platform/vis/Controls.tsx
@@ -9,7 +9,7 @@
 
 import "@/platform/vis/Controls.css";
 
-import { Flex } from "@synnaxlabs/pluto";
+import { Flex, stopPropagation } from "@synnaxlabs/pluto";
 import { type ReactElement } from "react";
 
 import { CSS } from "@/platform/css";
@@ -26,6 +26,7 @@ export const Controls = ({ className, ...rest }: ControlsProps): ReactElement =>
     role="toolbar"
     className={CSS.cls(CSS.B("controls"), className)}
     gap="small"
+    onDoubleClick={stopPropagation}
     {...rest}
   />
 );

--- a/docs/site/src/styles/pluto.css
+++ b/docs/site/src/styles/pluto.css
@@ -100,9 +100,13 @@
             }
         }
 
-        &.pluto--selected .pluto-text {
-            color: var(--pluto-text-color);
-            font-weight: 500;
+        &.pluto--selected {
+            box-shadow: inset 3px 0 0 0 var(--pluto-primary-z);
+
+            & .pluto-text {
+                color: var(--pluto-text-color);
+                font-weight: 500;
+            }
         }
 
         &:not(.pluto--has-children):not(.pluto--selected) {

--- a/pluto/src/button/Button.spec.tsx
+++ b/pluto/src/button/Button.spec.tsx
@@ -225,6 +225,24 @@ describe("Button", () => {
       const c = render(<Button.Button preventClick>Hello</Button.Button>);
       expect(c.getByText("Hello").className).toContain("pluto-btn--prevent-click");
     });
+
+    it("should cancel the press default on the chassis itself", () => {
+      const c = render(
+        <Button.Button preventClick el="div">
+          Hello
+        </Button.Button>,
+      );
+      expect(fireEvent.mouseDown(c.getByText("Hello"))).toBe(false);
+    });
+
+    it("should leave the press default alone for a focusable descendant", () => {
+      const c = render(
+        <Button.Button preventClick el="div">
+          <input aria-label="alias" />
+        </Button.Button>,
+      );
+      expect(fireEvent.mouseDown(c.getByLabelText("alias"))).toBe(true);
+    });
   });
 
   describe("disabled", () => {

--- a/pluto/src/button/Button.tsx
+++ b/pluto/src/button/Button.tsx
@@ -75,6 +75,9 @@ const resolveTriggerIndicator = (
   return undefined;
 };
 
+const FOCUSABLE =
+  'a[href], button, input, select, textarea, [contenteditable="true"], [tabindex]';
+
 /**
  * Use is a basic button component.
  * @param props - Props for the component, which are passed down to the underlying
@@ -155,8 +158,15 @@ const Base = <E extends ElementType = "button">({
 
   const handleMouseDown = (e: any) => {
     // Preventing default on mousedown cancels a native dragstart, so skip it for
-    // draggable buttons (e.g. roving-tabindex tabs that are also drag sources).
-    if (tabIndex == -1 && draggable !== true) e.preventDefault();
+    // draggable buttons (e.g. roving-tabindex tabs that are also drag sources). The
+    // cancelled default also moves focus, so skip it when a focusable descendant owns
+    // the press: the chassis is not the element the browser would focus.
+    if (
+      tabIndex == -1 &&
+      draggable !== true &&
+      (e.target as HTMLElement).closest(FOCUSABLE) === e.currentTarget
+    )
+      e.preventDefault();
     onMouseDown?.(e);
     if (isDisabled || preview === true || parsedDelay.isZero) return;
     document.addEventListener(

--- a/pluto/src/list/Item.css
+++ b/pluto/src/list/Item.css
@@ -19,6 +19,12 @@
     min-height: 5.5rem;
     border-radius: var(--pluto-border-radius-small);
 
+    /* Pairs with the hover and press gate in Button.css: a row that swallows its
+       own click is a container, not a control. */
+    &.pluto-btn--prevent-click {
+        cursor: default;
+    }
+
     /* Rows speak the list selection tier. The extra .pluto-btn outranks the
        control-tier default in Button.css; color resets to inherited because rows
        carry multi-color content. */

--- a/pluto/src/log/Base.tsx
+++ b/pluto/src/log/Base.tsx
@@ -245,7 +245,7 @@ export const Base = ({
     <Menu.ContextMenu className={menuClassName} menu={menuContent} {...menuProps}>
       <div
         ref={combinedRef}
-        tabIndex={0}
+        tabIndex={-1}
         className={CSS.cls(CSS.B("log"), className)}
         onWheel={(e) => {
           if (e.deltaY < 0 && !scrolling) setHold(true);

--- a/pluto/src/log/Log.css
+++ b/pluto/src/log/Log.css
@@ -18,6 +18,11 @@
     cursor: text;
     user-select: none;
 
+    &:focus,
+    &:focus-visible {
+        outline: none;
+    }
+
     & .pluto-log__content {
         height: 100%;
     }

--- a/pluto/src/schematic/node/general/scale/Primitive.tsx
+++ b/pluto/src/schematic/node/general/scale/Primitive.tsx
@@ -18,15 +18,30 @@ interface RenderProps extends Pick<Config, "indicator"> {
   className?: string;
 }
 
-const CONTAINER_STYLE: CSSProperties = { width: 40, height: 64, position: "relative" };
+// Authored at the size the picker shows: neighbors get 0.75 from Primitive.Div, a
+// chassis this one cannot take because it forces fill: none over the bar and caret.
+const WIDTH = 30;
+const HEIGHT = 48;
+const CONTAINER_STYLE: CSSProperties = {
+  width: WIDTH,
+  height: HEIGHT,
+  position: "relative",
+};
 
-const PREVIEW_RATIO = 0.6;
-const BAR_LEFT = 5;
-const BAR_RIGHT = 19;
-const BAR_TOP = 4;
-const BAR_BOTTOM = 60;
-const VALUE_Y = BAR_BOTTOM - (BAR_BOTTOM - BAR_TOP) * PREVIEW_RATIO;
-const TICK_YS = [BAR_TOP, VALUE_Y, BAR_BOTTOM];
+const BAR_LEFT = 4;
+const BAR_RIGHT = 16;
+const BAR_TOP = 3;
+const BAR_BOTTOM = 45;
+const TICK_LENGTH = 3;
+const CARET_SIZE = 3;
+const TICK_RATIOS = [0, 0.5, 1];
+// Kept off every tick ratio so the caret can never sit under a tick.
+const VALUE_RATIO = 0.75;
+
+const alongBar = (ratio: number): number => BAR_BOTTOM - (BAR_BOTTOM - BAR_TOP) * ratio;
+
+const VALUE_Y = alongBar(VALUE_RATIO);
+const TICK_YS = TICK_RATIOS.map(alongBar);
 
 const AXIS_FALLBACK = "var(--pluto-gray-l8)";
 
@@ -41,7 +56,7 @@ export const Scale = ({
   const axis = color.isZero(axisColor) ? AXIS_FALLBACK : color.hex(axisColor);
   return (
     <div className={CSS.cls(CSS.B("symbol-colored"), className)} style={containerStyle}>
-      <svg width="40" height="64" style={{ position: "absolute" }}>
+      <svg width={WIDTH} height={HEIGHT} style={{ position: "absolute" }}>
         {showFill && (
           <>
             <rect
@@ -74,23 +89,23 @@ export const Scale = ({
             strokeWidth={1}
           />
         )}
-        {showCaret && (
-          <path
-            d={`M ${BAR_RIGHT} ${VALUE_Y} L ${BAR_RIGHT + 5} ${VALUE_Y - 5} L ${BAR_RIGHT + 5} ${VALUE_Y + 5} Z`}
-            fill="var(--pluto-symbol-display)"
-          />
-        )}
         {TICK_YS.map((y) => (
           <line
             key={y}
             x1={BAR_RIGHT}
             y1={y}
-            x2={BAR_RIGHT + 4}
+            x2={BAR_RIGHT + TICK_LENGTH}
             y2={y}
             stroke={axis}
             strokeWidth={1}
           />
         ))}
+        {showCaret && (
+          <path
+            d={`M ${BAR_RIGHT} ${VALUE_Y} L ${BAR_RIGHT + CARET_SIZE} ${VALUE_Y - CARET_SIZE} L ${BAR_RIGHT + CARET_SIZE} ${VALUE_Y + CARET_SIZE} Z`}
+            fill="var(--pluto-symbol-display)"
+          />
+        )}
       </svg>
     </div>
   );

--- a/pluto/src/telem/control/Controller.tsx
+++ b/pluto/src/telem/control/Controller.tsx
@@ -30,8 +30,6 @@ export interface ContextValue {
   acquire: () => void;
   release: () => void;
   status: control.Status;
-  /** True while the controller is barred from holding control. */
-  disabled: boolean;
 }
 
 const [Context, useContext] = context.create<ContextValue>({
@@ -41,7 +39,6 @@ const [Context, useContext] = context.create<ContextValue>({
     acquire: () => {},
     release: () => {},
     status: "released",
-    disabled: false,
   },
   displayName: "Control.Context",
 });
@@ -75,9 +72,8 @@ export const Controller = ({
       acquire: methods.acquire,
       release: methods.release,
       status: status ?? "released",
-      disabled,
     }),
-    [key, needsControlOf, methods.acquire, methods.release, status, disabled],
+    [key, needsControlOf, methods.acquire, methods.release, status],
   );
   return (
     <Context value={value}>

--- a/pluto/src/telem/control/aether/controller.spec.ts
+++ b/pluto/src/telem/control/aether/controller.spec.ts
@@ -172,6 +172,28 @@ const interceptWrites = (
   return { openWriter, openCount: () => opens, writeCount: () => writes };
 };
 
+/**
+ * A writer factory whose open blocks until `finishOpen` is called, counting the writes
+ * that reach the Core. Lets a test change state while an acquisition is in flight.
+ */
+const gateWriter = () => {
+  let finishOpen!: () => void;
+  const gate = new Promise<void>((resolve) => (finishOpen = resolve));
+  let writes = 0;
+  const openWriter: OpenWriter = async (client, config) => {
+    await gate;
+    const w = await client.openWriter(config);
+    const write = w.write.bind(w);
+    return Object.assign(Object.create(w) as framer.Writer, {
+      write: async (...args: Parameters<typeof write>) => {
+        writes += 1;
+        return await write(...args);
+      },
+    });
+  };
+  return { openWriter, finishOpen: () => finishOpen(), writeCount: () => writes };
+};
+
 /** Binds every Controller the harness mounts to `openWriter`. */
 const registryWith = (openWriter: OpenWriter): aether.ComponentRegistry => ({
   [Controller.TYPE]: class extends Controller {
@@ -324,6 +346,34 @@ describe("control/aether/Controller", SUITE, () => {
     await controller.set({ [ch.key]: [1] });
     expect(openCount()).toEqual(0);
     expect(controller.state.status).not.toEqual("acquired");
+  });
+
+  it("should stand down when a write's writer opens after it was disabled", async () => {
+    const ch = await createIndexed();
+    const { openWriter, finishOpen, writeCount } = gateWriter();
+    const { controller, setState } = await setup(ch.key, openWriter);
+    controller.create(setChannelValue({ channel: ch.key }));
+    await expect.poll(() => controller.state.needsControlOf, POLL).toContain(ch.key);
+    const write = controller.set({ [ch.key]: [1] });
+    setState({ disabled: true });
+    finishOpen();
+    await write;
+    expect(writeCount()).toEqual(0);
+    expect(controller.state.status).toEqual("released");
+  });
+
+  it("should keep a writer the user asks for while a write is acquiring", async () => {
+    const ch = await createIndexed();
+    const { openWriter, finishOpen } = gateWriter();
+    const { controller, setState } = await setup(ch.key, openWriter);
+    controller.create(setChannelValue({ channel: ch.key }));
+    await expect.poll(() => controller.state.needsControlOf, POLL).toContain(ch.key);
+    const write = controller.set({ [ch.key]: [1] });
+    setState({ disabled: true });
+    controller.acquire();
+    finishOpen();
+    await write;
+    await expect.poll(() => controller.state.status, POLL).toEqual("acquired");
   });
 
   it("should keep control while it is not disabled", async () => {

--- a/pluto/src/telem/control/aether/controller.spec.ts
+++ b/pluto/src/telem/control/aether/controller.spec.ts
@@ -304,16 +304,26 @@ describe("control/aether/Controller", SUITE, () => {
     await expect.poll(() => source.value().message, POLL).toEqual("Uncontrolled");
   });
 
-  it("should release a writer that opened after it was disabled", async () => {
+  it("should take control when asked explicitly while disabled", async () => {
     const ch = await createIndexed();
     const { controller, source, setState } = await setup(ch.key);
     controller.create(setChannelValue({ channel: ch.key }));
-    // Disabling before the writer opens leaves nothing for afterUpdate to release, so
-    // only the check the acquire runs on its own way out catches this.
-    controller.acquire();
     setState({ disabled: true });
-    await expect.poll(() => controller.state.status, POLL).toEqual("released");
-    await expect.poll(() => source.value().message, POLL).toEqual("Uncontrolled");
+    controller.acquire();
+    await expect.poll(() => source.value().variant, POLL).toEqual("success");
+    expect(controller.state.status).toEqual("acquired");
+  });
+
+  it("should refuse to open a writer for a write while disabled", async () => {
+    const ch = await createIndexed();
+    const { openWriter, openCount } = interceptWrites();
+    const { controller, setState } = await setup(ch.key, openWriter);
+    controller.create(setChannelValue({ channel: ch.key }));
+    await expect.poll(() => controller.state.needsControlOf, POLL).toContain(ch.key);
+    setState({ disabled: true });
+    await controller.set({ [ch.key]: [1] });
+    expect(openCount()).toEqual(0);
+    expect(controller.state.status).not.toEqual("acquired");
   });
 
   it("should keep control while it is not disabled", async () => {

--- a/pluto/src/telem/control/aether/controller.ts
+++ b/pluto/src/telem/control/aether/controller.ts
@@ -108,6 +108,9 @@ export class Controller
   private readonly openWriter: OpenWriter;
   private writer?: framer.Writer;
   private acquirePromise?: Promise<void>;
+  /** Set while an acquisition the user asked for is in flight. The disabled bar does
+   * not apply to it: taking control is what clears the bar. */
+  private acquireExplicit = false;
 
   constructor(
     props: aether.ComponentConstructorProps,
@@ -158,6 +161,7 @@ export class Controller
   }
 
   acquire(): void {
+    this.acquireExplicit = true;
     this.internal.runAsync(() => this.doAcquire(), "failed to acquire control");
   }
 
@@ -172,6 +176,7 @@ export class Controller
       await this.acquirePromise;
     } finally {
       this.acquirePromise = undefined;
+      this.acquireExplicit = false;
     }
   }
 
@@ -198,6 +203,9 @@ export class Controller
         authorities: this.state.authority,
         autoIndex: true,
       });
+      // disabled can turn on while the writer opens. afterUpdate cannot catch that,
+      // because the status is not acquired yet.
+      if (!this.acquireExplicit && this.state.disabled) return await this.doRelease();
       this.setState((p) => ({ ...p, status: "acquired" }));
     } catch (err) {
       this.setState((p) => ({ ...p, status: "failed" }));

--- a/pluto/src/telem/control/aether/controller.ts
+++ b/pluto/src/telem/control/aether/controller.ts
@@ -47,8 +47,9 @@ export const controllerStateZ = z.object({
   authority: z.number().default(0),
   status: statusZ.optional(),
   needsControlOf: channel.keyZ.array().default([]),
-  // Bars the controller from holding write authority. It gives up any control it holds
-  // and refuses to take more until this clears.
+  // Bars the controller from writing or taking control on its own. It gives up any
+  // control it holds. An explicit acquire is still honored, so a caller that sets this
+  // owns what taking control means for its own state.
   disabled: z.boolean().default(false),
 });
 
@@ -157,7 +158,6 @@ export class Controller
   }
 
   acquire(): void {
-    if (this.state.disabled) return;
     this.internal.runAsync(() => this.doAcquire(), "failed to acquire control");
   }
 
@@ -198,7 +198,6 @@ export class Controller
         authorities: this.state.authority,
         autoIndex: true,
       });
-      if (this.state.disabled) return await this.doRelease();
       this.setState((p) => ({ ...p, status: "acquired" }));
     } catch (err) {
       this.setState((p) => ({ ...p, status: "failed" }));
@@ -241,6 +240,7 @@ export class Controller
   }
 
   private async withRetry(fn: () => Promise<void>): Promise<void> {
+    if (this.state.disabled) return;
     if (this.writer == null) await this.doAcquire();
     try {
       await fn();

--- a/pluto/src/telem/control/menu/ToggleItem.spec.tsx
+++ b/pluto/src/telem/control/menu/ToggleItem.spec.tsx
@@ -41,18 +41,19 @@ const renderItem = (
 };
 
 describe("Control.Menu.ToggleItem", () => {
-  it("should offer control while the controller is not disabled", () => {
+  it("should offer control", () => {
     const item = renderItem(<Control.Menu.ToggleItem />);
     expect(item.textContent).toContain("Take control");
     expect(item.getAttribute("aria-disabled")).toBeNull();
   });
 
-  it("should bar control while the controller is disabled", () => {
+  it("should still offer control while the controller is disabled", () => {
     const item = renderItem(<Control.Menu.ToggleItem />, { disabled: true });
-    expect(item.getAttribute("aria-disabled")).toEqual("true");
+    expect(item.textContent).toContain("Take control");
+    expect(item.getAttribute("aria-disabled")).toBeNull();
   });
 
-  it("should stay barred when only the caller disables it", () => {
+  it("should bar control when the caller disables it", () => {
     const item = renderItem(<Control.Menu.ToggleItem disabled />);
     expect(item.getAttribute("aria-disabled")).toEqual("true");
   });

--- a/pluto/src/telem/control/menu/ToggleItem.tsx
+++ b/pluto/src/telem/control/menu/ToggleItem.tsx
@@ -18,19 +18,15 @@ export interface ToggleItemProps extends Omit<
   "itemKey" | "onClick" | "children"
 > {}
 
-export const ToggleItem = ({
-  disabled,
-  ...rest
-}: ToggleItemProps): ReactElement | null => {
-  const { key, status, acquire, release, disabled: barred } = useContext();
+export const ToggleItem = (props: ToggleItemProps): ReactElement | null => {
+  const { key, status, acquire, release } = useContext();
   if (key === "") return null;
   const acquired = status === "acquired";
   return (
     <Item
       itemKey="control-toggle"
       onClick={() => (acquired ? release() : acquire())}
-      disabled={disabled || barred}
-      {...rest}
+      {...props}
     >
       <Icon.Control />
       {acquired ? "Release control" : "Take control"}


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4680](https://linear.app/synnax/issue/SY-4680/minor-ui-tweaks)

## Description

A group of small interaction and appearance fixes across the documentation site, Pluto,
and the Console.

**Documentation site navigation.** The selected page lost its marker. The RFC 0050
redesign moved the Pluto list item selected state onto background tokens, and the page
navigation sets `background: none` on tree items, so nothing was left to see. The blue
accent bar is restored in the site's own stylesheet.

**List rows that hold controls.** The line plot lines tab and the log channels list are
rows of form controls with nothing to select, yet they carried hover and press states.
They now pass `preventClick`, which already gates those states in `Button.css`, and the
cursor follows it. The log toolbar's hand-rolled version of the same effect is removed.

**Button focus.** `preventClick` sets `tabIndex` to -1, and the button then cancelled the
press default for every press that reached it, not only presses on the chassis. Focus
never landed on a nested input, so the alias field in a log channel row could not be
clicked. The cancel now applies only when the chassis itself is what the browser would
focus. This also repairs the range metadata rows, which had the same latent break.

**Log viewport.** It is out of the tab order and no longer paints a focus ring, matching
the diagram. Only the diagram was ever patched for this.

**Visualization controls.** A double click on the control cluster no longer reaches the
visualization behind it, where it opens the toolbar. The line plot cluster now sits
where the log's and the schematic's do: its wrapper padding already supplies the inset
the others get from the controls' own offset, so the offset is zeroed and the range
annotation special case disappears. The cluster stays visible for keyboard focus only,
because a click leaves focus on the button and the line plot, unlike the other two, has
no focusable root to take it back.

Tests cover the two behavioral changes: the Button press-default guard and the double
click containment. The rest is CSS, and jsdom applies no stylesheets, so an assertion
there would pass with the rules deleted.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR applies minor interaction and appearance refinements across the documentation site, Pluto, and Console.
- Restores selected-page navigation styling and adjusts visualization control placement and focus behavior.
- Makes control-bearing list rows inert without blocking their nested inputs.
- Restores the post-open controller guard while preserving user-requested acquisition during disabled edit state.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The previously reported disabled-acquisition race is resolved by rechecking the disabled state after the writer opens, while the explicit-acquisition exception is intentional and covered by the overlap test; no blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pluto/src/telem/control/aether/controller.ts | Restores the post-open disabled-state check and distinguishes explicit acquisition so automatic writes stand down without discarding user-requested control. |
| pluto/src/telem/control/aether/controller.spec.ts | Covers delayed automatic acquisition, explicit acquisition while disabled, and the shared-promise overlap ordering. |
| pluto/src/button/Button.tsx | Limits press-default cancellation to the button chassis so nested focusable controls can receive focus. |
| console/src/platform/vis/Controls.tsx | Contains double-clicks within visualization control clusters while allowing callers to override the handler. |

<sub>Reviews (2): Last reviewed commit: ["SY-4680: Resize the scale preview and cl..."](https://github.com/synnaxlabs/synnax/commit/0037c91d676bbcbcf0f8152a5695b8da03911e8b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55350219)</sub>

<!-- /greptile_comment -->