### PR TITLE
SY-4702: Stop an empty control key set matching every channel

### DIFF
--- a/client/ts/src/control/client.spec.ts
+++ b/client/ts/src/control/client.spec.ts
@@ -10,7 +10,11 @@
 import { DataType, id, TimeStamp } from "@synnaxlabs/x";
 import { describe, expect, it } from "vitest";
 
+import { type channel } from "@/channel";
+import { type RetrieveMultipleParams } from "@/control/client";
+import { type KeyedState } from "@/control/state";
 import { NotFoundError } from "@/errors";
+import { query } from "@/query";
 import { createTestClient } from "@/testutil";
 
 const client = createTestClient();
@@ -21,6 +25,9 @@ const createVirtual = async () =>
     dataType: DataType.FLOAT64,
     virtual: true,
   });
+
+const keysOf = (states: query.Cached<KeyedState[]> | undefined): channel.Key[] =>
+  query.isLive<KeyedState[]>(states) ? states.map(({ key }) => key) : [];
 
 describe("control client", () => {
   describe("retrieve", () => {
@@ -77,6 +84,65 @@ describe("control client", () => {
         expect(await client.control.retrieve([])).toHaveLength(0);
       } finally {
         await w.close();
+      }
+    });
+  });
+
+  describe("onChange", () => {
+    it("should deliver a live transfer when no keys are given", async () => {
+      const ch = await createVirtual();
+      const all: RetrieveMultipleParams = {};
+      const off = client.control.onChange(all, () => {});
+      try {
+        await client.control.retrieve(all);
+        const w = await client.openWriter({
+          start: TimeStamp.now(),
+          channels: [ch.key],
+          controlSubject: { key: "helena", name: "helena" },
+        });
+        try {
+          await expect
+            .poll(() => keysOf(client.control.getCached(all)))
+            .toContain(ch.key);
+        } finally {
+          await w.close();
+        }
+      } finally {
+        off();
+      }
+    });
+
+    it("should not deliver a live transfer for an empty key set", async () => {
+      const ch = await createVirtual();
+      const none: channel.Key[] = [];
+      const all: RetrieveMultipleParams = {};
+      const delivered: channel.Key[][] = [];
+      const offNone = client.control.onChange(none, (states) =>
+        delivered.push(keysOf(states)),
+      );
+      const offAll = client.control.onChange(all, () => {});
+      try {
+        expect(await client.control.retrieve(none)).toHaveLength(0);
+        await client.control.retrieve(all);
+        const w = await client.openWriter({
+          start: TimeStamp.now(),
+          channels: [ch.key],
+          controlSubject: { key: "missoula", name: "missoula" },
+        });
+        try {
+          // The unfiltered query witnesses the transfer landing in the table, which
+          // rechecks every subscribed query in the same batch.
+          await expect
+            .poll(() => keysOf(client.control.getCached(all)))
+            .toContain(ch.key);
+          expect(keysOf(client.control.getCached(none))).toEqual([]);
+          expect(delivered.flat()).toEqual([]);
+        } finally {
+          await w.close();
+        }
+      } finally {
+        offNone();
+        offAll();
       }
     });
   });

--- a/client/ts/src/control/client.ts
+++ b/client/ts/src/control/client.ts
@@ -8,7 +8,6 @@
 // included in the file licenses/APL.txt.
 
 import { type UnaryClient } from "@synnaxlabs/freighter";
-import { primitive } from "@synnaxlabs/x";
 import { z } from "zod";
 
 import { type channel } from "@/channel";
@@ -61,8 +60,7 @@ export class Client extends query.Retriever<
       request: {
         schema: retrieveMultiParamsZ,
         fetch: async (req) => await this.execRetrieve(req),
-        matches: (state, req) =>
-          !primitive.isNonZero(req.keys) || req.keys.includes(state.key),
+        matches: (state, req) => req.keys == null || req.keys.includes(state.key),
       },
     });
     this.cfg = cfg;


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4702](https://linear.app/synnax/issue/SY-4702/schematic-legend-shows-subjects-the-schematic-does-not-control)

## Description

A schematic that controls nothing gives its legend an empty `needsControlOf`, and the legend showed any subject that acquired control while the schematic was open. Closing and reopening cleared it.

`control.Client` read an empty key list two ways. `execRetrieve` short-circuits it to no results, because an empty list on the wire means "the whole cluster" to the Core. The live membership predicate did the opposite: `primitive.isZero([])` is `true`, since `isStringer([])` is `true` and `[].toString()` is empty, so `!isNonZero(req.keys)` admitted every control state in the cluster. The fetch answered nothing, then every later transfer passed the predicate and joined the cached answer.

The predicate now tests `req.keys == null`, which separates "no filter" from "no keys" and agrees with `execRetrieve`.

Other domain clients use `isNonZero(req.keys)` to mean "a non-empty filter" and their fetch agrees with their predicate, so they are unaffected.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR distinguishes an omitted control-key filter from an explicitly empty key set, preventing empty subscriptions from matching subsequent control transfers.
- Updates the live control-state predicate so omitted keys remain unfiltered while empty arrays match nothing.
- Adds tests for both unfiltered live transfers and empty-key subscriptions.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the production change and regression tests consistently enforcing the intended empty-key semantics.

Omitted keys remain an unfiltered query, explicit empty arrays consistently return and cache no states, and no blocking or non-blocking defects were identified.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| client/ts/src/control/client.ts | Correctly aligns live membership matching with retrieval semantics for empty and omitted control-key filters. |
| client/ts/src/control/client.spec.ts | Adds reliable regression coverage for unfiltered and explicitly empty live control queries. |

<sub>Reviews (1): Last reviewed commit: ["SY-4702: Stop an empty control key set m..."](https://github.com/synnaxlabs/synnax/commit/0213b9bc4f902106fbeabd5bca62d706a7fcb48d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55579517)</sub>

<!-- /greptile_comment -->