### PR TITLE
SY-4693: Anchor the loop timer to its deadline

### DIFF
--- a/driver/modbus/read_task_test.cpp
+++ b/driver/modbus/read_task_test.cpp
@@ -7,6 +7,10 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+#include <iomanip>
+#include <iostream>
+#include <thread>
+
 #include "gtest/gtest.h"
 
 #include "client/cpp/testutil/testutil.h"
@@ -20,6 +24,20 @@
 #include "driver/pipeline/mock/pipeline.h"
 
 namespace driver::modbus {
+/// @brief Allowed relative error of a task's achieved sample rate.
+constexpr double RATE_TOLERANCE = 0.10;
+/// @brief Wall time each rate runs for.
+const auto RATE_SPAN = 1 * x::telem::SECOND;
+
+/// @brief Logs the rate a task held and checks it against the tolerance.
+void expect_rate(const double measured, const int rate_hz) {
+    const double error = (measured - rate_hz) / rate_hz * 100;
+    std::cout << std::fixed << std::setprecision(1);
+    std::cout << rate_hz << " Hz: " << measured << " Hz measured (" << error << "%)\n";
+    EXPECT_NEAR(measured, rate_hz, rate_hz * RATE_TOLERANCE)
+        << "at " << rate_hz << " Hz";
+}
+
 /// @brief Test fixture for Modbus read task tests.
 class ModbusReadTest : public ::testing::Test {
 protected:
@@ -914,5 +932,59 @@ TEST_F(ModbusReadTest, testAutoStartFalse) {
     // Stop the task to clean up
     synnax::task::Command stop_cmd{.task = task.key, .type = "stop"};
     configured_task->exec(stop_cmd);
+}
+
+/// @brief it should hold each configured sample rate over time.
+TEST_F(ModbusReadTest, testHoldsSampleRate) {
+    mock::SlaveConfig slave_cfg;
+    slave_cfg.input_registers[0] = 42;
+    slave_cfg.host = "127.0.0.1";
+    slave_cfg.port = 1502;
+    auto slave = mock::Slave(slave_cfg);
+    ASSERT_NIL(slave.start());
+    x::defer::defer stop_slave([&slave] { slave.stop(); });
+
+    const auto data_channel = ASSERT_NIL_P(client->channels.create(
+        make_unique_channel_name("rate_input"),
+        x::telem::UINT16_T,
+        index_channel.key,
+        false
+    ));
+
+    for (const int rate_hz: {25, 50, 100}) {
+        auto cfg = create_base_config();
+        cfg["sample_rate"] = rate_hz;
+        cfg["stream_rate"] = rate_hz;
+        cfg["channels"].push_back(
+            create_channel_config("input_register", data_channel, 0)
+        );
+        auto p = x::json::Parser(cfg);
+        auto task_cfg = std::make_unique<ReadTaskConfig>(client, p);
+        ASSERT_NIL(p.error());
+
+        auto factory = std::make_shared<pipeline::mock::WriterFactory>();
+        auto devs = std::make_shared<device::Manager>();
+        auto task = common::ReadTask(
+            synnax::task::Task{
+                .rack = rack.key,
+                .name = "rate_test",
+                .type = "modbus_read",
+            },
+            ctx,
+            x::breaker::default_config("rate_test"),
+            std::make_unique<ReadTaskSource>(devs, std::move(*task_cfg)),
+            factory
+        );
+
+        task.start("start_cmd");
+        ASSERT_EVENTUALLY_GE(factory->writes->size(), 1);
+        std::this_thread::sleep_for(RATE_SPAN.chrono());
+        task.stop("stop_cmd", true);
+
+        expect_rate(
+            pipeline::mock::measured_rate(*factory->writes, index_channel.key),
+            rate_hz
+        );
+    }
 }
 }

--- a/driver/opcua/read_task_test.cpp
+++ b/driver/opcua/read_task_test.cpp
@@ -7,6 +7,10 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+#include <iomanip>
+#include <iostream>
+#include <thread>
+
 #include "gtest/gtest.h"
 #include "nlohmann/json.hpp"
 
@@ -19,6 +23,20 @@
 #include "driver/pipeline/mock/pipeline.h"
 
 namespace driver::opcua {
+/// @brief Allowed relative error of a task's achieved sample rate.
+constexpr double RATE_TOLERANCE = 0.10;
+/// @brief Wall time each rate runs for.
+const auto RATE_SPAN = 1 * x::telem::SECOND;
+
+/// @brief Logs the rate a task held and checks it against the tolerance.
+void expect_rate(const double measured, const int rate_hz) {
+    const double error = (measured - rate_hz) / rate_hz * 100;
+    std::cout << std::fixed << std::setprecision(1);
+    std::cout << rate_hz << " Hz: " << measured << " Hz measured (" << error << "%)\n";
+    EXPECT_NEAR(measured, rate_hz, rate_hz * RATE_TOLERANCE)
+        << "at " << rate_hz << " Hz";
+}
+
 class TestReadTask : public ::testing::Test {
 protected:
     synnax::task::Task task;
@@ -1197,5 +1215,28 @@ TEST(OPCReadTaskConfig, testOPCDriverSetsAutoCommitTrue) {
     // Verify that writer_config has enable_auto_commit set to true
     auto writer_cfg = cfg->writer_config();
     ASSERT_TRUE(writer_cfg.enable_auto_commit);
+}
+
+/// @brief it should hold each configured sample rate over time.
+TEST_F(TestReadTask, testHoldsSampleRate) {
+    for (const int rate_hz: {25, 50, 100}) {
+        this->task_cfg_json["sample_rate"] = rate_hz;
+        this->task_cfg_json["stream_rate"] = rate_hz;
+        this->mock_factory = std::make_shared<pipeline::mock::WriterFactory>();
+
+        const auto rt = create_task();
+        rt->start("start_cmd");
+        ASSERT_EVENTUALLY_GE(this->mock_factory->writes->size(), 1);
+        std::this_thread::sleep_for(RATE_SPAN.chrono());
+        rt->stop("stop_cmd", true);
+
+        expect_rate(
+            pipeline::mock::measured_rate(
+                *this->mock_factory->writes,
+                this->index_channel.key
+            ),
+            rate_hz
+        );
+    }
 }
 }

--- a/driver/pipeline/mock/pipeline.h
+++ b/driver/pipeline/mock/pipeline.h
@@ -270,6 +270,26 @@ public:
     }
 };
 
+/// @brief Returns the sample rate the captured frames' own index timestamps imply,
+/// the way the integration suite derives a running task's rate. Returns 0 when fewer
+/// than two samples were written.
+inline double measured_rate(
+    const std::vector<x::telem::Frame> &writes,
+    const synnax::channel::Key index_key
+) {
+    std::vector<x::telem::TimeStamp> stamps;
+    for (const auto &fr: writes) {
+        if (!fr.contains(index_key)) continue;
+        for (size_t i = 0; i < fr.length(); i++)
+            stamps.push_back(
+                fr.at<x::telem::TimeStamp>(index_key, static_cast<int>(i))
+            );
+    }
+    if (stamps.size() < 2) return 0;
+    const auto span = x::telem::TimeSpan(stamps.back() - stamps.front());
+    return static_cast<double>(stamps.size() - 1) / span.seconds();
+}
+
 // Mock implementation of pipeline::Sink for testing.
 class Sink : public pipeline::Sink {
 public:

--- a/integration/tests/driver/task.py
+++ b/integration/tests/driver/task.py
@@ -31,7 +31,7 @@ _STATUS_CHANNEL = "sy_status_set"
 # because the runners host the Core, the Driver, the Console, Playwright, and the
 # Python sims, and NI software (Windows) all at once, and a 1 s window leaves little
 # time to reach steady state.
-RATE_TOLERANCE = 0.50
+RATE_TOLERANCE = 0.20
 
 # ── Channel creation helpers ─────────────────────────────────────
 

--- a/x/cpp/loop/loop.h
+++ b/x/cpp/loop/loop.h
@@ -9,6 +9,7 @@
 
 #pragma once
 
+#include <algorithm>
 #include <chrono>
 #include <cmath>
 #include <thread>
@@ -54,11 +55,14 @@ public:
             return {telem::TimeSpan(elapsed), false};
         }
         const auto remaining = interval - elapsed;
+        const auto deadline = now + remaining.chrono();
         if (this->high_rate())
             this->precise_sleep(remaining);
         else
             std::this_thread::sleep_for(remaining.chrono());
-        last = hs_clock::now();
+        // Anchor to the deadline so a late wake shortens the next sleep instead of
+        // stretching every period. An early wake keeps the wake time.
+        last = std::min(deadline, hs_clock::now());
         return {telem::TimeSpan(elapsed), true};
     }
 
@@ -70,13 +74,14 @@ public:
             return {telem::TimeSpan(elapsed), false};
         }
         const auto remaining = interval - elapsed;
+        const auto deadline = now + remaining.chrono();
         if (this->high_rate())
             this->precise_sleep(remaining);
         else if (this->medium_rate())
             std::this_thread::sleep_for(remaining.chrono());
         else
             breaker.wait_for(remaining);
-        last = hs_clock::now();
+        last = std::min(deadline, hs_clock::now());
         return {telem::TimeSpan(elapsed), true};
     }
 

--- a/x/cpp/loop/loop_test.cpp
+++ b/x/cpp/loop/loop_test.cpp
@@ -7,12 +7,73 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+#include <iomanip>
+#include <iostream>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
 #include "gtest/gtest.h"
 
 #include "x/cpp/loop/loop.h"
 #include "x/cpp/telem/telem.h"
 
 namespace x::loop {
+/// @brief Allowed relative error of a measured rate.
+constexpr double RATE_TOLERANCE = 0.05;
+/// @brief Wall time each rate is measured over.
+constexpr int SPAN_SECONDS = 1;
+
+/// @brief Logs the timer resolution a sleep on this machine rounds up to. Windows
+/// defaults to 15.625 ms, but any process raising it changes what every other process
+/// measures, so the rates below only mean something next to this number.
+void log_timer_resolution() {
+#ifdef _WIN32
+    using Query = LONG(WINAPI *)(PULONG, PULONG, PULONG);
+    const auto ntdll = GetModuleHandleW(L"ntdll.dll");
+// C4191 fires on every GetProcAddress cast; the signature is fixed by the ntdll ABI.
+#pragma warning(push)
+#pragma warning(disable : 4191)
+    const auto query = reinterpret_cast<Query>(
+        GetProcAddress(ntdll, "NtQueryTimerResolution")
+    );
+#pragma warning(pop)
+    if (query == nullptr) {
+        std::cout << "timer resolution: NtQueryTimerResolution unavailable\n";
+        return;
+    }
+    ULONG min_100ns = 0, max_100ns = 0, current_100ns = 0;
+    query(&min_100ns, &max_100ns, &current_100ns);
+    std::cout << std::fixed << std::setprecision(4);
+    std::cout << "timer resolution: " << current_100ns / 10000.0 << " ms current, "
+              << max_100ns / 10000.0 << " ms best, " << min_100ns / 10000.0
+              << " ms default\n";
+#endif
+}
+
+/// @brief Calls wait count times and returns the rate measured from the first return
+/// to the last, the same way the integration tests measure a task's sample rate.
+template<typename Wait>
+double measure_rate(Wait &wait, const int count) {
+    wait();
+    const auto first = hs_clock::now();
+    for (int i = 1; i < count; i++)
+        wait();
+    return (count - 1) / telem::TimeSpan(hs_clock::now() - first).seconds();
+}
+
+/// @brief Logs the rate wait holds at rate_hz and checks it against the tolerance.
+template<typename Wait>
+void expect_rate(Wait wait, const int rate_hz) {
+    const double measured = measure_rate(wait, rate_hz * SPAN_SECONDS);
+    const double error = (measured - rate_hz) / rate_hz * 100;
+    std::cout << std::fixed << std::setprecision(1);
+    std::cout << rate_hz << " Hz: " << measured << " Hz measured (" << error << "%)\n";
+    EXPECT_NEAR(measured, rate_hz, rate_hz * RATE_TOLERANCE)
+        << "at " << rate_hz << " Hz";
+}
+
 /// @brief it should correctly wait for an expended number of requests.
 TEST(LoopTest, testWaitPrecise) {
     const auto rate = telem::HERTZ * 5000;
@@ -87,5 +148,62 @@ TEST(LoopTest, testWaitBreaker) {
         (telem::MILLISECOND * 10).nanoseconds()
     );
     t.join();
+}
+
+/// @brief it should hold each configured rate over time on the sleep path.
+TEST(LoopTest, testWaitHoldsRate) {
+    log_timer_resolution();
+    // 199 through 201 bracket the 5 ms high_rate() threshold, where a late wake used
+    // to cost 20% of the rate on one side and nothing on the other.
+    for (const int rate_hz: {50, 100, 199, 200, 201, 500, 1000}) {
+        Timer timer{telem::Rate(rate_hz)};
+        expect_rate([&] { timer.wait(); }, rate_hz);
+    }
+}
+
+/// @brief it should hold each configured rate over time on the breaker path.
+TEST(LoopTest, testWaitBreakerHoldsRate) {
+    log_timer_resolution();
+    auto brk = breaker::Breaker(breaker::default_config("test"));
+    brk.start();
+    for (const int rate_hz: {5, 10, 20, 50}) {
+        Timer timer{telem::Rate(rate_hz)};
+        expect_rate([&] { timer.wait(brk); }, rate_hz);
+    }
+    brk.stop();
+}
+
+/// @brief it should not stretch the next wait after the breaker interrupts a sleep.
+TEST(LoopTest, testWaitBreakerEarlyWake) {
+    auto brk = breaker::Breaker(breaker::default_config("test"));
+    brk.start();
+    Timer timer{telem::Rate(2)};
+    std::thread t([&] { timer.wait(brk); });
+    std::this_thread::sleep_for((telem::MILLISECOND * 100).chrono());
+    brk.stop();
+    t.join();
+    brk.start();
+    const auto start = hs_clock::now();
+    timer.wait(brk);
+    const auto elapsed = telem::TimeSpan(hs_clock::now() - start);
+    brk.stop();
+    EXPECT_GT(elapsed, telem::MILLISECOND * 250);
+    EXPECT_LT(elapsed, telem::MILLISECOND * 700);
+}
+
+/// @brief it should re-anchor after an overrun instead of catching up on the missed
+/// periods.
+TEST(LoopTest, testWaitOverrunNoCatchUp) {
+    Timer timer{telem::Rate(50)};
+    timer.wait();
+    std::this_thread::sleep_for((telem::MILLISECOND * 50).chrono());
+    const auto [elapsed, on_time] = timer.wait();
+    EXPECT_FALSE(on_time);
+    EXPECT_GE(elapsed, telem::MILLISECOND * 50);
+    const auto start = hs_clock::now();
+    timer.wait();
+    const auto next = telem::TimeSpan(hs_clock::now() - start);
+    EXPECT_GT(next, telem::MILLISECOND * 15);
+    EXPECT_LT(next, telem::MILLISECOND * 60);
 }
 }


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4693](https://linear.app/synnax/issue/SY-4693)

## Description

`Timer::wait` in `x/cpp/loop` measured each period from when the sleep actually woke, not from the deadline it was aiming at. The OS always wakes a few ms late, so that lateness was added to every iteration instead of absorbed. Software-timed read tasks paid it directly: a 50 Hz OPC UA or Modbus task sampled at 43 Hz on Mac and 44 Hz on Windows, and the error grew with rate.

`wait` now anchors to the deadline, so a late wake shortens the next sleep. An early wake, which only happens when the breaker stops, keeps the wake time so a restart is not delayed.

This also removes a cliff at the 5 ms `high_rate()` threshold that selects the spin path. A task at 200 Hz achieved 166 Hz on Mac while 201 Hz achieved 198. Both now hold their rate.

Worst case across all three platforms went from -44.6% to -1.3%.

### Mac

<img width="874" height="462" alt="image" src="https://github.com/user-attachments/assets/00d9481a-2225-4439-befb-a316b007f642" />


### Windows

<img width="871" height="471" alt="image" src="https://github.com/user-attachments/assets/7ec46461-a437-4316-a507-d83d1b57a0fa" />

### Ubuntu (ASan)

<img width="869" height="461" alt="image" src="https://github.com/user-attachments/assets/c8d88180-7354-43d4-bc18-800d514d07fb" />

Red is the zero state, green is with the anchor, same y scale on all three. Ubuntu drifted least, but still lost 6.2% at 500 Hz, and unlike the others its worst rates were on the spin path rather than the sleep path.


Data came from `workflow_dispatch` runs of `test.x.cpp.yaml` on `sy/experimental-driver-loop`, with `RATE_TOLERANCE` set to 0 so every rate logged its measured value:

- Zero state: [32471673846](https://github.com/synnaxlabs/synnax/actions/runs/32471673846)
- With the anchor: [32472023930](https://github.com/synnaxlabs/synnax/actions/runs/32472023930)
- Windows timer resolution: [32474521330](https://github.com/synnaxlabs/synnax/actions/runs/32474521330)

Mac numbers are local, since the macOS CI leg filters out `no-asan` tests and skips this suite.

`loop_test` sweeps 50 Hz to 1 kHz on both `wait` overloads and logs each rate. New tests in the Modbus and OPC UA read suites assert the same end to end against their mock servers, and fail on the pre-fix timer. The integration rate tolerance drops from 50% to 20% now that tasks hold their rate.

## Phase two

This fixes accumulation, not lateness. Windows rounds every `sleep_for` up to a 15.625 ms tick by default and nothing in the driver raises the resolution, so a machine at the default still caps near 64 Hz. The follow-up moves Arc's high-resolution waitable timer (`arc/cpp/runtime/loop/loop_windows.cpp`) into `x/cpp/loop` so `Timer` and Arc's loop share it.


## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR anchors loop timing to the intended deadline so ordinary wake-up latency is absorbed by subsequent waits instead of accumulating across iterations.
- Updates both regular and breaker-aware timer waits while preserving actual wake time for early interruption.
- Adds timer, Modbus, and OPC UA rate tests covering deadline anchoring, overruns, breaker interruption, and the high-rate threshold.
- Adds a timestamp-based mock pipeline rate helper and tightens the integration rate tolerance.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete correctness or security failures identified.

The deadline anchoring preserves explicit overrun re-anchoring and early breaker-wake behavior while preventing ordinary sleep latency from accumulating, and the added tests cover the principal changed timing paths.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| x/cpp/loop/loop.h | Anchors both Timer wait paths to their calculated deadlines while retaining wake-time anchoring for early interruption. |
| x/cpp/loop/loop_test.cpp | Adds rate sweeps and focused tests for breaker interruption and overrun re-anchoring. |
| driver/pipeline/mock/pipeline.h | Adds a helper that derives achieved sample rate from captured frame index timestamps. |
| driver/modbus/read_task_test.cpp | Adds end-to-end sample-rate checks for software-timed Modbus reads. |
| driver/opcua/read_task_test.cpp | Adds end-to-end sample-rate checks for software-timed OPC UA reads. |
| integration/tests/driver/task.py | Tightens the accepted integration-test sample-rate deviation from 50% to 20%. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant Timer
    participant Clock
    Caller->>Timer: wait()
    Timer->>Clock: read current time
    Timer->>Timer: "deadline = now + remaining"
    Timer->>Clock: sleep remaining
    Clock-->>Timer: wake time
    alt wake is late
        Timer->>Timer: "last = deadline"
        Note over Timer: Next wait absorbs lateness
    else wake is early
        Timer->>Timer: "last = wake time"
        Note over Timer: Restart is not delayed
    end
    Timer-->>Caller: elapsed, on_time
```

<sub>Reviews (1): Last reviewed commit: ["SY-4693: Anchor the loop timer to its de..."](https://github.com/synnaxlabs/synnax/commit/f5b9b8b501ddd8798b30d205769276a88421c192) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55529122)</sub>

<!-- /greptile_comment -->