### PR TITLE
SY-4809: Fire entry nodes once per activation in the Arc scheduler

### DIFF
--- a/arc/cpp/runtime/runtime_test.cpp
+++ b/arc/cpp/runtime/runtime_test.cpp
@@ -377,7 +377,7 @@ TEST(BuildAuthoritiesTest, NoDefaultUsesAbsolute) {
     EXPECT_EQ(result[1], x::control::AUTHORITY_ABSOLUTE);
 }
 
-/// @brief Mock node that sets a configurable deadline on each execution.
+/// @brief Mock node that, like a real timer, self-marks and sets a deadline each run.
 struct DeadlineNode final : public node::Node {
     std::atomic<int64_t> deadline_ns;
 
@@ -385,6 +385,7 @@ struct DeadlineNode final : public node::Node {
         deadline_ns(deadline.nanoseconds()) {}
 
     x::errors::Error next(node::Context &ctx) override {
+        ctx.mark_self_changed();
         const auto d = x::telem::TimeSpan(this->deadline_ns.load());
         if (d != x::telem::TimeSpan::max()) ctx.set_deadline(d);
         return x::errors::NIL;

--- a/arc/cpp/runtime/scheduler/scheduler.h
+++ b/arc/cpp/runtime/scheduler/scheduler.h
@@ -78,6 +78,9 @@ class Scheduler {
         std::string key;
         /// @brief position in changed_flags / self_changed_flags.
         size_t idx = 0;
+        /// @brief marks a node with no incoming edges and no channel reads.
+        /// Entry nodes fire once per activation.
+        bool entry = false;
         /// @brief propagation table indexed by output ordinal.
         std::vector<OutputResolved> outputs;
     };
@@ -159,6 +162,10 @@ class Scheduler {
     /// to request replay on the next cycle. Cleared when the replay runs
     /// or when the owning member is deactivated.
     std::vector<uint8_t> self_changed_flags;
+    /// @brief fired_flags[i] is set when node i runs and cleared on
+    /// (re)activation. An entry node with the flag set skips the unconditional
+    /// stratum-0 dispatch.
+    std::vector<uint8_t> fired_flags;
     /// @brief marked_flags[i] is set when the (node, output) pair behind
     /// transition handle i fired truthy this cycle. Cleared at end of
     /// cycle so transitions fire on fresh marks, not stale truthiness.
@@ -207,6 +214,7 @@ public:
     void reset() {
         std::ranges::fill(this->changed_flags, 0);
         std::ranges::fill(this->self_changed_flags, 0);
+        std::ranges::fill(this->fired_flags, 0);
         std::ranges::fill(this->marked_flags, 0);
         this->curr_node = NO_INDEX;
         for (auto &sc: this->scopes) {
@@ -287,9 +295,9 @@ private:
         }
     }
 
-    /// @brief walks a nested-scope member or runs a leaf-node member.
-    /// A leaf runs when stratum_idx==0, when changed_flags is set, or when
-    /// the node was self-changed on a prior cycle. Running consumes the flag.
+    /// @brief walks a nested-scope member or runs a leaf-node member. A leaf
+    /// runs when stratum_idx==0 (entry nodes: once per activation), on
+    /// changed_flags, or on a prior-cycle self-change. Running consumes the flag.
     void execute_member(const size_t stratum_idx, MemberState &m) {
         if (m.scope != NO_INDEX) {
             this->walk(this->scopes[m.scope]);
@@ -300,18 +308,22 @@ private:
         this->visited_flags[idx] = 1;
         const bool was_self_changed = this->self_changed_flags[idx] != 0;
         if (was_self_changed) this->self_changed_flags[idx] = 0;
-        if (stratum_idx == 0 || this->changed_flags[idx] || was_self_changed) {
+        const bool forced = stratum_idx == 0 &&
+                            (!this->nodes[idx].entry || this->fired_flags[idx] == 0);
+        if (forced || this->changed_flags[idx] || was_self_changed) {
             this->changed_flags[idx] = 0;
+            this->fired_flags[idx] = 1;
             this->curr_node = m.node;
             this->nodes[this->curr_node].node->next(this->ctx);
         }
     }
 
-    /// @brief clears self-changed and calls reset on m's node. No-op if m is
-    /// a scope member or an unresolved node-key.
+    /// @brief clears self-changed and fired and calls reset on m's node. No-op
+    /// if m is a scope member or an unresolved node-key.
     void reset_leaf_node(MemberState &m) {
         if (m.is_node() && m.node != NO_INDEX) {
             this->self_changed_flags[m.node] = 0;
+            this->fired_flags[m.node] = 0;
             this->nodes[m.node].node->reset();
         }
     }
@@ -506,6 +518,7 @@ private:
         this->s->nodes.resize(n);
         this->s->changed_flags.assign(n, 0);
         this->s->self_changed_flags.assign(n, 0);
+        this->s->fired_flags.assign(n, 0);
         this->s->visited_flags.assign(n, 0);
         this->nodes_by_key.reserve(n);
         this->output_by_param.resize(n);
@@ -515,6 +528,7 @@ private:
             auto &wrapper = this->s->nodes[idx];
             wrapper.key = ir_node.key;
             wrapper.idx = idx;
+            wrapper.entry = ir::is_entry_node(this->s->prog, ir_node);
             const auto impl_it = node_impls.find(ir_node.key);
             if (impl_it != node_impls.end()) wrapper.node = std::move(impl_it->second);
             // Pre-seed outputs in the IR's declared order. Node impls

--- a/arc/cpp/runtime/scheduler/scheduler_test.cpp
+++ b/arc/cpp/runtime/scheduler/scheduler_test.cpp
@@ -276,14 +276,15 @@ TEST_F(SchedulerTest, ExecutesAllPhaseZeroMembers) {
 
 // ----- Phase-based execution -----
 
-TEST_F(SchedulerTest, Phase0ExecutesUnconditionallyEachCycle) {
+TEST_F(SchedulerTest, RunsAnEntryPhase0MemberOncePerActivation) {
     auto &a = mock("A");
     auto ir = program_of({ir_node("A")}, {}, root_scope({ir::node_member("A")}));
     const auto s = build(std::move(ir));
     s->next(x::telem::MILLISECOND, node::RunReason::TimerTick);
     s->next(2 * x::telem::MILLISECOND, node::RunReason::TimerTick);
     s->next(3 * x::telem::MILLISECOND, node::RunReason::TimerTick);
-    EXPECT_EQ(a.next_called, 3);
+    // A has no inputs, so it is an entry node: one run per activation.
+    EXPECT_EQ(a.next_called, 1);
 }
 
 TEST_F(SchedulerTest, PhaseNSkipsWithoutIncomingChange) {
@@ -322,7 +323,10 @@ TEST_F(SchedulerTest, ContinuousEdgePropagatesToDownstream) {
 TEST_F(SchedulerTest, ConditionalEdgeGatedOnSourceTruthiness) {
     auto &a = mock("A");
     auto &b = mock("B");
-    a.on_next = mark_on_next(0);
+    a.on_next = [](node::Context &ctx) {
+        ctx.mark_changed(0);
+        ctx.mark_self_changed();
+    };
     auto ir = program_of(
         {ir_node("A", {"output"}), ir_node("B")},
         {conditional_edge("A", "output", "B", "input")},
@@ -443,7 +447,8 @@ TEST_F(SchedulerTest, IgnoresEdgesWithEndpointsOutsideMembership) {
 // ----- Conditional edge lifecycle -----
 
 TEST_F(SchedulerTest, ConditionalFiresEveryCycleWhileTruthy) {
-    mock("A", {true});
+    auto &a = mock("A", {true});
+    a.on_next = [](node::Context &ctx) { ctx.mark_self_changed(); };
     auto &b = mock("B");
     auto ir = program_of(
         {ir_node("A", {"output"}), ir_node("B")},
@@ -461,6 +466,7 @@ TEST_F(SchedulerTest, ConditionalFiresEveryCycleWhileTruthy) {
 
 TEST_F(SchedulerTest, ConditionalStopsFiringWhenSourceBecomesFalsy) {
     auto &a = mock("A", {true});
+    a.on_next = [](node::Context &ctx) { ctx.mark_self_changed(); };
     auto &b = mock("B");
     auto ir = program_of(
         {ir_node("A", {"output"}), ir_node("B")},
@@ -558,6 +564,7 @@ TEST_F(SchedulerTest, SelfChangedReplaysUntilNodeStopsMarking) {
 
 TEST_F(SchedulerTest, ElapsedTimePassedThrough) {
     auto &a = mock("A");
+    a.on_next = [](node::Context &ctx) { ctx.mark_self_changed(); };
     auto ir = program_of({ir_node("A")}, {}, root_scope({ir::node_member("A")}));
     const auto s = build(std::move(ir));
     s->next(5 * x::telem::MILLISECOND, node::RunReason::TimerTick);
@@ -609,6 +616,7 @@ TEST_F(SchedulerTest, NextDeadlineResetsBetweenCycles) {
     int call = 0;
     a.on_next = [&call](const node::Context &ctx) {
         call++;
+        ctx.mark_self_changed();
         if (call == 1) ctx.set_deadline(x::telem::SECOND);
     };
     auto ir = program_of({ir_node("A")}, {}, root_scope({ir::node_member("A")}));
@@ -653,9 +661,10 @@ TEST_F(SchedulerTest, GatedScopeActivatesOnceHandleFires) {
     s->next(x::telem::MILLISECOND, node::RunReason::TimerTick);
     EXPECT_EQ(stage_node.next_called, 1);
     EXPECT_EQ(stage_node.reset_called, 1);
+    // Stays active without re-activating; the entry member fired once.
     s->next(2 * x::telem::MILLISECOND, node::RunReason::TimerTick);
-    EXPECT_EQ(stage_node.next_called, 2);
-    EXPECT_EQ(stage_node.reset_called, 1); // no re-activation
+    EXPECT_EQ(stage_node.next_called, 1);
+    EXPECT_EQ(stage_node.reset_called, 1);
 }
 
 // ----- Activation cascading & reset -----
@@ -747,6 +756,7 @@ TEST_F(SchedulerTest, CascadeThroughNestedAlwaysScopesAtDepth) {
 TEST_F(SchedulerTest, AdvancesOnTransitionFire) {
     mock("trigger", {true});
     auto &first = mock("first_node");
+    first.on_next = [](node::Context &ctx) { ctx.mark_self_changed(); };
     auto &second = mock("second_node");
 
     auto first_scope = parallel_scope(
@@ -787,14 +797,9 @@ TEST_F(SchedulerTest, AdvancesOnTransitionFire) {
 }
 
 TEST_F(SchedulerTest, ExitTargetDeactivatesSequence) {
-    auto &trigger = mock("trigger", {true});
+    mock("trigger", {true});
     auto &first = mock("first_node");
-    // One-shot: release trigger after cycle 1 so exit is permanent.
-    int cycle = 0;
-    trigger.on_next = [&cycle, &trigger](const node::Context &) {
-        cycle++;
-        if (cycle > 1) trigger.output_truthy[0] = false;
-    };
+    first.on_next = [](node::Context &ctx) { ctx.mark_self_changed(); };
 
     auto first_scope = parallel_scope(
         "first",
@@ -816,6 +821,7 @@ TEST_F(SchedulerTest, ExitTargetDeactivatesSequence) {
     );
     const auto s = build(std::move(ir));
     s->next(x::telem::MILLISECOND, node::RunReason::TimerTick);
+    // The exit trips on cycle 2; the one-shot trigger cannot re-activate main.
     first.set_truthy(0);
     s->next(2 * x::telem::MILLISECOND, node::RunReason::TimerTick);
     const int count_at_exit = first.next_called;
@@ -826,6 +832,7 @@ TEST_F(SchedulerTest, ExitTargetDeactivatesSequence) {
 TEST_F(SchedulerTest, FirstMatchWinsWhenMultipleTransitionsTruthy) {
     mock("trigger", {true});
     auto &first = mock("first_node");
+    first.on_next = [](node::Context &ctx) { ctx.mark_self_changed(); };
     auto &a = mock("a_node");
     auto &b = mock("b_node");
 
@@ -1054,7 +1061,8 @@ TEST_F(
     mock("trigger", {true});
     auto &latch = mock("latch", {true});
     latch.suppress_auto_mark = true;
-    mock("worker");
+    auto &worker = mock("worker");
+    worker.on_next = [](node::Context &ctx) { ctx.mark_self_changed(); };
 
     auto body = parallel_scope("body", {stratum_of({ir::node_member("worker")})});
     ir::Transition t_exit;
@@ -1093,10 +1101,12 @@ TEST_F(
     int marks = 0;
     latch.on_next = [&marks](const node::Context &ctx) {
         marks++;
+        ctx.mark_self_changed();
         if (marks == 1) ctx.mark_changed(0);
     };
     mock("worker_a");
-    mock("worker_b");
+    auto &worker_b = mock("worker_b");
+    worker_b.on_next = [](node::Context &ctx) { ctx.mark_self_changed(); };
 
     auto a = parallel_scope("a", {stratum_of({ir::node_member("worker_a")})});
     auto b = parallel_scope("b", {stratum_of({ir::node_member("worker_b")})});
@@ -1144,6 +1154,7 @@ TEST_F(SchedulerTest, FiresTransitionAgainWhenSourceFreshlyMarksChangedOnLaterCy
     int cycle = 0;
     latch.on_next = [&cycle, &latch](const node::Context &ctx) {
         cycle++;
+        ctx.mark_self_changed();
         if (cycle == 2) {
             latch.set_truthy(0);
             ctx.mark_changed(0);
@@ -1315,14 +1326,99 @@ TEST_F(SchedulerTest, RunsTheNextSequentialStepOnTheSettlePassSoItObservesPriorW
     );
     const auto s = build(std::move(program));
     s->next(x::telem::MICROSECOND, node::RunReason::TimerTick);
-    // The transition fires on pass 1, but second_node waits for the settle
-    // pass and runs after V has absorbed first_node's write.
+    // The transition fires on pass 1, but second_node waits for the settle pass and
+    // runs after V has absorbed first_node's write. The entry trigger does not re-run
+    // on the settle pass.
     EXPECT_EQ(
         order,
-        (std::vector<std::string>{"trigger", "V", "first", "trigger", "V", "second"})
+        (std::vector<std::string>{"trigger", "V", "first", "V", "second"})
     );
     EXPECT_EQ(first_node.next_called, 1);
     EXPECT_EQ(second_node.next_called, 1);
+}
+
+// ----- Entry node one-shot -----
+
+TEST_F(SchedulerTest, RunsAnEntryNodeOncePerActivationAcrossCycles) {
+    auto &a = mock("A");
+    auto ir = program_of({ir_node("A")}, {}, root_scope({ir::node_member("A")}));
+    const auto s = build(std::move(ir));
+    s->next(x::telem::MICROSECOND, node::RunReason::TimerTick);
+    s->next(2 * x::telem::MICROSECOND, node::RunReason::TimerTick);
+    s->next(3 * x::telem::MICROSECOND, node::RunReason::TimerTick);
+    EXPECT_EQ(a.next_called, 1);
+}
+
+TEST_F(SchedulerTest, KeepsDispatchingANonEntryStratumZeroNodeEveryCycle) {
+    auto &reader = mock("reader");
+    auto n = ir_node("reader", {"output"});
+    // A channel read makes the node non-entry.
+    n.channels.read[1] = "ch";
+    auto ir = program_of({n}, {}, root_scope({ir::node_member("reader")}));
+    const auto s = build(std::move(ir));
+    s->next(x::telem::MICROSECOND, node::RunReason::TimerTick);
+    s->next(2 * x::telem::MICROSECOND, node::RunReason::TimerTick);
+    s->next(3 * x::telem::MICROSECOND, node::RunReason::TimerTick);
+    EXPECT_EQ(reader.next_called, 3);
+}
+
+TEST_F(SchedulerTest, ReplaysAnEntryNodeThatMarksItself) {
+    auto &a = mock("A");
+    a.on_next = [](node::Context &ctx) { ctx.mark_self_changed(); };
+    auto ir = program_of({ir_node("A")}, {}, root_scope({ir::node_member("A")}));
+    const auto s = build(std::move(ir));
+    s->next(x::telem::MICROSECOND, node::RunReason::TimerTick);
+    s->next(2 * x::telem::MICROSECOND, node::RunReason::TimerTick);
+    s->next(3 * x::telem::MICROSECOND, node::RunReason::TimerTick);
+    EXPECT_EQ(a.next_called, 3);
+}
+
+TEST_F(SchedulerTest, ReFiresAnEntryNodeWhenItsScopeReActivates) {
+    auto &trigger = mock("trigger", {true});
+    trigger.suppress_auto_mark = true;
+    // Marks on cycles 1 and 3; self-marks keep the trigger running.
+    trigger.on_next = [&trigger](node::Context &ctx) {
+        ctx.mark_self_changed();
+        if (trigger.next_called == 1 || trigger.next_called == 3) ctx.mark_changed(0);
+    };
+    auto &entry_node = mock("A", {true});
+    auto first = parallel_scope("first", {stratum_of({ir::node_member("A")})});
+    ir::Transition t;
+    t.on = ir::Handle{"A", "output"};
+    t.target_key = exit_target();
+    auto main = sequential_scope("main", {ir::scope_member(std::move(first))}, {t});
+    main.activation = ir::Handle{"trigger", "output"};
+    auto program = program_of(
+        {ir_node("trigger", {"output"}), ir_node("A", {"output"})},
+        {},
+        root_scope({ir::node_member("trigger"), ir::scope_member(std::move(main))})
+    );
+    const auto s = build(std::move(program));
+    // Cycle 1: main activates; A runs once and exits the sequence.
+    s->next(x::telem::MICROSECOND, node::RunReason::TimerTick);
+    EXPECT_EQ(entry_node.next_called, 1);
+    s->next(2 * x::telem::MICROSECOND, node::RunReason::TimerTick);
+    EXPECT_EQ(entry_node.next_called, 1);
+    // Cycle 3: main re-activates; the reset lets A fire again.
+    s->next(3 * x::telem::MICROSECOND, node::RunReason::TimerTick);
+    EXPECT_EQ(entry_node.next_called, 2);
+}
+
+TEST_F(SchedulerTest, RunsAnEntrySequentialFlowStepOnceWhileTheStepStaysActive) {
+    mock("trigger", {true});
+    auto &step = mock("step");
+    auto main = sequential_scope("main", {ir::node_member("step")});
+    main.activation = ir::Handle{"trigger", "output"};
+    auto program = program_of(
+        {ir_node("trigger", {"output"}), ir_node("step")},
+        {},
+        root_scope({ir::node_member("trigger"), ir::scope_member(std::move(main))})
+    );
+    const auto s = build(std::move(program));
+    s->next(x::telem::MICROSECOND, node::RunReason::TimerTick);
+    s->next(2 * x::telem::MICROSECOND, node::RunReason::TimerTick);
+    s->next(3 * x::telem::MICROSECOND, node::RunReason::TimerTick);
+    EXPECT_EQ(step.next_called, 1);
 }
 
 // ----- Change-flag consumption -----
@@ -1422,9 +1518,9 @@ TEST_F(SchedulerTest, FiresAStagesOneShotTriggeredNodeOncePerActivation) {
     );
     const auto s = build(std::move(program));
     s->next(x::telem::MICROSECOND, node::RunReason::TimerTick);
-    // The entry re-runs each pass but marks once; the creator must dispatch
-    // exactly once, like a range create in a stage.
-    EXPECT_EQ(entry.next_called, 2);
+    // The entry node fires once per activation; the creator must dispatch exactly
+    // once, like a range create in a stage.
+    EXPECT_EQ(entry.next_called, 1);
     EXPECT_EQ(creator.next_called, 1);
 }
 
@@ -1510,7 +1606,10 @@ TEST_F(SchedulerTest, PreservesAMarkANodeSetsOnItselfWhileItRuns) {
 TEST_F(SchedulerTest, DispatchesAgainOnAFreshMarkInTheNextCycle) {
     auto &a = mock("A");
     auto &worker = mock("worker");
-    a.on_next = mark_on_next(0);
+    a.on_next = [](node::Context &ctx) {
+        ctx.mark_changed(0);
+        ctx.mark_self_changed();
+    };
     auto program = program_of(
         {ir_node("A", {"output"}), ir_node("worker")},
         {continuous_edge("A", "output", "worker", "in")},
@@ -1551,8 +1650,9 @@ TEST_F(SchedulerTest, ResetsASequentialScopesStrataMembersOnActivation) {
 TEST_F(SchedulerTest, ClearsAPendingSelfChangeAndReResetsOnScopeReEntry) {
     auto &trigger = mock("trigger", {true});
     trigger.suppress_auto_mark = true;
-    // Activate main on cycles 1 and 3 only.
+    // Activate main on cycles 1 and 3; self-marks keep the entry trigger running.
     trigger.on_next = [&trigger](node::Context &ctx) {
+        ctx.mark_self_changed();
         if (trigger.next_called == 1 || trigger.next_called == 3) ctx.mark_changed(0);
     };
     auto &src = mock("src");
@@ -1562,6 +1662,7 @@ TEST_F(SchedulerTest, ClearsAPendingSelfChangeAndReResetsOnScopeReEntry) {
     auto &v = mock("V");
     v.on_next = [](node::Context &ctx) { ctx.mark_self_changed(); };
     auto &stage_node = mock("A");
+    stage_node.on_next = [](node::Context &ctx) { ctx.mark_self_changed(); };
     auto first = parallel_scope(
         "first",
         {stratum_of({ir::node_member("A")}), stratum_of({ir::node_member("V")})}

--- a/arc/cpp/runtime/wasm/node.h
+++ b/arc/cpp/runtime/wasm/node.h
@@ -59,10 +59,7 @@ public:
         const Module::Function &func,
         std::shared_ptr<stl::strings::State> str_state
     ):
-        ir(node),
-        state(std::move(state)),
-        func(func),
-        str_state(std::move(str_state)) {
+        ir(node), state(std::move(state)), func(func), str_state(std::move(str_state)) {
         const auto &func_ir = prog.function(node.type);
         this->inputs.resize(node.inputs.size());
         this->offsets.resize(node.outputs.size());

--- a/arc/cpp/runtime/wasm/node.h
+++ b/arc/cpp/runtime/wasm/node.h
@@ -35,8 +35,6 @@ class Node : public node::Node {
     std::vector<bool> var_inputs;
     std::vector<bool> string_outputs;
     std::shared_ptr<stl::strings::State> str_state;
-    bool initialized = false;
-    bool is_entry_node = false;
     /// @brief marks a node with no $sel input.
     static constexpr size_t NO_SEL = ~size_t{0};
     size_t sel_idx = NO_SEL;
@@ -64,8 +62,7 @@ public:
         ir(node),
         state(std::move(state)),
         func(func),
-        str_state(std::move(str_state)),
-        is_entry_node(arc::ir::is_entry_node(prog, node)) {
+        str_state(std::move(str_state)) {
         const auto &func_ir = prog.function(node.type);
         this->inputs.resize(node.inputs.size());
         this->offsets.resize(node.outputs.size());
@@ -87,11 +84,6 @@ public:
     }
 
     x::errors::Error next(node::Context &ctx) override {
-        if (this->is_entry_node) {
-            if (this->initialized) return x::errors::NIL;
-            this->initialized = true;
-        }
-
         // A $sel-only change re-points without emitting; the value fires on the
         // next input.
         if (this->sel_idx != NO_SEL && !this->data_fresh()) {
@@ -261,7 +253,6 @@ public:
     }
 
     void reset() override {
-        this->initialized = false;
         this->state.reset();
         this->state.clear_node(this->ir.key);
     }

--- a/arc/cpp/runtime/wasm/node_test.cpp
+++ b/arc/cpp/runtime/wasm/node_test.cpp
@@ -654,8 +654,8 @@ func passthrough(val f32) f32 {
     EXPECT_TRUE(node.is_output_truthy(0));
 }
 
-/// @brief entry nodes with no inputs execute only once per stage entry.
-TEST(NodeTest, NoInputNodeExecutesOncePerStageEntry) {
+/// @brief nodes with no inputs execute on every call to next().
+TEST(NodeTest, NoInputNodeExecutesOnEveryNext) {
     const auto client = new_test_client();
 
     auto output_idx_name = random_name("output_idx");
@@ -714,7 +714,7 @@ constant{} -> )" + output_name;
 
     changed_outputs.clear();
     ASSERT_NIL(node.next(ctx));
-    EXPECT_TRUE(changed_outputs.empty());
+    EXPECT_EQ(changed_outputs.size(), 1);
 
     node.reset();
 

--- a/arc/cpp/stl/constant/constant.h
+++ b/arc/cpp/stl/constant/constant.h
@@ -15,38 +15,27 @@
 #include "x/cpp/mem/local_shared.h"
 #include "x/cpp/telem/telem.h"
 
-#include "arc/cpp/ir/ir.h"
 #include "arc/cpp/runtime/node/node.h"
 #include "arc/cpp/runtime/state/state.h"
 #include "arc/cpp/stl/stl.h"
 #include "arc/cpp/types/types.h"
 
 namespace arc::stl::constant {
-/// @brief Node that outputs a configured or var-bound value. Entry nodes fire
-/// once per activation; triggered constants fire on every run.
+/// @brief Node that outputs a configured or var-bound value.
 class Constant : public runtime::node::Node {
     runtime::state::Node state;
     x::telem::MonoClock clock;
     x::telem::SampleValue value;
-    bool is_entry_node;
-    bool initialized = false;
 
 public:
     Constant(
         runtime::state::Node &&state,
         const x::telem::SampleValue &value,
-        const x::telem::DataType &data_type,
-        const bool is_entry_node
+        const x::telem::DataType &data_type
     ):
-        state(std::move(state)),
-        value(data_type.cast(value)),
-        is_entry_node(is_entry_node) {}
+        state(std::move(state)), value(data_type.cast(value)) {}
 
     x::errors::Error next(runtime::node::Context &ctx) override {
-        if (this->is_entry_node) {
-            if (this->initialized) return x::errors::NIL;
-            this->initialized = true;
-        }
         const auto &o = this->state.output(0);
         const auto &o_time = this->state.output_time(0);
         // A var-bound value input emits the referenced variable's latest value;
@@ -71,7 +60,7 @@ public:
         return x::errors::NIL;
     }
 
-    void reset() override { this->initialized = false; }
+    void reset() override { this->state.reset(); }
 
     [[nodiscard]] bool is_output_truthy(size_t output_idx) const override {
         return this->state.is_output_truthy(output_idx);
@@ -98,14 +87,8 @@ public:
                 )
             };
         auto data_type = cfg.node.outputs[0].type.telem();
-        const bool is_entry = ir::is_entry_node(cfg.prog, cfg.node);
         return {
-            std::make_unique<Constant>(
-                std::move(cfg.state),
-                *sample_value,
-                data_type,
-                is_entry
-            ),
+            std::make_unique<Constant>(std::move(cfg.state), *sample_value, data_type),
             x::errors::NIL
         };
     }

--- a/arc/cpp/stl/constant/constant_test.cpp
+++ b/arc/cpp/stl/constant/constant_test.cpp
@@ -106,7 +106,7 @@ TEST(ConstantModuleTest, ErrorsWhenValueMissing) {
 /// @brief Test that next() outputs the constant value on first call.
 TEST(ConstantTest, NextOutputsValueOnFirstCall) {
     TestSetup setup(types::Kind::F32, 42.5f);
-    Constant node(setup.make_node(), 42.5f, x::telem::FLOAT32_T, true);
+    Constant node(setup.make_node(), 42.5f, x::telem::FLOAT32_T);
 
     auto ctx = make_context();
     ASSERT_NIL(node.next(ctx));
@@ -117,10 +117,10 @@ TEST(ConstantTest, NextOutputsValueOnFirstCall) {
     EXPECT_FLOAT_EQ(output->at<float>(0), 42.5f);
 }
 
-/// @brief Test that next() is a no-op on subsequent calls.
-TEST(ConstantTest, NextNoOpsOnSubsequentCalls) {
+/// @brief Test that next() re-emits the configured value on every call.
+TEST(ConstantTest, ReEmitsTheValueOnEveryNextCall) {
     TestSetup setup(types::Kind::F32, 42.5f);
-    Constant node(setup.make_node(), 42.5f, x::telem::FLOAT32_T, true);
+    Constant node(setup.make_node(), 42.5f, x::telem::FLOAT32_T);
 
     auto ctx = make_context();
     node.next(ctx);
@@ -130,13 +130,13 @@ TEST(ConstantTest, NextNoOpsOnSubsequentCalls) {
     output->set(0, 999.0f);
 
     ASSERT_NIL(node.next(ctx));
-    EXPECT_FLOAT_EQ(output->at<float>(0), 999.0f);
+    EXPECT_FLOAT_EQ(output->at<float>(0), 42.5f);
 }
 
-/// @brief Test that reset() allows the value to be output again.
-TEST(ConstantTest, ResetAllowsValueToBeOutputAgain) {
+/// @brief Test that reset() succeeds and the value is still emitted.
+TEST(ConstantTest, StillEmitsAfterReset) {
     TestSetup setup(types::Kind::F32, 42.5f);
-    Constant node(setup.make_node(), 42.5f, x::telem::FLOAT32_T, true);
+    Constant node(setup.make_node(), 42.5f, x::telem::FLOAT32_T);
 
     auto ctx = make_context();
     node.next(ctx);
@@ -154,7 +154,7 @@ TEST(ConstantTest, ResetAllowsValueToBeOutputAgain) {
 /// @brief Test that float32 values are correctly cast and output.
 TEST(ConstantTest, ValueIsCastToCorrectDataType_Float32) {
     TestSetup setup(types::Kind::F32, 3.14f);
-    Constant node(setup.make_node(), 3.14f, x::telem::FLOAT32_T, true);
+    Constant node(setup.make_node(), 3.14f, x::telem::FLOAT32_T);
 
     auto ctx = make_context();
     node.next(ctx);
@@ -168,8 +168,7 @@ TEST(ConstantTest, ValueIsCastToCorrectDataType_Float32) {
 /// @brief Test that int64 values are correctly cast and output.
 TEST(ConstantTest, ValueIsCastToCorrectDataType_Int64) {
     TestSetup setup(types::Kind::I64, static_cast<int64_t>(12345));
-    Constant
-        node(setup.make_node(), static_cast<int64_t>(12345), x::telem::INT64_T, true);
+    Constant node(setup.make_node(), static_cast<int64_t>(12345), x::telem::INT64_T);
 
     auto ctx = make_context();
     node.next(ctx);
@@ -183,8 +182,7 @@ TEST(ConstantTest, ValueIsCastToCorrectDataType_Int64) {
 /// @brief Test that uint8 values are correctly cast and output.
 TEST(ConstantTest, ValueIsCastToCorrectDataType_U8) {
     TestSetup setup(types::Kind::U8, static_cast<uint8_t>(255));
-    Constant
-        node(setup.make_node(), static_cast<uint8_t>(255), x::telem::UINT8_T, true);
+    Constant node(setup.make_node(), static_cast<uint8_t>(255), x::telem::UINT8_T);
 
     auto ctx = make_context();
     node.next(ctx);
@@ -197,8 +195,7 @@ TEST(ConstantTest, ValueIsCastToCorrectDataType_U8) {
 
 TEST(ConstantTest, ValueIsCastToCorrectDataType_Bool) {
     TestSetup setup(types::Kind::Bool, true);
-    Constant
-        node(setup.make_node(), static_cast<uint8_t>(1), x::telem::BOOLEAN_T, true);
+    Constant node(setup.make_node(), static_cast<uint8_t>(1), x::telem::BOOLEAN_T);
 
     auto ctx = make_context();
     node.next(ctx);
@@ -231,7 +228,7 @@ TEST(ConstantModuleTest, CreatesBoolConstantFromJsonTrue) {
 /// @brief Test that is_output_truthy delegates to state.
 TEST(ConstantTest, IsOutputTruthyDelegatesToState) {
     TestSetup setup(types::Kind::F32, 42.5f);
-    Constant node(setup.make_node(), 42.5f, x::telem::FLOAT32_T, true);
+    Constant node(setup.make_node(), 42.5f, x::telem::FLOAT32_T);
 
     auto ctx = make_context();
     node.next(ctx);
@@ -242,7 +239,7 @@ TEST(ConstantTest, IsOutputTruthyDelegatesToState) {
 /// @brief Test that mark_changed is called on first next().
 TEST(ConstantTest, MarkChangedCalledOnFirstNext) {
     TestSetup setup(types::Kind::F32, 42.5f);
-    Constant node(setup.make_node(), 42.5f, x::telem::FLOAT32_T, true);
+    Constant node(setup.make_node(), 42.5f, x::telem::FLOAT32_T);
 
     std::vector<size_t> marked;
     auto ctx = make_context();
@@ -254,10 +251,10 @@ TEST(ConstantTest, MarkChangedCalledOnFirstNext) {
     EXPECT_EQ(marked[0], 0);
 }
 
-/// @brief Test that mark_changed is not called on subsequent next() calls.
-TEST(ConstantTest, MarkChangedNotCalledOnSubsequentNext) {
+/// @brief Test that mark_changed is called on every next() call.
+TEST(ConstantTest, MarksChangedOnEveryNextCall) {
     TestSetup setup(types::Kind::F32, 42.5f);
-    Constant node(setup.make_node(), 42.5f, x::telem::FLOAT32_T, true);
+    Constant node(setup.make_node(), 42.5f, x::telem::FLOAT32_T);
 
     auto ctx = make_context();
     node.next(ctx);
@@ -268,13 +265,13 @@ TEST(ConstantTest, MarkChangedNotCalledOnSubsequentNext) {
     node.next(ctx);
     node.next(ctx);
 
-    EXPECT_EQ(call_count, 0);
+    EXPECT_EQ(call_count, 2);
 }
 
 /// @brief Test that timestamp is populated on first next().
 TEST(ConstantTest, TimestampOutputOnFirstNext) {
     TestSetup setup(types::Kind::F32, 42.5f);
-    Constant node(setup.make_node(), 42.5f, x::telem::FLOAT32_T, true);
+    Constant node(setup.make_node(), 42.5f, x::telem::FLOAT32_T);
 
     auto ctx = make_context();
     node.next(ctx);
@@ -289,7 +286,7 @@ TEST(ConstantTest, TimestampOutputOnFirstNext) {
 TEST(ConstantTest, StringValueIsOutput) {
     const std::string val = "hello";
     TestSetup setup(types::Kind::String, val);
-    Constant node(setup.make_node(), val, x::telem::STRING_T, true);
+    Constant node(setup.make_node(), val, x::telem::STRING_T);
 
     auto ctx = make_context();
     ASSERT_NIL(node.next(ctx));
@@ -300,11 +297,11 @@ TEST(ConstantTest, StringValueIsOutput) {
     EXPECT_EQ(output->at<std::string>(0), val);
 }
 
-/// @brief Test that reset() allows the string value to be output again.
-TEST(ConstantTest, StringResetAllowsValueToBeOutputAgain) {
+/// @brief Test that reset() succeeds and the string value is still emitted.
+TEST(ConstantTest, StringStillEmitsAfterReset) {
     const std::string val = "hello";
     TestSetup setup(types::Kind::String, val);
-    Constant node(setup.make_node(), val, x::telem::STRING_T, true);
+    Constant node(setup.make_node(), val, x::telem::STRING_T);
 
     auto ctx = make_context();
     node.next(ctx);
@@ -317,10 +314,10 @@ TEST(ConstantTest, StringResetAllowsValueToBeOutputAgain) {
     EXPECT_EQ(output->at<std::string>(0), val);
 }
 
-/// @brief Test that reset produces a new timestamp on subsequent next().
-TEST(ConstantTest, ResetProducesNewTimestamp) {
+/// @brief Test that every next() produces a fresh timestamp.
+TEST(ConstantTest, ProducesAFreshTimestampOnEveryNext) {
     TestSetup setup(types::Kind::F32, 42.5f);
-    Constant node(setup.make_node(), 42.5f, x::telem::FLOAT32_T, true);
+    Constant node(setup.make_node(), 42.5f, x::telem::FLOAT32_T);
 
     auto ctx = make_context();
     node.next(ctx);
@@ -329,7 +326,6 @@ TEST(ConstantTest, ResetProducesNewTimestamp) {
     const auto &output_time = checker.output_time(0);
     const auto ts1 = output_time->at<int64_t>(0);
 
-    node.reset();
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
     node.next(ctx);
 

--- a/arc/docs/spec.md
+++ b/arc/docs/spec.md
@@ -703,6 +703,10 @@ stage is active.
 `bool` `true`, a non-zero numeric, or a non-empty string). A transition to an
 already-active stage is a no-op, preventing re-entry.
 
+**Entry nodes**: Fire once per scope activation, and again on re-entry. A node is an
+entry node when nothing flows into it and it reads no channels: a literal, or a call
+taking only `{...}` inputs.
+
 ### Scope Entry Semantics
 
 When entering a stage or a sequence:

--- a/arc/go/analyzer/flow/flow.go
+++ b/arc/go/analyzer/flow/flow.go
@@ -750,6 +750,8 @@ func analyzeOutputRoutingTable(
 			}
 			analyzeRoutingTargetWithParam(
 				child,
+				flowNodes[i-1],
+				isLastNode,
 				nodeSourceType,
 				nextFuncType,
 				targetParam,
@@ -869,6 +871,8 @@ func analyzeInputRoutingTable(
 
 func analyzeRoutingTargetWithParam(
 	ctx context.Context[parser.IFlowNodeContext],
+	prevNode parser.IFlowNodeContext,
+	isLastNode bool,
 	sourceType types.Type,
 	nextFuncType types.Type,
 	targetParam *string,
@@ -932,47 +936,7 @@ func analyzeRoutingTargetWithParam(
 			)
 		}
 	} else if idNode := ctx.AST.Identifier(); idNode != nil {
-		idName := idNode.IDENTIFIER().GetText()
-		idSym, err := ctx.Resolve(idName)
-		if err != nil {
-			ctx.Diagnostics.Add(diagnostics.Error(err, ctx.AST))
-			return
-		}
-
-		// Allow channels, sequences, and stages as routing targets
-		if idSym.Kind != symbol.KindChannel && idSym.Kind != symbol.KindSequence &&
-			idSym.Kind != symbol.KindStage {
-			ctx.Diagnostics.Add(
-				diagnostics.Errorf(
-					ctx.AST,
-					"%s is not a channel, sequence, or stage",
-					idName,
-				),
-			)
-			return
-		}
-
-		// Only do type checking for channels (sequences/stages accept any input for
-		// activation)
-		if idSym.Kind == symbol.KindChannel {
-			valueType := idSym.Type.Unwrap()
-			if err = atypes.Check(
-				ctx.Constraints,
-				sourceType,
-				valueType,
-				ctx.AST,
-				"routing table output to channel",
-			); err != nil {
-				ctx.Diagnostics.Add(diagnostics.Errorf(
-					ctx.AST,
-					"type mismatch: output type %s does not match channel %s value type %s",
-					sourceType,
-					idName,
-					valueType,
-				))
-				return
-			}
-		}
+		analyzeIdentifier(context.Child(ctx, idNode), prevNode, isLastNode)
 	} else if expr := ctx.AST.Expression(); expr != nil {
 		AnalyzeSingleExpression(context.Child(ctx, expr))
 	}

--- a/arc/go/analyzer/flow/flow_test.go
+++ b/arc/go/analyzer/flow/flow_test.go
@@ -987,7 +987,7 @@ sensor_chan -> {
 			)
 
 			It(
-				"Should detect when routing target is not a channel or sequence",
+				"Should reject a routing entry writing to a top-level variable",
 				func(bCtx SpecContext) {
 					localResolver := []symbol.Symbol{
 						{
@@ -995,17 +995,15 @@ sensor_chan -> {
 							Kind: symbol.KindChannel,
 							Type: types.Chan(types.F64()),
 						},
-						{
-							Name: "some_var",
-							Kind: symbol.KindVariable,
-							Type: types.F64(),
-						},
 					}
 					ast := MustSucceed(parser.Parse(`
 func demux(value f64) (high f64, low f64) {
     high = value
     low = value
 }
+
+some_var f64 := 0.0
+
 sensor_chan -> demux{} -> {
     high: true -> some_var
 }`))
@@ -1014,7 +1012,138 @@ sensor_chan -> demux{} -> {
 					Expect(ctx.Diagnostics.Ok()).To(BeFalse())
 					Expect(
 						(*ctx.Diagnostics)[0].Message,
-					).To(Equal("some_var is not a channel, sequence, or stage"))
+					).To(Equal("cannot write to top-level variable 'some_var'"))
+				},
+			)
+
+			It(
+				"Should accept a stage-scoped variable as a routing entry sink",
+				func(bCtx SpecContext) {
+					localResolver := []symbol.Symbol{
+						{
+							Name: "sensor_chan",
+							Kind: symbol.KindChannel,
+							Type: types.Chan(types.F64()),
+						},
+					}
+					ast := MustSucceed(parser.Parse(`
+func demux(value f64) (high f64, low f64) {
+    high = value
+    low = value
+}
+
+sequence main {
+    stage first {
+        v := false
+        sensor_chan -> demux{} -> {
+            high: true -> v
+        }
+    }
+}`))
+					ctx := context.NewRoot(bCtx, ast, NewRoot(nil, localResolver...))
+					analyzer.AnalyzeProgram(ctx)
+					Expect(ctx.Diagnostics.Ok()).To(BeTrue(), ctx.Diagnostics.String())
+				},
+			)
+
+			It(
+				"Should accept a channel alias as a routing entry sink",
+				func(bCtx SpecContext) {
+					localResolver := []symbol.Symbol{
+						{
+							Name: "sensor_chan",
+							Kind: symbol.KindChannel,
+							Type: types.Chan(types.F64()),
+						},
+						{
+							Name: "out_chan",
+							Kind: symbol.KindChannel,
+							Type: types.Chan(types.U8()),
+						},
+					}
+					ast := MustSucceed(parser.Parse(`
+func demux(value f64) (high f64, low f64) {
+    high = value
+    low = value
+}
+
+sequence main {
+    stage first {
+        sink := out_chan
+        sensor_chan -> demux{} -> {
+            high: true -> sink
+        }
+    }
+}`))
+					ctx := context.NewRoot(bCtx, ast, NewRoot(nil, localResolver...))
+					analyzer.AnalyzeProgram(ctx)
+					Expect(ctx.Diagnostics.Ok()).To(BeTrue(), ctx.Diagnostics.String())
+				},
+			)
+
+			It(
+				"Should reject a channel-read variable as a routing entry sink",
+				func(bCtx SpecContext) {
+					localResolver := []symbol.Symbol{
+						{
+							Name: "sensor_chan",
+							Kind: symbol.KindChannel,
+							Type: types.Chan(types.F64()),
+						},
+					}
+					ast := MustSucceed(parser.Parse(`
+func demux(value f64) (high f64, low f64) {
+    high = value
+    low = value
+}
+
+sequence main {
+    stage first {
+        v := sensor_chan * 2.0
+        sensor_chan -> demux{} -> {
+            high: 1.0 -> v
+        }
+    }
+}`))
+					ctx := context.NewRoot(bCtx, ast, NewRoot(nil, localResolver...))
+					analyzer.AnalyzeProgram(ctx)
+					Expect(ctx.Diagnostics.Ok()).To(BeFalse())
+					Expect(
+						(*ctx.Diagnostics)[0].Message,
+					).To(Equal("cannot write to channel-read variable v; it is read-only"))
+				},
+			)
+
+			It(
+				"Should reject a routing entry whose output does not match the variable sink type",
+				func(bCtx SpecContext) {
+					localResolver := []symbol.Symbol{
+						{
+							Name: "sensor_chan",
+							Kind: symbol.KindChannel,
+							Type: types.Chan(types.F64()),
+						},
+					}
+					ast := MustSucceed(parser.Parse(`
+func demux(value f64) (high f64, low f64) {
+    high = value
+    low = value
+}
+
+sequence main {
+    stage first {
+        v u8 := 0
+        sensor_chan -> demux{} -> {
+            high: "hello" -> v
+        }
+    }
+}`))
+					ctx := context.NewRoot(bCtx, ast, NewRoot(nil, localResolver...))
+					analyzer.AnalyzeProgram(ctx)
+					Expect(ctx.Diagnostics.Ok()).To(BeFalse())
+					Expect(
+						(*ctx.Diagnostics)[0].Message,
+					).To(ContainSubstring("does not match channel v value type u8"))
 				},
 			)
 

--- a/arc/go/analyzer/flow/flow_test.go
+++ b/arc/go/analyzer/flow/flow_test.go
@@ -1467,7 +1467,7 @@ sequence main {
 				Expect(ctx.Diagnostics.Ok()).To(BeFalse())
 				Expect(
 					(*ctx.Diagnostics)[0].Message,
-				).To(ContainSubstring("type mismatch"))
+				).To(ContainSubstring("does not match channel log_str value type str"))
 			},
 		)
 
@@ -1502,7 +1502,9 @@ sequence main {
 				ctx := context.NewRoot(bCtx, ast, NewRoot(customResolver))
 				analyzer.AnalyzeProgram(ctx)
 				Expect(ctx.Diagnostics.Ok()).To(BeFalse())
-				Expect(ctx.Diagnostics.String()).To(ContainSubstring("type mismatch"))
+				Expect(ctx.Diagnostics.String()).To(
+					ContainSubstring("does not match channel log_str value type str"),
+				)
 			},
 		)
 

--- a/arc/go/ir/node_test.go
+++ b/arc/go/ir/node_test.go
@@ -21,6 +21,9 @@ var _ = Describe("Node", func() {
 		reads := func(key uint32) types.Channels {
 			return types.Channels{Read: map[uint32]string{key: "ch"}}
 		}
+		writes := func(key uint32) types.Channels {
+			return types.Channels{Write: map[uint32]string{key: "ch"}}
+		}
 		edgeInto := func(nodeKey string) ir.Edge {
 			return ir.Edge{Target: ir.Handle{Node: nodeKey, Param: "input"}}
 		}
@@ -39,6 +42,8 @@ var _ = Describe("Node", func() {
 				ir.Node{Key: "n", Channels: reads(1)}, ir.Edges{edgeInto("n")}, false),
 			Entry("an edge that targets a different node",
 				ir.Node{Key: "n"}, ir.Edges{edgeInto("other")}, true),
+			Entry("a channel write only",
+				ir.Node{Key: "n", Channels: writes(2)}, ir.Edges{}, true),
 		)
 	})
 

--- a/arc/go/runtime/scheduler/builder.go
+++ b/arc/go/runtime/scheduler/builder.go
@@ -59,6 +59,7 @@ func newBuilder(prog ir.IR, runtimeNodes map[string]rnode.Node) *builder {
 		rn := &node{
 			key:     n.Key,
 			idx:     i,
+			entry:   n.IsEntryNode(prog.Edges),
 			Node:    runtimeNodes[n.Key],
 			outputs: make([]outputResolved, 0, len(n.Outputs)),
 		}
@@ -102,6 +103,7 @@ func (b *builder) build(prog ir.IR, tolerance telem.TimeSpan) *Scheduler {
 	s := &Scheduler{
 		changedFlags:     make([]uint8, len(prog.Nodes)),
 		selfChangedFlags: make([]uint8, len(prog.Nodes)),
+		firedFlags:       make([]uint8, len(prog.Nodes)),
 		visitedFlags:     make([]uint8, len(prog.Nodes)),
 		tolerance:        tolerance,
 	}

--- a/arc/go/runtime/scheduler/scheduler.go
+++ b/arc/go/runtime/scheduler/scheduler.go
@@ -52,6 +52,9 @@ type node struct {
 	key string
 	// idx is the node's position in changedFlags / selfChangedFlags.
 	idx int
+	// entry marks a node with no incoming edges and no channel reads. Entry
+	// nodes fire once per activation.
+	entry bool
 }
 
 // member mirrors an ir.Member: exactly one of node or scope is set.
@@ -128,6 +131,9 @@ type Scheduler struct {
 	// replay on the next cycle. Cleared when the replay runs or when the
 	// owning member is deactivated.
 	selfChangedFlags []uint8
+	// firedFlags[i] is set when node i runs and cleared on (re)activation. An
+	// entry node with the flag set skips the unconditional stratum-0 dispatch.
+	firedFlags []uint8
 	// markedFlags[i] is set when the (node, output) pair behind transition
 	// handle i fired truthy this cycle. Cleared at end of cycle so
 	// transitions fire on fresh marks, not stale truthiness.
@@ -250,9 +256,9 @@ func (s *Scheduler) walkSequential(ss *scope) {
 	}
 }
 
-// executeMember walks a nested-scope member or runs a leaf-node member.
-// A leaf runs when stratumIdx==0, when changedFlags is set, or when the
-// node was self-changed on a prior cycle. Running consumes the flag.
+// executeMember walks a nested-scope member or runs a leaf-node member. A leaf
+// runs when stratumIdx==0 (entry nodes: once per activation), on changedFlags,
+// or on a prior-cycle self-change. Running consumes the flag.
 func (s *Scheduler) executeMember(stratumIdx int, m *member) {
 	if m.scope != nil {
 		s.walk(m.scope)
@@ -267,8 +273,10 @@ func (s *Scheduler) executeMember(stratumIdx int, m *member) {
 	if wasSelfChanged {
 		s.selfChangedFlags[idx] = 0
 	}
-	if stratumIdx == 0 || s.changedFlags[idx] != 0 || wasSelfChanged {
+	forced := stratumIdx == 0 && (!m.node.entry || s.firedFlags[idx] == 0)
+	if forced || s.changedFlags[idx] != 0 || wasSelfChanged {
 		s.changedFlags[idx] = 0
+		s.firedFlags[idx] = 1
 		s.currNode = m.node
 		s.currNode.Next(s.nodeCtx)
 	}
@@ -313,10 +321,11 @@ func (s *Scheduler) evaluateTransitions(ss *scope) bool {
 	return false
 }
 
-// resetLeafNode clears selfChanged and calls Reset on m's node.
+// resetLeafNode clears selfChanged and fired and calls Reset on m's node.
 func (s *Scheduler) resetLeafNode(m *member) {
 	if n := m.node; m.isNode() && n != nil {
 		s.selfChangedFlags[n.idx] = 0
+		s.firedFlags[n.idx] = 0
 		n.Reset()
 	}
 }

--- a/arc/go/runtime/scheduler/scheduler_test.go
+++ b/arc/go/runtime/scheduler/scheduler_test.go
@@ -289,7 +289,7 @@ var _ = Describe("Scheduler", func() {
 
 	Describe("Phase-based execution", func() {
 		It(
-			"Should execute phase-0 members unconditionally each cycle",
+			"Should run an entry phase-0 member once per activation",
 			func(ctx SpecContext) {
 				nodeA := mock("A")
 				prog := programOf(
@@ -301,7 +301,8 @@ var _ = Describe("Scheduler", func() {
 				s.Next(ctx, telem.Microsecond, node.ReasonTimerTick)
 				s.Next(ctx, 2*telem.Microsecond, node.ReasonTimerTick)
 				s.Next(ctx, 3*telem.Microsecond, node.ReasonTimerTick)
-				Expect(nodeA.NextCalled).To(Equal(3))
+				// A has no inputs, so it is an entry node: one run per activation.
+				Expect(nodeA.NextCalled).To(Equal(1))
 			},
 		)
 
@@ -351,7 +352,10 @@ var _ = Describe("Scheduler", func() {
 			func(ctx SpecContext) {
 				nodeA := mock("A")
 				nodeB := mock("B")
-				nodeA.OnNext = markOnNext(0)
+				nodeA.OnNext = func(c node.Context) {
+					c.MarkChanged(0)
+					c.MarkSelfChanged()
+				}
 				// Output is not truthy — B must not fire.
 				prog := programOf(
 					[]ir.Node{irNode("A", "output"), irNode("B")},
@@ -387,6 +391,7 @@ var _ = Describe("Scheduler", func() {
 				triggerCalls := 0
 				trigger.OnNext = func(c node.Context) {
 					triggerCalls++
+					c.MarkSelfChanged()
 					if triggerCalls == 2 {
 						c.MarkChanged(0)
 					}
@@ -415,6 +420,7 @@ var _ = Describe("Scheduler", func() {
 	Describe("Context pass-through", func() {
 		It("Should pass elapsed time to node context", func(ctx SpecContext) {
 			nodeA := mock("A")
+			nodeA.OnNext = func(c node.Context) { c.MarkSelfChanged() }
 			prog := programOf(
 				[]ir.Node{irNode("A")},
 				nil,
@@ -501,9 +507,9 @@ var _ = Describe("Scheduler", func() {
 				Expect(stage.NextCalled).To(Equal(1))
 				// Reset called once on activation.
 				Expect(stage.ResetCalled).To(Equal(1))
-				// Stays active in subsequent cycles without re-activating.
+				// Stays active without re-activating; the entry member fired once.
 				s.Next(ctx, 2*telem.Microsecond, node.ReasonTimerTick)
-				Expect(stage.NextCalled).To(Equal(2))
+				Expect(stage.NextCalled).To(Equal(1))
 				Expect(stage.ResetCalled).To(Equal(1))
 			},
 		)
@@ -542,6 +548,7 @@ var _ = Describe("Scheduler", func() {
 			func(ctx SpecContext) {
 				mock("trigger", true)
 				firstNode := mock("first_node")
+				firstNode.OnNext = func(c node.Context) { c.MarkSelfChanged() }
 				secondNode := mock("second_node")
 				prog := buildTwoStepSeq("first_node")
 				s := build(prog)
@@ -565,18 +572,9 @@ var _ = Describe("Scheduler", func() {
 		)
 
 		It("Should exit the sequence when target is exit", func(ctx SpecContext) {
-			trigger := mock("trigger", true)
+			mock("trigger", true)
 			firstNode := mock("first_node")
-			// Model a one-shot rising-edge trigger: fires on cycle 1
-			// (so main activates), then releases on later cycles so the
-			// activation handle isn't re-satisfying after exit.
-			cycleCount := 0
-			trigger.OnNext = func(ctx node.Context) {
-				cycleCount++
-				if cycleCount > 1 {
-					trigger.OutputTruthy[0] = false
-				}
-			}
+			firstNode.OnNext = func(c node.Context) { c.MarkSelfChanged() }
 			first := parallelScope("first", stratum(ir.NodeMember("first_node")))
 			main := sequentialScope("main",
 				[]ir.Member{{Scope: &first}},
@@ -596,8 +594,7 @@ var _ = Describe("Scheduler", func() {
 			s.Next(ctx, telem.Microsecond, node.ReasonTimerTick)
 			Expect(firstNode.NextCalled).To(Equal(1))
 
-			// Trip exit transition on cycle 2. The exit deactivates main;
-			// trigger has already been released, so no re-activation.
+			// The exit trips on cycle 2; the one-shot trigger cannot re-activate main.
 			firstNode.SetTruthy(0)
 			s.Next(ctx, 2*telem.Microsecond, node.ReasonTimerTick)
 			countAtExit := firstNode.NextCalled
@@ -610,6 +607,7 @@ var _ = Describe("Scheduler", func() {
 			func(ctx SpecContext) {
 				mock("trigger", true)
 				firstNode := mock("first_node")
+				firstNode.OnNext = func(c node.Context) { c.MarkSelfChanged() }
 				// Two transitions from first, in source order: first jumps to
 				// `a`, the second would jump to `b`. Both are truthy at the
 				// same cycle.
@@ -982,7 +980,8 @@ var _ = Describe("Scheduler", func() {
 		It(
 			"Should fire every cycle while the source stays truthy",
 			func(ctx SpecContext) {
-				mock("A", true)
+				nodeA := mock("A", true)
+				nodeA.OnNext = func(c node.Context) { c.MarkSelfChanged() }
 				nodeB := mock("B")
 				prog := programOf(
 					[]ir.Node{irNode("A", "output"), irNode("B")},
@@ -1004,6 +1003,7 @@ var _ = Describe("Scheduler", func() {
 			"Should stop firing when the source transitions from truthy to falsy",
 			func(ctx SpecContext) {
 				nodeA := mock("A", true)
+				nodeA.OnNext = func(c node.Context) { c.MarkSelfChanged() }
 				nodeB := mock("B")
 				prog := programOf(
 					[]ir.Node{irNode("A", "output"), irNode("B")},
@@ -1208,6 +1208,7 @@ var _ = Describe("Scheduler", func() {
 				call := 0
 				nodeA.OnNext = func(c node.Context) {
 					call++
+					c.MarkSelfChanged()
 					if call == 1 {
 						c.SetDeadline(telem.Second)
 					}
@@ -1383,7 +1384,8 @@ var _ = Describe("Scheduler", func() {
 		It(
 			"Should not re-activate an already-active gated scope on a subsequent cycle",
 			func(ctx SpecContext) {
-				mock("trigger", true)
+				trigger := mock("trigger", true)
+				trigger.OnNext = func(c node.Context) { c.MarkSelfChanged() }
 				stageNode := mock("stage_node")
 				act := ir.Handle{Node: "trigger", Param: "output"}
 				gated := parallelScope("stage", stratum(ir.NodeMember("stage_node")))
@@ -1468,19 +1470,17 @@ var _ = Describe("Scheduler", func() {
 		It(
 			"Should reset sequence members when reactivated after an exit",
 			func(ctx SpecContext) {
-				// One-shot trigger: cycle 1 activates main, exit transition
-				// fires on cycle 2, cycle 3 re-triggers, main re-activates.
+				// Trigger marks on cycles 1 and 3; each mark activates main,
+				// which runs first_node and exits in the same cycle.
 				trigger := mock("trigger", true)
+				trigger.SuppressAutoMark = true
 				firstNode := mock("first_node", true)
 				cycle := 0
 				trigger.OnNext = func(c node.Context) {
 					cycle++
-					// Release after cycle 1, re-assert on cycle 3.
-					if cycle == 2 {
-						trigger.OutputTruthy[0] = false
-					}
-					if cycle == 3 {
-						trigger.OutputTruthy[0] = true
+					c.MarkSelfChanged()
+					if cycle == 1 || cycle == 3 {
+						c.MarkChanged(0)
 					}
 				}
 				first := parallelScope("first", stratum(ir.NodeMember("first_node")))
@@ -1511,12 +1511,12 @@ var _ = Describe("Scheduler", func() {
 					ctx,
 					2*telem.Microsecond,
 					node.ReasonTimerTick,
-				) // trigger released, no action
+				) // no mark, no action
 				s.Next(
 					ctx,
 					3*telem.Microsecond,
 					node.ReasonTimerTick,
-				) // trigger reasserted, main re-activates, runs, exits
+				) // re-activate + run + exit
 				// Two activations ⇒ two Reset calls on first_node.
 				Expect(firstNode.ResetCalled).To(Equal(2))
 			},
@@ -1543,7 +1543,8 @@ var _ = Describe("Scheduler", func() {
 				mock("trigger", true)
 				latch := mock("latch", true)
 				latch.SuppressAutoMark = true
-				mock("worker")
+				worker := mock("worker")
+				worker.OnNext = func(c node.Context) { c.MarkSelfChanged() }
 
 				body := parallelScope("body", stratum(ir.NodeMember("worker")))
 				main := sequentialScope("main", []ir.Member{
@@ -1594,12 +1595,14 @@ var _ = Describe("Scheduler", func() {
 				marks := 0
 				latch.OnNext = func(c node.Context) {
 					marks++
+					c.MarkSelfChanged()
 					if marks == 1 {
 						c.MarkChanged(0)
 					}
 				}
 				mock("worker_a")
-				mock("worker_b")
+				workerB := mock("worker_b")
+				workerB.OnNext = func(c node.Context) { c.MarkSelfChanged() }
 
 				a := parallelScope("a", stratum(ir.NodeMember("worker_a")))
 				b := parallelScope("b", stratum(ir.NodeMember("worker_b")))
@@ -1664,6 +1667,7 @@ var _ = Describe("Scheduler", func() {
 				cycle := 0
 				latch.OnNext = func(c node.Context) {
 					cycle++
+					c.MarkSelfChanged()
 					if cycle == 2 {
 						latch.SetTruthy(0)
 						c.MarkChanged(0)
@@ -1917,11 +1921,130 @@ var _ = Describe("Scheduler", func() {
 				s.Next(ctx, telem.Microsecond, node.ReasonTimerTick)
 				// The transition fires on pass 1, but second_node waits for the
 				// settle pass and runs after V has absorbed first_node's write.
+				// The entry trigger does not re-run on the settle pass.
 				Expect(order).To(Equal([]string{
-					"trigger", "V", "first", "trigger", "V", "second",
+					"trigger", "V", "first", "V", "second",
 				}))
 				Expect(firstNode.NextCalled).To(Equal(1))
 				Expect(secondNode.NextCalled).To(Equal(1))
+			},
+		)
+	})
+
+	Describe("Entry node one-shot", func() {
+		It(
+			"Should run an entry node once per activation across cycles",
+			func(ctx SpecContext) {
+				nodeA := mock("A")
+				prog := programOf(
+					[]ir.Node{irNode("A")},
+					nil,
+					rootScope(ir.NodeMember("A")),
+				)
+				s := build(prog)
+				s.Next(ctx, telem.Microsecond, node.ReasonTimerTick)
+				s.Next(ctx, 2*telem.Microsecond, node.ReasonTimerTick)
+				s.Next(ctx, 3*telem.Microsecond, node.ReasonTimerTick)
+				Expect(nodeA.NextCalled).To(Equal(1))
+			},
+		)
+
+		It(
+			"Should keep dispatching a non-entry stratum-0 node every cycle",
+			func(ctx SpecContext) {
+				reader := mock("reader")
+				n := irNode("reader", "output")
+				// A channel read makes the node non-entry.
+				n.Channels = types.Channels{Read: map[uint32]string{1: "ch"}}
+				prog := programOf(
+					[]ir.Node{n},
+					nil,
+					rootScope(ir.NodeMember("reader")),
+				)
+				s := build(prog)
+				s.Next(ctx, telem.Microsecond, node.ReasonTimerTick)
+				s.Next(ctx, 2*telem.Microsecond, node.ReasonTimerTick)
+				s.Next(ctx, 3*telem.Microsecond, node.ReasonTimerTick)
+				Expect(reader.NextCalled).To(Equal(3))
+			},
+		)
+
+		It(
+			"Should replay an entry node that marks itself",
+			func(ctx SpecContext) {
+				nodeA := mock("A")
+				nodeA.OnNext = func(c node.Context) { c.MarkSelfChanged() }
+				prog := programOf(
+					[]ir.Node{irNode("A")},
+					nil,
+					rootScope(ir.NodeMember("A")),
+				)
+				s := build(prog)
+				s.Next(ctx, telem.Microsecond, node.ReasonTimerTick)
+				s.Next(ctx, 2*telem.Microsecond, node.ReasonTimerTick)
+				s.Next(ctx, 3*telem.Microsecond, node.ReasonTimerTick)
+				Expect(nodeA.NextCalled).To(Equal(3))
+			},
+		)
+
+		It(
+			"Should re-fire an entry node when its scope re-activates",
+			func(ctx SpecContext) {
+				trigger := mock("trigger", true)
+				trigger.SuppressAutoMark = true
+				// Marks on cycles 1 and 3; self-marks keep the trigger running.
+				trigger.OnNext = func(c node.Context) {
+					c.MarkSelfChanged()
+					if trigger.NextCalled == 1 || trigger.NextCalled == 3 {
+						c.MarkChanged(0)
+					}
+				}
+				entryNode := mock("A", true)
+				first := parallelScope("first", stratum(ir.NodeMember("A")))
+				main := sequentialScope("main",
+					[]ir.Member{{Scope: &first}},
+					ir.Transition{
+						On:        ir.Handle{Node: "A", Param: "output"},
+						TargetKey: exitTarget(),
+					},
+				)
+				triggerH := ir.Handle{Node: "trigger", Param: "output"}
+				main.Activation = &triggerH
+				prog := programOf(
+					[]ir.Node{irNode("trigger", "output"), irNode("A", "output")},
+					nil,
+					rootScope(ir.NodeMember("trigger"), ir.ScopeMember(main)),
+				)
+				s := build(prog)
+				// Cycle 1: main activates; A runs once and exits the sequence.
+				s.Next(ctx, telem.Microsecond, node.ReasonTimerTick)
+				Expect(entryNode.NextCalled).To(Equal(1))
+				s.Next(ctx, 2*telem.Microsecond, node.ReasonTimerTick)
+				Expect(entryNode.NextCalled).To(Equal(1))
+				// Cycle 3: main re-activates; the reset lets A fire again.
+				s.Next(ctx, 3*telem.Microsecond, node.ReasonTimerTick)
+				Expect(entryNode.NextCalled).To(Equal(2))
+			},
+		)
+
+		It(
+			"Should run an entry sequential flow-step once while the step stays active",
+			func(ctx SpecContext) {
+				mock("trigger", true)
+				step := mock("step")
+				main := sequentialScope("main", []ir.Member{ir.NodeMember("step")})
+				triggerH := ir.Handle{Node: "trigger", Param: "output"}
+				main.Activation = &triggerH
+				prog := programOf(
+					[]ir.Node{irNode("trigger", "output"), irNode("step")},
+					nil,
+					rootScope(ir.NodeMember("trigger"), ir.ScopeMember(main)),
+				)
+				s := build(prog)
+				s.Next(ctx, telem.Microsecond, node.ReasonTimerTick)
+				s.Next(ctx, 2*telem.Microsecond, node.ReasonTimerTick)
+				s.Next(ctx, 3*telem.Microsecond, node.ReasonTimerTick)
+				Expect(step.NextCalled).To(Equal(1))
 			},
 		)
 	})
@@ -2045,9 +2168,9 @@ var _ = Describe("Scheduler", func() {
 				)
 				s := build(prog)
 				s.Next(ctx, telem.Microsecond, node.ReasonTimerTick)
-				// The entry re-runs each pass but marks once; the creator must
+				// The entry node fires once per activation; the creator must
 				// dispatch exactly once, like a range create in a stage.
-				Expect(entry.NextCalled).To(Equal(2))
+				Expect(entry.NextCalled).To(Equal(1))
 				Expect(creator.NextCalled).To(Equal(1))
 			},
 		)
@@ -2159,7 +2282,10 @@ var _ = Describe("Scheduler", func() {
 			func(ctx SpecContext) {
 				nodeA := mock("A")
 				worker := mock("worker")
-				nodeA.OnNext = markOnNext(0)
+				nodeA.OnNext = func(c node.Context) {
+					c.MarkChanged(0)
+					c.MarkSelfChanged()
+				}
 				prog := programOf(
 					[]ir.Node{irNode("A", "output"), irNode("worker")},
 					[]ir.Edge{continuousEdge("A", "output", "worker", "in")},
@@ -2207,8 +2333,10 @@ var _ = Describe("Scheduler", func() {
 			func(ctx SpecContext) {
 				trigger := mock("trigger", true)
 				trigger.SuppressAutoMark = true
-				// Activate main on cycles 1 and 3 only.
+				// Activate main on cycles 1 and 3; self-marks keep the entry
+				// trigger running.
 				trigger.OnNext = func(ctx node.Context) {
+					ctx.MarkSelfChanged()
 					if trigger.NextCalled == 1 || trigger.NextCalled == 3 {
 						ctx.MarkChanged(0)
 					}
@@ -2222,6 +2350,7 @@ var _ = Describe("Scheduler", func() {
 				nodeV := mock("V")
 				nodeV.OnNext = func(ctx node.Context) { ctx.MarkSelfChanged() }
 				stageNode := mock("A")
+				stageNode.OnNext = func(ctx node.Context) { ctx.MarkSelfChanged() }
 				first := parallelScope("first",
 					stratum(ir.NodeMember("A")),
 					stratum(ir.NodeMember("V")),

--- a/arc/go/sequence_test.go
+++ b/arc/go/sequence_test.go
@@ -7088,4 +7088,217 @@ var _ = Describe("Sequence", func() {
 			Expect(countOf(out, 401, "parent")).To(BeZero())
 		})
 	})
+
+	// An entry node (no incoming edges, no channel reads) fires once per activation.
+	Describe("Entry node one-shot", func() {
+		It(
+			"fires a config-only function once per stage activation",
+			func(ctx SpecContext) {
+				resolver := channelSymbols(map[string]channelDef{
+					"start_cmd": {types.U8(), 402},
+					"log":       {types.String(), 403},
+					"data":      {types.F32(), 404},
+					"out_str":   {types.String(), 405},
+				})
+				h := newRuntimeHarness(ctx, `
+    func event_log{msg str} () {
+        log = msg
+    }
+    func seen(v f32) str {
+        return "seen"
+    }
+    sequence main {
+        stage s1 {
+            event_log{"armed"}
+            data -> seen{} -> out_str
+        }
+    }
+    start_cmd => main`, resolver,
+					channels.Digest{Key: 402, DataType: telem.Uint8T},
+					channels.Digest{Key: 403, DataType: telem.StringT},
+					channels.Digest{Key: 404, DataType: telem.Float32T},
+					channels.Digest{Key: 405, DataType: telem.StringT},
+				)
+				defer h.Close(ctx)
+				trigger(h, ctx, 402)
+				out, _ := h.Flush()
+				Expect(countOf(out, 403, "armed")).To(Equal(1))
+				for range 3 {
+					h.Ingest(404, telem.NewSeriesV[float32](1.5))
+					for range 5 {
+						advance(h, ctx, telem.Millisecond)
+					}
+				}
+				out, _ = h.Flush()
+				Expect(countOf(out, 405, "seen")).To(Equal(3),
+					"each sample must tick the channel-driven flow")
+				Expect(countOf(out, 403, "armed")).To(BeZero(),
+					"scheduler ticks must not re-fire the config-only entry")
+			},
+		)
+
+		It(
+			"re-fires a config-only function on stage re-entry",
+			func(ctx SpecContext) {
+				resolver := channelSymbols(map[string]channelDef{
+					"start_cmd": {types.U8(), 406},
+					"go_b":      {types.U8(), 407},
+					"go_a":      {types.U8(), 408},
+					"log":       {types.String(), 409},
+				})
+				h := newRuntimeHarness(ctx, `
+    func event_log{msg str} () {
+        log = msg
+    }
+    sequence main {
+        stage a {
+            event_log{"a"}
+            go_b => b
+        }
+        stage b {
+            go_a => a
+        }
+    }
+    start_cmd => main`, resolver,
+					channels.Digest{Key: 406, DataType: telem.Uint8T},
+					channels.Digest{Key: 407, DataType: telem.Uint8T},
+					channels.Digest{Key: 408, DataType: telem.Uint8T},
+					channels.Digest{Key: 409, DataType: telem.StringT},
+				)
+				defer h.Close(ctx)
+				trigger(h, ctx, 406)
+				trigger(h, ctx, 407)
+				trigger(h, ctx, 408)
+				out, _ := h.Flush()
+				Expect(countOf(out, 409, "a")).To(Equal(2),
+					"stage re-entry must re-fire the config-only entry")
+			},
+		)
+
+		It(
+			"fires a bare time.now source once per activation",
+			func(ctx SpecContext) {
+				resolver := channelSymbols(map[string]channelDef{
+					"start_cmd": {types.U8(), 410},
+					"ts_out":    {types.I64(), 411},
+				})
+				h := newRuntimeHarness(ctx, `import time
+    sequence main {
+        stage s1 {
+            time.now{} -> ts_out
+        }
+    }
+    start_cmd => main`, resolver,
+					channels.Digest{Key: 410, DataType: telem.Uint8T},
+					channels.Digest{Key: 411, DataType: telem.Int64T},
+				)
+				defer h.Close(ctx)
+				trigger(h, ctx, 410)
+				out, _ := h.Flush()
+				samples := int64(0)
+				for _, s := range out.Get(411).Series {
+					samples += s.Len()
+				}
+				Expect(samples).To(Equal(int64(1)))
+				advance(h, ctx, 10*telem.Millisecond)
+				advance(h, ctx, 20*telem.Millisecond)
+				advance(h, ctx, 50*telem.Millisecond)
+				out, _ = h.Flush()
+				Expect(out.Get(411).Series).To(BeEmpty(),
+					"idle cycles must not re-fire the one-shot source")
+			},
+		)
+
+		// Threshold math for the interval beside the one-shot:
+		//   BaseInterval = 50ms (only timer in the program)
+		//   tolerance    = BaseInterval / 2 = 25ms
+		//   fire when    = elapsed - lastFired >= period - tolerance = 25ms
+		//   lastFired    = -period initially, so activation fires immediately
+		// Fires land at ~1ms (activation), 60ms, 120ms, and 180ms; the 10ms tick
+		// is only 9ms past the last fire and stays below the threshold.
+		It(
+			"keeps an interval repeating beside a one-shot source",
+			func(ctx SpecContext) {
+				resolver := channelSymbols(map[string]channelDef{
+					"start_cmd": {types.U8(), 412},
+					"tick_ch":   {types.U8(), 413},
+					"log":       {types.String(), 414},
+				})
+				h := newRuntimeHarness(ctx, `
+    func event_log{msg str} () {
+        log = msg
+    }
+    sequence main {
+        stage s1 {
+            interval{50ms} -> tick_ch
+            event_log{"once"}
+        }
+    }
+    start_cmd => main`, resolver,
+					channels.Digest{Key: 412, DataType: telem.Uint8T},
+					channels.Digest{Key: 413, DataType: telem.Uint8T},
+					channels.Digest{Key: 414, DataType: telem.StringT},
+				)
+				defer h.Close(ctx)
+				trigger(h, ctx, 412)
+				advance(h, ctx, 10*telem.Millisecond)
+				advance(h, ctx, 60*telem.Millisecond)
+				advance(h, ctx, 120*telem.Millisecond)
+				advance(h, ctx, 180*telem.Millisecond)
+				out, _ := h.Flush()
+				ticks := int64(0)
+				for _, s := range out.Get(413).Series {
+					ticks += s.Len()
+				}
+				Expect(ticks).To(BeNumerically(">=", 3),
+					"the interval must keep repeating")
+				Expect(countOf(out, 414, "once")).To(Equal(1),
+					"timer cycles must not re-fire the config-only entry")
+			},
+		)
+
+		// Threshold math for the wait:
+		//   BaseInterval = 100ms (only timer in the program)
+		//   tolerance    = BaseInterval / 2 = 50ms
+		//   fire when    = elapsed - startTime >= duration - tolerance = 50ms
+		// startTime lands at ~1ms during activation, so 20ms is safely below the
+		// threshold and 160ms safely past it.
+		It(
+			"fires time.wait once at its deadline and never again",
+			func(ctx SpecContext) {
+				resolver := channelSymbols(map[string]channelDef{
+					"start_cmd": {types.U8(), 415},
+					"done_ch":   {types.U8(), 416},
+				})
+				h := newRuntimeHarness(ctx, `
+    sequence main {
+        stage s1 {
+            wait{100ms} -> done_ch
+        }
+    }
+    start_cmd => main`, resolver,
+					channels.Digest{Key: 415, DataType: telem.Uint8T},
+					channels.Digest{Key: 416, DataType: telem.Uint8T},
+				)
+				defer h.Close(ctx)
+				trigger(h, ctx, 415)
+				advance(h, ctx, 20*telem.Millisecond)
+				out, _ := h.Flush()
+				Expect(out.Get(416).Series).To(BeEmpty(),
+					"wait must not fire below its deadline")
+				advance(h, ctx, 160*telem.Millisecond)
+				out, _ = h.Flush()
+				samples := int64(0)
+				for _, s := range out.Get(416).Series {
+					samples += s.Len()
+				}
+				Expect(samples).To(Equal(int64(1)))
+				advance(h, ctx, 300*telem.Millisecond)
+				advance(h, ctx, 500*telem.Millisecond)
+				out, _ = h.Flush()
+				Expect(out.Get(416).Series).To(BeEmpty(),
+					"a fired wait must stay quiet")
+			},
+		)
+	})
 })

--- a/arc/go/stl/constant/constant.go
+++ b/arc/go/stl/constant/constant.go
@@ -55,30 +55,18 @@ func (h *Host) Create(_ context.Context, cfg node.Config) (node.Node, error) {
 	if cfg.Node.Type != symbolName {
 		return nil, query.ErrNotFound
 	}
-	return &constant{
-		State:       cfg.State,
-		value:       cfg.Node.Inputs[0].Value,
-		isEntryNode: cfg.Node.IsEntryNode(cfg.Program.Edges),
-	}, nil
+	return &constant{State: cfg.State, value: cfg.Node.Inputs[0].Value}, nil
 }
 
 type constant struct {
 	*node.State
-	clock       telem.MonoClock
-	value       any
-	isEntryNode bool
-	initialized bool
+	clock telem.MonoClock
+	value any
 }
 
 var _ node.Node = (*constant)(nil)
 
 func (c *constant) Next(ctx node.Context) {
-	if c.isEntryNode {
-		if c.initialized {
-			return
-		}
-		c.initialized = true
-	}
 	d := c.Output(0)
 	// A var-bound value input emits the referenced variable's latest value;
 	// otherwise the configured value is emitted.
@@ -98,5 +86,3 @@ func (c *constant) Next(ctx node.Context) {
 	*t = telem.NewSeriesV[telem.TimeStamp](c.clock.Now())
 	ctx.MarkChanged(0)
 }
-
-func (c *constant) Reset() { c.initialized = false }

--- a/arc/go/stl/constant/constant_test.go
+++ b/arc/go/stl/constant/constant_test.go
@@ -14,7 +14,6 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/synnaxlabs/arc/graph"
 	"github.com/synnaxlabs/arc/ir"
-	"github.com/synnaxlabs/arc/program"
 	"github.com/synnaxlabs/arc/runtime/node"
 	"github.com/synnaxlabs/arc/stl/constant"
 	"github.com/synnaxlabs/arc/symbol"
@@ -341,133 +340,92 @@ var _ = Describe("Constant", func() {
 			Expect(vals[0]).To(Equal(int64(-42)))
 		})
 
-		It(
-			"Should only emit once across multiple Next calls when node has no incoming edges",
-			func(ctx SpecContext) {
-				cfg := node.Config{
-					Node: ir.Node{
-						Type: "constant",
-						Inputs: types.Params{
-							{Name: "value", Type: types.I64(), Value: int64(42)},
-						},
+		It("Should emit and mark changed on every Next call", func(ctx SpecContext) {
+			cfg := node.Config{
+				Node: ir.Node{
+					Type: "constant",
+					Inputs: types.Params{
+						{Name: "value", Type: types.I64(), Value: int64(42)},
 					},
-					State: s.Node("const"),
-				}
-				constNode := s.Node("const")
-				*constNode.Output(0) = telem.NewSeriesV[int64](0)
-				n := MustSucceed(factory.Create(ctx, cfg))
+				},
+				State: s.Node("const"),
+			}
+			constNode := s.Node("const")
+			*constNode.Output(0) = telem.NewSeriesV[int64](0)
+			n := MustSucceed(factory.Create(ctx, cfg))
+			for range 3 {
 				n.Next(node.Context{Context: ctx, MarkChanged: func(i int) {
 					marked = append(marked, i)
 				}})
-				Expect(marked).To(HaveLen(1))
-				n.Next(node.Context{Context: ctx, MarkChanged: func(i int) {
-					marked = append(marked, i)
-				}})
-				Expect(marked).To(HaveLen(1))
-			},
-		)
+			}
+			Expect(marked).To(Equal([]int{0, 0, 0}))
+		})
 
-		It(
-			"Should emit again after Reset is called when node has no incoming edges",
-			func(ctx SpecContext) {
-				cfg := node.Config{
-					Node: ir.Node{
-						Type: "constant",
-						Inputs: types.Params{
-							{Name: "value", Type: types.I64(), Value: int64(42)},
-						},
+		It("Should still emit after Reset", func(ctx SpecContext) {
+			cfg := node.Config{
+				Node: ir.Node{
+					Type: "constant",
+					Inputs: types.Params{
+						{Name: "value", Type: types.I64(), Value: int64(42)},
 					},
-					State: s.Node("const"),
-				}
-				constNode := s.Node("const")
-				*constNode.Output(0) = telem.NewSeriesV[int64](0)
-				n := MustSucceed(factory.Create(ctx, cfg))
-				n.Next(node.Context{Context: ctx, MarkChanged: func(i int) {
-					marked = append(marked, i)
-				}})
-				Expect(marked).To(HaveLen(1))
-				n.Reset()
-				n.Next(node.Context{Context: ctx, MarkChanged: func(i int) {
-					marked = append(marked, i)
-				}})
-				Expect(marked).To(HaveLen(2))
-			},
-		)
+				},
+				State: s.Node("const"),
+			}
+			constNode := s.Node("const")
+			*constNode.Output(0) = telem.NewSeriesV[int64](0)
+			n := MustSucceed(factory.Create(ctx, cfg))
+			n.Next(node.Context{Context: ctx, MarkChanged: func(i int) {
+				marked = append(marked, i)
+			}})
+			Expect(marked).To(HaveLen(1))
+			n.Reset()
+			n.Next(node.Context{Context: ctx, MarkChanged: func(i int) {
+				marked = append(marked, i)
+			}})
+			Expect(marked).To(HaveLen(2))
+			Expect(telem.ValueAt[int64](*constNode.Output(0), 0)).To(Equal(int64(42)))
+		})
 
-		It(
-			"Should emit on every Next call when node has incoming edges",
-			func(ctx SpecContext) {
-				cfg := node.Config{
-					Node: ir.Node{
-						Key:  "const",
-						Type: "constant",
-						Inputs: types.Params{
-							{Name: "value", Type: types.I64(), Value: int64(42)},
-						},
+		It("Should stamp a fresh timestamp on every Next", func(ctx SpecContext) {
+			cfg := node.Config{
+				Node: ir.Node{
+					Type: "constant",
+					Inputs: types.Params{
+						{Name: "value", Type: types.I64(), Value: int64(42)},
 					},
-					State: s.Node("const"),
-					Program: program.Program{IR: ir.IR{Edges: ir.Edges{
-						{
-							Source: ir.Handle{
-								Node:  "upstream",
-								Param: ir.DefaultOutputParam,
-							},
-							Target: ir.Handle{
-								Node:  "const",
-								Param: ir.DefaultInputParam,
-							},
-						},
-					}}},
-				}
-				constNode := s.Node("const")
-				*constNode.Output(0) = telem.NewSeriesV[int64](0)
-				n := MustSucceed(factory.Create(ctx, cfg))
-				for range 3 {
-					n.Next(node.Context{Context: ctx, MarkChanged: func(i int) {
-						marked = append(marked, i)
-					}})
-				}
-				Expect(marked).To(HaveLen(3))
-			},
-		)
+				},
+				State: s.Node("const"),
+			}
+			constNode := s.Node("const")
+			*constNode.Output(0) = telem.NewSeriesV[int64](0)
+			n := MustSucceed(factory.Create(ctx, cfg))
+			noop := node.Context{Context: ctx, MarkChanged: func(int) {}}
+			n.Next(noop)
+			t0 := telem.ValueAt[telem.TimeStamp](*constNode.OutputTime(0), 0)
+			n.Next(noop)
+			t1 := telem.ValueAt[telem.TimeStamp](*constNode.OutputTime(0), 0)
+			Expect(t1).To(BeNumerically(">", t0))
+		})
 
-		It(
-			"Should not require Reset to re-fire when node has incoming edges",
-			func(ctx SpecContext) {
-				cfg := node.Config{
-					Node: ir.Node{
-						Key:  "const",
-						Type: "constant",
-						Inputs: types.Params{
-							{Name: "value", Type: types.I64(), Value: int64(42)},
-						},
+		It("Should overwrite a stale output value on Next", func(ctx SpecContext) {
+			cfg := node.Config{
+				Node: ir.Node{
+					Type: "constant",
+					Inputs: types.Params{
+						{Name: "value", Type: types.I64(), Value: int64(42)},
 					},
-					State: s.Node("const"),
-					Program: program.Program{IR: ir.IR{Edges: ir.Edges{
-						{
-							Source: ir.Handle{
-								Node:  "upstream",
-								Param: ir.DefaultOutputParam,
-							},
-							Target: ir.Handle{
-								Node:  "const",
-								Param: ir.DefaultInputParam,
-							},
-						},
-					}}},
-				}
-				constNode := s.Node("const")
-				*constNode.Output(0) = telem.NewSeriesV[int64](0)
-				n := MustSucceed(factory.Create(ctx, cfg))
-				n.Next(node.Context{Context: ctx, MarkChanged: func(i int) {
-					marked = append(marked, i)
-				}})
-				n.Next(node.Context{Context: ctx, MarkChanged: func(i int) {
-					marked = append(marked, i)
-				}})
-				Expect(marked).To(HaveLen(2))
-			},
-		)
+				},
+				State: s.Node("const"),
+			}
+			constNode := s.Node("const")
+			*constNode.Output(0) = telem.NewSeriesV[int64](0)
+			n := MustSucceed(factory.Create(ctx, cfg))
+			noop := node.Context{Context: ctx, MarkChanged: func(int) {}}
+			n.Next(noop)
+			*constNode.Output(0) = telem.NewSeriesV[int64](999)
+			n.Next(noop)
+			Expect(telem.ValueAt[int64](*constNode.Output(0), 0)).To(Equal(int64(42)))
+		})
 	})
 
 	Describe("Var-bound value", func() {
@@ -476,8 +434,7 @@ var _ = Describe("Constant", func() {
 			factory = constant.NewHost()
 		})
 
-		// build wires a constant whose value input references variable node "v"
-		// and gives it an inbound trigger edge so it re-emits on every Next.
+		// build wires a constant whose value input references variable node "v".
 		build := func(valueType types.Type, initial any) (node.Config, *node.ProgramState) {
 			v := ir.Node{
 				Key:     "v",
@@ -494,16 +451,8 @@ var _ = Describe("Constant", func() {
 				}},
 				Outputs: types.Params{{Name: ir.DefaultOutputParam, Type: valueType}},
 			}
-			edges := ir.Edges{{
-				Source: ir.Handle{Node: "up", Param: ir.DefaultOutputParam},
-				Target: ir.Handle{Node: "n", Param: ir.DefaultInputParam},
-			}}
-			state := node.New(ir.IR{Nodes: ir.Nodes{v, n}, Edges: edges})
-			cfg := node.Config{
-				Node:    n,
-				State:   state.Node("n"),
-				Program: program.Program{IR: ir.IR{Edges: edges}},
-			}
+			state := node.New(ir.IR{Nodes: ir.Nodes{v, n}})
+			cfg := node.Config{Node: n, State: state.Node("n")}
 			return cfg, state
 		}
 		next := func(ctx SpecContext, n node.Node) {
@@ -605,7 +554,7 @@ var _ = Describe("Constant", func() {
 		)
 
 		It(
-			"Should re-emit on every trigger, tracking the variable",
+			"Should re-emit on every Next, tracking the variable",
 			func(ctx SpecContext) {
 				cfg, state := build(types.I64(), int64(42))
 				n := MustSucceed(factory.Create(ctx, cfg))
@@ -623,6 +572,18 @@ var _ = Describe("Constant", func() {
 				Expect(marked).To(HaveLen(2))
 			},
 		)
+
+		It("Should keep tracking the variable after Reset", func(ctx SpecContext) {
+			cfg, state := build(types.I64(), int64(42))
+			n := MustSucceed(factory.Create(ctx, cfg))
+			*state.Node("v").Output(0) = telem.NewSeriesV[int64](7)
+			next(ctx, n)
+			n.Reset()
+			*state.Node("v").Output(0) = telem.NewSeriesV[int64](9)
+			next(ctx, n)
+			Expect(telem.ValueAt[int64](*state.Node("n").Output(0), 0)).
+				To(Equal(int64(9)))
+		})
 	})
 
 	Describe("Symbols", func() {
@@ -636,6 +597,12 @@ var _ = Describe("Constant", func() {
 			}
 			Expect(sym).ToNot(BeNil())
 			Expect(sym.Name).To(Equal("constant"))
+		})
+
+		It("Should mark the symbol internal", func() {
+			sym := constant.NewSymbols()[0]
+			Expect(sym.Internal).To(BeTrue())
+			Expect(sym.Kind).To(Equal(symbol.KindFunction))
 		})
 	})
 })

--- a/arc/go/stl/wasm/node.go
+++ b/arc/go/stl/wasm/node.go
@@ -50,8 +50,6 @@ type nodeImpl struct {
 	memBase       uint32
 	params        []uint64
 	offsets       []int
-	initialized   bool
-	isEntryNode   bool
 	selIdx        int
 	clock         telem.MonoClock
 	nodeKeySetter NodeKeySetter
@@ -110,13 +108,6 @@ func (n *nodeImpl) Next(ctx node.Context) {
 			ctx.ReportError(errors.Newf("WASM trap in node %s: %v", n.ir.Key, r))
 		}
 	}()
-
-	if n.isEntryNode {
-		if n.initialized {
-			return
-		}
-		n.initialized = true
-	}
 
 	// A $sel-only change re-points without emitting; the value fires on the next input.
 	if n.selIdx >= 0 && !n.dataFresh() {
@@ -306,7 +297,6 @@ func (n *nodeImpl) Next(ctx node.Context) {
 
 func (n *nodeImpl) Reset() {
 	n.State.Reset()
-	n.initialized = false
 	if n.nodeKeySetter != nil {
 		n.nodeKeySetter.ClearNode(n.ir.Key)
 	}

--- a/arc/go/stl/wasm/wasm.go
+++ b/arc/go/stl/wasm/wasm.go
@@ -39,8 +39,6 @@ func (w *Module) Create(_ context.Context, cfg node.Config) (node.Node, error) {
 	if fn == nil {
 		return nil, query.ErrNotFound
 	}
-	isEntryNode := cfg.Node.IsEntryNode(cfg.Program.Edges)
-
 	// Each input fills one WASM param slot. Edge-fed inputs (nil Value) are streamed
 	// per sample in Next; literal inputs get their constant value set once here.
 	params := make([]uint64, len(irFn.Inputs))
@@ -110,7 +108,6 @@ func (w *Module) Create(_ context.Context, cfg node.Config) (node.Node, error) {
 		memBase:       base,
 		params:        params,
 		offsets:       make([]int, len(irFn.Outputs)),
-		isEntryNode:   isEntryNode,
 		selIdx:        selIdx,
 		nodeKeySetter: w.NodeKeySetter,
 		stringInputs:  stringInputs,

--- a/arc/go/stl/wasm/wasm_test.go
+++ b/arc/go/stl/wasm/wasm_test.go
@@ -2221,9 +2221,9 @@ trigger_ch -> emit_period{period=1s}
 		)
 	})
 
-	Describe("No-Input Node Initialization", func() {
+	Describe("No-Input Node Execution", func() {
 		It(
-			"Should execute only once per stage entry for nodes with no inputs",
+			"Should execute on every Next call for nodes with no inputs",
 			func(ctx SpecContext) {
 				// Create a stateful counter function with no inputs
 				g := singleFunctionGraph("init_counter", types.I64(), `{
@@ -2243,18 +2243,21 @@ trigger_ch -> emit_period{period=1s}
 					telem.UnmarshalSeries[int64](h.Output("init_counter", 0))[0],
 				).To(Equal(int64(1)))
 
-				// Second call - should NOT execute again (initialized flag)
+				// Second call - with no data inputs RefreshInputs never gates,
+				// so the node runs again and the counter advances
 				changed = h.NextChanged(ctx, n, "init_counter")
-				// No output should be marked as changed since we didn't execute
-				Expect(changed.Contains(ir.DefaultOutputParam)).To(BeFalse())
+				Expect(changed.Contains(ir.DefaultOutputParam)).To(BeTrue())
+				Expect(
+					telem.UnmarshalSeries[int64](h.Output("init_counter", 0))[0],
+				).To(Equal(int64(2)))
 
 				// Reset the node (simulating stage re-entry)
 				n.Reset()
 
-				// Third call - should execute again after reset
+				// Third call - Reset cleared the stateful scope, so the counter
+				// restarts
 				changed = h.NextChanged(ctx, n, "init_counter")
 				Expect(changed.Contains(ir.DefaultOutputParam)).To(BeTrue())
-				// Stage re-entry re-initializes the counter
 				Expect(
 					telem.UnmarshalSeries[int64](h.Output("init_counter", 0))[0],
 				).To(Equal(int64(1)))
@@ -2262,7 +2265,7 @@ trigger_ch -> emit_period{period=1s}
 		)
 
 		It(
-			"Should execute every time for non-entry nodes with inputs",
+			"Should execute every time for nodes with edge-fed inputs",
 			func(ctx SpecContext) {
 				g := binaryOpGraph(
 					"add",
@@ -3181,7 +3184,7 @@ trigger_ch -> emit_period{period=1s}
 
 	Describe("Flow Expression Execution", func() {
 		It(
-			"Should execute only once for a flow expression node with no inputs",
+			"Should execute on every Next for a flow expression node with no inputs",
 			func(ctx SpecContext) {
 				g := singleFunctionGraph("expression_0", types.I64(), `{
 				count i64 $= 0
@@ -3202,17 +3205,17 @@ trigger_ch -> emit_period{period=1s}
 				n.Next(nCtx)
 				Expect(
 					telem.UnmarshalSeries[int64](h.Output("expression_0", 0))[0],
-				).To(Equal(int64(1)))
+				).To(Equal(int64(2)))
 
 				n.Next(nCtx)
 				Expect(
 					telem.UnmarshalSeries[int64](h.Output("expression_0", 0))[0],
-				).To(Equal(int64(1)))
+				).To(Equal(int64(3)))
 			},
 		)
 
 		It(
-			"Should execute again after reset for a flow expression node with no inputs",
+			"Should re-initialize stateful variables on Reset for a flow expression node",
 			func(ctx SpecContext) {
 				g := singleFunctionGraph("expression_0", types.I64(), `{
 				count i64 $= 0
@@ -3238,41 +3241,15 @@ trigger_ch -> emit_period{period=1s}
 				n.Next(nCtx)
 				Expect(
 					telem.UnmarshalSeries[int64](h.Output("expression_0", 0))[0],
-				).To(Equal(int64(1)))
-				Expect(executions).To(Equal(1))
+				).To(Equal(int64(2)))
+				Expect(executions).To(Equal(2))
 
 				n.Reset()
 
 				n.Next(nCtx)
-				Expect(executions).To(Equal(2))
+				Expect(executions).To(Equal(3))
 				Expect(
 					telem.UnmarshalSeries[int64](h.Output("expression_0", 0))[0],
-				).To(Equal(int64(1)))
-			},
-		)
-
-		It(
-			"Should not treat non-expression nodes as expressions",
-			func(ctx SpecContext) {
-				g := singleFunctionGraph("expr_0", types.I64(), `{
-				count i64 $= 0
-				count = count + 1
-				return count
-			}`)
-				h := newHarness(ctx, g, nil)
-				defer h.Close(ctx)
-
-				n := h.CreateNode(ctx, "expr_0")
-				nCtx := node.Context{Context: ctx, MarkChanged: func(int) {}}
-
-				n.Next(nCtx)
-				Expect(
-					telem.UnmarshalSeries[int64](h.Output("expr_0", 0))[0],
-				).To(Equal(int64(1)))
-
-				n.Next(nCtx)
-				Expect(
-					telem.UnmarshalSeries[int64](h.Output("expr_0", 0))[0],
 				).To(Equal(int64(1)))
 			},
 		)

--- a/arc/go/text/text_test.go
+++ b/arc/go/text/text_test.go
@@ -7748,6 +7748,81 @@ time.wait{duration=500ms} -> output`
 				},
 			)
 		})
+
+		Context("Entry Node Classification", func() {
+			It(
+				"Should lower a config-only call in a stage to an entry node",
+				func(ctx SpecContext) {
+					resolver := []symbol.Symbol{
+						{
+							Name: "out",
+							Kind: symbol.KindChannel,
+							Type: types.Chan(types.String()),
+							ID:   10171,
+						},
+					}
+					source := `
+				func f{v str} () {
+				    out = v
+				}
+
+				sequence main {
+				    stage start {
+				        f{"x"}
+				    }
+				}`
+					parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
+					inter, diagnostics := text.Analyze(
+						ctx,
+						parsedText,
+						NewRoot(nil, resolver...),
+					)
+					Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
+
+					callNode := findNodeByType(inter.Nodes, "f")
+					for _, edge := range inter.Edges {
+						Expect(edge.Target.Node).ToNot(Equal(callNode.Key))
+					}
+					Expect(callNode.IsEntryNode(inter.Edges)).To(BeTrue())
+				},
+			)
+
+			It(
+				"Should keep a constant-triggered call off the entry set",
+				func(ctx SpecContext) {
+					resolver := []symbol.Symbol{
+						{
+							Name: "out",
+							Kind: symbol.KindChannel,
+							Type: types.Chan(types.String()),
+							ID:   10172,
+						},
+					}
+					source := `
+				func f{v str} () {
+				    out = v
+				}
+
+				true => f{"x"}`
+					parsedText := MustSucceed(text.Parse(text.Text{Raw: source}))
+					inter, diagnostics := text.Analyze(
+						ctx,
+						parsedText,
+						NewRoot(nil, resolver...),
+					)
+					Expect(diagnostics.Ok()).To(BeTrue(), diagnostics.String())
+
+					constNode := findNodeByType(inter.Nodes, "constant")
+					callNode := findNodeByType(inter.Nodes, "f")
+					Expect(inter.Edges).To(HaveLen(1))
+					edge := inter.Edges[0]
+					Expect(edge.Source.Node).To(Equal(constNode.Key))
+					Expect(edge.Target.Node).To(Equal(callNode.Key))
+					Expect(edge.Kind).To(Equal(ir.EdgeKindConditional))
+					Expect(callNode.IsEntryNode(inter.Edges)).To(BeFalse())
+				},
+			)
+		})
 	})
 
 	Describe("Synthesized Format-String Functions", func() {

--- a/core/pkg/service/arc/task/task_test.go
+++ b/core/pkg/service/arc/task/task_test.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"maps"
+	"slices"
 	"time"
 
 	"github.com/google/uuid"
@@ -25,6 +26,7 @@ import (
 	"github.com/synnaxlabs/synnax/pkg/distribution/framer/frame"
 	"github.com/synnaxlabs/synnax/pkg/distribution/mock"
 	svcarc "github.com/synnaxlabs/synnax/pkg/service/arc"
+	"github.com/synnaxlabs/synnax/pkg/service/arc/ranges"
 	arcstatus "github.com/synnaxlabs/synnax/pkg/service/arc/status"
 	arctask "github.com/synnaxlabs/synnax/pkg/service/arc/task"
 	"github.com/synnaxlabs/synnax/pkg/service/channel"
@@ -164,7 +166,9 @@ var _ = Describe("Task", Ordered, func() {
 	newTextFactory := func(ctx context.Context, prof arc.Text) driver.Factory {
 		return newFactoryWith(func(_ context.Context, _ uuid.UUID) (svcarc.Arc, error) {
 			resolver := channelSvc.NewArcSymbolResolver(nil)
-			root := arc.NewRoot(resolver, arcstatus.NewSymbols()...)
+			root := arc.NewRoot(resolver, slices.Concat(
+				arcstatus.NewSymbols(), ranges.NewSymbols(),
+			)...)
 			module, err := arc.CompileText(ctx, prof, root)
 			if err != nil {
 				return svcarc.Arc{}, err
@@ -1024,6 +1028,255 @@ var _ = Describe("Task", Ordered, func() {
 			Expect(byName(base + "_c").Variant).To(BeEquivalentTo("warning"))
 			Expect(byName(base + "_d").Variant).To(BeEquivalentTo("loading"))
 		})
+	})
+
+	Describe("Entry node one-shot", func() {
+		It(
+			"Should create exactly one status for an untriggered status.set in a stage",
+			func(ctx SpecContext) {
+				trig := createVirtualCh(ctx, "entry_status_trig", telem.Uint8T)
+				name := "entry_status_" + uuid.NewString()[:8]
+				prog := arc.Text{Raw: fmt.Sprintf(`
+					import status
+
+					sequence main {
+					    stage report {
+					        status.set{key_or_name="%s", message="m", variant="info"}
+					    }
+					}
+
+					%s => main
+				`, name, trig.Name)}
+
+				svcTask := task.Task{
+					Key:    uuid.New(),
+					Name:   "test-entry-status-once",
+					Type:   arctask.Type,
+					Config: configToMap(arctask.Config{ArcKey: uuid.New()}),
+				}
+				t := MustSucceed(
+					newTextFactory(ctx, prog).ConfigureTask(ctx, svcTask, "cmd-1"),
+				)
+				Expect(t.Exec(ctx, task.Command{Type: "start"})).To(Succeed())
+				defer func() { Expect(t.Stop(true)).To(Succeed()) }()
+
+				time.Sleep(20 * time.Millisecond)
+				w := MustSucceed(framerSvc.OpenWriter(ctx, framer.WriterConfig{
+					Keys:  []channel.Key{trig.Key()},
+					Start: telem.Now(),
+				}))
+				Expect(
+					w.Write(frame.NewUnary(trig.Key(), telem.NewSeriesV[uint8](1))),
+				).To(BeTrue())
+
+				oneRow := func(g Gomega) {
+					var rows []svcarc.Status
+					g.Expect(status.NewRetrieve[svcarc.StatusDetails](statusSvc).
+						Where(status.Match(func(_ gorp.Context, _ status.Retrieve[svcarc.StatusDetails], s *svcarc.Status) (bool, error) {
+							return s.Name == name, nil
+						})).
+						Entries(&rows).Exec(ctx, nil)).To(Succeed())
+					g.Expect(rows).To(HaveLen(1))
+				}
+				Eventually(oneRow).Should(Succeed())
+
+				// status.set upserts by name, so a re-fire keeps one row; the
+				// range spec below is the sharp duplicate detector.
+				for range 3 {
+					Expect(
+						w.Write(frame.NewUnary(trig.Key(), telem.NewSeriesV[uint8](1))),
+					).To(BeTrue())
+					time.Sleep(20 * time.Millisecond)
+				}
+				Expect(w.Close()).To(Succeed())
+				Consistently(oneRow).Should(Succeed())
+			},
+		)
+
+		It(
+			"Should create exactly one range for an untriggered ranges.create in a stage",
+			func(ctx SpecContext) {
+				trig := createVirtualCh(ctx, "entry_range_trig", telem.Uint8T)
+				name := "entry_range_" + uuid.NewString()[:8]
+				prog := arc.Text{Raw: fmt.Sprintf(`
+					import ranges
+
+					sequence main {
+					    stage report {
+					        ranges.create{name="%s"}
+					    }
+					}
+
+					%s => main
+				`, name, trig.Name)}
+
+				svcTask := task.Task{
+					Key:    uuid.New(),
+					Name:   "test-entry-range-once",
+					Type:   arctask.Type,
+					Config: configToMap(arctask.Config{ArcKey: uuid.New()}),
+				}
+				t := MustSucceed(
+					newTextFactory(ctx, prog).ConfigureTask(ctx, svcTask, "cmd-1"),
+				)
+				Expect(t.Exec(ctx, task.Command{Type: "start"})).To(Succeed())
+				defer func() { Expect(t.Stop(true)).To(Succeed()) }()
+
+				time.Sleep(20 * time.Millisecond)
+				w := MustSucceed(framerSvc.OpenWriter(ctx, framer.WriterConfig{
+					Keys:  []channel.Key{trig.Key()},
+					Start: telem.Now(),
+				}))
+				Expect(
+					w.Write(frame.NewUnary(trig.Key(), telem.NewSeriesV[uint8](1))),
+				).To(BeTrue())
+
+				// Every extra fire creates a new identically-named range, so a
+				// stable count of one proves the entry node dispatched once.
+				oneRange := func(g Gomega) {
+					g.Expect(rangerSvc.NewRetrieve().
+						Where(ranger.MatchNames(name)).
+						Count(ctx, nil)).To(Equal(1))
+				}
+				Eventually(oneRange).Should(Succeed())
+
+				for range 3 {
+					Expect(
+						w.Write(frame.NewUnary(trig.Key(), telem.NewSeriesV[uint8](1))),
+					).To(BeTrue())
+					time.Sleep(20 * time.Millisecond)
+				}
+				Expect(w.Close()).To(Succeed())
+				Consistently(oneRange).Should(Succeed())
+			},
+		)
+	})
+
+	Describe("Routing entry host calls", func() {
+		It(
+			"Should fire a bare status.set routing entry once per truthy mark",
+			func(ctx SpecContext) {
+				data := createVirtualCh(ctx, "route_status_data", telem.BooleanT)
+				out := createVirtualCh(ctx, "route_status_out", telem.StringT)
+				name := "press_high_" + uuid.NewString()[:8]
+				prog := arc.Text{Raw: fmt.Sprintf(`
+					import status
+
+					%s -> select{} => {
+					    true: status.set{
+					        key_or_name="%s",
+					        message="tank pressure above limit",
+					        variant="warning"
+					    } -> %s
+					}
+				`, data.Name, name, out.Name)}
+
+				svcTask := task.Task{
+					Key:    uuid.New(),
+					Name:   "test-route-status-bare",
+					Type:   arctask.Type,
+					Config: configToMap(arctask.Config{ArcKey: uuid.New()}),
+				}
+				t := MustSucceed(
+					newTextFactory(ctx, prog).ConfigureTask(ctx, svcTask, "cmd-1"),
+				)
+				Expect(t.Exec(ctx, task.Command{Type: "start"})).To(Succeed())
+				defer func() { Expect(t.Stop(true)).To(Succeed()) }()
+
+				time.Sleep(20 * time.Millisecond)
+				w := MustSucceed(framerSvc.OpenWriter(ctx, framer.WriterConfig{
+					Keys:  []channel.Key{data.Key()},
+					Start: telem.Now(),
+				}))
+				Expect(
+					w.Write(frame.NewUnary(data.Key(), telem.NewSeriesV[bool](true))),
+				).To(BeTrue())
+
+				oneRow := func(g Gomega) {
+					var rows []svcarc.Status
+					g.Expect(status.NewRetrieve[svcarc.StatusDetails](statusSvc).
+						Where(status.Match(func(_ gorp.Context, _ status.Retrieve[svcarc.StatusDetails], s *svcarc.Status) (bool, error) {
+							return s.Name == name, nil
+						})).
+						Entries(&rows).Exec(ctx, nil)).To(Succeed())
+					g.Expect(rows).To(HaveLen(1))
+				}
+				Eventually(oneRow).Should(Succeed())
+
+				// Falsy samples pick the absent false branch: no re-fire.
+				for range 3 {
+					Expect(
+						w.Write(frame.NewUnary(data.Key(), telem.NewSeriesV[bool](false))),
+					).To(BeTrue())
+					time.Sleep(20 * time.Millisecond)
+				}
+				Expect(w.Close()).To(Succeed())
+				Consistently(oneRow).Should(Succeed())
+			},
+		)
+
+		It(
+			"Should fire a bare ranges.create routing entry once per truthy mark",
+			func(ctx SpecContext) {
+				data := createVirtualCh(ctx, "route_range_data", telem.BooleanT)
+				out := createVirtualCh(ctx, "route_range_out", telem.StringT)
+				name := "overpressure_" + uuid.NewString()[:8]
+				prog := arc.Text{Raw: fmt.Sprintf(`
+					import ranges
+
+					%s -> select{} => {
+					    true: ranges.create{name="%s"} -> %s
+					}
+				`, data.Name, name, out.Name)}
+
+				svcTask := task.Task{
+					Key:    uuid.New(),
+					Name:   "test-route-range-bare",
+					Type:   arctask.Type,
+					Config: configToMap(arctask.Config{ArcKey: uuid.New()}),
+				}
+				t := MustSucceed(
+					newTextFactory(ctx, prog).ConfigureTask(ctx, svcTask, "cmd-1"),
+				)
+				Expect(t.Exec(ctx, task.Command{Type: "start"})).To(Succeed())
+				defer func() { Expect(t.Stop(true)).To(Succeed()) }()
+
+				time.Sleep(20 * time.Millisecond)
+				w := MustSucceed(framerSvc.OpenWriter(ctx, framer.WriterConfig{
+					Keys:  []channel.Key{data.Key()},
+					Start: telem.Now(),
+				}))
+				rangeCount := func(want int) func(g Gomega) {
+					return func(g Gomega) {
+						g.Expect(rangerSvc.NewRetrieve().
+							Where(ranger.MatchNames(name)).
+							Count(ctx, nil)).To(Equal(want))
+					}
+				}
+
+				Expect(
+					w.Write(frame.NewUnary(data.Key(), telem.NewSeriesV[bool](true))),
+				).To(BeTrue())
+				Eventually(rangeCount(1)).Should(Succeed())
+
+				// Falsy samples pick the absent false branch: no re-fire.
+				for range 2 {
+					Expect(
+						w.Write(frame.NewUnary(data.Key(), telem.NewSeriesV[bool](false))),
+					).To(BeTrue())
+					time.Sleep(20 * time.Millisecond)
+				}
+				Consistently(rangeCount(1)).Should(Succeed())
+
+				// A fresh truthy mark fires the entry again: per-trigger, not
+				// per-activation.
+				Expect(
+					w.Write(frame.NewUnary(data.Key(), telem.NewSeriesV[bool](true))),
+				).To(BeTrue())
+				Expect(w.Close()).To(Succeed())
+				Eventually(rangeCount(2)).Should(Succeed())
+			},
+		)
 	})
 
 	Describe("Status Reporting", func() {

--- a/core/pkg/service/arc/task/task_test.go
+++ b/core/pkg/service/arc/task/task_test.go
@@ -1218,6 +1218,157 @@ var _ = Describe("Task", Ordered, func() {
 		)
 
 		It(
+			"Should fire a status.set routing entry into a variable once per truthy mark",
+			func(ctx SpecContext) {
+				trig := createVirtualCh(ctx, "route_status_var_trig", telem.Uint8T)
+				data := createVirtualCh(ctx, "route_status_var_data", telem.BooleanT)
+				name := "press_high_" + uuid.NewString()[:8]
+				prog := arc.Text{Raw: fmt.Sprintf(`
+					import status
+
+					sequence main {
+					    stage watch {
+					        v str := ""
+					        %s -> select{} => {
+					            true: status.set{
+					                key_or_name="%s",
+					                message="tank pressure above limit",
+					                variant="warning"
+					            } -> v
+					        }
+					    }
+					}
+
+					%s => main
+				`, data.Name, name, trig.Name)}
+
+				svcTask := task.Task{
+					Key:    uuid.New(),
+					Name:   "test-route-status-var",
+					Type:   arctask.Type,
+					Config: configToMap(arctask.Config{ArcKey: uuid.New()}),
+				}
+				t := MustSucceed(
+					newTextFactory(ctx, prog).ConfigureTask(ctx, svcTask, "cmd-1"),
+				)
+				Expect(t.Exec(ctx, task.Command{Type: "start"})).To(Succeed())
+				defer func() { Expect(t.Stop(true)).To(Succeed()) }()
+
+				time.Sleep(20 * time.Millisecond)
+				w := MustSucceed(framerSvc.OpenWriter(ctx, framer.WriterConfig{
+					Keys:  []channel.Key{trig.Key(), data.Key()},
+					Start: telem.Now(),
+				}))
+				Expect(
+					w.Write(frame.NewUnary(trig.Key(), telem.NewSeriesV[uint8](1))),
+				).To(BeTrue())
+				time.Sleep(20 * time.Millisecond)
+				Expect(
+					w.Write(frame.NewUnary(data.Key(), telem.NewSeriesV[bool](true))),
+				).To(BeTrue())
+
+				oneRow := func(g Gomega) {
+					var rows []svcarc.Status
+					g.Expect(status.NewRetrieve[svcarc.StatusDetails](statusSvc).
+						Where(status.Match(func(_ gorp.Context, _ status.Retrieve[svcarc.StatusDetails], s *svcarc.Status) (bool, error) {
+							return s.Name == name, nil
+						})).
+						Entries(&rows).Exec(ctx, nil)).To(Succeed())
+					g.Expect(rows).To(HaveLen(1))
+				}
+				Eventually(oneRow).Should(Succeed())
+
+				// Falsy samples pick the absent false branch: no re-fire.
+				for range 3 {
+					Expect(
+						w.Write(
+							frame.NewUnary(data.Key(), telem.NewSeriesV[bool](false)),
+						),
+					).To(BeTrue())
+					time.Sleep(20 * time.Millisecond)
+				}
+				Expect(w.Close()).To(Succeed())
+				Consistently(oneRow).Should(Succeed())
+			},
+		)
+
+		It(
+			"Should fire a status.set routing entry into a channel alias once per truthy mark",
+			func(ctx SpecContext) {
+				trig := createVirtualCh(ctx, "route_status_alias_trig", telem.Uint8T)
+				data := createVirtualCh(ctx, "route_status_alias_data", telem.BooleanT)
+				out := createVirtualCh(ctx, "route_status_alias_out", telem.StringT)
+				name := "press_high_" + uuid.NewString()[:8]
+				prog := arc.Text{Raw: fmt.Sprintf(`
+					import status
+
+					sequence main {
+					    stage watch {
+					        sink := %s
+					        %s -> select{} => {
+					            true: status.set{
+					                key_or_name="%s",
+					                message="tank pressure above limit",
+					                variant="warning"
+					            } -> sink
+					        }
+					    }
+					}
+
+					%s => main
+				`, out.Name, data.Name, name, trig.Name)}
+
+				svcTask := task.Task{
+					Key:    uuid.New(),
+					Name:   "test-route-status-alias",
+					Type:   arctask.Type,
+					Config: configToMap(arctask.Config{ArcKey: uuid.New()}),
+				}
+				t := MustSucceed(
+					newTextFactory(ctx, prog).ConfigureTask(ctx, svcTask, "cmd-1"),
+				)
+				Expect(t.Exec(ctx, task.Command{Type: "start"})).To(Succeed())
+				defer func() { Expect(t.Stop(true)).To(Succeed()) }()
+
+				time.Sleep(20 * time.Millisecond)
+				w := MustSucceed(framerSvc.OpenWriter(ctx, framer.WriterConfig{
+					Keys:  []channel.Key{trig.Key(), data.Key()},
+					Start: telem.Now(),
+				}))
+				Expect(
+					w.Write(frame.NewUnary(trig.Key(), telem.NewSeriesV[uint8](1))),
+				).To(BeTrue())
+				time.Sleep(20 * time.Millisecond)
+				Expect(
+					w.Write(frame.NewUnary(data.Key(), telem.NewSeriesV[bool](true))),
+				).To(BeTrue())
+
+				oneRow := func(g Gomega) {
+					var rows []svcarc.Status
+					g.Expect(status.NewRetrieve[svcarc.StatusDetails](statusSvc).
+						Where(status.Match(func(_ gorp.Context, _ status.Retrieve[svcarc.StatusDetails], s *svcarc.Status) (bool, error) {
+							return s.Name == name, nil
+						})).
+						Entries(&rows).Exec(ctx, nil)).To(Succeed())
+					g.Expect(rows).To(HaveLen(1))
+				}
+				Eventually(oneRow).Should(Succeed())
+
+				// Falsy samples pick the absent false branch: no re-fire.
+				for range 3 {
+					Expect(
+						w.Write(
+							frame.NewUnary(data.Key(), telem.NewSeriesV[bool](false)),
+						),
+					).To(BeTrue())
+					time.Sleep(20 * time.Millisecond)
+				}
+				Expect(w.Close()).To(Succeed())
+				Consistently(oneRow).Should(Succeed())
+			},
+		)
+
+		It(
 			"Should fire a bare ranges.create routing entry once per truthy mark",
 			func(ctx SpecContext) {
 				data := createVirtualCh(ctx, "route_range_data", telem.BooleanT)
@@ -1279,6 +1430,372 @@ var _ = Describe("Task", Ordered, func() {
 				).To(BeTrue())
 				Expect(w.Close()).To(Succeed())
 				Eventually(rangeCount(2)).Should(Succeed())
+			},
+		)
+
+		It(
+			"Should fire a ranges.create routing entry into a variable once per truthy mark",
+			func(ctx SpecContext) {
+				trig := createVirtualCh(ctx, "route_range_var_trig", telem.Uint8T)
+				data := createVirtualCh(ctx, "route_range_var_data", telem.BooleanT)
+				name := "overpressure_" + uuid.NewString()[:8]
+				prog := arc.Text{Raw: fmt.Sprintf(`
+					import ranges
+
+					sequence main {
+					    stage watch {
+					        v str := ""
+					        %s -> select{} => {
+					            true: ranges.create{name="%s"} -> v
+					        }
+					    }
+					}
+
+					%s => main
+				`, data.Name, name, trig.Name)}
+
+				svcTask := task.Task{
+					Key:    uuid.New(),
+					Name:   "test-route-range-var",
+					Type:   arctask.Type,
+					Config: configToMap(arctask.Config{ArcKey: uuid.New()}),
+				}
+				t := MustSucceed(
+					newTextFactory(ctx, prog).ConfigureTask(ctx, svcTask, "cmd-1"),
+				)
+				Expect(t.Exec(ctx, task.Command{Type: "start"})).To(Succeed())
+				defer func() { Expect(t.Stop(true)).To(Succeed()) }()
+
+				time.Sleep(20 * time.Millisecond)
+				w := MustSucceed(framerSvc.OpenWriter(ctx, framer.WriterConfig{
+					Keys:  []channel.Key{trig.Key(), data.Key()},
+					Start: telem.Now(),
+				}))
+				rangeCount := func(want int) func(g Gomega) {
+					return func(g Gomega) {
+						g.Expect(rangerSvc.NewRetrieve().
+							Where(ranger.MatchNames(name)).
+							Count(ctx, nil)).To(Equal(want))
+					}
+				}
+
+				Expect(
+					w.Write(frame.NewUnary(trig.Key(), telem.NewSeriesV[uint8](1))),
+				).To(BeTrue())
+				time.Sleep(20 * time.Millisecond)
+				Expect(
+					w.Write(frame.NewUnary(data.Key(), telem.NewSeriesV[bool](true))),
+				).To(BeTrue())
+				Eventually(rangeCount(1)).Should(Succeed())
+
+				// Falsy samples pick the absent false branch: no re-fire.
+				for range 2 {
+					Expect(
+						w.Write(
+							frame.NewUnary(data.Key(), telem.NewSeriesV[bool](false)),
+						),
+					).To(BeTrue())
+					time.Sleep(20 * time.Millisecond)
+				}
+				Consistently(rangeCount(1)).Should(Succeed())
+
+				// A fresh truthy mark fires the entry again: per-trigger, not
+				// per-activation.
+				Expect(
+					w.Write(frame.NewUnary(data.Key(), telem.NewSeriesV[bool](true))),
+				).To(BeTrue())
+				Expect(w.Close()).To(Succeed())
+				Eventually(rangeCount(2)).Should(Succeed())
+			},
+		)
+
+		It(
+			"Should fire a ranges.create routing entry into a channel alias once per truthy mark",
+			func(ctx SpecContext) {
+				trig := createVirtualCh(ctx, "route_range_alias_trig", telem.Uint8T)
+				data := createVirtualCh(ctx, "route_range_alias_data", telem.BooleanT)
+				out := createVirtualCh(ctx, "route_range_alias_out", telem.StringT)
+				name := "overpressure_" + uuid.NewString()[:8]
+				prog := arc.Text{Raw: fmt.Sprintf(`
+					import ranges
+
+					sequence main {
+					    stage watch {
+					        sink := %s
+					        %s -> select{} => {
+					            true: ranges.create{name="%s"} -> sink
+					        }
+					    }
+					}
+
+					%s => main
+				`, out.Name, data.Name, name, trig.Name)}
+
+				svcTask := task.Task{
+					Key:    uuid.New(),
+					Name:   "test-route-range-alias",
+					Type:   arctask.Type,
+					Config: configToMap(arctask.Config{ArcKey: uuid.New()}),
+				}
+				t := MustSucceed(
+					newTextFactory(ctx, prog).ConfigureTask(ctx, svcTask, "cmd-1"),
+				)
+				Expect(t.Exec(ctx, task.Command{Type: "start"})).To(Succeed())
+				defer func() { Expect(t.Stop(true)).To(Succeed()) }()
+
+				time.Sleep(20 * time.Millisecond)
+				w := MustSucceed(framerSvc.OpenWriter(ctx, framer.WriterConfig{
+					Keys:  []channel.Key{trig.Key(), data.Key()},
+					Start: telem.Now(),
+				}))
+				rangeCount := func(want int) func(g Gomega) {
+					return func(g Gomega) {
+						g.Expect(rangerSvc.NewRetrieve().
+							Where(ranger.MatchNames(name)).
+							Count(ctx, nil)).To(Equal(want))
+					}
+				}
+
+				Expect(
+					w.Write(frame.NewUnary(trig.Key(), telem.NewSeriesV[uint8](1))),
+				).To(BeTrue())
+				time.Sleep(20 * time.Millisecond)
+				Expect(
+					w.Write(frame.NewUnary(data.Key(), telem.NewSeriesV[bool](true))),
+				).To(BeTrue())
+				Eventually(rangeCount(1)).Should(Succeed())
+
+				// Falsy samples pick the absent false branch: no re-fire.
+				for range 2 {
+					Expect(
+						w.Write(
+							frame.NewUnary(data.Key(), telem.NewSeriesV[bool](false)),
+						),
+					).To(BeTrue())
+					time.Sleep(20 * time.Millisecond)
+				}
+				Consistently(rangeCount(1)).Should(Succeed())
+
+				// A fresh truthy mark fires the entry again: per-trigger, not
+				// per-activation.
+				Expect(
+					w.Write(frame.NewUnary(data.Key(), telem.NewSeriesV[bool](true))),
+				).To(BeTrue())
+				Expect(w.Close()).To(Succeed())
+				Eventually(rangeCount(2)).Should(Succeed())
+			},
+		)
+		It(
+			"Should write the created range key to a channel sink",
+			func(ctx SpecContext) {
+				data := createVirtualCh(ctx, "route_range_val_data", telem.BooleanT)
+				out := createVirtualCh(ctx, "route_range_val_out", telem.StringT)
+				name := "overpressure_" + uuid.NewString()[:8]
+				prog := arc.Text{Raw: fmt.Sprintf(`
+					import ranges
+
+					%s -> select{} => {
+					    true: ranges.create{name="%s"} -> %s
+					}
+				`, data.Name, name, out.Name)}
+
+				responses, closeStreamer := openTestStreamer(
+					ctx, channel.Keys{out.Key()}, 10,
+				)
+				defer closeStreamer()
+				time.Sleep(10 * time.Millisecond)
+
+				svcTask := task.Task{
+					Key:    uuid.New(),
+					Name:   "test-route-range-val-chan",
+					Type:   arctask.Type,
+					Config: configToMap(arctask.Config{ArcKey: uuid.New()}),
+				}
+				t := MustSucceed(
+					newTextFactory(ctx, prog).ConfigureTask(ctx, svcTask, "cmd-1"),
+				)
+				Expect(t.Exec(ctx, task.Command{Type: "start"})).To(Succeed())
+				defer func() { Expect(t.Stop(true)).To(Succeed()) }()
+
+				time.Sleep(20 * time.Millisecond)
+				w := MustSucceed(framerSvc.OpenWriter(ctx, framer.WriterConfig{
+					Keys:  []channel.Key{data.Key()},
+					Start: telem.Now(),
+				}))
+				Expect(
+					w.Write(frame.NewUnary(data.Key(), telem.NewSeriesV[bool](true))),
+				).To(BeTrue())
+
+				var rng ranger.Range
+				Eventually(func(g Gomega) {
+					g.Expect(rangerSvc.NewRetrieve().
+						Where(ranger.MatchNames(name)).
+						Entry(&rng).Exec(ctx, nil)).To(Succeed())
+				}).Should(Succeed())
+				expected := rng.Key.String()
+
+				found := false
+				for !found {
+					var fr framer.StreamerResponse
+					Eventually(responses).Should(Receive(&fr))
+					for _, ser := range fr.Frame.Get(out.Key()).Series {
+						for _, v := range telem.UnmarshalSeries[string](ser) {
+							found = found || v == expected
+						}
+					}
+				}
+				Expect(w.Close()).To(Succeed())
+			},
+		)
+
+		It(
+			"Should write the created range key to a variable sink",
+			func(ctx SpecContext) {
+				trig := createVirtualCh(ctx, "route_range_val_trig", telem.Uint8T)
+				data := createVirtualCh(ctx, "route_range_val_data", telem.BooleanT)
+				probe := createVirtualCh(ctx, "route_range_val_probe", telem.StringT)
+				name := "overpressure_" + uuid.NewString()[:8]
+				prog := arc.Text{Raw: fmt.Sprintf(`
+					import ranges
+
+					sequence main {
+					    stage watch {
+					        v str := ""
+					        %s -> select{} => {
+					            true: ranges.create{name="%s"} -> v
+					        }
+					        v -> %s
+					    }
+					}
+
+					%s => main
+				`, data.Name, name, probe.Name, trig.Name)}
+
+				responses, closeStreamer := openTestStreamer(
+					ctx, channel.Keys{probe.Key()}, 10,
+				)
+				defer closeStreamer()
+				time.Sleep(10 * time.Millisecond)
+
+				svcTask := task.Task{
+					Key:    uuid.New(),
+					Name:   "test-route-range-val-var",
+					Type:   arctask.Type,
+					Config: configToMap(arctask.Config{ArcKey: uuid.New()}),
+				}
+				t := MustSucceed(
+					newTextFactory(ctx, prog).ConfigureTask(ctx, svcTask, "cmd-1"),
+				)
+				Expect(t.Exec(ctx, task.Command{Type: "start"})).To(Succeed())
+				defer func() { Expect(t.Stop(true)).To(Succeed()) }()
+
+				time.Sleep(20 * time.Millisecond)
+				w := MustSucceed(framerSvc.OpenWriter(ctx, framer.WriterConfig{
+					Keys:  []channel.Key{trig.Key(), data.Key()},
+					Start: telem.Now(),
+				}))
+				Expect(
+					w.Write(frame.NewUnary(trig.Key(), telem.NewSeriesV[uint8](1))),
+				).To(BeTrue())
+				time.Sleep(20 * time.Millisecond)
+				Expect(
+					w.Write(frame.NewUnary(data.Key(), telem.NewSeriesV[bool](true))),
+				).To(BeTrue())
+
+				var rng ranger.Range
+				Eventually(func(g Gomega) {
+					g.Expect(rangerSvc.NewRetrieve().
+						Where(ranger.MatchNames(name)).
+						Entry(&rng).Exec(ctx, nil)).To(Succeed())
+				}).Should(Succeed())
+				expected := rng.Key.String()
+
+				found := false
+				for !found {
+					var fr framer.StreamerResponse
+					Eventually(responses).Should(Receive(&fr))
+					for _, ser := range fr.Frame.Get(probe.Key()).Series {
+						for _, v := range telem.UnmarshalSeries[string](ser) {
+							found = found || v == expected
+						}
+					}
+				}
+				Expect(w.Close()).To(Succeed())
+			},
+		)
+
+		It(
+			"Should write the created range key to a channel alias sink",
+			func(ctx SpecContext) {
+				trig := createVirtualCh(ctx, "route_range_val_trig", telem.Uint8T)
+				data := createVirtualCh(ctx, "route_range_val_data", telem.BooleanT)
+				out := createVirtualCh(ctx, "route_range_val_out", telem.StringT)
+				name := "overpressure_" + uuid.NewString()[:8]
+				prog := arc.Text{Raw: fmt.Sprintf(`
+					import ranges
+
+					sequence main {
+					    stage watch {
+					        sink := %s
+					        %s -> select{} => {
+					            true: ranges.create{name="%s"} -> sink
+					        }
+					    }
+					}
+
+					%s => main
+				`, out.Name, data.Name, name, trig.Name)}
+
+				responses, closeStreamer := openTestStreamer(
+					ctx, channel.Keys{out.Key()}, 10,
+				)
+				defer closeStreamer()
+				time.Sleep(10 * time.Millisecond)
+
+				svcTask := task.Task{
+					Key:    uuid.New(),
+					Name:   "test-route-range-val-alias",
+					Type:   arctask.Type,
+					Config: configToMap(arctask.Config{ArcKey: uuid.New()}),
+				}
+				t := MustSucceed(
+					newTextFactory(ctx, prog).ConfigureTask(ctx, svcTask, "cmd-1"),
+				)
+				Expect(t.Exec(ctx, task.Command{Type: "start"})).To(Succeed())
+				defer func() { Expect(t.Stop(true)).To(Succeed()) }()
+
+				time.Sleep(20 * time.Millisecond)
+				w := MustSucceed(framerSvc.OpenWriter(ctx, framer.WriterConfig{
+					Keys:  []channel.Key{trig.Key(), data.Key()},
+					Start: telem.Now(),
+				}))
+				Expect(
+					w.Write(frame.NewUnary(trig.Key(), telem.NewSeriesV[uint8](1))),
+				).To(BeTrue())
+				time.Sleep(20 * time.Millisecond)
+				Expect(
+					w.Write(frame.NewUnary(data.Key(), telem.NewSeriesV[bool](true))),
+				).To(BeTrue())
+
+				var rng ranger.Range
+				Eventually(func(g Gomega) {
+					g.Expect(rangerSvc.NewRetrieve().
+						Where(ranger.MatchNames(name)).
+						Entry(&rng).Exec(ctx, nil)).To(Succeed())
+				}).Should(Succeed())
+				expected := rng.Key.String()
+
+				found := false
+				for !found {
+					var fr framer.StreamerResponse
+					Eventually(responses).Should(Receive(&fr))
+					for _, ser := range fr.Frame.Get(out.Key()).Series {
+						for _, v := range telem.UnmarshalSeries[string](ser) {
+							found = found || v == expected
+						}
+					}
+				}
+				Expect(w.Close()).To(Succeed())
 			},
 		)
 	})

--- a/core/pkg/service/arc/task/task_test.go
+++ b/core/pkg/service/arc/task/task_test.go
@@ -1206,7 +1206,9 @@ var _ = Describe("Task", Ordered, func() {
 				// Falsy samples pick the absent false branch: no re-fire.
 				for range 3 {
 					Expect(
-						w.Write(frame.NewUnary(data.Key(), telem.NewSeriesV[bool](false))),
+						w.Write(
+							frame.NewUnary(data.Key(), telem.NewSeriesV[bool](false)),
+						),
 					).To(BeTrue())
 					time.Sleep(20 * time.Millisecond)
 				}
@@ -1262,7 +1264,9 @@ var _ = Describe("Task", Ordered, func() {
 				// Falsy samples pick the absent false branch: no re-fire.
 				for range 2 {
 					Expect(
-						w.Write(frame.NewUnary(data.Key(), telem.NewSeriesV[bool](false))),
+						w.Write(
+							frame.NewUnary(data.Key(), telem.NewSeriesV[bool](false)),
+						),
 					).To(BeTrue())
 					time.Sleep(20 * time.Millisecond)
 				}

--- a/docs/site/src/pages/reference/control/arc/effective-arc.mdx
+++ b/docs/site/src/pages/reference/control/arc/effective-arc.mdx
@@ -43,8 +43,8 @@ If multiple transitions are true simultaneously, the first one wins.
 
 ### Use `->` for Streaming, `=>` for Transitions
 
-Continuous edges (`->`) fire on every data arrival. Conditional edges (`=>`) fire while
-the source is truthy.
+Continuous edges (`->`) fire whenever the source produces a value. Conditional edges
+(`=>`) fire while the source is truthy.
 
 ```arc channels="sensor, output, pressure"
 // Streaming: continuously process sensor data

--- a/docs/site/src/pages/reference/control/arc/get-started.mdx
+++ b/docs/site/src/pages/reference/control/arc/get-started.mdx
@@ -138,8 +138,8 @@ covers persistence and reset behavior in more depth.
 tank_pressure -> scale_reading{} -> pressure_scaled
 ```
 
-The `->` arrow creates a **flow**, a reactive connection that runs every time new data
-arrives:
+The `->` arrow creates a **flow**, a reactive connection that runs whenever the source
+produces a value:
 
 - `tank_pressure` is the source channel
 - `scale_reading{}` processes each value (the `{}` instantiates the function)
@@ -216,8 +216,8 @@ New concepts in this example:
   Here, `limit=15.0` sets the threshold
 - **Return type `bool`**: The comparison `reading > limit` returns `true` or `false`
 - **Conditional edge** (`=>`) -> fires the target while the source is truthy. Unlike
-  `->`, which fires on every data arrival, `=>` only fires on ticks where the source
-  expression holds
+  `->`, which fires whenever the source produces a value, `=>` only fires on ticks where
+  the source expression holds
 - **Standard library function** (`status.set`): Publishes a status notification to the
   Core. It lives in the `status` module, so the program imports it with `import status`
   at the top

--- a/docs/site/src/pages/reference/control/arc/reference/flow.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/flow.mdx
@@ -23,14 +23,14 @@ function bodies.
 
 | Operator | Name             | Behavior                                                                                  |
 | -------- | ---------------- | ----------------------------------------------------------------------------------------- |
-| `->`     | Continuous flow  | Fires on every data arrival                                                               |
+| `->`     | Continuous flow  | Fires whenever the source produces a value                                                |
 | `=>`     | Conditional flow | Fires while the source is [truthy](/reference/control/arc/reference/operators#truthiness) |
 
 <Divider.Divider x />
 
 ## Continuous Flow (`->`)
 
-Runs every execution cycle when the source produces data:
+Runs whenever the source produces data:
 
 ```arc channels="sensor, output"
 sensor -> filter{} -> output
@@ -41,7 +41,7 @@ input. The chain executes whenever the leftmost source fires.
 
 ```arc channels="valve_cmd, sensor, output"
 stage active {
-    true -> valve_cmd               // keeps valve open every cycle
+    true -> valve_cmd               // writes true once on stage entry
     sensor -> filter{} -> output    // processes every sample
 }
 ```

--- a/docs/site/src/pages/reference/control/arc/reference/stages.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/stages.mdx
@@ -36,9 +36,9 @@ stage pressurize {
     pressure > 500 => next
     abort_btn => abort
 
-    // Continuous flows (run every cycle)
-    true -> press_vlv_cmd
-    sensor -> controller{}
+    // Continuous flows
+    true -> press_vlv_cmd    // once on entry
+    sensor -> controller{}   // every sample
 }
 ```
 

--- a/docs/site/src/pages/reference/control/arc/reference/standard-library/status.mdx
+++ b/docs/site/src/pages/reference/control/arc/reference/standard-library/status.mdx
@@ -60,9 +60,9 @@ addressing it by name or by key, and outputs the resolved status key.
 
 <Fragment slot="flow">
 
-```arc channels="trigger, status_key"
+```arc channels="status_key"
 stage main {
-  trigger -> status.set{
+  status.set{
     key_or_name = "ox_alarm",
     message = "Overpressure detected",
     variant = "error",

--- a/integration/tests/arc/stl_ranges.py
+++ b/integration/tests/arc/stl_ranges.py
@@ -105,6 +105,16 @@ sequence flow_capture_seq {
         time.wait{100ms} -> 1 -> ranges_done
     }
 }
+
+// ──────────────────────── Entry One-Shot ─────────────────────────
+start_stl_ranges_cmd => one_shot_seq
+
+sequence one_shot_seq {
+    stage spin {
+        ranges.create{name="RangeOneShot"}
+        range_one_shot_tick -> range_one_shot_echo // For verification
+    }
+}
 """
 
 
@@ -151,6 +161,7 @@ CASES: list[Case] = [
     Case("RangeFlow_Parent", None, True, FLOW_END_DELAY),
     Case("RangeFlow_Child", sy.Color("rgb(10, 20, 30)"), False),
     Case("RangeFlow_Child_NoColor", None, False),
+    Case("RangeOneShot", None, False),
 ]
 
 # Each Arc-created parent range and the children its captured key must parent.
@@ -170,12 +181,18 @@ class StlRanges(ArcCase):
     arc_source = ARC_STL_RANGES_SOURCE
     arc_name_prefix = "ArcStlRanges"
     start_cmd_channel = "start_stl_ranges_cmd"
-    subscribe_channels = [DONE, FLOW_PARENT_KEY_OUT]
+    subscribe_channels = [DONE, FLOW_PARENT_KEY_OUT, "range_one_shot_echo"]
     collect_task_status = True
 
     def setup(self) -> None:
         create_virtual_channel(self.client, DONE, sy.DataType.UINT8)
         create_virtual_channel(self.client, FLOW_PARENT_KEY_OUT, sy.DataType.STRING)
+        create_virtual_channel(self.client, "range_one_shot_tick", sy.DataType.UINT8)
+        create_virtual_channel(self.client, "range_one_shot_echo", sy.DataType.UINT8)
+        # A leftover row from a prior run would break the one-shot count.
+        leftover = self.client.ranges.retrieve(names=["RangeOneShot"])
+        if leftover:
+            self.client.ranges.delete([r.key for r in leftover])
         self._before = sy.TimeStamp.now()
         super().setup()
 
@@ -207,6 +224,16 @@ class StlRanges(ArcCase):
 
         self._verify_parents(found)
         self._verify_invalid_color_rejected()
+        self._verify_entry_one_shot()
+
+    def _verify_entry_one_shot(self) -> None:
+        self.log("Driving extra passes: the untriggered create must not fire again")
+        for tick in (1, 2, 3):
+            self.writer.write("range_one_shot_tick", tick)
+        self.wait_for_eq("range_one_shot_echo", 3)
+        rows = self.client.ranges.retrieve(names=["RangeOneShot"])
+        if len(rows) != 1:
+            self.fail(f"RangeOneShot: expected 1 range, got {len(rows)}")
 
     def _verify_invalid_color_rejected(self) -> None:
         if not self.wait_for_task_status(


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4809](https://linear.app/synnax/issue/SY-4809)

## Description

### The bug

An untriggered `ranges.create{}` or `status.set{}` in a stage fired on every scheduler pass, creating a new range or status each time. The one-shot latch lived inside individual node types (`constant` and the WASM node), so host calls and user functions never got one.

### The fix

The latch now lives in the scheduler's dispatch gate. An entry node (no incoming edges, no channel reads) gets exactly one forced stratum-0 dispatch per activation and runs again only when it marks itself changed or its scope re-enters. This covers every node type, including user-defined functions, so the per-node latches are deleted in both the Go runtime and the C++ driver mirror.

### Behavior changes

- `time.now{} -> ch` is now one-shot per activation.
- Timers are unaffected: they self-mark to stay scheduled, so `time.interval{}` still repeats and `time.wait{}` still fires once at its deadline.
- Channel-fed flows are unaffected because channel readers are not entry nodes.

### Testing and docs

- Unit tests across the Go and C++ schedulers, `constant`, WASM, and the Arc task service, including specs proving untriggered host calls do not spam.
- An integration case in `stl_ranges` that drives extra passes and asserts a single created range.
- Updates to `spec.md` and the Arc user docs.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

The PR moves one-shot entry-node dispatch behavior from individual constant and WASM nodes into the Go and C++ schedulers.
- Adds scheduler-level entry classification and per-activation fired state.
- Clears fired state when nodes or scopes are reactivated.
- Removes redundant node-specific latches.
- Updates scheduler, runtime, standard-library, service, and integration tests.
- Documents the new entry-node execution semantics.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because no concrete blocking or independently actionable issue remains.

The Go and C++ schedulers consistently reset entry-node fired state on activation, preserve ordinary changed and self-changed dispatch, and the repeating timer implementations explicitly self-mark for subsequent passes.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| arc/go/runtime/scheduler/scheduler.go | Adds the scheduler-level fired latch and applies it at the dispatch gate while preserving changed and self-changed execution. |
| arc/go/runtime/scheduler/builder.go | Classifies entry nodes during scheduler construction and allocates their fired-state storage. |
| arc/cpp/runtime/scheduler/scheduler.h | Mirrors entry classification, dispatch gating, and activation reset behavior in the C++ scheduler. |
| arc/go/stl/constant/constant.go | Removes the constant node’s redundant local one-shot state now that the scheduler owns this behavior. |
| arc/go/stl/wasm/node.go | Removes WASM-local entry latching in favor of the common scheduler dispatch gate. |
| arc/cpp/runtime/wasm/node.h | Removes the corresponding C++ WASM-local one-shot latch. |
| arc/docs/spec.md | Documents that entry nodes receive one forced dispatch per scope activation and must self-mark to continue running. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Scope activation] --> B[Reset entry node fired state]
    B --> C{Scheduler visits node}
    C -->|First stratum-0 visit| D[Dispatch node]
    D --> E[Set fired state]
    E --> F{Node marks itself changed?}
    F -->|Yes| G[Dispatch on a later pass]
    F -->|No| H[Skip unconditional dispatch]
    G --> F
    H --> I[Wait for input or scope reactivation]
    I -->|Scope reactivation| B
```

<sub>Reviews (1): Last reviewed commit: ["formatting"](https://github.com/synnaxlabs/synnax/commit/ba85f7828a63f9cd373f09dafb3158f723d5eb45) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59246618)</sub>

<!-- /greptile_comment -->