### PR TITLE
SY-4768: Space Arc derivative test writes past Windows timer jitter

### DIFF
--- a/integration/tests/arc/stl_math.py
+++ b/integration/tests/arc/stl_math.py
@@ -306,8 +306,10 @@ class StlMath(ArcCase):
         self,
         channel: str,
         values: list[float],
-        dt_ms: int = 20,
+        dt_ms: int = 200,
     ) -> None:
+        # Windows timers step in about 16 ms, so a spacing near that size makes the
+        # slope a measure of scheduler jitter instead of the data.
         for i, val in enumerate(values):
             self.writer.write(channel, val)
             if i < len(values) - 1:
@@ -393,8 +395,8 @@ class StlMath(ArcCase):
         self.wait_for_eq("stat_max_out", 30.0)
 
         self._write_spaced("stat_deriv_in", [0.0, 1.0])
-        self.log("[deriv] Expecting ≈ 50")
-        self.wait_for_near("stat_deriv_out", 50.0, tolerance=25.0)
+        self.log("[deriv] Expecting ≈ 5")
+        self.wait_for_near("stat_deriv_out", 5.0, tolerance=2.5)
 
     def _verify_stat_count_window(self) -> None:
         self.log("Count window (count=5): 15 samples, 3 windows")
@@ -466,8 +468,8 @@ class StlMath(ArcCase):
         self.wait_for_eq("stat_neg_max_out", 100.0)
 
         self._write_spaced("stat_deriv_in", [-1.0, 1.0])
-        self.log("[neg_deriv] Expecting ≈ 100")
-        self.wait_for_near("stat_deriv_out", 100.0, tolerance=50.0)
+        self.log("[neg_deriv] Expecting ≈ 10")
+        self.wait_for_near("stat_deriv_out", 10.0, tolerance=5.0)
 
     def _verify_stat_all_identical(self) -> None:
         self.log("All identical: [42, 42, 42, 42, 42]")
@@ -484,21 +486,21 @@ class StlMath(ArcCase):
         self.wait_for_eq("stat_edge_max_out", 3e12)
 
     def _verify_stat_derivative_constant(self) -> None:
-        self.log("Derivative constant: 2 x 5.0 at 20ms")
+        self.log("Derivative constant: 2 x 5.0 at 200ms")
         self._write_spaced("stat_deriv_in", [5.0, 5.0])
 
         self.log("[deriv] Expecting rate = 0")
         self.wait_for_eq("stat_deriv_out", 0.0)
 
     def _verify_stat_derivative_alternating(self) -> None:
-        self.log("Derivative positive: [0, 1.0] at 20ms")
+        self.log("Derivative positive: [0, 1.0] at 200ms")
         self._write_spaced("stat_deriv_in", [0.0, 1.0])
 
-        self.log("[deriv] Expecting ≈ 50")
-        self.wait_for_near("stat_deriv_out", 50.0, tolerance=25.0)
+        self.log("[deriv] Expecting ≈ 5")
+        self.wait_for_near("stat_deriv_out", 5.0, tolerance=2.5)
 
-        self.log("Derivative negative: [1.0, 0] at 20ms")
+        self.log("Derivative negative: [1.0, 0] at 200ms")
         self._write_spaced("stat_deriv_in", [1.0, 0.0])
 
-        self.log("[deriv] Expecting ≈ -50")
-        self.wait_for_near("stat_deriv_out", -50.0, tolerance=25.0)
+        self.log("[deriv] Expecting ≈ -5")
+        self.wait_for_near("stat_deriv_out", -5.0, tolerance=2.5)


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4768](https://linear.app/synnax/issue/SY-4768/arc-stl-math-derivative-assertions-fail-on-windows-from-sleep-jitter)

## Description

`arc/stl_math` fails intermittently on Windows. The derivative assertions wrote two
samples to `stat_deriv_in` separated by a 20 ms `sy.sleep` and expected a slope of
1.0 / 0.020 = 50. Windows timers step in about 16 ms, so the real spacing reached 42 ms
and the slope came out at 23.75, outside the tolerance of 25.

Arc is right. `Derivative` takes the interval from the sample timestamps, and each
sample is stamped when it is written, so the node reports the slope that actually
happened. The test assumed a spacing the platform does not deliver.

The samples now sit 200 ms apart, where the same 16 ms of jitter is an 8 percent error
rather than 100 percent, and the four expected slopes scale to match. Widening the
tolerance instead would have hidden real regressions. The test takes about a second
longer.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR stabilizes Arc derivative integration tests on Windows by increasing sample spacing from 20 ms to 200 ms and rescaling the expected slopes and tolerances accordingly.
- Documents why spacing near the Windows timer granularity produces unreliable derivative assertions.
- Updates positive, negative, constant, and alternating derivative test cases consistently.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

All uses of the changed spacing helper exercise timestamp-based derivatives, their expected slopes were consistently rescaled, and the modest runtime increase remains well within the integration test timeout.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| integration/tests/arc/stl_math.py | Increases derivative sample spacing and consistently adjusts expected rates, tolerances, and diagnostic messages without affecting windowed tests or timeout budgets. |

<sub>Reviews (1): Last reviewed commit: ["SY-4768: Space Arc derivative test write..."](https://github.com/synnaxlabs/synnax/commit/f89daa80c60bb199786ca71d41b60c102f06aff1) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=56999293)</sub>

<!-- /greptile_comment -->