### PR TITLE
SY-4737: Subscribe rolling plot sources to live data before the history read

### DIFF
--- a/client/ts/src/index.ts
+++ b/client/ts/src/index.ts
@@ -25,6 +25,7 @@ export * from "@/connection";
 export { control } from "@/control";
 export { device } from "@/device";
 export {
+  AccessDeniedError,
   AuthError,
   ContiguityError,
   DisconnectedError,

--- a/pluto/src/telem/aether/remote.spec.ts
+++ b/pluto/src/telem/aether/remote.spec.ts
@@ -764,7 +764,139 @@ describe("remote", () => {
       expect(c.streamF).toHaveBeenCalledWith(c.streamHandler, [c.channel.key]);
     });
 
-    it("should not subscribe or retain data when cleaned up while reading", async () => {
+    // The stream must open before the back-fill read resolves, so a stalled or failed
+    // back-fill cannot block live data.
+    describe("live stream before back-fill", () => {
+      it("should serve live data while the back-fill read is pending", async () => {
+        let release = (): void => {};
+        const gate = new Promise<void>((resolve) => (release = resolve));
+        c.feed.read = async (): Promise<MultiSeries> => {
+          await gate;
+          return new MultiSeries([]);
+        };
+        const cd = new StreamChannelData(c, {
+          timeSpan: TimeSpan.MAX,
+          channel: c.channel.key,
+        });
+        await waitForStream(cd, c);
+        const live = new Series({
+          data: new Float32Array([1, 2, 3]),
+          timeRange: new TimeRange(TimeStamp.now(), TimeStamp.MAX),
+        });
+        c.streamHandler?.(new Map([[c.channel.key, new MultiSeries([live])]]));
+        const [b, data] = cd.value();
+        expect(b).toStrictEqual({ lower: 1, upper: 3 });
+        expect(data.series).toHaveLength(1);
+        expect(data.series[0]).toBe(live);
+        cd.cleanup();
+        release();
+      });
+
+      it("should serve live data and post a status on back-fill failure", async () => {
+        const statuses: cstatus.Crude[] = [];
+        c.feed.read = async (): Promise<MultiSeries> => {
+          throw new Error("read exploded");
+        };
+        const cd = new StreamChannelData(
+          c,
+          { timeSpan: TimeSpan.MAX, channel: c.channel.key },
+          { onStatusChange: (s) => statuses.push(s) },
+        );
+        await waitForStream(cd, c);
+        await expect.poll(() => statuses.length > 0).toBe(true);
+        expect(statuses[0].variant).toEqual("error");
+        expect(statuses[0].message).toEqual("Failed to read channel data");
+        expect(statuses[0].description).toEqual("read exploded");
+        const live = new Series({
+          data: new Float32Array([4, 5]),
+          timeRange: new TimeRange(TimeStamp.now(), TimeStamp.MAX),
+        });
+        c.streamHandler?.(new Map([[c.channel.key, new MultiSeries([live])]]));
+        const [, data] = cd.value();
+        expect(data.series).toHaveLength(1);
+        expect(data.series[0]).toBe(live);
+        cd.cleanup();
+      });
+
+      it("should retry the back-fill after a failure", async () => {
+        const now = TimeStamp.now();
+        const series = new Series({
+          data: new Float32Array([1, 2, 3]),
+          timeRange: new TimeRange(
+            now.sub(TimeSpan.milliseconds(3)),
+            now.add(TimeSpan.milliseconds(1)),
+          ),
+        });
+        let calls = 0;
+        c.feed.read = async (): Promise<MultiSeries> => {
+          calls++;
+          if (calls === 1) throw new Error("transient");
+          return new MultiSeries([series]);
+        };
+        const cd = new StreamChannelData(c, {
+          timeSpan: TimeSpan.MAX,
+          channel: c.channel.key,
+        });
+        await waitForStream(cd, c);
+        // The failure invalidated the read, so the next value() call retries.
+        await expect.poll(() => cd.value()[1].series.length).toBe(1);
+        expect(calls).toBeGreaterThanOrEqual(2);
+        expect(cd.value()[1].series[0]).toBe(series);
+        cd.cleanup();
+      });
+
+      it("should insert a late back-fill in front of live series", async () => {
+        const now = TimeStamp.now();
+        const historical = new Series({
+          data: new Float32Array([1, 2]),
+          timeRange: new TimeRange(now.sub(TimeSpan.seconds(2)), now),
+          alignment: 0n,
+        });
+        let release = (): void => {};
+        const gate = new Promise<void>((resolve) => (release = resolve));
+        c.feed.read = async (): Promise<MultiSeries> => {
+          await gate;
+          return new MultiSeries([historical]);
+        };
+        const cd = new StreamChannelData(c, {
+          timeSpan: TimeSpan.MAX,
+          channel: c.channel.key,
+        });
+        await waitForStream(cd, c);
+        const live = new Series({
+          data: new Float32Array([3, 4]),
+          timeRange: new TimeRange(now, TimeStamp.MAX),
+          alignment: 2n,
+        });
+        c.streamHandler?.(new Map([[c.channel.key, new MultiSeries([live])]]));
+        release();
+        await expect.poll(() => cd.value()[1].series.length).toBe(2);
+        const [, data] = cd.value();
+        expect(data.series[0]).toBe(historical);
+        expect(data.series[1]).toBe(live);
+        cd.cleanup();
+      });
+    });
+
+    it("should not subscribe when cleaned up during channel retrieval", async () => {
+      let release = (): void => {};
+      const gate = new Promise<void>((resolve) => (release = resolve));
+      c.channels.retrieve = async (): Promise<channel.Channel> => {
+        await gate;
+        return c.channel;
+      };
+      const cd = new StreamChannelData(c, {
+        timeSpan: TimeSpan.MAX,
+        channel: c.channel.key,
+      });
+      cd.value();
+      cd.cleanup();
+      release();
+      await new Promise((resolve) => setTimeout(resolve, 5));
+      expect(c.streamF).not.toHaveBeenCalled();
+    });
+
+    it("should stop streaming and drop a back-fill pending at cleanup", async () => {
       const series = new Series({ data: new Float32Array([1, 2, 3]) });
       let release = (): void => {};
       const gate = new Promise<void>((resolve) => (release = resolve));
@@ -776,11 +908,11 @@ describe("remote", () => {
         timeSpan: TimeSpan.MAX,
         channel: c.channel.key,
       });
-      cd.value();
+      await waitForStream(cd, c);
       cd.cleanup();
+      expect(c.streamDestructorF).toHaveBeenCalled();
       release();
       await new Promise((resolve) => setTimeout(resolve, 5));
-      expect(c.streamF).not.toHaveBeenCalled();
       expect(series.refCount).toBe(0);
     });
 

--- a/pluto/src/telem/aether/remote.spec.ts
+++ b/pluto/src/telem/aether/remote.spec.ts
@@ -13,6 +13,7 @@ import {
   type framer,
   type status as cstatus,
   TimeRange,
+  ValidationError,
 } from "@synnaxlabs/client";
 import { bounds, id, MultiSeries, Series, TimeSpan, TimeStamp } from "@synnaxlabs/x";
 import { beforeEach, describe, expect, it, type Mock, vi } from "vitest";
@@ -818,7 +819,7 @@ describe("remote", () => {
         cd.cleanup();
       });
 
-      it("should retry the back-fill after a failure", async () => {
+      it("should retry the back-fill under the breaker after a failure", async () => {
         const now = TimeStamp.now();
         const series = new Series({
           data: new Float32Array([1, 2, 3]),
@@ -833,16 +834,89 @@ describe("remote", () => {
           if (calls === 1) throw new Error("transient");
           return new MultiSeries([series]);
         };
-        const cd = new StreamChannelData(c, {
-          timeSpan: TimeSpan.MAX,
-          channel: c.channel.key,
-        });
+        const cd = new StreamChannelData(
+          c,
+          { timeSpan: TimeSpan.MAX, channel: c.channel.key },
+          {},
+          undefined,
+          { sleepFn: async () => {} },
+        );
         await waitForStream(cd, c);
-        // The failure invalidated the read, so the next value() call retries.
+        // The retry runs on its own; the polled value() calls only observe it.
         await expect.poll(() => cd.value()[1].series.length).toBe(1);
-        expect(calls).toBeGreaterThanOrEqual(2);
+        expect(calls).toBe(2);
         expect(cd.value()[1].series[0]).toBe(series);
         cd.cleanup();
+      });
+
+      it("should post one status per distinct failure across retries", async () => {
+        const statuses: cstatus.Crude[] = [];
+        let calls = 0;
+        const failures = ["boom", "boom", "other"];
+        c.feed.read = async (): Promise<MultiSeries> => {
+          const failure = failures[calls];
+          calls++;
+          if (failure != null) throw new Error(failure);
+          return new MultiSeries([]);
+        };
+        const cd = new StreamChannelData(
+          c,
+          { timeSpan: TimeSpan.MAX, channel: c.channel.key },
+          { onStatusChange: (s) => statuses.push(s) },
+          undefined,
+          { sleepFn: async () => {} },
+        );
+        cd.value();
+        await expect.poll(() => calls).toBe(4);
+        expect(statuses.map((s) => s.description)).toEqual(["boom", "other"]);
+        cd.cleanup();
+      });
+
+      it("should park without retrying on a definitive rejection", async () => {
+        const statuses: cstatus.Crude[] = [];
+        let calls = 0;
+        c.feed.read = async (): Promise<MultiSeries> => {
+          calls++;
+          throw new ValidationError("bad request");
+        };
+        const cd = new StreamChannelData(
+          c,
+          { timeSpan: TimeSpan.MAX, channel: c.channel.key },
+          { onStatusChange: (s) => statuses.push(s) },
+          undefined,
+          { sleepFn: async () => {} },
+        );
+        await waitForStream(cd, c);
+        await expect.poll(() => statuses.length).toBe(1);
+        // Neither time nor further value() calls restart a parked source.
+        cd.value();
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        expect(calls).toBe(1);
+        // The live stream opened before the back-fill and stays open while parked.
+        expect(c.streamDestructorF).not.toHaveBeenCalled();
+        cd.cleanup();
+      });
+
+      it("should stop retrying at cleanup", async () => {
+        let calls = 0;
+        c.feed.read = async (): Promise<MultiSeries> => {
+          calls++;
+          throw new Error("boom");
+        };
+        const cd = new StreamChannelData(
+          c,
+          { timeSpan: TimeSpan.MAX, channel: c.channel.key },
+          {},
+          undefined,
+          { baseInterval: TimeSpan.milliseconds(1), scale: 1, jitter: 0 },
+        );
+        cd.value();
+        // Retries pace themselves on the breaker's own timer while the source lives.
+        await expect.poll(() => calls >= 3).toBe(true);
+        cd.cleanup();
+        const settled = calls;
+        await new Promise((resolve) => setTimeout(resolve, 20));
+        expect(calls).toBe(settled);
       });
 
       it("should insert a late back-fill in front of live series", async () => {

--- a/pluto/src/telem/aether/remote.spec.ts
+++ b/pluto/src/telem/aether/remote.spec.ts
@@ -765,6 +765,14 @@ describe("remote", () => {
       expect(c.streamF).toHaveBeenCalledWith(c.streamHandler, [c.channel.key]);
     });
 
+    // Mirrors cesium's leading-alignment region: streamed, not-yet-persisted data
+    // carries alignments whose domain index starts at MaxUint32 - 1e6, sorting after
+    // any committed alignment.
+    const leadingAlignment = (domain: bigint, sample: bigint): bigint =>
+      ((0xffffffffn - 1_000_000n + domain) << 32n) | sample;
+    const committedAlignment = (domain: bigint, sample: bigint): bigint =>
+      (domain << 32n) | sample;
+
     // The stream must open before the back-fill read resolves, so a stalled or failed
     // back-fill cannot block live data.
     describe("live stream before back-fill", () => {
@@ -917,6 +925,79 @@ describe("remote", () => {
         const settled = calls;
         await new Promise((resolve) => setTimeout(resolve, 20));
         expect(calls).toBe(settled);
+      });
+
+      it("should insert committed back-fill before leading live series", async () => {
+        const now = TimeStamp.now();
+        const fetched = new Series({
+          data: new Float32Array([1, 2]),
+          timeRange: new TimeRange(now.sub(TimeSpan.seconds(2)), now),
+          alignment: committedAlignment(3n, 0n),
+        });
+        let release = (): void => {};
+        const gate = new Promise<void>((resolve) => (release = resolve));
+        c.feed.read = async (): Promise<MultiSeries> => {
+          await gate;
+          return new MultiSeries([fetched]);
+        };
+        const cd = new StreamChannelData(c, {
+          timeSpan: TimeSpan.MAX,
+          channel: c.channel.key,
+        });
+        await waitForStream(cd, c);
+        const live = new Series({
+          data: new Float32Array([3, 4]),
+          timeRange: new TimeRange(now, TimeStamp.MAX),
+          alignment: leadingAlignment(1n, 0n),
+        });
+        c.streamHandler?.(new Map([[c.channel.key, new MultiSeries([live])]]));
+        release();
+        await expect.poll(() => cd.value()[1].series.length).toBe(2);
+        const [, data] = cd.value();
+        expect(data.series[0]).toBe(fetched);
+        expect(data.series[1]).toBe(live);
+        cd.cleanup();
+      });
+
+      // Unary.read documents that a span can return in both its streamed and fetched
+      // representation. The plot needs both: each alignment space must pair x with y
+      // completely, so neither representation may be dropped.
+      it("should retain both representations of a span", async () => {
+        const now = TimeStamp.now();
+        const span = new TimeRange(now.sub(TimeSpan.seconds(1)), now);
+        const live = new Series({
+          data: new Float32Array([5, 6]),
+          timeRange: span,
+          alignment: leadingAlignment(1n, 0n),
+        });
+        const fetched = new Series({
+          data: new Float32Array([5, 6]),
+          timeRange: span,
+          alignment: committedAlignment(4n, 0n),
+        });
+        let release = (): void => {};
+        const gate = new Promise<void>((resolve) => (release = resolve));
+        c.feed.read = async (): Promise<MultiSeries> => {
+          await gate;
+          return new MultiSeries([fetched, live]);
+        };
+        const cd = new StreamChannelData(c, {
+          timeSpan: TimeSpan.MAX,
+          channel: c.channel.key,
+        });
+        await waitForStream(cd, c);
+        c.streamHandler?.(new Map([[c.channel.key, new MultiSeries([live])]]));
+        release();
+        await expect.poll(() => cd.value()[1].series.length).toBe(2);
+        const [b, data] = cd.value();
+        expect(data.series[0]).toBe(fetched);
+        expect(data.series[1]).toBe(live);
+        expect(live.refCount).toBe(1);
+        expect(fetched.refCount).toBe(1);
+        expect(b).toStrictEqual({ lower: 5, upper: 6 });
+        cd.cleanup();
+        expect(live.refCount).toBe(0);
+        expect(fetched.refCount).toBe(0);
       });
 
       it("should insert a late back-fill in front of live series", async () => {

--- a/pluto/src/telem/aether/remote.ts
+++ b/pluto/src/telem/aether/remote.ts
@@ -8,18 +8,23 @@
 // included in the file licenses/APL.txt.
 
 import {
+  AccessDeniedError,
   channel,
   type framer,
   NotFoundError,
   status as cstatus,
+  ValidationError,
 } from "@synnaxlabs/client";
 import {
   bounds,
+  breaker,
   DataType,
   type destructor,
+  errors,
   MultiSeries,
   primitive,
   type Series,
+  sync,
   TimeRange,
   TimeSpan,
   TimeStamp,
@@ -273,6 +278,9 @@ export class StreamChannelData
   private stopStreaming?: destructor.Destructor;
   private valid: boolean = false;
   private generation = 0;
+  private readonly breaker: breaker.Breaker;
+  private readonly retryNotifier = new sync.Notifier();
+  private lastFailure?: string;
   schema = streamChannelDataPropsZ;
 
   constructor(
@@ -280,11 +288,27 @@ export class StreamChannelData
     props: unknown,
     options?: CreateOptions,
     now: () => TimeStamp = () => TimeStamp.now(),
+    breakerConfig?: breaker.Config,
   ) {
     super(props);
     this.client = client;
     this.now = now;
     this.onStatusChange = options?.onStatusChange;
+    this.breaker = new breaker.Breaker({
+      baseInterval: TimeSpan.seconds(1),
+      // A tall interval cap: live data flows independently of this loop, and a
+      // back-fill loses value as the window fills with live samples.
+      maxInterval: TimeSpan.seconds(30),
+      maxRetries: Infinity,
+      scale: 2,
+      jitter: 0.25,
+      // cleanup interrupts a pending backoff so a retired source's retry loop ends
+      // promptly instead of sleeping through it
+      sleepFn: async (duration) => {
+        await this.retryNotifier.wait(duration);
+      },
+      ...breakerConfig,
+    });
   }
 
   value(): [bounds.Bounds, MultiSeries] {
@@ -303,7 +327,10 @@ export class StreamChannelData
     return [b, this.data];
   }
 
-  /** Never rejects: a failure invalidates the read and reaches onStatusChange. */
+  /**
+   * Never rejects. A connectivity failure retries under the breaker; a definitive
+   * rejection parks the source. Every distinct failure reaches onStatusChange.
+   */
   private async read(): Promise<void> {
     const generation = this.generation;
     this.valid = true;
@@ -312,9 +339,30 @@ export class StreamChannelData
       this.onStatusChange?.(DISCONNECTED_STATUS);
       return;
     }
+    while (generation === this.generation)
+      try {
+        await this.attempt(generation, client);
+        this.breaker.reset();
+        this.lastFailure = undefined;
+        return;
+      } catch (e) {
+        // Retrying only fixes connectivity; a definitive rejection recurs on every
+        // attempt.
+        if (
+          AccessDeniedError.matches(e) ||
+          ValidationError.matches(e) ||
+          NotFoundError.matches(e)
+        )
+          return;
+        if (!(await this.breaker.wait())) return;
+      }
+  }
+
+  // One full read attempt: it opens the live stream, then runs the historical
+  // back-fill, so a stalled or failed back-fill never blocks live data. Throws the
+  // failure after posting its status.
+  private async attempt(generation: number, client: Client): Promise<void> {
     const { channel, useIndexOfChannel, timeSpan } = this.props;
-    // The live stream opens before the historical back-fill runs, so a stalled or
-    // failed back-fill never blocks live data.
     let fetched: SelectedChannelProperties;
     try {
       fetched = await fetchChannelProperties(client, channel, useIndexOfChannel);
@@ -331,9 +379,8 @@ export class StreamChannelData
       this.stopStreaming?.();
       this.stopStreaming = client.feed.stream(handler, [fetched.key]).close;
     } catch (e) {
-      this.valid = false;
-      this.onStatusChange?.(cstatus.fromException(e, "Failed to stream channel data"));
-      return;
+      this.reportFailure(e, "Failed to stream channel data");
+      throw errors.fromUnknown(e);
     }
     if (!fetched.virtual || fetched.isCalculated)
       try {
@@ -353,16 +400,21 @@ export class StreamChannelData
         )
           console.warn("failed to read calculated channel data", e);
         else {
-          // The stream stays open; invalidating lets the next value() call retry the
-          // back-fill.
-          this.valid = false;
-          this.onStatusChange?.(
-            cstatus.fromException(e, "Failed to read channel data"),
-          );
-          return;
+          this.reportFailure(e, "Failed to read channel data");
+          throw errors.fromUnknown(e);
         }
       }
     this.notify();
+  }
+
+  // Retries repeat at the breaker's pace, so an incident posts one status when it
+  // starts and again only when the failure changes. Success clears the memory.
+  private reportFailure(e: unknown, message: string): void {
+    const failure = cstatus.fromException(e, message);
+    const key = `${failure.message}: ${failure.description}`;
+    if (this.lastFailure === key) return;
+    this.lastFailure = key;
+    this.onStatusChange?.(failure);
   }
 
   // feed.read returns the live leading buffer that the stream's first delivery repeats,
@@ -388,6 +440,7 @@ export class StreamChannelData
 
   cleanup(): void {
     this.generation++;
+    this.retryNotifier.notify();
     this.stopStreaming?.();
     this.stopStreaming = undefined;
     this.data.release();

--- a/pluto/src/telem/aether/remote.ts
+++ b/pluto/src/telem/aether/remote.ts
@@ -17,7 +17,6 @@ import {
   bounds,
   DataType,
   type destructor,
-  errors,
   MultiSeries,
   primitive,
   type Series,
@@ -313,30 +312,14 @@ export class StreamChannelData
       this.onStatusChange?.(DISCONNECTED_STATUS);
       return;
     }
+    const { channel, useIndexOfChannel, timeSpan } = this.props;
+    // The live stream opens before the historical back-fill runs, so a stalled or
+    // failed back-fill never blocks live data.
+    let fetched: SelectedChannelProperties;
     try {
-      const { channel, useIndexOfChannel, timeSpan } = this.props;
-      const fetched = await fetchChannelProperties(client, channel, useIndexOfChannel);
+      fetched = await fetchChannelProperties(client, channel, useIndexOfChannel);
       if (generation !== this.generation) return;
       this.channel = fetched;
-      const tr = this.now().spanRange(-timeSpan);
-      if (!this.channel.virtual || this.channel.isCalculated)
-        try {
-          const res = await client.feed.read(tr, this.channel.key);
-          if (generation !== this.generation) return;
-          this.pushNew(res.series);
-        } catch (e) {
-          // Certain calculated channels can fail to read because they need access to
-          // virtual channels that cannot be read from historically.
-          if (
-            e instanceof Error &&
-            (e.message.includes("cannot open iterator on virtual channel") ||
-              e.message.includes("cannot read from free channel"))
-          )
-            console.warn("failed to read calculated channel data", e);
-          else throw errors.fromUnknown(e);
-        }
-
-      this.stopStreaming?.();
       const handler: framer.StreamHandler = (res) => {
         if (generation !== this.generation || this.channel == null) return;
         const series = res.get(this.channel.key);
@@ -345,22 +328,53 @@ export class StreamChannelData
         this.notify();
         this.gcOutOfRangeData();
       };
-      if (generation !== this.generation) return;
-      this.stopStreaming = client.feed.stream(handler, [this.channel.key]).close;
-      this.notify();
+      this.stopStreaming?.();
+      this.stopStreaming = client.feed.stream(handler, [fetched.key]).close;
     } catch (e) {
       this.valid = false;
       this.onStatusChange?.(cstatus.fromException(e, "Failed to stream channel data"));
+      return;
     }
+    if (!fetched.virtual || fetched.isCalculated)
+      try {
+        const res = await client.feed.read(
+          this.now().spanRange(-timeSpan),
+          fetched.key,
+        );
+        if (generation !== this.generation) return;
+        this.pushNew(res.series);
+      } catch (e) {
+        // Certain calculated channels can fail to read because they need access to
+        // virtual channels that cannot be read from historically.
+        if (
+          e instanceof Error &&
+          (e.message.includes("cannot open iterator on virtual channel") ||
+            e.message.includes("cannot read from free channel"))
+        )
+          console.warn("failed to read calculated channel data", e);
+        else {
+          // The stream stays open; invalidating lets the next value() call retry the
+          // back-fill.
+          this.valid = false;
+          this.onStatusChange?.(
+            cstatus.fromException(e, "Failed to read channel data"),
+          );
+          return;
+        }
+      }
+    this.notify();
   }
 
-  // feed.read returns the live leading buffer that the stream's first delivery
-  // repeats, so series already held by identity are skipped.
+  // feed.read returns the live leading buffer that the stream's first delivery repeats,
+  // so series already held by identity are skipped. A late back-fill is inserted by
+  // alignment: consumers assume the array is chronological.
   private pushNew(series: Series[]): void {
     for (const s of series) {
       if (this.data.series.includes(s)) continue;
       s.acquire();
-      this.data.push(s);
+      const at = this.data.series.findIndex((held) => held.alignment > s.alignment);
+      if (at === -1) this.data.push(s);
+      else this.data.series.splice(at, 0, s);
     }
   }
 

--- a/pluto/src/telem/aether/transformers.spec.ts
+++ b/pluto/src/telem/aether/transformers.spec.ts
@@ -191,6 +191,38 @@ describe("SeriesDownsampler", () => {
       expect(result2.series[0].at(1)).toBe(3.5);
     });
 
+    // A rolling source inserts a late back-fill in front of its live series, so the
+    // positional cache sees a new head and must rebuild instead of throwing.
+    it("should rebuild the cache when a series is inserted at the front", () => {
+      const downsampler = new SeriesDownsampler({
+        mode: "average",
+        windowSize: 2,
+      });
+
+      const live = new Series({
+        key: "live",
+        data: new Float32Array([10, 20, 30, 40]),
+        dataType: DataType.FLOAT32,
+        timeRange: new TimeRange(4n, 8n),
+        alignment: 4n,
+      });
+      downsampler.transform(new MultiSeries([live]));
+
+      const backfill = new Series({
+        key: "backfill",
+        data: new Float32Array([1, 2, 3, 4]),
+        dataType: DataType.FLOAT32,
+        timeRange: new TimeRange(0n, 4n),
+        alignment: 0n,
+      });
+      const result = downsampler.transform(new MultiSeries([backfill, live]));
+      expect(result.series).toHaveLength(2);
+      expect(result.series[0].at(0)).toBe(1.5);
+      expect(result.series[0].at(1)).toBe(3.5);
+      expect(result.series[1].at(0)).toBe(15);
+      expect(result.series[1].at(1)).toBe(35);
+    });
+
     it("should evict old series from cache", () => {
       const downsampler = new SeriesDownsampler({
         mode: "average",


### PR DESCRIPTION
## Key Information

- **Linear Issue**: [SY-4737](https://linear.app/synnax/issue/SY-4737/subscribe-rolling-plot-sources-to-live-data-before-the-history-read)

## Description

`StreamChannelData`, the source behind rolling line plots, opened its live stream subscription only after the historical back-fill read resolved. A stalled back-fill blocked live data entirely, and while the read pended the source stayed valid, so nothing retried. This amplified the v0.57 incident: rolling plots stayed blank while schematic values, whose source subscribes immediately, streamed fine on the same socket.

The read now opens the live stream as soon as the channel properties resolve and runs the back-fill after. Because the back-fill can now land after live series, `pushNew` inserts by alignment instead of appending: the average-mode downsampler and the front-only GC both assume the series array is chronological.

Failed reads retry under a `breaker.Breaker` (base 1s, scale 2, cap 30s, infinite retries) instead of once per `value()` call, following the `HardenedStreamer` precedent: definitive rejections (`AccessDenied`, `Validation`, `NotFound`) park the source without retrying, an incident posts one status per distinct failure, and `cleanup` interrupts a pending backoff through a `sync.Notifier`. The retry loop is self-driven, so a source whose first attempt fails before the stream opens still recovers. `AccessDeniedError` is now exported from the client barrel alongside its sibling typed errors so the classification can match it.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant tests to cover the changes to CI.
- [ ] I have updated user facing documentation accordingly.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR opens rolling-plot live subscriptions before historical back-fills and adds self-driven retry handling for failed reads.
- Exports `AccessDeniedError` through the TypeScript client barrel.
- Adds retry, cleanup, definitive-rejection, and stream-before-back-fill tests.
- Inserts late back-fill series by alignment, but identity-only deduplication still permits overlapping fetched and streamed representations.

<h3>Confidence Score: 4/5</h3>

The PR is not yet safe to merge because a late back-fill can duplicate a span already supplied by the live stream.

Identity-only deduplication removes the repeated dynamic object but not a distinct fetched representation of the same span, allowing overlapping samples to reach rolling-plot downsampling and rendering.

**Files Needing Attention:** pluto/src/telem/aether/remote.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| pluto/src/telem/aether/remote.ts | Reorders subscription and back-fill work and adds retries, but identity-only deduplication can retain overlapping fetched and streamed series. |
| pluto/src/telem/aether/remote.spec.ts | Adds broad lifecycle and retry coverage, though the deduplication test covers only the identity-identical representation. |
| client/ts/src/index.ts | Correctly exposes AccessDeniedError for definitive retry classification. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant Plot as Rolling plot
  participant Source as StreamChannelData
  participant Feed as Shared feed cache
  Plot->>Source: value()
  Source->>Feed: stream(channel)
  Feed-->>Source: dynamic leading Series
  Source->>Source: pushNew(dynamic)
  Source->>Feed: read(back-fill range)
  Feed-->>Source: fetched Series + same dynamic Series
  Source->>Source: identity check drops dynamic only
  Source->>Source: retain overlapping fetched Series
  Source-->>Plot: MultiSeries containing duplicated span
```

<sub>Reviews (2): Last reviewed commit: ["SY-4737: Pace the rolling source&#39;s retri..."](https://github.com/synnaxlabs/synnax/commit/31caf6fd4e8a036131049b9e95eb1d3398de9d8e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56611800)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Knowledge Base — [Console data tools and visualization](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/console-data-tools.md)

<!-- /greptile_comment -->