### PR TITLE
SY-4717: Fix the graph toolbar and focus toggle integration failures

### DIFF
--- a/console/src/app/triggers/use.spec.tsx
+++ b/console/src/app/triggers/use.spec.tsx
@@ -174,12 +174,18 @@ describe("app/triggers", () => {
   });
 
   describe("focus", () => {
-    it("should put the focused tab into focus mode and leave it there", async () => {
+    it("should toggle the focused tab in and out of focus mode", async () => {
       const { result, store } = await renderTriggers();
       focusTab(store);
       act(() => press(CONTROL, "KeyL"));
       expect(result.current.overlaid).toBe(true);
-      // The trigger only enters focus mode; Escape is the single way back out.
+      act(() => press(CONTROL, "KeyL"));
+      expect(result.current.overlaid).toBe(false);
+    });
+
+    it("should also leave focus mode on Escape", async () => {
+      const { result, store } = await renderTriggers();
+      focusTab(store);
       act(() => press(CONTROL, "KeyL"));
       expect(result.current.overlaid).toBe(true);
       act(pressEscape);

--- a/console/src/app/triggers/use.ts
+++ b/console/src/app/triggers/use.ts
@@ -58,7 +58,11 @@ export const use = (): void => {
     loose: true,
     callback: useCallback(
       ({ stage }: Triggers.UseEvent) => {
-        if (stage !== "start" || getIsOverlaid()) return;
+        if (stage !== "start") return;
+        if (getIsOverlaid()) {
+          sessionDispatch(Session.Panel.stopOverlaying({}));
+          return;
+        }
         const focused = getFocusedTab();
         if (focused != null) sessionDispatch(Session.Panel.startOverlaying({}));
       },

--- a/console/src/feature/arc/editor/toolbar/graph/Nodes.tsx
+++ b/console/src/feature/arc/editor/toolbar/graph/Nodes.tsx
@@ -25,6 +25,9 @@ import { type ReactElement, useCallback, useMemo, useState } from "react";
 
 import { CSS } from "@/platform/css";
 
+const STAGES_LABEL = "Stages";
+const STAGE_GROUPS_LABEL = "Stage groups";
+
 const StaticListItem = (props: List.ItemProps<string>): ReactElement | null => {
   const { itemKey } = props;
   const { startDrag, onDragEnd } = Haul.useDrag({
@@ -44,6 +47,7 @@ const StaticListItem = (props: List.ItemProps<string>): ReactElement | null => {
   return (
     <Select.ListItem
       className={CSS.cls(CSS.BE("arc-stages", "button"))}
+      aria-label={name}
       align="center"
       gap="tiny"
       draggable
@@ -88,7 +92,13 @@ export const StaticStageList = ({
       allowNone
       onChange={onSelect}
     >
-      <List.Items x className={CSS.BE("arc", "stages", "group")} wrap>
+      <List.Items
+        x
+        className={CSS.BE("arc", "stages", "group")}
+        wrap
+        role="listbox"
+        aria-label={STAGES_LABEL}
+      >
         {staticListItem}
       </List.Items>
     </Select.Frame>
@@ -145,7 +155,13 @@ export const Stages = (): ReactElement => {
   );
   return (
     <Flex.Box y empty full className={CSS.BE("arc", "stages")}>
-      <Flex.Box x sharp className={CSS.BE("arc", "stages", "group", "list")}>
+      <Flex.Box
+        x
+        sharp
+        className={CSS.BE("arc", "stages", "group", "list")}
+        role="group"
+        aria-label={STAGE_GROUPS_LABEL}
+      >
         <GroupList value={selectedGroup} onChange={setSelectedGroup} />
       </Flex.Box>
       <StaticStageList groupKey={selectedGroup} onSelect={handleAddNode} />

--- a/console/src/feature/panel/ContextMenu.spec.tsx
+++ b/console/src/feature/panel/ContextMenu.spec.tsx
@@ -199,7 +199,7 @@ describe("Panel.TabMenuItems", () => {
         fireEvent.click(screen.getByText("Focus"));
       });
       await waitFor(() => expect(screen.getByText("Exit focus")).toBeTruthy());
-      expect(hintOf("Exit focus")).toContain("esc");
+      expect(hintOf("Exit focus")).toContain("l");
     });
 
     it("withholds every hint from a menu open on a tab that is not focused", async () => {

--- a/console/src/feature/panel/ContextMenu.tsx
+++ b/console/src/feature/panel/ContextMenu.tsx
@@ -8,7 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { panel, query } from "@synnaxlabs/client";
-import { Access, Icon, Menu, Panel, Synnax, Triggers } from "@synnaxlabs/pluto";
+import { Access, Icon, Menu, Panel, Synnax } from "@synnaxlabs/pluto";
 import { type ReactElement, useCallback } from "react";
 
 import { useMovePicker } from "@/feature/panel/MovePicker";
@@ -51,9 +51,7 @@ const FocusItem = (): ReactElement => {
     <Menu.Item
       itemKey="focus"
       onClick={handleFocus}
-      triggerIndicator={
-        isFocused && (isOverlaid ? Triggers.ESCAPE : Panel.OVERLAY_TRIGGER)
-      }
+      triggerIndicator={isFocused && Panel.OVERLAY_TRIGGER}
     >
       {isOverlaid ? <Icon.Collapse /> : <Icon.Focus />}
       {isOverlaid ? "Exit focus" : "Focus"}

--- a/integration/console/arc.py
+++ b/integration/console/arc.py
@@ -315,8 +315,8 @@ class ArcClient(ResourceClient):
         self.layout.delete_with_confirmation(item)
 
     GRAPH_CLASS = ".pluto-arc"
-    STAGES_CLASS = ".console-arc__stages"
-    STAGE_BUTTON_CLASS = ".console-arc-stages__button"
+    STAGES_LABEL = "Stages"
+    STAGE_GROUPS_LABEL = "Stage groups"
 
     def open_graph(self, name: str) -> None:
         """Open a graph-mode Arc, waiting on the canvas rather than the text editor.
@@ -330,16 +330,22 @@ class ArcClient(ResourceClient):
             state="visible", timeout=10000
         )
 
+    def _stages(self) -> Locator:
+        """Return the listbox holding the selected group's node selectors."""
+        return self.layout.page.get_by_role("listbox", name=self.STAGES_LABEL)
+
+    def _stage_groups(self) -> Locator:
+        """Return the group of buttons that pick the stage group."""
+        return self.layout.page.get_by_role("group", name=self.STAGE_GROUPS_LABEL)
+
     def show_graph_toolbar(self) -> None:
         """Show the graph Arc's stage palette in the bottom Component drawer."""
         self.layout.show_visualization_toolbar()
-        self.layout.page.locator(self.STAGES_CLASS).wait_for(
-            state="visible", timeout=5000
-        )
+        self._stages().wait_for(state="visible", timeout=5000)
 
     def stage_group_names(self) -> list[str]:
         """Return the stage group names offered by the graph toolbar."""
-        groups = self.layout.page.locator(f"{self.STAGES_CLASS} .pluto-btn")
+        groups = self._stage_groups().get_by_role("button")
         return [groups.nth(i).inner_text().strip() for i in range(groups.count())]
 
     def select_stage_group(self, name: str) -> None:
@@ -348,12 +354,17 @@ class ArcClient(ResourceClient):
         Args:
             name: The group's label, e.g. "Telemetry".
         """
-        self.layout.page.locator(self.STAGES_CLASS).get_by_role(
-            "button", name=name, exact=True
-        ).click()
+        self._stage_groups().get_by_role("button", name=name, exact=True).click()
 
     def stage_names(self) -> list[str]:
-        """Return the node selector names shown for the selected stage group."""
-        stages = self.layout.page.locator(self.STAGE_BUTTON_CLASS)
+        """Return the node selector names shown for the selected stage group.
+
+        Each selector renders a preview that repeats the name and shows a sample value,
+        so the name comes from the option's accessible name rather than its text.
+        """
+        stages = self._stages().get_by_role("option")
         stages.first.wait_for(state="visible", timeout=5000)
-        return [stages.nth(i).inner_text().strip() for i in range(stages.count())]
+        return [
+            stages.nth(i).get_attribute("aria-label") or ""
+            for i in range(stages.count())
+        ]


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4717](https://linear.app/synnax/issue/SY-4717/fix-the-graph-toolbar-and-focus-toggle-integration-failures)

## Description

The `console` integration suite fails on both Ubuntu and Windows: `console/arc/graph_toolbar` and `console/layout/mosaic_operations`. Both trace to SY-4643 (#2759), which merged with the suite already red.

**Graph toolbar.** The Arc stage palette gave its `role="option"` entries no accessible name, so the name came from the content. Each entry renders the stage name, then a preview that repeats the name and shows a sample value, so an option announced as "Constant Constant 0". The integration helper read that same string, and the `"Constant" in basic` assertion could never pass. The options now carry the stage name, and the stage listbox and group row carry labels, so the helpers select on roles and names instead of CSS classes. Classes stay in `Toolbar.css` for styling. This also clears a latent bug: `stage_group_names()` matched `.console-arc__stages .pluto-btn`, and a list item renders a button, so it returned the four groups plus every stage option.

**Focus toggle.** SY-4643 changed Ctrl+L from a toggle to enter-only, leaving Escape as the single exit, and `mosaic_operations` presses Ctrl+L to leave focus mode in two places. Ctrl+L toggles again. Escape still exits, and the context menu goes back to naming the toggle key on both states, since it advertised Escape on "Exit focus" only because Ctrl+L had stopped exiting.

Neither integration test needed a change beyond the helper.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR restores Ctrl+L as a focus-mode toggle and improves the Arc graph toolbar’s accessible naming and integration-test selectors.
- Makes Ctrl+L enter and exit focus mode while retaining Escape as an exit path.
- Updates context-menu shortcut hints and unit tests to reflect toggle behavior.
- Adds accessible labels to stage groups, stage options, and the stage listbox.
- Replaces CSS-based Arc integration selectors with role-and-name-based locators.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness, security, or quality issues identified.

The focus toggle remains consistently scoped to the originating window, and the accessibility-based toolbar selectors align with the labels introduced by the changed components.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| console/src/app/triggers/use.ts | Changes the focus shortcut from enter-only behavior to a guarded toggle while preserving Escape handling. |
| console/src/app/triggers/use.spec.tsx | Covers both Ctrl+L toggle directions and the independent Escape exit path. |
| console/src/feature/arc/editor/toolbar/graph/Nodes.tsx | Supplies stable accessible roles and names for the stage palette without changing node-selection behavior. |
| console/src/feature/panel/ContextMenu.tsx | Advertises Ctrl+L consistently for both entering and exiting focus mode. |
| console/src/feature/panel/ContextMenu.spec.tsx | Updates the focus-menu hint expectation to match restored toggle semantics. |
| integration/console/arc.py | Scopes graph-toolbar interactions through accessible groups, listboxes, options, and names instead of styling classes. |

<sub>Reviews (1): Last reviewed commit: ["SY-4717: Fix the graph toolbar and focus..."](https://github.com/synnaxlabs/synnax/commit/899c5f66eb0b2e72663ef17031931ffd29817502) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56159970)</sub>

<!-- /greptile_comment -->