### PR TITLE
SY-4715: Fix the flaky task rack stand-in spec

### DIFF
--- a/client/ts/src/task/task.spec.ts
+++ b/client/ts/src/task/task.spec.ts
@@ -857,7 +857,10 @@ describe("Task", async () => {
       let seeWrite = (_: status.Status): void => {};
       const written = new Promise<status.Status>((resolve) => (seeWrite = resolve));
       const off = client.statuses.store.subscribe((event) => {
-        if (event.variant === "set") seeWrite(event.value);
+        // The creation-time "has not been deployed" placeholder echoes back over the
+        // status stream at its own pace, so a disabled event is never the command's.
+        if (event.variant === "set" && event.value.variant !== "disabled")
+          seeWrite(event.value);
       }, key);
       try {
         await client.tasks.executeCommand({ task: t.key, type: "start" });


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4715](https://linear.app/synnax/issue/SY-4715/fix-failing-clienttssrctasktaskspects)

## Description

The spec "stands the rack's problem in for a wait its Driver cannot answer" resolves on the first status store write for the task's status key. When a task is created, the Core persists a disabled "has not been deployed" placeholder, and that write echoes back to the client over the status set channel. Under CI load the echo can land after the spec subscribes, so the promise resolves with the placeholder instead of the command's rack stand-in.

The subscription now skips disabled events. On this key they can only be the placeholder echo, so the assertion still fails on any wrong stand-in the command writes.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR stabilizes a task rack stand-in test by ignoring the delayed disabled placeholder status.
- Filters disabled status-store events before resolving the test promise.
- Preserves the assertion against the expected warning stand-in.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The changed filter targets the delayed disabled placeholder, while the test still requires the command's warning status and exact details.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| client/ts/src/task/task.spec.ts | The test subscription now excludes the known creation-time placeholder without weakening its warning-status assertion. |

<sub>Reviews (1): Last reviewed commit: ["Ignore the deploy placeholder echo in th..."](https://github.com/synnaxlabs/synnax/commit/756abcfa17e61511b3176c88aee98518fef1f90a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56113775)</sub>

<!-- /greptile_comment -->