### PR TITLE
SY-4758: Poll for the arc text a dispatch materializes

### DIFF
--- a/client/ts/src/arc/arc.spec.ts
+++ b/client/ts/src/arc/arc.spec.ts
@@ -41,6 +41,8 @@ describe("arc", () => {
     });
   });
 
+  // A dispatch posts its ops to the Core, and the materialized text reaches this
+  // client's cache through the change stream, so reads after one poll.
   describe("dispatch", () => {
     it("materializes insert_char ops into the document's raw text", async () => {
       const created = await client.arcs.create(newTextArc(`dispatch-${id.create()}`));
@@ -61,8 +63,9 @@ describe("arc", () => {
       const insertOps = gen.insert(0, "hello").map((op) => arc.insertChar(op));
       const deleteOps = gen.delete(0, 1).map((op) => arc.deleteChar(op));
       await client.arcs.dispatch(created.key, [...insertOps, ...deleteOps]);
-      const res = await client.arcs.retrieve(created.key);
-      expect(res.text.raw).toEqual("ello");
+      await expect
+        .poll(async () => (await client.arcs.retrieve(created.key)).text.raw)
+        .toEqual("ello");
     });
 
     it("reclaims tombstoned characters via a forget_chars dispatch", async () => {
@@ -77,10 +80,16 @@ describe("arc", () => {
       await client.arcs.dispatch(created.key, [
         arc.forgetChars({ ids: deletes.map((op) => op.id) }),
       ]);
-      const res = await client.arcs.retrieve(created.key);
-      expect(res.text.raw).toEqual("hell");
-      expect(res.text.doc.deletes).toHaveLength(0);
-      expect(res.text.doc.inserts).toHaveLength(4);
+      await expect
+        .poll(async () => {
+          const { text } = await client.arcs.retrieve(created.key);
+          return {
+            raw: text.raw,
+            deletes: text.doc.deletes.length,
+            inserts: text.doc.inserts.length,
+          };
+        })
+        .toEqual({ raw: "hell", deletes: 0, inserts: 4 });
     });
   });
 


### PR DESCRIPTION
## Linear Issue

[SY-4758](https://linear.app/synnax/issue/SY-4758/live-core-specs-flake-locally-in-the-client-and-pluto-suites)

## Description

Two `arc.spec` tests read the materialized text straight after a dispatch. A dispatch
posts its ops to the Core, and the local reducer only appends to `text.doc.inserts` and
`text.doc.deletes`, so `text.raw` reaches the client through the change stream. Both
reads raced it, and one was seen returning the empty text of the freshly created arc.
They now poll, matching the sibling test in the same block.

This is one of several live-Core flakes seen while running the client and Pluto suites
repeatedly against one Core. The rest are inventoried in SY-4758; none of them
reproduced on demand in about 60 full-suite runs, so they are not touched here.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR makes two Arc integration tests wait for asynchronously materialized text instead of reading it immediately after dispatch.
- Polls until insert and delete operations appear in the document’s raw text.
- Polls raw text and document-operation counts together after forgotten characters are reclaimed.
- Documents why post-dispatch assertions must accommodate change-stream propagation.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because it only strengthens asynchronous integration-test synchronization and introduces no actionable defect.

The revised assertions repeatedly retrieve the Arc until the expected server-materialized state reaches the client, matching the asynchronous dispatch and change-stream behavior described by the test.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| client/ts/src/arc/arc.spec.ts | Replaces race-prone immediate assertions with polling assertions that wait for a consistent materialized Arc state. |

<sub>Reviews (1): Last reviewed commit: ["SY-4758: Poll for the arc text a dispatc..."](https://github.com/synnaxlabs/synnax/commit/8722cf13e6387b2647c3ec593214b0e46708f98a) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56865421)</sub>

<!-- /greptile_comment -->