### PR TITLE
SY-4698: Stop a settling fetch handing back a stale answer

### DIFF
--- a/client/ts/src/query/query.spec.ts
+++ b/client/ts/src/query/query.spec.ts
@@ -891,7 +891,8 @@ describe("Answers", () => {
       const pending = answers.retrieve({ min: 3 });
       table.set("a", rec("a", 5));
       release([]);
-      await pending;
+      // A caller that writes the awaited answer back loses the record.
+      expect(await pending).toEqual([rec("a", 5)]);
       expect(answers.getCached({ min: 3 })).toEqual([rec("a", 5)]);
       // patching the answer without announcing it leaves subscribers blind
       expect(handler).toHaveBeenLastCalledWith([rec("a", 5)]);
@@ -909,7 +910,7 @@ describe("Answers", () => {
       const pending = answers.retrieve({ min: 3 });
       table.set("a", rec("a", 1));
       release(["a"]);
-      await pending;
+      expect(await pending).toEqual([]);
       expect(answers.getCached({ min: 3 })).toEqual([]);
     });
 

--- a/client/ts/src/query/query.ts
+++ b/client/ts/src/query/query.ts
@@ -616,7 +616,10 @@ export class Space<
     const promise = this.config.fetch(query.params, options).then(
       (keys) => {
         this.settle(query, loading, { variant: "ready", keys });
-        return this.composedOf(query, keys);
+        // The settle drains membership changes that raced the fetch, so the answer
+        // comes off the query: the keys the fetch returned are already stale.
+        const { state } = query;
+        return this.composedOf(query, state.variant === "ready" ? state.keys : keys);
       },
       (reason: unknown) => {
         const error = errors.fromUnknown(reason);


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4698](https://linear.app/synnax/issue/SY-4698/investigate-the-failing-console-platformtreetreespectsx-test)

## Description

`console/src/platform/tree/Tree.spec.tsx > should add a node when a child is created under the root after render` failed on about one CI run in ten. The tree rendered completely empty and stayed that way past the 5s `waitFor`.

The defect is in the client query cache, not the tree. `Space.fetch` resolved the caller with the keys the fetch itself returned. `settle` runs `drainRechecks` before that, so a Rule 2 membership change that raced the in-flight fetch was already patched into the query, and the returned answer was stale by the time the promise resolved.

The Console tree both subscribes through `onChange` and applies the awaited `retrieve` result. On a slow runner the group creation beat the tree's in-flight children fetch, so `settle` delivered `[child]` through the subscription and the awaited `retrieve` then applied `[]` over it. Nothing fired again, so the tree stayed empty.

`retrieve` now returns the answer the settle left on the query, falling back to the fetched keys when the settle left it non-ready (reset, superseded fetch, deletion). Only Rule 2 spaces change: rules 1 and 3 never patch membership, so their state already equals the fetched keys.

Two existing regression tests awaited the pending promise without asserting its value. They now pin the resolved answer, which is the assertion that was missing.

Causality was confirmed by delaying `ontology.Client.fetchDependents` so the creation always beat the settle: without the fix the Console test fails with the same DOM and the same line as CI, with it the test passes.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes a query-cache race where an in-flight fetch could resolve with stale membership after settlement had already applied deferred changes.
- Resolves successful fetches from the query’s post-settlement keys when the query remains ready.
- Adds regression assertions for records admitted or evicted while a Rule 2 fetch is in flight.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the changed return behavior matching the cache’s post-settlement state.

The ready-state branch now returns membership after deferred rechecks, while superseded and non-ready states retain their previous fallback behavior; the regression tests cover both admission and eviction races.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| client/ts/src/query/query.ts | Successful fetches now return the post-settlement ready answer, preventing deferred membership updates from being overwritten by stale fetched keys. |
| client/ts/src/query/query.spec.ts | Existing in-flight admission and eviction regressions now assert the resolved promise value as well as cached state. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Caller
  participant Space
  participant Fetch
  participant Table
  Caller->>Space: retrieve(query)
  Space->>Fetch: fetch(params)
  Table-->>Space: membership changes while loading
  Space->>Space: defer membership recheck
  Fetch-->>Space: fetched keys
  Space->>Space: settle and drain rechecks
  Space-->>Caller: compose post-settlement keys
```

<sub>Reviews (1): Last reviewed commit: ["SY-4698: Stop a settling fetch handing b..."](https://github.com/synnaxlabs/synnax/commit/871e7481ea0ddee8a6516bc8fc44d33fb43c937a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55611837)</sub>

<!-- /greptile_comment -->