### PR TITLE
SY-4725: Render the docs version indicator on the server

### DIFF
--- a/docs/site/src/components/layout/Header.astro
+++ b/docs/site/src/components/layout/Header.astro
@@ -12,7 +12,10 @@ import { Logo } from "@synnaxlabs/media";
 import { Icon, Button, Flex } from "@synnaxlabs/pluto";
 import Search from "@/components/search/Search.astro";
 import { PageMobile } from "@/components/nav/Page";
+import { fetchVersion } from "@/util/fetchVersion";
 const url = Astro.url.pathname;
+const version = await fetchVersion().catch(() => null);
+const label = version?.split(".").slice(0, -1).join(".");
 ---
 
 <Flex.Box className="main-header" justify="center" align="center" el="header" empty>
@@ -65,7 +68,7 @@ const url = Astro.url.pathname;
                     variant="outlined"
                     href="https://github.com/synnaxlabs/synnax"
                 >
-                    <p class="version" transition:persist></p>
+                    <p class="version">{label}</p>
                     <Icon.Logo.Github />
                 </Button.Button>
                 <PageMobile client:only="react" currentPage={Astro.url.pathname} />

--- a/docs/site/src/layouts/Root.astro
+++ b/docs/site/src/layouts/Root.astro
@@ -85,17 +85,6 @@ const fullTitle = cleanTitle ? `${cleanTitle} | Synnax` : "Synnax";
     </body><script>
         import { addCodeButtonListeners } from "@/components/code/codeUtil";
         import { startUpdatingIframeHref } from "@/util/iframe";
-        import { fetchVersion } from "@/util/fetchVersion";
-        const updateVersion = () => {
-            fetchVersion().then((version) => {
-                const versionElement = document.querySelectorAll(".version");
-                versionElement.forEach((element) => {
-                    if (element.classList.contains("full")) element.innerHTML = version;
-                    else element.innerHTML = version.split(".").slice(0, -1).join(".");
-                });
-            });
-        };
-
         const bindClickHandlersToHeadingAnchors = () => {
             const anchors =
                 document.querySelectorAll<HTMLAnchorElement>(".heading-anchor");
@@ -111,12 +100,10 @@ const fullTitle = cleanTitle ? `${cleanTitle} | Synnax` : "Synnax";
             });
         };
 
-        updateVersion();
         addCodeButtonListeners();
         startUpdatingIframeHref();
         bindClickHandlersToHeadingAnchors();
         document.addEventListener("astro:after-swap", () => {
-            updateVersion();
             addCodeButtonListeners();
             startUpdatingIframeHref();
             bindClickHandlersToHeadingAnchors();


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4725](https://linear.app/synnax/issue/SY-4725/documentation-version-indicator-is-blank)

## Description

The version chip next to the GitHub icon in the documentation header is blank on
production. The header filled it from a client-side `fetchVersion()` call in
`Root.astro`, which requests `https://api.github.com`. That host is not in the
`connect-src` allowlist of the Content Security Policy in
`docs/site/src/middleware.ts`, so the browser blocks the request.

The header was the only `fetchVersion()` caller that ran in the browser; every other
one resolves the version in Astro frontmatter. `Header.astro` now does the same, and
the client-side path is deleted. This leaves the CSP unchanged and removes an
unauthenticated GitHub API call from every page view, which is rate limited to 60
requests per hour per IP. On an API outage the chip stays blank instead of failing
the page.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR moves the documentation Header's version lookup from a browser-side GitHub request into Astro server rendering and removes the shared client-side updater.

- Fetches and shortens the release version in Header frontmatter.
- Removes version fetching during initial browser load and Astro navigation.
- Inadvertently leaves the Releases page's separate full-version heading empty.

<h3>Confidence Score: 4/5</h3>

The PR should not merge until the Releases page's full-version heading is populated through a server-rendered replacement.

The Header's server-rendered label works for its own chip, but deleting the only shared `.version` updater leaves the separate empty `version full` element on the Releases page unchanged.

**Files Needing Attention:** docs/site/src/layouts/Root.astro and docs/site/src/components/layout/Header.astro

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| docs/site/src/components/layout/Header.astro | Moves the Header's shortened version label to server rendering, with failures producing an empty chip rather than failing the page. |
| docs/site/src/layouts/Root.astro | Removes the shared updater but does not replace its responsibility for the Releases layout's full-version element. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Request[Documentation page request] --> Header[Header Astro frontmatter]
  Header --> Fetch[fetchVersion]
  Fetch --> Chip[Render shortened Header chip]
  Request --> Releases{Releases page?}
  Releases -->|Yes| Full[Empty full-version heading]
```

<sub>Reviews (1): Last reviewed commit: ["SY-4725: Render the docs version indicat..."](https://github.com/synnaxlabs/synnax/commit/d36d08146ec1ad83cee0e5a28445a3b8d52ff5b1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56314396)</sub>

> Greptile also left **2 inline comments** on this PR.

**Context used:**

- Rule used - When making changes to functionality, add correspo... ([source](https://app.greptile.com/synnax/-/custom-context?memory=8b39d83e-3d2b-4dd4-9e14-d0644d6bfe58))

**Learned From**
[synnaxlabs/synnax#1550](https://github.com/synnaxlabs/synnax/pull/1550)

<!-- /greptile_comment -->