### PR TITLE
SY-4700: Move Go linting off the Windows and macOS runners

### DIFF
--- a/.github/workflows/test.go.yaml
+++ b/.github/workflows/test.go.yaml
@@ -66,11 +66,13 @@ jobs:
           CGO_ENABLED: "0"
         run: |
           ./custom-gcl config verify
-          for goos in linux windows; do
-            echo "::group::GOOS=$goos"
-            GOOS=$goos ./custom-gcl run
-            echo "::endgroup::"
-          done
+          echo "::group::GOOS=linux"
+          GOOS=linux ./custom-gcl run
+          echo "::endgroup::"
+          echo "::group::GOOS=windows"
+          # A throwaway cache keeps the shared setup-go cache down to one GOOS.
+          GOOS=windows GOCACHE="$RUNNER_TEMP/gocache-windows" ./custom-gcl run
+          echo "::endgroup::"
 
   test:
     name: Test (${{ matrix.os }})

--- a/.github/workflows/test.go.yaml
+++ b/.github/workflows/test.go.yaml
@@ -36,6 +36,42 @@ on:
         default: false
 
 jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Set up Go
+        uses: actions/setup-go@v7
+        with:
+          go-version-file: ${{ inputs.directory }}/go.mod
+          cache-dependency-path: |
+            ${{ inputs.directory }}/go.mod
+            ${{ inputs.directory }}/go.sum
+
+      - name: Build the custom golangci-lint binary
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.12.2
+          working-directory: ${{ inputs.directory }}
+          install-only: true
+
+      # The Windows runner does not have the disk space for a cold lint, so lint both
+      # GOOS values here. No package has a darwin-only file, so linux covers macOS.
+      - name: Lint
+        working-directory: ${{ inputs.directory }}
+        env:
+          CGO_ENABLED: "0"
+        run: |
+          ./custom-gcl config verify
+          for goos in linux windows; do
+            echo "::group::GOOS=$goos"
+            GOOS=$goos ./custom-gcl run
+            echo "::endgroup::"
+          done
+
   test:
     name: Test (${{ matrix.os }})
     strategy:
@@ -78,12 +114,6 @@ jobs:
       - name: Verify `go generate` is up to date
         if: matrix.codegen
         run: scripts/check_go_generate.sh ${{ inputs.directory }}
-
-      - name: Lint
-        uses: golangci/golangci-lint-action@v9
-        with:
-          version: v2.12.2
-          working-directory: ${{ inputs.directory }}
 
       - name: Test
         timeout-minutes: 150

--- a/docs/claude/toolchains/go.md
+++ b/docs/claude/toolchains/go.md
@@ -22,7 +22,8 @@ golangci-lint built-in formatters (gofmt, gofumpt, gci, goimports, golines, swag
 configured in the root `.golangci.yaml`), 88-char lines, standard Go idioms. Imports
 grouped: stdlib, then all others (gci). Format with `golangci-lint fmt` in the module,
 check with `golangci-lint fmt --diff`. `golangci-lint run` (CI) also fails on
-unformatted files.
+unformatted files. CI lints each module for both `GOOS=linux` and `GOOS=windows`, so
+reproduce a Windows-only failure with `GOOS=windows CGO_ENABLED=0 golangci-lint run`.
 
 ## Packages & Naming
 


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4700](https://linear.app/synnax/issue/SY-4700)

## Description

The `core` Windows lint job failed intermittently with `golangci-lint exit with code 7`.
The lint itself reported `0 issues`; the job died on a disk error:

```
level=error msg="[linters_context] typechecking error: : mkdir
  C:\Users\RUNNER~1\AppData\Local\Temp\go-build.../b1975\: There is not enough space on
  the disk."
```

`windows-latest` moved to Windows Server 2025, which leaves about 33 GB of usable disk
([runner-images#12609](https://github.com/actions/runner-images/issues/12609)).
`GOCACHE`, `GOMODCACHE`, `GOTMPDIR`, and `hostedtoolcache` all live on that volume, and
the `setup-go` cache alone restores 3.36 GB compressed. A cold golangci-lint run over
`core` exhausts what is left. The job passed only when the golangci-lint action cache
hit and made the run cheap.

Linting is now its own `ubuntu-latest` job. It builds the custom golangci-lint binary
once, then runs it for `GOOS=linux` and `GOOS=windows`, so `start_windows.go`,
`service_windows.go`, and `cmd_windows.go` stay covered. No package has a darwin-only
file, so `GOOS=linux` covers macOS.

Two things improve as a result. The lint gate now runs on every pull request instead of
only the ones into `main`. The Windows and macOS test legs also gain the headroom that
the golangci-lint module graph and the custom binary build used to take.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves Go linting from each operating-system test leg into a dedicated Ubuntu job, where the custom linter checks both Linux and Windows build contexts.

- Removes repeated lint execution from the Windows, macOS, and Linux test matrix.
- Builds the custom golangci-lint binary once and runs it with `GOOS=linux` and `GOOS=windows`.
- Documents how to reproduce Windows-specific lint failures locally.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the dedicated lint job preserving Linux and Windows source coverage while reducing resource use on Windows and macOS runners.

The custom lint binary is built in the module working directory before the explicit Linux and Windows lint invocations, and the reusable-workflow callers continue to execute both lint and test jobs.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/test.go.yaml | Adds a dedicated Ubuntu lint job covering Linux and Windows targets and removes linting from the platform test matrix; no concrete defect was established. |
| docs/claude/toolchains/go.md | Updates Go linting documentation to match the new cross-platform CI commands. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  C[Reusable Go workflow caller] --> L[Ubuntu lint job]
  C --> T[OS test matrix]
  L --> B[Build custom golangci-lint]
  B --> LL[Lint with GOOS=linux]
  B --> LW[Lint with GOOS=windows]
  T --> U[Ubuntu tests]
  T --> W[Windows tests]
  T --> M[macOS tests]
```

<sub>Reviews (1): Last reviewed commit: ["SY-4700: Move Go linting off the Windows..."](https://github.com/synnaxlabs/synnax/commit/8fe0b2a50c89239af84f095a452f91583c1d0d28) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55606781)</sub>

<!-- /greptile_comment -->