### PR TITLE
SY-4760: Add cut support to Pluto diagram clipboards (Part 1)

### DIFF
--- a/pluto/src/arc/graph/Editor.tsx
+++ b/pluto/src/arc/graph/Editor.tsx
@@ -127,7 +127,7 @@ export const Editor = ({
   const { undo, canUndo } = useUndo();
   const { redo, canRedo } = useRedo();
 
-  const { onCopy, onPaste } = useClipboard({
+  const { onCopy, onCut, onPaste } = useClipboard({
     key,
     selected,
     onPaste: onSelectionChange,
@@ -178,6 +178,7 @@ export const Editor = ({
         editable={editable}
         onContextMenu={contextMenu.open}
         onCopy={onCopy}
+        onCut={onCut}
         onPaste={onPaste}
         nodes={nodes}
         edges={edges}

--- a/pluto/src/arc/graph/Editor.tsx
+++ b/pluto/src/arc/graph/Editor.tsx
@@ -130,6 +130,7 @@ export const Editor = ({
   const { onCopy, onCut, onPaste } = useClipboard({
     key,
     selected,
+    onCut: onSelectionChange,
     onPaste: onSelectionChange,
   });
 

--- a/pluto/src/arc/graph/clipboard.spec.tsx
+++ b/pluto/src/arc/graph/clipboard.spec.tsx
@@ -95,14 +95,18 @@ const fakeClipboardEvent = () => {
 };
 
 describe("arc graph clipboard", () => {
-  const setup = async (selected: string[], onPaste?: (keys: string[]) => void) => {
+  const setup = async (
+    selected: string[],
+    onPaste?: (keys: string[]) => void,
+    onCut?: (keys: string[]) => void,
+  ) => {
     const { key } = await createGraphArc();
     await loadArc(key);
     const { result } = renderHook(
       () => ({
         nodes: Arc.useAllNodes({ key }),
         edges: Arc.useAllEdges({ key }),
-        clipboard: useClipboard({ key, selected, onPaste }),
+        clipboard: useClipboard({ key, selected, onPaste, onCut }),
       }),
       { wrapper },
     );
@@ -196,6 +200,18 @@ describe("arc graph clipboard", () => {
 
     await waitFor(() => expect(result.current.nodes.map((n) => n.key)).toEqual([N2]));
     expect(result.current.edges).toHaveLength(0);
+  });
+
+  it("should report the surviving selection to onCut", async () => {
+    const onCut = vi.fn();
+    const { result } = await setup([N1], undefined, onCut);
+
+    const e = fakeClipboardEvent();
+    await act(async () => {
+      result.current.clipboard.onCut(e, xy.ZERO);
+    });
+
+    expect(onCut).toHaveBeenCalledWith([]);
   });
 
   it("should not change the cache when the selection cuts nothing", async () => {

--- a/pluto/src/arc/graph/clipboard.spec.tsx
+++ b/pluto/src/arc/graph/clipboard.spec.tsx
@@ -173,4 +173,28 @@ describe("arc graph clipboard", () => {
       .map((n) => n.key);
     expect(onPaste).toHaveBeenCalledWith(newKeys);
   });
+
+  it("should remove the cut subgraph from the cache", async () => {
+    const { result } = await setup([N1, N2, EDGE_KEY]);
+
+    const e = fakeClipboardEvent();
+    await act(async () => {
+      result.current.clipboard.onCut(e, xy.ZERO);
+    });
+
+    await waitFor(() => expect(result.current.nodes).toHaveLength(0));
+    expect(result.current.edges).toHaveLength(0);
+  });
+
+  it("should not change the cache when the selection cuts nothing", async () => {
+    const { result } = await setup(["does-not-exist"]);
+
+    const e = fakeClipboardEvent();
+    await act(async () => {
+      result.current.clipboard.onCut(e, xy.ZERO);
+    });
+
+    expect(result.current.nodes).toHaveLength(2);
+    expect(result.current.edges).toHaveLength(1);
+  });
 });

--- a/pluto/src/arc/graph/clipboard.spec.tsx
+++ b/pluto/src/arc/graph/clipboard.spec.tsx
@@ -186,6 +186,18 @@ describe("arc graph clipboard", () => {
     expect(result.current.edges).toHaveLength(0);
   });
 
+  it("should remove the connected edge when cutting a node alone", async () => {
+    const { result } = await setup([N1]);
+
+    const e = fakeClipboardEvent();
+    await act(async () => {
+      result.current.clipboard.onCut(e, xy.ZERO);
+    });
+
+    await waitFor(() => expect(result.current.nodes.map((n) => n.key)).toEqual([N2]));
+    expect(result.current.edges).toHaveLength(0);
+  });
+
   it("should not change the cache when the selection cuts nothing", async () => {
     const { result } = await setup(["does-not-exist"]);
 

--- a/pluto/src/arc/graph/clipboard.ts
+++ b/pluto/src/arc/graph/clipboard.ts
@@ -54,6 +54,15 @@ export const useClipboard = ({
       dispatch({ key, actions });
       onPaste?.(newKeys);
     },
+    remove: ({ nodes, edges }) => {
+      dispatch({
+        key,
+        actions: [
+          ...nodes.map((k) => arc.removeNode({ key: k })),
+          ...edges.map((k) => arc.removeEdge({ key: k })),
+        ],
+      });
+    },
   };
   return Diagram.useClipboard({ adapter, selected });
 };

--- a/pluto/src/arc/graph/clipboard.ts
+++ b/pluto/src/arc/graph/clipboard.ts
@@ -21,12 +21,14 @@ const MIME = "web application/synnax-arc+json";
 export interface UseClipboardParams {
   key: arc.Key;
   selected?: string[];
+  onCut?: (remaining: string[]) => void;
   onPaste?: (newKeys: string[]) => void;
 }
 
 export const useClipboard = ({
   key,
   selected,
+  onCut,
   onPaste,
 }: UseClipboardParams): Diagram.UseClipboardReturn => {
   const { dispatch } = useDispatch();
@@ -64,5 +66,5 @@ export const useClipboard = ({
       });
     },
   };
-  return Diagram.useClipboard({ adapter, selected });
+  return Diagram.useClipboard({ adapter, selected, onCut });
 };

--- a/pluto/src/schematic/Schematic.tsx
+++ b/pluto/src/schematic/Schematic.tsx
@@ -127,7 +127,7 @@ export const Schematic = ({
   const { undo, canUndo } = useUndo();
   const { redo, canRedo } = useRedo();
 
-  const { onCopy, onPaste } = useClipboard({
+  const { onCopy, onCut, onPaste } = useClipboard({
     selected,
     onPaste: onSelectionChange,
   });
@@ -177,6 +177,7 @@ export const Schematic = ({
       onDoubleClick={onDoubleClick}
       onContextMenu={contextMenu.open}
       onCopy={onCopy}
+      onCut={onCut}
       onPaste={onPaste}
       nodes={nodes}
       edges={edges}

--- a/pluto/src/schematic/Schematic.tsx
+++ b/pluto/src/schematic/Schematic.tsx
@@ -129,6 +129,7 @@ export const Schematic = ({
 
   const { onCopy, onCut, onPaste } = useClipboard({
     selected,
+    onCut: onSelectionChange,
     onPaste: onSelectionChange,
   });
 

--- a/pluto/src/schematic/clipboard.spec.tsx
+++ b/pluto/src/schematic/clipboard.spec.tsx
@@ -209,6 +209,100 @@ describe("schematic clipboard", () => {
       expect(event.preventDefault).not.toHaveBeenCalled();
     });
 
+    // Chain n1 -e1-> n2 -e2-> n3 for cut tests that leave connected edges
+    // unselected. Cut must remove those edges so no dangling edge persists.
+    const createChainSchematic = async (): Promise<schematic.Schematic> => {
+      const proj = await client.projects.create({
+        name: `project_${uuid.create()}`,
+        layout: {},
+      });
+      return await client.schematics.create(proj.key, {
+        name: `schem_${uuid.create()}`,
+        nodes: [
+          { key: "n1", position: { x: 0, y: 0 } },
+          { key: "n2", position: { x: 100, y: 100 } },
+          { key: "n3", position: { x: 200, y: 200 } },
+        ],
+        edges: [
+          {
+            key: "e1",
+            source: { node: "n1", param: "out" },
+            target: { node: "n2", param: "in" },
+          },
+          {
+            key: "e2",
+            source: { node: "n2", param: "out" },
+            target: { node: "n3", param: "in" },
+          },
+        ],
+        configs: {},
+      });
+    };
+
+    const setupChain = async (selected: string[]) => {
+      const Wrapper = await createAsyncSynnaxWrapper({ client });
+      const schem = await createChainSchematic();
+      await loadSchematic(Wrapper, schem.key);
+      const { result } = renderHook(
+        () => ({
+          clipboard: Schematic.useClipboard({ selected }),
+          nodes: Schematic.useAllNodes({ key: schem.key }),
+          edges: Schematic.useAllEdges({ key: schem.key }),
+        }),
+        { wrapper: scoped(Wrapper, schem.key) },
+      );
+      return result;
+    };
+
+    it("removes both unselected connected edges when cutting a middle node", async () => {
+      const result = await setupChain(["n2"]);
+
+      const data = createDataTransfer();
+      const event = createClipboardEvent(data);
+      await act(async () => {
+        result.current.clipboard.onCut(event, xy.ZERO);
+      });
+
+      // The clipboard payload carries only the selection.
+      const payload = JSON.parse(data.getData(MIME));
+      expect(payload.nodes.map((n: schematic.Node) => n.key)).toEqual(["n2"]);
+      expect(payload.edges).toHaveLength(0);
+      await waitFor(() =>
+        expect(result.current.nodes.map((n) => n.key).sort()).toEqual(["n1", "n3"]),
+      );
+      expect(result.current.edges).toHaveLength(0);
+    });
+
+    it("keeps edges not connected to the cut node", async () => {
+      const result = await setupChain(["n1"]);
+
+      const data = createDataTransfer();
+      const event = createClipboardEvent(data);
+      await act(async () => {
+        result.current.clipboard.onCut(event, xy.ZERO);
+      });
+
+      await waitFor(() =>
+        expect(result.current.nodes.map((n) => n.key).sort()).toEqual(["n2", "n3"]),
+      );
+      expect(result.current.edges.map((e) => e.key)).toEqual(["e2"]);
+    });
+
+    it("cuts an edge alone without touching its endpoint nodes", async () => {
+      const result = await setupChain(["e1"]);
+
+      const data = createDataTransfer();
+      const event = createClipboardEvent(data);
+      await act(async () => {
+        result.current.clipboard.onCut(event, xy.ZERO);
+      });
+
+      await waitFor(() =>
+        expect(result.current.edges.map((e) => e.key)).toEqual(["e2"]),
+      );
+      expect(result.current.nodes).toHaveLength(3);
+    });
+
     it("pastes copied nodes and edges with fresh keys at the cursor offset", async () => {
       const Wrapper = await createAsyncSynnaxWrapper({ client });
       const schem = await createSchematicWithGraph();

--- a/pluto/src/schematic/clipboard.spec.tsx
+++ b/pluto/src/schematic/clipboard.spec.tsx
@@ -159,6 +159,56 @@ describe("schematic clipboard", () => {
       expect(event.preventDefault).not.toHaveBeenCalled();
     });
 
+    it("removes the cut nodes and edges from the schematic on cut", async () => {
+      const Wrapper = await createAsyncSynnaxWrapper({ client });
+      const schem = await createSchematicWithGraph();
+      await loadSchematic(Wrapper, schem.key);
+
+      const { result } = renderHook(
+        () => ({
+          clipboard: Schematic.useClipboard({ selected: ["n1", "n2", "e1"] }),
+          nodes: Schematic.useAllNodes({ key: schem.key }),
+          edges: Schematic.useAllEdges({ key: schem.key }),
+        }),
+        { wrapper: scoped(Wrapper, schem.key) },
+      );
+
+      const data = createDataTransfer();
+      const event = createClipboardEvent(data);
+      await act(async () => {
+        result.current.clipboard.onCut(event, xy.ZERO);
+      });
+
+      expect(data.getData(MIME)).not.toBe("");
+      await waitFor(() =>
+        expect(result.current.nodes.map((n) => n.key)).toEqual(["n3"]),
+      );
+      expect(result.current.edges).toHaveLength(0);
+      expect(event.preventDefault).toHaveBeenCalled();
+    });
+
+    it("does nothing on cut when nothing is selected", async () => {
+      const Wrapper = await createAsyncSynnaxWrapper({ client });
+      const schem = await createSchematicWithGraph();
+      await loadSchematic(Wrapper, schem.key);
+
+      const { result } = renderHook(
+        () => ({
+          clipboard: Schematic.useClipboard({ selected: [] }),
+          nodes: Schematic.useAllNodes({ key: schem.key }),
+        }),
+        { wrapper: scoped(Wrapper, schem.key) },
+      );
+
+      const data = createDataTransfer();
+      const event = createClipboardEvent(data);
+      act(() => result.current.clipboard.onCut(event, xy.ZERO));
+
+      expect(data.getData(MIME)).toBe("");
+      expect(result.current.nodes).toHaveLength(3);
+      expect(event.preventDefault).not.toHaveBeenCalled();
+    });
+
     it("pastes copied nodes and edges with fresh keys at the cursor offset", async () => {
       const Wrapper = await createAsyncSynnaxWrapper({ client });
       const schem = await createSchematicWithGraph();

--- a/pluto/src/schematic/clipboard.spec.tsx
+++ b/pluto/src/schematic/clipboard.spec.tsx
@@ -239,13 +239,13 @@ describe("schematic clipboard", () => {
       });
     };
 
-    const setupChain = async (selected: string[]) => {
+    const setupChain = async (selected: string[], onCut?: (keys: string[]) => void) => {
       const Wrapper = await createAsyncSynnaxWrapper({ client });
       const schem = await createChainSchematic();
       await loadSchematic(Wrapper, schem.key);
       const { result } = renderHook(
         () => ({
-          clipboard: Schematic.useClipboard({ selected }),
+          clipboard: Schematic.useClipboard({ selected, onCut }),
           nodes: Schematic.useAllNodes({ key: schem.key }),
           edges: Schematic.useAllEdges({ key: schem.key }),
         }),
@@ -286,6 +286,19 @@ describe("schematic clipboard", () => {
         expect(result.current.nodes.map((n) => n.key).sort()).toEqual(["n2", "n3"]),
       );
       expect(result.current.edges.map((e) => e.key)).toEqual(["e2"]);
+    });
+
+    it("reports the surviving selection to onCut", async () => {
+      const onCut = vi.fn();
+      const result = await setupChain(["n2"], onCut);
+
+      const data = createDataTransfer();
+      const event = createClipboardEvent(data);
+      await act(async () => {
+        result.current.clipboard.onCut(event, xy.ZERO);
+      });
+
+      expect(onCut).toHaveBeenCalledWith([]);
     });
 
     it("cuts an edge alone without touching its endpoint nodes", async () => {

--- a/pluto/src/schematic/clipboard.ts
+++ b/pluto/src/schematic/clipboard.ts
@@ -52,6 +52,12 @@ export const useClipboard = ({
       dispatch(actions);
       if (actions.length > 0) onPaste?.(newKeys);
     },
+    remove: ({ nodes, edges }) => {
+      dispatch([
+        ...nodes.map((key) => schematic.removeNode({ key })),
+        ...edges.map((key) => schematic.removeEdge({ key })),
+      ]);
+    },
   };
   return Diagram.useClipboard({ adapter, selected });
 };

--- a/pluto/src/schematic/clipboard.ts
+++ b/pluto/src/schematic/clipboard.ts
@@ -53,9 +53,20 @@ export const useClipboard = ({
       if (actions.length > 0) onPaste?.(newKeys);
     },
     remove: ({ nodes, edges }) => {
+      // removeNode does not cascade, so cut unselected connected edges too;
+      // they would otherwise persist as invisible dangling edges.
+      const cut = new Set(nodes);
+      const cached = client?.schematics.getCached(key);
+      const connected = query.isLive(cached)
+        ? cached.edges
+            .filter((e) => cut.has(e.source.node) || cut.has(e.target.node))
+            .map((e) => e.key)
+        : [];
       dispatch([
         ...nodes.map((key) => schematic.removeNode({ key })),
-        ...edges.map((key) => schematic.removeEdge({ key })),
+        ...[...new Set([...edges, ...connected])].map((key) =>
+          schematic.removeEdge({ key }),
+        ),
       ]);
     },
   };

--- a/pluto/src/schematic/clipboard.ts
+++ b/pluto/src/schematic/clipboard.ts
@@ -21,11 +21,13 @@ const MIME = "web application/synnax-schematic+json";
 
 export interface UseClipboardParams {
   selected?: string[];
+  onCut?: (remaining: string[]) => void;
   onPaste?: (newKeys: string[]) => void;
 }
 
 export const useClipboard = ({
   selected,
+  onCut,
   onPaste,
 }: UseClipboardParams): Diagram.UseClipboardReturn => {
   const key = useKey();
@@ -70,5 +72,5 @@ export const useClipboard = ({
       ]);
     },
   };
-  return Diagram.useClipboard({ adapter, selected });
+  return Diagram.useClipboard({ adapter, selected, onCut });
 };

--- a/pluto/src/vis/diagram/Diagram.tsx
+++ b/pluto/src/vis/diagram/Diagram.tsx
@@ -140,7 +140,7 @@ export type ClipboardHandler = (
 
 export interface DiagramProps
   extends
-    Omit<ComponentPropsWithRef<"div">, "onError" | "onCopy" | "onPaste">,
+    Omit<ComponentPropsWithRef<"div">, "onError" | "onCopy" | "onCut" | "onPaste">,
     Pick<z.infer<typeof diagram.Diagram.stateZ>, "visible" | "autoRenderInterval">,
     Aether.ComponentProps,
     Pick<
@@ -176,6 +176,12 @@ export interface DiagramProps
    * the most recent mousemove over the diagram.
    */
   onCopy?: ClipboardHandler;
+  /**
+   * Called when a cut event fires on the diagram. The second argument is the
+   * cursor position in diagram space at the moment of the cut, derived from
+   * the most recent mousemove over the diagram. Ignored when not editable.
+   */
+  onCut?: ClipboardHandler;
   /**
    * Called when a paste event fires on the diagram. The second argument is the
    * cursor position in diagram space at the moment of the paste, derived from
@@ -287,6 +293,7 @@ export const create = ({
     autoRenderInterval,
     onDoubleClick,
     onCopy,
+    onCut,
     onPaste,
     onMouseMove,
     onContextMenu,
@@ -540,6 +547,14 @@ export const create = ({
       [onCopy, cursorInDiagramSpace],
     );
 
+    const handleCut = useCallback(
+      (e: ReactClipboardEvent<HTMLDivElement>): void => {
+        if (!editable) return;
+        onCut?.(e, cursorInDiagramSpace(e.currentTarget));
+      },
+      [onCut, editable, cursorInDiagramSpace],
+    );
+
     const handlePaste = useCallback(
       (e: ReactClipboardEvent<HTMLDivElement>): void => {
         onPaste?.(e, cursorInDiagramSpace(e.currentTarget));
@@ -553,6 +568,7 @@ export const create = ({
         ref={containerRefs}
         onDoubleClick={onDoubleClick}
         onCopy={handleCopy}
+        onCut={handleCut}
         onPaste={handlePaste}
         onMouseMove={handleMouseMove}
         onContextMenu={onContextMenu}

--- a/pluto/src/vis/diagram/clipboard.spec.ts
+++ b/pluto/src/vis/diagram/clipboard.spec.ts
@@ -80,8 +80,11 @@ const pasteResultOf = (
   adapter: ClipboardAdapter<Node, Edge>,
 ): PasteResult<Node, Edge> => vi.mocked(adapter.apply).mock.calls[0][0];
 
-const renderClipboard = (adapter: ClipboardAdapter<Node, Edge>, selected?: string[]) =>
-  renderHook(() => useClipboard({ adapter, selected })).result.current;
+const renderClipboard = (
+  adapter: ClipboardAdapter<Node, Edge>,
+  selected?: string[],
+  onCut?: (remaining: string[]) => void,
+) => renderHook(() => useClipboard({ adapter, selected, onCut })).result.current;
 
 const readPayload = (store: Map<string, string>) => JSON.parse(store.get(MIME) ?? "");
 
@@ -246,6 +249,38 @@ describe("clipboard", () => {
         nodes: ["a", "b"],
         edges: ["e1"],
       });
+    });
+
+    it("should report the surviving selection to onCut", () => {
+      const snapshot: Snapshot<Node, Edge> = {
+        nodes: [node("a", xy.ZERO), node("b", xy.ZERO)],
+        edges: [],
+        configs: {},
+      };
+      const onCutCb = vi.fn();
+      // "b" is selected but absent from the snapshot, so it survives the cut.
+      const snapshotOnlyA = { ...snapshot, nodes: [node("a", xy.ZERO)] };
+      const { onCut } = renderClipboard(
+        makeAdapter(snapshotOnlyA),
+        ["a", "b"],
+        onCutCb,
+      );
+      const { event } = fakeClipboardEvent();
+      onCut(event, xy.ZERO);
+      expect(onCutCb).toHaveBeenCalledWith(["b"]);
+    });
+
+    it("should not invoke onCut when nothing was written", () => {
+      const snapshot: Snapshot<Node, Edge> = {
+        nodes: [node("a", xy.ZERO)],
+        edges: [],
+        configs: {},
+      };
+      const onCutCb = vi.fn();
+      const { onCut } = renderClipboard(makeAdapter(snapshot), [], onCutCb);
+      const { event } = fakeClipboardEvent();
+      onCut(event, xy.ZERO);
+      expect(onCutCb).not.toHaveBeenCalled();
     });
 
     it("should not remove anything when nothing is selected", () => {

--- a/pluto/src/vis/diagram/clipboard.spec.ts
+++ b/pluto/src/vis/diagram/clipboard.spec.ts
@@ -73,6 +73,7 @@ const makeAdapter = (
   edgeKey,
   getSnapshot: () => snapshot,
   apply: vi.fn(),
+  remove: vi.fn(),
 });
 
 const pasteResultOf = (
@@ -223,6 +224,61 @@ describe("clipboard", () => {
       onCopy(event, xy.ZERO);
       expect(preventDefault).not.toHaveBeenCalled();
       expect(store.has(MIME)).toBe(false);
+    });
+  });
+
+  describe("onCut", () => {
+    it("should write the selection and remove it from the diagram", () => {
+      const snapshot: Snapshot<Node, Edge> = {
+        nodes: [node("a", xy.ZERO), node("b", xy.ZERO)],
+        edges: [edge("e1", "a", "b")],
+        configs: {},
+      };
+      const adapter = makeAdapter(snapshot);
+      const { onCut } = renderClipboard(adapter, ["a", "b", "e1"]);
+      const { event, store, preventDefault } = fakeClipboardEvent();
+      onCut(event, xy.ZERO);
+      expect(preventDefault).toHaveBeenCalled();
+      const payload = readPayload(store);
+      expect(payload.nodes.map((n: Node) => n.key)).toEqual(["a", "b"]);
+      expect(payload.edges.map((e: Edge) => e.key)).toEqual(["e1"]);
+      expect(adapter.remove).toHaveBeenCalledWith({
+        nodes: ["a", "b"],
+        edges: ["e1"],
+      });
+    });
+
+    it("should not remove anything when nothing is selected", () => {
+      const snapshot: Snapshot<Node, Edge> = {
+        nodes: [node("a", xy.ZERO)],
+        edges: [],
+        configs: {},
+      };
+      const adapter = makeAdapter(snapshot);
+      const { onCut } = renderClipboard(adapter);
+      const { event, store, preventDefault } = fakeClipboardEvent();
+      onCut(event, xy.ZERO);
+      expect(preventDefault).not.toHaveBeenCalled();
+      expect(store.has(MIME)).toBe(false);
+      expect(adapter.remove).not.toHaveBeenCalled();
+    });
+
+    it("should defer to the browser when a text selection exists", () => {
+      vi.spyOn(window, "getSelection").mockReturnValue({
+        toString: () => "selected text",
+      } as Selection);
+      const snapshot: Snapshot<Node, Edge> = {
+        nodes: [node("a", xy.ZERO)],
+        edges: [],
+        configs: {},
+      };
+      const adapter = makeAdapter(snapshot);
+      const { onCut } = renderClipboard(adapter, ["a"]);
+      const { event, store, preventDefault } = fakeClipboardEvent();
+      onCut(event, xy.ZERO);
+      expect(preventDefault).not.toHaveBeenCalled();
+      expect(store.has(MIME)).toBe(false);
+      expect(adapter.remove).not.toHaveBeenCalled();
     });
   });
 

--- a/pluto/src/vis/diagram/clipboard.ts
+++ b/pluto/src/vis/diagram/clipboard.ts
@@ -8,7 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { type record, uuid, xy } from "@synnaxlabs/x";
-import { useCallback } from "react";
+import { type ClipboardEvent, useCallback } from "react";
 
 import { useSyncedRef } from "@/hooks";
 import { type ClipboardHandler } from "@/vis/diagram/Diagram";
@@ -67,8 +67,14 @@ export interface PasteResult<N extends ClipboardNode, E extends ClipboardEdge> {
   newKeys: string[];
 }
 
+/** SelectionKeys identifies clipboard items by key, split by kind. */
+export interface SelectionKeys {
+  nodes: string[];
+  edges: string[];
+}
+
 /**
- * ClipboardAdapter binds the generic copy/paste mechanics to a diagram domain.
+ * ClipboardAdapter binds the generic cut/copy/paste mechanics to a diagram domain.
  * It deals only in plain diagram data: the adapter reads a snapshot to copy and
  * receives a paste result to apply. The diagram has no knowledge of how that data
  * is stored or persisted.
@@ -85,6 +91,8 @@ export interface ClipboardAdapter<N extends ClipboardNode, E extends ClipboardEd
   getSnapshot: () => Snapshot<N, E> | null;
   /** apply persists a paste result. Called only when at least one item pasted. */
   apply: (result: PasteResult<N, E>) => void;
+  /** remove deletes the given items from the diagram. Called by cut after it copies. */
+  remove: (keys: SelectionKeys) => void;
 }
 
 export interface UseClipboardParams<N extends ClipboardNode, E extends ClipboardEdge> {
@@ -94,6 +102,7 @@ export interface UseClipboardParams<N extends ClipboardNode, E extends Clipboard
 
 export interface UseClipboardReturn {
   onCopy: ClipboardHandler;
+  onCut: ClipboardHandler;
   onPaste: ClipboardHandler;
 }
 
@@ -110,8 +119,8 @@ const centroid = (nodes: ClipboardNode[]): xy.XY => {
 };
 
 /**
- * useClipboard provides copy and paste handlers for a node/edge diagram. It owns
- * the clipboard mechanics (MIME plumbing, version gating, anchor geometry, key
+ * useClipboard provides copy, cut, and paste handlers for a node/edge diagram. It
+ * owns the clipboard mechanics (MIME plumbing, version gating, anchor geometry, key
  * remapping); the adapter supplies the diagram data and persists the result.
  */
 export const useClipboard = <N extends ClipboardNode, E extends ClipboardEdge>({
@@ -121,34 +130,57 @@ export const useClipboard = <N extends ClipboardNode, E extends ClipboardEdge>({
   const adapterRef = useSyncedRef(adapter);
   const selectedRef = useSyncedRef(selected ?? []);
 
-  const onCopy = useCallback<ClipboardHandler>((e) => {
-    // Defer to the browser if the user has a real text selection.
-    const text = window.getSelection()?.toString();
-    if (text != null && text.length > 0) return;
-    const { mime, edgeKey, getSnapshot } = adapterRef.current;
-    const snapshot = getSnapshot();
-    if (snapshot == null) return;
-    const sel = new Set(selectedRef.current);
-    if (sel.size === 0) return;
-    const nodes = snapshot.nodes.filter((n) => sel.has(n.key));
-    const edges = snapshot.edges.filter((edge) => sel.has(edgeKey(edge)));
-    if (nodes.length === 0 && edges.length === 0) return;
-    const configs: Record<string, record.Unknown> = {};
-    for (const k of [...nodes.map((n) => n.key), ...edges.map(edgeKey)]) {
-      const c = snapshot.configs[k];
-      if (c != null) configs[k] = c;
-    }
-    const payload: Payload<N, E> = {
-      version: VERSION,
-      nodes,
-      edges,
-      configs,
-      anchor: centroid(nodes),
-    };
-    e.preventDefault();
-    e.clipboardData.setData(mime, JSON.stringify(payload));
-    e.clipboardData.setData("text/plain", describe(nodes.length, edges.length));
-  }, []);
+  // Writes the selection to the event's clipboard data. Returns the written keys,
+  // or null when nothing was written.
+  const writeSelection = useCallback(
+    (e: ClipboardEvent<HTMLDivElement>): SelectionKeys | null => {
+      // Defer to the browser if the user has a real text selection.
+      const text = window.getSelection()?.toString();
+      if (text != null && text.length > 0) return null;
+      const { mime, edgeKey, getSnapshot } = adapterRef.current;
+      const snapshot = getSnapshot();
+      if (snapshot == null) return null;
+      const sel = new Set(selectedRef.current);
+      if (sel.size === 0) return null;
+      const nodes = snapshot.nodes.filter((n) => sel.has(n.key));
+      const edges = snapshot.edges.filter((edge) => sel.has(edgeKey(edge)));
+      if (nodes.length === 0 && edges.length === 0) return null;
+      const keys: SelectionKeys = {
+        nodes: nodes.map((n) => n.key),
+        edges: edges.map(edgeKey),
+      };
+      const configs: Record<string, record.Unknown> = {};
+      for (const k of [...keys.nodes, ...keys.edges]) {
+        const c = snapshot.configs[k];
+        if (c != null) configs[k] = c;
+      }
+      const payload: Payload<N, E> = {
+        version: VERSION,
+        nodes,
+        edges,
+        configs,
+        anchor: centroid(nodes),
+      };
+      e.preventDefault();
+      e.clipboardData.setData(mime, JSON.stringify(payload));
+      e.clipboardData.setData("text/plain", describe(nodes.length, edges.length));
+      return keys;
+    },
+    [],
+  );
+
+  const onCopy = useCallback<ClipboardHandler>(
+    (e) => void writeSelection(e),
+    [writeSelection],
+  );
+
+  const onCut = useCallback<ClipboardHandler>(
+    (e) => {
+      const keys = writeSelection(e);
+      if (keys != null) adapterRef.current.remove(keys);
+    },
+    [writeSelection],
+  );
 
   const onPaste = useCallback<ClipboardHandler>((e, cursor) => {
     const { mime, edgeKey, apply } = adapterRef.current;
@@ -190,5 +222,5 @@ export const useClipboard = <N extends ClipboardNode, E extends ClipboardEdge>({
     apply({ nodes, edges, newKeys: Object.values(remap) });
   }, []);
 
-  return { onCopy, onPaste };
+  return { onCopy, onCut, onPaste };
 };

--- a/pluto/src/vis/diagram/clipboard.ts
+++ b/pluto/src/vis/diagram/clipboard.ts
@@ -98,6 +98,8 @@ export interface ClipboardAdapter<N extends ClipboardNode, E extends ClipboardEd
 export interface UseClipboardParams<N extends ClipboardNode, E extends ClipboardEdge> {
   adapter: ClipboardAdapter<N, E>;
   selected?: string[];
+  /** onCut receives the selection that survives a cut. */
+  onCut?: (remaining: string[]) => void;
 }
 
 export interface UseClipboardReturn {
@@ -126,9 +128,11 @@ const centroid = (nodes: ClipboardNode[]): xy.XY => {
 export const useClipboard = <N extends ClipboardNode, E extends ClipboardEdge>({
   adapter,
   selected,
+  onCut: onCutProp,
 }: UseClipboardParams<N, E>): UseClipboardReturn => {
   const adapterRef = useSyncedRef(adapter);
   const selectedRef = useSyncedRef(selected ?? []);
+  const onCutRef = useSyncedRef(onCutProp);
 
   // Writes the selection to the event's clipboard data. Returns the written keys,
   // or null when nothing was written.
@@ -177,7 +181,10 @@ export const useClipboard = <N extends ClipboardNode, E extends ClipboardEdge>({
   const onCut = useCallback<ClipboardHandler>(
     (e) => {
       const keys = writeSelection(e);
-      if (keys != null) adapterRef.current.remove(keys);
+      if (keys == null) return;
+      adapterRef.current.remove(keys);
+      const removed = new Set([...keys.nodes, ...keys.edges]);
+      onCutRef.current?.(selectedRef.current.filter((k) => !removed.has(k)));
     },
     [writeSelection],
   );


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4760](https://linear.app/synnax/issue/SY-4760)

## Description

Part 1 of the schematic context menu work: cut (Ctrl+X) for the schematic and the Arc graph editor. The generic diagram clipboard hook now returns an `onCut` handler that writes the selection to the clipboard and then deletes it through a new required `remove` method on `ClipboardAdapter`. The Diagram accepts an `onCut` prop wired to the native cut event and ignores it when the diagram is not editable, since the controlled selection can outlive edit mode. Both adapters implement `remove` with their domain's `removeNode`/`removeEdge` actions. Part 2 adds cut/copy/paste to the context menu on top of these handlers.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.









<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds cut support to Pluto diagrams by serializing the current selection before removing it through domain-specific clipboard adapters.
- Wires native cut events through the generic diagram component with an edit-mode guard.
- Adds removal implementations for schematic and Arc graph nodes and edges.
- Updates selection after successful cuts and adds unit coverage for cut behavior, connected-edge cleanup, and empty selections.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| pluto/src/vis/diagram/clipboard.ts | Implements generic cut handling by reusing clipboard serialization, removing copied keys, and reporting the surviving selection. |
| pluto/src/vis/diagram/Diagram.tsx | Forwards native cut events to the diagram clipboard only while the diagram is editable. |
| pluto/src/schematic/clipboard.ts | Removes cut schematic items and connected edges to prevent dangling-edge state. |
| pluto/src/arc/graph/clipboard.ts | Implements Arc graph removal through node and edge actions. |
| pluto/src/schematic/clipboard.spec.tsx | Covers schematic cuts, connected-edge cleanup, edge-only cuts, selection updates, and no-op behavior. |
| pluto/src/arc/graph/clipboard.spec.tsx | Covers Arc graph cut removal, cascading edge cleanup, selection updates, and missing selections. |

<sub>Reviews (5): Last reviewed commit: ["SY-4760: Cascade edges and prune selecti..."](https://github.com/synnaxlabs/synnax/commit/59bc04a638f75dfb6523917f7825b918534f3f34) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56907495)</sub>

<!-- /greptile_comment -->