### PR TITLE
SY-4761: Enable scale and rotation on the schematic switch symbol

### DIFF
--- a/pluto/src/input/Switch.css
+++ b/pluto/src/input/Switch.css
@@ -16,6 +16,14 @@
 }
 
 .pluto-input__switch {
+    /* The gap caps so a big switch keeps a slim knob inset. */
+    --pluto-switch-width: calc(5rem * var(--pluto-switch-scale, 1));
+    --pluto-switch-height: calc(2.5rem * var(--pluto-switch-scale, 1));
+    --pluto-switch-gap: min(0.25rem * var(--pluto-switch-scale, 1), 0.5rem);
+
+    /* Travel = width - knob - both gaps, which reduces to width - height. */
+    --pluto-switch-travel: calc(var(--pluto-switch-width) - var(--pluto-switch-height));
+
     display: flex;
     justify-content: center;
     align-items: center;
@@ -42,16 +50,14 @@
         z-index: 100;
     }
 
-    /* --pluto-switch-scale (default 1) uniformly magnifies the control; the
-       schematic switch symbol sets it. */
     .pluto-input__switch-indicator {
         position: relative;
         display: inline-block;
-        width: calc(5rem * var(--pluto-switch-scale, 1));
-        height: calc(2.5rem * var(--pluto-switch-scale, 1));
+        width: var(--pluto-switch-width);
+        height: var(--pluto-switch-height);
 
         /* Half the track height: the pill shape holds at every scale. */
-        border-radius: calc(1.25rem * var(--pluto-switch-scale, 1));
+        border-radius: calc(var(--pluto-switch-height) / 2);
         background: var(--pluto-gray-l4);
         cursor: pointer;
         transition: 0.15s;
@@ -60,10 +66,10 @@
     .pluto-input__switch-indicator::before {
         position: absolute;
         content: "";
-        height: calc(2rem * var(--pluto-switch-scale, 1));
-        width: calc(2rem * var(--pluto-switch-scale, 1));
-        left: calc(0.25rem * var(--pluto-switch-scale, 1));
-        bottom: calc(0.25rem * var(--pluto-switch-scale, 1));
+        height: calc(var(--pluto-switch-height) - 2 * var(--pluto-switch-gap));
+        width: calc(var(--pluto-switch-height) - 2 * var(--pluto-switch-gap));
+        left: var(--pluto-switch-gap);
+        bottom: var(--pluto-switch-gap);
         background: var(--pluto-gray-l7);
         transition: 0.15s;
         cursor: pointer;
@@ -75,8 +81,7 @@
     }
 
     input:checked ~ .pluto-input__switch-indicator::before {
-        /* 125% of the 2rem knob = 2.5rem of travel, scaling with the knob itself. */
-        transform: translateX(125%);
+        transform: translateX(var(--pluto-switch-travel));
         background: var(--pluto-primary-p1);
     }
 
@@ -84,9 +89,11 @@
         * {
             cursor: not-allowed !important;
         }
+
         .pluto-input__switch-indicator {
             background: var(--pluto-gray-l3-50);
         }
+
         .pluto-input__switch-indicator::before {
             background: var(--pluto-gray-l6-70);
         }

--- a/pluto/src/input/Switch.css
+++ b/pluto/src/input/Switch.css
@@ -42,12 +42,16 @@
         z-index: 100;
     }
 
+    /* --pluto-switch-scale (default 1) uniformly magnifies the control; the
+       schematic switch symbol sets it. */
     .pluto-input__switch-indicator {
         position: relative;
         display: inline-block;
-        width: 5rem;
-        height: 2.5rem;
-        border-radius: var(--pluto-border-radius-medium);
+        width: calc(5rem * var(--pluto-switch-scale, 1));
+        height: calc(2.5rem * var(--pluto-switch-scale, 1));
+
+        /* Half the track height: the pill shape holds at every scale. */
+        border-radius: calc(1.25rem * var(--pluto-switch-scale, 1));
         background: var(--pluto-gray-l4);
         cursor: pointer;
         transition: 0.15s;
@@ -56,10 +60,10 @@
     .pluto-input__switch-indicator::before {
         position: absolute;
         content: "";
-        height: 2rem;
-        width: 2rem;
-        left: 0.25rem;
-        bottom: 0.25rem;
+        height: calc(2rem * var(--pluto-switch-scale, 1));
+        width: calc(2rem * var(--pluto-switch-scale, 1));
+        left: calc(0.25rem * var(--pluto-switch-scale, 1));
+        bottom: calc(0.25rem * var(--pluto-switch-scale, 1));
         background: var(--pluto-gray-l7);
         transition: 0.15s;
         cursor: pointer;
@@ -71,7 +75,8 @@
     }
 
     input:checked ~ .pluto-input__switch-indicator::before {
-        transform: translateX(2.5rem);
+        /* 125% of the 2rem knob = 2.5rem of travel, scaling with the knob itself. */
+        transform: translateX(125%);
         background: var(--pluto-primary-p1);
     }
 

--- a/pluto/src/schematic/node/general/switch/Primitive.spec.tsx
+++ b/pluto/src/schematic/node/general/switch/Primitive.spec.tsx
@@ -71,6 +71,24 @@ describe("switch symbol", () => {
     });
   });
 
+  describe("scale", () => {
+    // The dimensions are computed from the scale var in Switch.css; jsdom cannot
+    // compute them, so we assert the source var.
+    it("should set the scale var from the scale prop", () => {
+      const { container } = render(<Switch scale={3} />);
+      expect(getRoot(container).style.getPropertyValue("--pluto-switch-scale")).toBe(
+        "3",
+      );
+    });
+
+    it("should default the scale var to 1", () => {
+      const { container } = render(<Switch />);
+      expect(getRoot(container).style.getPropertyValue("--pluto-switch-scale")).toBe(
+        "1",
+      );
+    });
+  });
+
   describe("enabled", () => {
     it("should reflect the enabled state on the input", () => {
       const { container } = render(<Switch enabled />);

--- a/pluto/src/schematic/node/general/switch/Primitive.spec.tsx
+++ b/pluto/src/schematic/node/general/switch/Primitive.spec.tsx
@@ -91,19 +91,15 @@ describe("switch symbol", () => {
 
   describe("orientation", () => {
     // The box swap and rotation live in switch.css; jsdom cannot compute them, so we
-    // assert the location class that keys them.
-    it("should carry the location class for the orientation prop", () => {
+    // assert the direction class that keys them.
+    it("should carry the direction class for the orientation prop", () => {
       const { container } = render(<Switch orientation="bottom" />);
-      expect(getRoot(container).getAttribute("class")).toContain(
-        "pluto--location-bottom",
-      );
+      expect(getRoot(container).getAttribute("class")).toContain("pluto--direction-y");
     });
 
-    it("should default to the left location", () => {
+    it("should default to the x direction", () => {
       const { container } = render(<Switch />);
-      expect(getRoot(container).getAttribute("class")).toContain(
-        "pluto--location-left",
-      );
+      expect(getRoot(container).getAttribute("class")).toContain("pluto--direction-x");
     });
   });
 

--- a/pluto/src/schematic/node/general/switch/Primitive.spec.tsx
+++ b/pluto/src/schematic/node/general/switch/Primitive.spec.tsx
@@ -89,6 +89,24 @@ describe("switch symbol", () => {
     });
   });
 
+  describe("orientation", () => {
+    // The box swap and rotation live in switch.css; jsdom cannot compute them, so we
+    // assert the location class that keys them.
+    it("should carry the location class for the orientation prop", () => {
+      const { container } = render(<Switch orientation="bottom" />);
+      expect(getRoot(container).getAttribute("class")).toContain(
+        "pluto--location-bottom",
+      );
+    });
+
+    it("should default to the left location", () => {
+      const { container } = render(<Switch />);
+      expect(getRoot(container).getAttribute("class")).toContain(
+        "pluto--location-left",
+      );
+    });
+  });
+
   describe("enabled", () => {
     it("should reflect the enabled state on the input", () => {
       const { container } = render(<Switch enabled />);

--- a/pluto/src/schematic/node/general/switch/Primitive.tsx
+++ b/pluto/src/schematic/node/general/switch/Primitive.tsx
@@ -9,6 +9,7 @@
 
 import "@/schematic/node/general/switch/switch.css";
 
+import { location } from "@synnaxlabs/x";
 import { type CSSProperties, type MouseEventHandler, type ReactElement } from "react";
 
 import { CSS } from "@/css";
@@ -18,9 +19,9 @@ import { Primitive } from "@/schematic/node/common/primitive";
 import { type Toggle } from "@/schematic/node/common/toggle";
 import { symbolColorVar } from "@/schematic/symbolColor";
 
-export interface Props
-  extends Omit<Toggle.ButtonProps, "onClick">, Primitive.SVGBasedProps {
+export interface Props extends Omit<Toggle.ButtonProps, "onClick"> {
   onClick?: MouseEventHandler<HTMLElement>;
+  scale?: number;
 }
 
 export const Switch = ({
@@ -41,7 +42,7 @@ export const Switch = ({
       className={CSS.cls(
         colorVar != null && CSS.B("symbol-colored"),
         colorVar != null && CSS.BM("switch-symbol", "colored"),
-        CSS.loc(orientation),
+        CSS.dir(location.direction(orientation)),
       )}
       style={style}
     >

--- a/pluto/src/schematic/node/general/switch/Primitive.tsx
+++ b/pluto/src/schematic/node/general/switch/Primitive.tsx
@@ -41,6 +41,7 @@ export const Switch = ({
       className={CSS.cls(
         colorVar != null && CSS.B("symbol-colored"),
         colorVar != null && CSS.BM("switch-symbol", "colored"),
+        CSS.loc(orientation),
       )}
       style={style}
     >

--- a/pluto/src/schematic/node/general/switch/Primitive.tsx
+++ b/pluto/src/schematic/node/general/switch/Primitive.tsx
@@ -18,7 +18,8 @@ import { Primitive } from "@/schematic/node/common/primitive";
 import { type Toggle } from "@/schematic/node/common/toggle";
 import { symbolColorVar } from "@/schematic/symbolColor";
 
-export interface Props extends Omit<Toggle.ButtonProps, "onClick"> {
+export interface Props
+  extends Omit<Toggle.ButtonProps, "onClick">, Primitive.SVGBasedProps {
   onClick?: MouseEventHandler<HTMLElement>;
 }
 
@@ -27,10 +28,13 @@ export const Switch = ({
   onClick,
   orientation = "left",
   color: colorVal,
+  scale = 1,
 }: Props): ReactElement => {
   const colorVar = symbolColorVar(colorVal);
-  const style: CSSProperties | undefined =
-    colorVar != null ? { [CSS.variable("symbol-color")]: colorVar } : undefined;
+  const style: CSSProperties = {
+    [CSS.variable("switch-scale")]: scale,
+    [CSS.variable("symbol-color")]: colorVar,
+  };
   return (
     <Primitive.Div
       orientation={orientation}

--- a/pluto/src/schematic/node/general/switch/switch.css
+++ b/pluto/src/schematic/node/general/switch/switch.css
@@ -39,9 +39,10 @@
     min-height: 0;
     padding: 0;
 
-    /* Geometry must track resize drags instantly, so transition only the colors
-       and the toggle slide. */
+    /* Transition only paint so geometry tracks resize drags instantly. Flex must not
+       shrink the indicator into the narrower vertical box. */
     .pluto-input__switch-indicator {
+        flex: none;
         transition: background 0.15s;
     }
 
@@ -50,4 +51,27 @@
             transform 0.15s,
             background 0.15s;
     }
+}
+
+/*
+ * The shared svg rotation in primitive.css cannot rotate this HTML symbol, and
+ * rotating an HTML element leaves its layout box unrotated. So swap the box by hand
+ * and rotate the flex-centered indicator inside it.
+ */
+.pluto-symbol-primitive.pluto--location-top > .pluto-input__switch,
+.pluto-symbol-primitive.pluto--location-bottom > .pluto-input__switch {
+    width: calc(2.5rem * var(--pluto-switch-scale, 1));
+    height: calc(5rem * var(--pluto-switch-scale, 1));
+}
+
+.pluto-symbol-primitive.pluto--location-bottom .pluto-input__switch-indicator {
+    rotate: 90deg;
+}
+
+.pluto-symbol-primitive.pluto--location-top .pluto-input__switch-indicator {
+    rotate: -90deg;
+}
+
+.pluto-symbol-primitive.pluto--location-right .pluto-input__switch-indicator {
+    rotate: 180deg;
 }

--- a/pluto/src/schematic/node/general/switch/switch.css
+++ b/pluto/src/schematic/node/general/switch/switch.css
@@ -31,3 +31,23 @@
         background: var(--pluto-gray-l1);
     }
 }
+
+/*
+ * Zero the button chrome so the symbol box hugs the track at every scale.
+ */
+.pluto-symbol-primitive > .pluto-btn.pluto-input__switch {
+    min-height: 0;
+    padding: 0;
+
+    /* Geometry must track resize drags instantly, so transition only the colors
+       and the toggle slide. */
+    .pluto-input__switch-indicator {
+        transition: background 0.15s;
+    }
+
+    .pluto-input__switch-indicator::before {
+        transition:
+            transform 0.15s,
+            background 0.15s;
+    }
+}

--- a/pluto/src/schematic/node/general/switch/switch.css
+++ b/pluto/src/schematic/node/general/switch/switch.css
@@ -58,20 +58,11 @@
  * rotating an HTML element leaves its layout box unrotated. So swap the box by hand
  * and rotate the flex-centered indicator inside it.
  */
-.pluto-symbol-primitive.pluto--location-top > .pluto-input__switch,
-.pluto-symbol-primitive.pluto--location-bottom > .pluto-input__switch {
-    width: calc(2.5rem * var(--pluto-switch-scale, 1));
-    height: calc(5rem * var(--pluto-switch-scale, 1));
+.pluto-symbol-primitive.pluto--direction-y > .pluto-input__switch {
+    width: var(--pluto-switch-height);
+    height: var(--pluto-switch-width);
 }
 
-.pluto-symbol-primitive.pluto--location-bottom .pluto-input__switch-indicator {
-    rotate: 90deg;
-}
-
-.pluto-symbol-primitive.pluto--location-top .pluto-input__switch-indicator {
+.pluto-symbol-primitive.pluto--direction-y .pluto-input__switch-indicator {
     rotate: -90deg;
-}
-
-.pluto-symbol-primitive.pluto--location-right .pluto-input__switch-indicator {
-    rotate: 180deg;
 }


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4761](https://linear.app/synnax/issue/SY-4761)

## Description

The `switch` symbol's Style tab showed a Scale control and the rotate button cycled its orientation, but neither changed the rendering. The switch is the only symbol with these controls that draws itself in HTML instead of through `Primitive.SVG`: its primitive dropped the `scale` prop, and the track and knob sizes were hard-coded in the shared input CSS.

- Scale: the shared `Input.Switch` geometry now multiplies by a `--pluto-switch-scale` variable (default 1, so switches elsewhere in the app are unchanged), and the symbol primitive sets it from `scale`. Symbol-scoped CSS zeros the button chrome so the node box hugs the track, and transitions only paint so drag-resize tracks instantly.
- Rotation: the primitive now carries the standard location class, and the symbol CSS swaps the layout box and rotates the indicator inside it, the HTML equivalent of the SVG symbols' box swap and rotation.

A switch that was drag-resized while the control was dead silently stored a `scale`. That value is now honored, a one-time visual jump that reflects what was dragged. Never-resized switches store `scale: 1` and render pixel-identical.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR makes the HTML-based schematic switch honor its stored scale and orientation while preserving the default geometry of shared input switches.
- Scales the shared switch track, knob, offsets, and knob travel through `--pluto-switch-scale`.
- Adds orientation classes and symbol-specific layout-box rotation rules.
- Adds unit coverage for scale variables, orientation classes, color behavior, and enabled state.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no concrete changed-code failures identified.

The scaled geometry remains equivalent at scale 1, knob travel scales consistently, and the orientation-specific layout boxes agree with the switch’s handle placement.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| pluto/src/input/Switch.css | Replaces fixed switch geometry with scale-aware calculations while preserving equivalent geometry at the default scale. |
| pluto/src/schematic/node/general/switch/Primitive.tsx | Propagates scale and orientation to CSS through a custom property and standard location class. |
| pluto/src/schematic/node/general/switch/switch.css | Removes schematic button chrome and aligns rotated visual geometry with orientation-aware node bounds. |
| pluto/src/schematic/node/general/switch/Primitive.spec.tsx | Adds assertions for scale propagation and orientation classes alongside existing switch behavior coverage. |

<sub>Reviews (1): Last reviewed commit: ["SY-4761: Fix rotation on the schematic s..."](https://github.com/synnaxlabs/synnax/commit/72316f7a1165d1f3d7472a0c7613f166bdba3794) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=58862815)</sub>

<!-- /greptile_comment -->