### PR TITLE
SY-4762: Page the range overview child list fetch

### DIFF
--- a/client/ts/src/ranger/client.ts
+++ b/client/ts/src/ranger/client.ts
@@ -288,6 +288,21 @@ const retrieveMultiParamsZ = retrieveRequestZ
 
 const retrieveResZ = z.object({ ranges: payloadZ.array().default(() => []) });
 
+/** Request addressing a page of a range's children, in relationship-key order. */
+export type ChildrenRequest = {
+  key: Key;
+  limit?: number;
+  offset?: number;
+};
+
+/** Params addressing a range's children. A bare key addresses all of them. */
+export type ChildrenParams = Key | ChildrenRequest;
+
+const CHILDREN_SERVER_FIELDS = ["limit", "offset"] as const;
+
+const normalizeChildren = (params: ChildrenParams): ChildrenRequest =>
+  typeof params === "string" ? { key: params } : params;
+
 /** The base flags applied to every composed range fetch. */
 const BASE_REQUEST: Partial<RetrieveRequest> = {
   includeLabels: true,
@@ -386,7 +401,7 @@ export class Client extends query.Retriever<
   /** The range alias table; injected into sibling clients at wiring. */
   readonly aliases: query.Table<string, alias.Alias>;
   /** Cached queries for the children of a range, keyed by the parent's key. */
-  readonly children: query.Retrieves<Key, Range[]>;
+  readonly children: query.Retrieves<ChildrenParams, Range[]>;
   /**
    * Cached queries for the closest range parent of a resource, keyed by the
    * child's ontology ID.
@@ -453,17 +468,27 @@ export class Client extends query.Retriever<
     this.store = ranges;
     this.kvPairs = kvPairs;
     this.aliases = aliases;
-    this.children = cache.queries<Key, Range[], Key, Range>({
+    const children = cache.queries<ChildrenRequest, Range[], Key, Range>({
       name: "child ranges",
       table: composed,
       fetch: async (query) => (await this.fetchChildren(query)).map((r) => r.key),
       compose: (records) => records,
       matches: (r, query) => {
         const parent = this.cfg.ontology.cache.parentID(ontologyID(r.key));
-        return parent != null && ontology.idsEqual(parent, ontologyID(query));
+        return parent != null && ontology.idsEqual(parent, ontologyID(query.key));
       },
-      watch: [watchRelationships<Key>(this.cfg.ontology.cache.relationships)],
+      serverFields: CHILDREN_SERVER_FIELDS,
+      watch: [
+        watchRelationships<ChildrenRequest>(this.cfg.ontology.cache.relationships),
+      ],
     });
+    this.children = {
+      retrieve: async (params, options) =>
+        await children.retrieve(normalizeChildren(params), options),
+      onChange: (params, handler) =>
+        children.onChange(normalizeChildren(params), handler),
+      getCached: (params) => children.getCached(normalizeChildren(params)),
+    };
     this.parent = cache.queries<ontology.ID, Range | null, Key, Range>({
       name: "parent range",
       table: composed,
@@ -721,10 +746,12 @@ export class Client extends query.Retriever<
     return true;
   }
 
-  private async fetchChildren(query: Key): Promise<Range[]> {
+  private async fetchChildren(query: ChildrenRequest): Promise<Range[]> {
     const resources = await this.cfg.ontology.children.retrieve({
-      ids: ontologyID(query),
+      ids: ontologyID(query.key),
       types: ["range"],
+      limit: query.limit,
+      offset: query.offset,
     });
     if (resources.length === 0) return [];
     return await this.store.retrieve(resources.map(({ id: { key } }) => key));

--- a/client/ts/src/ranger/ranger.spec.ts
+++ b/client/ts/src/ranger/ranger.spec.ts
@@ -720,6 +720,51 @@ describe("cached reads", () => {
         off();
       }
     });
+
+    it("pages children with limit and offset in a stable order", async () => {
+      const parent = await createRange();
+      await Promise.all(
+        Array.from({ length: 5 }, () =>
+          createRange(client, { parent: { key: parent.key } }),
+        ),
+      );
+      const all = await client.ranges.children.retrieve(parent.key);
+      expect(all).toHaveLength(5);
+      const first = await client.ranges.children.retrieve({
+        key: parent.key,
+        limit: 3,
+        offset: 0,
+      });
+      const second = await client.ranges.children.retrieve({
+        key: parent.key,
+        limit: 3,
+        offset: 3,
+      });
+      expect(first).toHaveLength(3);
+      expect(second).toHaveLength(2);
+      const paged = [...first, ...second].map((r) => r.key).sort();
+      expect(paged).toEqual(all.map((r) => r.key).sort());
+    });
+
+    it("sends the page bounds to the cluster instead of fetching every child", async () => {
+      const parent = await createRange();
+      await Promise.all(
+        Array.from({ length: 3 }, () =>
+          createRange(client, { parent: { key: parent.key } }),
+        ),
+      );
+      const spy = vi.spyOn(client.ontology.children, "retrieve");
+      try {
+        const page = await client.ranges.children.retrieve({
+          key: parent.key,
+          limit: 2,
+        });
+        expect(page).toHaveLength(2);
+        expect(spy).toHaveBeenCalledWith(expect.objectContaining({ limit: 2 }));
+      } finally {
+        spy.mockRestore();
+      }
+    });
   });
 
   describe("parent", () => {

--- a/pluto/src/ranger/queries.spec.ts
+++ b/pluto/src/ranger/queries.spec.ts
@@ -17,7 +17,7 @@ import {
   type ReactElement,
   Suspense,
 } from "react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Ranger } from "@/ranger";
 import { renderHookSuspended } from "@/testutil/render";
@@ -424,6 +424,37 @@ describe("queries", () => {
       expect(result.current.data.length).toBeGreaterThanOrEqual(2);
       expect(result.current.data).toContain(child1.key);
       expect(result.current.data).toContain(child2.key);
+    });
+
+    it("should forward the page bounds to the client", async () => {
+      const parentRange = await client.ranges.create({
+        name: "pagedParent",
+        timeRange: TimeStamp.now().spanRange(TimeSpan.seconds(10)),
+      });
+      await Promise.all(
+        Array.from({ length: 3 }, (_, i) =>
+          client.ranges.create({
+            name: `pagedChild${i}`,
+            timeRange: TimeStamp.now().spanRange(TimeSpan.seconds(1)),
+            parent: parentRange,
+          }),
+        ),
+      );
+      const spy = vi.spyOn(client.ranges.children, "retrieve");
+      try {
+        const { result } = renderHook(() => Ranger.useListChildren(), { wrapper });
+        act(() => {
+          result.current.retrieve(
+            { key: parentRange.key, limit: 2, offset: 0 },
+            { signal: controller.signal },
+          );
+        });
+        await waitFor(() => expect(result.current.variant).toEqual("success"));
+        expect(result.current.data).toHaveLength(2);
+        expect(spy).toHaveBeenCalledWith({ key: parentRange.key, limit: 2, offset: 0 });
+      } finally {
+        spy.mockRestore();
+      }
     });
 
     it("should get individual child ranges using getItem", async () => {

--- a/pluto/src/ranger/queries.ts
+++ b/pluto/src/ranger/queries.ts
@@ -52,18 +52,18 @@ export const useListChildren = Flux.createList<
   ranger.Range
 >({
   name: PLURAL_CHILDREN_RESOURCE_NAME,
-  retrieve: async ({ client, query: { key } }) => {
+  retrieve: async ({ client, query: { key, limit, offset } }) => {
     if (key == null) return [];
-    return await client.ranges.children.retrieve(key);
+    return await client.ranges.children.retrieve({ key, limit, offset });
   },
   retrieveByKey: async ({ client, key }) => await client.ranges.retrieve(key),
-  onChange: ({ client, query: { key } }, handler) => {
+  onChange: ({ client, query: { key, limit, offset } }, handler) => {
     if (key == null) return () => {};
-    return client.ranges.children.onChange(key, handler);
+    return client.ranges.children.onChange({ key, limit, offset }, handler);
   },
-  getCached: ({ client, query: { key } }) => {
+  getCached: ({ client, query: { key, limit, offset } }) => {
     if (key == null) return undefined;
-    return client.ranges.children.getCached(key);
+    return client.ranges.children.getCached({ key, limit, offset });
   },
 });
 


### PR DESCRIPTION
## Linear Issue

[SY-4762](https://linear.app/synnax/issue/SY-4762/range-overview-child-list-fetches-every-child-range-and-freezes-the)

## Description

Same class as SY-4755, on a path PR #2834 does not cover, and this one runs on the
main thread: opening the overview of a range with many children fetches every child
as a fully composed range and writes them all through the cache synchronously, so
the whole window freezes. Reproduced with 20,000 children: 5.9s for the first fetch
and 0.6s for every cached re-read, in Node with no UI attached.

The child list UI already pages: its fetch-more path sends `{offset: 0, limit: 25}`
from the first fetch on. The break was that `useListChildren` dropped those params
and the client's `children` query could not accept them. The `children` query now
takes `Key | { key, limit, offset }` with `serverFields: ["limit", "offset"]`,
mirroring `ontology.dependentSurface`, and forwards the page to the ontology
children retrieval, which the Core answers in stable relationship-key order.
`useListChildren` forwards the pager params it already typed. A bare key still
retrieves every child, so scripting callers are unchanged.

With the fix, the same 20,000-child parent answers a 25-item page in ~0.5s with no
main-thread lock proportional to child count. The remaining ~0.4s is the Core's
children traversal, which walks every child before applying the limit; that
server-side push-down is a follow-up.

`searchTerm` is deliberately not part of the children query: the Core's search
branch ignores the parent filter, so accepting it would lie.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR adds paged range-child retrieval and forwards page bounds through the Pluto list query.
- Adds `limit` and `offset` to the TypeScript range-child query.
- Preserves bare-key retrieval for callers that need all children.
- Adds client and Pluto pagination tests.

<h3>Confidence Score: 4/5</h3>

The PR appears safe to merge after the non-blocking test-format issue is corrected.

The paged query uses distinct cache identities, preserves input order through composition, and refetches server-computed pages after relationship changes; only one formatting issue remains.

**Files Needing Attention:** pluto/src/ranger/queries.spec.ts

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| client/ts/src/ranger/client.ts | Adds normalized paged child parameters, server-computed query fields, and page forwarding to ontology retrieval. |
| client/ts/src/ranger/ranger.spec.ts | Tests stable page membership and verifies that page bounds reach the ontology client. |
| pluto/src/ranger/queries.ts | Forwards list pager parameters consistently through retrieval, subscriptions, and cache reads. |
| pluto/src/ranger/queries.spec.ts | Tests pager forwarding but adds one assertion that exceeds the repository line limit. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as Range overview
    participant Pluto as Pluto list query
    participant Client as Range client
    participant Ontology as Ontology client
    participant Core as Core
    UI->>Pluto: Request child page
    Pluto->>Client: "retrieve({key, limit, offset})"
    Client->>Ontology: "retrieve({ids, types, limit, offset})"
    Ontology->>Core: Fetch child resources
    Core-->>Ontology: Ordered page
    Ontology-->>Client: Child resource IDs
    Client-->>Pluto: Composed ranges
    Pluto-->>UI: Page of child keys
```

<sub>Reviews (1): Last reviewed commit: ["SY-4762: Page the range child list fetch"](https://github.com/synnaxlabs/synnax/commit/421f136e12fc5e57328f2cf07349430d165f5406) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56969936)</sub>

> Greptile also left **1 inline comment** on this PR.

**Context used:**

- Context used - CLAUDE.md ([source](https://github.com/synnaxlabs/synnax/blob/main/CLAUDE.md))

<!-- /greptile_comment -->