### PR TITLE
SY-4719: Constrain the HTTP server connect dialog size

### DIFF
--- a/console/src/feature/http/device/Connect.css
+++ b/console/src/feature/http/device/Connect.css
@@ -10,7 +10,12 @@
  */
 
 .console-http-connect {
+    position: relative;
+    width: 155rem;
+    max-height: 145rem;
+
     .console-content {
+        width: 100%;
         padding: 3rem 4rem;
         overflow-y: auto;
     }


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4719](https://linear.app/synnax/issue/SY-4719/constrain-the-http-server-connect-dialog-size)

## Description

The HTTP server connect dialog set no width or height, so it fell back to Pluto's modal
defaults (`max-width: 100%`) and filled the whole window. `.console-http-connect` now
pins the same 155rem width as the Modbus and OPC UA connect dialogs, plus a 145rem max
height so the form scrolls instead of growing past the window.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR constrains the HTTP server connection dialog to match sibling device dialogs and enables vertical scrolling for long form content.
- Sets the dialog width to `155rem`.
- Limits its height to `145rem`.
- Makes the content fill the dialog width and scroll vertically.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The modal framework constrains the new fixed width to the available viewport, and no concrete blocking or non-blocking defect remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| console/src/feature/http/device/Connect.css | Adds bounded dialog dimensions and content scrolling without an identified regression. |

<sub>Reviews (1): Last reviewed commit: ["SY-4719: Constrain the HTTP server conne..."](https://github.com/synnaxlabs/synnax/commit/b88520f561bcc25cb14198ca454b01d18bafc486) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56169460)</sub>

<!-- /greptile_comment -->