### PR TITLE
SY-4616: Disallow mixed integer and float operands in Arc expressions

### DIFF
--- a/arc/go/analyzer/analyzer_test.go
+++ b/arc/go/analyzer/analyzer_test.go
@@ -481,6 +481,75 @@ var _ = Describe("Analyzer Integration", func() {
 		})
 	})
 
+	Describe("Variable Type Checking Across Contexts", func() {
+		// A function body and a sequence body both route their declarations through
+		// the statement analyzer, so the same code must type-check the same way in
+		// both.
+		inFunction := func(body string) string { return "func f() {" + body + "}" }
+		inSequence := func(body string) string {
+			return "sequence main {" + body + "\nstage s1 {}\n}"
+		}
+		DescribeTable(
+			"Should reject a type mismatch in both contexts",
+			func(bCtx SpecContext, body string) {
+				fn := analyzeAndExpectErrorWithResolver(bCtx, inFunction(body), nil)
+				Expect(fn.Diagnostics.String()).To(ContainSubstring("type mismatch"))
+				seq := analyzeAndExpectErrorWithResolver(bCtx, inSequence(body), nil)
+				Expect(seq.Diagnostics.String()).To(ContainSubstring("type mismatch"))
+			},
+			Entry("inferred integer variable and inferred float variable", `
+				x := 34.
+				y := 42
+				b := y < x
+			`),
+			Entry("inferred float variable and inferred integer variable", `
+				x := 34.
+				y := 42
+				b := x < y
+			`),
+			Entry("exact-integer float literal and inferred integer variable", `
+				a := 34
+				b := 42.0 < a
+			`),
+			Entry("inferred integer variable and exact-integer float literal", `
+				a := 34
+				b := a < 42.0
+			`),
+			Entry("float literal added to an inferred integer variable", `
+				a := 34
+				b := a + 42.0
+			`),
+			Entry("fractional float literal and inferred integer variable", `
+				a := 34
+				b := 42.5 < a
+			`),
+		)
+		DescribeTable(
+			"Should accept compatible types in both contexts",
+			func(bCtx SpecContext, body string) {
+				analyzeAndExpectWithResolver(bCtx, inFunction(body), nil)
+				analyzeAndExpectWithResolver(bCtx, inSequence(body), nil)
+			},
+			Entry("integer literal and inferred integer variable", `
+				a := 34
+				b := a < 42
+			`),
+			Entry("integer literal and inferred float variable", `
+				a := 34.0
+				b := a < 42
+			`),
+			Entry("float literal and inferred float variable", `
+				a := 34.0
+				b := a < 42.0
+			`),
+			Entry("two inferred integer variables", `
+				a := 34
+				b := 42
+				c := a < b
+			`),
+		)
+	})
+
 	Describe("Channel Propagation Through Function Calls", func() {
 		It(
 			"Should propagate callee channels to caller when callee is declared first",

--- a/arc/go/analyzer/constraints/unify.go
+++ b/arc/go/analyzer/constraints/unify.go
@@ -299,7 +299,13 @@ func (s *System) unifyTypeVariableWithVisited(
 			)
 		}
 	} else if tv.Constraint.Kind == types.KindExactIntegerFloatConstant {
-		if !checkType.IsNumeric() {
+		// As an operand, an exact-integer float literal is a float like any other;
+		// only assignment to a declared integer type accepts it.
+		accepts := checkType.IsNumeric()
+		if source.Kind == KindCompatible {
+			accepts = checkType.IsFloat()
+		}
+		if !accepts {
 			return errors.Wrapf(
 				ErrConstraintViolation,
 				"%v does not satisfy exact integer float constraint",

--- a/arc/go/analyzer/expression/literal_inference_test.go
+++ b/arc/go/analyzer/expression/literal_inference_test.go
@@ -71,14 +71,26 @@ var _ = Describe("Literal Type Inference", func() {
 		)
 
 		It(
-			"Should allow comparison of i32 variable with exact-integer float literal",
+			"Should reject comparison of i32 variable with exact-integer float literal",
 			func(ctx SpecContext) {
-				expectSuccess(ctx, `
+				expectFailure(ctx, `
 				func testFunc() {
 					x i32 := 10
 					z := x > 5.0
 				}
-			`, nil)
+			`, nil, "type mismatch")
+			},
+		)
+
+		It(
+			"Should reject comparison of exact-integer float literal with i32 variable",
+			func(ctx SpecContext) {
+				expectFailure(ctx, `
+				func testFunc() {
+					x i32 := 10
+					z := 5.0 < x
+				}
+			`, nil, "type mismatch")
 			},
 		)
 

--- a/arc/go/analyzer/function/function_test.go
+++ b/arc/go/analyzer/function/function_test.go
@@ -1400,4 +1400,87 @@ var _ = Describe("Function Analyzer", func() {
 			)
 		})
 	})
+
+	Describe("Variable Type Checking", func() {
+		logResolver := []symbol.Symbol{
+			{
+				Name: "log",
+				Kind: symbol.KindChannel,
+				Type: types.Chan(types.String()),
+				ID:   1,
+			},
+		}
+		It(
+			"should reject a float literal compared to an inferred integer variable",
+			func(bCtx SpecContext) {
+				analyzeExpectError(bCtx, `
+					func my_func{}() {
+						a := 34
+						b := 42.0 < a
+						log = str(b)
+					}
+				`, logResolver, ContainSubstring("type mismatch"))
+			},
+		)
+		It(
+			"should reject an inferred float variable compared to an int variable",
+			func(bCtx SpecContext) {
+				analyzeExpectError(bCtx, `
+					func my_func{}() {
+						x := 34.
+						y := 42
+						log = str(y < x)
+					}
+				`, logResolver, ContainSubstring("type mismatch"))
+			},
+		)
+		It(
+			"should reject an inferred integer variable compared to a float literal",
+			func(bCtx SpecContext) {
+				analyzeExpectError(bCtx, `
+					func my_func{}() {
+						a := 34
+						b := a < 42.0
+						log = str(b)
+					}
+				`, logResolver, ContainSubstring("type mismatch"))
+			},
+		)
+		It(
+			"should reject an inferred integer variable added to a float literal",
+			func(bCtx SpecContext) {
+				analyzeExpectError(bCtx, `
+					func my_func{}() {
+						a := 34
+						b := 42.0 + a
+						log = str(b)
+					}
+				`, logResolver, ContainSubstring("type mismatch"))
+			},
+		)
+		It(
+			"should reject a float literal added to an inferred integer variable",
+			func(bCtx SpecContext) {
+				analyzeExpectError(bCtx, `
+					func my_func{}() {
+						a := 34
+						b := a + 42.0
+						log = str(b)
+					}
+				`, logResolver, ContainSubstring("type mismatch"))
+			},
+		)
+		It(
+			"should accept an integer literal compared to an inferred integer variable",
+			func(bCtx SpecContext) {
+				analyzeExpectSuccess(bCtx, `
+					func my_func{}() {
+						a := 34
+						b := 42 < a
+						log = str(b)
+					}
+				`, logResolver)
+			},
+		)
+	})
 })

--- a/arc/go/analyzer/statement/statement_test.go
+++ b/arc/go/analyzer/statement/statement_test.go
@@ -1837,6 +1837,14 @@ var _ = Describe("Statement", func() {
 					a := 5
 					x := [a, 12.5]
 				}`),
+				Entry("inferred int variable and exact-integer float literal", `{
+					a := 5
+					x := [a, 12.0]
+				}`),
+				Entry("exact-integer float literal and inferred int variable", `{
+					a := 5
+					x := [12.0, a]
+				}`),
 			)
 		})
 
@@ -2111,11 +2119,7 @@ var _ = Describe("Statement", func() {
 					a := 10
 					x := [5, a * 2]
 				}`),
-				// Inferred type variables with literals - int/float literals can coerce
-				Entry("inferred int variable and float literal", `{
-					a := 5
-					x := [a, 12.0]
-				}`),
+				// An integer literal widens to an inferred float variable.
 				Entry("inferred float variable and int literal", `{
 					a := 12.0
 					x := [a, 5]

--- a/arc/go/analyzer/types/infer_expression.go
+++ b/arc/go/analyzer/types/infer_expression.go
@@ -540,11 +540,9 @@ func constraintAccepts(constraint *types.Type, concreteType types.Type) bool {
 		return true
 	}
 	switch constraint.Kind {
-	case types.KindNumericConstant,
-		types.KindIntegerConstant,
-		types.KindExactIntegerFloatConstant:
+	case types.KindNumericConstant, types.KindIntegerConstant:
 		return concreteType.IsNumeric()
-	case types.KindFloatConstant:
+	case types.KindFloatConstant, types.KindExactIntegerFloatConstant:
 		return concreteType.IsFloat()
 	default:
 		return types.Equal(*constraint, concreteType)

--- a/arc/go/compiler/compiler_test.go
+++ b/arc/go/compiler/compiler_test.go
@@ -1152,10 +1152,10 @@ var _ = Describe("Compiler", func() {
 			Expect(results).To(ConsistOf(uint64(math.Float32bits(5.5))))
 		})
 
-		It("Should compile decimal literal with i32 variable", func(ctx SpecContext) {
+		It("Should compile integer literal with i32 variable", func(ctx SpecContext) {
 			output := MustSucceed(compile(ctx, `
 			func compare(x i32) bool {
-				return x > 5.0
+				return x > 5
 			}
 			`, nil))
 
@@ -1334,11 +1334,11 @@ var _ = Describe("Compiler", func() {
 		)
 
 		It(
-			"Should allow float literals in comparisons with i64",
+			"Should allow integer literals in comparisons with i64",
 			func(ctx SpecContext) {
 				output := MustSucceed(compile(ctx, `
 			func isPositive(x i64) bool {
-				return x > 0.0
+				return x > 0
 			}
 			`, nil))
 

--- a/arc/go/compiler/statement/statement_test.go
+++ b/arc/go/compiler/statement/statement_test.go
@@ -1042,52 +1042,6 @@ var _ = Describe("Statement Compiler", func() {
 
 	Describe("Series Literals with Inferred Variables and Literal Coercion", func() {
 		It(
-			"Should compile inferred int variable with exact-integer float literal",
-			func(bCtx SpecContext) {
-				// a := 5 creates an i64 variable
-				// 12.0 is an exact integer float that should coerce to i64
-				// Result: series[i64] with elements [5, 12]
-				block := MustSucceed(parser.ParseBlock(`{
-				a := 5
-				x := [a, 12.0]
-			}`))
-				aCtx := acontext.NewRoot(bCtx, block, NewRoot(nil))
-				analyzer.AnalyzeBlock(aCtx)
-				Expect(aCtx.Diagnostics.Ok()).To(BeTrue(), aCtx.Diagnostics.String())
-
-				ctx := context.NewRoot(
-					bCtx,
-					aCtx.Scope,
-					aCtx.TypeMap,
-					resolve.NewResolver(),
-				)
-				diverged := MustSucceed(
-					statement.CompileBlock(context.Child(ctx, block)),
-				)
-				Expect(diverged).To(BeFalse())
-
-				Expect(FinalizeContext(ctx)).To(MatchOpcodes(
-					// a := 5
-					OpI64Const, int64(5),
-					OpLocalSet, 0,
-					// x := [a, 12.0] - create series[i64] with 2 elements
-					OpI32Const, int32(2),
-					OpCall, uint32(0),
-					// set element 0 = a
-					OpI32Const, int32(0),
-					OpLocalGet, 0,
-					OpCall, uint32(1),
-					// set element 1 = 12 (12.0 coerced to i64)
-					OpI32Const, int32(1),
-					OpI64Const, int64(12),
-					OpCall, uint32(1),
-					// store series in x
-					OpLocalSet, 1,
-				))
-			},
-		)
-
-		It(
 			"Should compile inferred float variable with int literal",
 			func(bCtx SpecContext) {
 				// a := 12.0 creates an f64 variable
@@ -1129,60 +1083,6 @@ var _ = Describe("Statement Compiler", func() {
 					OpCall, uint32(1),
 					// store series in x
 					OpLocalSet, 1,
-				))
-			},
-		)
-
-		It(
-			"Should compile multiple inferred variables with mixed literals",
-			func(bCtx SpecContext) {
-				// a := 5, b := 10 creates i64 variables
-				// 15.0 is an exact integer float that should coerce to i64
-				// Result: series[i64] with elements [5, 10, 15]
-				block := MustSucceed(parser.ParseBlock(`{
-				a := 5
-				b := 10
-				x := [a, b, 15.0]
-			}`))
-				aCtx := acontext.NewRoot(bCtx, block, NewRoot(nil))
-				analyzer.AnalyzeBlock(aCtx)
-				Expect(aCtx.Diagnostics.Ok()).To(BeTrue(), aCtx.Diagnostics.String())
-
-				ctx := context.NewRoot(
-					bCtx,
-					aCtx.Scope,
-					aCtx.TypeMap,
-					resolve.NewResolver(),
-				)
-				diverged := MustSucceed(
-					statement.CompileBlock(context.Child(ctx, block)),
-				)
-				Expect(diverged).To(BeFalse())
-
-				Expect(FinalizeContext(ctx)).To(MatchOpcodes(
-					// a := 5
-					OpI64Const, int64(5),
-					OpLocalSet, 0,
-					// b := 10
-					OpI64Const, int64(10),
-					OpLocalSet, 1,
-					// x := [a, b, 15.0] - create series[i64] with 3 elements
-					OpI32Const, int32(3),
-					OpCall, uint32(0),
-					// set element 0 = a
-					OpI32Const, int32(0),
-					OpLocalGet, 0,
-					OpCall, uint32(1),
-					// set element 1 = b
-					OpI32Const, int32(1),
-					OpLocalGet, 1,
-					OpCall, uint32(1),
-					// set element 2 = 15 (15.0 coerced to i64)
-					OpI32Const, int32(2),
-					OpI64Const, int64(15),
-					OpCall, uint32(1),
-					// store series in x
-					OpLocalSet, 2,
 				))
 			},
 		)


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4616](https://linear.app/synnax/issue/SY-4616)

## Description

Operations between values of different types require an explicit conversion. An integer variable can no longer be compared, combined, or placed in a series with a float literal, whichever side it is on. Previously a float literal with a whole-number value such as `42.0` was accepted as an integer operand, so the same mismatch passed in one form and failed in another.

```arc
func f() {
    a := 34              // a is i64
    b := a < 42.0        // error (new): float operand, integer operand
    c := 42.0 < a        // error (new): same, flipped
    d := a + 42.0        // error (new)
    e := a < 42.5        // error (unchanged)
    s := [a, 12.0]       // error (new): float element, integer element
    t := [a, 12]         // ok
}
```


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes exact-integer float literals remain floats when Arc checks operand and series compatibility.

- Rejects mixed integer and float binary operands in either order.
- Rejects mixed integer and exact-float series elements.
- Preserves integer-literal widening and explicit integer assignment behavior.
- Adds analyzer and compiler coverage for the revised rules.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The changed checks consistently reject mixed integer and float operands while preserving declared integer assignment through the separate equality-constraint path, and no actionable failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| arc/go/analyzer/constraints/unify.go | Narrows exact-integer float acceptance only for compatible operand constraints while retaining numeric acceptance for equality constraints. |
| arc/go/analyzer/types/infer_expression.go | Treats exact-integer float constants as floats during series-element compatibility checks. |
| arc/go/analyzer/analyzer_test.go | Adds cross-context coverage for mixed numeric operands in functions and sequences. |
| arc/go/analyzer/statement/statement_test.go | Updates series-literal tests to reject integer and exact-float mixtures in both orders. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Arc numeric expression] --> B{Context}
    B -->|Declared assignment| C[Equality constraint]
    C --> D[Exact-integer float can satisfy numeric target]
    B -->|Binary operands| E[Compatible constraint]
    E --> F{Operand types match}
    F -->|Integer and float| G[Type mismatch]
    F -->|Compatible numeric types| H[Analysis succeeds]
    B -->|Series literal| I[Element compatibility]
    I --> J{Element types match}
    J -->|Integer and float| G
    J -->|Compatible element types| H
```

<sub>Reviews (1): Last reviewed commit: ["SY-####: Disallow mixed integer and floa..."](https://github.com/synnaxlabs/synnax/commit/43e6d3ea20f8eb4774affe2b1fb4d6797ba6829b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55576223)</sub>

<!-- /greptile_comment -->