### PR TITLE
SY-4769: Standardize schematic symbol heights

### DIFF
--- a/pluto/src/component/SelectSize.tsx
+++ b/pluto/src/component/SelectSize.tsx
@@ -19,11 +19,13 @@ export interface SelectComponentSizeProps extends Omit<
   "keys"
 > {}
 
-/** A button group for picking a {@link Size}, labeled S, M, and L. */
+/** A button group for picking a {@link Size}, labeled XS through XL. */
 export const SelectSize = (props: SelectComponentSizeProps): ReactElement => (
   <Buttons {...props} keys={SIZES}>
-    <Button itemKey="tiny">S</Button>
-    <Button itemKey="small">M</Button>
-    <Button itemKey="medium">L</Button>
+    <Button itemKey="tiny">XS</Button>
+    <Button itemKey="small">S</Button>
+    <Button itemKey="medium">M</Button>
+    <Button itemKey="large">L</Button>
+    <Button itemKey="huge">XL</Button>
   </Buttons>
 );

--- a/pluto/src/component/size.ts
+++ b/pluto/src/component/size.ts
@@ -19,5 +19,14 @@ export const size = z.enum(SIZES);
  */
 export type Size = z.infer<typeof size>;
 
+/** Height in pixels for each {@link Size}. Mirrors the `--pluto-height-*` CSS vars. */
+export const HEIGHTS: Record<Size, number> = {
+  tiny: 21,
+  small: 24,
+  medium: 28,
+  large: 36,
+  huge: 48,
+};
+
 /** @returns true if the value is one of {@link SIZES}. */
 export const isSize = (value: unknown): value is Size => size.safeParse(value).success;

--- a/pluto/src/schematic/node/common/form/Size.tsx
+++ b/pluto/src/schematic/node/common/form/Size.tsx
@@ -7,10 +7,12 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+import { type text } from "@synnaxlabs/x";
 import { type ReactElement } from "react";
 
 import { Component } from "@/component";
 import { Form } from "@/form";
+import { levelSize, SIZE_LEVELS } from "@/schematic/node/common/size";
 
 export const SizeField = (
   props: Partial<Form.FieldProps<Component.Size>>,
@@ -27,3 +29,23 @@ export const SizeField = (
 );
 
 const selectSize = Component.renderProp(Component.SelectSize);
+
+/** A size field for symbols that store a text level instead of a size. */
+export const LevelSizeField = (
+  props: Partial<Form.FieldProps<text.Level>>,
+): ReactElement => (
+  <Form.Field<text.Level>
+    path="level"
+    label="Size"
+    hideIfNull
+    padHelpText={false}
+    {...props}
+  >
+    {({ value, onChange }) => (
+      <Component.SelectSize
+        value={levelSize(value)}
+        onChange={(size: Component.Size) => onChange(SIZE_LEVELS[size])}
+      />
+    )}
+  </Form.Field>
+);

--- a/pluto/src/schematic/node/common/form/Size.tsx
+++ b/pluto/src/schematic/node/common/form/Size.tsx
@@ -12,7 +12,7 @@ import { type ReactElement } from "react";
 
 import { Component } from "@/component";
 import { Form } from "@/form";
-import { levelSize, SIZE_LEVELS } from "@/schematic/node/common/size";
+import { LEVEL_SIZES, SIZE_LEVELS } from "@/schematic/node/common/size";
 
 export const SizeField = (
   props: Partial<Form.FieldProps<Component.Size>>,
@@ -41,11 +41,21 @@ export const LevelSizeField = (
     padHelpText={false}
     {...props}
   >
-    {({ value, onChange }) => (
-      <Component.SelectSize
-        value={levelSize(value)}
-        onChange={(size: Component.Size) => onChange(SIZE_LEVELS[size])}
-      />
-    )}
+    {selectLevelSize}
   </Form.Field>
 );
+
+const SelectLevelSize = ({
+  value,
+  onChange,
+}: {
+  value: text.Level;
+  onChange: (level: text.Level) => void;
+}): ReactElement => (
+  <Component.SelectSize
+    value={LEVEL_SIZES[value]}
+    onChange={(size: Component.Size) => onChange(SIZE_LEVELS[size])}
+  />
+);
+
+const selectLevelSize = Component.renderProp(SelectLevelSize);

--- a/pluto/src/schematic/node/common/size.spec.ts
+++ b/pluto/src/schematic/node/common/size.spec.ts
@@ -1,0 +1,31 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { describe, expect, it } from "vitest";
+
+import { SIZES } from "@/component/size";
+import { levelSize, SIZE_LEVELS } from "@/schematic/node/common/size";
+
+describe("levelSize", () => {
+  describe("levels the picker offers", () => {
+    it("should round-trip every rung back to itself", () =>
+      SIZES.forEach((size) => expect(levelSize(SIZE_LEVELS[size])).toBe(size)));
+
+    it("should give every rung a distinct level", () =>
+      expect(new Set(SIZES.map((size) => SIZE_LEVELS[size])).size).toBe(SIZES.length));
+  });
+
+  describe("levels the picker does not offer", () => {
+    it("should fall back to medium for h1", () =>
+      expect(levelSize("h1")).toBe("medium"));
+
+    // Legacy string displays store p, and medium is the height they already rendered at.
+    it("should fall back to medium for p", () => expect(levelSize("p")).toBe("medium"));
+  });
+});

--- a/pluto/src/schematic/node/common/size.spec.ts
+++ b/pluto/src/schematic/node/common/size.spec.ts
@@ -10,12 +10,12 @@
 import { describe, expect, it } from "vitest";
 
 import { SIZES } from "@/component/size";
-import { levelSize, SIZE_LEVELS } from "@/schematic/node/common/size";
+import { LEVEL_SIZES, SIZE_LEVELS } from "@/schematic/node/common/size";
 
-describe("levelSize", () => {
+describe("LEVEL_SIZES", () => {
   describe("levels the picker offers", () => {
     it("should round-trip every rung back to itself", () =>
-      SIZES.forEach((size) => expect(levelSize(SIZE_LEVELS[size])).toBe(size)));
+      SIZES.forEach((size) => expect(LEVEL_SIZES[SIZE_LEVELS[size]]).toBe(size)));
 
     it("should give every rung a distinct level", () =>
       expect(new Set(SIZES.map((size) => SIZE_LEVELS[size])).size).toBe(SIZES.length));
@@ -23,9 +23,9 @@ describe("levelSize", () => {
 
   describe("levels the picker does not offer", () => {
     it("should fall back to medium for h1", () =>
-      expect(levelSize("h1")).toBe("medium"));
+      expect(LEVEL_SIZES.h1).toBe("medium"));
 
     // Legacy string displays store p, and medium is the height they already rendered at.
-    it("should fall back to medium for p", () => expect(levelSize("p")).toBe("medium"));
+    it("should fall back to medium for p", () => expect(LEVEL_SIZES.p).toBe("medium"));
   });
 });

--- a/pluto/src/schematic/node/common/size.ts
+++ b/pluto/src/schematic/node/common/size.ts
@@ -9,7 +9,7 @@
 
 import { type text } from "@synnaxlabs/x";
 
-import { type Size, SIZES } from "@/component/size";
+import { type Size } from "@/component/size";
 
 /** The text level a symbol renders at for each size rung. */
 export const SIZE_LEVELS: Record<Size, text.Level> = {
@@ -20,6 +20,13 @@ export const SIZE_LEVELS: Record<Size, text.Level> = {
   huge: "h2",
 };
 
-/** @returns the rung for a level, falling back to medium for unoffered levels. */
-export const levelSize = (level: text.Level): Size =>
-  SIZES.find((size) => SIZE_LEVELS[size] === level) ?? "medium";
+/** The rung for each text level. Unoffered levels map to medium. */
+export const LEVEL_SIZES: Record<text.Level, Size> = {
+  h1: "medium",
+  h2: "huge",
+  h3: "large",
+  h4: "medium",
+  h5: "small",
+  p: "medium",
+  small: "tiny",
+};

--- a/pluto/src/schematic/node/common/size.ts
+++ b/pluto/src/schematic/node/common/size.ts
@@ -1,0 +1,25 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { type text } from "@synnaxlabs/x";
+
+import { type Size, SIZES } from "@/component/size";
+
+/** The text level a symbol renders at for each size rung. */
+export const SIZE_LEVELS: Record<Size, text.Level> = {
+  tiny: "small",
+  small: "h5",
+  medium: "h4",
+  large: "h3",
+  huge: "h2",
+};
+
+/** @returns the rung for a level, falling back to medium for unoffered levels. */
+export const levelSize = (level: text.Level): Size =>
+  SIZES.find((size) => SIZE_LEVELS[size] === level) ?? "medium";

--- a/pluto/src/schematic/node/general/input/Form.tsx
+++ b/pluto/src/schematic/node/general/input/Form.tsx
@@ -90,8 +90,8 @@ export const InputForm = (): ReactElement => (
         <Flex.Box y align="stretch" grow gap="small">
           <Label.Form path="label" />
           <Flex.Box x>
-            <Form.SizeField />
             <Form.ColorField path="color" />
+            <Form.SizeField />
           </Flex.Box>
         </Flex.Box>
       </Form.Wrapper>

--- a/pluto/src/schematic/node/general/input/external.tsx
+++ b/pluto/src/schematic/node/general/input/external.tsx
@@ -26,7 +26,7 @@ export const defaultConfig = (): Config => ({
   variant: VARIANT,
   orientation: "left",
   color: color.ZERO,
-  size: "small",
+  size: "medium",
   label: Label.defaultConfig("Input"),
   control: { show: true },
   sink: telem.sinkPipeline("string", {

--- a/pluto/src/schematic/node/general/select/Form.tsx
+++ b/pluto/src/schematic/node/general/select/Form.tsx
@@ -88,8 +88,8 @@ export const SelectForm = (): ReactElement => (
         <Flex.Box y align="stretch" grow gap="small">
           <Label.Form path="label" />
           <Flex.Box x>
-            <Form.SizeField />
             <Form.ColorField path="color" />
+            <Form.SizeField />
             <Base.NumericField
               path="inlineSize"
               label="Width"

--- a/pluto/src/schematic/node/general/select/external.tsx
+++ b/pluto/src/schematic/node/general/select/external.tsx
@@ -26,7 +26,7 @@ export const defaultConfig = (): Config => ({
   variant: VARIANT,
   orientation: "left",
   color: color.ZERO,
-  size: "small",
+  size: "medium",
   inlineSize: 100,
   options: [],
   label: Label.defaultConfig("Select"),

--- a/pluto/src/schematic/node/general/setpoint/Form.tsx
+++ b/pluto/src/schematic/node/general/setpoint/Form.tsx
@@ -88,9 +88,9 @@ export const SetpointForm = (): ReactElement => (
         <Flex.Box y align="stretch" grow gap="small">
           <Label.Form path="label" />
           <Flex.Box x>
-            <Form.UnitsField />
-            <Form.SizeField />
             <Form.ColorField path="color" />
+            <Form.SizeField />
+            <Form.UnitsField />
           </Flex.Box>
         </Flex.Box>
         <Orientation.Field path="" hideInner />

--- a/pluto/src/schematic/node/general/setpoint/external.tsx
+++ b/pluto/src/schematic/node/general/setpoint/external.tsx
@@ -27,7 +27,7 @@ export const defaultConfig = (): Config => ({
   orientation: "left",
   units: "mV",
   color: color.ZERO,
-  size: "small",
+  size: "medium",
   label: Label.defaultConfig("Setpoint"),
   control: { show: true },
   sink: telem.sinkPipeline("number", {

--- a/pluto/src/schematic/node/general/stringDisplay/Form.tsx
+++ b/pluto/src/schematic/node/general/stringDisplay/Form.tsx
@@ -8,7 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { type channel } from "@synnaxlabs/client";
-import { primitive, type text, zod } from "@synnaxlabs/x";
+import { primitive, zod } from "@synnaxlabs/x";
 import { type ReactElement } from "react";
 
 import { Channel } from "@/channel";
@@ -18,7 +18,6 @@ import { Input } from "@/input";
 import { Form } from "@/schematic/node/common/form";
 import { Label } from "@/schematic/node/common/label";
 import { Orientation } from "@/schematic/node/common/orientation";
-import { Select } from "@/select";
 import { Status } from "@/status";
 import { Synnax } from "@/synnax";
 import { Tabs } from "@/tabs";
@@ -66,22 +65,13 @@ const StyleForm = (): ReactElement => (
       <Label.Form path="label" />
       <Flex.Box x>
         <Form.ColorField path="color" />
+        <Form.LevelSizeField />
         <Base.NumericField
           path="inlineSize"
           label="Display width"
           hideIfNull
           inputProps={Form.VALUE_WIDTH_INPUT_PROPS}
         />
-        <Base.Field<text.Level>
-          path="level"
-          label="Size"
-          hideIfNull
-          padHelpText={false}
-        >
-          {({ value, onChange }) => (
-            <Select.Text.Level value={value} onChange={onChange} />
-          )}
-        </Base.Field>
       </Flex.Box>
     </Flex.Box>
     <Orientation.Field path="" hideInner />

--- a/pluto/src/schematic/node/general/stringDisplay/Primitive.tsx
+++ b/pluto/src/schematic/node/general/stringDisplay/Primitive.tsx
@@ -12,9 +12,11 @@ import "@/schematic/node/general/stringDisplay/stringDisplay.css";
 import { color } from "@synnaxlabs/x";
 import { type CSSProperties, type ReactElement, useMemo } from "react";
 
+import { HEIGHTS } from "@/component/size";
 import { CSS } from "@/css";
 import { Handle } from "@/schematic/node/common/handle";
 import { Primitive } from "@/schematic/node/common/primitive";
+import { levelSize } from "@/schematic/node/common/size";
 import { type Config } from "@/schematic/node/general/stringDisplay/config";
 import { symbolColorVar } from "@/schematic/symbolColor";
 import { Text } from "@/text";
@@ -42,8 +44,9 @@ export const StringDisplay = ({
     () => ({
       [CSS.variable("symbol-color")]: symbolColorVar(colorVal),
       width: inlineSize,
+      height: HEIGHTS[levelSize(level)],
     }),
-    [colorVal, inlineSize],
+    [colorVal, inlineSize, level],
   );
   const theme = Theming.use();
   const resolvedTextColor = stale

--- a/pluto/src/schematic/node/general/stringDisplay/Primitive.tsx
+++ b/pluto/src/schematic/node/general/stringDisplay/Primitive.tsx
@@ -16,7 +16,7 @@ import { HEIGHTS } from "@/component/size";
 import { CSS } from "@/css";
 import { Handle } from "@/schematic/node/common/handle";
 import { Primitive } from "@/schematic/node/common/primitive";
-import { levelSize } from "@/schematic/node/common/size";
+import { LEVEL_SIZES } from "@/schematic/node/common/size";
 import { type Config } from "@/schematic/node/general/stringDisplay/config";
 import { symbolColorVar } from "@/schematic/symbolColor";
 import { Text } from "@/text";
@@ -44,7 +44,7 @@ export const StringDisplay = ({
     () => ({
       [CSS.variable("symbol-color")]: symbolColorVar(colorVal),
       width: inlineSize,
-      height: HEIGHTS[levelSize(level)],
+      height: HEIGHTS[LEVEL_SIZES[level]],
     }),
     [colorVal, inlineSize, level],
   );

--- a/pluto/src/schematic/node/general/stringDisplay/external.tsx
+++ b/pluto/src/schematic/node/general/stringDisplay/external.tsx
@@ -25,7 +25,7 @@ export const defaultConfig = (): Config => ({
   variant: VARIANT,
   orientation: "left",
   color: color.ZERO,
-  level: "p",
+  level: "h4",
   inlineSize: 100,
   label: Label.defaultConfig("String display"),
   ...Staleness.ZERO_CONFIG,

--- a/pluto/src/schematic/node/general/stringDisplay/stringDisplay.css
+++ b/pluto/src/schematic/node/general/stringDisplay/stringDisplay.css
@@ -22,7 +22,9 @@
     justify-content: center;
 
     & .pluto-string-display__content {
-        padding: 0.5rem 1.5rem;
+        /* No vertical padding: the root sets an explicit height per text level and
+        centers the line box, so padding here would push past it. */
+        padding: 0 1.5rem;
         flex-grow: 1;
 
         /* Lets the content shrink below the text's intrinsic width so the ellipsis

--- a/pluto/src/schematic/node/general/stringDisplay/stringDisplay.spec.tsx
+++ b/pluto/src/schematic/node/general/stringDisplay/stringDisplay.spec.tsx
@@ -85,8 +85,8 @@ describe("StringDisplay", () => {
       expect(getText(container).textContent).toBe("hello");
     });
 
-    // The box takes its height from the text element's line box, so the element has to
-    // be in the DOM before a value arrives or the symbol renders collapsed.
+    // The text element must already be in the DOM when the first value arrives, so
+    // the value renders into it rather than remounting it.
     it("should render a text element when no value has arrived", () => {
       const { container } = render(<Primitive value="" />);
       expect(getText(container).textContent).toBe("");

--- a/pluto/src/schematic/node/general/value/Form.tsx
+++ b/pluto/src/schematic/node/general/value/Form.tsx
@@ -7,7 +7,6 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { type text } from "@synnaxlabs/x";
 import { type ReactElement } from "react";
 
 import { Flex } from "@/flex";
@@ -15,7 +14,6 @@ import { Form as Base } from "@/form";
 import { Form } from "@/schematic/node/common/form";
 import { Label } from "@/schematic/node/common/label";
 import { Orientation } from "@/schematic/node/common/orientation";
-import { Select } from "@/select";
 import { Tabs } from "@/tabs";
 import { Value } from "@/vis/value";
 
@@ -32,6 +30,7 @@ export const ValueForm = (): ReactElement => (
           <Label.Form path="label" />
           <Flex.Box x>
             <Form.ColorField path="color" />
+            <Form.LevelSizeField />
             <Form.UnitsField />
             <Base.NumericField
               path="inlineSize"
@@ -39,16 +38,6 @@ export const ValueForm = (): ReactElement => (
               hideIfNull
               inputProps={Form.VALUE_WIDTH_INPUT_PROPS}
             />
-            <Base.Field<text.Level>
-              path="level"
-              label="Size"
-              hideIfNull
-              padHelpText={false}
-            >
-              {({ value, onChange }) => (
-                <Select.Text.Level value={value} onChange={onChange} />
-              )}
-            </Base.Field>
           </Flex.Box>
         </Flex.Box>
         <Orientation.Field path="" hideInner />

--- a/pluto/src/schematic/node/general/value/Symbol.tsx
+++ b/pluto/src/schematic/node/general/value/Symbol.tsx
@@ -13,7 +13,7 @@ import { type ReactElement, useMemo } from "react";
 import { HEIGHTS } from "@/component/size";
 import { Grid } from "@/schematic/node/common/grid";
 import { Label } from "@/schematic/node/common/label";
-import { levelSize } from "@/schematic/node/common/size";
+import { LEVEL_SIZES } from "@/schematic/node/common/size";
 import { type Config } from "@/schematic/node/general/value/config";
 import { Value } from "@/schematic/node/general/value/Primitive";
 import { type NodeProps } from "@/schematic/node/spec";
@@ -42,7 +42,7 @@ export const Symbol = ({
     redline,
   },
 }: NodeProps<Config>): ReactElement => {
-  const valueBoxHeight = HEIGHTS[levelSize(level)];
+  const valueBoxHeight = HEIGHTS[LEVEL_SIZES[level]];
   const backgroundTelem = useMemo(() => {
     if (t == null || redline == null) return undefined;
     const { bounds, gradient } = redline;

--- a/pluto/src/schematic/node/general/value/Symbol.tsx
+++ b/pluto/src/schematic/node/general/value/Symbol.tsx
@@ -10,17 +10,18 @@
 import { box, scale, text, xy } from "@synnaxlabs/x";
 import { type ReactElement, useMemo } from "react";
 
+import { HEIGHTS } from "@/component/size";
 import { Grid } from "@/schematic/node/common/grid";
 import { Label } from "@/schematic/node/common/label";
+import { levelSize } from "@/schematic/node/common/size";
 import { type Config } from "@/schematic/node/general/value/config";
 import { Value } from "@/schematic/node/general/value/Primitive";
 import { type NodeProps } from "@/schematic/node/spec";
 import { telem } from "@/telem/aether";
-import { Theming } from "@/theming";
 import { Value as BaseValue } from "@/vis/value";
 
-const VALUE_BACKGROUND_OVERSCAN = xy.construct(10, -3);
-const VALUE_BACKGROUND_SHIFT = xy.construct(1, 1);
+const VALUE_BACKGROUND_OVERSCAN = xy.construct(1, -4);
+const VALUE_BACKGROUND_SHIFT = xy.construct(2, 2);
 
 export const Symbol = ({
   nodeKey,
@@ -41,8 +42,7 @@ export const Symbol = ({
     redline,
   },
 }: NodeProps<Config>): ReactElement => {
-  const font = Theming.useTypography(level);
-  const valueBoxHeight = (font.lineHeight + 0.5) * font.baseSize + 2;
+  const valueBoxHeight = HEIGHTS[levelSize(level)];
   const backgroundTelem = useMemo(() => {
     if (t == null || redline == null) return undefined;
     const { bounds, gradient } = redline;

--- a/pluto/src/schematic/node/general/value/external.tsx
+++ b/pluto/src/schematic/node/general/value/external.tsx
@@ -28,7 +28,7 @@ export const defaultConfig = (): Config => ({
   orientation: "left",
   color: color.ZERO,
   units: "psi",
-  level: "h5",
+  level: "h4",
   inlineSize: 70,
   label: Label.defaultConfig("Value"),
   ...Staleness.ZERO_CONFIG,

--- a/pluto/src/select/Button.spec.tsx
+++ b/pluto/src/select/Button.spec.tsx
@@ -7,10 +7,11 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { fireEvent, render } from "@testing-library/react";
+import { fireEvent, render, type RenderResult } from "@testing-library/react";
 import { useState } from "react";
 import { describe, expect, it, vi } from "vitest";
 
+import { Component } from "@/component";
 import { Select } from "@/select";
 
 describe("Select.Button", () => {
@@ -113,4 +114,38 @@ describe("Select.Button", () => {
       expect(onChange).not.toHaveBeenCalled();
     });
   });
+});
+
+// Arrow keys walk the `keys` array, so buttons that drift out of that order break
+// navigation with nothing on screen to show it.
+describe("picker button order", () => {
+  const ids = (c: RenderResult): string[] =>
+    Array.from(c.container.querySelectorAll("button")).map((b) => b.id);
+
+  it("should render text levels from XS to XL", () =>
+    expect(ids(render(<Select.Text.Level value="h4" onChange={vi.fn()} />))).toEqual([
+      "small",
+      "h5",
+      "h4",
+      "h3",
+      "h2",
+    ]));
+
+  it("should render component sizes from XS to XL", () =>
+    expect(
+      ids(render(<Component.SelectSize value="medium" onChange={vi.fn()} />)),
+    ).toEqual(["tiny", "small", "medium", "large", "huge"]));
+
+  it("should render text weights from light to bold", () =>
+    expect(ids(render(<Select.Text.Weight value={400} onChange={vi.fn()} />))).toEqual([
+      "250",
+      "400",
+      "500",
+      "600",
+    ]));
+
+  it("should render alignments from start to end", () =>
+    expect(
+      ids(render(<Select.Flex.Alignment value="center" onChange={vi.fn()} />)),
+    ).toEqual(["start", "center", "end"]));
 });

--- a/pluto/src/select/flex/Alignment.tsx
+++ b/pluto/src/select/flex/Alignment.tsx
@@ -9,7 +9,7 @@
 
 import { type ReactElement } from "react";
 
-import { Flex } from "@/flex";
+import { type Flex } from "@/flex";
 import { Icon } from "@/icon";
 import { type Select } from "@/select";
 import { Button, Buttons } from "@/select/Button";
@@ -19,8 +19,11 @@ export interface AlignmentProps extends Omit<
   "keys"
 > {}
 
+/** The alignments the picker offers, in render order. */
+const KEYS: Flex.Alignment[] = ["start", "center", "end"];
+
 export const Alignment = ({ value, ...rest }: AlignmentProps): ReactElement => (
-  <Buttons {...rest} value={value} keys={Flex.ALIGNMENTS}>
+  <Buttons {...rest} value={value} keys={KEYS}>
     <Button itemKey="start">
       <Icon.TextAlign.Left />
     </Button>

--- a/pluto/src/select/text/Level.tsx
+++ b/pluto/src/select/text/Level.tsx
@@ -7,7 +7,7 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
-import { text } from "@synnaxlabs/x";
+import { type text } from "@synnaxlabs/x";
 import { type ReactElement } from "react";
 
 import { type Select } from "@/select";
@@ -15,8 +15,11 @@ import { Button, Buttons } from "@/select/Button";
 
 export interface LevelProps extends Omit<Select.ButtonsProps<text.Level>, "keys"> {}
 
+/** The levels the picker offers, in render order. */
+const KEYS: text.Level[] = ["small", "h5", "h4", "h3", "h2"];
+
 export const Level = (props: LevelProps): ReactElement => (
-  <Buttons {...props} keys={text.LEVELS}>
+  <Buttons {...props} keys={KEYS}>
     <Button itemKey="small" square>
       XS
     </Button>

--- a/pluto/src/select/text/Level.tsx
+++ b/pluto/src/select/text/Level.tsx
@@ -17,20 +17,20 @@ export interface LevelProps extends Omit<Select.ButtonsProps<text.Level>, "keys"
 
 export const Level = (props: LevelProps): ReactElement => (
   <Buttons {...props} keys={text.LEVELS}>
-    <Button itemKey="h2" square>
-      XL
-    </Button>
-    <Button itemKey="h3" square>
-      L
-    </Button>
-    <Button itemKey="h4" square>
-      M
+    <Button itemKey="small" square>
+      XS
     </Button>
     <Button itemKey="h5" square>
       S
     </Button>
-    <Button itemKey="small" square>
-      XS
+    <Button itemKey="h4" square>
+      M
+    </Button>
+    <Button itemKey="h3" square>
+      L
+    </Button>
+    <Button itemKey="h2" square>
+      XL
     </Button>
   </Buttons>
 );


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4769](https://linear.app/synnax/issue/SY-4769)

## Description

Laying out a schematic that looks tidy has been an exercise in frustration. Drop a `Value` next to a `Setpoint` next to a `String display` and none of them line up, so you nudge each one by hand, zoom in, nudge again, and still end up with a row that reads as slightly broken. There was no size you could pick that made them agree, because no two symbols measured themselves the same way.

I deliberately kept schema changes and migrations out of this. The point was to keep the change scoped and easy to review, so every symbol keeps the config field it already stores, `level` for `Value` and `String display` and `size` for the control symbols, and nothing on disk changes shape. Where a new field was tempting, a size picker for `State indicator`, I left it alone rather than widen the diff.

Six symbols each sized themselves differently. `Value` derived its height from a typography formula, `String display` and `State indicator` from text line height plus padding, and `Input`, `Setpoint`, and `Select` from the shared component size scale. At their defaults they rendered at 26, 28, 28, 24, 24, and 24 pixels. They now share one ladder, taken from the `--pluto-height-*` scale every other control already uses:

| Size | Height |
| ---- | ------ |
| XS | 21 |
| S | 24 |
| M | 28 |
| L | 36 |
| XL | 48 |

`M` is the default everywhere, which is what `State indicator` was already fixed at.

### Size pickers

`Value` and `String display` store a text level, not a size. A new `Form.LevelSizeField` gives them the same `XS` through `XL` picker as the control symbols and translates through `SIZE_LEVELS`, so nothing stored changes shape. `String display` defaulted to `p`, a level its own picker never offered, so there was no way to select it back; it now defaults to `h4`. `SelectSize` gained `XS` and `XL`, and its labels were shifted, since what it called `M` was `small`, or 24 pixels.

### Field order

All six rows now read color, size, width, then anything else.

### User impact

Existing `Value` symbols resize, since the height is computed at render rather than stored: 26 to 24 at `S`, 29 to 28 at `M`, 36.5 to 36 at `L`, 45.5 to 48 at `XL`. Connected edges re-anchor. Control symbols do not move, because `size` is stored and only the default changed. Legacy `String display` configs keep their 28 pixel height through the `medium` fallback.

### Rendering cost

Nothing worth measuring. `levelSize` is a five element `find` per render, and `Value` dropped a `Theming` context subscription in exchange. No new canvas work, no new Aether state, no extra re-render triggers.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR standardizes schematic symbol heights around the shared component-size scale while preserving existing persisted configuration shapes.
- Adds shared mappings between component sizes, pixel heights, and text levels.
- Updates Value and String Display sizing controls and rendering.
- Aligns default sizes and form-field ordering across the affected symbols.
- Corrects the Level and Alignment picker key arrays so keyboard navigation follows the rendered options.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| pluto/src/select/text/Level.tsx | The navigation key array now exactly matches the five rendered buttons in display order, resolving the previous mismatch. |
| pluto/src/select/flex/Alignment.tsx | Restricts navigation keys to the three alignments actually rendered by this picker. |
| pluto/src/select/Button.spec.tsx | Adds assertions that each button picker's rendered item order matches its intended navigation order. |
| pluto/src/schematic/node/common/size.ts | Introduces the shared size-to-text-level mapping and a medium fallback for legacy unoffered levels. |
| pluto/src/schematic/node/general/value/Symbol.tsx | Replaces typography-derived Value height with the standardized shared height ladder. |
| pluto/src/schematic/node/general/stringDisplay/Primitive.tsx | Applies the standardized explicit height based on the configured text level. |

<sub>Reviews (2): Last reviewed commit: ["SY-4769: Align picker nav keys with rend..."](https://github.com/synnaxlabs/synnax/commit/9fcad2965e79150cb3995428284bfb35fedec98b) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57369949)</sub>

<!-- /greptile_comment -->