### PR TITLE
SY-4708: Show independent notifications for statuses with distinct names

### DIFF
--- a/pluto/src/status/base/Aggregator.spec.tsx
+++ b/pluto/src/status/base/Aggregator.spec.tsx
@@ -94,6 +94,49 @@ describe("Aggregator", () => {
     });
   });
 
+  describe("grouping", () => {
+    it("should fold statuses with the same name, message, and variant", () => {
+      const { result } = renderHook(
+        () => ({
+          add: Status.useAdder(),
+          statuses: Status.useNotifications(),
+        }),
+        { wrapper },
+      );
+      act(() => {
+        result.current.add({ variant: "error", message: "Test" });
+      });
+      act(() => {
+        result.current.add({ variant: "error", message: "Test" });
+      });
+      expect(result.current.statuses.statuses).toHaveLength(1);
+      expect(result.current.statuses.statuses[0].count).toBe(2);
+    });
+
+    it("should keep statuses with distinct names separate", () => {
+      const { result } = renderHook(
+        () => ({
+          add: Status.useAdder(),
+          statuses: Status.useNotifications(),
+        }),
+        { wrapper },
+      );
+      act(() => {
+        result.current.add({ variant: "error", message: "Discrepancy", name: "1" });
+      });
+      act(() => {
+        result.current.add({ variant: "error", message: "Discrepancy", name: "2" });
+      });
+      act(() => {
+        result.current.add({ variant: "error", message: "Discrepancy", name: "3" });
+      });
+      const { statuses } = result.current.statuses;
+      expect(statuses).toHaveLength(3);
+      expect(statuses.map(({ name }) => name)).toEqual(["3", "2", "1"]);
+      statuses.forEach(({ count }) => expect(count).toBe(1));
+    });
+  });
+
   describe("silence", () => {
     it("should silence a notification", () => {
       const { result } = renderHook(
@@ -118,7 +161,7 @@ describe("Aggregator", () => {
       expect(result.current.statuses.statuses).toHaveLength(0);
     });
 
-    it("should silence all notifications with the same message and variant", () => {
+    it("should silence all notifications with the same name, message, and variant", () => {
       const { result } = renderHook(
         () => ({
           add: Status.useAdder(),
@@ -149,6 +192,29 @@ describe("Aggregator", () => {
         result.current.statuses.silence(key);
       });
       expect(result.current.statuses.statuses).toHaveLength(0);
+    });
+
+    it("should not silence a notification with a different name", () => {
+      const { result } = renderHook(
+        () => ({
+          add: Status.useAdder(),
+          statuses: Status.useNotifications(),
+        }),
+        { wrapper },
+      );
+      act(() => {
+        result.current.add({ variant: "error", message: "Discrepancy", name: "1" });
+      });
+      act(() => {
+        result.current.add({ variant: "error", message: "Discrepancy", name: "2" });
+      });
+      expect(result.current.statuses.statuses).toHaveLength(2);
+      const key = result.current.statuses.statuses[0].key;
+      act(() => {
+        result.current.statuses.silence(key);
+      });
+      expect(result.current.statuses.statuses).toHaveLength(1);
+      expect(result.current.statuses.statuses[0].name).toEqual("1");
     });
   });
 

--- a/pluto/src/status/base/Aggregator.tsx
+++ b/pluto/src/status/base/Aggregator.tsx
@@ -152,7 +152,7 @@ export const useNotifications = ({
     );
 
     const grouped = active.reduce((acc, status) => {
-      const key = `${status.variant}:${status.message}`;
+      const key = `${status.variant}:${status.message}:${status.name}`;
       if (!acc.has(key)) {
         acc.set(key, { ...status, count: 1 });
         return acc;
@@ -177,8 +177,10 @@ export const useNotifications = ({
       if (!prev.has(key)) next.add(key);
       if (existing != null) {
         const silenced = statusesRef.current.filter(
-          ({ message, variant }) =>
-            message === existing.message && variant === existing.variant,
+          ({ message, variant, name }) =>
+            message === existing.message &&
+            variant === existing.variant &&
+            name === existing.name,
         );
         silenced.forEach((status) => next.add(status.key));
       }


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4708](https://linear.app/synnax/issue/SY-4708)

## Description

An Arc program that calls `status.set` N times with distinct names off a shared trigger produced a single Console toast instead of N. The last name won the title and the rest were dropped, with only an `xN` badge hinting that the others fired.

### Root cause

The runtime and the Core are correct. Each call creates a distinct status resource, and all of them reach the Console. The collapse happens in Pluto's `useNotifications`, which groups toasts by `variant` and `message` alone. That key predates first-class statuses, when `message` was the whole identity of an ad hoc UI error. Statuses with distinct names but identical text fold into one bucket, and the newest entry seeds the rendered `name`.

### Fix

The grouping key now includes `name`, so named statuses stay separate while unnamed UI errors (created with an empty `name`) keep folding into one toast with a count. The `silence` predicate matches `name` as well, so dismissing one toast no longer silences every status that shares its text.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.




<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR updates notification grouping and silencing to distinguish statuses by name while preserving folding for statuses with equivalent identity.
- Adds `name` to the notification grouping key.
- Limits silencing to statuses with the same name, message, and variant.
- Adds grouping and silencing regression coverage for statuses with distinct names.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge.

No blocking failure remains.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| pluto/src/status/base/Aggregator.tsx | Adds status names to notification grouping and silencing comparisons; no eligible blocking issue remains. |
| pluto/src/status/base/Aggregator.spec.tsx | Adds regression coverage for folding equivalent statuses and separating or independently silencing statuses with distinct names. |

<sub>Reviews (2): Last reviewed commit: ["SY-4708: Include status name in notifica..."](https://github.com/synnaxlabs/synnax/commit/9ea58442b8466db1d78a23601d8432da1df51f82) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58772140)</sub>

<!-- /greptile_comment -->