### PR TITLE
SY-4776: Fix macOS Go test timeouts by lowering Ginkgo parallelism

### DIFF
--- a/.github/workflows/test.go.yaml
+++ b/.github/workflows/test.go.yaml
@@ -138,8 +138,9 @@ jobs:
       - name: Test
         timeout-minutes: 150
         run: >-
-          go run github.com/onsi/ginkgo/v2/ginkgo -r -p --randomize-all
-          --randomize-suites --fail-on-pending --fail-on-empty --keep-going --cover
+          go run github.com/onsi/ginkgo/v2/ginkgo -r ${{ runner.os == 'macOS' &&
+          '--procs=2 --compilers=2' || '-p' }} --randomize-all --randomize-suites
+          --fail-on-pending --fail-on-empty --keep-going --cover
           --coverprofile=cover.out --race --trace --timeout=2h --github-output ${{
           inputs.ginkgo_flags }}
         working-directory: ${{ inputs.directory }}


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4776](https://linear.app/synnax/issue/SY-4776)

## Description

`Test - Core` has been failing on `main` since 2026-08-25. The macOS job spent its whole budget compiling and reported all 219 suites as `[Suite did not run because the timeout elapsed]`, so no test ever ran. The same failure hit the 0.57 release PR from its first run on 2026-08-19, at a rate of 37 out of 58 runs.

The affected job is the GitHub-hosted `macos-latest` runner, image `macos-26-arm64` with three vCPUs. It is not one of our self-hosted `macos-build-bot` machines, which carry a different label and never receive this workflow. There is no shell access to the hosted runner, so everything below comes from job logs.

The cause is build cost, not a test. Ginkgo builds one race-instrumented binary per suite, and `core` grew from 86 suites to 219 over the 0.57 cycle. At the default parallelism the runner starts more concurrent compilers than it can carry, and the wedged processes reach the step timeout with every suite still unbuilt. The matrix skips macOS unless a ref targets `main`, so this only surfaced when 0.57 merged.

macOS now runs Ginkgo with `--procs=2 --compilers=2` in place of `-p`. Linux and Windows keep `-p` and are unchanged. `runner.os` resolves before the shell runs, so the substitution is safe under both bash and pwsh.

A `workflow_dispatch` run on this branch passed on all three platforms: https://github.com/synnaxlabs/synnax/actions/runs/33110258913. macOS built and ran all 219 suites in 54m31s, against a 150-minute step cap, where the last green run on `main` finished with 19 minutes to spare.

Two of the five `main` failures died on `The runner has received a shutdown signal`, one at 1h20m. That is GitHub reclaiming the VM and no flag prevents it, though a shorter job is less exposed.

## Basic Readiness

- [x] I have performed a self-review of my code.

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bounds Ginkgo test and compiler parallelism at two processes on macOS while preserving existing automatic parallelism on Linux and Windows.
- Selects `--procs=2 --compilers=2` when `runner.os` is `macOS`.
- Retains `-p` for all other runners.
- Leaves the remaining test options and timeout unchanged.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the macOS-specific command retains parallel execution with bounded process and compiler counts while other platforms remain unchanged.

The GitHub Actions expression resolves to supported Ginkgo flags on each matrix platform, and no changed-code-triggered failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/test.go.yaml | The platform-specific Ginkgo flags are valid, correctly select bounded parallelism on macOS, and preserve existing behavior elsewhere. |

<sub>Reviews (1): Last reviewed commit: ["Lower Ginkgo compiler and proc counts on..."](https://github.com/synnaxlabs/synnax/commit/b248e8889e698d5867fb8f4ed87e715085a1334e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=57684103)</sub>

<!-- /greptile_comment -->