### PR TITLE
SY-4696: Dial gRPC peers through the passthrough resolver

### DIFF
--- a/aspen/internal/cluster/cluster.go
+++ b/aspen/internal/cluster/cluster.go
@@ -64,16 +64,16 @@ func Open(ctx context.Context, configs ...Config) (c *Cluster, err error) {
 
 	sCtx, cancel := signal.WithCancel(cfg.T.Transfer(ctx, context.Background()))
 
-	c = &Cluster{
-		Store:    cfg.Gossip.Store,
-		shutdown: signal.NewHardShutdown(sCtx, cancel),
-		Config:   cfg,
-	}
+	// shutdown is held in a local because the cleanup below runs on error paths that
+	// return a nil Cluster.
+	shutdown := signal.NewHardShutdown(sCtx, cancel)
 	defer func() {
 		if err != nil {
-			err = errors.Combine(err, c.shutdown.Close())
+			err = errors.Combine(err, shutdown.Close())
 		}
 	}()
+
+	c = &Cluster{Store: cfg.Gossip.Store, shutdown: shutdown, Config: cfg}
 
 	// Attempt to open the Cluster store from kv. It's ok if we don't find it.
 	state, err := tryLoadPersistedState(ctx, cfg)
@@ -115,7 +115,7 @@ func Open(ctx context.Context, configs ...Config) (c *Cluster, err error) {
 		// initial view of the Cluster.
 		c.L.Info("gossiping initial state through peer addresses")
 		if err = c.gossipInitialState(ctx); err != nil {
-			return c, err
+			return nil, err
 		}
 	} else {
 		// If our store isn't valid, and we haven't received peers, assume we're
@@ -129,7 +129,7 @@ func Open(ctx context.Context, configs ...Config) (c *Cluster, err error) {
 		)
 		c.Pledge.ClusterKey = c.Key()
 		if err = pledge_.Arbitrate(c.Pledge); err != nil {
-			return c, err
+			return nil, err
 		}
 	}
 

--- a/aspen/internal/cluster/cluster.go
+++ b/aspen/internal/cluster/cluster.go
@@ -64,8 +64,6 @@ func Open(ctx context.Context, configs ...Config) (c *Cluster, err error) {
 
 	sCtx, cancel := signal.WithCancel(cfg.T.Transfer(ctx, context.Background()))
 
-	// shutdown is held in a local because the cleanup below runs on error paths that
-	// return a nil Cluster.
 	shutdown := signal.NewHardShutdown(sCtx, cancel)
 	defer func() {
 		if err != nil {

--- a/aspen/internal/cluster/cluster_test.go
+++ b/aspen/internal/cluster/cluster_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/synnaxlabs/aspen/internal/cluster/gossip"
 	"github.com/synnaxlabs/aspen/internal/cluster/pledge"
 	"github.com/synnaxlabs/aspen/internal/node"
+	"github.com/synnaxlabs/freighter/mock"
 	"github.com/synnaxlabs/x/address"
 	"github.com/synnaxlabs/x/signal"
 	. "github.com/synnaxlabs/x/testutil"
@@ -46,6 +47,31 @@ var _ = Describe("Cluster", func() {
 			Expect(builder.Close()).To(Succeed())
 			shutdown()
 			Expect(clusterCtx.Err()).To(MatchError(context.Canceled))
+		})
+	})
+
+	Describe("Open", func() {
+		It("Should return an error when the host cannot reach any peer", func(
+			ctx SpecContext,
+		) {
+			gossipNet := mock.NewNetwork[gossip.Message, gossip.Message]()
+			pledgeNet := mock.NewNetwork[pledge.Request, pledge.Response]()
+			gossipServer := gossipNet.UnaryServer("")
+			pledgeServer := pledgeNet.UnaryServer(gossipServer.Address)
+			openCtx, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
+			defer cancel()
+			Expect(cluster.Open(openCtx, cluster.FastConfig, cluster.Config{
+				HostAddress: gossipServer.Address,
+				Gossip: gossip.Config{
+					TransportClient: gossipNet.UnaryClient(),
+					TransportServer: gossipServer,
+				},
+				Pledge: pledge.Config{
+					TransportClient: pledgeNet.UnaryClient(),
+					TransportServer: pledgeServer,
+					Peers:           []address.Address{"unreachable"},
+				},
+			})).Error().To(MatchError(context.DeadlineExceeded))
 		})
 	})
 

--- a/aspen/internal/cluster/cluster_test.go
+++ b/aspen/internal/cluster/cluster_test.go
@@ -51,16 +51,13 @@ var _ = Describe("Cluster", func() {
 	})
 
 	Describe("Open", func() {
-		It("Should return an error when the host cannot reach any peer", func(
-			ctx SpecContext,
-		) {
+		// isolatedConfig puts both transports on their own in-memory networks, so the
+		// host has no reachable peer.
+		isolatedConfig := func() cluster.Config {
 			gossipNet := mock.NewNetwork[gossip.Message, gossip.Message]()
 			pledgeNet := mock.NewNetwork[pledge.Request, pledge.Response]()
 			gossipServer := gossipNet.UnaryServer("")
-			pledgeServer := pledgeNet.UnaryServer(gossipServer.Address)
-			openCtx, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
-			defer cancel()
-			Expect(cluster.Open(openCtx, cluster.FastConfig, cluster.Config{
+			return cluster.Config{
 				HostAddress: gossipServer.Address,
 				Gossip: gossip.Config{
 					TransportClient: gossipNet.UnaryClient(),
@@ -68,10 +65,30 @@ var _ = Describe("Cluster", func() {
 				},
 				Pledge: pledge.Config{
 					TransportClient: pledgeNet.UnaryClient(),
-					TransportServer: pledgeServer,
-					Peers:           []address.Address{"unreachable"},
+					TransportServer: pledgeNet.UnaryServer(gossipServer.Address),
 				},
-			})).Error().To(MatchError(context.DeadlineExceeded))
+			}
+		}
+
+		It("Should return an error when the host cannot reach any peer", func(
+			ctx SpecContext,
+		) {
+			cfg := isolatedConfig()
+			cfg.Pledge.Peers = []address.Address{"unreachable"}
+			openCtx, cancel := context.WithTimeout(ctx, 20*time.Millisecond)
+			defer cancel()
+			Expect(cluster.Open(openCtx, cluster.FastConfig, cfg)).Error().
+				To(MatchError(context.DeadlineExceeded))
+		})
+
+		It("Should return an error when the pledge config is invalid", func(
+			ctx SpecContext,
+		) {
+			cfg := isolatedConfig()
+			cfg.Pledge.RetryScale = 0.5
+			Expect(cluster.Open(ctx, cluster.FastConfig, cfg)).Error().To(MatchError(
+				ContainSubstring("retry_scale: must be greater than or equal to 1"),
+			))
 		})
 	})
 

--- a/freighter/go/grpc/pool.go
+++ b/freighter/go/grpc/pool.go
@@ -52,6 +52,12 @@ func OpenPool(targetPrefix address.Address, dialOpts ...grpc.DialOption) *Pool {
 	return pool.Open(&factory{dialOpts: dialOpts, targetPrefix: targetPrefix})
 }
 
+// passthroughScheme hands the target to the dialer verbatim. gRPC otherwise resolves
+// it through the DNS resolver, which queries a `_grpc_config` TXT record before it
+// reports any address. Every RPC on the connection blocks until that query answers, so
+// a resolver that drops it stalls the first request for the full DNS timeout.
+const passthroughScheme = "passthrough:///"
+
 type factory struct {
 	targetPrefix address.Address
 	dialOpts     []grpc.DialOption
@@ -59,7 +65,7 @@ type factory struct {
 
 func (f *factory) Open(addr address.Address) (*ClientConn, error) {
 	c, err := grpc.NewClient(
-		path.Join(f.targetPrefix.String(), addr.String()),
+		passthroughScheme+path.Join(f.targetPrefix.String(), addr.String()),
 		f.dialOpts...,
 	)
 	if err != nil {

--- a/freighter/go/grpc/pool.go
+++ b/freighter/go/grpc/pool.go
@@ -52,10 +52,9 @@ func OpenPool(targetPrefix address.Address, dialOpts ...grpc.DialOption) *Pool {
 	return pool.Open(&factory{dialOpts: dialOpts, targetPrefix: targetPrefix})
 }
 
-// passthroughScheme hands the target to the dialer verbatim. gRPC otherwise resolves
-// it through the DNS resolver, which queries a `_grpc_config` TXT record before it
-// reports any address. Every RPC on the connection blocks until that query answers, so
-// a resolver that drops it stalls the first request for the full DNS timeout.
+// passthroughScheme hands the target to the dialer verbatim. gRPC otherwise resolves it
+// with the DNS resolver, which withholds every address until a `_grpc_config` TXT query
+// answers, stalling the connection's first RPC for the full DNS timeout.
 const passthroughScheme = "passthrough:///"
 
 type factory struct {

--- a/freighter/go/grpc/pool.go
+++ b/freighter/go/grpc/pool.go
@@ -52,9 +52,10 @@ func OpenPool(targetPrefix address.Address, dialOpts ...grpc.DialOption) *Pool {
 	return pool.Open(&factory{dialOpts: dialOpts, targetPrefix: targetPrefix})
 }
 
-// passthroughScheme hands the target to the dialer verbatim. gRPC otherwise resolves it
-// with the DNS resolver, which withholds every address until a `_grpc_config` TXT query
-// answers, stalling the connection's first RPC for the full DNS timeout.
+// passthroughScheme skips gRPC's DNS resolver, which withholds every address until a
+// `_grpc_config` TXT query answers and so stalls the first RPC for the whole DNS
+// timeout. It rides on the target string because gRPC keeps the equivalent dial option
+// unexported, leaving only the process-wide resolver.SetDefaultScheme.
 const passthroughScheme = "passthrough:///"
 
 type factory struct {

--- a/freighter/go/grpc/pool_test.go
+++ b/freighter/go/grpc/pool_test.go
@@ -1,0 +1,43 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+package grpc_test
+
+import (
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	fgrpc "github.com/synnaxlabs/freighter/grpc"
+	. "github.com/synnaxlabs/x/testutil"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+)
+
+var _ = Describe("Pool", func() {
+	Describe("Acquire", func() {
+		It("Should dial the address through the passthrough resolver", func() {
+			pool := DeferClose(fgrpc.OpenPool(
+				"",
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+			))
+			conn := MustSucceed(pool.Acquire("localhost:12345"))
+			Expect(conn.CanonicalTarget()).To(Equal("passthrough:///localhost:12345"))
+		})
+
+		It("Should prepend the target prefix to the address", func() {
+			pool := DeferClose(fgrpc.OpenPool(
+				"unix",
+				grpc.WithTransportCredentials(insecure.NewCredentials()),
+			))
+			conn := MustSucceed(pool.Acquire("run/synnax.sock"))
+			Expect(conn.CanonicalTarget()).To(
+				Equal("passthrough:///unix/run/synnax.sock"),
+			)
+		})
+	})
+})

--- a/freighter/go/grpc/pool_test.go
+++ b/freighter/go/grpc/pool_test.go
@@ -29,14 +29,14 @@ var _ = Describe("Pool", func() {
 			Expect(conn.CanonicalTarget()).To(Equal("passthrough:///localhost:12345"))
 		})
 
-		It("Should prepend the target prefix to the address", func() {
+		It("Should lead the prefixed address with the scheme", func() {
 			pool := DeferClose(fgrpc.OpenPool(
-				"unix",
+				"scoped",
 				grpc.WithTransportCredentials(insecure.NewCredentials()),
 			))
-			conn := MustSucceed(pool.Acquire("run/synnax.sock"))
+			conn := MustSucceed(pool.Acquire("localhost:12345"))
 			Expect(conn.CanonicalTarget()).To(
-				Equal("passthrough:///unix/run/synnax.sock"),
+				Equal("passthrough:///scoped/localhost:12345"),
 			)
 		})
 	})

--- a/freighter/go/grpc/pool_test.go
+++ b/freighter/go/grpc/pool_test.go
@@ -10,13 +10,56 @@
 package grpc_test
 
 import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/tls"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"math/big"
+	"net"
+	"time"
+
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	fgrpc "github.com/synnaxlabs/freighter/grpc"
+	v1 "github.com/synnaxlabs/freighter/grpc/v1"
+	"github.com/synnaxlabs/x/address"
+	"github.com/synnaxlabs/x/errors"
 	. "github.com/synnaxlabs/x/testutil"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials"
 	"google.golang.org/grpc/credentials/insecure"
 )
+
+// selfSignedCert returns a certificate valid only for dnsName, along with a pool that
+// trusts it.
+func selfSignedCert(dnsName string) (tls.Certificate, *x509.CertPool) {
+	GinkgoHelper()
+	key := MustSucceed(ecdsa.GenerateKey(elliptic.P256(), rand.Reader))
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: dnsName},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		ExtKeyUsage:           []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth},
+		DNSNames:              []string{dnsName},
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der := MustSucceed(
+		x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key),
+	)
+	leaf := MustSucceed(x509.ParseCertificate(der))
+	roots := x509.NewCertPool()
+	roots.AddCert(leaf)
+	return tls.Certificate{
+		Certificate: [][]byte{der},
+		PrivateKey:  key,
+		Leaf:        leaf,
+	}, roots
+}
 
 var _ = Describe("Pool", func() {
 	Describe("Acquire", func() {
@@ -38,6 +81,45 @@ var _ = Describe("Pool", func() {
 			Expect(conn.CanonicalTarget()).To(
 				Equal("passthrough:///scoped/localhost:12345"),
 			)
+		})
+	})
+
+	Describe("TLS", func() {
+		// The Core dials peers with a tls.Config that leaves ServerName empty, so gRPC
+		// derives the name from the target. A target the dialer cannot reduce to the
+		// bare host breaks certificate verification for every secure cluster.
+		It("Should verify a peer certificate against the bare hostname", func(
+			ctx SpecContext,
+		) {
+			serverCert, roots := selfSignedCert("localhost")
+			lis := MustSucceed(net.Listen("tcp", "127.0.0.1:0"))
+			srv := grpc.NewServer(grpc.Creds(credentials.NewTLS(&tls.Config{
+				Certificates: []tls.Certificate{serverCert},
+				MinVersion:   tls.VersionTLS13,
+			})))
+			pool := DeferClose(fgrpc.OpenPool("", grpc.WithTransportCredentials(
+				credentials.NewTLS(&tls.Config{
+					RootCAs:    roots,
+					MinVersion: tls.VersionTLS13,
+				}),
+			)))
+			go func() {
+				defer GinkgoRecover()
+				if err := srv.Serve(lis); !errors.Is(err, grpc.ErrServerStopped) {
+					Expect(err).To(Succeed())
+				}
+			}()
+			DeferCleanup(srv.GracefulStop)
+			port := lis.Addr().(*net.TCPAddr).Port
+			conn := MustSucceed(pool.Acquire(address.Newf("localhost:%d", port)))
+			// An Unimplemented status can only come from the server, so reaching it
+			// means the handshake verified the certificate.
+			Expect(conn.Invoke(
+				ctx,
+				"/nonexistent.Service/Method",
+				new(v1.Request),
+				new(v1.Request),
+			)).Error().To(MatchError(ContainSubstring("unknown service")))
 		})
 	})
 })


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4696](https://linear.app/synnax/issue/SY-4696/investigate-failing-aspen-membership-test)

## Description

The Aspen membership spec `Should correctly join many nodes to the cluster concurrently` timed out on macOS CI, then panicked with a nil pointer dereference. Two separate defects.

**The stall.** `freighter/go/grpc` dialed peers with `grpc.NewClient("host:port")`. gRPC resolves a bare target through its DNS resolver, which queries a `_grpc_config` TXT record and holds the resolved addresses until that query answers. Every RPC on the connection blocks in `waitForResolvedAddrs` until then, so a resolver that drops the query stalls the first request for the full DNS timeout. Ten nodes pledging at once open a hundred connections, each firing the same TXT query, and the answers get dropped. The pool now dials through the `passthrough` resolver, which hands the address straight to the dialer. The peer address is a single node, so nothing wanted DNS load balancing in the first place.

Measured over 90 runs of the concurrent-pledge scenario under `-race`: the spec went from 120-140 ms typical with 5-10 s spikes to 40-56 ms with no spike. 100 consecutive runs of the spec itself now peak at 60 ms.

**The panic.** `cluster.Open` registered a deferred cleanup that read `c.shutdown`, but four error paths return a nil Cluster, which nils `c` before the defer runs. The stalled pledge took one of them, so the timeout surfaced as a crash instead of an error. The closer is now held in a local, and every error path returns a nil Cluster.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR routes gRPC peer connections through the passthrough resolver and makes cluster initialization return nil while safely closing its local shutdown handle on errors.
- Avoids DNS resolver delays for direct peer addresses.
- Prevents nil dereferences during failed cluster initialization cleanup.
- Adds resolver-target and cluster error-path tests.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with a non-blocking test-quality issue where the new cluster test bypasses the production transport path.

The resolver and shutdown changes have no established runtime regression, while the cluster test’s mocked networks weaken coverage of the real transport behavior.

**Files Needing Attention:** aspen/internal/cluster/cluster_test.go

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| aspen/internal/cluster/cluster.go | Holds shutdown independently of the named Cluster result and consistently returns a nil Cluster on initialization errors. |
| aspen/internal/cluster/cluster_test.go | Covers failed peer contact and cleanup behavior, but uses mock transports rather than the repository-required production test path. |
| freighter/go/grpc/pool.go | Prefixes direct peer targets with the gRPC passthrough scheme while preserving existing address assembly. |
| freighter/go/grpc/pool_test.go | Verifies canonical passthrough targets for ordinary and prefixed addresses. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Cluster as Aspen Cluster
  participant Pool as Freighter gRPC Pool
  participant Resolver as Passthrough Resolver
  participant Peer as Peer Node
  Cluster->>Pool: Acquire(peer address)
  Pool->>Resolver: passthrough:///host:port
  Resolver->>Peer: Dial address verbatim
  alt connection succeeds
    Peer-->>Cluster: RPC response
  else initialization fails
    Cluster->>Cluster: Close local shutdown handle
    Cluster-->>Cluster: Return nil, error
  end
```

<sub>Reviews (1): Last reviewed commit: ["SY-4696: Dial gRPC peers through the pas..."](https://github.com/synnaxlabs/synnax/commit/6cb8777f17cc4041d378c3bab617e7bb022f2522) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55602995)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/synnaxlabs/synnax/blob/main/CLAUDE.md))

<!-- /greptile_comment -->