### PR TITLE
SY-4726: Fix backdrop-filter dropped by CSS minifier

### DIFF
--- a/console/src-tauri/tauri.conf.json
+++ b/console/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Synnax",
-  "version": "0.57.0",
+  "version": "0.57.1",
   "build": {
     "beforeBuildCommand": "pnpm build-vite",
     "beforeDevCommand": "pnpm dev-vite",

--- a/docs/site/src/components/layout/Header.astro
+++ b/docs/site/src/components/layout/Header.astro
@@ -83,8 +83,8 @@ const label = version?.split(".").slice(0, -1).join(".");
         position: sticky;
         top: 0;
         background: var(--pluto-gray-l2-30);
-        backdrop-filter: blur(3rem);
         -webkit-backdrop-filter: blur(3rem);
+        backdrop-filter: blur(3rem);
 
         .header-row {
             height: var(--nav-height);

--- a/docs/site/src/styles/pluto.css
+++ b/docs/site/src/styles/pluto.css
@@ -247,8 +247,8 @@ article table th p {
 
 /* Dialog component */
 .pluto-dialog__bg.pluto--visible {
-    backdrop-filter: blur(2px);
     -webkit-backdrop-filter: blur(2px);
+    backdrop-filter: blur(2px);
 }
 
 @media (max-width: 600px) and (hover: none) {

--- a/pluto/package.json
+++ b/pluto/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@synnaxlabs/pluto",
-  "version": "0.57.0",
+  "version": "0.57.1",
   "type": "module",
   "scripts": {
     "build": "tsc --noEmit && vite build",

--- a/pluto/src/lineplot/rule/Rule.css
+++ b/pluto/src/lineplot/rule/Rule.css
@@ -31,8 +31,8 @@
         align-items: center;
         justify-content: center;
         border-color: var(--pluto-gray-l9);
-        backdrop-filter: var(--pluto-frost);
         -webkit-backdrop-filter: var(--pluto-frost);
+        backdrop-filter: var(--pluto-frost);
         .pluto-rule__label,
         .pluto-rule__value {
             padding: 0.5rem 1rem;

--- a/pluto/src/vis/legend/Container.css
+++ b/pluto/src/vis/legend/Container.css
@@ -13,9 +13,9 @@
     position: absolute;
     cursor: grabbing;
     z-index: 4;
-    backdrop-filter: var(--pluto-frost);
     padding: 0.5rem 1rem;
     -webkit-backdrop-filter: var(--pluto-frost);
+    backdrop-filter: var(--pluto-frost);
     border-radius: var(--pluto-border-radius-small);
     max-height: 50%;
     overflow-y: auto;


### PR DESCRIPTION
## Linear Issue

[SY-4726](https://linear.app/synnax/issue/SY-4726/backdrop-filter-minifier-collapse-drops-standard-property-in-docs-and)

## Description

The docs site header and a couple of Console/Pluto components (line plot rule label, legend) shipped in production without the standard `backdrop-filter` property, `-webkit-backdrop-filter` only. The build minifier collapses a manually-written prefixed/standard pair with an identical value down to whichever declaration is written last, so writing the standard property first drops it in production. Reordered to prefix-first, standard-last everywhere it was backwards, and bumped the pluto and console patch versions since this fix ships in those artifacts.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR preserves the standard `backdrop-filter` declaration in production CSS by placing the WebKit-prefixed declaration first. It also bumps the Pluto and Console patch versions.
- Reorders four prefixed and standard CSS declaration pairs.
- Updates Pluto and Console versions from 0.57.0 to 0.57.1.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The CSS changes only reorder equivalent declarations as required by the production minifier, and the related version updates follow the repository release process.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| console/src-tauri/tauri.conf.json | Bumps the Console patch version to match the Pluto release. |
| docs/site/src/components/layout/Header.astro | Reorders the header filter declarations so the standard property survives minification. |
| docs/site/src/styles/pluto.css | Reorders the dialog backdrop declarations without changing their values. |
| pluto/package.json | Bumps the Pluto package patch version for the CSS fix. |
| pluto/src/lineplot/rule/Rule.css | Reorders the rule-label backdrop declarations without changing their values. |
| pluto/src/vis/legend/Container.css | Reorders the legend backdrop declarations without changing their values. |

<sub>Reviews (1): Last reviewed commit: ["SY-4726: Fix backdrop-filter dropped by ..."](https://github.com/synnaxlabs/synnax/commit/ab8439095e3dbaf93ef6820e5465ecb68384c1c4) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56322128)</sub>

<!-- /greptile_comment -->