### PR TITLE
SY-4735: Reject non-positive periods in the Arc timer nodes

### DIFF
--- a/arc/cpp/stl/time/time.h
+++ b/arc/cpp/stl/time/time.h
@@ -56,6 +56,18 @@ live_span(const runtime::state::Node &s, const std::string &name) {
     return x::telem::TimeSpan(s.numeric_input<int64_t>(name));
 }
 
+/// @brief rejects a non-positive span stamped at compile time. Var-bound
+/// params are exempt: the runtime guard covers their live values.
+inline x::errors::Error
+validate_static_span(const x::telem::TimeSpan span, const types::Param &p) {
+    if (p.type.kind == types::Kind::VarRef || span.nanoseconds() > 0)
+        return x::errors::NIL;
+    return x::errors::Error(
+        x::errors::VALIDATION,
+        p.name + " must be positive, got " + span.to_string()
+    );
+}
+
 struct IntervalInputs {
     x::telem::TimeSpan interval;
 
@@ -71,16 +83,18 @@ struct IntervalInputs {
                     "interval node missing required period parameter"
                 )
             };
-        return {
-            {.interval = x::telem::TimeSpan(x::telem::cast<std::int64_t>(*sv))},
-            x::errors::NIL
-        };
+        const auto period = x::telem::TimeSpan(x::telem::cast<std::int64_t>(*sv));
+        if (auto err = validate_static_span(period, param)) return {{}, err};
+        return {{.interval = period}, x::errors::NIL};
     }
 };
 
 class Interval : public runtime::node::Node {
     runtime::state::Node state;
     x::telem::TimeSpan last_fired;
+    /// @brief dedupes the non-positive period error so a parked node does not
+    /// re-report on every scheduler pass.
+    bool invalid_span_reported = false;
 
 public:
     explicit Interval(runtime::state::Node &&state, const x::telem::TimeSpan period):
@@ -88,6 +102,22 @@ public:
 
     x::errors::Error next(runtime::node::Context &ctx) override {
         const auto period = live_span(this->state, "period");
+        // A non-positive period would keep the deadline permanently in the
+        // past, spinning the scheduler loop. Park without a deadline instead;
+        // a later reassignment to a positive value resumes the timer.
+        if (period.nanoseconds() <= 0) {
+            if (!this->invalid_span_reported) {
+                ctx.report_error(
+                    x::errors::Error(
+                        x::errors::VALIDATION,
+                        "interval period must be positive, got " + period.to_string()
+                    )
+                );
+                this->invalid_span_reported = true;
+            }
+            return x::errors::NIL;
+        }
+        this->invalid_span_reported = false;
         if (ctx.reason != runtime::node::RunReason::TimerTick) {
             ctx.mark_self_changed();
             ctx.set_deadline(this->last_fired + period);
@@ -115,6 +145,7 @@ public:
     void reset() override {
         this->state.reset();
         this->last_fired = -1 * live_span(this->state, "period");
+        this->invalid_span_reported = false;
     }
 
     [[nodiscard]] bool is_output_truthy(size_t output_idx) const override {
@@ -136,10 +167,9 @@ struct WaitInputs {
                     "wait node missing required duration parameter"
                 )
             };
-        return {
-            {.duration = x::telem::TimeSpan(x::telem::cast<std::int64_t>(*sv))},
-            x::errors::NIL
-        };
+        const auto duration = x::telem::TimeSpan(x::telem::cast<std::int64_t>(*sv));
+        if (auto err = validate_static_span(duration, param)) return {{}, err};
+        return {{.duration = duration}, x::errors::NIL};
     }
 };
 
@@ -148,14 +178,33 @@ class Wait : public runtime::node::Node {
     runtime::state::Node state;
     x::telem::TimeSpan start_time = x::telem::TimeSpan(-1);
     bool fired = false;
+    /// @brief dedupes the non-positive duration error so a parked node does
+    /// not re-report on every scheduler pass.
+    bool invalid_span_reported = false;
 
 public:
     explicit Wait(runtime::state::Node &&state): state(std::move(state)) {}
 
     x::errors::Error next(runtime::node::Context &ctx) override {
         if (this->fired) return x::errors::NIL;
-        if (this->start_time.nanoseconds() < 0) this->start_time = ctx.elapsed;
         const auto duration = live_span(this->state, "duration");
+        // A non-positive duration is a configuration error, not an instant
+        // fire. Park without starting the timer; a later reassignment to a
+        // positive value starts it.
+        if (duration.nanoseconds() <= 0) {
+            if (!this->invalid_span_reported) {
+                ctx.report_error(
+                    x::errors::Error(
+                        x::errors::VALIDATION,
+                        "wait duration must be positive, got " + duration.to_string()
+                    )
+                );
+                this->invalid_span_reported = true;
+            }
+            return x::errors::NIL;
+        }
+        this->invalid_span_reported = false;
+        if (this->start_time.nanoseconds() < 0) this->start_time = ctx.elapsed;
         ctx.set_deadline(this->start_time + duration);
         if (ctx.reason != runtime::node::RunReason::TimerTick) {
             ctx.mark_self_changed();
@@ -180,6 +229,7 @@ public:
         this->state.reset();
         this->start_time = x::telem::TimeSpan(-1);
         this->fired = false;
+        this->invalid_span_reported = false;
     }
 
     [[nodiscard]] bool is_output_truthy(size_t output_idx) const override {

--- a/arc/cpp/stl/time/time.h
+++ b/arc/cpp/stl/time/time.h
@@ -189,8 +189,8 @@ public:
         if (this->fired) return x::errors::NIL;
         const auto duration = live_span(this->state, "duration");
         // A non-positive duration is a configuration error, not an instant
-        // fire. Park without starting the timer; a later reassignment to a
-        // positive value starts it.
+        // fire: park instead. Timing stays anchored to start_time, so recovery
+        // re-checks the live duration against the original activation.
         if (duration.nanoseconds() <= 0) {
             if (!this->invalid_span_reported) {
                 ctx.report_error(
@@ -349,6 +349,9 @@ private:
     }
 
     void update_base_interval(const x::telem::TimeSpan span) {
+        // A non-positive span is not a real timer period. Folding it in would
+        // poison the GCD and drive the loop cadence off a parked timer.
+        if (span.nanoseconds() <= 0) return;
         if (this->base == UNSET_BASE_INTERVAL)
             this->base = span;
         else

--- a/arc/cpp/stl/time/time.h
+++ b/arc/cpp/stl/time/time.h
@@ -68,6 +68,38 @@ validate_static_span(const x::telem::TimeSpan span, const types::Param &p) {
     );
 }
 
+/// @brief guards a live timer span against non-positive values. Reports the
+/// first offense only, so a parked node does not re-report on every pass.
+class SpanGuard {
+    bool reported = false;
+
+public:
+    /// @brief returns true when span can drive a deadline. A non-positive span
+    /// reports a validation error naming label and returns false.
+    bool usable(
+        runtime::node::Context &ctx,
+        const x::telem::TimeSpan span,
+        const std::string &label
+    ) {
+        if (span.nanoseconds() > 0) {
+            this->reported = false;
+            return true;
+        }
+        if (!this->reported) {
+            ctx.report_error(
+                x::errors::Error(
+                    x::errors::VALIDATION,
+                    label + " must be positive, got " + span.to_string()
+                )
+            );
+            this->reported = true;
+        }
+        return false;
+    }
+
+    void reset() { this->reported = false; }
+};
+
 struct IntervalInputs {
     x::telem::TimeSpan interval;
 
@@ -92,9 +124,7 @@ struct IntervalInputs {
 class Interval : public runtime::node::Node {
     runtime::state::Node state;
     x::telem::TimeSpan last_fired;
-    /// @brief dedupes the non-positive period error so a parked node does not
-    /// re-report on every scheduler pass.
-    bool invalid_span_reported = false;
+    SpanGuard guard;
 
 public:
     explicit Interval(runtime::state::Node &&state, const x::telem::TimeSpan period):
@@ -105,19 +135,7 @@ public:
         // A non-positive period would keep the deadline permanently in the
         // past, spinning the scheduler loop. Park without a deadline instead;
         // a later reassignment to a positive value resumes the timer.
-        if (period.nanoseconds() <= 0) {
-            if (!this->invalid_span_reported) {
-                ctx.report_error(
-                    x::errors::Error(
-                        x::errors::VALIDATION,
-                        "interval period must be positive, got " + period.to_string()
-                    )
-                );
-                this->invalid_span_reported = true;
-            }
-            return x::errors::NIL;
-        }
-        this->invalid_span_reported = false;
+        if (!this->guard.usable(ctx, period, "interval period")) return x::errors::NIL;
         if (ctx.reason != runtime::node::RunReason::TimerTick) {
             ctx.mark_self_changed();
             ctx.set_deadline(this->last_fired + period);
@@ -145,7 +163,7 @@ public:
     void reset() override {
         this->state.reset();
         this->last_fired = -1 * live_span(this->state, "period");
-        this->invalid_span_reported = false;
+        this->guard.reset();
     }
 
     [[nodiscard]] bool is_output_truthy(size_t output_idx) const override {
@@ -178,9 +196,7 @@ class Wait : public runtime::node::Node {
     runtime::state::Node state;
     x::telem::TimeSpan start_time = x::telem::TimeSpan(-1);
     bool fired = false;
-    /// @brief dedupes the non-positive duration error so a parked node does
-    /// not re-report on every scheduler pass.
-    bool invalid_span_reported = false;
+    SpanGuard guard;
 
 public:
     explicit Wait(runtime::state::Node &&state): state(std::move(state)) {}
@@ -191,19 +207,7 @@ public:
         // A non-positive duration is a configuration error, not an instant
         // fire: park instead. Timing stays anchored to start_time, so recovery
         // re-checks the live duration against the original activation.
-        if (duration.nanoseconds() <= 0) {
-            if (!this->invalid_span_reported) {
-                ctx.report_error(
-                    x::errors::Error(
-                        x::errors::VALIDATION,
-                        "wait duration must be positive, got " + duration.to_string()
-                    )
-                );
-                this->invalid_span_reported = true;
-            }
-            return x::errors::NIL;
-        }
-        this->invalid_span_reported = false;
+        if (!this->guard.usable(ctx, duration, "wait duration")) return x::errors::NIL;
         if (this->start_time.nanoseconds() < 0) this->start_time = ctx.elapsed;
         ctx.set_deadline(this->start_time + duration);
         if (ctx.reason != runtime::node::RunReason::TimerTick) {
@@ -229,7 +233,7 @@ public:
         this->state.reset();
         this->start_time = x::telem::TimeSpan(-1);
         this->fired = false;
-        this->invalid_span_reported = false;
+        this->guard.reset();
     }
 
     [[nodiscard]] bool is_output_truthy(size_t output_idx) const override {

--- a/arc/cpp/stl/time/time_test.cpp
+++ b/arc/cpp/stl/time/time_test.cpp
@@ -101,6 +101,40 @@ TEST(IntervalInputsTest, ReturnsErrorForNullPeriod) {
     ASSERT_OCCURRED_AS_P(IntervalInputs::create(params), x::errors::VALIDATION);
 }
 
+TEST(IntervalInputsTest, ReturnsErrorForZeroPeriod) {
+    types::Param period_param;
+    period_param.name = "period";
+    period_param.type = types::Type{.kind = types::Kind::I64};
+    period_param.value = 0;
+    types::Params params;
+    params.push_back(period_param);
+    ASSERT_OCCURRED_AS_P(IntervalInputs::create(params), x::errors::VALIDATION);
+}
+
+TEST(IntervalInputsTest, ReturnsErrorForNegativePeriod) {
+    types::Param period_param;
+    period_param.name = "period";
+    period_param.type = types::Type{.kind = types::Kind::I64};
+    period_param.value = -x::telem::SECOND.nanoseconds();
+    types::Params params;
+    params.push_back(period_param);
+    ASSERT_OCCURRED_AS_P(IntervalInputs::create(params), x::errors::VALIDATION);
+}
+
+TEST(IntervalInputsTest, AllowsZeroVarBoundPeriod) {
+    types::Param period_param;
+    period_param.name = "period";
+    period_param.type = types::Type{
+        .kind = types::Kind::VarRef,
+        .elem = x::mem::indirect<types::Type>(types::Type{.kind = types::Kind::I64})
+    };
+    period_param.value = 0;
+    types::Params params;
+    params.push_back(period_param);
+    const auto inputs = ASSERT_NIL_P(IntervalInputs::create(params));
+    EXPECT_EQ(inputs.interval, x::telem::TimeSpan(0));
+}
+
 TEST(WaitInputsTest, CreatesInputsFromValidParams) {
     types::Param duration_param;
     duration_param.name = "duration";
@@ -117,6 +151,16 @@ TEST(WaitInputsTest, ReturnsErrorForNullDuration) {
     duration_param.name = "duration";
     duration_param.type = types::Type{.kind = types::Kind::I64};
     duration_param.value = nullptr;
+    types::Params params;
+    params.push_back(duration_param);
+    ASSERT_OCCURRED_AS_P(WaitInputs::create(params), x::errors::VALIDATION);
+}
+
+TEST(WaitInputsTest, ReturnsErrorForZeroDuration) {
+    types::Param duration_param;
+    duration_param.name = "duration";
+    duration_param.type = types::Type{.kind = types::Kind::I64};
+    duration_param.value = 0;
     types::Params params;
     params.push_back(duration_param);
     ASSERT_OCCURRED_AS_P(WaitInputs::create(params), x::errors::VALIDATION);
@@ -392,6 +436,46 @@ TEST(IntervalTest, OnlyFiresOnTimerTick) {
     ctx.elapsed = x::telem::SECOND * 2;
     ASSERT_NIL(node.next(ctx));
     ASSERT_TRUE(changed_called);
+}
+
+/// @brief Test that a non-positive live period parks the interval: no fire,
+/// no deadline, and the error reports only once.
+TEST(IntervalTest, ParksAndReportsOnceOnNonPositivePeriod) {
+    TestSetup setup("interval", "period", 0);
+    Interval node(setup.make_node(), x::telem::TimeSpan(0));
+
+    std::vector<x::errors::Error> reported;
+    int deadline_calls = 0;
+    bool changed_called = false;
+    auto ctx = make_context(x::telem::TimeSpan(0));
+    ctx.mark_changed = [&](size_t) { changed_called = true; };
+    ctx.set_deadline = [&](x::telem::TimeSpan) { deadline_calls++; };
+    ctx.report_error = [&](const x::errors::Error &e) { reported.push_back(e); };
+
+    ASSERT_NIL(node.next(ctx));
+    ctx.elapsed = x::telem::SECOND;
+    ASSERT_NIL(node.next(ctx));
+
+    EXPECT_FALSE(changed_called);
+    EXPECT_EQ(deadline_calls, 0);
+    ASSERT_EQ(reported.size(), 1);
+    EXPECT_TRUE(reported[0].matches(x::errors::VALIDATION));
+}
+
+/// @brief Test that reset re-arms the non-positive period error report.
+TEST(IntervalTest, ReportsNonPositivePeriodAgainAfterReset) {
+    TestSetup setup("interval", "period", 0);
+    Interval node(setup.make_node(), x::telem::TimeSpan(0));
+
+    std::vector<x::errors::Error> reported;
+    auto ctx = make_context(x::telem::TimeSpan(0));
+    ctx.report_error = [&](const x::errors::Error &e) { reported.push_back(e); };
+
+    ASSERT_NIL(node.next(ctx));
+    node.reset();
+    ASSERT_NIL(node.next(ctx));
+
+    EXPECT_EQ(reported.size(), 2);
 }
 
 /// @brief Test that Wait does not fire before the duration elapses.
@@ -740,6 +824,30 @@ TEST(WaitTest, ResetRestartsTimingFromZero) {
     node.next(ctx3);
 
     EXPECT_EQ(output->size(), 1);
+}
+
+/// @brief Test that a non-positive live duration parks the wait: no fire, no
+/// deadline, and the error reports only once.
+TEST(WaitTest, ParksAndReportsOnceOnNonPositiveDuration) {
+    TestSetup setup("wait", "duration", 0);
+    Wait node(setup.make_node());
+
+    std::vector<x::errors::Error> reported;
+    int deadline_calls = 0;
+    bool changed_called = false;
+    auto ctx = make_context(x::telem::TimeSpan(0));
+    ctx.mark_changed = [&](size_t) { changed_called = true; };
+    ctx.set_deadline = [&](x::telem::TimeSpan) { deadline_calls++; };
+    ctx.report_error = [&](const x::errors::Error &e) { reported.push_back(e); };
+
+    ASSERT_NIL(node.next(ctx));
+    ctx.elapsed = x::telem::SECOND;
+    ASSERT_NIL(node.next(ctx));
+
+    EXPECT_FALSE(changed_called);
+    EXPECT_EQ(deadline_calls, 0);
+    ASSERT_EQ(reported.size(), 1);
+    EXPECT_TRUE(reported[0].matches(x::errors::VALIDATION));
 }
 
 /// @brief Test calculate_tolerance for RT_EVENT mode.

--- a/arc/cpp/stl/time/time_test.cpp
+++ b/arc/cpp/stl/time/time_test.cpp
@@ -232,6 +232,22 @@ TEST(TimeModuleTest, BaseIntervalSetToFirstInterval) {
 }
 
 /// @brief Test that base_interval computes GCD across multiple intervals.
+/// @brief Test that a zero var-bound period does not fold into the base
+/// interval, so a parked timer cannot drive the loop cadence.
+TEST(TimeModuleTest, BaseIntervalUnsetForZeroVarBoundPeriod) {
+    TestSetup setup("interval", "period", 0);
+    auto ir_node = setup.ir.nodes[0];
+    ir_node.inputs[0].type = types::Type{
+        .kind = types::Kind::VarRef,
+        .elem = x::mem::indirect<types::Type>(types::Type{.kind = types::Kind::I64})
+    };
+    Module factory;
+    ASSERT_NIL_P(
+        factory.create(runtime::node::Config(setup.ir, ir_node, setup.make_node()))
+    );
+    EXPECT_EQ(factory.base_interval(), UNSET_BASE_INTERVAL);
+}
+
 TEST(TimeModuleTest, BaseIntervalComputesGCDAcrossNodes) {
     TestSetup setup1("interval", "period", (600 * x::telem::MILLISECOND).nanoseconds());
     TestSetup setup2("wait", "duration", (400 * x::telem::MILLISECOND).nanoseconds());

--- a/arc/go/arc_test.go
+++ b/arc/go/arc_test.go
@@ -1043,6 +1043,43 @@ var _ = DescribeTable(
 	Entry("nested in str()", `func f() { x := str(bool(1)) }`),
 )
 
+var _ = DescribeTable(
+	"non-positive timer span rejection",
+	func(ctx SpecContext, source, message string) {
+		root := symbol.NewRoot(nil, stl.NewSymbols())
+		out := arc.Symbol{
+			Name: "out",
+			Kind: symbol.KindChannel,
+			Type: types.Chan(types.U8()),
+			ID:   1,
+		}
+		root.Parent.AddChild(&out)
+		Expect(
+			arc.CompileText(ctx, arc.Text{Raw: source}, root),
+		).Error().To(MatchError(ContainSubstring(message)))
+	},
+	Entry(
+		"zero interval period",
+		"import time\n\ntime.interval{period=0ms} -> out",
+		"period must be positive, got 0s",
+	),
+	Entry(
+		"negative interval period",
+		"import time\n\ntime.interval{period=-1s} -> out",
+		"period must be positive, got",
+	),
+	Entry(
+		"zero interval period via bare alias",
+		`interval{period=0ms} -> out`,
+		"period must be positive, got 0s",
+	),
+	Entry(
+		"zero wait duration",
+		"import time\n\ntime.wait{duration=0ms} -> out",
+		"duration must be positive, got 0s",
+	),
+)
+
 // Boolean expression pipelines: an expression that yields bool (comparison or
 // logical) flows straight into a bool channel.
 var _ = Describe("Bool expression pipelines end-to-end runtime", func() {

--- a/arc/go/stl/time/time.go
+++ b/arc/go/stl/time/time.go
@@ -328,13 +328,33 @@ func liveSpan(s *node.State, name string) telem.TimeSpan {
 	return telem.TimeSpan(node.NumericInput[int64](s, name))
 }
 
+// spanGuard guards a live timer span against non-positive values. It reports
+// the first offense only, so a parked node does not re-report on every pass.
+type spanGuard struct{ reported bool }
+
+// usable reports whether span can drive a deadline. A non-positive span
+// reports a validation error naming label and returns false.
+func (g *spanGuard) usable(ctx node.Context, span telem.TimeSpan, label string) bool {
+	if span > 0 {
+		g.reported = false
+		return true
+	}
+	if !g.reported {
+		ctx.ReportError(errors.Wrapf(
+			validate.ErrValidation, "%s must be positive, got %s", label, span,
+		))
+		g.reported = true
+	}
+	return false
+}
+
+func (g *spanGuard) reset() { g.reported = false }
+
 // Interval is a node that fires repeatedly at a specified period.
 type Interval struct {
 	*node.State
 	lastFired telem.TimeSpan
-	// invalidSpanReported dedupes the non-positive period error so a parked
-	// node does not re-report on every scheduler pass.
-	invalidSpanReported bool
+	guard     spanGuard
 }
 
 func (i *Interval) Init(_ node.Context) {}
@@ -344,17 +364,9 @@ func (i *Interval) Next(ctx node.Context) {
 	// A non-positive period would keep the deadline permanently in the past,
 	// spinning the scheduler loop. Park without a deadline instead; a later
 	// reassignment to a positive value resumes the timer.
-	if period <= 0 {
-		if !i.invalidSpanReported {
-			ctx.ReportError(errors.Wrapf(
-				validate.ErrValidation,
-				"interval period must be positive, got %s", period,
-			))
-			i.invalidSpanReported = true
-		}
+	if !i.guard.usable(ctx, period, "interval period") {
 		return
 	}
-	i.invalidSpanReported = false
 	if ctx.Reason != node.ReasonTimerTick {
 		ctx.MarkSelfChanged()
 		ctx.SetDeadline(i.lastFired + period)
@@ -381,7 +393,7 @@ func (i *Interval) Next(ctx node.Context) {
 func (i *Interval) Reset() {
 	i.State.Reset()
 	i.lastFired = -liveSpan(i.State, periodInputParam)
-	i.invalidSpanReported = false
+	i.guard.reset()
 }
 
 // Wait is a one-shot timer that fires once after a specified duration.
@@ -389,9 +401,7 @@ type Wait struct {
 	*node.State
 	startTime telem.TimeSpan
 	fired     bool
-	// invalidSpanReported dedupes the non-positive duration error so a parked
-	// node does not re-report on every scheduler pass.
-	invalidSpanReported bool
+	guard     spanGuard
 }
 
 func (w *Wait) Init(_ node.Context) {}
@@ -404,17 +414,9 @@ func (w *Wait) Next(ctx node.Context) {
 	// A non-positive duration is a configuration error, not an instant fire:
 	// park instead. Timing stays anchored to startTime, so recovery re-checks
 	// the live duration against the original activation.
-	if duration <= 0 {
-		if !w.invalidSpanReported {
-			ctx.ReportError(errors.Wrapf(
-				validate.ErrValidation,
-				"wait duration must be positive, got %s", duration,
-			))
-			w.invalidSpanReported = true
-		}
+	if !w.guard.usable(ctx, duration, "wait duration") {
 		return
 	}
-	w.invalidSpanReported = false
 	if w.startTime < 0 {
 		w.startTime = ctx.Elapsed
 	}
@@ -441,7 +443,7 @@ func (w *Wait) Reset() {
 	w.State.Reset()
 	w.startTime = -1
 	w.fired = false
-	w.invalidSpanReported = false
+	w.guard.reset()
 }
 
 // Now outputs the current wall-clock timestamp when triggered.

--- a/arc/go/stl/time/time.go
+++ b/arc/go/stl/time/time.go
@@ -14,9 +14,12 @@ import (
 	"reflect"
 
 	"github.com/synnaxlabs/arc/ir"
+	"github.com/synnaxlabs/arc/literal"
+	"github.com/synnaxlabs/arc/parser"
 	"github.com/synnaxlabs/arc/runtime/node"
 	"github.com/synnaxlabs/arc/symbol"
 	"github.com/synnaxlabs/arc/types"
+	"github.com/synnaxlabs/x/diagnostics"
 	"github.com/synnaxlabs/x/errors"
 	"github.com/synnaxlabs/x/lsp/doc"
 	"github.com/synnaxlabs/x/query"
@@ -76,8 +79,9 @@ func NewSymbols() []*symbol.Symbol {
 			Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.U8()}},
 			Inputs:  types.Params{{Name: periodInputParam, Type: types.TimeSpan()}},
 		}),
-		Trigger: symbol.TriggerOnly,
-		Doc:     intervalDoc,
+		Trigger:          symbol.TriggerOnly,
+		Doc:              intervalDoc,
+		AnalyzeArguments: rejectNonPositiveSpan(periodInputParam),
 	}
 	wait := &symbol.Symbol{
 		Name: waitSymbolName,
@@ -87,8 +91,9 @@ func NewSymbols() []*symbol.Symbol {
 			Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: types.U8()}},
 			Inputs:  types.Params{{Name: durationInputParam, Type: types.TimeSpan()}},
 		}),
-		Trigger: symbol.TriggerOnly,
-		Doc:     waitDoc,
+		Trigger:          symbol.TriggerOnly,
+		Doc:              waitDoc,
+		AnalyzeArguments: rejectNonPositiveSpan(durationInputParam),
 	}
 	now := &symbol.Symbol{
 		Name: nowSymbolName,
@@ -111,6 +116,48 @@ func NewSymbols() []*symbol.Symbol {
 	nowBare := *now
 	nowBare.Deprecated = now
 	return []*symbol.Symbol{mod, &intervalBare, &waitBare, &nowBare}
+}
+
+// rejectNonPositiveSpan returns an AnalyzeArguments hook that rejects a
+// literal non-positive span bound to the named param. Non-literal arguments
+// pass through; the runtime guard covers their live values.
+func rejectNonPositiveSpan(param string) symbol.ArgumentsHook {
+	return func(diags *diagnostics.Diagnostics, args []symbol.Argument) {
+		for _, arg := range args {
+			if arg.Name != param && !(arg.Name == "" && arg.Index == 0) {
+				continue
+			}
+			if arg.Expr == nil || !parser.IsLiteral(arg.Expr) {
+				continue
+			}
+			lit := parser.GetLiteral(arg.Expr)
+			if lit == nil || lit.NumericLiteral() == nil {
+				continue
+			}
+			// Type mismatches are the analyzer's to report, not the hook's.
+			parsed, err := literal.Parse(lit, types.TimeSpan())
+			if err != nil {
+				continue
+			}
+			var span telem.TimeSpan
+			switch v := parsed.Value.(type) {
+			case telem.TimeSpan:
+				span = v
+			case int64:
+				span = telem.TimeSpan(v)
+			default:
+				continue
+			}
+			if parser.IsNegatedLiteral(arg.Expr) {
+				span = -span
+			}
+			if span <= 0 {
+				diags.Add(diagnostics.Errorf(
+					arg.AST, "%s must be positive, got %s", param, span,
+				))
+			}
+		}
+	}
 }
 
 // Host is the runtime host-side support for the time module: it registers
@@ -154,6 +201,9 @@ func (h *Host) Create(_ context.Context, cfg node.Config) (node.Node, error) {
 		if err != nil {
 			return nil, err
 		}
+		if err = validateStaticSpan(period, periodParam); err != nil {
+			return nil, err
+		}
 		h.updateBaseInterval(period)
 		h.foldReassignedSpans(cfg, periodParam)
 		return &Interval{
@@ -168,6 +218,9 @@ func (h *Host) Create(_ context.Context, cfg node.Config) (node.Node, error) {
 		}
 		duration, err := parseTime(durationParam.Value, durationParam.Name)
 		if err != nil {
+			return nil, err
+		}
+		if err = validateStaticSpan(duration, durationParam); err != nil {
 			return nil, err
 		}
 		h.updateBaseInterval(duration)
@@ -237,6 +290,18 @@ func gcd(a, b int64) int64 {
 	return a
 }
 
+// validateStaticSpan rejects a non-positive span stamped at compile time.
+// Var-bound params are exempt: the runtime guard covers their live values.
+func validateStaticSpan(span telem.TimeSpan, p types.Param) error {
+	if p.Type.Kind == types.KindVarRef || span > 0 {
+		return nil
+	}
+	return validate.PathedError(
+		errors.Wrapf(validate.ErrValidation, "must be positive, got %s", span),
+		p.Name,
+	)
+}
+
 func parseTime(v any, name string) (telem.TimeSpan, error) {
 	span, ok := v.(telem.TimeSpan)
 	if !ok {
@@ -262,12 +327,29 @@ func liveSpan(s *node.State, name string) telem.TimeSpan {
 type Interval struct {
 	*node.State
 	lastFired telem.TimeSpan
+	// invalidSpanReported dedupes the non-positive period error so a parked
+	// node does not re-report on every scheduler pass.
+	invalidSpanReported bool
 }
 
 func (i *Interval) Init(_ node.Context) {}
 
 func (i *Interval) Next(ctx node.Context) {
 	period := liveSpan(i.State, periodInputParam)
+	// A non-positive period would keep the deadline permanently in the past,
+	// spinning the scheduler loop. Park without a deadline instead; a later
+	// reassignment to a positive value resumes the timer.
+	if period <= 0 {
+		if !i.invalidSpanReported {
+			ctx.ReportError(errors.Wrapf(
+				validate.ErrValidation,
+				"interval period must be positive, got %s", period,
+			))
+			i.invalidSpanReported = true
+		}
+		return
+	}
+	i.invalidSpanReported = false
 	if ctx.Reason != node.ReasonTimerTick {
 		ctx.MarkSelfChanged()
 		ctx.SetDeadline(i.lastFired + period)
@@ -294,6 +376,7 @@ func (i *Interval) Next(ctx node.Context) {
 func (i *Interval) Reset() {
 	i.State.Reset()
 	i.lastFired = -liveSpan(i.State, periodInputParam)
+	i.invalidSpanReported = false
 }
 
 // Wait is a one-shot timer that fires once after a specified duration.
@@ -301,6 +384,9 @@ type Wait struct {
 	*node.State
 	startTime telem.TimeSpan
 	fired     bool
+	// invalidSpanReported dedupes the non-positive duration error so a parked
+	// node does not re-report on every scheduler pass.
+	invalidSpanReported bool
 }
 
 func (w *Wait) Init(_ node.Context) {}
@@ -309,10 +395,24 @@ func (w *Wait) Next(ctx node.Context) {
 	if w.fired {
 		return
 	}
+	duration := liveSpan(w.State, durationInputParam)
+	// A non-positive duration is a configuration error, not an instant fire.
+	// Park without starting the timer; a later reassignment to a positive
+	// value starts it.
+	if duration <= 0 {
+		if !w.invalidSpanReported {
+			ctx.ReportError(errors.Wrapf(
+				validate.ErrValidation,
+				"wait duration must be positive, got %s", duration,
+			))
+			w.invalidSpanReported = true
+		}
+		return
+	}
+	w.invalidSpanReported = false
 	if w.startTime < 0 {
 		w.startTime = ctx.Elapsed
 	}
-	duration := liveSpan(w.State, durationInputParam)
 	ctx.SetDeadline(w.startTime + duration)
 	if ctx.Reason != node.ReasonTimerTick {
 		ctx.MarkSelfChanged()
@@ -336,6 +436,7 @@ func (w *Wait) Reset() {
 	w.State.Reset()
 	w.startTime = -1
 	w.fired = false
+	w.invalidSpanReported = false
 }
 
 // Now outputs the current wall-clock timestamp when triggered.

--- a/arc/go/stl/time/time.go
+++ b/arc/go/stl/time/time.go
@@ -124,7 +124,7 @@ func NewSymbols() []*symbol.Symbol {
 func rejectNonPositiveSpan(param string) symbol.ArgumentsHook {
 	return func(diags *diagnostics.Diagnostics, args []symbol.Argument) {
 		for _, arg := range args {
-			if arg.Name != param && !(arg.Name == "" && arg.Index == 0) {
+			if arg.Name != param && (arg.Name != "" || arg.Index != 0) {
 				continue
 			}
 			if arg.Expr == nil || !parser.IsLiteral(arg.Expr) {

--- a/arc/go/stl/time/time.go
+++ b/arc/go/stl/time/time.go
@@ -276,6 +276,11 @@ func (h *Host) foldReassignedSpans(cfg node.Config, p types.Param) {
 }
 
 func (h *Host) updateBaseInterval(span telem.TimeSpan) {
+	// A non-positive span is not a real timer period. Folding it in would
+	// poison the GCD and drive the loop cadence off a parked timer.
+	if span <= 0 {
+		return
+	}
 	if h.BaseInterval == unsetBaseInterval {
 		h.BaseInterval = span
 	} else {
@@ -396,9 +401,9 @@ func (w *Wait) Next(ctx node.Context) {
 		return
 	}
 	duration := liveSpan(w.State, durationInputParam)
-	// A non-positive duration is a configuration error, not an instant fire.
-	// Park without starting the timer; a later reassignment to a positive
-	// value starts it.
+	// A non-positive duration is a configuration error, not an instant fire:
+	// park instead. Timing stays anchored to startTime, so recovery re-checks
+	// the live duration against the original activation.
 	if duration <= 0 {
 		if !w.invalidSpanReported {
 			ctx.ReportError(errors.Wrapf(

--- a/arc/go/stl/time/time_test.go
+++ b/arc/go/stl/time/time_test.go
@@ -206,6 +206,26 @@ var _ = Describe("Time", func() {
 				Expect(n).ToNot(BeNil())
 			},
 		)
+		It(
+			"Should not fold a zero var-bound period into the timing base",
+			func(ctx SpecContext) {
+				cfg := node.Config{
+					Node: ir.Node{
+						Type: "interval",
+						Inputs: types.Params{
+							{
+								Name:  "period",
+								Type:  types.VarRef(types.TimeSpan(), "p"),
+								Value: telem.TimeSpan(0),
+							},
+						},
+					},
+					State: s.Node("interval_1"),
+				}
+				MustSucceed(factory.Create(ctx, cfg))
+				Expect(factory.BaseInterval).To(Equal(telem.TimeSpanMax))
+			},
+		)
 		It("Should fire immediately on first tick", func(ctx SpecContext) {
 			cfg := node.Config{
 				Node: ir.Node{

--- a/arc/go/stl/time/time_test.go
+++ b/arc/go/stl/time/time_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/synnaxlabs/x/query"
 	"github.com/synnaxlabs/x/telem"
 	. "github.com/synnaxlabs/x/testutil"
+	"github.com/synnaxlabs/x/validate"
 	"github.com/tetratelabs/wazero"
 )
 
@@ -139,6 +140,70 @@ var _ = Describe("Time", func() {
 					State: s.Node("interval_1"),
 				}
 				Expect(factory.Create(ctx, cfg)).Error().To(BeAValidationPathError())
+			},
+		)
+		It(
+			"Should error at construction when the period is zero",
+			func(ctx SpecContext) {
+				cfg := node.Config{
+					Node: ir.Node{
+						Type: "interval",
+						Inputs: types.Params{
+							{
+								Name:  "period",
+								Type:  types.TimeSpan(),
+								Value: telem.TimeSpan(0),
+							},
+						},
+					},
+					State: s.Node("interval_1"),
+				}
+				Expect(factory.Create(ctx, cfg)).Error().To(SatisfyAll(
+					BeAValidationPathError(),
+					MatchError(ContainSubstring("period: must be positive, got 0s")),
+				))
+			},
+		)
+		It(
+			"Should error at construction when the period is negative",
+			func(ctx SpecContext) {
+				cfg := node.Config{
+					Node: ir.Node{
+						Type: "interval",
+						Inputs: types.Params{
+							{
+								Name:  "period",
+								Type:  types.TimeSpan(),
+								Value: -telem.Second,
+							},
+						},
+					},
+					State: s.Node("interval_1"),
+				}
+				Expect(factory.Create(ctx, cfg)).Error().To(SatisfyAll(
+					BeAValidationPathError(),
+					MatchError(ContainSubstring("period: must be positive, got")),
+				))
+			},
+		)
+		It(
+			"Should allow a zero var-bound period at construction",
+			func(ctx SpecContext) {
+				cfg := node.Config{
+					Node: ir.Node{
+						Type: "interval",
+						Inputs: types.Params{
+							{
+								Name:  "period",
+								Type:  types.VarRef(types.TimeSpan(), "p"),
+								Value: telem.TimeSpan(0),
+							},
+						},
+					},
+					State: s.Node("interval_1"),
+				}
+				n := MustSucceed(factory.Create(ctx, cfg))
+				Expect(n).ToNot(BeNil())
 			},
 		)
 		It("Should fire immediately on first tick", func(ctx SpecContext) {
@@ -458,6 +523,28 @@ var _ = Describe("Time", func() {
 					State: s.Node("wait_1"),
 				}
 				Expect(factory.Create(ctx, cfg)).Error().To(BeAValidationPathError())
+			},
+		)
+		It(
+			"Should error at construction when the duration is zero",
+			func(ctx SpecContext) {
+				cfg := node.Config{
+					Node: ir.Node{
+						Type: "wait",
+						Inputs: types.Params{
+							{
+								Name:  "duration",
+								Type:  types.TimeSpan(),
+								Value: telem.TimeSpan(0),
+							},
+						},
+					},
+					State: s.Node("wait_1"),
+				}
+				Expect(factory.Create(ctx, cfg)).Error().To(SatisfyAll(
+					BeAValidationPathError(),
+					MatchError(ContainSubstring("duration: must be positive, got 0s")),
+				))
 			},
 		)
 		It("Should not fire before duration elapses", func(ctx SpecContext) {
@@ -966,6 +1053,128 @@ var _ = Describe("Time", func() {
 				Expect(changedOutputs).To(BeEmpty())
 			},
 		)
+	})
+	Describe("Non-positive live span guard", func() {
+		var factory *time.Host
+		newState := func(
+			ctx context.Context,
+			nodeKey, typ, param string,
+			span int64,
+		) *node.ProgramState {
+			GinkgoHelper()
+			g := graph.Graph{
+				Nodes: []graph.Node{{Key: nodeKey}},
+				Inputs: map[string]msgpack.EncodedJSON{
+					nodeKey: {"type": typ, param: span},
+				},
+				Functions: []ir.Function{{
+					Key: typ,
+					Outputs: types.Params{
+						{Name: ir.DefaultOutputParam, Type: types.U8()},
+					},
+					Inputs: types.Params{
+						{Name: param, Type: types.I64()},
+					},
+				}},
+			}
+			analyzed, diagnostics := graph.Analyze(ctx, g, NewGraphRoot(nil))
+			Expect(diagnostics.Ok()).To(BeTrue())
+			return node.New(analyzed)
+		}
+		newNode := func(
+			ctx context.Context,
+			s *node.ProgramState,
+			nodeKey, typ, param string,
+		) node.Node {
+			GinkgoHelper()
+			cfg := node.Config{
+				Node: ir.Node{
+					Type: typ,
+					Inputs: types.Params{{
+						Name:  param,
+						Type:  types.VarRef(types.TimeSpan(), "p"),
+						Value: telem.TimeSpan(0),
+					}},
+				},
+				State: s.Node(nodeKey),
+			}
+			n := MustSucceed(factory.Create(ctx, cfg))
+			ns := s.Node(nodeKey)
+			*ns.Output(0) = telem.NewSeriesV[uint8]()
+			*ns.OutputTime(0) = telem.NewSeriesV[telem.TimeStamp]()
+			return n
+		}
+		var (
+			reported  []error
+			deadlines []telem.TimeSpan
+			changed   []int
+		)
+		tick := func(ctx context.Context, n node.Node, elapsed telem.TimeSpan) {
+			n.Next(node.Context{
+				Context:         ctx,
+				Elapsed:         elapsed,
+				Reason:          node.ReasonTimerTick,
+				MarkChanged:     func(i int) { changed = append(changed, i) },
+				MarkSelfChanged: func() {},
+				SetDeadline: func(d telem.TimeSpan) {
+					deadlines = append(deadlines, d)
+				},
+				ReportError: func(err error) { reported = append(reported, err) },
+			})
+		}
+		BeforeEach(func(ctx SpecContext) {
+			factory = MustSucceed(time.NewHost(ctx, nil))
+			reported, deadlines, changed = nil, nil, nil
+		})
+		It("Should park an interval and report the error once", func(ctx SpecContext) {
+			s := newState(ctx, "interval_1", "interval", "period", 0)
+			n := newNode(ctx, s, "interval_1", "interval", "period")
+			tick(ctx, n, 0)
+			tick(ctx, n, telem.Second)
+			Expect(changed).To(BeEmpty())
+			Expect(deadlines).To(BeEmpty())
+			Expect(reported).To(HaveLen(1))
+			Expect(reported[0]).To(SatisfyAll(
+				MatchError(validate.ErrValidation),
+				MatchError(ContainSubstring(
+					"interval period must be positive, got 0s",
+				)),
+			))
+		})
+		It(
+			"Should report an interval error again after a reset",
+			func(ctx SpecContext) {
+				s := newState(ctx, "interval_1", "interval", "period", 0)
+				n := newNode(ctx, s, "interval_1", "interval", "period")
+				tick(ctx, n, 0)
+				n.Reset()
+				tick(ctx, n, telem.Second)
+				Expect(reported).To(HaveLen(2))
+			},
+		)
+		It("Should park a wait and report the error once", func(ctx SpecContext) {
+			s := newState(ctx, "wait_1", "wait", "duration", 0)
+			n := newNode(ctx, s, "wait_1", "wait", "duration")
+			tick(ctx, n, 0)
+			tick(ctx, n, telem.Second)
+			Expect(changed).To(BeEmpty())
+			Expect(deadlines).To(BeEmpty())
+			Expect(reported).To(HaveLen(1))
+			Expect(reported[0]).To(SatisfyAll(
+				MatchError(validate.ErrValidation),
+				MatchError(ContainSubstring(
+					"wait duration must be positive, got 0s",
+				)),
+			))
+		})
+		It("Should park a wait with a negative duration", func(ctx SpecContext) {
+			s := newState(ctx, "wait_1", "wait", "duration", int64(-telem.Second))
+			n := newNode(ctx, s, "wait_1", "wait", "duration")
+			tick(ctx, n, 0)
+			Expect(changed).To(BeEmpty())
+			Expect(deadlines).To(BeEmpty())
+			Expect(reported).To(HaveLen(1))
+		})
 	})
 	Describe("TimingBase", func() {
 		It("Should compute GCD of multiple intervals", func(ctx SpecContext) {

--- a/arc/go/text/text_test.go
+++ b/arc/go/text/text_test.go
@@ -3096,8 +3096,7 @@ var _ = Describe("Text", func() {
 
 			It("Should handle negated time unit input value", func(ctx SpecContext) {
 				source := `
-				import time
-				time_trigger -> time.wait{duration=-3h} -> wait_out
+				time_trigger -> delay{span=-3h} -> wait_out
 				`
 				resolver := []symbol.Symbol{
 					{
@@ -3112,6 +3111,20 @@ var _ = Describe("Text", func() {
 						Type: types.Chan(types.U8()),
 						ID:   10043,
 					},
+					{
+						Name: "delay",
+						Kind: symbol.KindFunction,
+						Exec: symbol.ExecFlow,
+						Type: types.Function(types.FunctionProperties{
+							Outputs: types.Params{
+								{Name: ir.DefaultOutputParam, Type: types.U8()},
+							},
+							Inputs: types.Params{
+								{Name: "span", Type: types.TimeSpan()},
+							},
+						}),
+						Trigger: symbol.TriggerOnly,
+					},
 				}
 				parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
 				inter, diagnostics := text.Analyze(
@@ -3121,13 +3134,13 @@ var _ = Describe("Text", func() {
 				)
 				Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
 
-				waitNode := findNodeByType(inter.Nodes, "time.wait")
-				Expect(waitNode).ToNot(BeNil())
-				Expect(waitNode.Inputs).To(HaveLen(1))
-				Expect(waitNode.Inputs[0].Name).To(Equal("duration"))
+				delayNode := findNodeByType(inter.Nodes, "delay")
+				Expect(delayNode).ToNot(BeNil())
+				Expect(delayNode.Inputs).To(HaveLen(1))
+				Expect(delayNode.Inputs[0].Name).To(Equal("span"))
 				threeHoursNanos := int64(3*60*60) * int64(telem.Second)
 				Expect(
-					waitNode.Inputs[0].Value,
+					delayNode.Inputs[0].Value,
 				).To(Equal(telem.TimeSpan(-threeHoursNanos)))
 			})
 

--- a/core/pkg/service/arc/task/task_test.go
+++ b/core/pkg/service/arc/task/task_test.go
@@ -347,6 +347,26 @@ var _ = Describe("Task", Ordered, func() {
 				To(MatchError(query.ErrNotFound))
 		})
 
+		It(
+			"Should reject a zero-period interval program at configure",
+			func(ctx SpecContext) {
+				out := createVirtualCh(ctx, "zero_period", telem.Uint8T)
+				factory := newTextFactory(ctx, arc.Text{Raw: fmt.Sprintf(
+					"interval{period=0ms} -> %s\n", out.Name,
+				)})
+				svcTask := task.Task{
+					Key:    uuid.New(),
+					Name:   "test-zero-period",
+					Type:   arctask.Type,
+					Config: configToMap(arctask.Config{ArcKey: uuid.New()}),
+				}
+				Expect(factory.ConfigureTask(ctx, svcTask, "cmd-1")).Error().
+					To(MatchError(ContainSubstring(
+						"period must be positive, got 0s",
+					)))
+			},
+		)
+
 		It("Should set error status when config is invalid", func(ctx SpecContext) {
 			factory := MustSucceed(arctask.NewFactory(arctask.FactoryConfig{
 				Channel:    channelSvc,


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4735](https://linear.app/synnax/issue/SY-4735/reject-non-positive-periods-in-the-arc-timer-nodes)

## Description

A zero-period `interval` compiled and ran without complaint, and the scheduler spun at full speed (~650k cycles/sec on replication) while the task reported success. This is the leading explanation for the performance drop in the v0.57 customer incident (SY-4731).

The fix rejects a non-positive `interval` period and `wait` duration at three layers, so the failure is loud at the earliest point that can see it:

1. Text analyzer: an `AnalyzeArguments` hook on the `interval` and `wait` symbols rejects literal non-positive spans with a source-located diagnostic. The hook seam already existed; this is its first production use.
2. Node creation (Go and C++ runtimes): a non-positive static span fails the node factory, so graph-mode programs, which bypass the text analyzer hook, fail at configure. Var-bound params are exempt here.
3. Runtime guard (Go and C++ runtimes): a non-positive live span parks the node with a reported error instead of spinning; the report dedupes until the value changes or the node resets, and the timer resumes when the span turns positive.

A silent clamp to a minimum period was rejected: it would hide the user's mistake and emit telemetry at a rate they never asked for.

One existing spec, "Should handle negated time unit input value", used `time.wait{duration=-3h}` as its vehicle for pinning negated-time-literal parsing; that scenario is now invalid by design, so the spec pins the same mechanics through a custom test symbol instead.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds analyzer, factory, and runtime checks for non-positive Arc timer spans in Go and C++. Two runtime paths remain incorrect:
- A zero-valued variable reference still configures the C++ loop for high-rate polling.
- A wait that recovers from an invalid duration can use stale elapsed time and fire early.

<h3>Confidence Score: 3/5</h3>

The PR is not safe to merge until the C++ high-rate polling path and stale wait recovery time are fixed.

A zero-initialized variable timer can still cause high-frequency C++ scheduler wakeups, and recovered waits in both runtimes can fire using elapsed time from before they were parked.

**Files Needing Attention:** arc/cpp/stl/time/time.h and arc/go/stl/time/time.go

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| arc/cpp/stl/time/time.h | Adds static and runtime span guards, but a zero-initialized variable reference still drives a high-rate loop configuration. |
| arc/go/stl/time/time.go | Adds analyzer and runtime validation, but wait recovery preserves stale start time and can fire early. |
| arc/cpp/stl/time/time_test.cpp | Adds static-validation and parking tests but does not cover zero-base loop configuration or invalid-to-positive recovery. |
| arc/go/stl/time/time_test.go | Adds factory and live-span guard tests but does not test wait recovery after an invalid duration. |
| arc/go/arc_test.go | Adds end-to-end analyzer rejection tests for non-positive timer literals. |
| arc/go/text/text_test.go | Moves the negative-span parser test to a custom symbol so it remains a valid parser test. |
| core/pkg/service/arc/task/task_test.go | Confirms that task configuration rejects a zero-period text program. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Timer span input] --> B{Static literal?}
    B -->|Non-positive| C[Reject during analysis or creation]
    B -->|Variable reference| D[Read live span]
    D -->|Non-positive| E[Report and park]
    D -->|Positive| F[Schedule or fire timer]
    E -->|Later positive| F
```

<sub>Reviews (1): Last reviewed commit: ["SY-4735: Reject non-positive periods in ..."](https://github.com/synnaxlabs/synnax/commit/ab5d5d698b9936bd1ce44523d75973666bb7abdf) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56593088)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->