### PR TITLE
SY-4736: Prevent one hung gap read from blocking all telemetry reads

### DIFF
--- a/client/ts/src/framer/cache/reader.spec.ts
+++ b/client/ts/src/framer/cache/reader.spec.ts
@@ -473,7 +473,7 @@ describe("read spanning multiple fetches", () => {
   const tr = new TimeRange(TimeSpan.seconds(1), TimeSpan.seconds(8));
   const cached = new TimeRange(TimeSpan.seconds(3), TimeSpan.seconds(5));
 
-  const seedMiddle = (cache: Cache): void =>
+  const createMiddleEntry = (cache: Cache): void =>
     cache.get(1).writeStatic(
       new MultiSeries([
         new Series({
@@ -488,7 +488,7 @@ describe("read spanning multiple fetches", () => {
     const cache = new Cache();
     const remoteReadF = vi.fn();
     const reader = new Reader({ cache, readRemote: basicRemoteReadFunc(remoteReadF) });
-    seedMiddle(cache);
+    createMiddleEntry(cache);
     await reader.read(tr, 1);
     expect(remoteReadF).toHaveBeenCalledTimes(2);
     expect(remoteReadF).toHaveBeenCalledWith(
@@ -520,7 +520,7 @@ describe("read spanning multiple fetches", () => {
       );
     };
     const reader = new Reader({ cache, readRemote });
-    seedMiddle(cache);
+    createMiddleEntry(cache);
     await expect(reader.read(tr, 1)).rejects.toThrow("read exploded");
     cache.close();
   });

--- a/client/ts/src/framer/cache/reader.spec.ts
+++ b/client/ts/src/framer/cache/reader.spec.ts
@@ -426,6 +426,49 @@ describe("hung fetch", () => {
   });
 });
 
+describe("concurrent batches", () => {
+  // Batches no longer serialize, so two batches may fetch the same still-open gap.
+  // The cache discards the duplicate write and both reads must resolve.
+  it("should resolve both reads when two batches fetch the same range", async () => {
+    const cache = new Cache();
+    const calls: TimeRange[] = [];
+    const resolvers: Array<(f: Frame) => void> = [];
+    const readRemote: RemoteReader = async (tr) => {
+      calls.push(tr);
+      return await new Promise<Frame>((r) => resolvers.push(r));
+    };
+    const reader = new Reader({
+      cache,
+      readRemote,
+      batchDebounce: TimeSpan.milliseconds(10),
+    });
+    const tr = new TimeRange(TimeSpan.seconds(1), TimeSpan.seconds(3));
+    const first = reader.read(tr, 1);
+    await new Promise((r) => setTimeout(r, 30));
+    const second = reader.read(tr, 1);
+    await new Promise((r) => setTimeout(r, 30));
+    expect(calls).toEqual([tr, tr]);
+    resolvers.forEach((resolve) =>
+      resolve(
+        new Frame(
+          [1],
+          [
+            new Series({
+              data: new Float32Array([1, 2, 3]),
+              alignment: 0n,
+              timeRange: tr,
+            }),
+          ],
+        ),
+      ),
+    );
+    const [a, b] = await Promise.all([first, second]);
+    expect(a).toHaveLength(3);
+    expect(b).toHaveLength(3);
+    cache.close();
+  });
+});
+
 describe("read spanning multiple fetches", () => {
   const tr = new TimeRange(TimeSpan.seconds(1), TimeSpan.seconds(8));
   const cached = new TimeRange(TimeSpan.seconds(3), TimeSpan.seconds(5));

--- a/client/ts/src/framer/cache/reader.spec.ts
+++ b/client/ts/src/framer/cache/reader.spec.ts
@@ -7,6 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+import { Unreachable } from "@synnaxlabs/freighter";
 import { MultiSeries, TimeRange, TimeSpan } from "@synnaxlabs/x";
 import { describe, expect, it, type Mock, vi } from "vitest";
 
@@ -310,6 +311,174 @@ describe("read", () => {
     await reader.close();
     const tr = new TimeRange(TimeSpan.seconds(1), TimeSpan.seconds(3));
     await expect(reader.read(tr, 1)).rejects.toThrow(UnexpectedError);
+    cache.close();
+  });
+});
+
+describe("hung fetch", () => {
+  const HUNG_TR = new TimeRange(TimeSpan.seconds(10), TimeSpan.seconds(12));
+  const OK_TR = new TimeRange(TimeSpan.seconds(1), TimeSpan.seconds(3));
+
+  // Hangs forever for reads of HUNG_TR, resolves immediately otherwise.
+  const hangingRemote =
+    (fn: Mock): RemoteReader =>
+    async (tr, keys) => {
+      fn(tr, keys);
+      if (tr.equals(HUNG_TR)) return await new Promise<never>(() => {});
+      return new Frame(
+        keys,
+        keys.map(
+          () =>
+            new Series({
+              data: new Float32Array([1, 2, 3]),
+              alignment: 0n,
+              timeRange: tr,
+            }),
+        ),
+      );
+    };
+
+  it("should resolve a same-batch read whose own fetch succeeded", async () => {
+    const cache = new Cache();
+    const remoteReadF = vi.fn();
+    const reader = new Reader({
+      cache,
+      readRemote: hangingRemote(remoteReadF),
+      batchDebounce: TimeSpan.milliseconds(20),
+      fetchTimeout: TimeSpan.milliseconds(250),
+    });
+    const hung = reader.read(HUNG_TR, 1);
+    const ok = reader.read(OK_TR, 2);
+    const res = await ok;
+    expect(res).toHaveLength(3);
+    expect(remoteReadF).toHaveBeenCalledTimes(2);
+    await expect(hung).rejects.toThrow("timed out after 250ms");
+    cache.close();
+  });
+
+  it("should serve a later batch while a fetch hangs", async () => {
+    const cache = new Cache();
+    const remoteReadF = vi.fn();
+    const reader = new Reader({
+      cache,
+      readRemote: hangingRemote(remoteReadF),
+      batchDebounce: TimeSpan.milliseconds(20),
+      fetchTimeout: TimeSpan.milliseconds(500),
+    });
+    const hung = reader.read(HUNG_TR, 1);
+    await new Promise((r) => setTimeout(r, 50));
+    expect(remoteReadF).toHaveBeenCalledTimes(1);
+    const res = await reader.read(OK_TR, 2);
+    expect(res).toHaveLength(3);
+    expect(remoteReadF).toHaveBeenCalledTimes(2);
+    await reader.close();
+    await expect(hung).rejects.toThrow(UnexpectedError);
+    cache.close();
+  });
+
+  it("should close promptly and reject the hung read", async () => {
+    const cache = new Cache();
+    let release: ((f: Frame) => void) | undefined;
+    const readRemote: RemoteReader = async () =>
+      await new Promise<Frame>((r) => (release = r));
+    const reader = new Reader({
+      cache,
+      readRemote,
+      batchDebounce: TimeSpan.milliseconds(10),
+      fetchTimeout: TimeSpan.seconds(1),
+    });
+    const hung = reader.read(HUNG_TR, 1);
+    await new Promise((r) => setTimeout(r, 30));
+    await reader.close();
+    await expect(hung).rejects.toThrow(UnexpectedError);
+    // A late arrival is discarded without touching the cache.
+    release?.(
+      new Frame(
+        [1],
+        [
+          new Series({
+            data: new Float32Array([1]),
+            alignment: 0n,
+            timeRange: HUNG_TR,
+          }),
+        ],
+      ),
+    );
+    await new Promise((r) => setTimeout(r, 10));
+    expect(cache.get(1).read(HUNG_TR).gaps).toHaveLength(1);
+    cache.close();
+  });
+
+  it("should reject a hung read with Unreachable after the fetch timeout", async () => {
+    const cache = new Cache();
+    const reader = new Reader({
+      cache,
+      readRemote: hangingRemote(vi.fn()),
+      batchDebounce: TimeSpan.milliseconds(10),
+      fetchTimeout: TimeSpan.milliseconds(50),
+    });
+    const hung = reader.read(HUNG_TR, 1);
+    await expect(hung).rejects.toSatisfy((e) => Unreachable.matches(e));
+    await expect(hung).rejects.toThrow(
+      `gap read for ${HUNG_TR.toString()} timed out after 50ms`,
+    );
+    cache.close();
+  });
+});
+
+describe("read spanning multiple fetches", () => {
+  const tr = new TimeRange(TimeSpan.seconds(1), TimeSpan.seconds(8));
+  const cached = new TimeRange(TimeSpan.seconds(3), TimeSpan.seconds(5));
+
+  const seedMiddle = (cache: Cache): void =>
+    cache.get(1).writeStatic(
+      new MultiSeries([
+        new Series({
+          data: new Float32Array([1, 2, 3]),
+          alignment: 10n,
+          timeRange: cached,
+        }),
+      ]),
+    );
+
+  it("should resolve only after every fetch serving the read lands", async () => {
+    const cache = new Cache();
+    const remoteReadF = vi.fn();
+    const reader = new Reader({ cache, readRemote: basicRemoteReadFunc(remoteReadF) });
+    seedMiddle(cache);
+    await reader.read(tr, 1);
+    expect(remoteReadF).toHaveBeenCalledTimes(2);
+    expect(remoteReadF).toHaveBeenCalledWith(
+      new TimeRange(TimeSpan.seconds(1), TimeSpan.seconds(3)),
+      [1],
+    );
+    expect(remoteReadF).toHaveBeenCalledWith(
+      new TimeRange(TimeSpan.seconds(5), TimeSpan.seconds(8)),
+      [1],
+    );
+    cache.close();
+  });
+
+  it("should reject the read when any of its fetches fails", async () => {
+    const cache = new Cache();
+    const failing = new TimeRange(TimeSpan.seconds(5), TimeSpan.seconds(8));
+    const readRemote: RemoteReader = async (tr, keys) => {
+      if (tr.equals(failing)) throw new Error("read exploded");
+      return new Frame(
+        keys,
+        keys.map(
+          () =>
+            new Series({
+              data: new Float32Array([1, 2, 3]),
+              alignment: 0n,
+              timeRange: tr,
+            }),
+        ),
+      );
+    };
+    const reader = new Reader({ cache, readRemote });
+    seedMiddle(cache);
+    await expect(reader.read(tr, 1)).rejects.toThrow("read exploded");
     cache.close();
   });
 });

--- a/client/ts/src/framer/cache/reader.ts
+++ b/client/ts/src/framer/cache/reader.ts
@@ -7,11 +7,12 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+import { Unreachable } from "@synnaxlabs/freighter";
 import {
   debounce,
+  errors,
   MultiSeries,
   type Series,
-  sync,
   TimeRange,
   TimeSpan,
 } from "@synnaxlabs/x";
@@ -31,10 +32,18 @@ interface ReadRequest {
   gaps: TimeRange[];
 }
 
+// Tracks one read's outstanding fetches, so the read settles when its last fetch
+// lands. The first failure among them wins.
+interface Tracker {
+  entry: debounce.Entry<ReadRequest>;
+  remaining: number;
+  failure?: unknown;
+}
+
 interface BatchFetch {
   gap: TimeRange;
   channels: Set<channel.Key>;
-  entries: Set<debounce.Entry<ReadRequest>>;
+  trackers: Set<Tracker>;
 }
 
 export interface ReaderProps {
@@ -53,17 +62,25 @@ export interface ReaderProps {
    * @default TimeSpan.milliseconds(5)
    */
   overlapThreshold?: TimeSpan;
+  /**
+   * Deadline for a single remote fetch. A fetch that does not settle within it
+   * rejects the reads it serves with an Unreachable error.
+   * @default TimeSpan.seconds(30)
+   */
+  fetchTimeout?: TimeSpan;
 }
 
 /**
  * Reads historical telemetry, serving from the cache and batch-filling gaps from the
- * server. A batch failure rejects only the reads whose gaps were in the failed fetch.
+ * server. A fetch failure rejects only the reads whose gaps were in the failed fetch.
  */
 export class Reader {
   private readonly props: Required<Omit<ReaderProps, "batchDebounce">>;
   private readonly batcher: debounce.Batcher<ReadRequest>;
-  // Serializes batch execution against close, so close waits for the batch in flight.
-  private readonly mu = sync.newMutex({ closed: false });
+  private closed = false;
+  // Reads whose fetches are in flight, so close can reject them without waiting
+  // on the fetches themselves.
+  private readonly inFlight = new Set<Tracker>();
 
   constructor(props: ReaderProps) {
     const {
@@ -71,90 +88,144 @@ export class Reader {
       cache,
       batchDebounce = TimeSpan.milliseconds(50),
       overlapThreshold = TimeSpan.milliseconds(5),
+      fetchTimeout = TimeSpan.seconds(30),
     } = props;
-    this.props = { readRemote, cache, overlapThreshold };
+    this.props = { readRemote, cache, overlapThreshold, fetchTimeout };
     this.batcher = new debounce.Batcher({
       interval: batchDebounce,
-      exec: async (entries) =>
-        await this.mu.runExclusive(async () => {
-          if (this.mu.closed) throw new UnexpectedError("telemetry reader is closed");
-          await this.batchRead(entries);
-        }),
+      exec: async (entries) => {
+        if (this.closed) throw new UnexpectedError("telemetry reader is closed");
+        await this.batchRead(entries);
+      },
     });
   }
 
   /**
    * Reads the given time range for the given channel.
    * @throws {UnexpectedError} if the reader is closed while the read is pending.
+   * @throws {Unreachable} if a fetch serving the read exceeds the fetch timeout.
    */
   async read(tr: TimeRange, channel: channel.Key): Promise<MultiSeries> {
     const { cache } = this.props;
     const unary = cache.get(channel);
     const { series, gaps } = unary.read(tr);
     if (gaps.length === 0) return series;
-    if (this.mu.closed) throw new UnexpectedError("telemetry reader is closed");
+    if (this.closed) throw new UnexpectedError("telemetry reader is closed");
     await this.batcher.enqueue({ channel, gaps });
     return unary.read(tr).series;
   }
 
   private async batchRead(entries: Array<debounce.Entry<ReadRequest>>): Promise<void> {
-    const { readRemote, cache, overlapThreshold } = this.props;
+    const { cache, overlapThreshold } = this.props;
     const batched: BatchFetch[] = [];
+    const trackers = new Map<debounce.Entry<ReadRequest>, Tracker>();
     entries.forEach((entry) => {
       const unary = cache.get(entry.req.channel);
       entry.req.gaps.forEach((rawGap) => {
-        // A concurrent batch or a streaming write may have filled part of the gap
+        // An earlier batch or a streaming write may have filled part of the gap
         // while this entry sat in the debounce window.
         unary.read(rawGap).gaps.forEach((gap) => {
+          let tracker = trackers.get(entry);
+          if (tracker == null) {
+            tracker = { entry, remaining: 0 };
+            trackers.set(entry, tracker);
+            this.inFlight.add(tracker);
+          }
           const g = batched.find((r) => r.gap.equals(gap, overlapThreshold));
-          if (g == null)
+          if (g == null) {
             batched.push({
               gap,
               channels: new Set([entry.req.channel]),
-              entries: new Set([entry]),
+              trackers: new Set([tracker]),
             });
-          else {
+            tracker.remaining++;
+          } else {
             g.channels.add(entry.req.channel);
             g.gap = TimeRange.max(g.gap, gap);
-            g.entries.add(entry);
+            if (!g.trackers.has(tracker)) {
+              g.trackers.add(tracker);
+              tracker.remaining++;
+            }
           }
         });
       });
     });
-    const failures = new Map<debounce.Entry<ReadRequest>, unknown>();
-    await Promise.all(
-      batched.map(async ({ gap, channels, entries: served }) => {
-        try {
-          const frame = await readRemote(gap, Array.from(channels));
-          // Group series by key in one pass; per-key get() scans the whole frame.
-          const grouped = new Map<channel.Key, Series[]>();
-          frame.forEach((k, s) => {
-            const key = k as channel.Key;
-            const existing = grouped.get(key);
-            if (existing == null) grouped.set(key, [s]);
-            else existing.push(s);
-          });
-          channels.forEach((key) =>
-            cache.get(key).writeStatic(new MultiSeries(grouped.get(key) ?? [])),
-          );
-        } catch (err) {
-          served.forEach((entry) => {
-            if (!failures.has(entry)) failures.set(entry, err);
-          });
-        }
-      }),
-    );
     entries.forEach((entry) => {
-      const err = failures.get(entry);
-      if (err == null) entry.resolve();
-      else entry.reject(err);
+      if (!trackers.has(entry)) entry.resolve();
+    });
+    await Promise.all(batched.map(async (b) => await this.fetchGap(b)));
+  }
+
+  // Never throws: every outcome, including a deadline expiry and a post-close
+  // arrival, settles through the trackers.
+  private async fetchGap({ gap, channels, trackers }: BatchFetch): Promise<void> {
+    const { cache } = this.props;
+    let failure: unknown;
+    try {
+      const frame = await this.fetchWithDeadline(gap, Array.from(channels));
+      if (!this.closed) {
+        // Group series by key in one pass; per-key get() scans the whole frame.
+        const grouped = new Map<channel.Key, Series[]>();
+        frame.forEach((k, s) => {
+          const key = k as channel.Key;
+          const existing = grouped.get(key);
+          if (existing == null) grouped.set(key, [s]);
+          else existing.push(s);
+        });
+        channels.forEach((key) =>
+          cache.get(key).writeStatic(new MultiSeries(grouped.get(key) ?? [])),
+        );
+      }
+    } catch (err) {
+      failure = err;
+    }
+    trackers.forEach((tracker) => {
+      // close() already settled it.
+      if (!this.inFlight.has(tracker)) return;
+      if (failure != null) tracker.failure ??= failure;
+      tracker.remaining--;
+      if (tracker.remaining > 0) return;
+      this.inFlight.delete(tracker);
+      if (tracker.failure == null) tracker.entry.resolve();
+      else tracker.entry.reject(tracker.failure);
     });
   }
 
-  async close(): Promise<void> {
-    this.batcher.close(new UnexpectedError("telemetry reader is closed"));
-    await this.mu.runExclusive(async () => {
-      this.mu.closed = true;
+  private async fetchWithDeadline(
+    gap: TimeRange,
+    channels: channel.Key[],
+  ): Promise<Frame> {
+    const { readRemote, fetchTimeout } = this.props;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const deadline = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        const timeout = fetchTimeout.toString();
+        const message = `gap read for ${gap.toString()} timed out after ${timeout}`;
+        reject(new Unreachable({ message }));
+      }, fetchTimeout.milliseconds);
     });
+    const fetched = readRemote(gap, channels);
+    try {
+      return await Promise.race([fetched, deadline]);
+    } catch (err) {
+      // The read already failed for its callers; a late settle of the losing
+      // fetch must not surface as an unhandled rejection.
+      fetched.catch(() => {});
+      throw errors.fromUnknown(err);
+    } finally {
+      clearTimeout(timer);
+    }
+  }
+
+  /**
+   * Closes the reader, rejecting every pending read with an UnexpectedError.
+   * In-flight fetch results are discarded when they arrive.
+   */
+  async close(): Promise<void> {
+    this.closed = true;
+    const err = new UnexpectedError("telemetry reader is closed");
+    this.batcher.close(err);
+    this.inFlight.forEach(({ entry }) => entry.reject(err));
+    this.inFlight.clear();
   }
 }

--- a/client/ts/src/framer/cache/reader.ts
+++ b/client/ts/src/framer/cache/reader.ts
@@ -32,8 +32,8 @@ interface ReadRequest {
   gaps: TimeRange[];
 }
 
-// Tracks one read's outstanding fetches, so the read settles when its last fetch
-// lands. The first failure among them wins.
+// Tracks one read's outstanding fetches, so the read settles when its last fetch lands.
+// The first failure among them wins.
 interface Tracker {
   entry: debounce.Entry<ReadRequest>;
   remaining: number;
@@ -63,8 +63,8 @@ export interface ReaderProps {
    */
   overlapThreshold?: TimeSpan;
   /**
-   * Deadline for a single remote fetch. A fetch that does not settle within it
-   * rejects the reads it serves with an Unreachable error.
+   * Deadline for a single remote fetch. A fetch that does not settle within it rejects
+   * the reads it serves with an Unreachable error.
    * @default TimeSpan.seconds(30)
    */
   fetchTimeout?: TimeSpan;
@@ -78,8 +78,8 @@ export class Reader {
   private readonly props: Required<Omit<ReaderProps, "batchDebounce">>;
   private readonly batcher: debounce.Batcher<ReadRequest>;
   private closed = false;
-  // Reads whose fetches are in flight, so close can reject them without waiting
-  // on the fetches themselves.
+  // Reads whose fetches are in flight, so close can reject them without waiting on the
+  // fetches themselves.
   private readonly inFlight = new Set<Tracker>();
 
   constructor(props: ReaderProps) {
@@ -122,8 +122,8 @@ export class Reader {
     entries.forEach((entry) => {
       const unary = cache.get(entry.req.channel);
       entry.req.gaps.forEach((rawGap) => {
-        // An earlier batch or a streaming write may have filled part of the gap
-        // while this entry sat in the debounce window.
+        // An earlier batch or a streaming write may have filled part of the gap while
+        // this entry sat in the debounce window.
         unary.read(rawGap).gaps.forEach((gap) => {
           let tracker = trackers.get(entry);
           if (tracker == null) {
@@ -156,8 +156,8 @@ export class Reader {
     await Promise.all(batched.map(async (b) => await this.fetchGap(b)));
   }
 
-  // Never throws: every outcome, including a deadline expiry and a post-close
-  // arrival, settles through the trackers.
+  // Never throws: every outcome, including a deadline expiry and a post-close arrival,
+  // settles through the trackers.
   private async fetchGap({ gap, channels, trackers }: BatchFetch): Promise<void> {
     const { cache } = this.props;
     let failure: unknown;
@@ -208,8 +208,8 @@ export class Reader {
     try {
       return await Promise.race([fetched, deadline]);
     } catch (err) {
-      // The read already failed for its callers; a late settle of the losing
-      // fetch must not surface as an unhandled rejection.
+      // The read already failed for its callers; a late settle of the losing fetch must
+      // not surface as an unhandled rejection.
       fetched.catch(() => {});
       throw errors.fromUnknown(err);
     } finally {
@@ -218,8 +218,8 @@ export class Reader {
   }
 
   /**
-   * Closes the reader, rejecting every pending read with an UnexpectedError.
-   * In-flight fetch results are discarded when they arrive.
+   * Closes the reader, rejecting every pending read with an UnexpectedError. In-flight
+   * fetch results are discarded when they arrive.
    */
   async close(): Promise<void> {
     this.closed = true;


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4736](https://linear.app/synnax/issue/SY-4736/prevent-one-hung-gap-read-from-blocking-all-telemetry-reads)

## Description

Found replicating the v0.57 incident: the Feed's `Reader` holds one mutex across every remote gap fetch, and a fetch has no timeout. One remote read that never settles (for example a half-open socket) permanently blocks same-batch reads whose own fetches succeeded, every later batch on any channel, and `close()`. No error surfaces; only a clean TCP close recovers.

The lock-across-fetch shape was inherited from the Pluto reader, where it guarded a shared live request set. The 0.57 rewrite replaced that set with per-window immutable entry arrays, so the reason no longer exists. The cache already tolerates interleaved writes: the streamer writes into it with no coordination, and the insertion planner trims or discards overlap.

Changes:

- Drop the mutex. Batches plan and write synchronously; fetches run unlocked.
- Settle each read when its own fetches settle, so a hung fetch starves only the read that owns it.
- `close()` rejects every pending read immediately and discards late fetch results instead of waiting for the batch in flight.
- Bound each fetch with a deadline (`fetchTimeout`, default 30 seconds) that rejects the reads it serves with a freighter `Unreachable` error.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have updated user-facing documentation accordingly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR removes global serialization from cached telemetry gap reads, adds per-read fetch tracking and deadlines, and makes reader shutdown reject pending operations promptly.
- Allows successful reads and later batches to settle independently of a hung fetch.
- Adds a configurable 30-second default fetch timeout surfaced as `Unreachable`.
- Discards late results after close and adds focused timeout, concurrency, multi-gap, and shutdown tests.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge, with only a non-blocking test-helper naming issue to correct.

The new concurrency, timeout, and shutdown paths preserve per-read settlement and allow later batches to progress independently; the only accepted concern is the fixture helper’s repository-inconsistent name.

**Files Needing Attention:** client/ts/src/framer/cache/reader.spec.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| client/ts/src/framer/cache/reader.ts | Replaces mutex-serialized batch reads with independent fetch tracking, bounded deadlines, and prompt close semantics; no blocking correctness defect was established. |
| client/ts/src/framer/cache/reader.spec.ts | Adds strong coverage for hung fetch isolation, deadlines, close behavior, and multi-fetch reads, with one repository naming-convention violation. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Caller
  participant Reader
  participant Batcher
  participant Remote
  participant Cache
  Caller->>Reader: read(range, channel)
  Reader->>Batcher: enqueue gaps
  Batcher->>Reader: execute batch
  par Independent gap fetches
    Reader->>Remote: fetch gap A
    Reader->>Remote: fetch gap B
  end
  Remote-->>Reader: gap A result
  Reader->>Cache: write gap A
  Reader-->>Caller: settle reads served by A
  Note over Reader,Remote: Gap B may remain pending until its deadline
  Remote--xReader: gap B timeout
  Reader-->>Caller: reject reads served by B
  Note over Reader: close() rejects all tracked reads immediately
```

<sub>Reviews (1): Last reviewed commit: ["SY-4736: Prevent one hung gap read from ..."](https://github.com/synnaxlabs/synnax/commit/9c93b04095556b1758c439caec925643cfb6667a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56604699)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/synnaxlabs/synnax/blob/main/CLAUDE.md))

<!-- /greptile_comment -->