### PR TITLE
SY-4770: Invert value symbol units styling

### DIFF
--- a/pluto/src/schematic/node/general/value/value.css
+++ b/pluto/src/schematic/node/general/value/value.css
@@ -29,12 +29,10 @@
     & .pluto-value__units {
         display: flex;
         align-items: center;
-        height: calc(100% + 2px);
+        height: 100%;
         padding: 0 1rem;
-        background: var(--pluto-symbol-display);
-        color: var(--pluto-symbol-contrast);
-        padding-top: 1px;
-        margin-right: -1px;
+        background: transparent;
+        border-left: 2px solid var(--pluto-symbol-display);
         text-align: center;
 
         &.pluto--h4 {
@@ -46,7 +44,7 @@
         }
 
         & .pluto-text {
-            color: var(--pluto-symbol-contrast);
+            color: var(--pluto-symbol-display);
             font-weight: 500;
         }
     }


### PR DESCRIPTION
## Linear Issue
[SY-4770](https://linear.app/synnax/issue/SY-4770)

## Description

The `Value` symbol filled its units cell with the symbol color and set the unit text to `--pluto-symbol-contrast`. On a schematic carrying many values, those filled blocks pull the eye away from the numbers they label.

Color is the strongest signal on the canvas, so it goes to what the operator needs to read. Spending it on a static unit string takes focus away from the reading itself.

The units cell is now transparent, the unit text takes `--pluto-symbol-display`, and a `2px` divider in the same color separates it from the value. The frame still carries the accent, and the number reads first.

It also keeps a fill meaningful: a filled block now marks a control affordance, the `Send` and `Set` buttons on `Select`, `Setpoint`, and `Input`, so an indicator no longer looks like something you can press.

<img width="168" height="163" alt="image" src="https://github.com/user-attachments/assets/57f81ba1-14c1-43ac-964b-3750b151b901" />

## Basic Readiness
- [x] I have performed a self-review of my code.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR inverts the Value symbol’s units styling so the numeric reading remains visually dominant.
- Replaces the filled units background with a transparent background and a 2px accent divider.
- Changes units text from the contrast color to the symbol display color.
- Removes spacing adjustments that supported the previous filled-cell treatment.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness or layout failure identified.

The CSS changes consistently implement the documented visual treatment, and the existing border-box sizing and flex layout provide no evidence of broken symbol geometry.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| pluto/src/schematic/node/general/value/value.css | Updates the Value symbol’s units cell from a filled block to a transparent, accent-colored label with a left divider; no actionable defect was identified. |

<sub>Reviews (1): Last reviewed commit: ["SY-4770: Invert value symbol units styli..."](https://github.com/synnaxlabs/synnax/commit/80bf436cbae671dd3bc23a59376f7299aa385590) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57373630)</sub>

<!-- /greptile_comment -->