### PR TITLE
SY-4701: Make the severable proxy actually sever

### DIFF
--- a/integration/framework/proxy.py
+++ b/integration/framework/proxy.py
@@ -22,6 +22,7 @@ class SeverableProxy:
         self._lock = threading.Lock()
         self._sockets: set[socket.socket] = set()
         self._listener: socket.socket | None = None
+        self._severed = False
         self.port = self._listen(0)
 
     def _listen(self, port: int) -> int:
@@ -29,6 +30,8 @@ class SeverableProxy:
         listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
         listener.bind(("127.0.0.1", port))
         listener.listen()
+        with self._lock:
+            self._severed = False
         self._listener = listener
         threading.Thread(
             target=self._accept_loop, args=(listener,), daemon=True
@@ -48,9 +51,19 @@ class SeverableProxy:
             except OSError:
                 downstream.close()
                 continue
+            # create_connection leaves its connect timeout on the socket, where
+            # it would expire on a quiet stream and drop a healthy link.
+            upstream.settimeout(None)
             with self._lock:
-                self._sockets.add(downstream)
-                self._sockets.add(upstream)
+                live = not self._severed
+                if live:
+                    self._sockets.add(downstream)
+                    self._sockets.add(upstream)
+            # A sever took its snapshot before this pair was registered, so
+            # nothing else will ever close it.
+            if not live:
+                self._drop(downstream, upstream)
+                continue
             threading.Thread(
                 target=self._pump, args=(downstream, upstream), daemon=True
             ).start()
@@ -86,6 +99,7 @@ class SeverableProxy:
         if listener is not None:
             listener.close()
         with self._lock:
+            self._severed = True
             socks, self._sockets = list(self._sockets), set()
         for s in socks:
             try:


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4701](https://linear.app/synnax/issue/SY-4701/fix-flakey-connection-lifecycle-integration-test)

## Description

`console/cluster/connection_lifecycle` failed on roughly half of the ubuntu
integration runs, always in `test_outage_degrades_badge`, waiting either 10s for
the badge to read `Connecting` or 30s for it to read `Unreachable`.

The Console was right and the test harness was wrong: `SeverableProxy.sever()`
did not sever. `_accept_loop` adds a socket pair to `self._sockets` only after
`socket.create_connection()` returns, so a pair accepted before a sever but
registered just after it landed in the fresh set that `sever()` installed. Nothing
ever closed it, and it kept proxying to the Core. The trace from the failing run
shows `connectivity/check` returning live 200s, with `node_time` matching the
request, for seconds after the link was cut, while new connections were refused.

Both failure shapes follow. When the leaked pair is the change stream, no
`stream.drop` fires and the next check is a heartbeat 30 seconds out, so the badge
holds `Connected` through the whole 10s wait. When it is an HTTP keep-alive socket,
the stream dies and the badge reaches `Connecting` at once, but every check then
succeeds over the leaked socket, which holds the variant at `loading` and never
reaches `escalateAfter`.

A second defect in the same loop kept the accept loop busy and widened the window:
`create_connection(..., timeout=5)` leaves its timeout on the upstream socket,
where it applies to `recv`, so the proxy tore down every link idle for five
seconds, a quiet change stream included.

The fix is a `_severed` flag checked under the same lock that guards the socket
set, so a pair built across a sever is closed instead of registered, plus
`settimeout(None)` after the connect so the proxy stays transparent.

Measured against the real class with a concurrent dial harness: 11 of 60 severs
leaked a live connection before, 0 of 60 after. An idle link died at t+5.0s
before and survives past 12s after.

## Verification

`uv run tc console/cluster/connection_lifecycle` against a local Core passes 17 of 17
with the fix. The pre-fix proxy also passes 17 of 17 here, because this machine drains
the accept loop long before the sever lands, so a plain local run cannot tell the two
apart.

Adding `time.sleep(0.5)` after `accept()`, which emulates the loaded CI runner keeping
the serial accept loop behind, separates them cleanly:

| proxy | runs | result |
| --- | --- | --- |
| pre-fix, lagging accept loop | 4 | 2 failed, `Timeout 30000ms exceeded` waiting for `Unreachable`, the CI signature |
| fixed, same lag | 8 | all passed |

The sleep was an experiment only and is not part of the diff.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR repairs the integration proxy’s sever semantics and prevents healthy idle upstream links from inheriting the connection timeout.

- Tracks severed state under the socket-set lock and drops socket pairs completed across a sever.
- Restores blocking mode after upstream connection establishment.
- Adds no deterministic regression coverage for either corrected behavior.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with the non-blocking concern that its race and idle-connection fixes lack deterministic regression coverage.

The locking and cleanup paths close the reported socket leak without exposing a concrete current failure, while the corrected behaviors remain vulnerable to unnoticed future regressions because no focused tests exercise them.

**Files Needing Attention:** integration/framework/proxy.py

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| integration/framework/proxy.py | Corrects socket registration across sever operations and clears inherited connect timeouts, but lacks focused regression tests for both fixes. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Proxy as SeverableProxy
    participant Core
    Client->>Proxy: Connect
    Proxy->>Core: "create_connection(timeout=5)"
    Note over Proxy,Core: Connection establishment overlaps sever()
    Proxy->>Proxy: "severed = true under lock"
    Proxy->>Proxy: Check severed state under same lock
    Proxy--xClient: Close downstream socket
    Proxy--xCore: Close upstream socket
```

<sub>Reviews (1): Last reviewed commit: ["SY-4701: Close the sever race in the sev..."](https://github.com/synnaxlabs/synnax/commit/3f999e68949f7c7c33713e7d72300b2cc3ea53b6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55560260)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - When making changes to functionality, add correspo... ([source](https://app.greptile.com/synnax/-/custom-context?memory=8b39d83e-3d2b-4dd4-9e14-d0644d6bfe58))

**Learned From**
[synnaxlabs/synnax#1550](https://github.com/synnaxlabs/synnax/pull/1550)

<!-- /greptile_comment -->
