### PR TITLE
SY-4755: Stop the Console freezing on a Core with many ranges

### DIFF
--- a/client/ts/src/channel/channel.spec.ts
+++ b/client/ts/src/channel/channel.spec.ts
@@ -11,6 +11,7 @@ import { control, DataType, id, TimeRange, TimeSpan, TimeStamp } from "@synnaxla
 import { beforeAll, describe, expect, it, test, vi } from "vitest";
 
 import { Channel } from "@/channel/client";
+import type Synnax from "@/client";
 import { NotFoundError } from "@/errors";
 import { query } from "@/query";
 import {
@@ -423,6 +424,9 @@ describe("Channel", () => {
   });
 });
 
+const spyOnSendOf = (client: Synnax, field: "transport") =>
+  vi.spyOn(client[field].unary, "send");
+
 const createVirtual = async (c = client) =>
   await c.channels.create({
     name: `qry_${id.create()}`,
@@ -464,6 +468,22 @@ describe("cached reads", () => {
       await client.channels.retrieve(b.key);
       const res = await client.channels.retrieve([a.key, b.key]);
       expect(res.map((c) => c.key)).toEqual([a.key, b.key]);
+    });
+
+    // A plot panel resolves one channel per telemetry source in the same tick, so a
+    // single retrieve that skips the record table costs one request per channel.
+    it("coalesces concurrent single retrieves into one request", async () => {
+      const created = [await createVirtual(), await createVirtual()];
+      const local = createTestClient();
+      await local.connect();
+      const send = spyOnSendOf(local, "transport");
+      const res = await Promise.all(
+        created.map(async ({ key }) => await local.channels.retrieve(key)),
+      );
+      expect(res.map(({ key }) => key)).toEqual(created.map(({ key }) => key));
+      expect(
+        send.mock.calls.filter(([target]) => target === "/channel/retrieve"),
+      ).toHaveLength(1);
     });
   });
 

--- a/client/ts/src/channel/client.ts
+++ b/client/ts/src/channel/client.ts
@@ -765,10 +765,11 @@ export class Client extends query.Retriever<
     const { key, rangeKey } = query;
     let ch = this.store.get(key);
     if (ch == null) {
-      const payloads = await this.execRetrieve([key]);
-      checkForMultipleOrNoResults("channel", key, payloads, true);
-      ch = this.sugar(stripComposed(payloads[0]));
-      this.store.set(key, ch);
+      // Through the table, so concurrent misses coalesce into one request. A plot
+      // panel resolves one channel per telemetry source, all in the same tick.
+      const fetched = await this.store.retrieve([key]);
+      checkForMultipleOrNoResults("channel", key, fetched, true);
+      [ch] = fetched;
     }
     // A cached calculated channel without a cached status is ambiguous: the
     // status may not exist, or may simply never have been fetched.

--- a/client/ts/src/ranger/client.ts
+++ b/client/ts/src/ranger/client.ts
@@ -288,6 +288,21 @@ const retrieveMultiParamsZ = retrieveRequestZ
 
 const retrieveResZ = z.object({ ranges: payloadZ.array().default(() => []) });
 
+/** Request addressing a page of a range's children, in relationship-key order. */
+export type ChildrenRequest = {
+  key: Key;
+  limit?: number;
+  offset?: number;
+};
+
+/** Params addressing a range's children. A bare key addresses all of them. */
+export type ChildrenParams = Key | ChildrenRequest;
+
+const CHILDREN_SERVER_FIELDS = ["limit", "offset"] as const;
+
+const normalizeChildren = (params: ChildrenParams): ChildrenRequest =>
+  typeof params === "string" ? { key: params } : params;
+
 /** The base flags applied to every composed range fetch. */
 const BASE_REQUEST: Partial<RetrieveRequest> = {
   includeLabels: true,
@@ -386,7 +401,7 @@ export class Client extends query.Retriever<
   /** The range alias table; injected into sibling clients at wiring. */
   readonly aliases: query.Table<string, alias.Alias>;
   /** Cached queries for the children of a range, keyed by the parent's key. */
-  readonly children: query.Retrieves<Key, Range[]>;
+  readonly children: query.Retrieves<ChildrenParams, Range[]>;
   /**
    * Cached queries for the closest range parent of a resource, keyed by the
    * child's ontology ID.
@@ -453,17 +468,27 @@ export class Client extends query.Retriever<
     this.store = ranges;
     this.kvPairs = kvPairs;
     this.aliases = aliases;
-    this.children = cache.queries<Key, Range[], Key, Range>({
+    const children = cache.queries<ChildrenRequest, Range[], Key, Range>({
       name: "child ranges",
       table: composed,
       fetch: async (query) => (await this.fetchChildren(query)).map((r) => r.key),
       compose: (records) => records,
       matches: (r, query) => {
         const parent = this.cfg.ontology.cache.parentID(ontologyID(r.key));
-        return parent != null && ontology.idsEqual(parent, ontologyID(query));
+        return parent != null && ontology.idsEqual(parent, ontologyID(query.key));
       },
-      watch: [watchRelationships<Key>(this.cfg.ontology.cache.relationships)],
+      serverFields: CHILDREN_SERVER_FIELDS,
+      watch: [
+        watchRelationships<ChildrenRequest>(this.cfg.ontology.cache.relationships),
+      ],
     });
+    this.children = {
+      retrieve: async (params, options) =>
+        await children.retrieve(normalizeChildren(params), options),
+      onChange: (params, handler) =>
+        children.onChange(normalizeChildren(params), handler),
+      getCached: (params) => children.getCached(normalizeChildren(params)),
+    };
     this.parent = cache.queries<ontology.ID, Range | null, Key, Range>({
       name: "parent range",
       table: composed,
@@ -721,10 +746,12 @@ export class Client extends query.Retriever<
     return true;
   }
 
-  private async fetchChildren(query: Key): Promise<Range[]> {
+  private async fetchChildren(query: ChildrenRequest): Promise<Range[]> {
     const resources = await this.cfg.ontology.children.retrieve({
-      ids: ontologyID(query),
+      ids: ontologyID(query.key),
       types: ["range"],
+      limit: query.limit,
+      offset: query.offset,
     });
     if (resources.length === 0) return [];
     return await this.store.retrieve(resources.map(({ id: { key } }) => key));

--- a/client/ts/src/ranger/ranger.spec.ts
+++ b/client/ts/src/ranger/ranger.spec.ts
@@ -720,6 +720,51 @@ describe("cached reads", () => {
         off();
       }
     });
+
+    it("pages children with limit and offset in a stable order", async () => {
+      const parent = await createRange();
+      await Promise.all(
+        Array.from({ length: 5 }, () =>
+          createRange(client, { parent: { key: parent.key } }),
+        ),
+      );
+      const all = await client.ranges.children.retrieve(parent.key);
+      expect(all).toHaveLength(5);
+      const first = await client.ranges.children.retrieve({
+        key: parent.key,
+        limit: 3,
+        offset: 0,
+      });
+      const second = await client.ranges.children.retrieve({
+        key: parent.key,
+        limit: 3,
+        offset: 3,
+      });
+      expect(first).toHaveLength(3);
+      expect(second).toHaveLength(2);
+      const paged = [...first, ...second].map((r) => r.key).sort();
+      expect(paged).toEqual(all.map((r) => r.key).sort());
+    });
+
+    it("sends the page bounds to the cluster instead of fetching every child", async () => {
+      const parent = await createRange();
+      await Promise.all(
+        Array.from({ length: 3 }, () =>
+          createRange(client, { parent: { key: parent.key } }),
+        ),
+      );
+      const spy = vi.spyOn(client.ontology.children, "retrieve");
+      try {
+        const page = await client.ranges.children.retrieve({
+          key: parent.key,
+          limit: 2,
+        });
+        expect(page).toHaveLength(2);
+        expect(spy).toHaveBeenCalledWith(expect.objectContaining({ limit: 2 }));
+      } finally {
+        spy.mockRestore();
+      }
+    });
   });
 
   describe("parent", () => {

--- a/pluto/src/lineplot/range/aether/provider.spec.ts
+++ b/pluto/src/lineplot/range/aether/provider.spec.ts
@@ -1,0 +1,92 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { createTestClient, TEST_CLIENT_PARAMS } from "@synnaxlabs/client/testutil";
+import { box, id, scale, TimeRange, TimeSpan, TimeStamp } from "@synnaxlabs/x";
+import { describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { aether } from "@/aether/aether";
+import {
+  MAX_ANNOTATIONS,
+  Provider,
+  type ProviderProps,
+} from "@/lineplot/range/aether/provider";
+import { renderAether } from "@/testutil/renderAether";
+import { render } from "@/vis/render";
+import { canvasTest } from "@/vis/render/test";
+
+const REGION = box.construct({ x: 0, y: 0 }, { width: 1000, height: 500 });
+const PROVIDER_KEY = "annotations";
+
+/** Supplies the render requestor the provider reads, which production gets from the
+ * plot's canvas. A requested render has nothing to schedule: the test drives drawing
+ * by calling render itself. */
+class Requestor extends aether.Composite<typeof Requestor.stateZ> {
+  static readonly TYPE = "range-provider-test-requestor";
+  static readonly stateZ = z.object({});
+  schema = Requestor.stateZ;
+
+  afterUpdate(ctx: aether.Context): void {
+    render.control(ctx, () => {});
+  }
+}
+
+const renderProps = (timeRange: TimeRange): ProviderProps => ({
+  dataToDecimalScale: scale.Scale.scale(
+    Number(timeRange.start.valueOf()),
+    Number(timeRange.end.valueOf()),
+  ),
+  region: REGION,
+  viewport: REGION,
+  timeRange,
+});
+
+const mount = (): Provider => {
+  const h = renderAether(Requestor, {
+    state: {},
+    synnax: { props: TEST_CLIENT_PARAMS },
+    render: canvasTest.record(),
+    registry: { [Provider.TYPE]: Provider },
+    children: {
+      [PROVIDER_KEY]: {
+        type: Provider.TYPE,
+        state: { cursor: null, hovered: null, count: 0 },
+      },
+    },
+  });
+  return h.child<Provider>(PROVIDER_KEY);
+};
+
+describe("Provider", () => {
+  // A window over a Core an Arc fills with ranges overlaps far more than the strip can
+  // draw, and writing the unbounded answer through the cache stalls the worker for
+  // seconds, which freezes every plot in the window.
+  it("draws no more annotations than the fetch limit", async () => {
+    const client = createTestClient();
+    const start = TimeStamp.now();
+    const timeRange = new TimeRange(start, start.add(TimeSpan.seconds(10)));
+    await client.ranges.create(
+      Array.from({ length: MAX_ANNOTATIONS + 20 }, () => ({
+        name: `annotation-${id.create()}`,
+        timeRange,
+        color: "#7C3AED",
+      })),
+    );
+    const provider = mount();
+    const props = renderProps(timeRange);
+    await expect
+      .poll(() => {
+        provider.render(props);
+        return provider.state.count;
+      })
+      .toBeGreaterThan(0);
+    expect(provider.state.count).toBeLessThanOrEqual(MAX_ANNOTATIONS);
+  });
+});

--- a/pluto/src/lineplot/range/aether/provider.spec.ts
+++ b/pluto/src/lineplot/range/aether/provider.spec.ts
@@ -65,28 +65,32 @@ const mount = (): Provider => {
 };
 
 describe("Provider", () => {
-  // A window over a Core an Arc fills with ranges overlaps far more than the strip can
-  // draw, and writing the unbounded answer through the cache stalls the worker for
-  // seconds, which freezes every plot in the window.
-  it("draws no more annotations than the fetch limit", async () => {
+  // A window an Arc fills with ranges overlaps far more than the strip can draw, and
+  // writing the unbounded answer through the cache stalls the worker for seconds,
+  // which freezes every plot in the window.
+  it("stops drawing annotations once the window passes the cap", async () => {
     const client = createTestClient();
-    const start = TimeStamp.now();
-    const timeRange = new TimeRange(start, start.add(TimeSpan.seconds(10)));
-    await client.ranges.create(
-      Array.from({ length: MAX_ANNOTATIONS + 20 }, () => ({
-        name: `annotation-${id.create()}`,
-        timeRange,
-        color: "#7C3AED",
-      })),
-    );
+    // Far out enough that no other spec's ranges overlap the window, and stepped by
+    // the clock so ranges an earlier run left on the Core stay outside it.
+    const start = TimeStamp.now().add(TimeSpan.days(3650));
+    const timeRange = new TimeRange(start, start.add(TimeSpan.seconds(1)));
+    const create = async (count: number) =>
+      await client.ranges.create(
+        Array.from({ length: count }, () => ({
+          name: `annotation-${id.create()}`,
+          timeRange,
+          color: "#7C3AED",
+        })),
+      );
+    await create(5);
     const provider = mount();
     const props = renderProps(timeRange);
-    await expect
-      .poll(() => {
-        provider.render(props);
-        return provider.state.count;
-      })
-      .toBeGreaterThan(0);
-    expect(provider.state.count).toBeLessThanOrEqual(MAX_ANNOTATIONS);
+    const drawn = () => {
+      provider.render(props);
+      return provider.state.count;
+    };
+    await expect.poll(drawn).toEqual(5);
+    await create(MAX_ANNOTATIONS - 4);
+    await expect.poll(drawn).toEqual(0);
   });
 });

--- a/pluto/src/lineplot/range/aether/provider.ts
+++ b/pluto/src/lineplot/range/aether/provider.ts
@@ -43,12 +43,19 @@ interface InternalState {
   runAsync: status.ErrorHandler;
 }
 
-interface ProviderProps {
+export interface ProviderProps {
   dataToDecimalScale: scale.Scale;
   viewport: box.Box;
   region: box.Box;
   timeRange: TimeRange;
 }
+
+/**
+ * The most ranges the annotation strip fetches for one window. A dense window can
+ * overlap tens of thousands of ranges, which the strip cannot draw legibly in 32
+ * pixels and the worker cannot write through the cache without stalling for seconds.
+ */
+export const MAX_ANNOTATIONS = 100;
 
 // Snaps fetch boundaries outward to a grid roughly an eighth of the viewport wide,
 // so a requery takes a meaningful pan or zoom at any zoom level. Power-of-two grid
@@ -66,6 +73,7 @@ const quantize = (timeRange: TimeRange): TimeRange => {
 
 export class Provider extends aether.Leaf<typeof providerStateZ, InternalState> {
   static readonly TYPE = "range-provider";
+  static readonly stateZ = providerStateZ;
   schema = providerStateZ;
 
   afterUpdate(ctx: aether.Context): void {
@@ -95,7 +103,10 @@ export class Provider extends aether.Leaf<typeof providerStateZ, InternalState> 
     const { dataToDecimalScale, region, viewport, timeRange } = props;
     const { internal: i } = this;
     if (i.client != null)
-      i.retrieve.update(i.client, { overlapsWith: quantize(timeRange) });
+      i.retrieve.update(i.client, {
+        overlapsWith: quantize(timeRange),
+        limit: MAX_ANNOTATIONS,
+      });
     const { draw } = i;
     const ranges = i.retrieve.value ?? [];
     const visible = this.state.visible !== false;

--- a/pluto/src/lineplot/range/aether/provider.ts
+++ b/pluto/src/lineplot/range/aether/provider.ts
@@ -51,9 +51,10 @@ export interface ProviderProps {
 }
 
 /**
- * The most ranges the annotation strip fetches for one window. A dense window can
- * overlap tens of thousands of ranges, which the strip cannot draw legibly in 32
- * pixels and the worker cannot write through the cache without stalling for seconds.
+ * The most ranges the annotation strip draws for one window. A denser window draws
+ * none: the strip cannot label them legibly in 32 pixels, and the Core answers a
+ * limited query in key order, so drawing a truncated answer would show an arbitrary
+ * subset that changes as the window moves.
  */
 export const MAX_ANNOTATIONS = 100;
 
@@ -105,10 +106,12 @@ export class Provider extends aether.Leaf<typeof providerStateZ, InternalState> 
     if (i.client != null)
       i.retrieve.update(i.client, {
         overlapsWith: quantize(timeRange),
-        limit: MAX_ANNOTATIONS,
+        // One over the cap, so a saturated answer is distinguishable from a full one.
+        limit: MAX_ANNOTATIONS + 1,
       });
     const { draw } = i;
-    const ranges = i.retrieve.value ?? [];
+    const fetched = i.retrieve.value ?? [];
+    const ranges = fetched.length > MAX_ANNOTATIONS ? [] : fetched;
     const visible = this.state.visible !== false;
     const regionScale = dataToDecimalScale.scale(box.xBounds(region));
     const cursor = this.state.cursor == null ? null : this.state.cursor.x;

--- a/pluto/src/ranger/queries.spec.ts
+++ b/pluto/src/ranger/queries.spec.ts
@@ -17,7 +17,7 @@ import {
   type ReactElement,
   Suspense,
 } from "react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Ranger } from "@/ranger";
 import { renderHookSuspended } from "@/testutil/render";
@@ -424,6 +424,37 @@ describe("queries", () => {
       expect(result.current.data.length).toBeGreaterThanOrEqual(2);
       expect(result.current.data).toContain(child1.key);
       expect(result.current.data).toContain(child2.key);
+    });
+
+    it("should forward the page bounds to the client", async () => {
+      const parentRange = await client.ranges.create({
+        name: "pagedParent",
+        timeRange: TimeStamp.now().spanRange(TimeSpan.seconds(10)),
+      });
+      await Promise.all(
+        Array.from({ length: 3 }, (_, i) =>
+          client.ranges.create({
+            name: `pagedChild${i}`,
+            timeRange: TimeStamp.now().spanRange(TimeSpan.seconds(1)),
+            parent: parentRange,
+          }),
+        ),
+      );
+      const spy = vi.spyOn(client.ranges.children, "retrieve");
+      try {
+        const { result } = renderHook(() => Ranger.useListChildren(), { wrapper });
+        act(() => {
+          result.current.retrieve(
+            { key: parentRange.key, limit: 2, offset: 0 },
+            { signal: controller.signal },
+          );
+        });
+        await waitFor(() => expect(result.current.variant).toEqual("success"));
+        expect(result.current.data).toHaveLength(2);
+        expect(spy).toHaveBeenCalledWith({ key: parentRange.key, limit: 2, offset: 0 });
+      } finally {
+        spy.mockRestore();
+      }
     });
 
     it("should get individual child ranges using getItem", async () => {

--- a/pluto/src/ranger/queries.ts
+++ b/pluto/src/ranger/queries.ts
@@ -52,18 +52,18 @@ export const useListChildren = Flux.createList<
   ranger.Range
 >({
   name: PLURAL_CHILDREN_RESOURCE_NAME,
-  retrieve: async ({ client, query: { key } }) => {
+  retrieve: async ({ client, query: { key, limit, offset } }) => {
     if (key == null) return [];
-    return await client.ranges.children.retrieve(key);
+    return await client.ranges.children.retrieve({ key, limit, offset });
   },
   retrieveByKey: async ({ client, key }) => await client.ranges.retrieve(key),
-  onChange: ({ client, query: { key } }, handler) => {
+  onChange: ({ client, query: { key, limit, offset } }, handler) => {
     if (key == null) return () => {};
-    return client.ranges.children.onChange(key, handler);
+    return client.ranges.children.onChange({ key, limit, offset }, handler);
   },
-  getCached: ({ client, query: { key } }) => {
+  getCached: ({ client, query: { key, limit, offset } }) => {
     if (key == null) return undefined;
-    return client.ranges.children.getCached(key);
+    return client.ranges.children.getCached({ key, limit, offset });
   },
 });
 


### PR DESCRIPTION
## Linear Issue

[SY-4755](https://linear.app/synnax/issue/SY-4755/plot-range-annotations-fetch-every-overlapping-range-and-freeze-the)
[SY-4756](https://linear.app/synnax/issue/SY-4756/single-channel-retrieves-bypass-the-table-fetch-batcher),
and [SY-4762](https://linear.app/synnax/issue/SY-4762/range-overview-child-list-fetches-every-child-range-and-freezes-the)

## Description

A customer on v0.57 cannot use live plots: a plot paints once, then freezes, while
schematics keep working and neither a Console restart nor a Core restart helps. Two
DevTools traces from their machine, one on 0.57.1 and one on 0.57.2, show the same
failure. Opening a plot fetches every range that overlaps the window, which on their
Core is 16,456,738 bytes, byte-identical in both traces. The Aether worker then enters
`ranger.fetchRequest -> writeThroughMany -> Table.batch -> flush` and never comes back:
RunTask events stop at t=3.0s, no task completes for the remaining 4s of the recording,
and heap climbs 26MB to 185MB under constant GC. Because the worker is the plot's render
thread, every plot in that window stops. Schematics live in their own Console window with
their own worker, which is why they looked healthy.

The annotation strip now asks for at most `MAX_ANNOTATIONS` ranges. The strip is 32
pixels tall and cannot draw more than a handful legibly, and the cache treats `limit` as
a server field, so a limited query refetches on change instead of growing client-side.

The same traces showed one plot panel sending 60 `POST /api/v1/channel/retrieve` calls
inside 30ms, one per channel. Every telemetry source resolves its own channel through
`client.channels.retrieve(key)`, and on a miss the single path called the cluster
directly instead of going through the record table, where the fetch batcher coalesces
concurrent misses. It now resolves through the table, like the keys-only path already
did.

The range overview's child list is the same unbounded-fetch class on the main thread,
so it froze the whole window: `useListChildren` dropped the `{offset: 0, limit: 25}`
the list's fetch-more already sends, and the client's `children` query could not accept
page bounds at all. The `children` query now takes `Key | { key, limit, offset }` with
`serverFields`, mirroring `ontology.dependentSurface`, and the hook forwards the pager
params. A bare key still retrieves every child, so scripting callers are unchanged.
Measured against a parent with 20,000 children: 5.9s unbounded fetch plus 0.6s per
cached recompose before, ~0.5s per 25-item page after, with no main-thread work
proportional to child count. Most of that remaining page time is the Core walking every
child before applying the limit; that push-down is tracked in SY-4763.

Still open, tracked in SY-4755: the cache writes a bulk response through in one
synchronous batch, so any large answer can still stall the worker. `ranger`'s
`fetchSingle` bypasses the fetch batcher the same way `channel`'s did.

Verified against a local 0.57.2 Core: full Pluto suite (4267) and full client suite
(1890) pass, plus workspace `check-types`, `lint`, and `format`. Both new specs were
confirmed to fail without their fix — the annotation spec draws 120 of 120 ranges, and
the channel spec sends 2 requests instead of 1.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR limits line-plot annotation retrieval and routes single-channel cache misses through the record table for request batching.
- Caps each annotation query at 100 ranges.
- Coalesces concurrent single-channel retrievals.
- Adds regression tests for both paths.

<h3>Confidence Score: 4/5</h3>

The PR needs a deterministic visibility-aware range selection before merge because the new cap can hide annotations in the current viewport.

The channel batching path preserves the existing retrieval contract, but the annotation query limits an expanded window in UUID-key order before the provider clips off-screen ranges.

**Files Needing Attention:** pluto/src/lineplot/range/aether/provider.ts, pluto/src/lineplot/range/aether/provider.spec.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| client/ts/src/channel/client.ts | Routes single-channel misses through the record table while preserving transformation, caching, and not-found behavior. |
| client/ts/src/channel/channel.spec.ts | Verifies that concurrent single-channel misses produce one retrieve request. |
| pluto/src/lineplot/range/aether/provider.ts | Adds the annotation cap, but the unordered widened query can exclude visible ranges. |
| pluto/src/lineplot/range/aether/provider.spec.ts | Verifies the count cap but does not cover visible-range retention, and its new comment needs reflow. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    V[Visible plot window] --> Q[Outward quantization]
    Q --> R[Range overlap query]
    R --> L[First 100 UUID-ordered matches]
    L --> C[Clip off-screen ranges]
    C --> A[Rendered annotations]
```

<sub>Reviews (1): Last reviewed commit: ["SY-4755: Cap the ranges a plot fetches f..."](https://github.com/synnaxlabs/synnax/commit/bf31901f5d733502e15015f68adb1fec8cae04a6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56853073)</sub>

> Greptile also left **2 inline comments** on this PR.

<details><summary><h4>Context used (3)</h4></summary>

- Context used - CLAUDE.md ([source](https://github.com/synnaxlabs/synnax/blob/main/CLAUDE.md))
- Knowledge Base — [Console data tools and visualization](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/console-data-tools.md)
- Knowledge Base — [TypeScript and Python SDKs](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/typescript-python-sdks.md)
</details>


<!-- /greptile_comment -->
