### PR TITLE
SY-4750: Ship Pluto's Monaco workers with the Console build

### DIFF
--- a/console/vite.config.ts
+++ b/console/vite.config.ts
@@ -72,6 +72,36 @@ const stripSourcesContent = (): Plugin => ({
   },
 });
 
+// Pluto hard-codes its Monaco worker addresses as root-absolute "/pluto/assets/..."
+// paths and marks them @vite-ignore, so this build neither rewrites them nor emits the
+// files. Copying each referenced worker to the address it already names is what makes
+// it load, both in the desktop bundle and in the copy the Core serves.
+const plutoWorkers = (): Plugin => ({
+  name: "pluto-workers",
+  async writeBundle(options, bundle) {
+    const dir = options.dir;
+    if (dir == null) return;
+    const names = new Set<string>();
+    Object.values(bundle).forEach((chunk) => {
+      if (chunk.type !== "chunk") return;
+      for (const [, name] of chunk.code.matchAll(/\/pluto\/assets\/([\w.-]+)/g))
+        names.add(name);
+    });
+    const out = path.join(dir, "pluto", "assets");
+    await fs.mkdir(out, { recursive: true });
+    await Promise.all(
+      Array.from(names, async (name) => {
+        const from = path.resolve(repoRoot, "pluto/dist/assets", name);
+        try {
+          await fs.copyFile(from, path.join(out, name));
+        } catch (err) {
+          throw new Error(`missing ${from}. Run pnpm build:pluto.`, { cause: err });
+        }
+      }),
+    );
+  },
+});
+
 export default defineConfig({
   clearScreen: false,
   server: { port: 5173, strictPort: true },
@@ -91,7 +121,7 @@ export default defineConfig({
       : {},
   },
   envPrefix: ["VITE_", "TAURI_"],
-  plugins: [react(), workspaceSourcemaps(), stripSourcesContent()],
+  plugins: [react(), workspaceSourcemaps(), stripSourcesContent(), plutoWorkers()],
   build: {
     target: process.env.TAURI_PLATFORM === "windows" ? "chrome111" : "safari16.4",
     minify: !isDev,

--- a/console/vite.config.ts
+++ b/console/vite.config.ts
@@ -87,6 +87,11 @@ const plutoWorkers = (): Plugin => ({
       for (const [, name] of chunk.code.matchAll(/\/pluto\/assets\/([\w.-]+)/g))
         names.add(name);
     });
+    if (names.size === 0)
+      throw new Error(
+        "no /pluto/assets worker addresses in the bundle. Pluto's worker URL format " +
+          "changed; update the pattern above.",
+      );
     const out = path.join(dir, "pluto", "assets");
     await fs.mkdir(out, { recursive: true });
     await Promise.all(

--- a/console/vite.config.ts
+++ b/console/vite.config.ts
@@ -76,36 +76,51 @@ const stripSourcesContent = (): Plugin => ({
 // paths and marks them @vite-ignore, so this build neither rewrites them nor emits the
 // files. Copying each referenced worker to the address it already names is what makes
 // it load, both in the desktop bundle and in the copy the Core serves.
-const plutoWorkers = (): Plugin => ({
-  name: "pluto-workers",
-  async writeBundle(options, bundle) {
-    const dir = options.dir;
-    if (dir == null) return;
-    const names = new Set<string>();
-    Object.values(bundle).forEach((chunk) => {
-      if (chunk.type !== "chunk") return;
-      for (const [, name] of chunk.code.matchAll(/\/pluto\/assets\/([\w.-]+)/g))
-        names.add(name);
-    });
-    if (names.size === 0)
-      throw new Error(
-        "no /pluto/assets worker addresses in the bundle. Pluto's worker URL format " +
-          "changed; update the pattern above.",
-      );
-    const out = path.join(dir, "pluto", "assets");
-    await fs.mkdir(out, { recursive: true });
-    await Promise.all(
-      Array.from(names, async (name) => {
+const plutoWorkers = (): Plugin => {
+  const PATTERN = /\/pluto\/assets\/([\w.-]+)/g;
+  /** Adds every address in code to seen, returning only the ones new to it. */
+  const scan = (code: string, seen: Set<string>): string[] => {
+    const fresh: string[] = [];
+    for (const [, name] of code.matchAll(PATTERN))
+      if (!seen.has(name)) {
+        seen.add(name);
+        fresh.push(name);
+      }
+    return fresh;
+  };
+  return {
+    name: "pluto-workers",
+    async writeBundle(options, bundle) {
+      const dir = options.dir;
+      if (dir == null) return;
+      const seen = new Set<string>();
+      const pending: string[] = [];
+      Object.values(bundle).forEach((chunk) => {
+        if (chunk.type !== "chunk") return;
+        pending.push(...scan(chunk.code, seen));
+      });
+      if (seen.size === 0)
+        throw new Error(
+          "no /pluto/assets worker addresses in the bundle. Pluto's worker URL " +
+            "format changed; update the pattern above.",
+        );
+      const out = path.join(dir, "pluto", "assets");
+      await fs.mkdir(out, { recursive: true });
+      // A worker imports its own chunks, which the Console's bundle never names.
+      for (let name = pending.pop(); name != null; name = pending.pop()) {
         const from = path.resolve(repoRoot, "pluto/dist/assets", name);
+        let code: string;
         try {
-          await fs.copyFile(from, path.join(out, name));
+          code = await fs.readFile(from, "utf-8");
         } catch (err) {
           throw new Error(`missing ${from}. Run pnpm build:pluto.`, { cause: err });
         }
-      }),
-    );
-  },
-});
+        await fs.writeFile(path.join(out, name), code);
+        pending.push(...scan(code, seen));
+      }
+    },
+  };
+};
 
 export default defineConfig({
   clearScreen: false,

--- a/core/pkg/console/console_test.go
+++ b/core/pkg/console/console_test.go
@@ -33,7 +33,12 @@ var testFS = fstest.MapFS{
 			`<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1 1"><rect width="1" height="1"/></svg>`,
 		),
 	},
+	"pluto/assets/editor.worker-abc123.js": &fstest.MapFile{
+		Data: []byte(workerScript),
+	},
 }
+
+const workerScript = `self.onmessage = () => {};`
 
 var _ = Describe("Config", func() {
 	Describe("Override", func() {
@@ -108,6 +113,22 @@ var _ = Describe("Console", func() {
 				req := httptest.NewRequest(http.MethodGet, "/favicon.svg", nil)
 				res := MustSucceed(app.Test(req))
 				Expect(res.StatusCode).To(Equal(http.StatusOK))
+			})
+
+			// A module worker rejects a script served as HTML, so the SPA catch-all
+			// answering this path is indistinguishable from the file being absent.
+			It("Should serve a nested worker asset as JavaScript", func() {
+				req := httptest.NewRequest(
+					http.MethodGet,
+					"/pluto/assets/editor.worker-abc123.js",
+					nil,
+				)
+				res := MustSucceed(app.Test(req))
+				Expect(res.StatusCode).To(Equal(http.StatusOK))
+				Expect(res.Header.Get(fiber.HeaderContentType)).
+					To(ContainSubstring("javascript"))
+				body := MustSucceed(io.ReadAll(res.Body))
+				Expect(string(body)).To(Equal(workerScript))
 			})
 
 			It("Should serve index.html for SPA routes", func() {


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4750](https://linear.app/synnax/issue/SY-4750/monaco-workers-404-in-production-console-builds)

## Description

Every production Console build shipped three dead worker addresses. The code editor lost syntax highlighting, language services, and diffing, fell back to running worker code on the main thread, and filled the console with errors. Found in a customer's DevTools on v0.57.

Pluto emits its Monaco workers into `pluto/dist/assets/` and writes root-absolute addresses into `pluto.js`, marked `@vite-ignore`, so the Console build neither rewrites them nor emits the files:

```js
new Worker(new URL("/pluto/assets/editor.worker-1z6Nydep.js", import.meta.url), { type: "module" })
```

Nothing ever copied those files, so `console/dist/pluto/` did not exist. Served by the Core, the catch-all in `core/pkg/console/console.go` answered each address with `index.html`, and the worker failed to parse HTML as JavaScript. In the desktop app the file was simply absent. Development was unaffected, because it aliases Pluto to its source and Vite builds the workers itself, which is why this shipped.

The Console build now scans its emitted chunks for `/pluto/assets/<name>` addresses, copies each named file to the address it already points at, and follows the copied workers for further addresses, since a worker imports chunks the Console's own bundle never names. The build fails when the scan finds nothing, and when a referenced file is missing.

Source maps are deliberately not copied. They are 2.9 MB across the three workers, every byte of `console/dist` is embedded into the Core binary, and Pluto already publishes no source maps for the same reason.

A test in `core/pkg/console/console_test.go` pins the Core's serving path: a nested `pluto/assets/*.js` must come back as JavaScript. Without it the SPA catch-all answers with `index.html`, which a module worker rejects, making a missing asset and a misrouted one indistinguishable.

Follow-up, not in scope: a library should not ship hard-coded worker addresses at all. The right shape is for the consumer's build to construct them, injecting a `getWorker` into `Code.Provider` rather than `pluto/src/code/Provider.tsx` owning it. Separately, no PR-triggered workflow builds the Console, so this guard only runs when a release is cut.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds a Vite plugin that discovers Pluto's root-absolute Monaco worker references, recursively copies their dependencies into the Console output, and fails when expected artifacts are missing. It also tests that Core serves nested worker assets as JavaScript.

- Scans emitted Console and copied worker chunks for `/pluto/assets/` references.
- Copies referenced Pluto artifacts into the production output hierarchy.
- Adds a Core static-serving regression test for nested worker scripts.

<h3>Confidence Score: 4/5</h3>

The clean direct Console and Tauri build paths should declare or build Pluto before this change is merged.

The new write-bundle hook unconditionally reads untracked Pluto build artifacts, while supported package-level build commands can reach it without first generating those files.

**Files Needing Attention:** console/vite.config.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| console/vite.config.ts | Adds recursive Pluto worker discovery and copying, but direct Console and Tauri builds can fail because they do not prepare the required Pluto dist artifacts. |
| core/pkg/console/console_test.go | Adds focused coverage proving that a nested worker asset is served with JavaScript content and MIME type. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  A[Console Vite bundle] -->|scan worker URLs| B[Pluto dist assets]
  B -->|copy referenced workers and chunks| C[Console dist/pluto/assets]
  C --> D{Deployment}
  D --> E[Tauri desktop]
  D --> F[Core embedded Console]
  F -->|serve JavaScript| G[Monaco module workers]
```

<sub>Reviews (1): Last reviewed commit: ["Follow worker imports and pin the Core&#39;s..."](https://github.com/synnaxlabs/synnax/commit/7930e6c2e9b2adaf72785380a3e32b268ea4aa7c) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56759878)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->