### PR TITLE
SY-4690: Fix the failing Core server gRPC spec

### DIFF
--- a/core/pkg/server/grpc_test.go
+++ b/core/pkg/server/grpc_test.go
@@ -15,13 +15,17 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"github.com/synnaxlabs/synnax/pkg/server"
+	"github.com/synnaxlabs/x/address"
+	"github.com/synnaxlabs/x/net"
 	. "github.com/synnaxlabs/x/testutil"
 )
 
 var _ = Describe("Grpc", func() {
 	It("Should start a grpc server", func() {
+		port := MustSucceed(net.FindOpenPort())
+		addr := address.Newf("localhost:%d", port)
 		b := MustSucceed(server.Serve(server.Config{
-			Listeners: []server.Listener{{Address: "localhost:26260"}},
+			Listeners: []server.Listener{{Address: addr}},
 			Security: server.SecurityConfig{
 				Insecure: new(true),
 			},

--- a/core/pkg/server/http_redirect_test.go
+++ b/core/pkg/server/http_redirect_test.go
@@ -20,7 +20,9 @@ import (
 	"github.com/synnaxlabs/synnax/pkg/security/cert/file"
 	"github.com/synnaxlabs/synnax/pkg/security/mock"
 	"github.com/synnaxlabs/synnax/pkg/server"
+	"github.com/synnaxlabs/x/address"
 	xfs "github.com/synnaxlabs/x/io/fs"
+	"github.com/synnaxlabs/x/net"
 	. "github.com/synnaxlabs/x/testutil"
 )
 
@@ -37,10 +39,12 @@ var _ = Describe("HttpRedirect", func() {
 			"/usr/local/synnax/certs/node.crt",
 			"/usr/local/synnax/certs/node.key",
 		))
+		port := MustSucceed(net.FindOpenPort())
+		addr := address.Newf("localhost:%d", port)
 		received := false
 		b := MustSucceed(server.Serve(server.Config{
 			Listeners: []server.Listener{{
-				Address: "localhost:26260",
+				Address: addr,
 				TLS:     prov.TLSConfigFor(src),
 			}},
 			Security: server.SecurityConfig{Insecure: new(false)},
@@ -60,7 +64,7 @@ var _ = Describe("HttpRedirect", func() {
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true},
 		}
 		client := &http.Client{Transport: tr}
-		resp, err := client.Get("http://localhost:26260")
+		resp, err := client.Get("http://" + addr.String())
 		Expect(err).To(Succeed())
 		Expect(resp.StatusCode).To(Equal(http.StatusOK))
 		Expect(received).To(BeTrue())


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4690](<https://linear.app/synnax/issue/SY-4690>)

## Description

The `Grpc` and `HttpRedirect` specs in `core/pkg/server` both bound `localhost:26260`.
Ginkgo runs the suite across parallel processes, so the two specs raced for the port and
one lost the bind:

```
listen tcp :26260: bind: Only one usage of each socket address ... is normally permitted.
```

Both specs now take an open port from `net.FindOpenPort`, the pattern the sibling `HTTP`
and `MultiListener` specs already use. No hardcoded port remains in the package.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR replaces two fixed Core test ports with dynamically selected ports to reduce collisions between parallel Ginkgo processes.

- Updates the gRPC server spec to select an available port.
- Updates the HTTP redirect spec and its client URL to use the selected address.
- The probe and final bind remain separate operations, so a narrow port-allocation race remains.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, but a narrow non-blocking port-allocation race remains in both tests.

The dynamic ports remove the deterministic shared-port collision, while the released probe listener still permits another process to claim a selected port before the Core binds it.

**Files Needing Attention:** core/pkg/server/grpc_test.go and core/pkg/server/http_redirect_test.go

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| core/pkg/server/grpc_test.go | Uses a dynamic port but retains a narrow probe-then-bind race. |
| core/pkg/server/http_redirect_test.go | Uses the generated address consistently, but retains the same port-allocation race. |

<sub>Reviews (1): Last reviewed commit: ["SY-4690: Bind server specs to open ports..."](https://github.com/synnaxlabs/synnax/commit/f943c12667e26edc4f2ad3cb55fa5dff1c2217c2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55442275)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Core Server](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/core-server.md)

<!-- /greptile_comment -->