### PR TITLE
SY-4767: Fix schematic values painting outside their box

### DIFF
--- a/pluto/src/testutil/providers.ts
+++ b/pluto/src/testutil/providers.ts
@@ -20,6 +20,7 @@ import { telem } from "@/telem/aether";
 import { telemTest } from "@/telem/aether/test";
 import { theming } from "@/theming/aether";
 import { SYNNAX_LIGHT } from "@/theming/base/theme";
+import { type render } from "@/vis/render";
 import { canvasTest } from "@/vis/render/test";
 import { staleness } from "@/vis/staleness/aether";
 
@@ -54,9 +55,9 @@ export interface ProviderOptions {
   /** Staleness provider. Defaults on with a 250ms sweep. */
   staleness?: false | z.input<typeof staleness.Provider.z>;
   /** Canvas render context. Off by default. `true` injects a fresh recorder; pass a
-   * {@link canvasTest.Recorder} (or any `render.Context`-shaped value) to supply your
-   * own and assert on it afterward. */
-  render?: boolean | canvasTest.Recorder;
+   * {@link canvasTest.Recorder} to supply your own and assert on it afterward, or any
+   * other `render.Context`-shaped value to draw through it. */
+  render?: boolean | canvasTest.Recorder | render.Context;
   /** Extra component types to register on the worker tree. */
   registry?: aether.ComponentRegistry;
   /** Instrumentation for the worker driver. */
@@ -77,7 +78,8 @@ export interface MountedProviders {
 
 /** Result of {@link buildStack}: the worker driver, the path where the deepest provider
  * sits (descendants mount under it), the mounted provider instances, and the render
- * recorder if one was created or supplied. */
+ * recorder if one was created or supplied. The recorder is null when the caller
+ * supplied a plain render context instead. */
 export interface BuiltStack {
   driver: aetherTest.Driver;
   basePath: string[];
@@ -112,12 +114,15 @@ const buildTelemProvider = (
 export const buildStack = (options: ProviderOptions = {}): BuiltStack => {
   const { registry = {}, instrumentation, render: renderOpt } = options;
 
+  const supplied =
+    renderOpt == null || typeof renderOpt === "boolean" ? null : renderOpt;
   const recorder: canvasTest.Recorder | null =
     renderOpt === true
       ? canvasTest.record()
-      : renderOpt != null && renderOpt !== false
-        ? renderOpt
+      : supplied instanceof canvasTest.Recorder
+        ? supplied
         : null;
+  const renderContext = recorder ?? supplied;
 
   const telemFactories =
     typeof options.telem === "object" ? options.telem.factories : undefined;
@@ -204,9 +209,9 @@ export const buildStack = (options: ProviderOptions = {}): BuiltStack => {
     );
     providers.staleness = driver.find<staleness.Provider>([...path]);
   }
-  if (recorder != null) {
+  if (renderContext != null) {
     path.push(RENDER_KEY);
-    driver.update(path, canvasTest.RenderProvider.TYPE, { context: recorder });
+    driver.update(path, canvasTest.RenderProvider.TYPE, { context: renderContext });
     providers.render = driver.find<canvasTest.RenderProvider>([...path]);
   }
 

--- a/pluto/src/vis/axis/canvas.spec.ts
+++ b/pluto/src/vis/axis/canvas.spec.ts
@@ -1,0 +1,72 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { box, type location, scale, xy } from "@synnaxlabs/x";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { type AxisProps, axisStateZ } from "@/vis/axis/axis";
+import { newCanvas } from "@/vis/axis/canvas";
+import { canvasTest } from "@/vis/render/test";
+
+const LOCATIONS: location.Outer[] = ["bottom", "top", "left", "right"];
+
+const POSITION = xy.construct(20, 400);
+
+const PROPS: AxisProps = {
+  plot: box.construct({ x: 0, y: 0 }, { width: 300, height: 200 }),
+  position: POSITION,
+  size: 30,
+  decimalToDataScale: scale.Scale.scale<number>(0, 1).scale(0, 100),
+};
+
+const state = (loc: location.Outer) =>
+  axisStateZ.parse({
+    color: "#000000",
+    gridColor: "#333333",
+    font: "12px sans-serif",
+    location: loc,
+  });
+
+describe("axis/canvas", () => {
+  describe("ambient canvas text state", () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    // What Draw2D.text leaves on a shared canvas when a caller passes justify "center"
+    // and align "middle" and restores neither.
+    const glyphsAfter = (
+      loc: location.Outer,
+      align: CanvasTextAlign,
+      baseline: CanvasTextBaseline = "alphabetic",
+    ): xy.XY[] => {
+      const surface = canvasTest.atlasSurface();
+      const axis = newCanvas(loc, surface.context, state(loc));
+      surface.canvas.textAlign = align;
+      surface.canvas.textBaseline = baseline;
+      surface.clear();
+      axis.render(PROPS);
+      return surface.glyphs();
+    };
+
+    LOCATIONS.forEach((loc) =>
+      it(`should place ${loc} tick labels the same after a centered text draw`, () => {
+        const pinned = glyphsAfter(loc, "start");
+        expect(pinned.length).toBeGreaterThan(0);
+        expect(glyphsAfter(loc, "center", "middle")).toEqual(pinned);
+        expect(glyphsAfter(loc, "right", "top")).toEqual(pinned);
+      }),
+    );
+
+    it("should center a tick label on its tick", () => {
+      const [first] = glyphsAfter("bottom", "center", "middle");
+      expect(first.x).toBeCloseTo(POSITION.x - canvasTest.ATLAS_ADVANCE / 2);
+    });
+  });
+});

--- a/pluto/src/vis/axis/canvas.ts
+++ b/pluto/src/vis/axis/canvas.ts
@@ -67,9 +67,12 @@ export class Base {
     ticks: Tick[],
     f: (textDimensions: dimensions.Dimensions, tick: Tick) => void,
   ): dimensions.Dimensions {
+    const { lower2d: canvas } = this.renderCtx;
+    canvas.textAlign = "left";
+    canvas.textBaseline = "alphabetic";
     let maxDimensions = dimensions.ZERO;
     ticks.forEach((tick) => {
-      const d = this.renderCtx.lower2d.textDimensions(tick.label, FILL_TEXT_OPTIONS);
+      const d = canvas.textDimensions(tick.label, FILL_TEXT_OPTIONS);
       maxDimensions = dimensions.max([maxDimensions, d]);
       f(d, tick);
     });

--- a/pluto/src/vis/render/test/atlas.ts
+++ b/pluto/src/vis/render/test/atlas.ts
@@ -1,0 +1,112 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { box, xy } from "@synnaxlabs/x";
+import { vi } from "vitest";
+
+import { text } from "@/text/aether";
+import { SugaredOffscreenCanvasRenderingContext2D } from "@/vis/draw2d/canvas";
+import { type render } from "@/vis/render";
+
+const INK = 6;
+const PADDING = 2;
+
+/** Advance the atlas lays consecutive glyphs out on. */
+export const ATLAS_ADVANCE = INK + PADDING;
+
+const RUN_ASCENT = 9;
+const RUN_DESCENT = 3;
+const GLYPH_ASCENT = 8;
+
+const metrics = (ascent: number, descent: number): TextMetrics =>
+  ({
+    actualBoundingBoxLeft: 0,
+    actualBoundingBoxRight: INK,
+    actualBoundingBoxAscent: ascent,
+    actualBoundingBoxDescent: descent,
+  }) as TextMetrics;
+
+class StubOffscreenCanvas {
+  constructor(
+    readonly width: number,
+    readonly height: number,
+  ) {}
+
+  getContext() {
+    return {
+      scale: () => {},
+      clearRect: () => {},
+      measureText: (t: string) =>
+        t === "0" ? metrics(GLYPH_ASCENT, 0) : metrics(RUN_ASCENT, RUN_DESCENT),
+      fillText: () => {},
+    };
+  }
+}
+
+export interface AtlasSurface {
+  /** Canvas that draws text through a real atlas onto the recording surface. */
+  canvas: SugaredOffscreenCanvasRenderingContext2D;
+  /** A `render.Context`-shaped value whose canvases are all {@link canvas}. */
+  context: render.Context;
+  /** Where the atlas copied each glyph out to, in draw order. */
+  glyphs: () => xy.XY[];
+  /** Drops the glyphs recorded so far. */
+  clear: () => void;
+}
+
+/**
+ * Construct a surface that runs the production text path: a real Sugared context over a
+ * real atlas, recording where every glyph lands. Use it to assert where text was drawn,
+ * which the {@link Recorder} cannot show, since it stands in for the atlas instead of
+ * feeding it. Stubs `OffscreenCanvas`, so the caller must call `vi.unstubAllGlobals`
+ * after the test.
+ */
+export const atlasSurface = (): AtlasSurface => {
+  vi.stubGlobal("OffscreenCanvas", StubOffscreenCanvas);
+  const glyphs: xy.XY[] = [];
+  const target: Record<string, unknown> = {
+    font: "",
+    fillStyle: "#000000",
+    strokeStyle: "#000000",
+    textAlign: "start",
+    textBaseline: "alphabetic",
+    measureText: () => metrics(GLYPH_ASCENT, 0),
+    drawImage: (_: unknown, ...rest: number[]) =>
+      glyphs.push(xy.construct(rest[4], rest[5])),
+  };
+  const surface = new Proxy(target, {
+    get: (t, prop) => {
+      if (typeof prop !== "string") return undefined;
+      if (!(prop in t)) t[prop] = () => {};
+      return t[prop];
+    },
+  }) as unknown as OffscreenCanvasRenderingContext2D;
+  const canvas = new SugaredOffscreenCanvasRenderingContext2D(
+    surface,
+    new text.AtlasRegistry(),
+    1,
+  );
+  return {
+    canvas,
+    context: {
+      upper2d: canvas,
+      lower2d: canvas,
+      gl: canvas,
+      region: box.ZERO,
+      dpr: 1,
+      loop: { set: () => {} },
+      scissor: () => () => {},
+      erase: () => {},
+    } as unknown as render.Context,
+    glyphs: () => [...glyphs],
+    clear: () => {
+      glyphs.length = 0;
+    },
+  };
+};

--- a/pluto/src/vis/render/test/external.ts
+++ b/pluto/src/vis/render/test/external.ts
@@ -7,6 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+export * from "@/vis/render/test/atlas";
 export * from "@/vis/render/test/record";
 export * from "@/vis/render/test/Recorder";
 export * from "@/vis/render/test/RenderProvider";

--- a/pluto/src/vis/value/aether/value.spec.ts
+++ b/pluto/src/vis/value/aether/value.spec.ts
@@ -7,12 +7,14 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { box, color } from "@synnaxlabs/x";
+import { box, color, xy } from "@synnaxlabs/x";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { telemTest } from "@/telem/aether/test";
 import { renderAether } from "@/testutil/renderAether";
+import { AtlasRegistry } from "@/text/aether/atlas";
 import { SYNNAX_DARK, type Theme, themeZ } from "@/theming/base/theme";
+import { SugaredOffscreenCanvasRenderingContext2D } from "@/vis/draw2d/canvas";
 import { canvasTest } from "@/vis/render/test";
 import { value } from "@/vis/value/aether";
 
@@ -25,6 +27,7 @@ interface SetupOptions {
   background?: color.Color;
   state?: Record<string, unknown>;
   theme?: Theme;
+  render?: canvasTest.Recorder;
 }
 
 // Mounts a Value under the real provider stack with a recording render context. The
@@ -37,6 +40,7 @@ const setup = ({
   background,
   state = {},
   theme = THEME,
+  render,
 }: SetupOptions = {}) => {
   const source = telemTest.source<string>(initialValue);
   const backgroundSource =
@@ -53,7 +57,7 @@ const setup = ({
   const h = renderAether(value.Value, {
     state: parsed,
     theming: { theme, fontURLs: [] },
-    render: recorder,
+    render: render ?? recorder,
   });
   return {
     h,
@@ -91,6 +95,88 @@ const fillTextAt = (
 
 const fillRectArgs = (recorder: canvasTest.Recorder): number[] =>
   drawCalls(recorder, "fillRect")[0].args as number[];
+
+// Ink width the stubbed canvas reports for a digit, plus the atlas's per-cell padding.
+// Their sum is the advance the atlas lays glyphs out on.
+const ATLAS_INK = 6;
+const ATLAS_PADDING = 2;
+
+const atlasMetrics = (ascent: number, descent: number): TextMetrics =>
+  ({
+    actualBoundingBoxLeft: 0,
+    actualBoundingBoxRight: ATLAS_INK,
+    actualBoundingBoxAscent: ascent,
+    actualBoundingBoxDescent: descent,
+  }) as TextMetrics;
+
+interface AtlasSurface {
+  ctx: SugaredOffscreenCanvasRenderingContext2D;
+  /** Where the atlas copied each glyph out to, in draw order. */
+  glyphs: () => xy.XY[];
+  clear: () => void;
+}
+
+// The production text path over a recording surface: a real Sugared context and a real
+// atlas. The recorder above sits over that path and never reaches the atlas.
+const atlasSurface = (): AtlasSurface => {
+  class Canvas {
+    constructor(
+      readonly width: number,
+      readonly height: number,
+    ) {}
+
+    getContext() {
+      return {
+        scale: () => {},
+        clearRect: () => {},
+        measureText: (t: string) => atlasMetrics(t === "0" ? 8 : 9, t === "0" ? 0 : 3),
+        fillText: () => {},
+      };
+    }
+  }
+  vi.stubGlobal("OffscreenCanvas", Canvas);
+  const copies: xy.XY[] = [];
+  const props: Record<string, unknown> = {
+    font: "",
+    fillStyle: "#000000",
+    textAlign: "start",
+    textBaseline: "alphabetic",
+  };
+  const surface = {
+    measureText: () => atlasMetrics(8, 0),
+    fillText: () => {},
+    fillRect: () => {},
+    drawImage: (_: unknown, ...rest: number[]) =>
+      copies.push(xy.construct(rest[4], rest[5])),
+  } as unknown as OffscreenCanvasRenderingContext2D;
+  Object.keys(props).forEach((prop) =>
+    Object.defineProperty(surface, prop, {
+      get: () => props[prop],
+      set: (v: unknown) => (props[prop] = v),
+    }),
+  );
+  return {
+    ctx: new SugaredOffscreenCanvasRenderingContext2D(surface, new AtlasRegistry(), 1),
+    glyphs: () => [...copies],
+    clear: () => {
+      copies.length = 0;
+    },
+  };
+};
+
+// RenderProvider injects any render.Context-shaped value; the cast satisfies the setup
+// option's recorder type.
+const atlasRenderContext = (ctx: SugaredOffscreenCanvasRenderingContext2D) =>
+  ({
+    upper2d: ctx,
+    lower2d: ctx,
+    gl: ctx,
+    region: box.ZERO,
+    dpr: 1,
+    loop: { set: () => {} },
+    scissor: () => () => {},
+    erase: () => {},
+  }) as unknown as canvasTest.Recorder;
 
 describe("value/aether/Value", () => {
   describe("schema", () => {
@@ -221,6 +307,42 @@ describe("value/aether/Value", () => {
       expect(sign?.x).toBeCloseTo((digit?.x ?? 0) - FONT_HEIGHT * 0.6);
       expect(sign?.y).toBeCloseTo(digit?.y ?? 0);
       expect(sign?.x ?? 0).toBeLessThan(digit?.x ?? 0);
+    });
+  });
+
+  describe("ambient canvas text state", () => {
+    afterEach(() => {
+      vi.unstubAllGlobals();
+    });
+
+    // What Draw2D.text leaves on the shared canvas after a gauge or a scale symbol,
+    // which passes justify "center" and align "middle" and restores neither.
+    const glyphsAfter = (
+      align: CanvasTextAlign,
+      baseline: CanvasTextBaseline = "alphabetic",
+    ): xy.XY[] => {
+      const surface = atlasSurface();
+      const { component } = setup({
+        value: "72.55",
+        render: atlasRenderContext(surface.ctx),
+      });
+      surface.ctx.textAlign = align;
+      surface.ctx.textBaseline = baseline;
+      surface.clear();
+      component.render({});
+      return surface.glyphs();
+    };
+
+    it("should draw the value in the same place whatever text state the canvas holds", () => {
+      const pinned = glyphsAfter("start");
+      expect(pinned).toHaveLength("72.55".length);
+      expect(glyphsAfter("center", "middle")).toEqual(pinned);
+      expect(glyphsAfter("right", "top")).toEqual(pinned);
+    });
+
+    it("should draw the value from the left label offset", () => {
+      const [first] = glyphsAfter("center", "middle");
+      expect(first.x).toBeCloseTo(6 + FONT_HEIGHT * 0.75);
     });
   });
 

--- a/pluto/src/vis/value/aether/value.spec.ts
+++ b/pluto/src/vis/value/aether/value.spec.ts
@@ -7,14 +7,13 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { box, color, xy } from "@synnaxlabs/x";
+import { box, color, type xy } from "@synnaxlabs/x";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { telemTest } from "@/telem/aether/test";
+import { type ProviderOptions } from "@/testutil/providers";
 import { renderAether } from "@/testutil/renderAether";
-import { AtlasRegistry } from "@/text/aether/atlas";
 import { SYNNAX_DARK, type Theme, themeZ } from "@/theming/base/theme";
-import { SugaredOffscreenCanvasRenderingContext2D } from "@/vis/draw2d/canvas";
 import { canvasTest } from "@/vis/render/test";
 import { value } from "@/vis/value/aether";
 
@@ -27,7 +26,7 @@ interface SetupOptions {
   background?: color.Color;
   state?: Record<string, unknown>;
   theme?: Theme;
-  render?: canvasTest.Recorder;
+  render?: ProviderOptions["render"];
 }
 
 // Mounts a Value under the real provider stack with a recording render context. The
@@ -95,88 +94,6 @@ const fillTextAt = (
 
 const fillRectArgs = (recorder: canvasTest.Recorder): number[] =>
   drawCalls(recorder, "fillRect")[0].args as number[];
-
-// Ink width the stubbed canvas reports for a digit, plus the atlas's per-cell padding.
-// Their sum is the advance the atlas lays glyphs out on.
-const ATLAS_INK = 6;
-const ATLAS_PADDING = 2;
-
-const atlasMetrics = (ascent: number, descent: number): TextMetrics =>
-  ({
-    actualBoundingBoxLeft: 0,
-    actualBoundingBoxRight: ATLAS_INK,
-    actualBoundingBoxAscent: ascent,
-    actualBoundingBoxDescent: descent,
-  }) as TextMetrics;
-
-interface AtlasSurface {
-  ctx: SugaredOffscreenCanvasRenderingContext2D;
-  /** Where the atlas copied each glyph out to, in draw order. */
-  glyphs: () => xy.XY[];
-  clear: () => void;
-}
-
-// The production text path over a recording surface: a real Sugared context and a real
-// atlas. The recorder above sits over that path and never reaches the atlas.
-const atlasSurface = (): AtlasSurface => {
-  class Canvas {
-    constructor(
-      readonly width: number,
-      readonly height: number,
-    ) {}
-
-    getContext() {
-      return {
-        scale: () => {},
-        clearRect: () => {},
-        measureText: (t: string) => atlasMetrics(t === "0" ? 8 : 9, t === "0" ? 0 : 3),
-        fillText: () => {},
-      };
-    }
-  }
-  vi.stubGlobal("OffscreenCanvas", Canvas);
-  const copies: xy.XY[] = [];
-  const props: Record<string, unknown> = {
-    font: "",
-    fillStyle: "#000000",
-    textAlign: "start",
-    textBaseline: "alphabetic",
-  };
-  const surface = {
-    measureText: () => atlasMetrics(8, 0),
-    fillText: () => {},
-    fillRect: () => {},
-    drawImage: (_: unknown, ...rest: number[]) =>
-      copies.push(xy.construct(rest[4], rest[5])),
-  } as unknown as OffscreenCanvasRenderingContext2D;
-  Object.keys(props).forEach((prop) =>
-    Object.defineProperty(surface, prop, {
-      get: () => props[prop],
-      set: (v: unknown) => (props[prop] = v),
-    }),
-  );
-  return {
-    ctx: new SugaredOffscreenCanvasRenderingContext2D(surface, new AtlasRegistry(), 1),
-    glyphs: () => [...copies],
-    clear: () => {
-      copies.length = 0;
-    },
-  };
-};
-
-// RenderProvider injects any render.Context-shaped value; the cast satisfies the setup
-// option's recorder type.
-const atlasRenderContext = (ctx: SugaredOffscreenCanvasRenderingContext2D) =>
-  ({
-    upper2d: ctx,
-    lower2d: ctx,
-    gl: ctx,
-    region: box.ZERO,
-    dpr: 1,
-    loop: { set: () => {} },
-    scissor: () => () => {},
-    erase: () => {},
-  }) as unknown as canvasTest.Recorder;
 
 describe("value/aether/Value", () => {
   describe("schema", () => {
@@ -321,13 +238,10 @@ describe("value/aether/Value", () => {
       align: CanvasTextAlign,
       baseline: CanvasTextBaseline = "alphabetic",
     ): xy.XY[] => {
-      const surface = atlasSurface();
-      const { component } = setup({
-        value: "72.55",
-        render: atlasRenderContext(surface.ctx),
-      });
-      surface.ctx.textAlign = align;
-      surface.ctx.textBaseline = baseline;
+      const surface = canvasTest.atlasSurface();
+      const { component } = setup({ value: "72.55", render: surface.context });
+      surface.canvas.textAlign = align;
+      surface.canvas.textBaseline = baseline;
       surface.clear();
       component.render({});
       return surface.glyphs();

--- a/pluto/src/vis/value/aether/value.ts
+++ b/pluto/src/vis/value/aether/value.ts
@@ -175,6 +175,8 @@ export class Value
     const canvas = renderCtx.upper2d.applyScale(viewportScale);
     let value = telem.value();
     canvas.font = fontString;
+    canvas.textAlign = "left";
+    canvas.textBaseline = "alphabetic";
     const fontHeight = this.fontHeight;
     const isNegative = value[0] == "-";
     if (isNegative) value = value.slice(1);


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4767](https://linear.app/synnax/issue/SY-4767/schematic-value-numbers-paint-left-of-their-box-after-a-gauge-or-scale)

## Description

A schematic value could paint its number outside its box, half the number's own width to the left and half a glyph height down, so the leading digit fell outside the border and the digits rode the bottom edge. The box, the border and the units chip were all correct. Only the digits moved.

The 2D canvas is shared by every symbol, and its text state leaks between them. `Draw2D.text` sets `textAlign` from its `justify` and `textBaseline` from its `align`, and restores neither, so the gauge leaves `"center"` and `"middle"` behind. `Value.render` set `font` and `fillStyle` but neither of those two, and the glyph atlas honors both: `x -= totalWidth / 2` and `y += height / 2`. Any value drawn after a gauge on the same canvas shifted in both directions.

That is why panning, zooming and resizing never cleared it, why the horizontal drift grew with the digit count, and why one panel could be wrong while another was fine: it depends on what drew last on the shared canvas.

`Value.render` now pins both `textAlign` and `textBaseline`.

The existing Value suite could not see this. It mounts against `canvasTest.record()`, which stands above the Sugared context and never reaches the atlas. The new tests run the production path instead, a real Sugared context and a real atlas over a surface that records the glyph copies, and assert the number lands in the same place whatever text state the canvas already holds. Against the unfixed code they reproduce both reported offsets, and each of the two pinned properties fails the test on its own.

The line plot axis had the same weakness. Tick labels center themselves on the tick and drew through the atlas without declaring any text state. They draw on `lower2d`, where nothing writes a centered alignment today, so this was latent rather than live: one new centered label on that canvas would move every tick label in every plot. `drawTicks` now pins both properties for all four axes, covered by a test per axis. The atlas surface moved into `canvasTest` so both suites share it.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.