### PR TITLE
SY-3310: Stamp OPC UA array blocks with the window they took to read

### DIFF
--- a/driver/common/sample_clock.h
+++ b/driver/common/sample_clock.h
@@ -222,18 +222,17 @@ inline void generate_index_data(
     const x::telem::TimeStamp &start,
     const x::telem::TimeStamp &end,
     const size_t n_read,
-    const size_t offset,
-    const bool inclusive = false
+    const size_t offset
 ) {
     if (index_keys.empty()) return;
     // Hot path: Common to have one index, and it means we can avoid a deep copy.
     if (index_keys.size() == 1) {
         auto &s = f.series->at(offset);
         s.clear();
-        s.write_linspace(start, end, n_read, inclusive);
+        s.write_linspace(start, end, n_read);
         return;
     }
-    const auto index_data = x::telem::Series::linspace(start, end, n_read, inclusive);
+    const auto index_data = x::telem::Series::linspace(start, end, n_read);
     for (size_t i = offset; i < index_keys.size() + offset; i++) {
         auto &s = f.series->at(i);
         s.clear();

--- a/driver/common/sample_clock_test.cpp
+++ b/driver/common/sample_clock_test.cpp
@@ -491,26 +491,4 @@ TEST(TestCommonReadTask, testGenerateIndexDataEmptyIndices) {
     generate_index_data(fr, index_keys, start, end, n_read, offset);
     EXPECT_EQ(fr.size(), 1);
 }
-
-/// @brief it should generate inclusive timestamps including end point.
-TEST(TestCommonReadTask, testGenerateIndexDataInclusive) {
-    x::telem::Frame fr;
-    fr.reserve(2);
-    fr.emplace(1, x::telem::Series(x::telem::FLOAT64_T, 3)); // Data channel
-    fr.emplace(2, x::telem::Series(x::telem::TIMESTAMP_T, 3)); // Index channel
-
-    const std::set<synnax::channel::Key> index_keys = {2};
-    const auto start = x::telem::TimeStamp(1000);
-    const auto end = x::telem::TimeStamp(3000);
-    constexpr size_t n_read = 3;
-    constexpr size_t offset = 1;
-    constexpr bool inclusive = true;
-
-    generate_index_data(fr, index_keys, start, end, n_read, offset, inclusive);
-
-    // Check inclusive spacing (end point included in equal intervals)
-    EXPECT_EQ(fr.series->at(1).at<x::telem::TimeStamp>(0), x::telem::TimeStamp(1000));
-    EXPECT_EQ(fr.series->at(1).at<x::telem::TimeStamp>(1), x::telem::TimeStamp(2000));
-    EXPECT_EQ(fr.series->at(1).at<x::telem::TimeStamp>(2), x::telem::TimeStamp(3000));
-}
 }

--- a/driver/opcua/mock/server.h
+++ b/driver/opcua/mock/server.h
@@ -14,6 +14,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <cstddef>
 #include <string>
 #include <thread>
 
@@ -26,6 +27,9 @@
 #include "driver/opcua/types/types.h"
 
 namespace mock {
+/// @brief the length of the TestDoubleArray node, which array mode tasks must match.
+constexpr std::size_t DOUBLE_ARRAY_SIZE = 5;
+
 struct TestNode {
     std::int32_t ns;
     std::string node_id;
@@ -183,6 +187,17 @@ struct ServerConfig {
         UA_Variant_init(&double_val);
         UA_Variant_setScalarCopy(&double_val, &double_data, &UA_TYPES[UA_TYPES_DOUBLE]);
 
+        // double array node
+        UA_Double double_array_data[DOUBLE_ARRAY_SIZE] = {1.0, 2.0, 3.0, 4.0, 5.0};
+        UA_Variant double_array_val;
+        UA_Variant_init(&double_array_val);
+        UA_Variant_setArrayCopy(
+            &double_array_val,
+            double_array_data,
+            DOUBLE_ARRAY_SIZE,
+            &UA_TYPES[UA_TYPES_DOUBLE]
+        );
+
         // guid node
         UA_Variant guid_val;
         UA_Variant_init(&guid_val);
@@ -219,6 +234,11 @@ struct ServerConfig {
              &UA_TYPES[UA_TYPES_DOUBLE],
              double_val,
              "Test Double Node"},
+            {1,
+             "TestDoubleArray",
+             &UA_TYPES[UA_TYPES_DOUBLE],
+             double_array_val,
+             "Test Double Array Node"},
             {1, "TestGuid", &UA_TYPES[UA_TYPES_GUID], guid_val, "Test GUID Node"},
         };
 
@@ -233,6 +253,7 @@ struct ServerConfig {
         UA_Variant_clear(&int64_val);
         UA_Variant_clear(&float_val);
         UA_Variant_clear(&double_val);
+        UA_Variant_clear(&double_array_val);
         UA_Variant_clear(&guid_val);
 
         return cfg;

--- a/driver/opcua/read_task.h
+++ b/driver/opcua/read_task.h
@@ -207,18 +207,12 @@ protected:
     std::shared_ptr<connection::Pool> pool;
     connection::Pool::Connection connection;
     types::ReadRequestBuilder request_builder;
-    x::loop::Timer timer;
 
-    BaseReadTaskSource(
-        std::shared_ptr<connection::Pool> pool,
-        ReadTaskConfig cfg,
-        const ::x::telem::Rate rate
-    ):
+    BaseReadTaskSource(std::shared_ptr<connection::Pool> pool, ReadTaskConfig cfg):
         cfg(std::move(cfg)),
         pool(std::move(pool)),
         connection(nullptr, nullptr, ""),
-        request_builder(create_read_request(this->cfg)),
-        timer(rate) {}
+        request_builder(create_read_request(this->cfg)) {}
 
     synnax::framer::WriterConfig writer_config() const override {
         return this->cfg.writer_config();
@@ -238,13 +232,22 @@ protected:
 };
 
 class ArrayReadTaskSource final : public BaseReadTaskSource {
+    /// @brief regulates the read rate and times each block of samples.
+    common::SoftwareTimedSampleClock sample_clock;
+
 public:
     ArrayReadTaskSource(std::shared_ptr<connection::Pool> pool, ReadTaskConfig cfg):
-        BaseReadTaskSource(
-            std::move(pool),
-            std::move(cfg),
-            cfg.sample_rate / cfg.array_size
-        ) {}
+        BaseReadTaskSource(std::move(pool), std::move(cfg)),
+        sample_clock(this->cfg.sample_rate / this->cfg.array_size) {}
+
+    /// @brief re-arms the block timer. Without it, the first block after a restart
+    /// spans only the time the read took instead of a full acquisition window.
+    x::errors::Error start() override {
+        this->sample_clock = common::SoftwareTimedSampleClock(
+            this->cfg.sample_rate / this->cfg.array_size
+        );
+        return BaseReadTaskSource::start();
+    }
 
     std::vector<synnax::channel::Channel> channels() const override {
         return this->cfg.sy_channels();
@@ -253,7 +256,7 @@ public:
     common::ReadResult
     read(x::breaker::Breaker &breaker, ::x::telem::Frame &fr) override {
         common::ReadResult res;
-        this->timer.wait(breaker);
+        const auto start = this->sample_clock.wait(breaker);
         types::ReadResponse ua_res(UA_Client_Service_read(
             this->connection.get(),
             this->request_builder.build()
@@ -295,32 +298,33 @@ public:
                 error_messages.push_back(msg);
             }
         }
-        auto start = ::x::telem::TimeStamp::now();
-
         if (!error_messages.empty()) {
             fr.clear();
             res.warning = x::strings::join(error_messages, "; ");
             return res;
         }
-
-        auto end = start + this->cfg.array_size * this->cfg.sample_rate.period();
+        // Stamping ahead of the clock would make the next run of this task open its
+        // writer inside data this run already wrote.
         common::generate_index_data(
             fr,
             this->cfg.index_keys,
             start,
-            end,
+            this->sample_clock.end(),
             this->cfg.array_size,
-            this->cfg.channels.size(),
-            true
+            this->cfg.channels.size()
         );
         return res;
     }
 };
 
 class UnaryReadTaskSource final : public BaseReadTaskSource {
+    /// @brief regulates the rate individual samples are read at.
+    x::loop::Timer timer;
+
 public:
     UnaryReadTaskSource(std::shared_ptr<connection::Pool> pool, ReadTaskConfig cfg):
-        BaseReadTaskSource(std::move(pool), std::move(cfg), cfg.sample_rate) {}
+        BaseReadTaskSource(std::move(pool), std::move(cfg)),
+        timer(this->cfg.sample_rate) {}
 
     common::ReadResult
     read(x::breaker::Breaker &breaker, ::x::telem::Frame &fr) override {

--- a/driver/opcua/read_task_test.cpp
+++ b/driver/opcua/read_task_test.cpp
@@ -7,6 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+#include <chrono>
 #include <iomanip>
 #include <iostream>
 #include <thread>
@@ -1215,6 +1216,72 @@ TEST(OPCReadTaskConfig, testOPCDriverSetsAutoCommitTrue) {
     // Verify that writer_config has enable_auto_commit set to true
     auto writer_cfg = cfg->writer_config();
     ASSERT_TRUE(writer_cfg.enable_auto_commit);
+}
+
+/// @brief it should stamp array blocks with the interval they took to acquire, so
+/// the next run of the task does not open its writer inside data this run wrote.
+TEST_F(TestReadTask, testArrayTimestampsTrailTheClock) {
+    constexpr int SAMPLE_RATE = 25;
+    x::json::json array_cfg{
+        {"data_saving_disabled", false},
+        {"device", "opc_read_task_test_server_key"},
+        {"channels",
+         x::json::json::array(
+             {{{"key", "NS=2;I=1"},
+               {"name", "double_array_test"},
+               {"node_name", "TestDoubleArray"},
+               {"node_id", "NS=1;S=TestDoubleArray"},
+               {"channel", this->double_channel.key},
+               {"disabled", false},
+               {"is_index", false},
+               {"data_type", "float64"}}}
+         )},
+        {"sample_rate", SAMPLE_RATE},
+        {"array_mode", true},
+        {"array_size", mock::DOUBLE_ARRAY_SIZE},
+        {"stream_rate", SAMPLE_RATE}
+    };
+
+    auto p = x::json::Parser(array_cfg);
+    auto cfg = std::make_unique<ReadTaskConfig>(ctx->client, p);
+    ASSERT_NIL(p.error());
+
+    const auto rt = std::make_unique<common::ReadTask>(
+        task,
+        ctx,
+        x::breaker::default_config(task.name),
+        std::make_unique<ArrayReadTaskSource>(conn_pool, std::move(*cfg)),
+        mock_factory
+    );
+
+    rt->start("start_cmd");
+    ASSERT_EVENTUALLY_GE_WITH_TIMEOUT(
+        this->mock_factory->writes->size(),
+        static_cast<size_t>(3),
+        std::chrono::seconds(5),
+        std::chrono::milliseconds(25)
+    );
+    rt->stop("stop_cmd", true);
+    const auto stopped_at = x::telem::TimeStamp::now();
+
+    std::vector<x::telem::TimeStamp> stamps;
+    for (const auto &fr: *this->mock_factory->writes) {
+        if (!fr.contains(this->index_channel.key)) continue;
+        for (size_t i = 0; i < fr.length(); i++)
+            stamps.push_back(
+                fr.at<x::telem::TimeStamp>(this->index_channel.key, static_cast<int>(i))
+            );
+    }
+    ASSERT_GE(stamps.size(), 3 * mock::DOUBLE_ARRAY_SIZE);
+    EXPECT_LE(stamps.back(), stopped_at);
+    // A block that tiles the acquisition window holds its samples one period apart,
+    // including across the boundary into the next block. The stop cuts the block
+    // timer short, so the last block spans only the read that followed it.
+    const auto complete = stamps.size() - mock::DOUBLE_ARRAY_SIZE;
+    const auto min_spacing = x::telem::Rate(SAMPLE_RATE).period() / 4;
+    for (size_t i = 1; i < complete; i++)
+        EXPECT_GE(stamps[i] - stamps[i - 1], min_spacing)
+            << "samples " << i - 1 << " and " << i;
 }
 
 /// @brief it should hold each configured sample rate over time.


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-3310](https://linear.app/synnax/issue/SY-3310/opc-read-array-timestamp-overlap-on-rapid-task-reconfigure)

## Description

An OPC UA read task in array mode stamped each block of samples from the moment the
read returned forward, `start = now` and `end = start + array_size * period`. Stored
data therefore always led the wall clock by one block, 200 ms for the array task in the
integration suite. Start the task again inside that window and it opened its writer
inside data the previous run had already written. The Core rejected the open, and
`Acquisition::run` retries only an unreachable Core, so the task stopped for good and
streamed nothing. That is the `driver/opcua_read` failure that has been recurring on rc
and on feature branches. The one CI run this came from hit it twice, with margins of
9.5 µs and 6 µs, because the read timer keeps its phase across a stop and a start.

The block now spans the interval it took to acquire, through
`common::SoftwareTimedSampleClock`, which is what NI, LabJack, Modbus, EtherCAT, and the
OPC UA unary reader already do. Data trails the clock, and a run always begins after the
previous run's last sample.

Two smaller corrections come with it. The block dropped `inclusive`, which had divided
the window by `array_size - 1`, spreading five samples 50 ms apart over a 40 ms period
and landing the last sample of each block on the first sample of the next. This was its
last caller, so `common::generate_index_data` drops the parameter. And the block timer
is re-armed on start, so the first block after a restart spans a full window instead of
only the time the read took.

Residual risk, unchanged and out of scope: a backwards wall clock step can still place a
new block inside stored data, and the pipeline still stops the task there. Every
integration has that exposure.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR changes OPC UA array reads to stamp each sample block with its actual acquisition window instead of a future window.
- Re-arms the software sample clock when the task starts.
- Uses non-inclusive timestamp generation so adjacent blocks do not share a boundary sample.
- Adds an OPC UA array fixture and regression coverage for trailing, spaced timestamps.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

The new timestamp path follows the shared software-clock model, creates the configured number of non-overlapping timestamps, and preserves a full first acquisition window after each start.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| driver/opcua/read_task.h | Replaces forward array timestamps with a re-armed software-clock acquisition window and preserves unary timing. |
| driver/opcua/mock/server.h | Adds a fixed-size double-array node for OPC UA array-read tests. |
| driver/opcua/read_task_test.cpp | Adds regression coverage that verifies array timestamps trail wall time and retain positive spacing. |


<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Task as OPC UA read task
    participant Clock as Software sample clock
    participant Server as OPC UA server
    participant Core as Synnax Core
    Task->>Clock: Wait for block interval
    Clock-->>Task: Acquisition start
    Task->>Server: Read array node
    Server-->>Task: Array samples
    Task->>Clock: Get acquisition end
    Task->>Task: Generate timestamps in [start, end)
    Task->>Core: Write timestamped frame
```

<sub>Reviews (1): Last reviewed commit: ["SY-3310: Stamp OPC UA array blocks with ..."](https://github.com/synnaxlabs/synnax/commit/fea3ac3d5252595542d50f3b23815436eef7edc2) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56988304)</sub>

**Context used:**

- Knowledge Base — [Device driver runtime](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/device-driver.md)
- Knowledge Base — [Driver hardware protocol integrations](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/driver-hardware-protocols.md)

<!-- /greptile_comment -->
