### PR TITLE
SY-4741: Scale the y axis to data bounds when the window clip is empty

### DIFF
--- a/pluto/src/lineplot/aether/axis.spec.ts
+++ b/pluto/src/lineplot/aether/axis.spec.ts
@@ -1,0 +1,82 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { TimeSpan, TimeStamp } from "@synnaxlabs/x";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { autoBounds, emptyBounds } from "@/lineplot/aether/axis";
+
+describe("axis", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe("emptyBounds", () => {
+    it("should return decimal bounds for a linear axis", () => {
+      expect(emptyBounds("linear")).toStrictEqual({ lower: 0, upper: 1 });
+    });
+
+    it("should compute the time window at call time", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2030-01-02T03:04:05Z"));
+      const now = TimeStamp.now();
+      const b = emptyBounds("time");
+      expect(b.lower).toBe(Number(now.valueOf()));
+      expect(b.upper).toBe(Number(now.add(TimeSpan.HOUR).valueOf()));
+    });
+
+    it("should track a moving clock across calls", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2030-01-02T03:04:05Z"));
+      const first = emptyBounds("time");
+      vi.setSystemTime(new Date("2030-01-02T04:04:05Z"));
+      const second = emptyBounds("time");
+      expect(second.lower).toBeGreaterThan(first.lower);
+      expect(second.lower).toBe(Number(TimeStamp.now().valueOf()));
+    });
+  });
+
+  describe("autoBounds", () => {
+    it("should pad bounds by the given padding", () => {
+      expect(autoBounds([{ lower: 0, upper: 10 }], 0.1, "linear")).toStrictEqual({
+        lower: -1,
+        upper: 11,
+      });
+    });
+
+    it("should expand equal bounds by one", () => {
+      expect(autoBounds([{ lower: 5, upper: 5 }], 0.1, "linear")).toStrictEqual({
+        lower: 4,
+        upper: 6,
+      });
+    });
+
+    it("should ignore non-finite bounds", () => {
+      const b = [
+        { lower: Infinity, upper: -Infinity },
+        { lower: 0, upper: 10 },
+      ];
+      expect(autoBounds(b, 0, "linear")).toStrictEqual({ lower: 0, upper: 10 });
+    });
+
+    it("should fall back to decimal bounds for an empty linear axis", () => {
+      const b = [{ lower: Infinity, upper: -Infinity }];
+      expect(autoBounds(b, 0.1, "linear")).toStrictEqual({ lower: 0, upper: 1 });
+    });
+
+    it("should fall back to a now-anchored hour for an empty time axis", () => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2030-01-02T03:04:05Z"));
+      const now = TimeStamp.now();
+      const b = autoBounds([], 0.1, "time");
+      expect(b.lower).toBe(Number(now.valueOf()));
+      expect(b.upper).toBe(Number(now.add(TimeSpan.HOUR).valueOf()));
+    });
+  });
+});

--- a/pluto/src/lineplot/aether/axis.ts
+++ b/pluto/src/lineplot/aether/axis.ts
@@ -59,14 +59,16 @@ export const withinSizeThreshold = (prev: number, next: number): boolean =>
   );
 
 export const EMPTY_LINEAR_BOUNDS = bounds.DECIMAL;
-const now = TimeStamp.now();
-export const EMPTY_TIME_BOUNDS: bounds.Bounds = {
-  lower: Number(now.valueOf()),
-  upper: Number(now.add(TimeSpan.HOUR).valueOf()),
-};
 
-export const emptyBounds = (type: TickType): bounds.Bounds =>
-  type === "linear" ? EMPTY_LINEAR_BOUNDS : EMPTY_TIME_BOUNDS;
+// Computed per call so an empty time axis tracks the present instead of app start.
+export const emptyBounds = (type: TickType): bounds.Bounds => {
+  if (type === "linear") return EMPTY_LINEAR_BOUNDS;
+  const now = TimeStamp.now();
+  return {
+    lower: Number(now.valueOf()),
+    upper: Number(now.add(TimeSpan.HOUR).valueOf()),
+  };
+};
 
 export interface AxisRenderProps {
   grid: grid.Grid;

--- a/pluto/src/vis/line/aether/bounds.spec.ts
+++ b/pluto/src/vis/line/aether/bounds.spec.ts
@@ -8,7 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import {
-  bounds,
+  type bounds,
   DataType,
   MultiSeries,
   Series,
@@ -54,8 +54,10 @@ const xWindow = (loSec: number, hiSec: number): bounds.Bounds => ({
   upper: Number(TimeStamp.seconds(hiSec).valueOf()),
 });
 
+const FALLBACK: bounds.Bounds = { lower: -1234, upper: 1234 };
+
 const calc = (x: Series[], y: Series[], win: bounds.Bounds): bounds.Bounds =>
-  windowBounds(new MultiSeries(x), new MultiSeries(y), win, THRESHOLD);
+  windowBounds(new MultiSeries(x), new MultiSeries(y), win, THRESHOLD, FALLBACK);
 
 describe("windowBounds", () => {
   it("should bound only the samples inside the window", () => {
@@ -70,10 +72,22 @@ describe("windowBounds", () => {
     expect(calc([x], [y], xWindow(1, 9))).toStrictEqual({ lower: -250, upper: -200 });
   });
 
-  it("should return non-finite bounds when no samples fall in the window", () => {
+  it("should return the fallback when the window is beyond all samples", () => {
     const x = stamps(0, 10);
     const y = values(0, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
-    expect(bounds.isFinite(calc([x], [y], xWindow(20, 30)))).toBe(false);
+    expect(calc([x], [y], xWindow(20, 30))).toStrictEqual(FALLBACK);
+  });
+
+  it("should return the fallback when the window predates all samples", () => {
+    const x = stamps(20, 10);
+    const y = values(20, [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]);
+    expect(calc([x], [y], xWindow(0, 10))).toStrictEqual(FALLBACK);
+  });
+
+  it("should return the fallback when every value in the window is NaN", () => {
+    const x = stamps(0, 3);
+    const y = values(0, [NaN, NaN, NaN]);
+    expect(calc([x], [y], xWindow(0, 3))).toStrictEqual(FALLBACK);
   });
 
   it("should pair series with offset alignments", () => {
@@ -97,7 +111,7 @@ describe("windowBounds", () => {
   it("should not pair series whose time ranges do not overlap", () => {
     const x = stamps(0, 5, 0n);
     const y = values(100, [1, 2, 3, 4, 5], 0n);
-    expect(bounds.isFinite(calc([x], [y], xWindow(0, 5)))).toBe(false);
+    expect(calc([x], [y], xWindow(0, 5))).toStrictEqual(FALLBACK);
   });
 
   it("should apply the series sample offset", () => {

--- a/pluto/src/vis/line/aether/bounds.ts
+++ b/pluto/src/vis/line/aether/bounds.ts
@@ -85,7 +85,7 @@ export const windowBounds = (
       if (b.lower < lower) lower = b.lower;
       if (b.upper > upper) upper = b.upper;
     }
-  const b = { lower, upper };
-  if (!bounds.isFinite(b)) return fallback;
-  return b;
+  const result = { lower, upper };
+  if (!bounds.isFinite(result)) return fallback;
+  return result;
 };

--- a/pluto/src/vis/line/aether/bounds.ts
+++ b/pluto/src/vis/line/aether/bounds.ts
@@ -65,14 +65,15 @@ const clip = (
  * @param yData - the y series, paired with x by time range and alignment overlap.
  * @param xWindow - the x range to bound over.
  * @param overlapThreshold - minimum time range overlap for an x/y pair to count.
+ * @param fallback - returned when no paired sample falls inside the window.
  * @returns the bounds of y samples whose paired x value falls inside the window.
- * Non-finite when none do.
  */
 export const windowBounds = (
   xData: MultiSeries,
   yData: MultiSeries,
   xWindow: bounds.Bounds,
   overlapThreshold: TimeSpan,
+  fallback: bounds.Bounds,
 ): bounds.Bounds => {
   let lower = Infinity;
   let upper = -Infinity;
@@ -84,5 +85,7 @@ export const windowBounds = (
       if (b.lower < lower) lower = b.lower;
       if (b.upper > upper) upper = b.upper;
     }
-  return { lower, upper };
+  const b = { lower, upper };
+  if (!bounds.isFinite(b)) return fallback;
+  return b;
 };

--- a/pluto/src/vis/line/aether/line.ts
+++ b/pluto/src/vis/line/aether/line.ts
@@ -313,7 +313,8 @@ export class Line extends aether.Leaf<typeof stateZ, InternalState> {
 
   /**
    * @param xWindow - the visible x range. Bounds cover only samples whose x value
-   * falls inside it; non-finite windows fall back to the source's full bounds.
+   * falls inside it; when the window is non-finite or clips out every sample, the
+   * source's full bounds are used instead.
    * @returns the y bounds of this line's samples inside the window.
    */
   yBounds(xWindow: bounds.Bounds): bounds.Bounds {
@@ -321,7 +322,7 @@ export class Line extends aether.Leaf<typeof stateZ, InternalState> {
     const [b, yData] = yTelem.value();
     if (!bounds.isFinite(xWindow)) return b;
     const [, xData] = xTelem.value();
-    return windowBounds(xData, yData, xWindow, DEFAULT_OVERLAP_THRESHOLD);
+    return windowBounds(xData, yData, xWindow, DEFAULT_OVERLAP_THRESHOLD, b);
   }
 
   findByXValue(props: LineProps, target: number): FindResult {


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4741](https://linear.app/synnax/issue/SY-4741/scale-the-y-axis-to-data-bounds-when-the-window-clip-is-empty)

## Description

Fixes two line plot axis fallback defects found while replicating the v0.57 incident:

1. When no x/y pair fell inside the visible x window, `windowBounds` returned a non-finite sentinel and `autoBounds` collapsed the y axis to a meaningless 0-to-1 scale, blanking the plot with no error surfaced. `windowBounds` now takes an explicit fallback, and `Line.yBounds` passes the y source's full bounds, matching its existing fallback for a non-finite window. The 0-to-1 scale remains only when the source itself has no data.
2. The fallback window for an empty time axis was stamped once at module load, so a long-running Console pinned every empty x axis to app-start time. `emptyBounds` now computes the window at call time, and the throttled bounds update keeps it tracking the present.

## Basic Readiness

- [ ] I have performed a self-review of my code.
- [ ] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds full-data fallback bounds for empty line-window clips and computes empty time bounds at call time.
- Passes each line's full Y bounds into `windowBounds`.
- Adds tests for empty clips, NaN data, and clock-based time bounds.
- Leaves idle empty time axes without a periodic refresh.

<h3>Confidence Score: 4/5</h3>

The idle empty time-axis defect must be fixed before merging because the window still stops tracking the present without external render events.

Computing the current time per call does not solve the long-running idle case because line-plot bounds are recalculated only after explicit render requests.

**Files Needing Attention:** pluto/src/lineplot/aether/axis.ts and pluto/src/lineplot/aether/axis.spec.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| pluto/src/lineplot/aether/axis.ts | Computes empty time bounds per call, but no periodic caller advances them while an empty plot is idle. |
| pluto/src/vis/line/aether/bounds.ts | Adds an explicit fallback for clips that produce no finite Y bounds. |
| pluto/src/vis/line/aether/line.ts | Supplies full source Y bounds as the empty-window fallback. |
| pluto/src/lineplot/aether/axis.spec.ts | Tests repeated direct calls against a moving clock but does not cover idle plot refresh behavior. |
| pluto/src/vis/line/aether/bounds.spec.ts | Covers fallback behavior for out-of-range, unpaired, and all-NaN samples. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    A[Initial layout request] --> B[Render axis]
    B --> C[Compute empty bounds from current time]
    C --> D{New render request?}
    D -- Data or interaction --> B
    D -- Idle empty plot --> E[Bounds remain pinned]
```

<sub>Reviews (1): Last reviewed commit: ["SY-4741: Compute the empty time axis win..."](https://github.com/synnaxlabs/synnax/commit/339377a7ab030c3fa25b35badc8a13e2d95d52f1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56626111)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->