### PR TITLE
SY-4716: Move the Go caches off the Windows CI OS disk

### DIFF
--- a/.github/workflows/test.go.yaml
+++ b/.github/workflows/test.go.yaml
@@ -83,25 +83,43 @@ jobs:
         include:
           - os: ubuntu-latest
             codegen: true
+        # The full matrix runs for main, PRs into main, and manual dispatches; other
+        # refs run Linux only.
         exclude:
           - os:
-              ${{ (github.ref != 'refs/heads/main' && github.base_ref != 'main') &&
-              'macos-latest' }}
+              ${{ (github.ref != 'refs/heads/main' && github.base_ref != 'main' &&
+              github.event_name != 'workflow_dispatch') && 'macos-latest' }}
           - os:
-              ${{ (github.ref != 'refs/heads/main' && github.base_ref != 'main') &&
-              'windows-latest' }}
+              ${{ (github.ref != 'refs/heads/main' && github.base_ref != 'main' &&
+              github.event_name != 'workflow_dispatch') && 'windows-latest' }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
 
+      # Go keeps its caches and build scratch on the OS disk (C:), whose ~14GB of
+      # free space a --race --cover build of a large module overflows. RUNNER_TEMP
+      # sits on the far larger workspace drive. Runs before setup-go so its cache
+      # restores into the moved paths.
+      - name: Move the Go caches off the OS disk
+        if: runner.os == 'Windows'
+        run: |
+          New-Item -ItemType Directory -Force -Path "$env:RUNNER_TEMP\gotmp" | Out-Null
+          Add-Content $env:GITHUB_ENV "GOCACHE=$env:RUNNER_TEMP\gocache"
+          Add-Content $env:GITHUB_ENV "GOMODCACHE=$env:RUNNER_TEMP\gomod"
+          Add-Content $env:GITHUB_ENV "GOTMPDIR=$env:RUNNER_TEMP\gotmp"
+
       - name: Set up Go
         uses: actions/setup-go@v7
         with:
           go-version-file: ${{ inputs.directory }}/go.mod
+          # This workflow file salts the cache key: cache archives store absolute
+          # paths, so one saved before a cache-path move restores to the old spot
+          # and would otherwise pin the moved cache permanently cold.
           cache-dependency-path: |
             ${{ inputs.directory }}/go.mod
             ${{ inputs.directory }}/go.sum
+            .github/workflows/test.go.yaml
 
       - name: Install stringer
         if: matrix.codegen


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4716](https://linear.app/synnax/issue/SY-4716/fix-failing-corepkgdriverdriver_suite_testgo-on-windows)

## Description

Every recent Windows Test - Core failure on the 0.57 release PR is disk exhaustion, not a test bug. The workspace lives on the large D: drive, but Go keeps its build cache, module cache, and build scratch on C:, which has about 14GB free. A --race --cover build of the core module overflows that, and whichever compile is running when the disk fills dies: the Driver suite's mock driver build in one run, plain package compiles in others, and twice the runner could not even write its own logs.

The Windows test job now moves GOCACHE, GOMODCACHE, and GOTMPDIR onto RUNNER_TEMP, which sits on the workspace drive. The workflow file salts the setup-go cache key because cache archives store absolute paths: the old C:-path archive would restore to the old location and pin the moved cache permanently cold. The OS matrix also runs in full for workflow_dispatch, since Windows otherwise only runs on PRs into main and a fix like this could never be validated before a release PR.

Validated with a dispatch on this branch: [all four jobs green](https://github.com/synnaxlabs/synnax/actions/runs/32683447901), with the Windows job past its usual point of death and no disk errors in its log. The first run per module pays a cold cache rebuild from the key change; later runs restore the relocated cache.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR relocates Windows Go caches and build scratch space from the constrained OS disk to `RUNNER_TEMP`. It also invalidates caches created with the previous paths and enables the full OS matrix for manual workflow dispatches.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with the Windows cache relocation and manual-dispatch matrix behavior consistent with the stated intent.

The environment-file assignments use valid Windows paths, the required temporary directory is created before Go runs, setup-go executes after the new variables are exported, and other workflow invocation modes retain their previous matrix behavior.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/test.go.yaml | Relocates Windows Go cache paths before setup-go, salts cache keys after the path change, and correctly enables Windows and macOS for manual dispatches. |

<sub>Reviews (1): Last reviewed commit: ["Move Go caches off the Windows OS disk i..."](https://github.com/synnaxlabs/synnax/commit/36f30a1cc4bef07bbbaab3b55e5843a4e02d7ea1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56125475)</sub>

<!-- /greptile_comment -->