### PR TITLE
SY-4811: Clarify the bare select routing entry error

### DIFF
--- a/arc/go/analyzer/flow/flow.go
+++ b/arc/go/analyzer/flow/flow.go
@@ -723,7 +723,8 @@ func analyzeOutputRoutingTable(
 			!isInlineBody(flowNodes[0]) {
 			ctx.Diagnostics.Add(diagnostics.Errorf(
 				entry,
-				"routing entry '%s' must be a full statement (e.g. '%s: true => next')",
+				"routing entry must be a full statement, e.g. '%s: true => next' "+
+					"to transition or '%s: false -> some_chan' to send false",
 				outputName,
 				outputName,
 			))


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4811](https://linear.app/synnax/issue/SY-4811)

## Description

Clarifies the error shown when a `select{}` routing entry is a bare target, e.g. `false: vlv_cmd`.

The old message suggested `(e.g. 'true: true => next')`, which users read as the literal repeating the routing key: `true: true` looked redundant and `false: true` looked contradictory. The new message shows both full statement forms and names the role of each literal, so it is clear the value after the key is what gets sent or the transition condition, not an echo of the key:

`routing entry must be a full statement, e.g. 'false: true => next' to transition or 'false: false -> some_chan' to send false`


<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Clarifies the analyzer diagnostic for bare `select{}` routing targets by showing complete transition and channel-send statement forms.
- Rewords the routing-entry error to distinguish the routing key from the value being routed.
- Adds valid examples for both `=>` transitions and `->` channel sends.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no actionable defects identified.

The change only revises diagnostic text, and both examples are syntactically valid, semantically accurate, correctly formatted, and compatible with existing diagnostic assertions.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| arc/go/analyzer/flow/flow.go | Updates only the user-facing routing diagnostic; placeholders, Arc syntax examples, and operation descriptions are consistent. |

<sub>Reviews (1): Last reviewed commit: ["SY-4811: Clarify the bare select routing..."](https://github.com/synnaxlabs/synnax/commit/25204cf6e8e49ace7fab23b7d6fdbac6c3d4edc6) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=59628943)</sub>

<!-- /greptile_comment -->