### PR TITLE
SY-4681: Fix failing Pluto tests

### DIFF
--- a/pluto/src/mock/setuptests.ts
+++ b/pluto/src/mock/setuptests.ts
@@ -8,9 +8,14 @@
 // included in the file licenses/APL.txt.
 
 import { ResizeObserver } from "@juggle/resize-observer";
+import { configure } from "@testing-library/react";
 import { afterAll, beforeAll, vi } from "vitest";
 
 import { installTestWebSocket } from "@/testutil/websocket";
+
+// Live-core round-trips share the single test cluster with the rest of the suite, so
+// allow more than the 1s waitFor default.
+configure({ asyncUtilTimeout: 5000 });
 
 class MockIntersectionObserver {
   observe = vi.fn();

--- a/pluto/src/mock/setuptests.ts
+++ b/pluto/src/mock/setuptests.ts
@@ -13,8 +13,8 @@ import { afterAll, beforeAll, vi } from "vitest";
 
 import { installTestWebSocket } from "@/testutil/websocket";
 
-// Live-core round-trips share the single test cluster with the rest of the suite, so
-// allow more than the 1s waitFor default.
+// Live-Core round-trips share the single test Core with the rest of the suite, so allow
+// more than the 1s waitFor default.
 configure({ asyncUtilTimeout: 5000 });
 
 class MockIntersectionObserver {

--- a/pluto/src/panel/queries.spec.tsx
+++ b/pluto/src/panel/queries.spec.tsx
@@ -334,15 +334,10 @@ describe("Panel queries", () => {
           <Errors.SuspenseBoundary loading={null}>{children}</Errors.SuspenseBoundary>
         </Provider>
       );
-      let rendered!: RenderHookResult<panel.Key[], unknown>;
-      await act(async () => {
-        rendered = await renderHookSuspended(
-          () => Panel.useKeysByProject({ project: key }),
-          {
-            wrapper: suspended,
-          },
-        );
-      });
+      const rendered: RenderHookResult<panel.Key[], unknown> =
+        await renderHookSuspended(() => Panel.useKeysByProject({ project: key }), {
+          wrapper: suspended,
+        });
       await waitFor(() => expect(rendered.result.current).not.toBeNull());
       return rendered;
     };

--- a/pluto/src/testutil/render.tsx
+++ b/pluto/src/testutil/render.tsx
@@ -15,8 +15,9 @@ import {
   type RenderHookResult,
   type RenderOptions as RTLRenderOptions,
   type RenderResult as RTLRenderResult,
+  waitFor,
 } from "@testing-library/react";
-import { type FC, type PropsWithChildren, type ReactElement } from "react";
+import { type FC, type PropsWithChildren, type ReactElement, useEffect } from "react";
 
 import { Aether } from "@/aether";
 import { type aether } from "@/aether/aether";
@@ -47,15 +48,29 @@ export interface RenderResult extends RTLRenderResult {
 /**
  * Renders a hook that suspends on a cold cache, resolving once its render commits.
  * RTL's own `renderHook` never commits a tree that suspends during the initial render,
- * leaving `result.current` null forever.
+ * leaving `result.current` null forever. Never call this inside an `act` scope: the
+ * commit it waits on cannot land until that scope exits.
  */
 export const renderHookSuspended = async <Result, Props>(
   hook: (props: Props) => Result,
   options?: RenderHookOptions<Props>,
 ): Promise<RenderHookResult<Result, Props>> => {
+  let committed = false;
+  const Tracked = (props: Props): Result => {
+    const result = hook(props);
+    useEffect(() => {
+      committed = true;
+    }, []);
+    return result;
+  };
   let rendered!: RenderHookResult<Result, Props>;
+  // An async act drains microtasks and React work, but not a fetch still in flight, so
+  // the commit is waited on rather than assumed.
   await act(async () => {
-    rendered = rtlRenderHook(hook, options);
+    rendered = rtlRenderHook(Tracked, options);
+  });
+  await waitFor(() => {
+    if (!committed) throw new Error("the suspended render never committed");
   });
   return rendered;
 };

--- a/pluto/vite.config.ts
+++ b/pluto/vite.config.ts
@@ -94,6 +94,7 @@ export default defineConfig({
       ),
     },
     setupFiles: ["src/mock/setuptests.ts"],
+    testTimeout: 15_000,
     exclude: ["**/node_modules/**", "**/dist/**"],
     coverage: {
       include: ["src/**/*.ts", "src/**/*.tsx"],


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4681](https://linear.app/synnax/issue/SY-4681)

## Description

`renderHookSuspended` returned as soon as its async act drained. An act drains
microtasks and React work, but not a fetch still in flight, so the helper could hand
back before the suspended render committed. Specs then read a cache the hook had not
filled yet. `Access Queries > useEnsurePermissions > should cache the policies of
another subject` failed this way in four of the linked runs, and reproduced locally in
four of five runs. The helper now waits for the commit.

The Panel `useKeysByProject` helper wrapped `renderHookSuspended` in a second `act`.
The helper owns its own act, and the commit it now waits on cannot land while an outer
act scope holds the queue, so the redundant wrapper is removed.

Live-core specs also get the 5s `waitFor` budget the Console already uses. A 1s default
is too tight for a chain of Core round-trips on a loaded runner, which is how
`useDrifted > should not drift while the deployed instance matches`,
`use > should update when task status changes`, and
`useForm > should save form changes when save is called` each timed out.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR stabilizes Pluto’s asynchronous and live-Core tests by waiting for suspended hooks to commit and fitting the expanded React Testing Library wait budget inside a longer Vitest timeout.
- Tracks suspended-hook commits before returning from `renderHookSuspended`.
- Removes the redundant outer `act` from panel query tests.
- Sets the global `waitFor` budget to 5 seconds and Pluto’s test timeout to 15 seconds.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| pluto/src/testutil/render.tsx | Updates the suspended-hook helper to wait for a committed effect before returning. |
| pluto/src/panel/queries.spec.tsx | Removes the outer `act` that would prevent the newly awaited commit from landing. |
| pluto/src/mock/setuptests.ts | Expands React Testing Library’s asynchronous utility timeout for live-Core round trips. |
| pluto/vite.config.ts | Raises Pluto’s test timeout so the five-second asynchronous wait budget fits within the test lifecycle. |

<sub>Reviews (2): Last reviewed commit: ["SY-4681: Fit the waitFor budget inside t..."](https://github.com/synnaxlabs/synnax/commit/6c090bdfa9a43d38fad66570736458ad1cef24a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55372994)</sub>

<!-- /greptile_comment -->