### PR TITLE
SY-4683: Deflake the X Python timing tests

### DIFF
--- a/x/py/tests/test_timing.py
+++ b/x/py/tests/test_timing.py
@@ -44,10 +44,15 @@ class TestTiming:
 
     def test_sleep_rate(self) -> None:
         """Should sleep correctly based on a rate argument."""
-        t = Timer()
-        sleep(100 * Rate.HZ, precise=True)
-        assert t.elapsed() < TimeSpan.MILLISECOND * 11
-        assert t.elapsed() > TimeSpan.MILLISECOND * 9
+        samples: list[int] = []
+        for _ in range(10):
+            t = Timer()
+            sleep(100 * Rate.HZ, precise=True)
+            samples.append(t.elapsed())
+        # A wrong rate conversion is off by an order of magnitude, so bound the median
+        # loosely. test_loop covers the precision of the sleep itself.
+        median = TimeSpan(int(np.median(samples)))
+        assert TimeSpan.MILLISECOND * 5 < median < TimeSpan.MILLISECOND * 20
 
     def test_poll_returns_value_when_condition_met(self) -> None:
         """Should return the non-None value when the condition is met."""
@@ -91,13 +96,17 @@ class TestTiming:
         take a long time.
         """
         loop = Loop(TimeSpan.MILLISECOND * 10, precise=True)
-        i = 0
-        start = time.perf_counter_ns()
+        periods: list[int] = []
+        last = time.perf_counter_ns()
         with loop:
             for _ in loop:
-                i += 1
-                if i == 10:
+                now = time.perf_counter_ns()
+                periods.append(now - last)
+                last = now
+                if len(periods) == 20:
                     break
                 sleep(TimeSpan.MILLISECOND * 5, precise=True)
-        end = time.perf_counter_ns()
-        assert TimeSpan(end - start) < TimeSpan.MILLISECOND * 110
+        # The median period resists a scheduler stall that would skew the total. Without
+        # the loop, the 5 ms of work makes each period 15 ms.
+        median = TimeSpan(int(np.median(periods)))
+        assert TimeSpan.MILLISECOND * 8 < median < TimeSpan.MILLISECOND * 11

--- a/x/py/tests/test_timing.py
+++ b/x/py/tests/test_timing.py
@@ -43,14 +43,12 @@ class TestTiming:
         assert sum(accumulated_precise) < sum(accumulated_standard)
 
     def test_sleep_rate(self) -> None:
-        """Should sleep correctly based on a rate argument."""
+        """Should convert a rate argument into the equivalent sleep duration."""
         samples: list[int] = []
         for _ in range(10):
             t = Timer()
             sleep(100 * Rate.HZ, precise=True)
             samples.append(t.elapsed())
-        # A wrong rate conversion is off by an order of magnitude, so bound the median
-        # loosely. test_loop covers the precision of the sleep itself.
         median = TimeSpan(int(np.median(samples)))
         assert TimeSpan.MILLISECOND * 5 < median < TimeSpan.MILLISECOND * 20
 
@@ -106,7 +104,5 @@ class TestTiming:
                 if len(periods) == 20:
                     break
                 sleep(TimeSpan.MILLISECOND * 5, precise=True)
-        # The median period resists a scheduler stall that would skew the total. Without
-        # the loop, the 5 ms of work makes each period 15 ms.
         median = TimeSpan(int(np.median(periods)))
         assert TimeSpan.MILLISECOND * 8 < median < TimeSpan.MILLISECOND * 11


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4683](https://linear.app/synnax/issue/SY-4683)

## Description

`test_loop` failed on the macOS runner in 2 of the last 3 `Test - X (Python)`
failures. Both it and `test_sleep_rate` budgeted a fixed percentage over a
~100 ms wall clock, so one OS scheduler stall on a loaded runner exceeded the
bound. The failing run measured 131 ms against a 110 ms ceiling.

Both tests now assert on the median sample instead of the total, which discards
the stall outliers while keeping what each test verifies:

- `test_loop` records each iteration period and bounds the median to 8-11 ms.
  This is stronger than the old check, which had no lower bound at all. If the
  loop stopped absorbing the 5 ms of in-loop work, the median goes to 15 ms.
- `test_sleep_rate` bounds the median loosely. It verifies the `Rate` to
  duration conversion, and a wrong conversion is off by an order of magnitude.
  `test_loop` and `test_sleep` cover the precision of the sleep itself.

Verified by reproducing the failure under CPU contention, then running the suite
100 times at a load representative of the 3-core macOS runner with no failures.
Two mutations of `Loop` (never sleeping, and not absorbing loop-body time) both
fail the new assertions.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes Python timing tests less sensitive to isolated scheduler stalls while retaining checks on rate conversion and loop timing.
- Samples repeated sleeps and validates their median duration.
- Records individual loop periods and bounds their median.
- Replaces reviewer-facing rationale with concise behavioral docstrings.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| x/py/tests/test_timing.py | Reworks timing assertions around median samples and fully resolves the prior documentation-style feedback without introducing an eligible follow-up issue. |

<sub>Reviews (2): Last reviewed commit: ["Move the timing test rationale into the ..."](https://github.com/synnaxlabs/synnax/commit/7f148a9aaa15a0ecd783cbb02b96aaccdbac8efb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55384275)</sub>

<!-- /greptile_comment -->