### PR TITLE
SY-4705: Retire a task command status no Driver will answer

### DIFF
--- a/client/py/synnax/task/client.py
+++ b/client/py/synnax/task/client.py
@@ -29,6 +29,7 @@ from synnax.rack import Rack
 from synnax.task.types_gen import Command, Key, Payload, Status, ontology_id
 from synnax.telem import TimeSpan, TimeStamp
 from x.lists import check_for_none, normalize, override
+from x.timing import Timer
 
 
 class _CreateRequest(BaseModel):
@@ -207,10 +208,15 @@ class Task:
         :param timeout: The maximum time to wait for the driver to acknowledge the
         command before a timeout occurs.
         """
+        span = TimeSpan.from_seconds(timeout)
         with self._frame_client.open_streamer([_TASK_STATE_CHANNEL]) as s:
             key = self.execute_command(type_, args)
+            timer = Timer()
             while True:
-                frame = s.read(TimeSpan.from_seconds(timeout).seconds)
+                # The channel carries every status in the cluster, so the wait is a
+                # deadline: a frame answering some other command must not renew it.
+                remaining = span - timer.elapsed()
+                frame = s.read(remaining) if remaining > TimeSpan.ZERO else None
                 if frame is None:
                     raise TimeoutError(
                         f"timed out waiting for driver to acknowledge {type_} command"

--- a/client/py/tests/test_task.py
+++ b/client/py/tests/test_task.py
@@ -85,6 +85,35 @@ class TestTaskClient:
         tsk.execute_command_sync("test", {"key": "value"})
         t.join()
 
+    def test_execute_command_sync_timeout_is_a_deadline(
+        self, client: sy.Synnax
+    ) -> None:
+        """A status answering nothing must not renew the wait for an answer."""
+        tsk = client.tasks.create(name="test", type="pagerduty_alert")
+        stop = threading.Event()
+
+        def noise() -> None:
+            while not stop.is_set():
+                client.statuses.set(
+                    sy.Status(
+                        key=str(uuid4()),
+                        variant=sy.status.VARIANT_INFO,
+                        message="unrelated",
+                    )
+                )
+                sy.sleep(0.1)
+
+        t = threading.Thread(target=noise)
+        t.start()
+        try:
+            timer = sy.Timer()
+            with pytest.raises(TimeoutError):
+                tsk.execute_command_sync("test", timeout=1)
+            assert timer.elapsed() < 5 * sy.TimeSpan.SECOND
+        finally:
+            stop.set()
+            t.join()
+
     def test_execute_command_without_args_sends_empty_object(self, client: sy.Synnax):
         """Should send an empty object for args instead of null."""
         tsk = client.tasks.create(name="test", type="pagerduty_alert")

--- a/client/ts/src/task/client.ts
+++ b/client/ts/src/task/client.ts
@@ -27,10 +27,15 @@ import { z } from "zod";
 import { type framer } from "@/framer";
 import { ontology } from "@/ontology";
 import { query } from "@/query";
-import { type Key as RackKey, keyZ as rackKeyZ } from "@/rack/types.gen";
+import {
+  type Key as RackKey,
+  keyZ as rackKeyZ,
+  ontologyID as rackOntologyID,
+} from "@/rack/types.gen";
 import { type ranger } from "@/ranger";
 import { status } from "@/status";
 import {
+  type Command,
   commandZ,
   type Key,
   keyZ,
@@ -77,6 +82,14 @@ export const drifted = (task: DriftedParams): boolean => {
 // status of a task to loading.
 // Issue: https://linear.app/synnax/issue/SY-2723/fix-handling-of-non-startstop-commands-loading-indicators-in-tasks
 const LOADING_COMMANDS = ["start", "stop"];
+
+// The rack monitor marks a rack whose Driver is alive with one of these.
+const HEALTHY_RACK_VARIANTS: status.Variant[] = ["success", "info"];
+
+/** How long a command waits for the Driver before the wait is called off. */
+const COMMAND_DEADLINE = TimeSpan.seconds(10);
+
+const STATUS_NAME = "Task Status";
 
 const retrieveSnapshottedTo = async (taskKey: Key, ontologyClient: ontology.Client) => {
   const parents = await ontologyClient.parents.retrieve({ ids: ontologyID(taskKey) });
@@ -402,6 +415,7 @@ export class Client extends query.Retriever<
   /** The task record table; injected into sibling clients at wiring. */
   readonly store: query.Table<Key, Omit<Task, "status">>;
   private readonly cfg: ClientConfig;
+  private readonly commandDeadlines = new Map<Key, ReturnType<typeof setTimeout>>();
 
   constructor(cfg: ClientConfig) {
     const { cache, statusStore } = cfg;
@@ -441,28 +455,15 @@ export class Client extends query.Retriever<
       schema: commandZ,
       onChange: (commands) =>
         statusStore.batch(() =>
-          commands.forEach((changed) =>
-            statusStore.set(statusKey(changed.task), (prev) => {
-              if (prev == null || !LOADING_COMMANDS.includes(changed.type)) return prev;
-              // Carry the last known deploy info forward: zeroing it would make this
-              // optimistic status claim the task deployed with an empty config/rack.
-              const latest = this.latestStatusOf(changed.task);
-              return status.create<StatusDetailsZodObject>({
-                key: statusKey(changed.task),
-                name: "Task Status",
-                variant: "loading",
-                message: `Running ${changed.type} command...`,
-                details: {
-                  task: changed.task,
-                  running: true,
-                  cmd: "",
-                  configHash: latest?.details.configHash ?? "",
-                  rack: latest?.details.rack ?? 0,
-                  data: {},
-                },
-              });
-            }),
-          ),
+          commands.forEach((changed) => {
+            if (!LOADING_COMMANDS.includes(changed.type)) return;
+            const key = statusKey(changed.task);
+            if (statusStore.get(key) == null) return;
+            const optimistic = this.optimisticStatus(changed);
+            statusStore.set(key, optimistic);
+            if (optimistic.variant === "loading")
+              this.armCommandDeadline(changed, optimistic);
+          }),
         ),
     });
     const composed = cache.derive<Key, Omit<Task, "status">, Task>({
@@ -644,6 +645,78 @@ export class Client extends query.Retriever<
     const payload = cached.payload;
     if (st == null) return this.sugar(payload);
     return this.sugar({ ...payload, status: st });
+  }
+
+  // Every domain's statuses share one store, so a rack's status sits beside its
+  // tasks' under the rack's ontology ID.
+  private downRackStatus(rack: RackKey | undefined): status.Status | undefined {
+    if (rack == null || primitive.isZero(rack)) return undefined;
+    const stat = this.cfg.statusStore.get(ontology.idToString(rackOntologyID(rack)));
+    if (stat == null || HEALTHY_RACK_VARIANTS.includes(stat.variant)) return undefined;
+    return stat;
+  }
+
+  /**
+   * Builds the status shown while a command is in flight. A rack whose Driver is down
+   * answers nothing, so its warning stands in for a wait that would never end.
+   */
+  private optimisticStatus(cmd: Command): Status {
+    // Carry the last known deploy info forward: zeroing it would make this
+    // optimistic status claim the task deployed with an empty config/rack.
+    const latest = this.latestStatusOf(cmd.task);
+    const key = statusKey(cmd.task);
+    const details = {
+      task: cmd.task,
+      cmd: "",
+      configHash: latest?.details.configHash ?? "",
+      rack: latest?.details.rack ?? 0,
+      data: {},
+    };
+    const down = this.downRackStatus(this.store.get(cmd.task)?.rack);
+    if (down == null)
+      return status.create<StatusDetailsZodObject>({
+        key,
+        name: STATUS_NAME,
+        variant: "loading",
+        message: `Running ${cmd.type} command...`,
+        details: { ...details, running: true },
+      });
+    return status.create<StatusDetailsZodObject>({
+      key,
+      name: STATUS_NAME,
+      variant: "warning",
+      message: down.message,
+      description: down.description,
+      details: { ...details, running: false },
+    });
+  }
+
+  // Nothing else retires the loading status: a task on a silent rack waits on the
+  // Core's next dead-rack alert, which dampens to once a minute.
+  private armCommandDeadline(cmd: Command, optimistic: Status): void {
+    const { statusStore } = this.cfg;
+    const key = statusKey(cmd.task);
+    clearTimeout(this.commandDeadlines.get(cmd.task));
+    this.commandDeadlines.set(
+      cmd.task,
+      setTimeout(() => {
+        this.commandDeadlines.delete(cmd.task);
+        // Any later write replaced the exact object this deadline was armed for.
+        if (statusStore.get(key) !== optimistic) return;
+        statusStore.set(
+          key,
+          status.create<StatusDetailsZodObject>({
+            key,
+            name: STATUS_NAME,
+            variant: "warning",
+            message: `No response to the ${cmd.type} command`,
+            description: `The Driver did not respond within ${COMMAND_DEADLINE.toString()}.`,
+            // Nothing answered, so the command is taken to have had no effect.
+            details: { ...optimistic.details, running: cmd.type === "stop" },
+          }),
+        );
+      }, COMMAND_DEADLINE.milliseconds),
+    );
   }
 
   // A task's status may live under the "task:<key>" row or under any status
@@ -905,7 +978,7 @@ interface ExecuteCommandsSyncInternalParams<StatusData extends z.ZodType = z.Zod
 const executeCommandsSync = async <StatusData extends z.ZodType = z.ZodNever>({
   frameClient,
   commands,
-  timeout = TimeSpan.seconds(10),
+  timeout = COMMAND_DEADLINE,
   statusDataZ,
   name: taskName,
 }: ExecuteCommandsSyncInternalParams<StatusData>): Promise<Status<StatusData>[]> => {

--- a/client/ts/src/task/task.spec.ts
+++ b/client/ts/src/task/task.spec.ts
@@ -848,23 +848,24 @@ describe("Task", async () => {
         config: {},
         type: "pagerduty_alert",
       });
-      const params = { key: t.key };
-      const off = client.tasks.onChange(params, vi.fn());
+      const key = task.statusKey(t.key);
+      await client.tasks.retrieve({ key: t.key });
+      await setRackStatus(down.key, "warning", "no Driver here");
+      // The store is watched directly so the assertion reads the write the command
+      // makes. A subscribed query would let a refetch restore the stored status
+      // first, and a poll would only ever see whichever landed last.
+      let seeWrite = (_: status.Status): void => {};
+      const written = new Promise<status.Status>((resolve) => (seeWrite = resolve));
+      const off = client.statuses.store.subscribe((event) => {
+        if (event.variant === "set") seeWrite(event.value);
+      }, key);
       try {
-        await client.tasks.retrieve(params);
-        await setRackStatus(down.key, "warning", "no Driver here");
         await client.tasks.executeCommand({ task: t.key, type: "start" });
-        await expect
-          .poll(() => {
-            const cached = client.tasks.getCached(params);
-            if (!query.isLive(cached)) return undefined;
-            return cached.status;
-          })
-          .toMatchObject({
-            variant: "warning",
-            message: "no Driver here",
-            details: { running: false },
-          });
+        expect(await written).toMatchObject({
+          variant: "warning",
+          message: "no Driver here",
+          details: { running: false },
+        });
       } finally {
         off();
       }

--- a/client/ts/src/task/task.spec.ts
+++ b/client/ts/src/task/task.spec.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { id, TimeStamp, uuid } from "@synnaxlabs/x";
+import { id, TimeSpan, TimeStamp, uuid } from "@synnaxlabs/x";
 import { assert, beforeAll, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 
@@ -19,6 +19,9 @@ import { task } from "@/task";
 import { createTestClient, waitForStreamLive } from "@/testutil";
 
 const client = createTestClient();
+
+// Mirrors the deadline the task client gives an unanswered command.
+const COMMAND_DEADLINE = TimeSpan.seconds(10);
 
 describe("Task", async () => {
   const testRack = await client.racks.create({ name: "test" });
@@ -867,46 +870,39 @@ describe("Task", async () => {
       }
     });
 
-    it("gives up on a command no Driver answers", { timeout: 40000 }, async () => {
+    it("gives up on a command no Driver answers", async () => {
       const alive = await client.racks.create({ name: `alive-${id.create()}` });
       const t = await alive.createTask({
         name: `deadline-${id.create()}`,
         config: {},
         type: "pagerduty_alert",
       });
-      const params = { key: t.key };
+      const key = task.statusKey(t.key);
+      // The status store is watched directly, leaving no subscribed query behind:
+      // winding the clock forward would otherwise reach the cache streamer's
+      // reconcile, whose refetch replaces the very status under test.
       let seeLoading = (): void => {};
       const loading = new Promise<void>((resolve) => (seeLoading = resolve));
-      const off = client.tasks.onChange(params, (cached) => {
-        if (query.isLive(cached) && cached.status?.variant === "loading") seeLoading();
-      });
-      // The Core rewrites the statuses of every task on a rack it finds silent, so
-      // the rack is kept alive for the whole wait. The beat also proves unrelated
-      // status traffic neither renews the deadline nor cancels it.
-      const beat = setInterval(() => {
-        void setRackStatus(alive.key, "success", "Driver is running");
-      }, 1000);
+      const off = client.statuses.store.subscribe((event) => {
+        if (event.variant === "set" && event.value.variant === "loading") seeLoading();
+      }, key);
       try {
-        await client.tasks.retrieve(params);
+        await client.tasks.retrieve({ key: t.key });
         await setRackStatus(alive.key, "success", "Driver is running");
+        vi.useFakeTimers({
+          toFake: ["setTimeout", "clearTimeout"],
+          shouldAdvanceTime: true,
+        });
         await client.tasks.executeCommand({ task: t.key, type: "start" });
         await loading;
-        await expect
-          .poll(
-            () => {
-              const cached = client.tasks.getCached(params);
-              if (!query.isLive(cached)) return undefined;
-              return cached.status;
-            },
-            { timeout: 30000 },
-          )
-          .toMatchObject({
-            variant: "warning",
-            message: "No response to the start command",
-            details: { running: false },
-          });
+        await vi.advanceTimersByTimeAsync(COMMAND_DEADLINE.milliseconds);
+        expect(client.statuses.store.get(key)).toMatchObject({
+          variant: "warning",
+          message: "No response to the start command",
+          details: { running: false },
+        });
       } finally {
-        clearInterval(beat);
+        vi.useRealTimers();
         off();
       }
     });

--- a/client/ts/src/task/task.spec.ts
+++ b/client/ts/src/task/task.spec.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { id, TimeSpan, TimeStamp, uuid } from "@synnaxlabs/x";
+import { id, TimeStamp, uuid } from "@synnaxlabs/x";
 import { assert, beforeAll, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 
@@ -867,8 +867,9 @@ describe("Task", async () => {
       }
     });
 
-    it("gives up on a command no Driver answers", async () => {
-      const t = await testRack.createTask({
+    it("gives up on a command no Driver answers", { timeout: 40000 }, async () => {
+      const alive = await client.racks.create({ name: `alive-${id.create()}` });
+      const t = await alive.createTask({
         name: `deadline-${id.create()}`,
         config: {},
         type: "pagerduty_alert",
@@ -879,24 +880,33 @@ describe("Task", async () => {
       const off = client.tasks.onChange(params, (cached) => {
         if (query.isLive(cached) && cached.status?.variant === "loading") seeLoading();
       });
+      // The Core rewrites the statuses of every task on a rack it finds silent, so
+      // the rack is kept alive for the whole wait. The beat also proves unrelated
+      // status traffic neither renews the deadline nor cancels it.
+      const beat = setInterval(() => {
+        void setRackStatus(alive.key, "success", "Driver is running");
+      }, 1000);
       try {
         await client.tasks.retrieve(params);
-        await setRackStatus(testRack.key, "success", "Driver is running");
-        // Only the deadline is wound forward: the command and its echo still travel
-        // over the live stream, which never waits on a timer.
-        vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+        await setRackStatus(alive.key, "success", "Driver is running");
         await client.tasks.executeCommand({ task: t.key, type: "start" });
         await loading;
-        await vi.advanceTimersByTimeAsync(TimeSpan.seconds(10).milliseconds);
-        const cached = client.tasks.getCached(params);
-        assert(query.isLive(cached));
-        expect(cached.status).toMatchObject({
-          variant: "warning",
-          message: "No response to the start command",
-          details: { running: false },
-        });
+        await expect
+          .poll(
+            () => {
+              const cached = client.tasks.getCached(params);
+              if (!query.isLive(cached)) return undefined;
+              return cached.status;
+            },
+            { timeout: 30000 },
+          )
+          .toMatchObject({
+            variant: "warning",
+            message: "No response to the start command",
+            details: { running: false },
+          });
       } finally {
-        vi.useRealTimers();
+        clearInterval(beat);
         off();
       }
     });

--- a/client/ts/src/task/task.spec.ts
+++ b/client/ts/src/task/task.spec.ts
@@ -7,12 +7,14 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { id, TimeStamp, uuid } from "@synnaxlabs/x";
+import { id, TimeSpan, TimeStamp, uuid } from "@synnaxlabs/x";
 import { assert, beforeAll, describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 
 import { ontology } from "@/ontology";
 import { query } from "@/query";
+import { rack } from "@/rack";
+import { type status } from "@/status";
 import { task } from "@/task";
 import { createTestClient, waitForStreamLive } from "@/testutil";
 
@@ -709,6 +711,23 @@ describe("Task", async () => {
     });
   });
 
+  // A rack with no Driver goes down within seconds of its creation, and the client
+  // reads that state, so tests that need one state or the other must say which.
+  const setRackStatus = async (
+    key: number,
+    variant: status.Variant,
+    message: string,
+  ) => {
+    await client.statuses.set({
+      key: rack.statusKey(key),
+      name: "Rack Status",
+      variant,
+      message,
+      time: TimeStamp.now(),
+      details: { rack: key },
+    });
+  };
+
   describe("onChange", () => {
     it("merges a status keyed by details.task into a subscribed single query", async () => {
       const t = await testRack.createTask({
@@ -809,11 +828,75 @@ describe("Task", async () => {
             return cached.status?.details.configHash;
           })
           .toBe("deadbeef");
+        await setRackStatus(testRack.key, "success", "Driver is running");
         await client.tasks.executeCommand({ task: t.key, type: "stop" });
         await expect.poll(() => loading.length).toBeGreaterThan(0);
         expect(loading[0].details.configHash).toBe("deadbeef");
         expect(loading[0].details.rack).toBe(testRack.key);
       } finally {
+        off();
+      }
+    });
+
+    it("stands the rack's problem in for a wait its Driver cannot answer", async () => {
+      const down = await client.racks.create({ name: `down-${id.create()}` });
+      const t = await down.createTask({
+        name: `down-${id.create()}`,
+        config: {},
+        type: "pagerduty_alert",
+      });
+      const params = { key: t.key };
+      const off = client.tasks.onChange(params, vi.fn());
+      try {
+        await client.tasks.retrieve(params);
+        await setRackStatus(down.key, "warning", "no Driver here");
+        await client.tasks.executeCommand({ task: t.key, type: "start" });
+        await expect
+          .poll(() => {
+            const cached = client.tasks.getCached(params);
+            if (!query.isLive(cached)) return undefined;
+            return cached.status;
+          })
+          .toMatchObject({
+            variant: "warning",
+            message: "no Driver here",
+            details: { running: false },
+          });
+      } finally {
+        off();
+      }
+    });
+
+    it("gives up on a command no Driver answers", async () => {
+      const t = await testRack.createTask({
+        name: `deadline-${id.create()}`,
+        config: {},
+        type: "pagerduty_alert",
+      });
+      const params = { key: t.key };
+      let seeLoading = (): void => {};
+      const loading = new Promise<void>((resolve) => (seeLoading = resolve));
+      const off = client.tasks.onChange(params, (cached) => {
+        if (query.isLive(cached) && cached.status?.variant === "loading") seeLoading();
+      });
+      try {
+        await client.tasks.retrieve(params);
+        await setRackStatus(testRack.key, "success", "Driver is running");
+        // Only the deadline is wound forward: the command and its echo still travel
+        // over the live stream, which never waits on a timer.
+        vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+        await client.tasks.executeCommand({ task: t.key, type: "start" });
+        await loading;
+        await vi.advanceTimersByTimeAsync(TimeSpan.seconds(10).milliseconds);
+        const cached = client.tasks.getCached(params);
+        assert(query.isLive(cached));
+        expect(cached.status).toMatchObject({
+          variant: "warning",
+          message: "No response to the start command",
+          details: { running: false },
+        });
+      } finally {
+        vi.useRealTimers();
         off();
       }
     });

--- a/integration/tests/console/task/no_device.py
+++ b/integration/tests/console/task/no_device.py
@@ -108,17 +108,11 @@ class NoDevice(HardwareCase, ConsoleCase):
         self.log("Deploying task")
         ni_ai.deploy(expect=None)
 
-        # SY-4705: the start command can sit unresolved on a rack with no driver, so
-        # the status stalls on the running message instead of reaching the warning.
-        status = ni_ai.wait_for_status_level(("loading", "warning", "error"))
+        # No Driver answers a start command on this rack, so the Console stands the
+        # rack's own problem in for a wait that would never end.
+        status = ni_ai.wait_for_status_level(("warning", "error"))
         level = status["level"]
         msg = status["msg"]
-
-        if level == "loading":
-            assert "Running start command" in msg, (
-                f"<{msg}> should be <Running start command>"
-            )
-            return
 
         level_expected = "warning"
         msg_expected = f"Synnax Driver on {rack_name} not running"

--- a/integration/tests/console/task/no_device.py
+++ b/integration/tests/console/task/no_device.py
@@ -109,13 +109,11 @@ class NoDevice(HardwareCase, ConsoleCase):
         ni_ai.deploy(expect=None)
 
         # No Driver answers a start command on this rack, so the Console stands the
-        # rack's own problem in for a wait that would never end.
-        status = ni_ai.wait_for_status_level(("warning", "error"))
-        level = status["level"]
-        msg = status["msg"]
+        # rack's own problem in for a wait that would never end. The Core stamps a
+        # "status unknown" placeholder while the task saves, so the wait keys on the
+        # message rather than on the level.
+        ni_ai.wait_for_status(f"Synnax Driver on {rack_name} not running")
 
+        level = ni_ai.status()["level"]
         level_expected = "warning"
-        msg_expected = f"Synnax Driver on {rack_name} not running"
-
-        assert msg_expected in msg, f"<{msg}> should be <{msg_expected}>"
         assert level_expected == level, f"<{level}> should be <{level_expected}>"

--- a/pluto/src/task/queries.spec.tsx
+++ b/pluto/src/task/queries.spec.tsx
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { group, ontology, status, task } from "@synnaxlabs/client";
+import { group, ontology, rack, status, task } from "@synnaxlabs/client";
 import { createTestClient } from "@synnaxlabs/client/testutil";
 import { id, uuid } from "@synnaxlabs/x";
 import { act, render, renderHook, waitFor } from "@testing-library/react";
@@ -261,10 +261,10 @@ describe("queries", () => {
     });
 
     it("should update task status when a command is executed", async () => {
-      const rack = await client.racks.create({
+      const testRack = await client.racks.create({
         name: "testRack",
       });
-      const testTask = await rack.createTask({
+      const testTask = await testRack.createTask({
         name: "commandTask",
         type: "pagerduty_alert",
         config: {},
@@ -277,6 +277,19 @@ describe("queries", () => {
         result.current.retrieve({});
       });
       await waitFor(() => expect(result.current.variant).toEqual("success"));
+
+      // A rack with no Driver goes down within seconds of its creation, and a
+      // command on a down rack shows its warning rather than a wait for an answer.
+      await act(async () => {
+        await client.statuses.set(
+          status.create<typeof rack.statusDetailsZ>({
+            key: rack.statusKey(testRack.key),
+            variant: "success",
+            message: "Driver is running",
+            details: { rack: testRack.key },
+          }),
+        );
+      });
 
       const command: task.Command = {
         key: id.create(),


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4705](https://linear.app/synnax/issue/SY-4705/task-form-stalls-with-no-feedback-when-rackdevice-is-disconnected)

## Description

Deploying a task onto a rack whose Driver is down left the form on "Running start
command..." for up to a minute, with a page reload as the only way out.

The TS client writes that loading status the moment it sees a task command, and only a
later status from the cluster retires it. Nothing on the Core answers a command for a
rack with no Driver, so the only thing that ever replaced it was the rack monitor's next
dead-rack alert, which dampens to once every twelve health checks. Measured against a
live Core: the alert that would have cleared it landed 37s after the command. A reload
fixed it because the loading status is client-only, so dropping it revealed the correct
warning the Core already held.

Two changes, both in the listener that writes that status:

- A command on a rack whose status says its Driver is down now shows that rack's own
  warning instead of a wait that cannot end. The command still goes out, so a stale
  liveness reading costs nothing: a Driver that is in fact listening answers and its
  status wins.
- Every loading status now carries a ten second deadline, the same one
  `executeCommandSync` already uses. If our own status is still in place when it
  expires, it becomes a warning saying no response arrived.

`no_device.py` drops the tolerance it carried for this bug.

### Python client

The same symptom reached the Python client by another route.
`Task.execute_command_sync` gave every `read` the full timeout instead of holding one
deadline, so any frame renewed the budget. It streams `sy_status_set`, which carries
every status in the cluster, and the Core's embedded Driver heartbeats onto it once a
second. A command no Driver answered therefore never timed out at all. The timeout is
now a real deadline.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR prevents task forms from remaining indefinitely in a loading state when a Driver does not answer.
- Reuses an unhealthy rack’s warning instead of showing an unresolvable command wait.
- Adds a ten-second deadline that converts unanswered optimistic statuses into warnings.
- Adds unit coverage for both paths and tightens the disconnected-device integration expectation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no concrete blocking or non-blocking issues identified.

The deadline only replaces the exact optimistic status it created, current Driver responses replace that canonical row, and task deletion prevents the pending callback from restoring stale state.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| client/ts/src/task/client.ts | Adds unhealthy-rack substitution and identity-guarded command deadlines without an accepted correctness issue. |
| client/ts/src/task/task.spec.ts | Covers preservation of deployment metadata, unhealthy-rack warnings, and unanswered-command expiration. |
| integration/tests/console/task/no_device.py | Removes tolerance for the stale loading state and requires the disconnected-rack warning. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant UI as Console
  participant Client as TS task client
  participant Core
  participant Driver
  UI->>Client: start/stop command
  Client->>Core: publish command
  alt cached rack status is unhealthy
    Client-->>UI: show rack warning
  else rack appears healthy
    Client-->>UI: show loading status
    alt Driver responds within 10 seconds
      Driver->>Core: task status
      Core->>Client: task status
      Client-->>UI: show Driver status
    else no response
      Client-->>UI: show timeout warning
    end
  end
```

<sub>Reviews (1): Last reviewed commit: ["SY-4705: Retire a task command status no..."](https://github.com/synnaxlabs/synnax/commit/6ac2cdf74684d788308731bef1e2f7928555917f) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55845651)</sub>

<!-- /greptile_comment -->