### PR TITLE
SY-4760: Add cut, copy, and paste to the diagram context menus (Part 2)

### DIFF
--- a/pluto/src/arc/graph/Editor.tsx
+++ b/pluto/src/arc/graph/Editor.tsx
@@ -127,11 +127,12 @@ export const Editor = ({
   const { undo, canUndo } = useUndo();
   const { redo, canRedo } = useRedo();
 
-  const { onCopy, onCut, onPaste } = useClipboard({
+  const { onCopy, onCut, onPaste, copy, cut, paste } = useClipboard({
     key,
     selected,
     onCut: onSelectionChange,
     onPaste: onSelectionChange,
+    container: ref,
   });
 
   BaseDiagram.useTriggers({
@@ -149,6 +150,13 @@ export const Editor = ({
       <Menu.Menu level="small" gap="small">
         {editable && (
           <>
+            <BaseDiagram.Menu.ClipboardItems
+              cut={cut}
+              copy={copy}
+              paste={paste}
+              hasSelection={(selected?.length ?? 0) > 0}
+            />
+            <Menu.Divider />
             <Menu.UndoRedoItems
               undo={undo}
               redo={redo}
@@ -161,7 +169,18 @@ export const Editor = ({
         {extraMenuItems?.(menuProps)}
       </Menu.Menu>
     ),
-    [undo, redo, canUndo, canRedo, editable, extraMenuItems],
+    [
+      undo,
+      redo,
+      canUndo,
+      canRedo,
+      editable,
+      extraMenuItems,
+      selected,
+      cut,
+      copy,
+      paste,
+    ],
   );
 
   return (

--- a/pluto/src/arc/graph/clipboard.ts
+++ b/pluto/src/arc/graph/clipboard.ts
@@ -9,6 +9,7 @@
 
 import { arc, query } from "@synnaxlabs/client";
 import { uuid } from "@synnaxlabs/x";
+import { type RefObject } from "react";
 
 import { useDispatch } from "@/arc/queries";
 import { Synnax } from "@/synnax";
@@ -23,6 +24,7 @@ export interface UseClipboardParams {
   selected?: string[];
   onCut?: (remaining: string[]) => void;
   onPaste?: (newKeys: string[]) => void;
+  container?: RefObject<HTMLDivElement | null>;
 }
 
 export const useClipboard = ({
@@ -30,6 +32,7 @@ export const useClipboard = ({
   selected,
   onCut,
   onPaste,
+  container,
 }: UseClipboardParams): Diagram.UseClipboardReturn => {
   const { dispatch } = useDispatch();
   const client = Synnax.use();
@@ -66,5 +69,5 @@ export const useClipboard = ({
       });
     },
   };
-  return Diagram.useClipboard({ adapter, selected, onCut });
+  return Diagram.useClipboard({ adapter, selected, onCut, container });
 };

--- a/pluto/src/code/Editor.tsx
+++ b/pluto/src/code/Editor.tsx
@@ -37,9 +37,6 @@ import { Theming } from "@/theming";
 import { Triggers } from "@/triggers";
 
 const ESCAPE_TRIGGERS: Triggers.Trigger[] = [Triggers.ESCAPE];
-const CUT_TRIGGER: Triggers.Trigger = ["Control", "X"];
-const COPY_TRIGGER: Triggers.Trigger = ["Control", "C"];
-const PASTE_TRIGGER: Triggers.Trigger = ["Control", "V"];
 const RENAME_TRIGGER: Triggers.Trigger = ["F2"];
 const FORMAT_TRIGGER: Triggers.Trigger = ["Shift", "Alt", "F"];
 
@@ -527,7 +524,7 @@ const EditorInternal = ({
       <Menu.Menu level="small" gap="small">
         <Menu.Item
           itemKey="cut"
-          trigger={CUT_TRIGGER}
+          trigger={Triggers.CUT}
           triggerIndicator
           disabled={!hasSelection}
           onClick={createMenuAction("cut")}
@@ -537,7 +534,7 @@ const EditorInternal = ({
         </Menu.Item>
         <Menu.Item
           itemKey="copy"
-          trigger={COPY_TRIGGER}
+          trigger={Triggers.COPY}
           triggerIndicator
           disabled={!hasSelection}
           onClick={createMenuAction("copy")}
@@ -547,7 +544,7 @@ const EditorInternal = ({
         </Menu.Item>
         <Menu.Item
           itemKey="paste"
-          trigger={PASTE_TRIGGER}
+          trigger={Triggers.PASTE}
           triggerIndicator
           onClick={createMenuAction("paste")}
         >

--- a/pluto/src/log/Base.tsx
+++ b/pluto/src/log/Base.tsx
@@ -22,7 +22,6 @@ import { Status } from "@/status/base";
 import { Triggers } from "@/triggers";
 import { Canvas } from "@/vis/canvas";
 
-const COPY_TRIGGER: Triggers.Trigger = ["Control", "C"];
 export const PAUSE_TRIGGER: Triggers.Trigger = ["H"];
 
 // Select-all sends "to end" rather than a concrete index so the entry count never
@@ -232,7 +231,7 @@ export const Base = ({
         )}
         <Menu.Item
           itemKey="copy"
-          trigger={COPY_TRIGGER}
+          trigger={Triggers.COPY}
           triggerIndicator
           disabled={!hasSelection}
         >

--- a/pluto/src/schematic/Schematic.tsx
+++ b/pluto/src/schematic/Schematic.tsx
@@ -127,10 +127,11 @@ export const Schematic = ({
   const { undo, canUndo } = useUndo();
   const { redo, canRedo } = useRedo();
 
-  const { onCopy, onCut, onPaste } = useClipboard({
+  const { onCopy, onCut, onPaste, copy, cut, paste } = useClipboard({
     selected,
     onCut: onSelectionChange,
     onPaste: onSelectionChange,
+    container: ref,
   });
 
   BaseDiagram.useTriggers({
@@ -148,6 +149,13 @@ export const Schematic = ({
       <Menu.Menu level="small" gap="small">
         {editable && (
           <>
+            <BaseDiagram.Menu.ClipboardItems
+              cut={cut}
+              copy={copy}
+              paste={paste}
+              hasSelection={(selected?.length ?? 0) > 0}
+            />
+            <Menu.Divider />
             <Menu.UndoRedoItems
               undo={undo}
               redo={redo}
@@ -160,7 +168,18 @@ export const Schematic = ({
         {extraMenuItems?.(menuProps)}
       </Menu.Menu>
     ),
-    [undo, redo, canUndo, canRedo, editable, extraMenuItems],
+    [
+      undo,
+      redo,
+      canUndo,
+      canRedo,
+      editable,
+      extraMenuItems,
+      selected,
+      cut,
+      copy,
+      paste,
+    ],
   );
 
   return (

--- a/pluto/src/schematic/clipboard.ts
+++ b/pluto/src/schematic/clipboard.ts
@@ -9,6 +9,7 @@
 
 import { query, schematic } from "@synnaxlabs/client";
 import { uuid } from "@synnaxlabs/x";
+import { type RefObject } from "react";
 
 import { useSingleDispatch } from "@/schematic/queries";
 import { useKey } from "@/schematic/Suspended";
@@ -23,12 +24,14 @@ export interface UseClipboardParams {
   selected?: string[];
   onCut?: (remaining: string[]) => void;
   onPaste?: (newKeys: string[]) => void;
+  container?: RefObject<HTMLDivElement | null>;
 }
 
 export const useClipboard = ({
   selected,
   onCut,
   onPaste,
+  container,
 }: UseClipboardParams): Diagram.UseClipboardReturn => {
   const key = useKey();
   const dispatch = useSingleDispatch();
@@ -72,5 +75,5 @@ export const useClipboard = ({
       ]);
     },
   };
-  return Diagram.useClipboard({ adapter, selected, onCut });
+  return Diagram.useClipboard({ adapter, selected, onCut, container });
 };

--- a/pluto/src/triggers/triggers.ts
+++ b/pluto/src/triggers/triggers.ts
@@ -422,5 +422,11 @@ export const purgeMouse = (triggers: Trigger[]): Trigger[] =>
 export const UNDO: Trigger = ["Control", "Z"];
 /** The standard redo shortcut. */
 export const REDO: Trigger = ["Control", "Shift", "Z"];
+/** The standard cut shortcut. */
+export const CUT: Trigger = ["Control", "X"];
+/** The standard copy shortcut. */
+export const COPY: Trigger = ["Control", "C"];
+/** The standard paste shortcut. */
+export const PASTE: Trigger = ["Control", "V"];
 /** The escape key on its own. */
 export const ESCAPE: Trigger = ["Escape"];

--- a/pluto/src/vis/diagram/clipboard.spec.ts
+++ b/pluto/src/vis/diagram/clipboard.spec.ts
@@ -530,9 +530,45 @@ describe("clipboard", () => {
       return { current: el };
     };
 
+    // jsdom implements neither constructor the synthetic-paste fallback uses.
+    const stubSyntheticClipboard = () => {
+      class DataTransferStub {
+        private readonly data = new Map<string, string>();
+        setData(type: string, value: string): void {
+          this.data.set(type, value);
+        }
+        getData(type: string): string {
+          return this.data.get(type) ?? "";
+        }
+      }
+      class ClipboardEventStub extends Event {
+        readonly clipboardData: DataTransferStub | null;
+        constructor(
+          type: string,
+          init?: EventInit & { clipboardData?: DataTransferStub },
+        ) {
+          super(type, init);
+          this.clipboardData = init?.clipboardData ?? null;
+        }
+      }
+      vi.stubGlobal("DataTransfer", DataTransferStub);
+      vi.stubGlobal("ClipboardEvent", ClipboardEventStub);
+    };
+
+    const listenForPaste = (container: RefObject<HTMLDivElement | null>): string[] => {
+      const seen: string[] = [];
+      container.current?.addEventListener("paste", (e) => {
+        const data = (e as unknown as { clipboardData: DataTransfer | null })
+          .clipboardData;
+        seen.push(data?.getData(MIME) ?? "");
+      });
+      return seen;
+    };
+
     afterEach(() => {
       Reflect.deleteProperty(document, "execCommand");
       containers.splice(0).forEach((el) => el.remove());
+      vi.unstubAllGlobals();
     });
 
     it("should focus the container and fire a native copy", () => {
@@ -651,6 +687,55 @@ describe("clipboard", () => {
       const { paste } = renderClipboard(makeAdapter(SNAPSHOT), [], { container });
       paste();
       expect(execCommand).toHaveBeenCalledWith("paste");
+    });
+
+    it("should replay the last copied payload when the native paste is refused", () => {
+      const execCommand = stubExecCommand();
+      stubSyntheticClipboard();
+      const container = makeContainer();
+      const clipboard = renderClipboard(makeAdapter(SNAPSHOT), ["a", "e1"], {
+        container,
+      });
+      const { event } = fakeClipboardEvent();
+      execCommand.mockImplementation((command) => {
+        if (command !== "copy") return false;
+        clipboard.onCopy(event, xy.ZERO);
+        return true;
+      });
+      clipboard.copy();
+      const seen = listenForPaste(container);
+      clipboard.paste();
+      expect(seen).toHaveLength(1);
+      const payload = JSON.parse(seen[0]);
+      expect(payload.nodes.map((n: { key: string }) => n.key)).toEqual(["a"]);
+      expect(payload.edges.map((e: { key: string }) => e.key)).toEqual(["e1"]);
+    });
+
+    it("should not replay when the native paste succeeds", () => {
+      const execCommand = stubExecCommand();
+      stubSyntheticClipboard();
+      const container = makeContainer();
+      const clipboard = renderClipboard(makeAdapter(SNAPSHOT), ["a"], { container });
+      const { event } = fakeClipboardEvent();
+      execCommand.mockImplementation((command) => {
+        if (command === "copy") clipboard.onCopy(event, xy.ZERO);
+        return true;
+      });
+      clipboard.copy();
+      const seen = listenForPaste(container);
+      clipboard.paste();
+      expect(seen).toHaveLength(0);
+    });
+
+    it("should not replay before anything was copied", () => {
+      const execCommand = stubExecCommand();
+      stubSyntheticClipboard();
+      execCommand.mockImplementation(() => false);
+      const container = makeContainer();
+      const { paste } = renderClipboard(makeAdapter(SNAPSHOT), [], { container });
+      const seen = listenForPaste(container);
+      paste();
+      expect(seen).toHaveLength(0);
     });
 
     it("should compile only while the DOM standard defines execCommand", () => {

--- a/pluto/src/vis/diagram/clipboard.spec.ts
+++ b/pluto/src/vis/diagram/clipboard.spec.ts
@@ -81,14 +81,16 @@ const pasteResultOf = (
   adapter: ClipboardAdapter<Node, Edge>,
 ): PasteResult<Node, Edge> => vi.mocked(adapter.apply).mock.calls[0][0];
 
+interface RenderClipboardOpts {
+  onCut?: (remaining: string[]) => void;
+  container?: RefObject<HTMLDivElement | null>;
+}
+
 const renderClipboard = (
   adapter: ClipboardAdapter<Node, Edge>,
   selected?: string[],
-  onCut?: (remaining: string[]) => void,
-  container?: RefObject<HTMLDivElement | null>,
-) =>
-  renderHook(() => useClipboard({ adapter, selected, onCut, container })).result
-    .current;
+  opts: RenderClipboardOpts = {},
+) => renderHook(() => useClipboard({ adapter, selected, ...opts })).result.current;
 
 const readPayload = (store: Map<string, string>) => JSON.parse(store.get(MIME) ?? "");
 
@@ -264,11 +266,9 @@ describe("clipboard", () => {
       const onCutCb = vi.fn();
       // "b" is selected but absent from the snapshot, so it survives the cut.
       const snapshotOnlyA = { ...snapshot, nodes: [node("a", xy.ZERO)] };
-      const { onCut } = renderClipboard(
-        makeAdapter(snapshotOnlyA),
-        ["a", "b"],
-        onCutCb,
-      );
+      const { onCut } = renderClipboard(makeAdapter(snapshotOnlyA), ["a", "b"], {
+        onCut: onCutCb,
+      });
       const { event } = fakeClipboardEvent();
       onCut(event, xy.ZERO);
       expect(onCutCb).toHaveBeenCalledWith(["b"]);
@@ -281,7 +281,7 @@ describe("clipboard", () => {
         configs: {},
       };
       const onCutCb = vi.fn();
-      const { onCut } = renderClipboard(makeAdapter(snapshot), [], onCutCb);
+      const { onCut } = renderClipboard(makeAdapter(snapshot), [], { onCut: onCutCb });
       const { event } = fakeClipboardEvent();
       onCut(event, xy.ZERO);
       expect(onCutCb).not.toHaveBeenCalled();
@@ -538,7 +538,7 @@ describe("clipboard", () => {
     it("should focus the container and fire a native copy", () => {
       const execCommand = stubExecCommand();
       const container = makeContainer();
-      const { copy } = renderClipboard(makeAdapter(SNAPSHOT), ["a"], container);
+      const { copy } = renderClipboard(makeAdapter(SNAPSHOT), ["a"], { container });
       copy();
       expect(document.activeElement).toBe(container.current);
       expect(execCommand).toHaveBeenCalledWith("copy");
@@ -552,7 +552,7 @@ describe("clipboard", () => {
         removeAllRanges,
       } as unknown as Selection);
       const container = makeContainer();
-      const { copy } = renderClipboard(makeAdapter(SNAPSHOT), ["a"], container);
+      const { copy } = renderClipboard(makeAdapter(SNAPSHOT), ["a"], { container });
       copy();
       expect(removeAllRanges).toHaveBeenCalled();
       expect(execCommand).toHaveBeenCalledWith("copy");
@@ -569,7 +569,7 @@ describe("clipboard", () => {
       const execCommand = stubExecCommand();
       const container = makeContainer();
       const adapter = makeAdapter(SNAPSHOT);
-      const clipboard = renderClipboard(adapter, ["a", "b", "e1"], container);
+      const clipboard = renderClipboard(adapter, ["a", "b", "e1"], { container });
       const { event, store } = fakeClipboardEvent();
       execCommand.mockImplementation(() => {
         clipboard.onCopy(event, xy.ZERO);
@@ -587,7 +587,7 @@ describe("clipboard", () => {
       const execCommand = stubExecCommand();
       const container = makeContainer();
       const adapter = makeAdapter(SNAPSHOT);
-      const clipboard = renderClipboard(adapter, [], container);
+      const clipboard = renderClipboard(adapter, [], { container });
       const { event, store } = fakeClipboardEvent();
       execCommand.mockImplementation(() => {
         clipboard.onCopy(event, xy.ZERO);
@@ -602,7 +602,7 @@ describe("clipboard", () => {
       const execCommand = stubExecCommand();
       const container = makeContainer();
       const adapter = makeAdapter(SNAPSHOT);
-      const clipboard = renderClipboard(adapter, ["a", "b", "e1"], container);
+      const clipboard = renderClipboard(adapter, ["a", "b", "e1"], { container });
       const { event, store } = fakeClipboardEvent();
       execCommand.mockImplementation(() => {
         clipboard.onCopy(event, xy.ZERO);
@@ -617,7 +617,7 @@ describe("clipboard", () => {
       const execCommand = stubExecCommand();
       const container = makeContainer();
       const adapter = makeAdapter(SNAPSHOT);
-      const clipboard = renderClipboard(adapter, ["a", "b", "e1"], container);
+      const clipboard = renderClipboard(adapter, ["a", "b", "e1"], { container });
       const { event } = fakeClipboardEvent();
       execCommand.mockImplementation(() => {
         clipboard.onCopy(event, xy.ZERO);
@@ -630,10 +630,25 @@ describe("clipboard", () => {
       expect(adapter.remove).toHaveBeenCalledTimes(1);
     });
 
+    it("should not remove on a copy after a cut throws", () => {
+      const execCommand = stubExecCommand();
+      const container = makeContainer();
+      const adapter = makeAdapter(SNAPSHOT);
+      const clipboard = renderClipboard(adapter, ["a", "b", "e1"], { container });
+      execCommand.mockImplementation(() => {
+        throw new Error("denied");
+      });
+      expect(() => clipboard.cut()).toThrow("denied");
+      const { event, store } = fakeClipboardEvent();
+      clipboard.onCopy(event, xy.ZERO);
+      expect(store.has(MIME)).toBe(true);
+      expect(adapter.remove).not.toHaveBeenCalled();
+    });
+
     it("should fire a native paste", () => {
       const execCommand = stubExecCommand();
       const container = makeContainer();
-      const { paste } = renderClipboard(makeAdapter(SNAPSHOT), [], container);
+      const { paste } = renderClipboard(makeAdapter(SNAPSHOT), [], { container });
       paste();
       expect(execCommand).toHaveBeenCalledWith("paste");
     });

--- a/pluto/src/vis/diagram/clipboard.spec.ts
+++ b/pluto/src/vis/diagram/clipboard.spec.ts
@@ -9,6 +9,7 @@
 
 import { type record, xy } from "@synnaxlabs/x";
 import { renderHook } from "@testing-library/react";
+import { type RefObject } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -84,7 +85,10 @@ const renderClipboard = (
   adapter: ClipboardAdapter<Node, Edge>,
   selected?: string[],
   onCut?: (remaining: string[]) => void,
-) => renderHook(() => useClipboard({ adapter, selected, onCut })).result.current;
+  container?: RefObject<HTMLDivElement | null>,
+) =>
+  renderHook(() => useClipboard({ adapter, selected, onCut, container })).result
+    .current;
 
 const readPayload = (store: Map<string, string>) => JSON.parse(store.get(MIME) ?? "");
 
@@ -497,6 +501,148 @@ describe("clipboard", () => {
       // anchor is centroid (10, 0); offset to cursor (100, 100) -> (90, 100).
       expect(result.nodes[0].node.position).toEqual({ x: 90, y: 100 });
       expect(result.nodes[1].node.position).toEqual({ x: 110, y: 100 });
+    });
+  });
+
+  describe("menu triggers", () => {
+    const SNAPSHOT: Snapshot<Node, Edge> = {
+      nodes: [node("a", xy.ZERO), node("b", xy.construct(10, 20))],
+      edges: [edge("e1", "a", "b")],
+      configs: {},
+    };
+
+    const containers: HTMLDivElement[] = [];
+
+    const stubExecCommand = () => {
+      const execCommand = vi.fn<(command: string) => boolean>(() => true);
+      Object.defineProperty(document, "execCommand", {
+        configurable: true,
+        value: execCommand,
+      });
+      return execCommand;
+    };
+
+    const makeContainer = (): RefObject<HTMLDivElement | null> => {
+      const el = document.createElement("div");
+      el.tabIndex = -1;
+      document.body.appendChild(el);
+      containers.push(el);
+      return { current: el };
+    };
+
+    afterEach(() => {
+      Reflect.deleteProperty(document, "execCommand");
+      containers.splice(0).forEach((el) => el.remove());
+    });
+
+    it("should focus the container and fire a native copy", () => {
+      const execCommand = stubExecCommand();
+      const container = makeContainer();
+      const { copy } = renderClipboard(makeAdapter(SNAPSHOT), ["a"], container);
+      copy();
+      expect(document.activeElement).toBe(container.current);
+      expect(execCommand).toHaveBeenCalledWith("copy");
+    });
+
+    it("should clear an existing text selection before firing", () => {
+      const execCommand = stubExecCommand();
+      const removeAllRanges = vi.fn();
+      vi.spyOn(window, "getSelection").mockReturnValue({
+        toString: () => "",
+        removeAllRanges,
+      } as unknown as Selection);
+      const container = makeContainer();
+      const { copy } = renderClipboard(makeAdapter(SNAPSHOT), ["a"], container);
+      copy();
+      expect(removeAllRanges).toHaveBeenCalled();
+      expect(execCommand).toHaveBeenCalledWith("copy");
+    });
+
+    it("should do nothing without a container", () => {
+      const execCommand = stubExecCommand();
+      const { copy } = renderClipboard(makeAdapter(SNAPSHOT), ["a"]);
+      copy();
+      expect(execCommand).not.toHaveBeenCalled();
+    });
+
+    it("should remove what cut's copy event wrote", () => {
+      const execCommand = stubExecCommand();
+      const container = makeContainer();
+      const adapter = makeAdapter(SNAPSHOT);
+      const clipboard = renderClipboard(adapter, ["a", "b", "e1"], container);
+      const { event, store } = fakeClipboardEvent();
+      execCommand.mockImplementation(() => {
+        clipboard.onCopy(event, xy.ZERO);
+        return true;
+      });
+      clipboard.cut();
+      expect(store.has(MIME)).toBe(true);
+      expect(adapter.remove).toHaveBeenCalledWith({
+        nodes: ["a", "b"],
+        edges: ["e1"],
+      });
+    });
+
+    it("should not remove when cut's copy event writes nothing", () => {
+      const execCommand = stubExecCommand();
+      const container = makeContainer();
+      const adapter = makeAdapter(SNAPSHOT);
+      const clipboard = renderClipboard(adapter, [], container);
+      const { event, store } = fakeClipboardEvent();
+      execCommand.mockImplementation(() => {
+        clipboard.onCopy(event, xy.ZERO);
+        return true;
+      });
+      clipboard.cut();
+      expect(store.has(MIME)).toBe(false);
+      expect(adapter.remove).not.toHaveBeenCalled();
+    });
+
+    it("should never remove on a copy trigger", () => {
+      const execCommand = stubExecCommand();
+      const container = makeContainer();
+      const adapter = makeAdapter(SNAPSHOT);
+      const clipboard = renderClipboard(adapter, ["a", "b", "e1"], container);
+      const { event, store } = fakeClipboardEvent();
+      execCommand.mockImplementation(() => {
+        clipboard.onCopy(event, xy.ZERO);
+        return true;
+      });
+      clipboard.copy();
+      expect(store.has(MIME)).toBe(true);
+      expect(adapter.remove).not.toHaveBeenCalled();
+    });
+
+    it("should not remove on a copy after a cut completes", () => {
+      const execCommand = stubExecCommand();
+      const container = makeContainer();
+      const adapter = makeAdapter(SNAPSHOT);
+      const clipboard = renderClipboard(adapter, ["a", "b", "e1"], container);
+      const { event } = fakeClipboardEvent();
+      execCommand.mockImplementation(() => {
+        clipboard.onCopy(event, xy.ZERO);
+        return true;
+      });
+      clipboard.cut();
+      expect(adapter.remove).toHaveBeenCalledTimes(1);
+      const { event: second } = fakeClipboardEvent();
+      clipboard.onCopy(second, xy.ZERO);
+      expect(adapter.remove).toHaveBeenCalledTimes(1);
+    });
+
+    it("should fire a native paste", () => {
+      const execCommand = stubExecCommand();
+      const container = makeContainer();
+      const { paste } = renderClipboard(makeAdapter(SNAPSHOT), [], container);
+      paste();
+      expect(execCommand).toHaveBeenCalledWith("paste");
+    });
+
+    it("should compile only while the DOM standard defines execCommand", () => {
+      // Trips the type-check when TS drops execCommand from lib.dom, the signal that
+      // browsers removed it and the triggers need a new mechanism.
+      const canary: Pick<Document, "execCommand"> = document;
+      expect(canary).toBe(document);
     });
   });
 });

--- a/pluto/src/vis/diagram/clipboard.ts
+++ b/pluto/src/vis/diagram/clipboard.ts
@@ -222,8 +222,11 @@ export const useClipboard = <N extends ClipboardNode, E extends ClipboardEdge>({
   const cut = useCallback(() => {
     // Native cut events only fire in editable DOM, so cut copies, then removes.
     cutPendingRef.current = true;
-    exec("copy");
-    cutPendingRef.current = false;
+    try {
+      exec("copy");
+    } finally {
+      cutPendingRef.current = false;
+    }
   }, [exec]);
 
   const paste = useCallback(() => exec("paste"), [exec]);

--- a/pluto/src/vis/diagram/clipboard.ts
+++ b/pluto/src/vis/diagram/clipboard.ts
@@ -139,6 +139,7 @@ export const useClipboard = <N extends ClipboardNode, E extends ClipboardEdge>({
   const selectedRef = useSyncedRef(selected ?? []);
   const onCutRef = useSyncedRef(onCutProp);
   const cutPendingRef = useRef(false);
+  const lastCopiedRef = useRef<string | null>(null);
 
   // Writes the selection to the event's clipboard data. Returns the written keys,
   // or null when nothing was written.
@@ -172,8 +173,10 @@ export const useClipboard = <N extends ClipboardNode, E extends ClipboardEdge>({
         anchor: centroid(nodes),
       };
       e.preventDefault();
-      e.clipboardData.setData(mime, JSON.stringify(payload));
+      const json = JSON.stringify(payload);
+      e.clipboardData.setData(mime, json);
       e.clipboardData.setData("text/plain", describe(nodes.length, edges.length));
+      lastCopiedRef.current = json;
       return keys;
     },
     [],
@@ -203,21 +206,21 @@ export const useClipboard = <N extends ClipboardNode, E extends ClipboardEdge>({
   );
 
   const exec = useCallback(
-    (command: "copy" | "paste") => {
+    (command: "copy" | "paste"): boolean => {
       const el = container?.current;
-      if (el == null) return;
+      if (el == null) return false;
       window.getSelection()?.removeAllRanges();
       el.focus({ preventScroll: true });
       // Monaco's clipboard menu actions call execCommand the same way. It is deprecated
       // with no replacement: WebKit's clipboard API rejects custom MIME types. Only
       // these menu triggers use it; the keyboard path fires native events.
       // eslint-disable-next-line @typescript-eslint/no-deprecated
-      document.execCommand(command);
+      return document.execCommand(command);
     },
     [container],
   );
 
-  const copy = useCallback(() => exec("copy"), [exec]);
+  const copy = useCallback(() => void exec("copy"), [exec]);
 
   const cut = useCallback(() => {
     // Native cut events only fire in editable DOM, so cut copies, then removes.
@@ -229,7 +232,19 @@ export const useClipboard = <N extends ClipboardNode, E extends ClipboardEdge>({
     }
   }, [exec]);
 
-  const paste = useCallback(() => exec("paste"), [exec]);
+  const paste = useCallback(() => {
+    // Chromium refuses execCommand("paste"). Replay the last copied payload as a
+    // synthetic event so it flows through the normal handler and its cursor math.
+    if (exec("paste")) return;
+    const el = container?.current;
+    const raw = lastCopiedRef.current;
+    if (el == null || raw == null) return;
+    const data = new DataTransfer();
+    data.setData(adapterRef.current.mime, raw);
+    el.dispatchEvent(
+      new globalThis.ClipboardEvent("paste", { clipboardData: data, bubbles: true }),
+    );
+  }, [exec, container]);
 
   const onPaste = useCallback<ClipboardHandler>((e, cursor) => {
     const { mime, edgeKey, apply } = adapterRef.current;

--- a/pluto/src/vis/diagram/clipboard.ts
+++ b/pluto/src/vis/diagram/clipboard.ts
@@ -8,7 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { type record, uuid, xy } from "@synnaxlabs/x";
-import { type ClipboardEvent, useCallback } from "react";
+import { type ClipboardEvent, type RefObject, useCallback, useRef } from "react";
 
 import { useSyncedRef } from "@/hooks";
 import { type ClipboardHandler } from "@/vis/diagram/Diagram";
@@ -100,12 +100,16 @@ export interface UseClipboardParams<N extends ClipboardNode, E extends Clipboard
   selected?: string[];
   /** onCut receives the selection that survives a cut. */
   onCut?: (remaining: string[]) => void;
+  container?: RefObject<HTMLDivElement | null>;
 }
 
 export interface UseClipboardReturn {
   onCopy: ClipboardHandler;
   onCut: ClipboardHandler;
   onPaste: ClipboardHandler;
+  copy: () => void;
+  cut: () => void;
+  paste: () => void;
 }
 
 const describe = (nodeCount: number, edgeCount: number): string =>
@@ -129,10 +133,12 @@ export const useClipboard = <N extends ClipboardNode, E extends ClipboardEdge>({
   adapter,
   selected,
   onCut: onCutProp,
+  container,
 }: UseClipboardParams<N, E>): UseClipboardReturn => {
   const adapterRef = useSyncedRef(adapter);
   const selectedRef = useSyncedRef(selected ?? []);
   const onCutRef = useSyncedRef(onCutProp);
+  const cutPendingRef = useRef(false);
 
   // Writes the selection to the event's clipboard data. Returns the written keys,
   // or null when nothing was written.
@@ -173,21 +179,54 @@ export const useClipboard = <N extends ClipboardNode, E extends ClipboardEdge>({
     [],
   );
 
+  // Removes the written keys and reports the surviving selection.
+  const removeWritten = useCallback((keys: SelectionKeys) => {
+    adapterRef.current.remove(keys);
+    const removed = new Set([...keys.nodes, ...keys.edges]);
+    onCutRef.current?.(selectedRef.current.filter((k) => !removed.has(k)));
+  }, []);
+
   const onCopy = useCallback<ClipboardHandler>(
-    (e) => void writeSelection(e),
-    [writeSelection],
+    (e) => {
+      const keys = writeSelection(e);
+      if (cutPendingRef.current && keys != null) removeWritten(keys);
+    },
+    [writeSelection, removeWritten],
   );
 
   const onCut = useCallback<ClipboardHandler>(
     (e) => {
       const keys = writeSelection(e);
-      if (keys == null) return;
-      adapterRef.current.remove(keys);
-      const removed = new Set([...keys.nodes, ...keys.edges]);
-      onCutRef.current?.(selectedRef.current.filter((k) => !removed.has(k)));
+      if (keys != null) removeWritten(keys);
     },
-    [writeSelection],
+    [writeSelection, removeWritten],
   );
+
+  const exec = useCallback(
+    (command: "copy" | "paste") => {
+      const el = container?.current;
+      if (el == null) return;
+      window.getSelection()?.removeAllRanges();
+      el.focus({ preventScroll: true });
+      // Monaco's clipboard menu actions call execCommand the same way. It is deprecated
+      // with no replacement: WebKit's clipboard API rejects custom MIME types. Only
+      // these menu triggers use it; the keyboard path fires native events.
+      // eslint-disable-next-line @typescript-eslint/no-deprecated
+      document.execCommand(command);
+    },
+    [container],
+  );
+
+  const copy = useCallback(() => exec("copy"), [exec]);
+
+  const cut = useCallback(() => {
+    // Native cut events only fire in editable DOM, so cut copies, then removes.
+    cutPendingRef.current = true;
+    exec("copy");
+    cutPendingRef.current = false;
+  }, [exec]);
+
+  const paste = useCallback(() => exec("paste"), [exec]);
 
   const onPaste = useCallback<ClipboardHandler>((e, cursor) => {
     const { mime, edgeKey, apply } = adapterRef.current;
@@ -229,5 +268,5 @@ export const useClipboard = <N extends ClipboardNode, E extends ClipboardEdge>({
     apply({ nodes, edges, newKeys: Object.values(remap) });
   }, []);
 
-  return { onCopy, onCut, onPaste };
+  return { onCopy, onCut, onPaste, copy, cut, paste };
 };

--- a/pluto/src/vis/diagram/menu/ClipboardItems.spec.tsx
+++ b/pluto/src/vis/diagram/menu/ClipboardItems.spec.tsx
@@ -1,0 +1,77 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { fireEvent, render } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+
+import { Menu } from "@/menu";
+import { Triggers } from "@/triggers";
+import {
+  ClipboardItems,
+  type ClipboardItemsProps,
+} from "@/vis/diagram/menu/ClipboardItems";
+
+interface RenderProps extends Partial<ClipboardItemsProps> {}
+
+const renderItems = ({
+  cut = vi.fn(),
+  copy = vi.fn(),
+  paste = vi.fn(),
+  hasSelection = true,
+}: RenderProps = {}) => {
+  const c = render(
+    <Menu.Menu>
+      <ClipboardItems cut={cut} copy={copy} paste={paste} hasSelection={hasSelection} />
+    </Menu.Menu>,
+  );
+  return { c, cut, copy, paste };
+};
+
+describe("ClipboardItems", () => {
+  it("should run the handler the clicked entry names", () => {
+    const { c, cut, copy, paste } = renderItems();
+    fireEvent.click(c.getByText("Cut"));
+    expect(cut).toHaveBeenCalledTimes(1);
+    expect(copy).not.toHaveBeenCalled();
+    fireEvent.click(c.getByText("Copy"));
+    expect(copy).toHaveBeenCalledTimes(1);
+    fireEvent.click(c.getByText("Paste"));
+    expect(paste).toHaveBeenCalledTimes(1);
+  });
+
+  it("should advertise the shortcuts its host binds", () => {
+    const { c } = renderItems();
+    // The entries never bind the shortcut themselves, so a hint that drifted from
+    // Triggers.CUT / COPY / PASTE would advertise keys that do nothing. Modifiers
+    // render as icons, so the cap count is what ties the hint back to the constant.
+    const [cutHint, copyHint, pasteHint] = c.getAllByLabelText("trigger-indicator");
+    const caps = (el: HTMLElement): number =>
+      el.querySelectorAll(".pluto-text--keyboard").length;
+    expect(caps(cutHint)).toBe(Triggers.CUT.length);
+    expect(caps(copyHint)).toBe(Triggers.COPY.length);
+    expect(caps(pasteHint)).toBe(Triggers.PASTE.length);
+    expect(cutHint.textContent).toContain("X");
+    expect(copyHint.textContent).toContain("C");
+    expect(pasteHint.textContent).toContain("V");
+  });
+
+  it("should disable cut and copy without a selection", () => {
+    const { c, cut, copy, paste } = renderItems({ hasSelection: false });
+    const disabled = (label: string): string | null =>
+      c.getByText(label).closest("button")?.getAttribute("aria-disabled") ?? null;
+    expect(disabled("Cut")).toBe("true");
+    expect(disabled("Copy")).toBe("true");
+    fireEvent.click(c.getByText("Cut"));
+    fireEvent.click(c.getByText("Copy"));
+    expect(cut).not.toHaveBeenCalled();
+    expect(copy).not.toHaveBeenCalled();
+    fireEvent.click(c.getByText("Paste"));
+    expect(paste).toHaveBeenCalledTimes(1);
+  });
+});

--- a/pluto/src/vis/diagram/menu/ClipboardItems.tsx
+++ b/pluto/src/vis/diagram/menu/ClipboardItems.tsx
@@ -1,0 +1,62 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { type ReactElement } from "react";
+
+import { Icon } from "@/icon";
+import { Item } from "@/menu/Item";
+import { type Triggers } from "@/triggers";
+
+const CUT_TRIGGER: Triggers.Trigger = ["Control", "X"];
+const COPY_TRIGGER: Triggers.Trigger = ["Control", "C"];
+const PASTE_TRIGGER: Triggers.Trigger = ["Control", "V"];
+
+/** Props for {@link ClipboardItems}. */
+export interface ClipboardItemsProps {
+  cut: () => void;
+  copy: () => void;
+  paste: () => void;
+  hasSelection: boolean;
+}
+
+/**
+ * Renders the cut, copy, and paste entries of a diagram context menu, wired to the
+ * triggers from the diagram's useClipboard. Render inside a {@link Menu}.
+ */
+export const ClipboardItems = ({
+  cut,
+  copy,
+  paste,
+  hasSelection,
+}: ClipboardItemsProps): ReactElement => (
+  <>
+    <Item
+      itemKey="cut"
+      onClick={cut}
+      disabled={!hasSelection}
+      triggerIndicator={CUT_TRIGGER}
+    >
+      <Icon.Cut />
+      Cut
+    </Item>
+    <Item
+      itemKey="copy"
+      onClick={copy}
+      disabled={!hasSelection}
+      triggerIndicator={COPY_TRIGGER}
+    >
+      <Icon.Copy />
+      Copy
+    </Item>
+    <Item itemKey="paste" onClick={paste} triggerIndicator={PASTE_TRIGGER}>
+      <Icon.Paste />
+      Paste
+    </Item>
+  </>
+);

--- a/pluto/src/vis/diagram/menu/ClipboardItems.tsx
+++ b/pluto/src/vis/diagram/menu/ClipboardItems.tsx
@@ -11,11 +11,7 @@ import { type ReactElement } from "react";
 
 import { Icon } from "@/icon";
 import { Item } from "@/menu/Item";
-import { type Triggers } from "@/triggers";
-
-const CUT_TRIGGER: Triggers.Trigger = ["Control", "X"];
-const COPY_TRIGGER: Triggers.Trigger = ["Control", "C"];
-const PASTE_TRIGGER: Triggers.Trigger = ["Control", "V"];
+import { Triggers } from "@/triggers";
 
 /** Props for {@link ClipboardItems}. */
 export interface ClipboardItemsProps {
@@ -40,7 +36,7 @@ export const ClipboardItems = ({
       itemKey="cut"
       onClick={cut}
       disabled={!hasSelection}
-      triggerIndicator={CUT_TRIGGER}
+      triggerIndicator={Triggers.CUT}
     >
       <Icon.Cut />
       Cut
@@ -49,12 +45,12 @@ export const ClipboardItems = ({
       itemKey="copy"
       onClick={copy}
       disabled={!hasSelection}
-      triggerIndicator={COPY_TRIGGER}
+      triggerIndicator={Triggers.COPY}
     >
       <Icon.Copy />
       Copy
     </Item>
-    <Item itemKey="paste" onClick={paste} triggerIndicator={PASTE_TRIGGER}>
+    <Item itemKey="paste" onClick={paste} triggerIndicator={Triggers.PASTE}>
       <Icon.Paste />
       Paste
     </Item>

--- a/pluto/src/vis/diagram/menu/external.ts
+++ b/pluto/src/vis/diagram/menu/external.ts
@@ -7,4 +7,5 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+export * from "@/vis/diagram/menu/ClipboardItems";
 export * from "@/vis/diagram/menu/ToggleEditItem";


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4760](https://linear.app/synnax/issue/SY-4760/schematic-context-menu-improvements)

## Description

Stacked on Part 1 (#2837).

Adds `Cut`, `Copy`, and `Paste` entries to the schematic and Arc graph context menus. The entries are hidden when the diagram is not editable and `Cut`/`Copy` are disabled without a selection, matching the code editor's menu.

Menu clicks reuse the native clipboard path instead of adding a second one: `useClipboard` now takes the diagram container ref and returns imperative triggers that focus the container and call `document.execCommand`, so the menu and the keyboard shortcuts share one serialization and one MIME type. Cut fires a native copy event and then removes what it wrote, because browsers only fire cut events in editable DOM. The new `Diagram.Menu.ClipboardItems` component follows `Menu.UndoRedoItems`.

Tests cover the trigger behavior and add a compile-time canary that fails the build if `execCommand` is ever dropped from the DOM standard.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds Cut, Copy, and Paste actions to editable diagram context menus while sharing the existing native clipboard serialization path.
- Adds imperative clipboard triggers and fallback replay of the last copied diagram payload.
- Integrates clipboard menu items into schematic and Arc graph editors.
- Centralizes standard clipboard keyboard triggers and adds regression coverage for menu-trigger behavior.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| pluto/src/vis/diagram/clipboard.ts | Adds menu-driven clipboard commands and now clears pending cut state in a `finally` block, resolving the previously reported exception path. |
| pluto/src/vis/diagram/clipboard.spec.ts | Covers copy, cut, paste, fallback replay, and the regression where a throwing cut must not affect a later copy. |
| pluto/src/vis/diagram/menu/ClipboardItems.tsx | Adds reusable Cut, Copy, and Paste menu entries with selection-based disabling. |
| pluto/src/arc/graph/Editor.tsx | Connects Arc graph context-menu actions to the shared clipboard hook. |
| pluto/src/schematic/Schematic.tsx | Connects schematic context-menu actions to the shared clipboard hook. |

<sub>Reviews (3): Last reviewed commit: ["SY-4760: Fall back to in-memory paste wh..."](https://github.com/synnaxlabs/synnax/commit/84c93d0b8a7012ded89cc4f15f8a2110a7bb7870) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56964613)</sub>

<!-- /greptile_comment -->