### PR TITLE
SY-4742: Stop the live buffer from leaking into reads outside its data

### DIFF
--- a/client/ts/src/framer/cache/dynamic.spec.ts
+++ b/client/ts/src/framer/cache/dynamic.spec.ts
@@ -183,37 +183,61 @@ describe("DynamicCache", () => {
           );
         });
 
-        it("should fall back to the wall clock at a buffer split", () => {
+        it("should grow a buffer rather than split a series across two", () => {
           const cache = new Dynamic({ dynamicBufferSize: 2, now: () => WALL });
           const { flushed, allocated } = cache.write(
             new MultiSeries([
               stamped([1, 2, 3], TimeStamp.seconds(10).range(TimeStamp.seconds(13))),
             ]),
           );
-          // The split point's timestamp is unknowable from the data series, so the
-          // flushed buffer ends at the wall clock and the continuation starts there.
-          expect(flushed.series[0].timeRange).toEqual(
-            TimeStamp.seconds(10).range(WALL),
+          // Splitting would put the boundary at a timestamp the data does not carry.
+          expect(flushed).toHaveLength(0);
+          expect(allocated).toHaveLength(3);
+          expect(cache.dataTimeRange).toEqual(
+            TimeStamp.seconds(10).range(TimeStamp.seconds(13)),
           );
-          expect(allocated.series[1].timeRange.start).toEqual(WALL);
+        });
+
+        it("should stamp a rotation with the last written series' end", () => {
+          const cache = new Dynamic({ dynamicBufferSize: 2, now: () => WALL });
+          cache.write(
+            new MultiSeries([
+              stamped([1, 2], TimeStamp.seconds(10).range(TimeStamp.seconds(12))),
+            ]),
+          );
+          // The next series does not fit, so the full buffer is flushed at the end of
+          // the series it holds, and the new one starts where its own data starts.
+          const { flushed } = cache.write(
+            new MultiSeries([
+              stamped([3, 4], TimeStamp.seconds(12).range(TimeStamp.seconds(14)), 2n),
+            ]),
+          );
+          expect(flushed.series[0].timeRange).toEqual(
+            TimeStamp.seconds(10).range(TimeStamp.seconds(12)),
+          );
+          expect(cache.leadingBuffer?.timeRange.start).toEqual(TimeStamp.seconds(12));
         });
       });
 
       it("should correctly allocate a single new buffer when the current one is full", async () => {
         const cache = new Dynamic({ dynamicBufferSize: 2 });
-        const ser = f32([1, 2, 3]);
-        const { flushed, allocated } = cache.write(new MultiSeries([ser]));
+        const first = cache.write(new MultiSeries([f32([1, 2])]));
+        expect(first.flushed).toHaveLength(0);
+        const { flushed, allocated } = cache.write(
+          new MultiSeries([f32([3]).reAlign(2n)]),
+        );
         expect(flushed).toHaveLength(2);
-        expect(allocated).toHaveLength(3);
-        expect(flushed.series[0]).toBe(allocated.series[0]);
+        expect(allocated).toHaveLength(1);
+        expect(flushed.series[0]).toBe(first.allocated.series[0]);
         expect(cache.length).toEqual(1);
       });
       it("should correctly allocate multiple new buffers when the current one is full", () => {
         const cache = new Dynamic({ dynamicBufferSize: 1 });
-        const ser = f32([1, 2, 3]);
-        const { flushed, allocated } = cache.write(new MultiSeries([ser]));
-        expect(flushed).toHaveLength(2);
-        expect(allocated).toHaveLength(3);
+        cache.write(new MultiSeries([f32([1])]));
+        const second = cache.write(new MultiSeries([f32([2]).reAlign(1n)]));
+        const third = cache.write(new MultiSeries([f32([3]).reAlign(2n)]));
+        expect(second.flushed).toHaveLength(1);
+        expect(third.flushed).toHaveLength(1);
         expect(cache.length).toEqual(1);
       });
       it("it should correctly set multiple writes", async () => {
@@ -235,12 +259,14 @@ describe("DynamicCache", () => {
         const waitSpan = TimeSpan.milliseconds(10);
         await new Promise((resolve) => setTimeout(resolve, waitSpan.milliseconds));
         const { flushed, allocated } = cache.write(new MultiSeries([ser.reAlign(9n)]));
-        expect(allocated).toHaveLength(2);
+        expect(allocated).toHaveLength(3);
         expect(allocated.timeRange.start.sub(TimeStamp.now()).valueOf()).toBeLessThan(
           TimeSpan.milliseconds(3).valueOf(),
         );
         expect(allocated.timeRange.end.valueOf()).toEqual(TimeStamp.MAX.valueOf());
-        expect(flushed).toHaveLength(10);
+        // The fourth series does not fit in the space left, so the buffer flushes with
+        // the nine samples it holds instead of taking part of it.
+        expect(flushed).toHaveLength(9);
         // Slack for a loaded runner: the buffer's span tracks wall time, so the bound
         // only has to rule out a span untethered from it.
         expect(flushed.timeRange.span.sub(waitSpan).valueOf()).toBeLessThanOrEqual(
@@ -249,7 +275,6 @@ describe("DynamicCache", () => {
         expect(flushed.series[0].data.slice(0, 3)).toEqual(new Float32Array([1, 2, 3]));
         expect(flushed.series[0].data.slice(3, 6)).toEqual(new Float32Array([1, 2, 3]));
         expect(flushed.series[0].data.slice(6, 9)).toEqual(new Float32Array([1, 2, 3]));
-        expect(flushed.series[0].data.slice(9)).toEqual(new Float32Array([1]));
       });
       it("should allocate a new buffer if the two series are out of alignment", () => {
         const cache = new Dynamic({ dynamicBufferSize: 10 });
@@ -274,6 +299,22 @@ describe("DynamicCache", () => {
         expect(allocated.timeRange.end.valueOf()).toEqual(TimeStamp.MAX.valueOf());
         expect(flushed.series[0]).toBe(allocated.series[0]);
         expect(allocated).toHaveLength(6);
+      });
+      it("should fit a variable-length series that outgrows the byte estimate", () => {
+        // Capacity for variable types is estimated in bytes per sample, so a series of
+        // long strings needs more room than the sample count suggests.
+        const cache = new Dynamic({ dynamicBufferSize: 1 });
+        const ser = new Series({
+          data: ["a".repeat(200), "b".repeat(200)],
+          dataType: DataType.STRING,
+        });
+        const { flushed, allocated } = cache.write(new MultiSeries([ser]));
+        expect(flushed).toHaveLength(0);
+        expect(allocated).toHaveLength(2);
+        expect(Array.from(cache.leadingBuffer as Series)).toEqual([
+          "a".repeat(200),
+          "b".repeat(200),
+        ]);
       });
       it("should derive the buffer's data type from the first written series", () => {
         const cache = new Dynamic({ dynamicBufferSize: 100 });
@@ -434,24 +475,26 @@ describe("DynamicCache", () => {
               transform: glTransform,
               now: () => WALL_CLOCK,
             });
-            const ser = new Series({
-              data: [500n, 501n, 600n, 601n, 700n],
-              dataType: DataType.INT64,
-            });
-            const { flushed, allocated } = cache.write(new MultiSeries([ser]));
-            // Buffer A fills with [500, 501], anchored at 500.
-            expect(flushed.series[0].sampleOffset).toBe(500n);
-            expect(flushed.series[0].at(0)).toBe(500n);
-            expect(flushed.series[0].at(1)).toBe(501n);
-            // Buffer B fills with [600, 601], anchored at the first sample that
-            // landed in it, not at A's offset.
-            expect(flushed.series[1].sampleOffset).toBe(600n);
-            expect(flushed.series[1].at(0)).toBe(600n);
-            expect(flushed.series[1].at(1)).toBe(601n);
+            const int64 = (data: bigint[], alignment: bigint): MultiSeries =>
+              new MultiSeries([
+                new Series({ data, dataType: DataType.INT64 }).reAlign(alignment),
+              ]);
+            cache.write(int64([500n, 501n], 0n));
+            // Buffer A is full, so each later write rotates to a fresh buffer.
+            const second = cache.write(int64([600n, 601n], 2n));
+            const third = cache.write(int64([700n], 4n));
+            // Buffer A held [500, 501], anchored at 500.
+            expect(second.flushed.series[0].sampleOffset).toBe(500n);
+            expect(second.flushed.series[0].at(0)).toBe(500n);
+            expect(second.flushed.series[0].at(1)).toBe(501n);
+            // Buffer B held [600, 601], anchored at the first sample that landed in it,
+            // not at A's offset.
+            expect(third.flushed.series[0].sampleOffset).toBe(600n);
+            expect(third.flushed.series[0].at(0)).toBe(600n);
+            expect(third.flushed.series[0].at(1)).toBe(601n);
             // Buffer C is the trailing buffer holding [700], anchored at 700.
-            expect(allocated.series).toHaveLength(3);
-            expect(allocated.series[2].sampleOffset).toBe(700n);
-            expect(allocated.series[2].at(0)).toBe(700n);
+            expect(cache.leadingBuffer?.sampleOffset).toBe(700n);
+            expect(cache.leadingBuffer?.at(0)).toBe(700n);
           });
           it("anchors a fresh offset when alignment mismatch forces rotation", () => {
             const cache = bigCache();
@@ -560,6 +603,29 @@ describe("DynamicCache", () => {
       const cache = new Dynamic({ dynamicBufferSize: 100, now: () => WALL });
       cache.write(new MultiSeries([f32([1, 2, 3])]));
       expect(cache.dataTimeRange).toEqual(WALL.range(WALL));
+    });
+
+    // A rotation used to stamp the new buffer with the wall clock while its samples
+    // stayed far in the past, which read back as a range spanning both.
+    it("should keep a rotated buffer's range inside its own data", () => {
+      const cache = new Dynamic({ dynamicBufferSize: 2, now: () => WALL });
+      cache.write(
+        new MultiSeries([
+          stamped([1, 2], TimeStamp.seconds(10).range(TimeStamp.seconds(12))),
+        ]),
+      );
+      cache.write(
+        new MultiSeries([
+          stamped([3, 4], TimeStamp.seconds(12).range(TimeStamp.seconds(14)), 2n),
+        ]),
+      );
+      const range = cache.dataTimeRange;
+      expect(range?.isValid).toBe(true);
+      expect(range).toEqual(TimeStamp.seconds(12).range(TimeStamp.seconds(14)));
+      // WALL is 100s, so a read of the present must not reach the rotated buffer.
+      expect(
+        range?.overlapsWith(TimeStamp.seconds(90).range(TimeStamp.seconds(110))),
+      ).toBe(false);
     });
 
     it("should be null again after a flush", () => {

--- a/client/ts/src/framer/cache/dynamic.spec.ts
+++ b/client/ts/src/framer/cache/dynamic.spec.ts
@@ -522,4 +522,55 @@ describe("DynamicCache", () => {
       });
     });
   });
+
+  describe("dataTimeRange", () => {
+    const WALL = TimeStamp.seconds(100);
+    const stamped = (data: number[], tr: TimeRange, alignment = 0n): Series =>
+      new Series({
+        data: new Float32Array(data),
+        dataType: DataType.FLOAT32,
+        timeRange: tr,
+        alignment,
+      });
+
+    it("should be null when there is no buffer", () => {
+      const cache = new Dynamic({ dynamicBufferSize: 100 });
+      expect(cache.dataTimeRange).toBeNull();
+    });
+
+    it("should end at the last stamped write, not the buffer's MAX end", () => {
+      const cache = new Dynamic({ dynamicBufferSize: 100, now: () => WALL });
+      cache.write(
+        new MultiSeries([
+          stamped([1, 2, 3], TimeStamp.seconds(10).range(TimeStamp.seconds(13))),
+        ]),
+      );
+      cache.write(
+        new MultiSeries([
+          stamped([4, 5], TimeStamp.seconds(13).range(TimeStamp.seconds(15)), 3n),
+        ]),
+      );
+      expect(cache.leadingBuffer?.timeRange.end).toEqual(TimeStamp.MAX);
+      expect(cache.dataTimeRange).toEqual(
+        TimeStamp.seconds(10).range(TimeStamp.seconds(15)),
+      );
+    });
+
+    it("should fall back to the wall clock for unstamped data", () => {
+      const cache = new Dynamic({ dynamicBufferSize: 100, now: () => WALL });
+      cache.write(new MultiSeries([f32([1, 2, 3])]));
+      expect(cache.dataTimeRange).toEqual(WALL.range(WALL));
+    });
+
+    it("should be null again after a flush", () => {
+      const cache = new Dynamic({ dynamicBufferSize: 100 });
+      cache.write(
+        new MultiSeries([
+          stamped([1, 2, 3], TimeStamp.seconds(10).range(TimeStamp.seconds(13))),
+        ]),
+      );
+      cache.flush();
+      expect(cache.dataTimeRange).toBeNull();
+    });
+  });
 });

--- a/client/ts/src/framer/cache/dynamic.spec.ts
+++ b/client/ts/src/framer/cache/dynamic.spec.ts
@@ -217,6 +217,36 @@ describe("DynamicCache", () => {
           );
           expect(cache.leadingBuffer?.timeRange.start).toEqual(TimeStamp.seconds(12));
         });
+
+        it("should start a rotation after a trim where the flushed buffer ends", () => {
+          const cache = new Dynamic({ dynamicBufferSize: 2, now: () => WALL });
+          cache.write(
+            new MultiSeries([
+              stamped([1, 2], TimeStamp.seconds(10).range(TimeStamp.seconds(12))),
+            ]),
+          );
+          // The re-sent frame starts at second 11 but its first new sample is at
+          // second 12. Trimming keeps the frame's own start, so the buffer would
+          // claim a second of time it holds nothing for.
+          const { flushed } = cache.write(
+            new MultiSeries([
+              stamped(
+                [2, 3, 4],
+                TimeStamp.seconds(11).range(TimeStamp.seconds(14)),
+                1n,
+              ),
+            ]),
+          );
+          expect(flushed.series[0].timeRange).toEqual(
+            TimeStamp.seconds(10).range(TimeStamp.seconds(12)),
+          );
+          expect(cache.leadingBuffer?.timeRange.start).toEqual(TimeStamp.seconds(12));
+          expect(
+            cache.dataTimeRange?.overlapsWith(
+              TimeStamp.seconds(11).range(TimeStamp.milliseconds(11500)),
+            ),
+          ).toEqual(false);
+        });
       });
 
       it("should correctly allocate a single new buffer when the current one is full", async () => {

--- a/client/ts/src/framer/cache/dynamic.ts
+++ b/client/ts/src/framer/cache/dynamic.ts
@@ -54,6 +54,14 @@ const MAX_DEF_WRITES = 100;
 const VARIABLE_DT_MULTIPLIER = 40;
 
 /**
+ * @returns true when every byte of the series fits in the buffer's free space. Measured
+ * in bytes because a variable-length buffer counts its capacity that way.
+ */
+const fits = (buffer: Series, series: Series): boolean =>
+  series.byteLength.valueOf() <=
+  buffer.byteCapacity.valueOf() - buffer.byteLength.valueOf();
+
+/**
  * A cache for channel data that maintains a single, rolling Series as a buffer
  * for channel data. The buffer's data type is derived from the first written series,
  * so the cache needs no channel metadata.
@@ -127,7 +135,6 @@ export class Dynamic {
     alignment: bigint,
     start: TimeStamp,
     source: Series,
-    sampleIndex: number,
   ): Series {
     this.counter++;
     const dt = this.props.transform.resolveDataType(source.dataType);
@@ -139,8 +146,7 @@ export class Dynamic {
     let sampleOffset: math.Numeric = 0;
     if (narrowing)
       if (source.dataType.equals(DataType.TIMESTAMP)) sampleOffset = start.valueOf();
-      else if (sampleIndex < source.length)
-        sampleOffset = BigInt(source.data[sampleIndex].valueOf());
+      else if (source.length > 0) sampleOffset = BigInt(source.data[0].valueOf());
     return Series.alloc({
       capacity: dt.isVariable ? capacity * VARIABLE_DT_MULTIPLIER : capacity,
       dataType: dt,
@@ -152,25 +158,30 @@ export class Dynamic {
     });
   }
 
+  /**
+   * @returns the sample capacity for a buffer that must hold the given series whole:
+   * the configured size, or the series' own size when that is larger.
+   */
+  private capacityFor(source: Series): number {
+    const dt = this.props.transform.resolveDataType(source.dataType);
+    const required = dt.isVariable
+      ? Math.ceil(source.byteLength.valueOf() / VARIABLE_DT_MULTIPLIER)
+      : source.length;
+    return Math.max(this.nextBufferSize(), required);
+  }
+
   // Unstamped series (virtual channels, writes without an in-frame index) fall back
   // to the wall clock.
   private allocStart(series: Series): TimeStamp {
     return series.timeRange.isZero ? this.now() : series.timeRange.start;
   }
 
-  private allocCurr(
-    res: WriteResponse,
-    alignment: bigint,
-    start: TimeStamp,
-    source: Series,
-    sampleIndex: number,
-  ): Series {
+  private allocCurr(res: WriteResponse, source: Series): Series {
     this.curr = this.allocate(
-      this.nextBufferSize(),
-      alignment,
-      start,
+      this.capacityFor(source),
+      source.alignment,
+      this.allocStart(source),
       source,
-      sampleIndex,
     );
     res.allocated.push(this.curr);
     return this.curr;
@@ -206,9 +217,7 @@ export class Dynamic {
       }
     }
     let curr = this.curr;
-    if (curr == null)
-      curr = this.allocCurr(res, series.alignment, this.allocStart(series), series, 0);
-    else {
+    if (curr != null) {
       // overlap > 0: the incoming series steps back into samples the current buffer
       // already holds. overlap < 0: there is a gap between the buffer and the series.
       const overlap = Number(curr.alignment + BigInt(curr.length) - series.alignment);
@@ -219,36 +228,28 @@ export class Dynamic {
         series = series.sub(overlap);
       } else if (overlap < 0) {
         this.flushCurr(res);
-        curr = this.allocCurr(
-          res,
-          series.alignment,
-          this.allocStart(series),
-          series,
-          0,
-        );
+        curr = null;
       }
     }
-    while (true) {
-      const converted = transform.convert(series, curr.sampleOffset);
-      const amountWritten = curr.write(converted);
-      if (amountWritten === series.length) {
-        this.currDataEnd = series.timeRange.isZero ? null : series.timeRange.end;
-        this.updateAvgRate(series);
-        return;
+    const convert = (buffer: Series): Series =>
+      transform.convert(series, buffer.sampleOffset);
+    if (curr != null) {
+      const converted = convert(curr);
+      // A series never splits across two buffers. The timestamp where a split falls is
+      // not in the data, so both sides would have to guess the boundary they share, and
+      // a guess lands outside the data whenever samples are irregular.
+      if (fits(curr, converted)) curr.write(converted);
+      else {
+        this.flushCurr(res);
+        curr = null;
       }
-      // The timestamp at the split point is unknowable from the data series, so
-      // both sides fall back to the wall clock.
-      this.currDataEnd = null;
-      this.flushCurr(res);
-      curr = this.allocCurr(
-        res,
-        series.alignment + BigInt(amountWritten),
-        this.now(),
-        series,
-        amountWritten,
-      );
-      series = series.slice(amountWritten);
     }
+    if (curr == null) {
+      curr = this.allocCurr(res, series);
+      curr.write(convert(curr));
+    }
+    this.currDataEnd = series.timeRange.isZero ? null : series.timeRange.end;
+    this.updateAvgRate(series);
   }
 
   private updateAvgRate(series: Series): void {

--- a/client/ts/src/framer/cache/dynamic.ts
+++ b/client/ts/src/framer/cache/dynamic.ts
@@ -176,23 +176,31 @@ export class Dynamic {
     return series.timeRange.isZero ? this.now() : series.timeRange.start;
   }
 
-  private allocCurr(res: WriteResponse, source: Series): Series {
+  private allocCurr(
+    res: WriteResponse,
+    source: Series,
+    start: TimeStamp | null,
+  ): Series {
     this.curr = this.allocate(
       this.capacityFor(source),
       source.alignment,
-      this.allocStart(source),
+      start ?? this.allocStart(source),
       source,
     );
     res.allocated.push(this.curr);
     return this.curr;
   }
 
-  private flushCurr(res: WriteResponse): void {
-    if (this.curr == null) return;
-    this.curr.timeRange.end = this.currDataEnd ?? this.now();
+  /** @returns the timestamp the flushed buffer's end was stamped with, or null when
+   * there was no buffer. */
+  private flushCurr(res: WriteResponse): TimeStamp | null {
+    if (this.curr == null) return null;
+    const end = this.currDataEnd ?? this.now();
+    this.curr.timeRange.end = end;
     this.currDataEnd = null;
     res.flushed.push(this.curr);
     this.curr = null;
+    return end;
   }
 
   private _write(series: Series, res: WriteResponse): void {
@@ -217,6 +225,7 @@ export class Dynamic {
       }
     }
     let curr = this.curr;
+    let trimmed = false;
     if (curr != null) {
       // overlap > 0: the incoming series steps back into samples the current buffer
       // already holds. overlap < 0: there is a gap between the buffer and the series.
@@ -226,6 +235,7 @@ export class Dynamic {
         // the cache with overlapping series. sub() is zero-copy.
         if (overlap >= series.length) return;
         series = series.sub(overlap);
+        trimmed = true;
       } else if (overlap < 0) {
         this.flushCurr(res);
         curr = null;
@@ -233,6 +243,7 @@ export class Dynamic {
     }
     const convert = (buffer: Series): Series =>
       transform.convert(series, buffer.sampleOffset);
+    let rotationStart: TimeStamp | null = null;
     if (curr != null) {
       const converted = convert(curr);
       // A series never splits across two buffers. The timestamp where a split falls is
@@ -240,12 +251,16 @@ export class Dynamic {
       // a guess lands outside the data whenever samples are irregular.
       if (fits(curr, converted)) curr.write(converted);
       else {
-        this.flushCurr(res);
+        const end = this.flushCurr(res);
+        // A trimmed series keeps the whole frame's start, which is earlier than the
+        // samples it still holds. Those samples begin where the buffer they were
+        // trimmed against ends, so the next buffer starts there.
+        if (trimmed) rotationStart = end;
         curr = null;
       }
     }
     if (curr == null) {
-      curr = this.allocCurr(res, series);
+      curr = this.allocCurr(res, series, rotationStart);
       curr.write(convert(curr));
     }
     this.currDataEnd = series.timeRange.isZero ? null : series.timeRange.end;

--- a/client/ts/src/framer/cache/dynamic.ts
+++ b/client/ts/src/framer/cache/dynamic.ts
@@ -13,6 +13,7 @@ import {
   math,
   MultiSeries,
   Series,
+  TimeRange,
   type TimeSpan,
   TimeStamp,
 } from "@synnaxlabs/x";
@@ -94,6 +95,17 @@ export class Dynamic {
    */
   get leadingBuffer(): Series | null {
     return this.curr;
+  }
+
+  /**
+   * @returns the time range the buffer's samples actually cover: its start to the last
+   * stamped write, or the wall clock when the buffer holds unstamped data. Unlike the
+   * buffer's provisional time range, the end never claims future time. Null when there
+   * is no buffer.
+   */
+  get dataTimeRange(): TimeRange | null {
+    if (this.curr == null) return null;
+    return new TimeRange(this.curr.timeRange.start, this.currDataEnd ?? this.now());
   }
 
   /**

--- a/client/ts/src/framer/cache/unary.spec.ts
+++ b/client/ts/src/framer/cache/unary.spec.ts
@@ -7,7 +7,14 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { DataType, MultiSeries, Series, TimeRange, TimeStamp } from "@synnaxlabs/x";
+import {
+  DataType,
+  MultiSeries,
+  Series,
+  TimeRange,
+  TimeSpan,
+  TimeStamp,
+} from "@synnaxlabs/x";
 import { describe, expect, it } from "vitest";
 
 import { Unary } from "@/framer/cache/unary";
@@ -71,6 +78,40 @@ describe("Unary", () => {
       expect(gaps[0].equals(TimeStamp.seconds(2).range(TimeStamp.seconds(8)))).toBe(
         true,
       );
+    });
+
+    // The buffer's own time range ends at the provisional TimeStamp.MAX, which must not
+    // let it leak into reads of spans it holds no samples for.
+    it("should exclude the buffer when the read starts after its data ends", () => {
+      const u = newUnary();
+      u.writeDynamic(stamped(10, 13, [1, 2, 3], LEADING_ALIGNMENT));
+      const { series, gaps } = u.read(
+        TimeStamp.seconds(14).range(TimeStamp.seconds(20)),
+      );
+      expect(series.series).toHaveLength(0);
+      expect(gaps).toHaveLength(1);
+      expect(gaps[0].equals(TimeStamp.seconds(14).range(TimeStamp.seconds(20)))).toBe(
+        true,
+      );
+    });
+
+    it("should include an unstamped buffer for a read spanning the present", () => {
+      const u = newUnary();
+      u.writeDynamic(
+        new MultiSeries([
+          new Series({
+            data: new Float32Array([1, 2, 3]),
+            dataType: DataType.FLOAT32,
+            alignment: LEADING_ALIGNMENT,
+          }),
+        ]),
+      );
+      const now = TimeStamp.now();
+      const { series } = u.read(
+        now.sub(TimeSpan.seconds(5)).range(now.add(TimeSpan.seconds(5))),
+      );
+      expect(series.series).toHaveLength(1);
+      expect(series.series[0]).toBe(u.leadingBuffer);
     });
 
     it("should compute gaps from fetched entries alone", () => {

--- a/client/ts/src/framer/cache/unary.ts
+++ b/client/ts/src/framer/cache/unary.ts
@@ -83,9 +83,9 @@ export class Unary {
     this.checkOpen("read");
     const res = this.static.dirtyRead(tr);
     const buf = this.dynamic.leadingBuffer;
-    if (buf == null || buf.length === 0) return res;
     const dataTr = this.dynamic.dataTimeRange;
-    if (dataTr == null || !dataTr.overlapsWith(tr)) return res;
+    if (buf == null || dataTr == null || buf.length === 0 || !dataTr.overlapsWith(tr))
+      return res;
     res.series.push(buf);
     return res;
   }

--- a/client/ts/src/framer/cache/unary.ts
+++ b/client/ts/src/framer/cache/unary.ts
@@ -71,17 +71,21 @@ export class Unary {
   }
 
   /**
-   * Reads cached data overlapping the given time range. The result includes the
-   * live leading buffer when it overlaps, but the buffer never claims coverage:
-   * its samples carry provisional leading alignments that cannot pair with fetched
-   * data on another channel, so its span is still reported as a gap to fetch. A
+   * Reads cached data overlapping the given time range. The result includes the live
+   * leading buffer when the data it actually holds overlaps the range, judged by the
+   * last stamped write rather than the buffer's provisional MAX end, so the buffer
+   * never leaks into reads of spans it has no samples for. It never claims coverage
+   * either: its samples carry provisional leading alignments that cannot pair with
+   * fetched data on another channel, so its span is still reported as a gap to fetch. A
    * span may therefore return in both its streamed and fetched representation.
    */
   read(tr: TimeRange): DirtyReadResult {
     this.checkOpen("read");
     const res = this.static.dirtyRead(tr);
     const buf = this.dynamic.leadingBuffer;
-    if (buf == null || buf.length === 0 || !buf.timeRange.overlapsWith(tr)) return res;
+    if (buf == null || buf.length === 0) return res;
+    const dataTr = this.dynamic.dataTimeRange;
+    if (dataTr == null || !dataTr.overlapsWith(tr)) return res;
     res.series.push(buf);
     return res;
   }

--- a/client/ts/src/framer/feed.spec.ts
+++ b/client/ts/src/framer/feed.spec.ts
@@ -383,6 +383,51 @@ describe("feed", () => {
     }
   });
 
+  it("should keep far-past streamed data out of reads of the present", async () => {
+    const { time, data } = await createChannels();
+    const received: number[] = [];
+    const sub = feed.stream(
+      (res) => {
+        const series = res.get(data.key);
+        if (series != null) received.push(...(Array.from(series) as number[]));
+      },
+      [data.key],
+    );
+    // Epoch-anchored stamps: the incident's Arc defect streamed samples whose index
+    // timestamps sat decades in the past while writes marched forward in real time.
+    let epoch = TimeStamp.seconds(10);
+    const writer = await client.openWriter({
+      start: epoch,
+      channels: [time.key, data.key],
+    });
+    try {
+      await expect
+        .poll(
+          async () => {
+            epoch = epoch.add(TimeSpan.milliseconds(1));
+            await writer.write({ [time.key]: [epoch], [data.key]: [1] });
+            return received.length > 0;
+          },
+          { timeout: 10000, interval: 100 },
+        )
+        .toBe(true);
+    } finally {
+      await writer.close();
+    }
+    try {
+      // The live buffer holds only epoch-era samples, so a read of the recent past must
+      // come back empty instead of serving them.
+      const now = TimeStamp.now();
+      const recent = new TimeRange(now.sub(TimeSpan.seconds(30)), now);
+      expect((await feed.read(recent, data.key)).length).toBe(0);
+      // A read that targets the buffer's own era still serves it.
+      const past = new TimeRange(TimeStamp.ZERO, TimeStamp.seconds(60));
+      expect((await feed.read(past, data.key)).length).toBeGreaterThan(0);
+    } finally {
+      sub.close();
+    }
+  });
+
   it("should reject reads after the feed closes", async () => {
     const closable = client.openFeed();
     await closable.close();

--- a/x/ts/src/telem/series.spec.ts
+++ b/x/ts/src/telem/series.spec.ts
@@ -1316,6 +1316,99 @@ describe("Series", () => {
         expect(copy.at(1)).toBe(3); // 2.5 + 0.5
         expect(copy.at(2)).toBe(4); // 3.5 + 0.5
       });
+
+      // Every method below builds a new series from an existing one, so each asserts
+      // the full property set. A field dropped from one of these constructions is
+      // invisible until something downstream reads it.
+      const decimated = (): Series =>
+        new Series({
+          data: new Float32Array([1, 2, 3, 4, 5]),
+          dataType: DataType.FLOAT32,
+          timeRange: new TimeRange(TimeStamp.seconds(100), TimeStamp.seconds(200)),
+          sampleOffset: 10,
+          alignment: 100n,
+          // Above one whenever the samples average or decimate raw data.
+          alignmentMultiple: 5n,
+          key: "original-key",
+        });
+
+      it("should preserve properties through convert", () => {
+        const original = decimated();
+        const converted = original.convert(DataType.FLOAT64);
+        expect(converted.dataType).toEqual(DataType.FLOAT64);
+        expect(converted.timeRange).toEqual(original.timeRange);
+        expect(converted.sampleOffset).toBe(0);
+        expect(converted.alignment).toBe(100n);
+        expect(converted.alignmentMultiple).toBe(5n);
+        expect(converted.length).toBe(5);
+        expect(converted.alignmentBounds).toEqual({ lower: 100n, upper: 125n });
+        // The conversion holds different samples, so it is a different series.
+        expect(converted.key).not.toBe(original.key);
+      });
+
+      it("should preserve properties through slice", () => {
+        const original = decimated();
+        const sliced = original.slice(1, 3);
+        expect(sliced.dataType).toEqual(original.dataType);
+        expect(sliced.timeRange).toEqual(original.timeRange);
+        expect(sliced.sampleOffset).toBe(10);
+        expect(sliced.alignmentMultiple).toBe(5n);
+        // Each sample steps the alignment by the multiple, so dropping one sample
+        // moves the start by five.
+        expect(sliced.alignment).toBe(105n);
+        expect(sliced.length).toBe(2);
+        expect(sliced.alignmentBounds).toEqual({ lower: 105n, upper: 115n });
+        expect(sliced.key).not.toBe(original.key);
+      });
+
+      it("should preserve properties through sub", () => {
+        const original = decimated();
+        const subbed = original.sub(1, 3);
+        expect(subbed.dataType).toEqual(original.dataType);
+        expect(subbed.timeRange).toEqual(original.timeRange);
+        expect(subbed.sampleOffset).toBe(10);
+        expect(subbed.alignmentMultiple).toBe(5n);
+        expect(subbed.alignment).toBe(105n);
+        expect(subbed.length).toBe(2);
+        expect(subbed.alignmentBounds).toEqual({ lower: 105n, upper: 115n });
+        expect(subbed.key).not.toBe(original.key);
+      });
+
+      it("should preserve properties through reAlign", () => {
+        const original = decimated();
+        const realigned = original.reAlign(500n);
+        expect(realigned.dataType).toEqual(original.dataType);
+        expect(realigned.sampleOffset).toBe(10);
+        expect(realigned.alignmentMultiple).toBe(5n);
+        expect(realigned.alignment).toBe(500n);
+        expect(realigned.length).toBe(5);
+        expect(realigned.alignmentBounds).toEqual({ lower: 500n, upper: 525n });
+        // A realigned series is deliberately unstamped: the caller is placing it in a
+        // new alignment space, not asserting when it was recorded.
+        expect(realigned.timeRange).toEqual(TimeRange.ZERO);
+        expect(realigned.key).not.toBe(original.key);
+      });
+
+      it("should preserve properties through alloc", () => {
+        const allocated = Series.alloc({
+          capacity: 10,
+          dataType: DataType.FLOAT32,
+          timeRange: new TimeRange(TimeStamp.seconds(100), TimeStamp.seconds(200)),
+          sampleOffset: 10,
+          alignment: 100n,
+          alignmentMultiple: 5n,
+          key: "alloc-key",
+        });
+        expect(allocated.dataType).toEqual(DataType.FLOAT32);
+        expect(allocated.timeRange).toEqual(
+          new TimeRange(TimeStamp.seconds(100), TimeStamp.seconds(200)),
+        );
+        expect(allocated.sampleOffset).toBe(10);
+        expect(allocated.alignment).toBe(100n);
+        expect(allocated.alignmentMultiple).toBe(5n);
+        expect(allocated.capacity).toBe(10);
+        expect(allocated.key).toBe("alloc-key");
+      });
     });
   });
 

--- a/x/ts/src/telem/series.ts
+++ b/x/ts/src/telem/series.ts
@@ -635,6 +635,7 @@ export class Series<T extends TelemValue = TelemValue>
       sampleOffset,
       glBufferUsage: this.gl.bufferUsage,
       alignment: this.alignment,
+      alignmentMultiple: this.alignmentMultiple,
     });
   }
 
@@ -1106,7 +1107,9 @@ export class Series<T extends TelemValue = TelemValue>
     return this.derive(this.data.subarray(start, end), start);
   }
 
-  // Builds the series produced by a slice, offsetting the alignment by start.
+  // Builds the series produced by a slice, offsetting the alignment by start. Each
+  // sample advances the alignment by alignmentMultiple, which is above one when the
+  // samples are a decimated or averaged view of the raw data.
   private derive(data: TypedArray, start: number): Series {
     return new Series({
       data,
@@ -1114,7 +1117,8 @@ export class Series<T extends TelemValue = TelemValue>
       timeRange: this.timeRange,
       sampleOffset: this.sampleOffset,
       glBufferUsage: this.gl.bufferUsage,
-      alignment: this.alignment + BigInt(start),
+      alignment: this.alignment + BigInt(start) * this.alignmentMultiple,
+      alignmentMultiple: this.alignmentMultiple,
     });
   }
 
@@ -1150,6 +1154,7 @@ export class Series<T extends TelemValue = TelemValue>
       sampleOffset: this.sampleOffset,
       glBufferUsage: "static",
       alignment,
+      alignmentMultiple: this.alignmentMultiple,
     });
   }
 


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4742](https://linear.app/synnax/issue/SY-4742/stop-the-live-buffer-from-leaking-into-reads-outside-its-data)

## Description

While a channel streams, the client caches incoming samples in a live leading buffer whose recorded time range ends at `TimeStamp.MAX`, a placeholder for "still growing". `Unary.read` included the buffer in a read result whenever that recorded range overlapped the requested range, so the buffer "overlapped" every read that ended after its start, including ranges where it held no samples at all. In the v0.57.0 incident, epoch-stamped Arc samples made the buffer claim `[1970, forever)`: a read of the last 30 seconds correctly fetched nothing from the Core but returned the whole 1970 buffer anyway, exploding x auto-bounds and poisoning newly opened rolling plots through their backfill read.

The overlap test now judges the data the buffer actually holds. `Dynamic` exposes the buffer's real data range, ending at the last stamped write with the same wall-clock fallback the flush path uses, and `Unary.read` checks the requested range against it. The live edge is unaffected because a healthy live buffer's data end is essentially now, and a read that genuinely targets the buffer's era still gets it. This is the last layer of the coverage claim introduced in #2673: #2720 ended the claim when streaming stops and #2727 removed it from gap computation, both leaving the inclusion test on the provisional MAX end.

Two further defects in the same file came out of review, both of which put a wrong timestamp on a buffer boundary:

- A series that outgrew the buffer used to be split across two buffers, and both halves were stamped with the wall clock. The timestamp where a split falls is not in the data, and guessing it assumes samples arrive at an even rate, which a command channel never does. A series is now never split: the buffer grows to hold it whole, or it rotates, so every boundary sits between two series that carry real timestamps. The old split loop also allocated forever when a single variable-length sample exceeded the buffer's byte capacity.
- A frame trimmed of a re-sent prefix keeps the whole frame's start, so rotating on one gave the new buffer a start earlier than any sample it holds. The rotation now starts where the flushed buffer ends.

Auditing the series copy paths turned up a defect of its own: `convert`, `slice`, `sub` and `reAlign` all built their result without `alignmentMultiple`, so a decimated series silently reverted to one alignment step per sample, and `slice`/`sub` stepped the alignment by the sample count instead of the count times the multiple. Pluto's line renderer and its bounds computation both divide by that multiple. Every series-copying method now carries the full property set, pinned by a spec per method.

Covered by unit specs on `Dynamic.dataTimeRange`, rotation stamping, the `Unary.read` exclusion, the x series property preservation, plus a live-core regression in `feed.spec.ts` that streams epoch-stamped samples and asserts a read of the present comes back empty while a read of the buffer's own era still serves it. Every new discriminating spec fails against the code it replaces.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.
