### PR TITLE
SY-4720: Fix flaky notification silencing and the retry of async test pairs

### DIFF
--- a/integration/console/notifications.py
+++ b/integration/console/notifications.py
@@ -14,6 +14,10 @@ from playwright.sync_api import TimeoutError as PlaywrightTimeoutError
 
 import synnax as sy
 
+# A notification expires on its own after a few seconds, so a button that is still
+# attached resolves at once.
+SILENCE_TIMEOUT = 1000
+
 
 class NotificationsClient:
     """Notifications management for Console UI automation."""
@@ -118,19 +122,27 @@ class NotificationsClient:
     def close_all(self) -> int:
         """Silence every visible notification at once and wait for them to clear.
 
+        A notification that expires on its own before its click lands is already in
+        the wanted state, so it does not fail the call.
+
         :returns: Number of notifications silenced.
         """
         buttons = self._all().get_by_role("button", name="Silence", exact=True)
         count = buttons.count()
+        silenced = 0
         # Last to first: a silenced toast unmounts and shifts the indexes after it.
         for i in reversed(range(count)):
-            buttons.nth(i).dispatch_event("click")
-        if count > 0:
+            try:
+                buttons.nth(i).dispatch_event("click", timeout=SILENCE_TIMEOUT)
+                silenced += 1
+            except PlaywrightTimeoutError:
+                pass
+        if silenced > 0:
             try:
                 expect(buttons).to_have_count(0, timeout=2000)
             except AssertionError:
                 pass
-        return count
+        return silenced
 
     def close_connection(self) -> bool:
         """Close the 'Connected to...' notification if present.

--- a/integration/framework/execution_client.py
+++ b/integration/framework/execution_client.py
@@ -136,12 +136,6 @@ class ExecutionClient:
             self._log(f"Killed {killed} active test(s)", True)
 
     def _retry_failed(self, sequences: list[Sequence]) -> None:
-        all_defs: dict[str, TestDefinition] = {}
-        for seq in sequences:
-            for td in seq.tests:
-                key = str(td)
-                all_defs[key] = td
-
         with self._tests_lock:
             failed = [
                 t for t in self._tests if t.status in (STATUS.FAILED, STATUS.TIMEOUT)
@@ -150,26 +144,42 @@ class ExecutionClient:
         if not failed:
             return
 
-        retry_defs: list[TestDefinition] = []
-        for result in failed:
-            key = str(result)
-            if key in all_defs:
-                retry_defs.append(all_defs[key])
+        failed_keys = {str(result) for result in failed}
+        # A test in an asynchronous sequence can depend on its peers running at the
+        # same time, so each retry keeps its own sequence's order.
+        retries: list[tuple[Sequence, list[TestDefinition]]] = []
+        retry_keys: set[str] = set()
+        for seq in sequences:
+            defs = [
+                td
+                for td in seq.tests
+                if str(td) in failed_keys and str(td) not in retry_keys
+            ]
+            if len(defs) == 0:
+                continue
+            retry_keys.update(str(td) for td in defs)
+            retries.append((seq, defs))
 
-        if not retry_defs:
+        if len(retries) == 0:
             return
 
-        self._log(f"==== RETRYING {len(retry_defs)} FAILED TEST(S) ====\n", True)
-
-        retry_keys = {str(td) for td in retry_defs}
+        retry_total = sum(len(defs) for _, defs in retries)
+        self._log(f"==== RETRYING {retry_total} FAILED TEST(S) ====\n", True)
 
         with self._tests_lock:
             for result in failed:
-                self._tests.remove(result)
+                if str(result) in retry_keys:
+                    self._tests.remove(result)
             self._tests_offset = len(self._tests)
 
-        self._total_tests = len(retry_defs)
-        self._execute_sequential(retry_defs)
+        self._total_tests = retry_total
+        for seq, defs in retries:
+            if self.should_stop:
+                break
+            if seq.order == "asynchronous":
+                self._execute_async(seq.name, defs, seq.pool_size)
+            else:
+                self._execute_sequential(defs)
 
         with self._tests_lock:
             for test in self._tests:


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4720](<https://linear.app/synnax/issue/SY-4720/fix-the-flaky-notification-silencing-and-the-sequential-retry-of-async>)

## Description

Two harness defects took down the `Setpoint Control` sequence on Windows in [this run](https://github.com/synnaxlabs/synnax/actions/runs/32700907861/job/97361610931?pr=2806). Neither is a Console defect.

`NotificationsClient.close_all` counted the Silence buttons and then clicked them by index. Notifications drop off on their own after 7 seconds, so a toast present at `count()` can unmount before its `dispatch_event` resolves the element. The call then waited out the full 15 s locator timeout and raised, failing a test that was only clearing toasts before adding a schematic symbol. Each click now carries its own short timeout and tolerates a button that vanished, matching what `close_connection` already does; the return value counts what was actually silenced.

`ExecutionClient._retry_failed` sent every failed test to `_execute_sequential`, discarding the order its sequence declared. `Setpoint Control` is asynchronous and its two tests are co-dependent: `console/schematic/setpoint_press_user` drives the setpoint through the Console and `client/setpoint_press_auto` is the control loop that moves `press_pt`. Serially, both fail by construction, so one flake became two permanent failures and the retry overwrote the first attempt's `trace.zip` with a meaningless second attempt. Retries now group by originating sequence and keep that sequence's order.

A test whose asynchronous peer passed is still retried alone and can still fail on its peer's absence. Retrying the whole sequence would fix that, but most asynchronous sequences hold independent tests (up to 20 in `console/pages`), so it would cost far more than it recovers.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes notification cleanup tolerate buttons that expire while being silenced and retries failed tests according to their originating sequence's execution mode.
- Adds a short per-notification dispatch timeout and reports only successfully silenced notifications.
- Groups failed tests by sequence and preserves asynchronous execution during retries.
- The functional changes are not covered by focused automated tests.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with the non-blocking concern that both timing- and order-sensitive fixes lack focused regression tests.

The changed behavior addresses the reported races without an established current functional defect, but deterministic tests are needed to protect the notification-expiry and asynchronous-retry paths from regression.

**Files Needing Attention:** integration/console/notifications.py, integration/framework/execution_client.py

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| integration/console/notifications.py | Adds bounded, per-button timeout handling for expiring notifications; the timing-sensitive branch lacks focused automated coverage. |
| integration/framework/execution_client.py | Groups failed tests by source sequence and preserves asynchronous retries; the new grouping and dispatch behavior lacks focused automated coverage. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
  F[Collect failed test results] --> G[Group definitions by originating sequence]
  G --> O{Sequence order}
  O -->|asynchronous| A[Retry concurrently with sequence pool size]
  O -->|sequential or random| S[Retry sequentially]
  A --> R[Collect retry results]
  S --> R
  R --> P{Retry passed?}
  P -->|yes| K[Mark result flaky]
  P -->|no| D[Keep failure status]
```

<sub>Reviews (1): Last reviewed commit: ["SY-4720: Fix flaky notification silencin..."](https://github.com/synnaxlabs/synnax/commit/77d7d7003821230a7986f6fb683329e2f5dcaf1e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56172325)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Rule used - When making changes to functionality, add correspo... ([source](https://app.greptile.com/synnax/-/custom-context?memory=8b39d83e-3d2b-4dd4-9e14-d0644d6bfe58))

**Learned From**
[synnaxlabs/synnax#1550](https://github.com/synnaxlabs/synnax/pull/1550)
- Rule used - Place unit tests in the appropriate test files tha... ([source](https://app.greptile.com/synnax/-/custom-context?memory=f96c85c8-3531-4c44-9c22-1c7a35161001))

**Learned From**
[synnaxlabs/synnax#1550](https://github.com/synnaxlabs/synnax/pull/1550)

<!-- /greptile_comment -->