### PR TITLE
SY-4685: Deflake the C++ streamer set_channels test

### DIFF
--- a/client/cpp/framer/streamer_test.cpp
+++ b/client/cpp/framer/streamer_test.cpp
@@ -7,6 +7,8 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+#include <chrono>
+#include <future>
 #include <thread>
 
 #include "gtest/gtest.h"
@@ -62,13 +64,11 @@ TEST(StreamerTests, testStreamSetChannels) {
     auto data = create_virtual_channel(client);
     auto now = x::telem::TimeStamp::now();
 
-    auto streamer = ASSERT_NIL_P(client.telem.open_streamer(
-        synnax::framer::StreamerConfig{
-            {},
-        }
-    ));
+    auto streamer = ASSERT_NIL_P(
+        client.telem.open_streamer(synnax::framer::StreamerConfig{})
+    );
 
-    auto set_err = streamer.set_channels({data.key});
+    ASSERT_NIL(streamer.set_channels({data.key}));
 
     auto writer = ASSERT_NIL_P(client.telem.open_writer(
         synnax::framer::WriterConfig{
@@ -78,9 +78,6 @@ TEST(StreamerTests, testStreamSetChannels) {
             x::control::Subject{"test_writer"}
         }
     ));
-    // Sleep for 5 milliseconds to allow for the streamer to process the updated keys.
-    std::this_thread::sleep_for(std::chrono::milliseconds(5));
-    ASSERT_NIL(set_err);
 
     auto frame = x::telem::Frame(1);
     frame.emplace(
@@ -89,8 +86,22 @@ TEST(StreamerTests, testStreamSetChannels) {
             std::vector<float>{1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0}
         )
     );
-    ASSERT_NIL(writer.write(frame));
-    auto res_frame = ASSERT_NIL_P(streamer.read());
+
+    // The Core does not acknowledge an updated key set, so a write can reach the relay
+    // before the update does and be dropped. Write until the streamer receives a frame,
+    // closing the send side to unblock the read once the deadline expires.
+    auto read = std::async(std::launch::async, [&] { return streamer.read(); });
+    const auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    x::errors::Error write_err;
+    while (read.wait_for(std::chrono::milliseconds(10)) != std::future_status::ready) {
+        write_err = writer.write(frame);
+        if (write_err || std::chrono::steady_clock::now() > deadline) {
+            streamer.close_send();
+            break;
+        }
+    }
+    ASSERT_NIL(write_err);
+    auto res_frame = ASSERT_NIL_P(read.get());
 
     ASSERT_EQ(res_frame.size(), 1);
     ASSERT_EQ(res_frame.series->at(0).values<float>()[0], 1.0);

--- a/client/cpp/framer/streamer_test.cpp
+++ b/client/cpp/framer/streamer_test.cpp
@@ -9,7 +9,6 @@
 
 #include <chrono>
 #include <future>
-#include <thread>
 
 #include "gtest/gtest.h"
 
@@ -215,9 +214,6 @@ void test_downsample(
         synnax::framer::StreamerConfig{channels, downsample_factor}
     ));
 
-    // Sleep for 5 milliseconds to allow for the streamer to bootstrap.
-    std::this_thread::sleep_for(std::chrono::milliseconds(5));
-
     auto frame = x::telem::Frame(1);
     frame.emplace(data.key, x::telem::Series(raw_data));
     ASSERT_NIL(writer.write(frame));
@@ -348,8 +344,6 @@ void test_downsample_string(
     auto streamer = ASSERT_NIL_P(client.telem.open_streamer(
         synnax::framer::StreamerConfig{channels, downsample_factor}
     ));
-
-    std::this_thread::sleep_for(std::chrono::milliseconds(5));
 
     auto frame = x::telem::Frame(
         virtual_channel.key,

--- a/client/cpp/framer/writer_test.cpp
+++ b/client/cpp/framer/writer_test.cpp
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-#include <thread>
+#include <chrono>
 
 #include "gtest/gtest.h"
 
@@ -431,27 +431,38 @@ TEST(WriterTests, testSetAuthorityFireAndForgetTakesEffect) {
         false
     ));
 
-    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    // The release is not acknowledged, so a writer opened right after it can still be
+    // locked out. Retry until the release lands.
+    const auto take_control = [&]() -> x::errors::Error {
+        auto [w2, open_err] = client.telem.open_writer(
+            synnax::framer::WriterConfig{
+                .channels = std::vector{time.key, data.key},
+                .start = x::telem::TimeStamp::now(),
+                .authorities =
+                    std::vector{
+                        x::control::AUTHORITY_ABSOLUTE,
+                        x::control::AUTHORITY_ABSOLUTE
+                    },
+                .subject = x::control::Subject{"writer_2"},
+                .err_on_unauthorized = true
+            }
+        );
+        if (open_err) return open_err;
+        const auto now = x::telem::TimeStamp::now();
+        auto frame = x::telem::Frame(2);
+        frame.emplace(time.key, x::telem::Series(now + x::telem::SECOND));
+        frame.emplace(data.key, x::telem::Series(std::vector<uint8_t>{42}));
+        auto err = w2.write(frame);
+        if (!err) err = w2.commit().second;
+        const auto close_err = w2.close();
+        return err ? err : close_err;
+    };
+    ASSERT_EVENTUALLY_NIL_WITH_TIMEOUT(
+        take_control(),
+        std::chrono::seconds(10),
+        std::chrono::milliseconds(50)
+    );
 
-    auto w2 = ASSERT_NIL_P(client.telem.open_writer(
-        synnax::framer::WriterConfig{
-            .channels = std::vector{time.key, data.key},
-            .start = x::telem::TimeStamp::now(),
-            .authorities = std::
-                vector{x::control::AUTHORITY_ABSOLUTE, x::control::AUTHORITY_ABSOLUTE},
-            .subject = x::control::Subject{"writer_2"},
-            .err_on_unauthorized = true
-        }
-    ));
-
-    auto now = x::telem::TimeStamp::now();
-    auto frame = x::telem::Frame(2);
-    frame.emplace(time.key, x::telem::Series(now + x::telem::SECOND));
-    frame.emplace(data.key, x::telem::Series(std::vector<uint8_t>{42}));
-    ASSERT_NIL(w2.write(frame));
-    ASSERT_NIL_P(w2.commit());
-
-    ASSERT_NIL(w2.close());
     ASSERT_NIL(w1.close());
 }
 

--- a/x/cpp/test/test.h
+++ b/x/cpp/test/test.h
@@ -497,6 +497,20 @@ auto assert_occurred_as_p(
 #define ASSERT_EVENTUALLY_NIL(expr)                                                    \
     x::test::eventually_nil([&]() { return (expr); }, __FILE__, __LINE__)
 
+/// @brief macro asserting that the provided error will eventually be NIL, with a
+/// custom timeout and interval.
+/// @param expr The expression to evaluate
+/// @param timeout Maximum time to wait for the error to become nil
+/// @param interval Time to wait between checks
+#define ASSERT_EVENTUALLY_NIL_WITH_TIMEOUT(expr, timeout, interval)                    \
+    x::test::eventually_nil(                                                           \
+        [&]() { return (expr); },                                                      \
+        __FILE__,                                                                      \
+        __LINE__,                                                                      \
+        (timeout),                                                                     \
+        (interval)                                                                     \
+    )
+
 /// @brief Asserts that a pair's error component will eventually become nil and
 /// returns the value component
 /// @tparam T The type of the value component in the pair

--- a/x/cpp/test/test_test.cpp
+++ b/x/cpp/test/test_test.cpp
@@ -111,6 +111,21 @@ TEST_F(XTestTest, TestEventuallyLEWithCustomTimeout) {
     t.join();
 }
 
+/// @brief it should eventually return a nil error with custom timeout.
+TEST_F(XTestTest, TestEventuallyNILWithCustomTimeout) {
+    std::thread t([this] {
+        std::this_thread::sleep_for(std::chrono::milliseconds(150));
+        counter = 1;
+    });
+
+    ASSERT_EVENTUALLY_NIL_WITH_TIMEOUT(
+        counter.load() == 1 ? errors::NIL : errors::VALIDATION,
+        std::chrono::milliseconds(200),
+        std::chrono::milliseconds(10)
+    );
+    t.join();
+}
+
 /// @brief it should unwrap successful results with ASSERT_NIL_P.
 TEST_F(XTestTest, TestMustSucceedSuccess) {
     auto successful_op = []() -> std::pair<int, errors::Error> {


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4685](https://linear.app/synnax/issue/SY-4685)

## Description

`StreamerTests.testStreamSetChannels` hung on CI until the Bazel 600 s test
timeout, which failed the whole C++ client job.

The Core acknowledges a streamer open (`SendOpenAck`), but it does not
acknowledge an updated key set. The test slept 5 ms after `set_channels` and
then wrote once, so on a loaded runner the write reached the relay before the
update and was dropped. `read()` then blocked forever. Locally the update needs
about 100 ms to land, so the 5 ms sleep was never enough.

The test now writes in a loop until the streamer receives a frame. A 10 s
deadline closes the send side, so a real regression fails with an error instead
of hanging the job.

This also removes the other fixed sleeps in the framer tests:

- The 5 ms sleeps in the downsample helpers are dead weight. The streamer open
  ack is already a happens-before barrier for every later write.
- `testSetAuthorityFireAndForgetTakesEffect` slept 50 ms for an unacknowledged
  authority release. It now opens the second writer and takes control in a
  retry loop.

`ASSERT_EVENTUALLY_NIL` was the only eventual assertion without a
`_WITH_TIMEOUT` variant, which the header already promises for every family, so
this adds it.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR replaces a timing-dependent sleep in the C++ streamer channel-update test with repeated writes and a bounded deadline intended to prevent indefinite blocking.
- Starts the streamer read asynchronously.
- Retries writes until a frame arrives or ten seconds elapse.
- Half-closes the streamer send side when the deadline or a write error is reached.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete blocking or independently actionable non-blocking issue identified.

The changed test retries writes while waiting for the asynchronously received frame and adds a bounded failure path; the investigated batching, isolation, and lifecycle concerns did not establish an observable defect.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| client/cpp/framer/streamer_test.cpp | Reworks the set-channels test synchronization to tolerate delayed subscription propagation; no concrete actionable defect was established. |

<sub>Reviews (1): Last reviewed commit: ["SY-4685: Deflake the C++ streamer set\_ch..."](https://github.com/synnaxlabs/synnax/commit/243c0bfbfb4e449e68f2285d775867ad54fb74eb) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55402813)</sub>

<!-- /greptile_comment -->