### PR TITLE
SY-4801: Add Console access denied screen

### DIFF
--- a/console/src-tauri/tauri.conf.json
+++ b/console/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Synnax",
-  "version": "0.57.4",
+  "version": "0.57.5",
   "build": {
     "beforeBuildCommand": "pnpm build-vite",
     "beforeDevCommand": "pnpm dev-vite",

--- a/console/src/feature/auth/ConnectionGuard.tsx
+++ b/console/src/feature/auth/ConnectionGuard.tsx
@@ -9,7 +9,7 @@
 
 import "@/feature/auth/ConnectionGuard.css";
 
-import { type connection } from "@synnaxlabs/client";
+import { AccessDeniedError, type connection } from "@synnaxlabs/client";
 import {
   Access,
   Button,
@@ -66,21 +66,66 @@ const AwaitPermissions = ({ children }: PropsWithChildren): ReactNode => {
 };
 
 const PermissionsFallback = (props: Errors.FallbackProps): ReactElement => {
-  const { resetErrorBoundary } = props;
+  const { error, resetErrorBoundary } = props;
   const invalidate = Access.useInvalidatePermissions();
+  const logout = Session.useLogout();
+  const retry = (): void => {
+    invalidate({});
+    resetErrorBoundary();
+  };
+  // A denial is an expected state, not a crash, so it gets a calm surface.
+  if (AccessDeniedError.matches(error) || AccessDeniedError.matches(error.cause))
+    return <Denied retry={retry} />;
   return (
     <Errors.Fallback {...props}>
-      <Button.Button
-        variant="filled"
-        onClick={() => {
-          invalidate({});
-          resetErrorBoundary();
-        }}
-      >
+      <Button.Button variant="outlined" onClick={logout}>
+        <Icon.Logout />
+        Log out
+      </Button.Button>
+      <Button.Button variant="filled" onClick={retry}>
         <Icon.Refresh />
         Retry
       </Button.Button>
     </Errors.Fallback>
+  );
+};
+
+interface DeniedProps {
+  retry: () => void;
+}
+
+const Denied = ({ retry }: DeniedProps): ReactElement => {
+  const logout = Session.useLogout();
+  const target = Session.Core.useSelectSelected();
+  const subject =
+    target != null && target.username !== "" ? ` for ${target.username}` : "";
+  return (
+    <Shell.Frame className={CSS.B("connection")} connection={target}>
+      <Flex.Box
+        y
+        align="center"
+        justify="center"
+        gap={8}
+        className={CSS.cls(CSS.BE("connection", "body"), CSS.M("revealed"))}
+      >
+        <Status.Orbital core={<PlatformShell.Mark />} />
+        <Status.Summary
+          variant="warning"
+          message="Console access denied"
+          description={`Check role permissions${subject}.`}
+        />
+        <Flex.Box x gap="small">
+          <Button.Button variant="outlined" onClick={logout}>
+            <Icon.Logout />
+            Log out
+          </Button.Button>
+          <Button.Button variant="filled" onClick={retry}>
+            <Icon.Refresh />
+            Retry
+          </Button.Button>
+        </Flex.Box>
+      </Flex.Box>
+    </Shell.Frame>
   );
 };
 

--- a/console/src/feature/auth/Guard.spec.tsx
+++ b/console/src/feature/auth/Guard.spec.tsx
@@ -8,6 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { channel } from "@synnaxlabs/client";
+import { createTestClient } from "@synnaxlabs/client/testutil";
 import { Access, Synnax } from "@synnaxlabs/pluto";
 import { fireEvent, render, renderHook, screen, waitFor } from "@testing-library/react";
 import { type FC, type PropsWithChildren, type ReactElement } from "react";
@@ -244,4 +245,90 @@ describe("connection guard permissions", () => {
       await screen.findByText("authenticated content", {}, { timeout: 10000 }),
     ).toBeTruthy();
   });
+
+  const PASSWORD = "password123";
+
+  const assignRole = async (
+    client: ReturnType<typeof createTestClient>,
+    user: string,
+    roleName: string,
+  ): Promise<void> => {
+    const roles = await client.access.roles.retrieve({});
+    const role = roles.find(({ name }) => name === roleName);
+    if (role == null) throw new Error(`${roleName} role not provisioned`);
+    await client.access.roles.assign({ user, role: role.key });
+  };
+
+  const createUserWithRole = async (
+    client: ReturnType<typeof createTestClient>,
+    roleName: string,
+  ): Promise<{ username: string; key: string }> => {
+    const username = uniqueName("role_user");
+    const { key } = await client.users.create({ username, password: PASSWORD });
+    await assignRole(client, key, roleName);
+    return { username, key };
+  };
+
+  const renderGuardedContent = async (): Promise<void> => {
+    pinLocationOrigin("http://localhost:9090");
+    const { wrapper } = await createSessionConsoleWrapper({ client: null });
+    render(
+      <Session.SettledProvider>
+        <Auth.Guard>
+          <Auth.ConnectionGuard>
+            <span>authenticated content</span>
+          </Auth.ConnectionGuard>
+        </Auth.Guard>
+      </Session.SettledProvider>,
+      { wrapper },
+    );
+  };
+
+  it("should explain a denied policy fetch and recover through Retry", async () => {
+    const client = createTestClient();
+    // The Host role cannot retrieve policies, so the permissions fetch is denied.
+    const { username, key } = await createUserWithRole(client, "Host");
+    await renderGuardedContent();
+    submitCredentials(username, PASSWORD);
+    expect(
+      await screen.findByText("Console access denied", {}, { timeout: 10000 }),
+    ).toBeTruthy();
+    expect(screen.getByText(`Check role permissions for ${username}.`)).toBeTruthy();
+    // The denial renders the calm surface, not the crash fallback.
+    expect(screen.queryByText("Stack trace")).toBeNull();
+    expect(screen.queryByText("authenticated content")).toBeNull();
+    await assignRole(client, key, "Operator");
+    fireEvent.click(findButton("Retry"));
+    expect(
+      await screen.findByText("authenticated content", {}, { timeout: 10000 }),
+    ).toBeTruthy();
+  });
+
+  it("should return to the login surface through Log out", async () => {
+    const client = createTestClient();
+    const { username } = await createUserWithRole(client, "Host");
+    await renderGuardedContent();
+    submitCredentials(username, PASSWORD);
+    await screen.findByText("Console access denied", {}, { timeout: 10000 });
+    fireEvent.click(findButton("Log out"));
+    await waitFor(() =>
+      expect(screen.getAllByText("Log in").length).toBeGreaterThan(0),
+    );
+    expect(screen.queryByText("Console access denied")).toBeNull();
+    expect(screen.queryByText("authenticated content")).toBeNull();
+  });
+
+  it.each(["Owner", "Engineer", "Operator", "Viewer"])(
+    "should render the workspace for the %s role",
+    async (roleName) => {
+      const client = createTestClient();
+      const { username } = await createUserWithRole(client, roleName);
+      await renderGuardedContent();
+      submitCredentials(username, PASSWORD);
+      expect(
+        await screen.findByText("authenticated content", {}, { timeout: 10000 }),
+      ).toBeTruthy();
+      expect(screen.queryByText("Console access denied")).toBeNull();
+    },
+  );
 });


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4801](https://linear.app/synnax/issue/SY-4801)

## Description

Logging in with a role that cannot read policies (such as `Host`) previously landed on the generic crash screen with a raw `Failed to retrieve permissions` error, a stack trace, and no way out other than `Retry`. The denial is now treated as an expected state: the guard renders a dedicated access-denied screen with the message `Check role permissions for {username}`, a `Log out` button to reach another account, and `Retry` so the session recovers in place once an admin fixes the role.

Failures other than `AccessDeniedError` keep the crash fallback, which now also offers `Log out`. Live-Core tests in `Guard.spec.tsx` cover the denied screen, recovery through `Retry` after a role change, the logout escape, and workspace access for the built-in `Owner`, `Engineer`, `Operator`, and `Viewer` roles. The Console version is bumped to `0.57.5` to ship the fix.

<img width="532" height="543" alt="image" src="https://github.com/user-attachments/assets/ceb62821-41b5-41d8-8ff9-ef02f8a636df" />


## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR gives permission-denied sessions a dedicated recovery screen while preserving the generic fallback for other failures.
- Detects direct and wrapped access-denied errors during permission retrieval.
- Adds logout and retry actions to the denied and generic error states.
- Adds live-Core coverage for denial, retry recovery, logout, and built-in role access.
- Bumps the Console version to 0.57.5.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable correctness, security, or quality issues identified.

The denied-error classification matches the actual single-cause wrapper used by permission retrieval, retry follows the required synchronous invalidation sequence, and the new logout and recovery paths are covered by tests.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| console/src/feature/auth/ConnectionGuard.tsx | Correctly classifies the established permission-error shape and provides logout and invalidation-before-reset recovery actions. |
| console/src/feature/auth/Guard.spec.tsx | Adds focused integration coverage for denied access, repaired permissions, logout, and standard workspace roles. |
| console/src-tauri/tauri.conf.json | Bumps the packaged Console version from 0.57.4 to 0.57.5. |

<sub>Reviews (1): Last reviewed commit: ["SY-4801: bump console version"](https://github.com/synnaxlabs/synnax/commit/a6a9746fe7b66621c08d7fe8fa76a09b0fc93382) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58805050)</sub>

<!-- /greptile_comment -->