### PR TITLE
SY-4744: Bound the WebSocket handshake and streamer acknowledgement

### DIFF
--- a/client/ts/src/framer/keepalive.spec.ts
+++ b/client/ts/src/framer/keepalive.spec.ts
@@ -1,0 +1,156 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+// Pins silent-death detection on /frame/stream: the Core emits keepalive responses on
+// request, and the client fails a silent read with Unreachable instead of hanging
+// forever, which the hardened streamer turns into a reconnect.
+
+import { Unreachable } from "@synnaxlabs/freighter";
+import { sleep, TimeSpan, TimeStamp } from "@synnaxlabs/x";
+import { describe, expect, it, vi } from "vitest";
+
+import { type channel } from "@/channel";
+import { HardenedStreamer } from "@/framer/hardened";
+import {
+  createSeverableProxy,
+  createTestClient,
+  FAST_RETRY,
+  newVirtualChannel,
+} from "@/testutil";
+
+const client = createTestClient();
+
+const KEEPALIVE = TimeSpan.milliseconds(100);
+// KEEPALIVE_DEADLINE_FACTOR x KEEPALIVE: how long a read may stay silent once armed.
+const DEADLINE = TimeSpan.milliseconds(300);
+
+const write = async (ch: channel.Channel, values: number[]): Promise<void> => {
+  const writer = await client.openWriter({ start: TimeStamp.now(), channels: ch.key });
+  try {
+    await writer.write(ch.key, new Float64Array(values));
+  } finally {
+    await writer.close();
+  }
+};
+
+describe("streamer keepalive", () => {
+  it("should keep keepalives out of the frames a streamer serves", async () => {
+    const ch = await newVirtualChannel(client);
+    const streamer = await client.openStreamer({
+      channels: ch.key,
+      keepalive: KEEPALIVE,
+    });
+    try {
+      // Let several keepalives queue up so the read has to skip past them.
+      await sleep.sleep(TimeSpan.milliseconds(250));
+      await write(ch, [1, 2, 3]);
+      const frame = await streamer.read();
+      expect(Array.from(frame.get(ch.key))).toEqual([1, 2, 3]);
+    } finally {
+      streamer.close();
+    }
+  });
+
+  it("should reject an interval below the Core's minimum", async () => {
+    const ch = await newVirtualChannel(client);
+    await expect(
+      client.openStreamer({ channels: ch.key, keepalive: TimeSpan.milliseconds(5) }),
+    ).rejects.toThrow("keepalive: must be greater than or equal to 10ms");
+  });
+
+  it("should reject a silent read with Unreachable after the deadline", async () => {
+    const proxy = await createSeverableProxy();
+    try {
+      const proxied = createTestClient({ port: proxy.port });
+      const ch = await newVirtualChannel(client);
+      const streamer = await proxied.openStreamer({
+        channels: ch.key,
+        keepalive: KEEPALIVE,
+      });
+      // Receive at least one keepalive so the deadline is armed.
+      await sleep.sleep(TimeSpan.milliseconds(250));
+      expect(proxy.blackholeStreams()).toBeGreaterThan(0);
+      const started = performance.now();
+      await expect(streamer.read()).rejects.toSatisfy(
+        (exc) =>
+          Unreachable.matches(exc) &&
+          exc.message === `streamer received no response for ${DEADLINE.toString()}`,
+      );
+      // The deadline must actually elapse: an instant rejection would mean the deadline
+      // armed wrong, not that silence was detected.
+      expect(performance.now() - started).toBeGreaterThanOrEqual(
+        DEADLINE.milliseconds - 50,
+      );
+      streamer.close();
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  it("should reconnect and resume streaming after a silent death", async () => {
+    const proxy = await createSeverableProxy();
+    try {
+      const proxied = createTestClient({ port: proxy.port });
+      const ch = await newVirtualChannel(client);
+      const onDrop = vi.fn();
+      const onReopen = vi.fn();
+      const hardened = await HardenedStreamer.open(
+        async (cfg) => await proxied.openStreamer(cfg),
+        { channels: ch.key, keepalive: KEEPALIVE },
+        FAST_RETRY,
+        onReopen,
+        onDrop,
+      );
+      try {
+        await write(ch, [1]);
+        expect(Array.from((await hardened.read()).get(ch.key))).toEqual([1]);
+        await sleep.sleep(TimeSpan.milliseconds(250));
+        expect(proxy.blackholeStreams()).toBeGreaterThan(0);
+        // The proxy still forwards new connections, so the deadline trip inside this
+        // read reconnects and the read stays pending for the next frame.
+        const pending = hardened.read();
+        await expect.poll(() => onDrop.mock.calls.length, { timeout: 5000 }).toBe(1);
+        expect(Unreachable.matches(onDrop.mock.calls[0][0])).toBe(true);
+        await expect.poll(() => onReopen.mock.calls.length, { timeout: 5000 }).toBe(1);
+        await write(ch, [2]);
+        expect(Array.from((await pending).get(ch.key))).toEqual([2]);
+      } finally {
+        hardened.close();
+      }
+    } finally {
+      await proxy.close();
+    }
+  });
+
+  it("should leave a silent read pending when keepalive is disabled", async () => {
+    const proxy = await createSeverableProxy();
+    try {
+      const proxied = createTestClient({ port: proxy.port });
+      const ch = await newVirtualChannel(client);
+      const streamer = await proxied.openStreamer({
+        channels: ch.key,
+        keepalive: TimeSpan.ZERO,
+      });
+      await sleep.sleep(TimeSpan.milliseconds(250));
+      expect(proxy.blackholeStreams()).toBeGreaterThan(0);
+      // Without keepalives the deadline never arms, which is also how a client behaves
+      // against a Core that predates them: the read hangs, as before.
+      const pending = streamer.read();
+      pending.catch(() => {});
+      const result = await Promise.race([
+        pending.then(() => "settled"),
+        sleep.sleep(TimeSpan.seconds(1)).then(() => "pending"),
+      ]);
+      expect(result).toEqual("pending");
+      streamer.close();
+    } finally {
+      await proxy.close();
+    }
+  });
+});

--- a/client/ts/src/framer/streamer.spec.ts
+++ b/client/ts/src/framer/streamer.spec.ts
@@ -20,10 +20,12 @@ import {
 import { describe, expect, it, test, vi } from "vitest";
 
 import { type channel } from "@/channel";
+import { payloadZ } from "@/channel/types.gen";
 import { AccessDeniedError, ExpiredTokenError } from "@/errors";
+import { type ChannelRetriever } from "@/framer/adapter";
 import { Frame } from "@/framer/frame";
 import { HardenedStreamer, ObservableStreamer } from "@/framer/hardened";
-import { type Streamer, streamerConfigZ } from "@/framer/streamer";
+import { createStreamOpener, type Streamer, streamerConfigZ } from "@/framer/streamer";
 import {
   createTestClient,
   newIndexedPair,
@@ -1180,6 +1182,41 @@ describe("Streamer", () => {
       await observable.close();
 
       expect(onDead).not.toHaveBeenCalled();
+    });
+  });
+
+  // The socket is open by the time the acknowledgement is awaited, so the keepalive
+  // deadline is not yet armed and cannot cover it.
+  describe("open acknowledgement", () => {
+    const retrieveChannels: ChannelRetriever = async () => [
+      payloadZ.parse({ key: 1, name: "silent", dataType: DataType.FLOAT64.toString() }),
+    ];
+
+    it("should reject an acknowledgement that never arrives", async () => {
+      let closed = false;
+      // A client whose socket opens and is then never spoken to again.
+      const silent = {
+        withCodec: () => silent,
+        stream: async () => ({
+          send: () => {},
+          receive: async () => await new Promise<never>(() => {}),
+          received: () => false,
+          closeSend: () => {
+            closed = true;
+          },
+        }),
+      };
+      vi.useFakeTimers();
+      try {
+        const open = createStreamOpener(retrieveChannels, silent)({ channels: [1] });
+        const settled = expect(open).rejects.toThrow(Unreachable);
+        await vi.advanceTimersByTimeAsync(31_000);
+        await settled;
+        // The socket is released rather than left open with nobody holding it.
+        expect(closed).toBe(true);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 });

--- a/client/ts/src/framer/streamer.ts
+++ b/client/ts/src/framer/streamer.ts
@@ -13,7 +13,7 @@ import {
   Unreachable,
   type WebSocketClient,
 } from "@synnaxlabs/freighter";
-import { errors, Rate, TimeSpan, zod } from "@synnaxlabs/x";
+import { type binary, errors, Rate, sync, TimeSpan, zod } from "@synnaxlabs/x";
 import { z } from "zod";
 
 import { type channel } from "@/channel";
@@ -100,6 +100,17 @@ export interface StreamOpener {
   (config: StreamerConfig): Promise<Streamer>;
 }
 
+// Deadline for the Core to acknowledge a streamer once the socket is open. The
+// handshake already proved the connection, so only a death in the window between the
+// two reaches this.
+const OPEN_ACK_TIMEOUT = TimeSpan.seconds(30);
+
+/** The slice of a {@link WebSocketClient} that opening a streamer needs. */
+export interface StreamOpenerClient {
+  withCodec: (codec: binary.Codec) => StreamOpenerClient;
+  stream: WebSocketClient["stream"];
+}
+
 /**
  * Creates a function that opens streamers with the given channel resolver and client.
  * @param retrieveChannels - Resolves channel params to payloads for the codec
@@ -107,7 +118,7 @@ export interface StreamOpener {
  * @returns A function that opens streamers with the given configuration
  */
 export const createStreamOpener =
-  (retrieveChannels: ChannelRetriever, client: WebSocketClient): StreamOpener =>
+  (retrieveChannels: ChannelRetriever, client: StreamOpenerClient): StreamOpener =>
   async (config) => {
     const cfg = zod.parse(streamerConfigZ, config, { label: "streamer config" });
     const adapter = await ReadAdapter.open(retrieveChannels, cfg.channels);
@@ -130,8 +141,24 @@ export const createStreamOpener =
     });
     // A keepalive can beat the open ack onto the wire, so the ack is the first
     // non-keepalive response.
-    let res = await stream.receive();
-    while (res.keepalive === true) res = await stream.receive();
+    const ack = (async () => {
+      let res = await stream.receive();
+      while (res.keepalive === true) res = await stream.receive();
+    })();
+    const span = OPEN_ACK_TIMEOUT.toString();
+    try {
+      await sync.withTimeout(
+        ack,
+        OPEN_ACK_TIMEOUT,
+        () =>
+          new Unreachable({
+            message: `streamer was not acknowledged within ${span}`,
+          }),
+      );
+    } catch (err) {
+      streamer.close();
+      throw errors.fromUnknown(err);
+    }
     return streamer;
   };
 
@@ -208,24 +235,15 @@ class BaseStreamer implements Streamer {
   private async receiveWithDeadline(): Promise<z.infer<typeof resZ>> {
     const received = this.stream.receive();
     if (!this.armed) return await received;
-    let timer: ReturnType<typeof setTimeout> | undefined;
-    const deadline = new Promise<never>((_, reject) => {
-      timer = setTimeout(() => {
-        const silence = this.deadline.toString();
-        const message = `streamer received no response for ${silence}`;
-        reject(new Unreachable({ message }));
-      }, this.deadline.milliseconds);
-    });
-    try {
-      return await Promise.race([received, deadline]);
-    } catch (err) {
-      // The read already failed for its caller; a late settle of the losing receive
-      // must not surface as an unhandled rejection.
-      received.catch(() => {});
-      throw errors.fromUnknown(err);
-    } finally {
-      clearTimeout(timer);
-    }
+    const silence = this.deadline.toString();
+    return await sync.withTimeout(
+      received,
+      this.deadline,
+      () =>
+        new Unreachable({
+          message: `streamer received no response for ${silence}`,
+        }),
+    );
   }
 
   async update(channels: channel.Params): Promise<void> {

--- a/client/ts/src/framer/streamer.ts
+++ b/client/ts/src/framer/streamer.ts
@@ -7,8 +7,13 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { EOF, type Stream, type WebSocketClient } from "@synnaxlabs/freighter";
-import { errors, Rate, zod } from "@synnaxlabs/x";
+import {
+  EOF,
+  type Stream,
+  Unreachable,
+  type WebSocketClient,
+} from "@synnaxlabs/freighter";
+import { errors, Rate, TimeSpan, zod } from "@synnaxlabs/x";
 import { z } from "zod";
 
 import { type channel } from "@/channel";
@@ -23,6 +28,7 @@ const reqZ = z.object({
   downsampleFactor: z.int(),
   throttleRate: Rate.z.optional(),
   excludeGroups: z.uint32().array().optional(),
+  keepalive: TimeSpan.z.optional(),
 });
 
 /**
@@ -31,7 +37,11 @@ const reqZ = z.object({
  */
 export interface StreamerRequest extends z.infer<typeof reqZ> {}
 
-const resZ = z.object({ frame: frameZ });
+const resZ = z.object({
+  frame: frameZ,
+  /** Marks an empty response the Core emits so a dead connection is detectable. */
+  keepalive: z.boolean().optional(),
+});
 
 /**
  * Response interface for streaming frames from a Synnax cluster.
@@ -49,6 +59,10 @@ const intermediateStreamerConfigZ = z.object({
   /** excludeGroups sets writer group IDs whose frames should be filtered out by the
    Core. Used for telemetry bypass deduplication. */
   excludeGroups: z.uint32().array().default([]),
+  /** Interval at which the Core emits keepalive responses so a silently dead
+   connection fails reads instead of hanging forever. TimeSpan.ZERO disables
+   detection. Defaults to 5 seconds. */
+  keepalive: TimeSpan.z.default(TimeSpan.seconds(5)),
 });
 
 /** Zod schema for {@link StreamerConfig}. A bare channel list parses as a config. */
@@ -73,7 +87,11 @@ export interface Streamer extends AsyncIterator<Frame>, AsyncIterable<Frame> {
   update: (channels: channel.Params) => Promise<void>;
   /** Close the streamer and free all associated resources. */
   close: () => void;
-  /** Read the next frame of telemetry. */
+  /**
+   * Read the next frame of telemetry.
+   * @throws {Unreachable} if keepalives were flowing and the stream then stays silent
+   * past the keepalive deadline: the connection is presumed dead.
+   */
   read: () => Promise<Frame>;
 }
 
@@ -101,14 +119,19 @@ export const createStreamOpener =
       cfg.downsampleFactor,
       cfg.throttleRate,
       cfg.excludeGroups,
+      cfg.keepalive,
     );
     stream.send({
       keys: Array.from(adapter.keys),
       downsampleFactor: cfg.downsampleFactor,
       throttleRate: cfg.throttleRate,
       excludeGroups: cfg.excludeGroups,
+      keepalive: cfg.keepalive,
     });
-    await stream.receive();
+    // A keepalive can beat the open ack onto the wire, so the ack is the first
+    // non-keepalive response.
+    let res = await stream.receive();
+    while (res.keepalive === true) res = await stream.receive();
     return streamer;
   };
 
@@ -124,12 +147,20 @@ export const openStreamer = async (
   config: StreamerConfig,
 ): Promise<Streamer> => await createStreamOpener(retrieveChannels, client)(config);
 
+// Missing this many keepalive intervals in a row fails the pending read: one is normal
+// jitter, three is a dead connection.
+const KEEPALIVE_DEADLINE_FACTOR = 3;
+
 class BaseStreamer implements Streamer {
   private readonly stream: StreamProxy<typeof reqZ, typeof resZ>;
   private readonly adapter: ReadAdapter;
   private readonly downsampleFactor: number;
   private readonly throttleRate: Rate;
   private readonly excludeGroups: number[];
+  private readonly deadline: TimeSpan;
+  // Set once the Core proves keepalive support by sending one, so the deadline never
+  // arms against a Core that will not send them.
+  private armed = false;
 
   constructor(
     stream: Stream<typeof reqZ, typeof resZ>,
@@ -137,12 +168,16 @@ class BaseStreamer implements Streamer {
     downsampleFactor: number = 1,
     throttleRate: Rate = new Rate(0),
     excludeGroups: number[] = [],
+    keepalive: TimeSpan = TimeSpan.ZERO,
   ) {
     this.stream = new StreamProxy("Streamer", stream);
     this.adapter = adapter;
     this.downsampleFactor = downsampleFactor;
     this.throttleRate = throttleRate;
     this.excludeGroups = excludeGroups;
+    this.deadline = TimeSpan.milliseconds(
+      keepalive.milliseconds * KEEPALIVE_DEADLINE_FACTOR,
+    );
   }
 
   get keys(): channel.Key[] {
@@ -160,7 +195,37 @@ class BaseStreamer implements Streamer {
   }
 
   async read(): Promise<Frame> {
-    return this.adapter.adapt(new Frame((await this.stream.receive()).frame));
+    while (true) {
+      const res = await this.receiveWithDeadline();
+      if (res.keepalive === true) {
+        if (!this.deadline.isZero) this.armed = true;
+        continue;
+      }
+      return this.adapter.adapt(new Frame(res.frame));
+    }
+  }
+
+  private async receiveWithDeadline(): Promise<z.infer<typeof resZ>> {
+    const received = this.stream.receive();
+    if (!this.armed) return await received;
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const deadline = new Promise<never>((_, reject) => {
+      timer = setTimeout(() => {
+        const silence = this.deadline.toString();
+        const message = `streamer received no response for ${silence}`;
+        reject(new Unreachable({ message }));
+      }, this.deadline.milliseconds);
+    });
+    try {
+      return await Promise.race([received, deadline]);
+    } catch (err) {
+      // The read already failed for its caller; a late settle of the losing receive
+      // must not surface as an unhandled rejection.
+      received.catch(() => {});
+      throw errors.fromUnknown(err);
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   async update(channels: channel.Params): Promise<void> {

--- a/client/ts/src/testutil/proxy.ts
+++ b/client/ts/src/testutil/proxy.ts
@@ -35,10 +35,25 @@ export interface SeverableProxy {
   port: number;
   /** Drops every live connection and refuses new ones, as if the cluster died. */
   sever: () => Promise<void>;
+  /**
+   * Silently kills every live WebSocket connection, modeling a half-open socket (NAT
+   * timeout, VPN drop, laptop sleep): the cluster side is destroyed while the client
+   * side is held open with its writes discarded, so no close or reset ever reaches the
+   * client. New connections still forward. Returns how many connections were
+   * blackholed.
+   */
+  blackholeStreams: () => number;
   /** Accepts connections again on the same port. */
   restore: () => Promise<void>;
   /** Shuts the proxy down for good. */
   close: () => Promise<void>;
+}
+
+interface ProxiedPair {
+  downstream: Socket;
+  upstream: Socket;
+  /** Whether a WebSocket upgrade was observed on this connection. */
+  ws: boolean;
 }
 
 /**
@@ -50,7 +65,10 @@ export const createSeverableProxy = async (
   target: SeverableProxyTarget = {},
 ): Promise<SeverableProxy> => {
   const { host, port } = { ...DEFAULT_TARGET, ...target };
-  const sockets = new Set<Socket>();
+  const pairs = new Set<ProxiedPair>();
+  // Client-side sockets of blackholed connections: held open, silent, until the proxy
+  // is severed or closed.
+  const zombies = new Set<Socket>();
   let severed = false;
   const server = createServer((downstream) => {
     // A connection the kernel accepted before the sever is still delivered after it,
@@ -60,10 +78,16 @@ export const createSeverableProxy = async (
       return;
     }
     const upstream = connect(port, host);
-    sockets.add(downstream).add(upstream);
+    const pair: ProxiedPair = { downstream, upstream, ws: false };
+    pairs.add(pair);
+    // The upgrade can arrive on any request of a pooled keep-alive connection, not just
+    // the first, so every chunk is sniffed until one is seen.
+    downstream.on("data", (chunk: Buffer) => {
+      if (!pair.ws && /upgrade:\s*websocket/i.test(chunk.toString("latin1")))
+        pair.ws = true;
+    });
     const destroy = (): void => {
-      sockets.delete(downstream);
-      sockets.delete(upstream);
+      pairs.delete(pair);
       downstream.destroy();
       upstream.destroy();
     };
@@ -90,13 +114,42 @@ export const createSeverableProxy = async (
   const sever = async (): Promise<void> => {
     severed = true;
     const closed = new Promise<void>((resolve) => server.close(() => resolve()));
-    sockets.forEach((socket) => socket.destroy());
-    sockets.clear();
+    pairs.forEach(({ downstream, upstream }) => {
+      downstream.destroy();
+      upstream.destroy();
+    });
+    pairs.clear();
+    zombies.forEach((socket) => socket.destroy());
+    zombies.clear();
     await closed;
+  };
+  const blackholeStreams = (): number => {
+    let count = 0;
+    for (const pair of [...pairs]) {
+      if (!pair.ws) continue;
+      count += 1;
+      const { downstream, upstream } = pair;
+      downstream.unpipe(upstream);
+      upstream.unpipe(downstream);
+      for (const socket of [downstream, upstream]) {
+        socket.removeAllListeners("close");
+        socket.removeAllListeners("error");
+        socket.on("error", () => {});
+      }
+      // Discard anything the client still writes so backpressure cannot close the
+      // socket on the proxy's behalf.
+      downstream.on("data", () => {});
+      downstream.resume();
+      upstream.destroy();
+      pairs.delete(pair);
+      zombies.add(downstream);
+    }
+    return count;
   };
   return {
     port: boundPort,
     sever,
+    blackholeStreams,
     restore: async () => {
       severed = false;
       await listen(boundPort);

--- a/core/pkg/api/framer/framer.go
+++ b/core/pkg/api/framer/framer.go
@@ -232,14 +232,20 @@ func (s *Service) Stream(ctx context.Context, stream StreamerStream) error {
 		ctx, signal.WithInstrumentation(s.Child("frame_streamer")),
 	)
 	defer cancel()
-	streamer, err := s.openStreamer(sCtx, auth.GetSubject(ctx), stream)
+	streamer, req, err := s.openStreamer(sCtx, auth.GetSubject(ctx), stream)
 	if err != nil {
 		return err
 	}
 	var (
 		receiver = &freightfluence.Receiver[StreamerRequest]{Receiver: stream}
 		sender   = &freightfluence.Sender[StreamerResponse]{
-			Sender: freighter.SenderNopCloser[StreamerResponse]{StreamSender: stream},
+			Sender: freighter.SenderNopCloser[StreamerResponse]{
+				StreamSender: stream,
+			},
+			KeepaliveInterval: req.Keepalive.Duration(),
+			NewKeepalive: func() StreamerResponse {
+				return StreamerResponse{Keepalive: true}
+			},
 		}
 		pipe = plumber.New()
 	)
@@ -261,22 +267,26 @@ func (s *Service) openStreamer(
 	ctx context.Context,
 	subject ontology.ID,
 	stream StreamerStream,
-) (framer.Streamer, error) {
+) (framer.Streamer, StreamerRequest, error) {
 	req, err := stream.Receive()
 	if err != nil {
-		return nil, err
+		return nil, req, err
 	}
 	if err = s.access.NewEnforcer(nil).Enforce(ctx, access.Request{
 		Subject: subject,
 		Action:  access.ActionRetrieve,
 		Objects: framer.OntologyIDs(req.Keys),
 	}); err != nil {
-		return nil, err
+		return nil, req, err
 	}
 	// The ack fires only after the relay applies this streamer's demands, so a write
 	// issued after the client sees it is guaranteed to be delivered.
 	req.SendOpenAck = true
-	return s.internal.NewStreamer(ctx, req)
+	streamer, err := s.internal.NewStreamer(ctx, req)
+	if err != nil {
+		return nil, req, err
+	}
+	return streamer, req, nil
 }
 
 type WriterCommand = framer.WriterCommand

--- a/core/pkg/distribution/framer/relay/transport.go
+++ b/core/pkg/distribution/framer/relay/transport.go
@@ -30,6 +30,10 @@ type Response struct {
 	// Group identifies the control group that produced the frame, used to filter
 	// relayed frames (see relay ExcludeGroups).
 	Group uint32 `json:"group" msgpack:"group"`
+	// Keepalive marks an empty response emitted on the wire so the client can detect a
+	// silently dead connection. The relay never sets it; the API layer's response
+	// sender does.
+	Keepalive bool `json:"keepalive" msgpack:"keepalive"`
 }
 
 func reqToStorage(req Request) ts.StreamerRequest {

--- a/core/pkg/service/framer/streamer/streamer.go
+++ b/core/pkg/service/framer/streamer/streamer.go
@@ -32,12 +32,29 @@ type (
 	responseSegment = confluence.Segment[Response, Response]
 )
 
+// MinKeepalive is the fastest keepalive cadence a streamer accepts. Anything faster is
+// client misconfiguration, not liveness detection.
+const MinKeepalive = 10 * telem.Millisecond
+
 type Config struct {
-	Keys             channel.Keys `json:"keys"              msgpack:"keys"`
-	SendOpenAck      bool         `json:"send_open_ack"     msgpack:"send_open_ack"`
-	DownsampleFactor int          `json:"downsample_factor" msgpack:"downsample_factor"`
-	ThrottleRate     telem.Rate   `json:"throttle_rate"     msgpack:"throttle_rate"`
-	ExcludeGroups    []uint32     `json:"exclude_groups"    msgpack:"exclude_groups"`
+	// Keys are the channels to stream live samples from.
+	Keys channel.Keys `json:"keys" msgpack:"keys"`
+	// SendOpenAck sets whether an empty readiness response is sent once the relay has
+	// applied the streamer's demands.
+	SendOpenAck bool `json:"send_open_ack" msgpack:"send_open_ack"`
+	// DownsampleFactor keeps every n-th sample of each frame. Values below 2 keep
+	// every sample.
+	DownsampleFactor int `json:"downsample_factor" msgpack:"downsample_factor"`
+	// ThrottleRate caps the rate at which frames are delivered. Zero disables
+	// throttling.
+	ThrottleRate telem.Rate `json:"throttle_rate" msgpack:"throttle_rate"`
+	// ExcludeGroups are writer group IDs whose frames are filtered out before delivery
+	// (see relay ExcludeGroups).
+	ExcludeGroups []uint32 `json:"exclude_groups" msgpack:"exclude_groups"`
+	// Keepalive is the interval at which the wire sender emits empty keepalive
+	// responses so the client can detect a silently dead connection. Zero disables
+	// them. Applied at open; ignored on later requests.
+	Keepalive telem.TimeSpan `json:"keepalive" msgpack:"keepalive"`
 }
 
 var _ config.Config[Config] = Config{}
@@ -47,6 +64,9 @@ func (c Config) Validate() error {
 	v := validate.New("streamer.config")
 	validate.GreaterThanEq(v, "downsample_factor", c.DownsampleFactor, 0)
 	validate.GreaterThanEq(v, "throttle_rate", c.ThrottleRate, 0)
+	if c.Keepalive != 0 {
+		validate.GreaterThanEq(v, "keepalive", c.Keepalive, MinKeepalive)
+	}
 	return v.Error()
 }
 
@@ -57,6 +77,7 @@ func (c Config) Override(other Config) Config {
 	c.DownsampleFactor = override.Numeric(c.DownsampleFactor, other.DownsampleFactor)
 	c.ThrottleRate = override.Numeric(c.ThrottleRate, other.ThrottleRate)
 	c.ExcludeGroups = override.Slice(c.ExcludeGroups, other.ExcludeGroups)
+	c.Keepalive = override.Numeric(c.Keepalive, other.Keepalive)
 	return c
 }
 

--- a/core/pkg/service/framer/streamer/streamer_test.go
+++ b/core/pkg/service/framer/streamer/streamer_test.go
@@ -91,6 +91,28 @@ var _ = Describe("Streamer", Ordered, func() {
 		}))
 	})
 
+	Describe("Config Validation", func() {
+		DescribeTable("Keepalive",
+			func(ctx SpecContext, keepalive telem.TimeSpan, valid bool) {
+				cfg := streamer.Config{Keepalive: keepalive}
+				if valid {
+					MustSucceed(streamerSvc.New(ctx, cfg))
+					return
+				}
+				Expect(streamerSvc.New(ctx, cfg)).Error().To(
+					MatchError("keepalive: must be greater than or equal to 10ms"),
+				)
+			},
+			Entry("zero disables keepalives", telem.TimeSpan(0), true),
+			Entry("the minimum interval is accepted", streamer.MinKeepalive, true),
+			Entry(
+				"a nonzero interval below the minimum is rejected",
+				streamer.MinKeepalive-1,
+				false,
+			),
+		)
+	})
+
 	Describe("Happy Path", func() {
 		It("Should stream data", func(ctx SpecContext) {
 			ch := &channel.Channel{

--- a/freighter/go/freightfluence/sender.go
+++ b/freighter/go/freightfluence/sender.go
@@ -11,6 +11,7 @@ package freightfluence
 
 import (
 	"context"
+	"time"
 
 	"github.com/synnaxlabs/freighter"
 	"github.com/synnaxlabs/x/address"
@@ -23,6 +24,12 @@ import (
 // interface for sending messages over a network freighter.
 type Sender[M freighter.Payload] struct {
 	Sender freighter.StreamSenderCloser[M]
+	// KeepaliveInterval, when positive, emits NewKeepalive() on this cadence so the
+	// peer can detect a silently dead connection. Zero disables keepalives.
+	KeepaliveInterval time.Duration
+	// NewKeepalive constructs the message emitted every KeepaliveInterval. Required
+	// when KeepaliveInterval is positive.
+	NewKeepalive func() M
 	confluence.UnarySink[M]
 }
 
@@ -35,23 +42,45 @@ func (s *Sender[M]) send(ctx context.Context) (err error) {
 	defer func() {
 		err = errors.Combine(s.Sender.CloseSend(), err)
 	}()
+	// A nil channel never fires, so the keepalive case is inert when disabled.
+	var keepalive <-chan time.Time
+	if s.KeepaliveInterval > 0 {
+		if s.NewKeepalive == nil {
+			return errors.New("keepalive interval set without a message constructor")
+		}
+		ticker := time.NewTicker(s.KeepaliveInterval)
+		defer ticker.Stop()
+		keepalive = ticker.C
+	}
 	for {
 		select {
 		case <-ctx.Done():
-			err = ctx.Err()
-			return err
+			return ctx.Err()
+		case <-keepalive:
+			if err = s.sendMsg(s.NewKeepalive()); err != nil {
+				return err
+			}
 		case res, ok := <-s.In.Outlet():
 			if !ok {
 				return nil
 			}
-			if err = s.Sender.Send(res); err != nil {
-				if errors.Is(err, freighter.ErrStreamClosed) {
-					return context.Canceled
-				}
+			if err = s.sendMsg(res); err != nil {
 				return err
 			}
 		}
 	}
+}
+
+// sendMsg sends one message, translating a closed stream into context.Canceled so
+// closure is not treated as a routine failure.
+func (s *Sender[M]) sendMsg(msg M) error {
+	if err := s.Sender.Send(msg); err != nil {
+		if errors.Is(err, freighter.ErrStreamClosed) {
+			return context.Canceled
+		}
+		return err
+	}
+	return nil
 }
 
 // TransformSender wraps freighter.StreamSenderCloser to provide a confluence compatible

--- a/freighter/go/freightfluence/sender_test.go
+++ b/freighter/go/freightfluence/sender_test.go
@@ -11,6 +11,7 @@ package freightfluence_test
 
 import (
 	"context"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -79,6 +80,82 @@ var _ = Describe("Sender", func() {
 				_, ok := <-receiverStream.Outlet()
 				Expect(ok).To(BeFalse())
 			})
+		})
+		Describe("Sender Keepalive", func() {
+			It(
+				"Should emit keepalives on the configured cadence",
+				func(ctx SpecContext) {
+					sCtx, cancel := signal.WithCancel(ctx)
+					defer cancel()
+					stream := MustSucceed(client.Stream(sCtx, "localhost:0"))
+					sender := &freightfluence.Sender[int]{
+						Sender:            stream,
+						KeepaliveInterval: 5 * time.Millisecond,
+						NewKeepalive:      func() int { return -1 },
+					}
+					sender.InFrom(senderStream)
+					sender.Flow(sCtx)
+					Eventually(receiverStream.Outlet()).Should(Receive(Equal(-1)))
+					Eventually(receiverStream.Outlet()).Should(Receive(Equal(-1)))
+				},
+			)
+			It("Should keep delivering data between keepalives", func(ctx SpecContext) {
+				sCtx, cancel := signal.WithCancel(ctx)
+				defer cancel()
+				stream := MustSucceed(client.Stream(sCtx, "localhost:0"))
+				sender := &freightfluence.Sender[int]{
+					Sender:            stream,
+					KeepaliveInterval: 5 * time.Millisecond,
+					NewKeepalive:      func() int { return -1 },
+				}
+				sender.InFrom(senderStream)
+				sender.Flow(sCtx)
+				senderStream.Inlet() <- 1
+				Eventually(receiverStream.Outlet()).Should(Receive(Equal(1)))
+			})
+			It("Should not emit keepalives when disabled", func(ctx SpecContext) {
+				sCtx, cancel := signal.WithCancel(ctx)
+				defer cancel()
+				stream := MustSucceed(client.Stream(sCtx, "localhost:0"))
+				sender := &freightfluence.Sender[int]{Sender: stream}
+				sender.InFrom(senderStream)
+				sender.Flow(sCtx)
+				Consistently(receiverStream.Outlet()).ShouldNot(Receive())
+			})
+			It(
+				"Should fail loud when the interval is set without a constructor",
+				func(ctx SpecContext) {
+					sCtx, cancel := signal.WithCancel(ctx)
+					defer cancel()
+					stream := MustSucceed(client.Stream(sCtx, "localhost:0"))
+					sender := &freightfluence.Sender[int]{
+						Sender:            stream,
+						KeepaliveInterval: 5 * time.Millisecond,
+					}
+					sender.InFrom(senderStream)
+					sender.Flow(sCtx)
+					Expect(sCtx.Wait()).To(MatchError(ContainSubstring(
+						"keepalive interval set without a message constructor",
+					)))
+				},
+			)
+			It(
+				"Should not treat ErrStreamClosed on a keepalive as a routine failure",
+				func(ctx SpecContext) {
+					sCtx, cancel := signal.WithCancel(ctx)
+					defer cancel()
+					sender := &freightfluence.Sender[int]{
+						Sender: &errSenderCloser{
+							sendErr: freighter.ErrStreamClosed,
+						},
+						KeepaliveInterval: 5 * time.Millisecond,
+						NewKeepalive:      func() int { return -1 },
+					}
+					sender.InFrom(confluence.NewStream[int](1))
+					sender.Flow(sCtx, confluence.CancelOnFail())
+					Expect(sCtx.Wait()).To(MatchError(context.Canceled))
+				},
+			)
 		})
 		Describe("TransformSender", func() {
 			It("Should transform values before sending them", func(ctx SpecContext) {

--- a/freighter/ts/src/handshake.spec.ts
+++ b/freighter/ts/src/handshake.spec.ts
@@ -1,0 +1,83 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { createServer, type Server, type Socket } from "node:net";
+
+import { binary, TimeSpan, url } from "@synnaxlabs/x";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { Unreachable } from "@/errors";
+import { WebSocketClient } from "@/websocket";
+
+const messageZ = z.object({ message: z.string().optional() });
+
+/**
+ * Accepts connections and then says nothing, modeling a path that swallows the
+ * upgrade: the socket is neither refused nor closed, so no error event ever fires.
+ */
+const createSilentServer = async (): Promise<{
+  port: number;
+  dropped: () => number;
+  close: () => void;
+}> => {
+  const held: Socket[] = [];
+  let dropped = 0;
+  const server: Server = createServer((socket) => {
+    held.push(socket);
+    socket.on("close", () => dropped++);
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as { port: number };
+  return {
+    port,
+    dropped: () => dropped,
+    close: () => {
+      held.forEach((s) => s.destroy());
+      server.close();
+    },
+  };
+};
+
+describe("websocket handshake deadline", () => {
+  let silent: Awaited<ReturnType<typeof createSilentServer>>;
+
+  beforeEach(async () => {
+    silent = await createSilentServer();
+  });
+  afterEach(() => silent.close());
+
+  it("should reject a handshake that is never answered", async () => {
+    const client = new WebSocketClient(
+      new url.URL({ host: "127.0.0.1", port: silent.port }),
+      new binary.JSONCodec(),
+      false,
+      TimeSpan.milliseconds(150),
+    );
+    const start = performance.now();
+    await expect(client.stream("/test", messageZ, messageZ)).rejects.toThrow(
+      Unreachable,
+    );
+    expect(performance.now() - start).toBeLessThan(2000);
+    // The abandoned socket is released rather than left to connect unheld.
+    await expect.poll(() => silent.dropped()).toBeGreaterThan(0);
+  });
+
+  it("should carry the deadline across withCodec", async () => {
+    const client = new WebSocketClient(
+      new url.URL({ host: "127.0.0.1", port: silent.port }),
+      new binary.JSONCodec(),
+      false,
+      TimeSpan.milliseconds(150),
+    ).withCodec(new binary.JSONCodec());
+    await expect(client.stream("/test", messageZ, messageZ)).rejects.toThrow(
+      Unreachable,
+    );
+  });
+});

--- a/freighter/ts/src/websocket.ts
+++ b/freighter/ts/src/websocket.ts
@@ -7,10 +7,10 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { type binary, errors, url, zod } from "@synnaxlabs/x";
+import { type binary, errors, sync, TimeSpan, url, zod } from "@synnaxlabs/x";
 import { z } from "zod";
 
-import { EOF, StreamClosed } from "@/errors";
+import { EOF, StreamClosed, Unreachable } from "@/errors";
 import { CONTENT_TYPE_HEADER_KEY, FREIGHTER_METADATA_PREFIX } from "@/http";
 import { type Context, MiddlewareCollector } from "@/middleware";
 import { type Stream, type StreamClient } from "@/stream";
@@ -146,28 +146,49 @@ class WebSocketStream<
 const CLOSE_NORMAL = 1000;
 
 /**
+ * Generous by design: a handshake this slow is a dead connection, not a busy Core, so
+ * the deadline never fires on a healthy dial.
+ */
+const DEFAULT_HANDSHAKE_TIMEOUT = TimeSpan.seconds(30);
+
+/**
  * WebSocketClient is an implementation of StreamClient that is backed by websockets.
  */
 export class WebSocketClient extends MiddlewareCollector implements StreamClient {
   baseUrl: url.URL;
   encoder: binary.Codec;
   secure: boolean;
+  handshakeTimeout: TimeSpan;
 
   static readonly MESSAGE_TYPE = "arraybuffer";
 
   /**
    * @param encoder - The encoder to use for encoding messages and decoding responses.
    * @param baseEndpoint - A base url to use as a prefix for all requests.
+   * @param handshakeTimeout - Deadline for the socket to open and acknowledge. A
+   * connection that stops answering mid-handshake produces no error event, so without
+   * a deadline the dial never settles. A non-positive span disables the deadline.
    */
-  constructor(baseEndpoint: url.URL, encoder: binary.Codec, secure = false) {
+  constructor(
+    baseEndpoint: url.URL,
+    encoder: binary.Codec,
+    secure = false,
+    handshakeTimeout: TimeSpan = DEFAULT_HANDSHAKE_TIMEOUT,
+  ) {
     super();
     this.secure = secure;
     this.baseUrl = baseEndpoint.replace({ protocol: secure ? "wss" : "ws" });
     this.encoder = encoder;
+    this.handshakeTimeout = handshakeTimeout;
   }
 
   withCodec(codec: binary.Codec): WebSocketClient {
-    const c = new WebSocketClient(this.baseUrl, codec, this.secure);
+    const c = new WebSocketClient(
+      this.baseUrl,
+      codec,
+      this.secure,
+      this.handshakeTimeout,
+    );
     c.use(...this.middleware);
     return c;
   }
@@ -209,7 +230,7 @@ export class WebSocketClient extends MiddlewareCollector implements StreamClient
     reqSchema: RQ,
     resSchema: RS,
   ): Promise<WebSocketStream<RQ, RS>> {
-    return await new Promise((resolve, reject) => {
+    const opened = new Promise<WebSocketStream<RQ, RS>>((resolve, reject) => {
       ws.onopen = () => {
         const oWs = new WebSocketStream<RQ, RS>(
           ws,
@@ -228,5 +249,24 @@ export class WebSocketClient extends MiddlewareCollector implements StreamClient
         reject(new Error(ev_.message ?? "websocket error", { cause: ev_.error ?? ev }));
       };
     });
+    const endpoint = this.baseUrl.child(target);
+    const { handshakeTimeout } = this;
+    const span = handshakeTimeout.toString();
+    try {
+      return await sync.withTimeout(
+        opened,
+        handshakeTimeout,
+        () =>
+          new Unreachable({
+            url: endpoint,
+            message: `websocket handshake did not complete within ${span}`,
+          }),
+      );
+    } catch (err) {
+      // A failed dial leaves the socket live: it may still connect, with nobody
+      // holding it and its messages queueing behind a stream no caller received.
+      ws.close();
+      throw errors.fromUnknown(err);
+    }
   }
 }

--- a/x/ts/src/sync/external.ts
+++ b/x/ts/src/sync/external.ts
@@ -9,3 +9,4 @@
 
 export * from "@/sync/mutex";
 export * from "@/sync/notifier";
+export * from "@/sync/timeout";

--- a/x/ts/src/sync/timeout.spec.ts
+++ b/x/ts/src/sync/timeout.spec.ts
@@ -1,0 +1,63 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { withTimeout } from "@/sync/timeout";
+import { TimeSpan } from "@/telem";
+
+const deadline = (): Error => new Error("deadline");
+
+describe("withTimeout", () => {
+  beforeEach(() => vi.useFakeTimers());
+  afterEach(() => vi.useRealTimers());
+
+  it("should return the value when the promise settles in time", async () => {
+    await expect(
+      withTimeout(Promise.resolve(1), TimeSpan.seconds(1), deadline),
+    ).resolves.toEqual(1);
+  });
+
+  it("should propagate the promise's own rejection", async () => {
+    await expect(
+      withTimeout(Promise.reject(new Error("original")), TimeSpan.seconds(1), deadline),
+    ).rejects.toThrow("original");
+  });
+
+  it("should reject with the timeout error when the deadline passes", async () => {
+    const res = withTimeout(new Promise(() => {}), TimeSpan.seconds(1), deadline);
+    const settled = expect(res).rejects.toThrow("deadline");
+    await vi.advanceTimersByTimeAsync(1_500);
+    await settled;
+  });
+
+  it("should wait forever on a non-positive span", async () => {
+    let resolve!: (v: number) => void;
+    const pending = new Promise<number>((r) => (resolve = r));
+    const res = withTimeout(pending, TimeSpan.ZERO, deadline);
+    await vi.advanceTimersByTimeAsync(TimeSpan.hours(1).milliseconds);
+    resolve(2);
+    await expect(res).resolves.toEqual(2);
+  });
+
+  it("should not leave a rejected loser unhandled", async () => {
+    const unhandled = vi.fn();
+    process.on("unhandledRejection", unhandled);
+    const late = new Promise<never>((_, reject) =>
+      setTimeout(() => reject(new Error("late")), 2_000),
+    );
+    const res = withTimeout(late, TimeSpan.seconds(1), deadline);
+    const settled = expect(res).rejects.toThrow("deadline");
+    await vi.advanceTimersByTimeAsync(3_000);
+    await settled;
+    await vi.advanceTimersByTimeAsync(0);
+    expect(unhandled).not.toHaveBeenCalled();
+    process.off("unhandledRejection", unhandled);
+  });
+});

--- a/x/ts/src/sync/timeout.ts
+++ b/x/ts/src/sync/timeout.ts
@@ -1,0 +1,37 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { TimeSpan } from "@/telem";
+
+/**
+ * Bounds how long the caller waits on promise.
+ * @param span - The deadline. A non-positive span waits forever.
+ * @param onTimeout - Builds the error to reject with when the deadline passes.
+ * @returns the promise's value.
+ * @throws the promise's own rejection, or the error from onTimeout.
+ */
+export const withTimeout = async <V>(
+  promise: Promise<V>,
+  span: TimeSpan,
+  onTimeout: () => Error,
+): Promise<V> => {
+  if (span.lessThanOrEqual(TimeSpan.ZERO)) return await promise;
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const deadline = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(onTimeout()), span.milliseconds);
+  });
+  try {
+    return await Promise.race([promise, deadline]);
+  } finally {
+    clearTimeout(timer);
+    // A promise that loses the race still settles. Left alone, a late rejection
+    // reaches nobody and surfaces as an unhandled one.
+    promise.catch(() => {});
+  }
+};


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4744](https://linear.app/synnax/issue/SY-4744/bound-the-telemetry-streamers-connection-waits)

## Description

A WebSocket dial that stops answering mid-handshake produces no error event. `wrapSocket` settles only on `onopen` plus `receiveOpenAck()`, or on `onerror`, and `receiveOpenAck()` parks a promise that only a message or an `onclose` can resolve. With no deadline, the dial waits until the operating system tears down TCP, which is many minutes or longer. SY-4740 does not cover this: its read deadline arms only after the first keepalive arrives, and at open none has.

`MultiplexedStreamer.reconcile` takes that wait under `connMu`, so the consequence is worse than a slow dial. No new channel reaches the stream, which leaves a plot opened after that moment with nothing; channels already on the stream keep flowing at full rate, so the failure is silent; and `close()` waits on the same lock, so the Feed cannot be rebuilt inside the process.

Three changes:

- `WebSocketClient` gains a `handshakeTimeout`, default 30 seconds, applied across the socket open and the acknowledgement. On expiry it rejects with `Unreachable` and closes the socket, which also stops a failed dial from leaving a live socket that nobody holds.
- `createStreamOpener` bounds the streamer's own open acknowledgement, the trip after the handshake that SY-4740 leaves unarmed, and closes the streamer when it expires.
- `sync.withTimeout` in `x` replaces what would have been a third hand-rolled deadline race, after `Reader.fetchWithDeadline` (SY-4736) and `BaseStreamer.receiveWithDeadline` (SY-4740). Converting those two is left for a follow-up so this change stays reviewable.

No per-call override is added. `defaultTimeoutMs` plus a per-call `timeoutMs` is the standard shape in TypeScript RPC clients, but nothing needs the override yet, and it is a small addition when something does.

The HTTP transport has the same gap and is tracked separately in [SY-4745](https://linear.app/synnax/issue/SY-4745/give-the-typescript-client-a-default-request-timeout). Python's `freighter` transport is missing a bound as well.

Scope note: this is hardening. There is no evidence it fired during the v0.57.0 incident, and it does not explain a freeze that survives a restart.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds reusable timeout handling and applies 30-second deadlines to WebSocket handshakes and streamer acknowledgements.
- Adds `sync.withTimeout` with tests for resolution, rejection, disabled deadlines, and late loser rejection.
- Propagates a configurable WebSocket handshake timeout through `WebSocketClient.withCodec`.
- Times out stalled streamer acknowledgements, although its cleanup does not fully close an unresponsive socket.

<h3>Confidence Score: 4/5</h3>

The streamer acknowledgement cleanup should fully close the underlying WebSocket before merging so a dead peer cannot leave an orphaned connection.

The new acknowledgement deadline releases its caller after 30 seconds, but its cleanup sends only a protocol close frame; when the peer is unresponsive, neither the underlying WebSocket nor the pending receive is guaranteed to terminate.

**Files Needing Attention:** client/ts/src/framer/streamer.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| client/ts/src/framer/streamer.ts | Adds the streamer acknowledgement deadline, but timeout cleanup only closes the send side and can leave an unresponsive WebSocket orphaned. |
| freighter/ts/src/websocket.ts | Adds a configurable handshake timeout, preserves it across codec changes, and explicitly closes failed sockets. |
| x/ts/src/sync/timeout.ts | Introduces a reusable promise timeout helper with timer cleanup and observation of late loser rejection. |
| client/ts/src/framer/openAck.spec.ts | Covers timeout rejection but its mock equates `closeSend()` with full socket closure, so it does not detect the orphaned-socket behavior. |
| freighter/ts/src/handshake.spec.ts | Covers stalled handshake rejection and timeout propagation through `withCodec`. |
| x/ts/src/sync/timeout.spec.ts | Covers the timeout helper's principal success, failure, disabled-deadline, and late-rejection behavior. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
  participant C as Stream opener
  participant W as WebSocket
  participant S as Server
  C->>W: Open WebSocket stream
  W-->>C: Handshake acknowledged
  C->>S: Streamer request
  Note over S: Server becomes unresponsive
  C->>C: 30-second timeout
  C->>W: closeSend()
  W-->>S: Protocol close frame
  Note over W,S: Underlying socket remains open
  C-->>C: Reject with Unreachable
```

<sub>Reviews (1): Last reviewed commit: [66fe150](https://github.com/synnaxlabs/synnax/commit/66fe15065fe8c55b21f152e08ccd56f455a26894) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56648363)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->