### PR TITLE
[Schematic Symbols] Rqeorder form tabs for consistency

### DIFF
--- a/pluto/src/schematic/node/general/select/Form.tsx
+++ b/pluto/src/schematic/node/general/select/Form.tsx
@@ -80,8 +80,8 @@ export const SelectForm = (): ReactElement => (
   <Tabs.Frame initialValue="style" grow>
     <Tabs.Selector>
       <Tabs.Tab itemKey="style">Style</Tabs.Tab>
-      <Tabs.Tab itemKey="options">Options</Tabs.Tab>
       <Tabs.Tab itemKey="control">Control</Tabs.Tab>
+      <Tabs.Tab itemKey="options">Options</Tabs.Tab>
     </Tabs.Selector>
     <Tabs.Content itemKey="style">
       <Form.Wrapper y align="stretch">

--- a/pluto/src/schematic/node/general/stateIndicator/Form.tsx
+++ b/pluto/src/schematic/node/general/stateIndicator/Form.tsx
@@ -60,8 +60,8 @@ export const StateIndicatorForm = (): ReactElement => (
   <Tabs.Frame initialValue="style" grow>
     <Tabs.Selector>
       <Tabs.Tab itemKey="style">Style</Tabs.Tab>
-      <Tabs.Tab itemKey="options">Options</Tabs.Tab>
       <Tabs.Tab itemKey="telemetry">Telemetry</Tabs.Tab>
+      <Tabs.Tab itemKey="options">Options</Tabs.Tab>
     </Tabs.Selector>
     <Tabs.Content itemKey="style">
       <Form.Wrapper y align="stretch">


### PR DESCRIPTION
Found it very painful that the tabs were not in the same relative location when trying to click through all symbols and verify the correct channels and labels were applied.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Reorders tabs in two schematic symbol forms so Control or Telemetry remains in a consistent relative position while Options moves to the end.
- Moves the Select form’s Options tab after Control.
- Moves the State Indicator form’s Options tab after Telemetry.
- Preserves tab keys, content panels, and the initial Style selection.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it only changes the deliberate visual and keyboard traversal order of existing keyed tabs.

Tab selection and content matching remain keyed by unchanged item keys, and no persisted state, caller, or test depends on the previous ordering.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| pluto/src/schematic/node/general/select/Form.tsx | Reorders existing keyed tabs without changing their content or selection behavior. |
| pluto/src/schematic/node/general/stateIndicator/Form.tsx | Moves Options after Telemetry while preserving all tab keys and content mappings. |

<sub>Reviews (1): Last reviewed commit: ["\[schematic symbols\] reorder form tabs fo..."](https://github.com/synnaxlabs/synnax/commit/01dc2b959398ee52bdaa830f890a3ce6c068f071) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=55925419)</sub>

<!-- /greptile_comment -->