### PR TITLE
SY-4692: Stop a stale log worker push from undoing the pause toggle

### DIFF
--- a/pluto/src/log/Base.spec.tsx
+++ b/pluto/src/log/Base.spec.tsx
@@ -48,6 +48,7 @@ const DEFAULT_STATE = {
   region: { one: { x: 0, y: 0 }, two: { x: 400, y: 500 } },
   wheelPos: 0,
   scrolling: false,
+  resumedAt: 0,
   empty: true,
   visible: true,
   channelNamesHidden: false,
@@ -219,7 +220,7 @@ describe("log/Base", () => {
       setupAether({ empty: false, scrolling: true });
       const onHold = vi.fn();
       renderLog({ hold: true, onHold });
-      pushAetherState({ scrolling: false });
+      pushAetherState({ scrolling: false, resumedAt: 1 });
       expect(onHold).toHaveBeenCalledExactlyOnceWith(false);
     });
 
@@ -231,11 +232,45 @@ describe("log/Base", () => {
       expect(onHold).not.toHaveBeenCalled();
     });
 
+    it("should not call onHold when the worker echoes the previous hold state", () => {
+      setupAether({ empty: false, scrolling: true });
+      const onHold = vi.fn();
+      renderLog({ hold: false, onHold });
+      pushAetherState({ scrolling: true });
+      expect(onHold).not.toHaveBeenCalled();
+    });
+
+    it("should not call onHold when a stale push still shows the log live", () => {
+      setupAether({ empty: false, scrolling: false });
+      const onHold = vi.fn();
+      renderLog({ hold: true, onHold });
+      pushAetherState({ scrolling: false });
+      expect(onHold).not.toHaveBeenCalled();
+    });
+
+    it("should call onHold once per resume", () => {
+      setupAether({ empty: false, scrolling: true });
+      const onHold = vi.fn();
+      renderLog({ hold: true, onHold });
+      pushAetherState({ scrolling: false, resumedAt: 1 });
+      pushAetherState({ scrolling: false, resumedAt: 1 });
+      expect(onHold).toHaveBeenCalledExactlyOnceWith(false);
+    });
+
+    it("should ignore a resume stamp older than the last one seen", () => {
+      setupAether({ empty: false, scrolling: true });
+      const onHold = vi.fn();
+      renderLog({ hold: true, onHold });
+      pushAetherState({ scrolling: false, resumedAt: 2 });
+      pushAetherState({ scrolling: false, resumedAt: 1 });
+      expect(onHold).toHaveBeenCalledExactlyOnceWith(false);
+    });
+
     it("should not call onHold on a worker push when hold is uncontrolled", () => {
       setupAether({ empty: false, scrolling: true });
       const onHold = vi.fn();
       renderLog({ onHold });
-      pushAetherState({ scrolling: false });
+      pushAetherState({ scrolling: false, resumedAt: 1 });
       expect(onHold).not.toHaveBeenCalled();
     });
 

--- a/pluto/src/log/aether/Log.spec.ts
+++ b/pluto/src/log/aether/Log.spec.ts
@@ -209,6 +209,17 @@ describe("log/aether/Log", () => {
       updateState({ scrolling: true, empty: false, wheelPos: 0 });
       expect(log.state.scrolling).toBe(false);
     });
+
+    it("should stamp resumedAt only when it resumes on its own", () => {
+      const entries = Array.from({ length: 100 }, (_, i) => makeEntry(i));
+      const { log, updateState } = setup(entries);
+      updateState({ scrolling: false, empty: false });
+      updateState({ scrolling: true, empty: false, wheelPos: 0 });
+      updateState({ scrolling: true, empty: false, wheelPos: 300 });
+      expect(log.state.resumedAt).toBe(0);
+      updateState({ scrolling: true, empty: false, wheelPos: 0 });
+      expect(log.state.resumedAt).toBeGreaterThan(0);
+    });
   });
 
   describe("entries", () => {

--- a/pluto/src/log/aether/Log.ts
+++ b/pluto/src/log/aether/Log.ts
@@ -43,6 +43,7 @@ export const logStateZ = log.logZ
     region: box.box,
     wheelPos: z.number(),
     scrolling: z.boolean(),
+    resumedAt: z.number().default(0),
     empty: z.boolean(),
     visible: z.boolean(),
     // channelNames: server-side display names (fetched fresh, never persisted)
@@ -241,7 +242,11 @@ export class Log extends aether.Leaf<typeof logStateZ, InternalState> {
       // taken at the bottom starts there, so it takes a return or a downward scroll.
       if (scrollState.offset < this.entries.length) scrollState.awayFromEnd = true;
       else if (scrollState.awayFromEnd || dist < 0)
-        this.setState((s) => ({ ...s, scrolling: false }));
+        this.setState((s) => ({
+          ...s,
+          scrolling: false,
+          resumedAt: performance.now(),
+        }));
     }
 
     this.entries = this.internal.telem.value();

--- a/pluto/src/log/use.ts
+++ b/pluto/src/log/use.ts
@@ -14,6 +14,7 @@ import {
   useCallback,
   useEffect,
   useMemo,
+  useRef,
 } from "react";
 import { type z } from "zod";
 
@@ -33,6 +34,7 @@ export interface UseProps
         | "scrollback"
         | "empty"
         | "scrolling"
+        | "resumedAt"
         | "wheelPos"
         | "selectionStart"
         | "selectionEnd"
@@ -113,12 +115,14 @@ export const use = ({
   });
 
   const holdRef = useSyncedRef(hold);
-  // The worker resumes on its own once the user has scrolled back to the bottom. It
-  // pushes for other reasons too, so only a value that disagrees with hold is a change.
+  const resumedAtRef = useRef(0);
+  // The worker stamps resumedAt when it resumes on its own. Its pushes can still echo
+  // a stale scrolling value after a hold change, so the stamp is the only signal.
   const handleAetherChange = useCallback(
-    ({ scrolling }: LogState) => {
-      const { current: hold } = holdRef;
-      if (hold != null && scrolling !== hold) onHold?.(scrolling);
+    ({ resumedAt }: LogState) => {
+      if (resumedAt <= resumedAtRef.current) return;
+      resumedAtRef.current = resumedAt;
+      if (holdRef.current != null) onHold?.(false);
     },
     [onHold],
   );


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4692](https://linear.app/synnax/issue/SY-4692)

## Description

Fixes the flaky `console/log/log_lifecycle` integration test. Its pause/resume step fails when the `pages` sequence runs six cases at once: the resume click lands but the toggle stays pressed. The flake is a real Console bug that load exposes, not a test timing issue.

Clicking pause or resume on a log could silently do nothing. The Console (Redux `hold`) and the Pluto log worker (`scrolling`) both own the pause flag, and the worker pushes its full state on every `setState`. The hold button's mousedown bubbles into the log and starts a worker round trip; when that push lands after the click flipped `hold`, `use.ts` read `scrolling !== hold` as a worker-side change and flipped `hold` back. Load only decides the ordering.

The worker now stamps `resumedAt` when it resumes on its own, the only time it changes `scrolling` itself. `use.ts` calls `onHold(false)` when the stamp advances and ignores the raw `scrolling` value. The stamp is monotonic, so a stale value the main thread sends back is harmless. No user-facing behavior changes; `resumedAt` is in-memory worker state and is not persisted.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents stale Aether state pushes from undoing log pause changes.

- Adds a worker-generated `resumedAt` stamp for autonomous resumes.
- Uses monotonic resume stamps instead of echoed `scrolling` values to update controlled hold state.
- Adds unit coverage for stale, duplicate, and older worker pushes.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The resume stamp prevents stale full-state pushes from changing the controlled hold state, and the added tests cover the relevant ordering cases without exposing a concrete regression.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| pluto/src/log/aether/Log.ts | Adds the default resume stamp and updates it only when the worker resumes autonomously. |
| pluto/src/log/use.ts | Replaces raw scrolling reconciliation with monotonic resume-stamp handling. |
| pluto/src/log/Base.spec.tsx | Tests duplicate, stale, echoed, controlled, and uncontrolled resume notifications. |
| pluto/src/log/aether/Log.spec.ts | Verifies that only an autonomous worker resume updates the stamp. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant UI as React log
  participant Store as Aether store
  participant Worker as Log worker
  UI->>Store: Set hold / scrolling
  Store->>Worker: Push full state
  Worker->>Worker: Resume at log end
  Worker->>Worker: "Set scrolling=false and resumedAt"
  Worker->>Store: Push full state
  Store->>UI: Deliver resumedAt
  UI->>UI: Ignore old stamp or call onHold(false)
```

<sub>Reviews (1): Last reviewed commit: ["SY-4692: Stop a stale log worker push fr..."](https://github.com/synnaxlabs/synnax/commit/0b9b4446aba3e4da27ceab8737de7ea85b6c9a70) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55479151)</sub>

<!-- /greptile_comment -->