### PR TITLE
SY-4678: Fix flaky Core cert test

### DIFF
--- a/x/go/io/fs/mem.go
+++ b/x/go/io/fs/mem.go
@@ -58,7 +58,7 @@ func (y *MemFS) Open(fullName string, flag int) (File, error) {
 			if flag&os.O_TRUNC != 0 {
 				n.mu.Lock()
 				n.mu.data = n.mu.data[:0]
-				n.mu.modTime = time.Now()
+				n.touch()
 				n.mu.Unlock()
 			}
 
@@ -271,6 +271,17 @@ func (f *memNode) ModTime() time.Time {
 	return f.mu.modTime
 }
 
+// touch advances the modification time. The caller must hold f.mu. The new time is
+// always strictly after the old one: the Windows wall clock is too coarse to separate
+// writes landing in the same tick, and callers detect a change by comparing mod times.
+func (f *memNode) touch() {
+	now := time.Now()
+	if !now.After(f.mu.modTime) {
+		now = f.mu.modTime.Add(time.Nanosecond)
+	}
+	f.mu.modTime = now
+}
+
 const standardPerm = UserRWX | GroupRX | OtherRX
 
 func (f *memNode) Mode() os.FileMode {
@@ -414,7 +425,7 @@ func (f *memFile) Write(p []byte) (int, error) {
 	}
 	f.n.mu.Lock()
 	defer f.n.mu.Unlock()
-	f.n.mu.modTime = time.Now()
+	f.n.touch()
 	if f.wpos+len(p) <= len(f.n.mu.data) {
 		n := copy(f.n.mu.data[f.wpos:f.wpos+len(p)], p)
 		if n != len(p) {
@@ -439,7 +450,7 @@ func (f *memFile) WriteAt(p []byte, ofs int64) (int, error) {
 	}
 	f.n.mu.Lock()
 	defer f.n.mu.Unlock()
-	f.n.mu.modTime = time.Now()
+	f.n.touch()
 
 	for len(f.n.mu.data) < int(ofs)+len(p) {
 		f.n.mu.data = append(f.n.mu.data, 0)
@@ -478,7 +489,7 @@ func (f *memFile) Truncate(size int64) error {
 
 	f.n.mu.Lock()
 	defer f.n.mu.Unlock()
-	f.n.mu.modTime = time.Now()
+	f.n.touch()
 
 	if size > int64(len(f.n.mu.data)) {
 		f.n.mu.data = append(f.n.mu.data, make([]byte, size-int64(len(f.n.mu.data)))...)

--- a/x/go/io/fs/mem_test.go
+++ b/x/go/io/fs/mem_test.go
@@ -15,13 +15,13 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	xfs "github.com/synnaxlabs/x/io/fs"
+	"github.com/synnaxlabs/x/io/fs"
 	. "github.com/synnaxlabs/x/testutil"
 )
 
 var _ = Describe("Mem", func() {
 	It("Should advance the modification time on every write", func() {
-		fs := xfs.NewMem()
+		fs := fs.NewMem()
 		var prev time.Time
 		for range 100 {
 			f := MustSucceed(fs.Open("f.txt", os.O_CREATE|os.O_WRONLY|os.O_TRUNC))

--- a/x/go/io/fs/mem_test.go
+++ b/x/go/io/fs/mem_test.go
@@ -1,0 +1,35 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+package fs_test
+
+import (
+	"os"
+	"time"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	xfs "github.com/synnaxlabs/x/io/fs"
+	. "github.com/synnaxlabs/x/testutil"
+)
+
+var _ = Describe("Mem", func() {
+	It("Should advance the modification time on every write", func() {
+		fs := xfs.NewMem()
+		var prev time.Time
+		for range 100 {
+			f := MustSucceed(fs.Open("f.txt", os.O_CREATE|os.O_WRONLY|os.O_TRUNC))
+			MustSucceed(f.Write([]byte("tacocat")))
+			Expect(f.Close()).To(Succeed())
+			mod := MustSucceed(fs.Stat("f.txt")).ModTime()
+			Expect(mod).To(BeTemporally(">", prev))
+			prev = mod
+		}
+	})
+})


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4678](https://linear.app/synnax/issue/SY-4678)

## Description

`Cert File Suite` failed intermittently on Windows CI: the "Should reload the
certificate when the files change" spec read back the old `hostA` certificate after the
files were replaced with the `hostB` pair.

The file certificate source detects rotation by comparing file mod times. The mem FS
stamped every write with `time.Now()`, and the Windows wall clock is too coarse to
separate writes that land in the same tick. The two copies got an identical mod time,
so the source served its stale cache.

The mem FS now advances a node's mod time to a value strictly after the previous one, so
a change is always visible. Only the certificate source reads `ModTime()`, so nothing
else is affected.

Verified by simulating a 16 ms clock in the mem FS: the cert spec reproduces the exact
CI failure before the change and passes after it. The new mem FS spec is the regression
guard and fails under the same simulation.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes MemFS modification timestamps strictly increase so rapid certificate-file replacements remain detectable on coarse clocks.
- Adds a locked `touch` helper and applies it to truncation and write paths.
- Adds a MemFS specification asserting that modification times advance across repeated writes.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge after addressing the non-blocking style issues and making the regression test deterministically exercise a same-tick collision.

The monotonic timestamp implementation fixes the current certificate-cache failure without breaking known consumers, but the added test can miss a regression on fine-resolution clocks.

**Files Needing Attention:** x/go/io/fs/mem.go, x/go/io/fs/mem_test.go

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| x/go/io/fs/mem.go | Introduces monotonic per-node modification timestamps; the behavior is sound for current consumers, with one formatting violation. |
| x/go/io/fs/mem_test.go | Adds coverage for increasing timestamps, but does not deterministically reproduce the coarse-clock collision and has a sentence-case violation. |

<sub>Reviews (1): Last reviewed commit: ["SY-4678: Give mem FS strictly increasing..."](https://github.com/synnaxlabs/synnax/commit/3b6676367a4f5f0ff9a173797b997ff8c8909405) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55362593)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/synnaxlabs/synnax/blob/main/CLAUDE.md))

<!-- /greptile_comment -->