### PR TITLE
SY-4711: Fix table column labels past Z and the rounded corner cell

### DIFF
--- a/pluto/src/table/Indicator.spec.tsx
+++ b/pluto/src/table/Indicator.spec.tsx
@@ -10,7 +10,7 @@
 import { fireEvent, render } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
 
-import { Indicator } from "@/table/Indicator";
+import { getCellColumn, Indicator } from "@/table/Indicator";
 
 const renderIndicator = (props: Partial<React.ComponentProps<typeof Indicator>>) =>
   render(
@@ -59,5 +59,25 @@ describe("Indicator", () => {
       0,
       expect.objectContaining({ type: "contextmenu" }),
     );
+  });
+});
+
+describe("getCellColumn", () => {
+  it.each([
+    [0, "A"],
+    [25, "Z"],
+    [26, "AA"],
+    [27, "AB"],
+    [51, "AZ"],
+    [52, "BA"],
+    [701, "ZZ"],
+    [702, "AAA"],
+  ])("labels index %i as %s", (index, label) => {
+    expect(getCellColumn(index)).toEqual(label);
+  });
+
+  it("renders the label on a column indicator past the alphabet", () => {
+    const { container } = renderIndicator({ index: 26 });
+    expect(container.textContent).toContain("AA");
   });
 });

--- a/pluto/src/table/Indicator.tsx
+++ b/pluto/src/table/Indicator.tsx
@@ -25,11 +25,15 @@ const ALPHABET = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
 /** Pixel size of an indicator strip, mirroring --pluto-table-indicator-size. */
 export const INDICATOR_SIZE = 4.5 * 6;
 
-// getCellColumn maps a 0-based column index to a spreadsheet-style letter
-// ("A", "B", "C", ...). Defined here so consumers building UI chrome (e.g.,
-// breadcrumb labels in a toolbar) can label cells using the same convention
-// the table renders.
-export const getCellColumn = (index: number): string => ALPHABET[index];
+// getCellColumn maps a 0-based column index to a spreadsheet-style label ("A", "B",
+// ... "Z", "AA", "AB", ...). Exported so consumers labeling cells outside the table
+// (toolbar breadcrumbs, menu items) use the same convention the table renders.
+export const getCellColumn = (index: number): string => {
+  let label = "";
+  for (let i = index; i >= 0; i = Math.floor(i / ALPHABET.length) - 1)
+    label = ALPHABET[i % ALPHABET.length] + label;
+  return label;
+};
 
 export interface ColumnIndicatorsProps {
   columns: number[];
@@ -127,7 +131,7 @@ export const Indicator = ({
     ),
   });
   const style = useMemo(() => ({ [direction.dimension(dir)]: value }), [dir, value]);
-  const label = dir === "x" ? ALPHABET[index] : index + 1;
+  const label = dir === "x" ? getCellColumn(index) : index + 1;
   return (
     <td
       id={`resizer-${dir}-${index}`}

--- a/pluto/src/table/Row.tsx
+++ b/pluto/src/table/Row.tsx
@@ -55,21 +55,27 @@ export const Row = memo(
   }: RowProps): ReactElement => {
     let xCursor = x;
     const theme = Theming.use();
-    // CSS rounds the table's outer corners on the corner <td>, but a cell that paints
-    // its background on the canvas squares them off unless it knows the radius. The
-    // indicators occupy the first row and column when shown, so a data cell only
-    // reaches the top and left edges without them.
+    // Table.css rounds the table's outer corners on the corner <td> by
+    // --pluto-border-radius-small, but a cell that paints its background on the canvas
+    // squares them off unless it knows the radius, so both sides read the same theme
+    // step. The indicators occupy the first row and column when shown, so a data cell
+    // only reaches the top and left edges without them.
     const borderRadii = useMemo(() => {
       const r = theme.sizes.border.radius.small * theme.sizes.base;
       const top = index === 0 && !showIndicator;
-      return cells.map((_, i): border.CrudeRadius => {
+      return cells.map((_, i): border.CrudeRadius | undefined => {
         const left = i === 0 && !showIndicator;
         const right = i === cells.length - 1;
+        const topLeft = top && left;
+        const topRight = top && right;
+        const bottomRight = last && right;
+        const bottomLeft = last && left;
+        if (!topLeft && !topRight && !bottomRight && !bottomLeft) return undefined;
         return {
-          topLeft: top && left ? r : 0,
-          topRight: top && right ? r : 0,
-          bottomRight: last && right ? r : 0,
-          bottomLeft: last && left ? r : 0,
+          topLeft: topLeft ? r : 0,
+          topRight: topRight ? r : 0,
+          bottomRight: bottomRight ? r : 0,
+          bottomLeft: bottomLeft ? r : 0,
         };
       });
     }, [cells, index, last, showIndicator, theme]);
@@ -116,7 +122,7 @@ interface VariantCellProps {
   y: number;
   width: number;
   height: number;
-  borderRadius: border.CrudeRadius;
+  borderRadius?: border.CrudeRadius;
   editable: boolean;
   onSelect: (cellKey: string, ev: MouseEvent) => void;
 }

--- a/pluto/src/table/Row.tsx
+++ b/pluto/src/table/Row.tsx
@@ -8,7 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { table } from "@synnaxlabs/client";
-import { box, deep, dimensions, type record, xy } from "@synnaxlabs/x";
+import { type border, box, deep, dimensions, type record, xy } from "@synnaxlabs/x";
 import { memo, type ReactElement, useCallback, useMemo } from "react";
 
 import { CSS } from "@/css";
@@ -29,6 +29,8 @@ export interface RowProps {
   cells: string[];
   columns: number[];
   editable: boolean;
+  /** True when this is the table's bottom row. */
+  last: boolean;
   showIndicator?: boolean;
   onResize: (size: number, index: number) => void;
   onSelect: (index: number, ev: React.MouseEvent) => void;
@@ -45,12 +47,32 @@ export const Row = memo(
     cells,
     columns,
     editable,
+    last,
     showIndicator = true,
     onResize,
     onSelect,
     onCellSelect,
   }: RowProps): ReactElement => {
     let xCursor = x;
+    const theme = Theming.use();
+    // CSS rounds the table's outer corners on the corner <td>, but a cell that paints
+    // its background on the canvas squares them off unless it knows the radius. The
+    // indicators occupy the first row and column when shown, so a data cell only
+    // reaches the top and left edges without them.
+    const borderRadii = useMemo(() => {
+      const r = theme.sizes.border.radius.small * theme.sizes.base;
+      const top = index === 0 && !showIndicator;
+      return cells.map((_, i): border.CrudeRadius => {
+        const left = i === 0 && !showIndicator;
+        const right = i === cells.length - 1;
+        return {
+          topLeft: top && left ? r : 0,
+          topRight: top && right ? r : 0,
+          bottomRight: last && right ? r : 0,
+          bottomLeft: last && left ? r : 0,
+        };
+      });
+    }, [cells, index, last, showIndicator, theme]);
     return (
       <tr className={CSS.cls(CSS.BE("table", "row"))}>
         {showIndicator && (
@@ -75,6 +97,7 @@ export const Row = memo(
               y={y}
               width={columns[i]}
               height={size}
+              borderRadius={borderRadii[i]}
               editable={editable}
               onSelect={onCellSelect}
             />
@@ -93,6 +116,7 @@ interface VariantCellProps {
   y: number;
   width: number;
   height: number;
+  borderRadius: border.CrudeRadius;
   editable: boolean;
   onSelect: (cellKey: string, ev: MouseEvent) => void;
 }
@@ -113,6 +137,7 @@ const VariantCell = memo(
     y,
     width,
     height,
+    borderRadius,
     editable,
     onSelect,
   }: VariantCellProps): ReactElement | null => {
@@ -149,6 +174,7 @@ const VariantCell = memo(
       <Spec.Cell
         cellKey={cellKey}
         box={b}
+        borderRadius={borderRadius}
         selected={selected}
         editable={editable}
         onSelect={onSelect}

--- a/pluto/src/table/Table.spec.tsx
+++ b/pluto/src/table/Table.spec.tsx
@@ -21,6 +21,7 @@ import { INDICATOR_SIZE } from "@/table/Indicator";
 import { telemTest } from "@/telem/aether/test";
 import { mockBoundingClientRect } from "@/testutil/dom";
 import { createAsyncSynnaxWrapper } from "@/testutil/Synnax";
+import { Theming } from "@/theming";
 import { canvasTest } from "@/vis/render/test";
 import { Value } from "@/vis/value";
 import { value } from "@/vis/value/aether";
@@ -38,6 +39,9 @@ const expectedOffset = (contentWidth: number, contentHeight: number) => ({
 });
 
 const RECT = mockBoundingClientRect(0, 0, SURFACE_WIDTH, SURFACE_HEIGHT)();
+
+const THEME = Theming.themeZ.parse(Theming.SYNNAX_THEMES.synnaxLight);
+const RADIUS = THEME.sizes.border.radius.small * THEME.sizes.base;
 
 // Single-hook bootstrap so the suspending useEnsure is not followed by other
 // hooks, which trips a React 19 concurrent replay warning (same pattern as
@@ -164,13 +168,15 @@ describe("Table", () => {
     request.render();
   };
 
-  // The value cell clips its canvas draw to its own box, so the latest scissor
-  // call on the upper2d canvas carries the box the cell last drew at.
-  const lastCellBox = (): box.Box => {
+  const lastScissor = (): canvasTest.Call => {
     const scissor = recorder.upper2d.calls.findLast((c) => c.op === "scissor");
     if (scissor == null) throw new Error("no cell draw was recorded");
-    return scissor.args[0] as box.Box;
+    return scissor;
   };
+
+  // The value cell clips its canvas draw to its own box, so the latest scissor
+  // call on the upper2d canvas carries the box the cell last drew at.
+  const lastCellBox = (): box.Box => lastScissor().args[0] as box.Box;
 
   const expectPlacement = async (
     frame: () => HTMLElement,
@@ -275,6 +281,23 @@ describe("Table", () => {
       await expectDrawnAt(ORIGIN);
       scrollTo(scroller, { x: 10, y: 20 });
       await expectDrawnAt({ x: ORIGIN.x - 10, y: ORIGIN.y - 20 });
+    });
+  });
+
+  describe("corner radius", () => {
+    // CSS rounds the table's bottom-right <td>, so the cell's canvas background
+    // has to clip to the same radius or it fills the corner square.
+    it("rounds the bottom-right cell's clip region", async () => {
+      renderTable(false);
+      await waitFor(() => {
+        pumpRender();
+        expect(lastScissor().args[2]).toEqual({
+          topLeft: 0,
+          topRight: 0,
+          bottomRight: RADIUS,
+          bottomLeft: 0,
+        });
+      });
     });
   });
 

--- a/pluto/src/table/Table.spec.tsx
+++ b/pluto/src/table/Table.spec.tsx
@@ -9,7 +9,7 @@
 
 import { table } from "@synnaxlabs/client";
 import { createTestClient } from "@synnaxlabs/client/testutil";
-import { box, type scale, xy } from "@synnaxlabs/x";
+import { type border, box, type scale, xy } from "@synnaxlabs/x";
 import { act, fireEvent, render, renderHook, waitFor } from "@testing-library/react";
 import { type PropsWithChildren, type ReactElement } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -168,8 +168,11 @@ describe("Table", () => {
     request.render();
   };
 
+  const scissors = (): canvasTest.Call[] =>
+    recorder.upper2d.calls.filter((c) => c.op === "scissor");
+
   const lastScissor = (): canvasTest.Call => {
-    const scissor = recorder.upper2d.calls.findLast((c) => c.op === "scissor");
+    const scissor = scissors().at(-1);
     if (scissor == null) throw new Error("no cell draw was recorded");
     return scissor;
   };
@@ -285,19 +288,87 @@ describe("Table", () => {
   });
 
   describe("corner radius", () => {
-    // CSS rounds the table's bottom-right <td>, so the cell's canvas background
-    // has to clip to the same radius or it fills the corner square.
-    it("rounds the bottom-right cell's clip region", async () => {
-      renderTable(false);
+    const corner = (name: keyof border.Radius): Record<string, number> => ({
+      topLeft: 0,
+      topRight: 0,
+      bottomRight: 0,
+      bottomLeft: 0,
+      [name]: RADIUS,
+    });
+
+    // Renders a fresh grid of value cells and returns the clip radius each one drew
+    // with, in row-major order.
+    const renderGrid = async (
+      name: string,
+      rows: number,
+      cols: number,
+      showIndicators: boolean,
+    ): Promise<unknown[]> => {
+      const source = telemTest.source("1");
+      const cells: Record<string, table.Cell> = {};
+      const rowSpecs = Array.from({ length: rows }, (_, r) => ({
+        size: ROW_SIZE,
+        cells: Array.from({ length: cols }, (_, c) => {
+          const cellKey = `${r}-${c}`;
+          cells[cellKey] = {
+            key: cellKey,
+            variant: "value",
+            props: {
+              telem: telemTest.stringSourceSpec(source),
+              redline: Value.ZERO_READLINE,
+              level: "h5",
+              color: "#000000",
+              units: "",
+            },
+          };
+          return cellKey;
+        }),
+      }));
+      const project = await client.projects.create({ name, layout: {} });
+      const created = await client.tables.create(project.key, {
+        name: `${name}_table`,
+        rows: rowSpecs,
+        columns: Array.from({ length: cols }, () => ({ size: COL_SIZE })),
+        cells,
+      });
+      await loadTable(wrapper, created.key);
+      const Wrapped = (): ReactElement => (
+        <Table.Suspended tableKey={created.key}>
+          <Table.Table visible showIndicators={showIndicators} />
+        </Table.Suspended>
+      );
+      render(<Wrapped />, { wrapper });
+      let radii: unknown[] = [];
       await waitFor(() => {
         pumpRender();
-        expect(lastScissor().args[2]).toEqual({
-          topLeft: 0,
-          topRight: 0,
-          bottomRight: RADIUS,
-          bottomLeft: 0,
-        });
+        // One scissor per cell, so the last rows * cols are this render's.
+        radii = scissors()
+          .slice(-rows * cols)
+          .map((c) => c.args[2]);
+        expect(radii).toHaveLength(rows * cols);
       });
+      return radii;
+    };
+
+    // CSS rounds the table's outer corners on the corner <td>, so a cell painting its
+    // background on the canvas has to clip to the same radius or it fills the corner
+    // square. The indicators hold the first row and column when shown, leaving the
+    // bottom-right cell as the only data cell at a corner.
+    it("rounds only the bottom-right cell when the indicators are shown", async () => {
+      const radii = await renderGrid("indicated", 2, 2, true);
+      expect(radii).toEqual([undefined, undefined, undefined, corner("bottomRight")]);
+    });
+
+    it("rounds all four corners when the indicators are hidden", async () => {
+      const radii = await renderGrid("bare", 2, 3, false);
+      expect(radii).toEqual([
+        corner("topLeft"),
+        undefined,
+        corner("topRight"),
+        corner("bottomLeft"),
+        undefined,
+        corner("bottomRight"),
+      ]);
     });
   });
 

--- a/pluto/src/table/Table.tsx
+++ b/pluto/src/table/Table.tsx
@@ -569,6 +569,7 @@ export const Table = ({
                           y={yPos}
                           size={row.size}
                           editable={editable}
+                          last={rowIndex === rows.length - 1}
                           showIndicator={showIndicators}
                           onSelect={handleRowSelect}
                           onResize={handleRowResize}

--- a/pluto/src/table/cells/Cells.tsx
+++ b/pluto/src/table/cells/Cells.tsx
@@ -9,7 +9,15 @@
 
 import "@/table/cells/Cells.css";
 
-import { box, color, location, type record, scale, text } from "@synnaxlabs/x";
+import {
+  type border,
+  box,
+  color,
+  location,
+  type record,
+  scale,
+  text,
+} from "@synnaxlabs/x";
 import { type ReactElement, useMemo } from "react";
 import { z } from "zod";
 
@@ -34,6 +42,11 @@ export type TextProps = z.infer<typeof textPropsZ>;
 export type CellProps<P extends object = record.Unknown> = P & {
   cellKey: string;
   box: box.Box;
+  /**
+   * Rounding of the cell's corners in px. Only cells at the table's outer corners
+   * round.
+   */
+  borderRadius?: border.CrudeRadius;
   selected: boolean;
   editable: boolean;
   onSelect: (key: string, ev: React.MouseEvent) => void;
@@ -104,6 +117,7 @@ export type ValueProps = z.infer<typeof valuePropsZ>;
 
 export const Value = ({
   cellKey,
+  borderRadius,
   telem: t,
   level,
   color,
@@ -138,6 +152,7 @@ export const Value = ({
     }),
     location: { x: "center", y: "center" },
     clip: true,
+    borderRadius,
   });
   const handleSelect = (e: React.MouseEvent) => onSelect(cellKey, e);
   // Use the column-driven box width, not BaseValue's natural text width: when

--- a/pluto/src/vis/draw2d/canvas.spec.ts
+++ b/pluto/src/vis/draw2d/canvas.spec.ts
@@ -11,7 +11,10 @@ import { scale, xy } from "@synnaxlabs/x";
 import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vitest";
 
 import { text } from "@/text/aether";
-import { SugaredOffscreenCanvasRenderingContext2D } from "@/vis/draw2d/canvas";
+import {
+  domRadii,
+  SugaredOffscreenCanvasRenderingContext2D,
+} from "@/vis/draw2d/canvas";
 
 /** The properties the wrapper caches, so a repeat set never reaches the canvas. */
 const CACHED_PROPS = [
@@ -371,5 +374,41 @@ describe("SugaredOffscreenCanvasRenderingContext2D", () => {
         expect(warn).not.toHaveBeenCalled();
       });
     });
+  });
+});
+
+describe("domRadii", () => {
+  it("should order the corners top-left, top-right, bottom-right, bottom-left", () => {
+    const radius = {
+      topLeft: { x: 1, y: 2 },
+      topRight: { x: 3, y: 4 },
+      bottomLeft: { x: 5, y: 6 },
+      bottomRight: { x: 7, y: 8 },
+    };
+    expect(domRadii(radius)).toEqual([
+      radius.topLeft,
+      radius.topRight,
+      radius.bottomRight,
+      radius.bottomLeft,
+    ]);
+  });
+
+  it("should spread a scalar over every corner", () => {
+    expect(domRadii(4)).toEqual([
+      { x: 4, y: 4 },
+      { x: 4, y: 4 },
+      { x: 4, y: 4 },
+      { x: 4, y: 4 },
+    ]);
+  });
+
+  it("should widen per-corner numbers into pairs", () => {
+    const radii = domRadii({ topLeft: 1, topRight: 0, bottomRight: 3, bottomLeft: 0 });
+    expect(radii).toEqual([
+      { x: 1, y: 1 },
+      { x: 0, y: 0 },
+      { x: 3, y: 3 },
+      { x: 0, y: 0 },
+    ]);
   });
 });

--- a/pluto/src/vis/draw2d/canvas.ts
+++ b/pluto/src/vis/draw2d/canvas.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { box, type destructor, dimensions, scale, xy } from "@synnaxlabs/x";
+import { border, box, type destructor, dimensions, scale, xy } from "@synnaxlabs/x";
 
 import { text } from "@/text/aether";
 import { applyOverScan } from "@/vis/render/util";
@@ -16,11 +16,20 @@ export interface FillTextOptions {
   useAtlas?: boolean;
 }
 
-type Radii = number | DOMPointInit | Array<number | DOMPointInit>;
+export type Radii = number | DOMPointInit | Array<number | DOMPointInit>;
 
 const scaleRadius = (s: scale.XY, r: number | DOMPointInit): number | DOMPointInit => {
   if (typeof r === "number") return s.x.dim(r);
   return { x: s.x.dim(r.x ?? 0), y: s.y.dim(r.y ?? 0) };
+};
+
+/**
+ * Radii for `roundRect` in the order the canvas and CSS use: top-left, top-right,
+ * bottom-right, bottom-left.
+ */
+export const domRadii = (radius: border.CrudeRadius): Radii => {
+  const { topLeft, topRight, bottomRight, bottomLeft } = border.constructRadius(radius);
+  return [topLeft, topRight, bottomRight, bottomLeft];
 };
 
 // Corner radii reach roundRect as a number, a single pair, or one entry per corner. All
@@ -720,10 +729,19 @@ export class SugaredOffscreenCanvasRenderingContext2D implements OffscreenCanvas
     this.dpr = x;
   }
 
-  scissor(region: box.Box, overScan: xy.XY = xy.ZERO): destructor.Destructor {
+  scissor(
+    region: box.Box,
+    overScan: xy.XY = xy.ZERO,
+    radius?: border.CrudeRadius,
+  ): destructor.Destructor {
     const p = new ScaledPath2D(this.scale_);
     region = applyOverScan(region, overScan);
-    p.rect(...xy.couple(box.topLeft(region)), ...dimensions.couple(box.dims(region)));
+    const args = [
+      ...xy.couple(box.topLeft(region)),
+      ...dimensions.couple(box.dims(region)),
+    ] as const;
+    if (radius == null) p.rect(...args);
+    else p.roundRect(...args, domRadii(radius));
     this.save();
     this.clip(p.getPath());
     return () => this.restore();

--- a/pluto/src/vis/render/test/Recorder.ts
+++ b/pluto/src/vis/render/test/Recorder.ts
@@ -7,7 +7,14 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { box, type destructor, type dimensions, scale, xy } from "@synnaxlabs/x";
+import {
+  type border,
+  box,
+  type destructor,
+  type dimensions,
+  scale,
+  xy,
+} from "@synnaxlabs/x";
 
 import { type render } from "@/vis/render";
 
@@ -47,7 +54,11 @@ export interface RecordingCanvas {
   /** Recorded method calls and property sets, in encounter order. */
   calls: Call[];
   /** Restrict drawing to a region; records the call and returns a no-op destructor. */
-  scissor(region: box.Box, overScan?: xy.XY): destructor.Destructor;
+  scissor(
+    region: box.Box,
+    overScan?: xy.XY,
+    radius?: border.CrudeRadius,
+  ): destructor.Destructor;
   /** Records the call and returns this same recording surface, so chained draw calls
    * land on the same {@link calls} list (production returns a scaled sub-context). */
   applyScale(scale: scale.XY): RecordingCanvas;
@@ -62,8 +73,12 @@ const buildCanvas = (width = 800, height = 600): RecordingCanvas => {
   const target: Record<string, unknown> = {
     canvas: { width, height },
     calls,
-    scissor: (region: box.Box, overScan: xy.XY = xy.ZERO) => {
-      calls.push({ op: "scissor", args: [region, overScan] });
+    scissor: (
+      region: box.Box,
+      overScan: xy.XY = xy.ZERO,
+      radius?: border.CrudeRadius,
+    ) => {
+      calls.push({ op: "scissor", args: [region, overScan, radius] });
       return () => {};
     },
     ...STYLE_DEFAULTS,

--- a/pluto/src/vis/scale/aether/scale.spec.ts
+++ b/pluto/src/vis/scale/aether/scale.spec.ts
@@ -223,6 +223,28 @@ describe("scale/aether/Scale", () => {
     });
   });
 
+  describe("corner radii", () => {
+    // A symbol with a rounded container (a tank) clips the fill to its corners, so the
+    // liquid keeps the container's shape at the top and bottom of its travel.
+    it("should round the fill by each corner", () => {
+      const cornerRadii = {
+        topLeft: { x: 1, y: 2 },
+        topRight: { x: 3, y: 4 },
+        bottomLeft: { x: 5, y: 6 },
+        bottomRight: { x: 7, y: 8 },
+      };
+      const { recorder } = setup({ cornerRadii });
+      const regions = fillRegions(recorder);
+      expect(regions).toHaveLength(1);
+      expect(regions[0][4]).toEqual([
+        cornerRadii.topLeft,
+        cornerRadii.topRight,
+        cornerRadii.bottomRight,
+        cornerRadii.bottomLeft,
+      ]);
+    });
+  });
+
   describe("color", () => {
     it("should stroke the ticks and the outline with the axis color", () => {
       const { recorder } = setup({ showCaret: false, axisColor: ACCENT });

--- a/pluto/src/vis/scale/aether/scale.ts
+++ b/pluto/src/vis/scale/aether/scale.ts
@@ -28,6 +28,7 @@ import { fontString } from "@/theming/base/fontString";
 import { newTickFactory, type Tick, type TickFactory } from "@/vis/axis/ticks";
 import { type Element } from "@/vis/diagram/aether/Diagram";
 import { Draw2D } from "@/vis/draw2d";
+import { domRadii } from "@/vis/draw2d/canvas";
 import { render } from "@/vis/render";
 import { staleness } from "@/vis/staleness/aether";
 
@@ -275,12 +276,13 @@ export class Scale
       // full rounded bar so the tank's rounded corners are preserved at the fill edges.
       const restore = ctx.scissor(region);
       ctx.beginPath();
-      ctx.roundRect(box.left(bar), box.top(bar), box.width(bar), box.height(bar), [
-        cornerRadii.topLeft,
-        cornerRadii.topRight,
-        cornerRadii.bottomRight,
-        cornerRadii.bottomLeft,
-      ]);
+      ctx.roundRect(
+        box.left(bar),
+        box.top(bar),
+        box.width(bar),
+        box.height(bar),
+        domRadii(cornerRadii),
+      );
       ctx.fillStyle = color.hex(fillColor);
       ctx.fill();
       restore();

--- a/pluto/src/vis/value/aether/value.spec.ts
+++ b/pluto/src/vis/value/aether/value.spec.ts
@@ -470,6 +470,24 @@ describe("value/aether/Value", () => {
       component.render({});
       expect(drawCalls(recorder, "scissor")).toHaveLength(0);
     });
+
+    it("should leave the clip region square by default", () => {
+      const { component, recorder } = setup({ value: "1", state: { clip: true } });
+      recorder.clear();
+      component.render({});
+      expect(drawCalls(recorder, "scissor")[0].args[2]).toBeUndefined();
+    });
+
+    it("should round the clip region by borderRadius", () => {
+      const radius = { topLeft: 0, topRight: 0, bottomRight: 6, bottomLeft: 0 };
+      const { component, recorder } = setup({
+        value: "1",
+        state: { clip: true, borderRadius: radius },
+      });
+      recorder.clear();
+      component.render({});
+      expect(drawCalls(recorder, "scissor")[0].args[2]).toEqual(radius);
+    });
   });
 
   describe("afterDelete", () => {

--- a/pluto/src/vis/value/aether/value.ts
+++ b/pluto/src/vis/value/aether/value.ts
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { box, color, location, notation, scale, text, xy } from "@synnaxlabs/x";
+import { border, box, color, location, notation, scale, text, xy } from "@synnaxlabs/x";
 import { z } from "zod";
 
 import { aether } from "@/aether/aether";
@@ -44,6 +44,9 @@ const valueState = staleness.configZ.extend({
   // host can't grow to fit the natural text width (e.g. a table cell);
   // overflow gets truncated at the cell edge instead of bleeding past.
   clip: z.boolean().default(false),
+  // borderRadius rounds the clip region, in px. Set it when the host has rounded
+  // corners, so the background fill does not square them off.
+  borderRadius: border.crudeRadiusZ.optional(),
 });
 
 const CANVAS_VARIANTS: render.Canvas2DVariant[] = ["upper2d", "lower2d"];
@@ -190,7 +193,9 @@ export class Value
 
     const labelPosition = xy.translate(bTopLeft, labelOffset);
 
-    const undoClip = this.state.clip ? canvas.scissor(b) : null;
+    const undoClip = this.state.clip
+      ? canvas.scissor(b, xy.ZERO, this.state.borderRadius)
+      : null;
     try {
       if (this.state.backgroundTelem.type != noopColorSourceSpec.type) {
         const colorValue = backgroundTelem.value();

--- a/pluto/src/vis/value/use.ts
+++ b/pluto/src/vis/value/use.ts
@@ -44,6 +44,7 @@ export const use = ({
   valueBackgroundOverScan,
   valueBackgroundShift,
   clip,
+  borderRadius,
 }: UseProps): UseReturn => {
   const memoProps = useMemoDeepEqual({
     box,
@@ -61,6 +62,7 @@ export const use = ({
     valueBackgroundOverScan,
     valueBackgroundShift,
     clip,
+    borderRadius,
   });
   const [, state, setState] = Aether.use({
     aetherKey,


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4711](https://linear.app/synnax/issue/SY-4711/fix-two-table-rendering-defects-column-labels-past-z-and-the-rounded)

## Description

Two rendering defects in the table.

**Column labels stopped at Z.** `getCellColumn` indexed a 26-character alphabet string directly, so any column index past 25 returned `undefined`. Headers rendered blank from the 27th column onward, and the blank label reached the toolbar breadcrumb and the delete-column menu item too. Labels are now bijective base-26: `Z` -> `AA` -> `AB` ... `ZZ` -> `AAA`.

**A value cell squared off the table's rounded corner.** CSS rounds the table's outer corners on the corner `<td>`, but a value cell paints its redline background on the canvas with a plain `fillRect`, which fills the corner square. The aether `Value` now takes a `borderRadius` and rounds its clip region, and `Row` gives each cell the radii for the corners it occupies. With the indicators shown only the bottom-right data cell rounds; without them all four corners do.

The radius uses `border.CrudeRadius` from X, the same per-corner type the schematic tank configs use, so the table names its corners instead of ordering a tuple. A new `domRadii` helper in `pluto/src/vis/draw2d/canvas.ts` holds the one fact that the canvas orders corners top-left, top-right, bottom-right, bottom-left; the aether `Scale` had that ordering written out inline and now calls the helper.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR fixes spreadsheet-style table labels beyond column Z and prevents canvas-rendered value backgrounds from covering rounded table corners.
- Implements bijective base-26 column labels and adds coverage through `AAA`.
- Propagates per-corner table radii into value-cell clipping.
- Centralizes conversion from named border radii to DOM canvas corner order.
- Extends canvas recording and value-rendering tests for rounded clipping.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or security defects identified.

Current callers satisfy the new label helper’s index assumptions, and the rounded clipping path preserves coordinate scaling, corner ordering, and default square clipping behavior.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| pluto/src/table/Indicator.tsx | Correctly replaces direct alphabet indexing with bijective base-26 column labeling for current non-negative integer callers. |
| pluto/src/table/Row.tsx | Computes named radii for data cells that occupy table corners while accounting for indicator rows and columns. |
| pluto/src/table/Table.tsx | Correctly identifies the final rendered row for bottom-corner radius propagation. |
| pluto/src/vis/draw2d/canvas.ts | Adds optional rounded scissor paths and consistently converts named radii into canvas corner order. |
| pluto/src/vis/value/aether/value.ts | Applies the optional border radius to the existing value clip region without changing square clipping defaults. |
| pluto/src/vis/scale/aether/scale.ts | Refactors the existing radius ordering through the shared helper without changing rendering semantics. |

<sub>Reviews (1): Last reviewed commit: ["Clip a table cell&#39;s canvas background to..."](https://github.com/synnaxlabs/synnax/commit/a766326f936e90221be36c9d2a6b9d377c9acb26) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56001268)</sub>

<!-- /greptile_comment -->