### PR TITLE
SY-4714: Fix the flaky task form render spec

### DIFF
--- a/console/src/platform/task/Form.spec.tsx
+++ b/console/src/platform/task/Form.spec.tsx
@@ -102,8 +102,12 @@ describe("wrapForm", () => {
       taskKey: tsk.key,
     });
     await waitFor(() => expect(screen.getByText("child-form-body")).toBeTruthy());
-    expect(findNameInput()).toBeTruthy();
-    expect(container.querySelector(".pluto-icon--play")).toBeTruthy();
+    // The name input and the play button appear once the async update and command
+    // grants resolve; until then the form renders in preview mode.
+    await waitFor(findNameInput);
+    await waitFor(() =>
+      expect(container.querySelector(".pluto-icon--play")).toBeTruthy(),
+    );
   });
 
   it("should omit the controls when showControls is false", async () => {


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4714](https://linear.app/synnax/issue/SY-4714/fix-failing-consolesrcplatformtaskformspectsx)

## Description

The spec "should render the header name field, the child form, and the controls" queried for the name input synchronously after the child form body appeared. The task form mounts in preview mode until the async update grant resolves, and in preview mode the name field renders as static text with no input element. The play button is gated the same way on the command grant. The child form body renders in both modes, so under CI load the spec could look for the input inside the preview window and fail with "name input not found".

The spec now waits for the name input and the play button, matching the wait the autosave spec in the same file already uses.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR stabilizes the task form render test by waiting for UI elements that depend on asynchronous access grants.
- Waits for the task name input to render.
- Waits for the play control to appear after command access resolves.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The test now waits for access-dependent UI elements, and no blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| console/src/platform/task/Form.spec.tsx | Replaces premature synchronous assertions with appropriate asynchronous waits. |

<sub>Reviews (1): Last reviewed commit: ["Wait out the preview window in the task ..."](https://github.com/synnaxlabs/synnax/commit/8f20aee8c05f66bdd4549b000b289c0a0165bb3d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56115127)</sub>

<!-- /greptile_comment -->