### PR TITLE
SY-4679: Deflake the TypeScript client test suite

### DIFF
--- a/client/ts/src/arc/arc.spec.ts
+++ b/client/ts/src/arc/arc.spec.ts
@@ -15,7 +15,12 @@ import { AccessDeniedError } from "@/errors";
 import { query } from "@/query";
 import { status } from "@/status";
 import { task } from "@/task";
-import { createTestClient, createTestClientWithPolicy, expectLive } from "@/testutil";
+import {
+  createTestClient,
+  createTestClientWithPolicy,
+  expectLive,
+  waitForStreamLive,
+} from "@/testutil";
 
 const client = createTestClient();
 
@@ -257,10 +262,12 @@ describe("arc", () => {
   });
 
   describe("task sync", () => {
-    // The writing client's task cache still holds the pre-dispatch copy, so
-    // assertions read through a fresh client to reach the Core.
+    // The writing client's task cache still holds the pre-dispatch copy, so assertions
+    // read through a fresh client to reach the Core. That client learns of a rewrite
+    // through the task set signal, so its stream must be live first.
     it("rewrites the task config when a dispatch changes the content", async () => {
       const fresh = createTestClient();
+      await waitForStreamLive(fresh.connection);
       const rack = await client.racks.create({ name: `rack-${id.create()}` });
       const created = await client.arcs.create(newTextArc(`sync-${id.create()}`));
       const deployed = await client.arcs.setRack(created.key, rack.key);
@@ -268,13 +275,16 @@ describe("arc", () => {
       const gen = new crdt.Text(2);
       const ops = gen.insert(0, "x -> y").map((op) => arc.insertChar(op));
       await client.arcs.dispatch(created.key, ops);
+      await expect
+        .poll(async () => (await fresh.tasks.retrieve(deployed.key)).configHash)
+        .not.toEqual(deployed.configHash);
       const synced = await fresh.tasks.retrieve(deployed.key);
       expect(synced.config.hash).not.toEqual(deployed.config.hash);
-      expect(synced.configHash).not.toEqual(deployed.configHash);
     });
 
     it("restores the deployed config when an edit is undone", async () => {
       const fresh = createTestClient();
+      await waitForStreamLive(fresh.connection);
       const rack = await client.racks.create({ name: `rack-${id.create()}` });
       const created = await client.arcs.create(newTextArc(`undo-${id.create()}`));
       const deployed = await client.arcs.setRack(created.key, rack.key);
@@ -282,9 +292,15 @@ describe("arc", () => {
       const gen = new crdt.Text(2);
       const [op] = gen.insert(0, "x");
       await client.arcs.dispatch(created.key, [arc.insertChar(op)]);
+      // Waiting for the edit to reach the task keeps the undo assertion from passing
+      // against a config the insert has not touched yet.
+      await expect
+        .poll(async () => (await fresh.tasks.retrieve(deployed.key)).configHash)
+        .not.toEqual(deployed.configHash);
       await client.arcs.dispatch(created.key, [arc.deleteChar({ id: op.id })]);
-      const synced = await fresh.tasks.retrieve(deployed.key);
-      expect(synced.configHash).toEqual(deployed.configHash);
+      await expect
+        .poll(async () => (await fresh.tasks.retrieve(deployed.key)).configHash)
+        .toEqual(deployed.configHash);
     });
   });
 });

--- a/client/ts/src/channel/channel.spec.ts
+++ b/client/ts/src/channel/channel.spec.ts
@@ -505,6 +505,10 @@ describe("cached reads", () => {
     }, 30000);
 
     it("fetches only the names the store cannot resolve", async () => {
+      // Created before the local client exists, so neither its cache nor its change
+      // stream ever carries it. Severing proves the fetch went out for this name and
+      // not for the known one.
+      const unknown = await createVirtual(remote);
       const proxy = await createSeverableProxy();
       const local = createTestClient({
         ...TEST_CLIENT_PARAMS,
@@ -513,9 +517,6 @@ describe("cached reads", () => {
       });
       try {
         const known = await createVirtual(local);
-        // Created by another client, so `local` has never seen it. Severing
-        // proves the fetch went out for this name and not for the known one.
-        const unknown = await createVirtual(remote);
         await proxy.sever();
         await expect(
           local.channels.retrieve([known.name, unknown.name]),

--- a/client/ts/src/connection/downtime.spec.ts
+++ b/client/ts/src/connection/downtime.spec.ts
@@ -18,6 +18,7 @@ import {
   type SeverableProxy,
   TEST_CLIENT_PARAMS,
   waitForStatus,
+  waitForStreamLive,
 } from "@/testutil";
 
 interface ProxiedClient {
@@ -76,10 +77,7 @@ describe("downtime", () => {
         client.projects.create({ name: "unreachable", layout: {} }),
       ).rejects.toThrow(DisconnectedError);
       await proxy.restore();
-      const status = await waitForStatus(
-        client.connection,
-        ({ variant, details }) => variant === "success" && details.streamLive,
-      );
+      const status = await waitForStreamLive(client.connection);
       expect(status.details.clusterKey).toBe(firstKey);
       // A fresh write proves the unary path recovered, not just the check loop.
       const recovered = await client.projects.create({ name: "recovered", layout: {} });
@@ -133,10 +131,7 @@ describe("downtime", () => {
       await proxy.restore();
       const created = await inFlight;
       expect(created.name).toBe("blip");
-      await waitForStatus(
-        client.connection,
-        ({ variant, details }) => variant === "success" && details.streamLive,
-      );
+      await waitForStreamLive(client.connection);
       expect(internal.map(chainOf)).toEqual([]);
     } finally {
       await client.close();

--- a/client/ts/src/framer/cache/dynamic.spec.ts
+++ b/client/ts/src/framer/cache/dynamic.spec.ts
@@ -241,8 +241,10 @@ describe("DynamicCache", () => {
         );
         expect(allocated.timeRange.end.valueOf()).toEqual(TimeStamp.MAX.valueOf());
         expect(flushed).toHaveLength(10);
+        // Slack for a loaded runner: the buffer's span tracks wall time, so the bound
+        // only has to rule out a span untethered from it.
         expect(flushed.timeRange.span.sub(waitSpan).valueOf()).toBeLessThanOrEqual(
-          TimeSpan.milliseconds(20).valueOf(),
+          TimeSpan.milliseconds(500).valueOf(),
         );
         expect(flushed.series[0].data.slice(0, 3)).toEqual(new Float32Array([1, 2, 3]));
         expect(flushed.series[0].data.slice(3, 6)).toEqual(new Float32Array([1, 2, 3]));

--- a/client/ts/src/framer/reader.spec.ts
+++ b/client/ts/src/framer/reader.spec.ts
@@ -695,6 +695,8 @@ describe("Reader", () => {
       const nonEmptyValues = firstDataRow.filter((v) => v !== "");
       expect(nonEmptyValues.length).toBeGreaterThan(0);
     });
+    // Writing and streaming 100k samples outlasts the default budget on a loaded
+    // runner, so this spec carries its own.
     it("should handle large dense and sparse indexes with correct ordering and merging", async () => {
       const denseSamples = 100_000;
       const sparseStep = 1_000;
@@ -825,6 +827,6 @@ describe("Reader", () => {
       expect(chunkCount).toBeGreaterThan(1);
       expect(totalRows).toBe(denseSamples);
       expect(sparseRows).toBe(sparseSamples);
-    });
+    }, 60_000);
   });
 });

--- a/client/ts/src/ontology/ontology.spec.ts
+++ b/client/ts/src/ontology/ontology.spec.ts
@@ -232,10 +232,6 @@ describe("Ontology", () => {
         parent: ontology.ROOT_ID,
         name: name2,
       });
-      const oldRootLength = (
-        await client.ontology.children.retrieve({ ids: ontology.ROOT_ID })
-      ).length;
-
       await client.ontology.moveChildren(
         ontology.ROOT_ID,
         group.ontologyID(g.key),
@@ -246,10 +242,13 @@ describe("Ontology", () => {
         ids: group.ontologyID(g.key),
       });
       expect(children.length).toEqual(1);
-      const newRootLength = (
+      // Other specs write to the root concurrently, so only the two groups this test
+      // owns can be asserted on.
+      const rootKeys = (
         await client.ontology.children.retrieve({ ids: ontology.ROOT_ID })
-      ).length;
-      expect(newRootLength).toEqual(oldRootLength - 1);
+      ).map(({ key }) => key);
+      expect(rootKeys).toContain(ontology.idToString(group.ontologyID(g.key)));
+      expect(rootKeys).not.toContain(ontology.idToString(group.ontologyID(g2.key)));
     });
   });
 

--- a/client/ts/src/status/status.spec.ts
+++ b/client/ts/src/status/status.spec.ts
@@ -8,7 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { color, id, TimeStamp, uuid } from "@synnaxlabs/x";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it } from "vitest";
 import z from "zod";
 
 import { group } from "@/group";
@@ -18,9 +18,6 @@ import { status } from "@/status";
 import { createTestClient, expectLive } from "@/testutil";
 
 const client = createTestClient();
-// A second client with its own cache: this client learns of its writes only through the
-// cluster's change streams.
-const remote = createTestClient();
 
 describe("Status", () => {
   describe("set", () => {
@@ -194,26 +191,22 @@ describe("Status", () => {
     it("should leave no corpse behind when the write fails", async () => {
       const crude = createCrude();
       const key = crude.key as status.Key;
-      // A second client owns the record, so this one's cache never held it.
-      await remote.statuses.set(crude);
-      const handler = vi.fn();
-      const off = client.statuses.onChange(key, handler);
-      try {
-        await expect(
-          client.statuses.set(
-            { ...crude, message: "replacement" },
-            {
-              onOptimistic: () => {
-                throw new Error("write failed");
-              },
+      await client.statuses.set(crude);
+      // Another client owns the record, and this one neither streams nor subscribes, so
+      // nothing puts the record in its cache before the rollback.
+      const observer = createTestClient();
+      await expect(
+        observer.statuses.set(
+          { ...crude, message: "replacement" },
+          {
+            onOptimistic: () => {
+              throw new Error("write failed");
             },
-          ),
-        ).rejects.toThrow("write failed");
-        expect(client.statuses.getCached(key)).toBeUndefined();
-        expect((await client.statuses.retrieve(key)).message).toEqual(crude.message);
-      } finally {
-        off();
-      }
+          },
+        ),
+      ).rejects.toThrow("write failed");
+      expect(observer.statuses.getCached(key)).toBeUndefined();
+      expect((await observer.statuses.retrieve(key)).message).toEqual(crude.message);
     });
 
     it("should restore the previous status when the write fails", async () => {

--- a/client/ts/src/task/task.spec.ts
+++ b/client/ts/src/task/task.spec.ts
@@ -14,7 +14,7 @@ import { z } from "zod";
 import { ontology } from "@/ontology";
 import { query } from "@/query";
 import { task } from "@/task";
-import { createTestClient } from "@/testutil";
+import { createTestClient, waitForStreamLive } from "@/testutil";
 
 const client = createTestClient();
 
@@ -777,7 +777,14 @@ describe("Task", async () => {
         type: "pagerduty_alert",
       });
       const params = { key: t.key };
-      const off = client.tasks.onChange(params, vi.fn());
+      // The optimistic status is transient: a real one from the cluster replaces it, so
+      // it has to be captured as it is delivered rather than read back later.
+      const loading: Array<NonNullable<task.Task["status"]>> = [];
+      const off = client.tasks.onChange(params, (cached) => {
+        if (!query.isLive(cached)) return;
+        const { status } = cached;
+        if (status?.variant === "loading") loading.push(status);
+      });
       try {
         await client.tasks.retrieve(params);
         await client.statuses.set({
@@ -803,17 +810,9 @@ describe("Task", async () => {
           })
           .toBe("deadbeef");
         await client.tasks.executeCommand({ task: t.key, type: "stop" });
-        await expect
-          .poll(() => {
-            const cached = client.tasks.getCached(params);
-            if (!query.isLive(cached)) return undefined;
-            return cached.status?.variant;
-          })
-          .toBe("loading");
-        const cached = client.tasks.getCached(params);
-        if (!query.isLive(cached)) throw new Error("expected live cached task");
-        expect(cached.status?.details.configHash).toBe("deadbeef");
-        expect(cached.status?.details.rack).toBe(testRack.key);
+        await expect.poll(() => loading.length).toBeGreaterThan(0);
+        expect(loading[0].details.configHash).toBe("deadbeef");
+        expect(loading[0].details.rack).toBe(testRack.key);
       } finally {
         off();
       }
@@ -826,7 +825,9 @@ describe("Task", async () => {
         type: "pagerduty_alert",
       });
       const remote = createTestClient();
-      await remote.connect();
+      // The set signal is the only thing that refreshes a reading client's cache, so a
+      // write before its stream goes live is never seen.
+      await waitForStreamLive(remote.connection);
       const params = { key: t.key };
       const off = remote.tasks.onChange(params, vi.fn());
       try {
@@ -850,7 +851,7 @@ describe("Task", async () => {
 
     it("merges a metadata-only set signal into a cached task", async () => {
       const remote = createTestClient();
-      await remote.connect();
+      await waitForStreamLive(remote.connection);
       const t = await testRack.createTask({
         name: `set-merge-${id.create()}`,
         config: { routingKey: "dog" },
@@ -878,7 +879,7 @@ describe("Task", async () => {
 
     it("fetches an uncached task moved onto a subscribed rack", async () => {
       const remote = createTestClient();
-      await remote.connect();
+      await waitForStreamLive(remote.connection);
       const source = await client.racks.create({ name: `set-move-src-${id.create()}` });
       const dest = await client.racks.create({ name: `set-move-dest-${id.create()}` });
       const t = await source.createTask({

--- a/client/ts/src/testutil/connection.ts
+++ b/client/ts/src/testutil/connection.ts
@@ -31,3 +31,17 @@ export const waitForStatus = async (
     });
   });
 };
+
+/**
+ * Resolves once the handle's change stream is live, so every later cluster write
+ * reaches the client's cache.
+ */
+export const waitForStreamLive = async (
+  handle: connection.Handle,
+  timeout?: TimeSpan,
+): Promise<connection.Status> =>
+  await waitForStatus(
+    handle,
+    ({ variant, details }) => variant === "success" && details.streamLive,
+    timeout,
+  );

--- a/client/ts/src/testutil/proxy.ts
+++ b/client/ts/src/testutil/proxy.ts
@@ -51,7 +51,14 @@ export const createSeverableProxy = async (
 ): Promise<SeverableProxy> => {
   const { host, port } = { ...DEFAULT_TARGET, ...target };
   const sockets = new Set<Socket>();
+  let severed = false;
   const server = createServer((downstream) => {
+    // A connection the kernel accepted before the sever is still delivered after it,
+    // and forwarding it would let a request through a severed link.
+    if (severed) {
+      downstream.destroy();
+      return;
+    }
     const upstream = connect(port, host);
     sockets.add(downstream).add(upstream);
     const destroy = (): void => {
@@ -81,6 +88,7 @@ export const createSeverableProxy = async (
     throw new Error("proxy failed to bind a port");
   const boundPort = address.port;
   const sever = async (): Promise<void> => {
+    severed = true;
     const closed = new Promise<void>((resolve) => server.close(() => resolve()));
     sockets.forEach((socket) => socket.destroy());
     sockets.clear();
@@ -89,7 +97,10 @@ export const createSeverableProxy = async (
   return {
     port: boundPort,
     sever,
-    restore: async () => await listen(boundPort),
+    restore: async () => {
+      severed = false;
+      await listen(boundPort);
+    },
     close: sever,
   };
 };


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4679](https://linear.app/synnax/issue/SY-4679/fix-failing-typescript-client-tests)

## Description

The client suite failed in CI on assertions that raced the cluster. Every one had
the same shape: a test read a client cache the cluster had not refreshed yet, or
asserted on state that other specs share.

Reading clients now wait for their change stream to go live before the write they
observe, so the set signal that refreshes their cache cannot be missed. Tests
whose premise is "this client has never seen the record" now create the record
before the reading client exists, because a live stream mirrors every write. The
one test that polled for a transient optimistic status now records it as it is
delivered. Assertions on the ontology root name the records the test owns instead
of counting children other specs create. Two wall-clock bounds got slack for a
loaded runner.

The severable test proxy also drops connections the kernel accepted before the
sever, which could otherwise carry a request through a link the test believes is
down.

Verified with eight consecutive clean runs of the full client suite against a live
Core.

Two flakes found in those repeat runs are not fixed here, and neither appears in
the CI runs on the issue. `framer/feed.spec.ts` read back fewer samples than it
wrote, which reads as real sample loss rather than a test defect.
`project.spec.ts` search returned every project while the index lagged, which
only reproduced against a local Core holding many runs of accumulated data.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR deflakes the TypeScript client suite by synchronizing tests with live change streams, isolating shared state, capturing transient status updates as delivered, and relaxing two timing budgets. It also strengthens the severable test proxy by rejecting connections accepted while the link is severed.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| client/ts/src/status/status.spec.ts | Reworks the failed optimistic-write test so the observer begins without the pre-existing status in its cache. |
| client/ts/src/testutil/connection.ts | Adds a focused helper that waits until a client's change stream is live. |
| client/ts/src/testutil/proxy.ts | Tracks severed state and destroys late-accepted connections before they can be forwarded. |
| client/ts/src/task/task.spec.ts | Synchronizes remote readers with their streams and records transient optimistic task status in the change callback. |
| client/ts/src/arc/arc.spec.ts | Waits for task rewrites and undo propagation instead of immediately reading asynchronously refreshed state. |
| client/ts/src/ontology/ontology.spec.ts | Replaces a shared root-child count assertion with checks scoped to records owned by the test. |

<sub>Reviews (2): Last reviewed commit: ["SY-4679: Deflake the TypeScript client t..."](https://github.com/synnaxlabs/synnax/commit/09a4a36d97fe6d00c594bbc2d7fd58a4f9f92c57) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55352446)</sub>

<!-- /greptile_comment -->