### PR TITLE
[rc] Fix worker crash and connection storm on empty plot ranges

### DIFF
--- a/.github/workflows/build.synnax.yaml
+++ b/.github/workflows/build.synnax.yaml
@@ -275,7 +275,9 @@ jobs:
             ${{ !inputs.debug && '--config=opt-windows' || '--output_groups=+pdb_file' }} //driver
 
       - name: Upload Windows Debug Symbols
-        if: inputs.driver && inputs.debug && matrix.os == 'windows-build-bot'
+        if:
+          inputs.driver && inputs.driver_ref_run_id == '' && inputs.debug && matrix.os
+          == 'windows-build-bot'
         uses: actions/upload-artifact@v7
         with:
           name:
@@ -296,12 +298,16 @@ jobs:
             --config=opt-unix //driver
 
       - name: Extract Debug Symbols (macOS)
-        if: inputs.driver && inputs.debug && startsWith(matrix.os, 'macos')
+        if:
+          inputs.driver && inputs.driver_ref_run_id == '' && inputs.debug &&
+          startsWith(matrix.os, 'macos')
         run: |
           dsymutil bazel-bin/driver/driver -o bazel-bin/driver/driver.dSYM
 
       - name: Upload macOS Debug Symbols
-        if: inputs.driver && inputs.debug && startsWith(matrix.os, 'macos')
+        if:
+          inputs.driver && inputs.driver_ref_run_id == '' && inputs.debug &&
+          startsWith(matrix.os, 'macos')
         uses: actions/upload-artifact@v7
         with:
           name:
@@ -379,12 +385,16 @@ jobs:
             --config=opt-unix //driver
 
       - name: Extract Debug Symbols (Linux)
-        if: inputs.driver && inputs.debug && matrix.os == 'ubuntu-build-bot'
+        if:
+          inputs.driver && inputs.driver_ref_run_id == '' && inputs.debug && matrix.os
+          == 'ubuntu-build-bot'
         run: |
           objcopy --only-keep-debug bazel-bin/driver/driver bazel-bin/driver/driver.debug
 
       - name: Upload Linux Debug Symbols
-        if: inputs.driver && inputs.debug && matrix.os == 'ubuntu-build-bot'
+        if:
+          inputs.driver && inputs.driver_ref_run_id == '' && inputs.debug && matrix.os
+          == 'ubuntu-build-bot'
         uses: actions/upload-artifact@v7
         with:
           name:

--- a/client/ts/src/framer/cache/cache.ts
+++ b/client/ts/src/framer/cache/cache.ts
@@ -49,6 +49,7 @@ export class Cache {
       instrumentation = DEFAULT_STATIC_PROPS.instrumentation,
       transform = DEFAULT_STATIC_PROPS.transform,
       staleEntryThreshold = DEFAULT_STATIC_PROPS.staleEntryThreshold,
+      coverageTTL = DEFAULT_STATIC_PROPS.coverageTTL,
     } = props;
     this.props = {
       dynamicBufferSize,
@@ -56,6 +57,7 @@ export class Cache {
       instrumentation,
       transform,
       staleEntryThreshold,
+      coverageTTL,
     };
     this.gcInterval = setInterval(() => this.gc(), gcInterval.milliseconds);
   }
@@ -70,11 +72,13 @@ export class Cache {
       throw new UnexpectedError(`get(${key}) called on a closed telemetry cache`);
     const existing = this.cache.get(key);
     if (existing != null) return existing;
-    const { dynamicBufferSize, transform, staleEntryThreshold } = this.props;
+    const { dynamicBufferSize, transform, staleEntryThreshold, coverageTTL } =
+      this.props;
     const unary = new Unary({
       dynamicBufferSize,
       transform,
       staleEntryThreshold,
+      coverageTTL,
       instrumentation: this.props.instrumentation.child(`cache-${key}`),
     });
     this.cache.set(key, unary);

--- a/client/ts/src/framer/cache/cache.ts
+++ b/client/ts/src/framer/cache/cache.ts
@@ -49,7 +49,7 @@ export class Cache {
       instrumentation = DEFAULT_STATIC_PROPS.instrumentation,
       transform = DEFAULT_STATIC_PROPS.transform,
       staleEntryThreshold = DEFAULT_STATIC_PROPS.staleEntryThreshold,
-      coverageTTL = DEFAULT_STATIC_PROPS.coverageTTL,
+      staleCoverageThreshold = DEFAULT_STATIC_PROPS.staleCoverageThreshold,
     } = props;
     this.props = {
       dynamicBufferSize,
@@ -57,7 +57,7 @@ export class Cache {
       instrumentation,
       transform,
       staleEntryThreshold,
-      coverageTTL,
+      staleCoverageThreshold,
     };
     this.gcInterval = setInterval(() => this.gc(), gcInterval.milliseconds);
   }
@@ -72,13 +72,17 @@ export class Cache {
       throw new UnexpectedError(`get(${key}) called on a closed telemetry cache`);
     const existing = this.cache.get(key);
     if (existing != null) return existing;
-    const { dynamicBufferSize, transform, staleEntryThreshold, coverageTTL } =
-      this.props;
+    const {
+      dynamicBufferSize,
+      transform,
+      staleEntryThreshold,
+      staleCoverageThreshold,
+    } = this.props;
     const unary = new Unary({
       dynamicBufferSize,
       transform,
       staleEntryThreshold,
-      coverageTTL,
+      staleCoverageThreshold,
       instrumentation: this.props.instrumentation.child(`cache-${key}`),
     });
     this.cache.set(key, unary);

--- a/client/ts/src/framer/cache/reader.spec.ts
+++ b/client/ts/src/framer/cache/reader.spec.ts
@@ -98,7 +98,7 @@ describe("read", () => {
   });
 
   it("should refetch an empty range after its coverage expires", async () => {
-    const cache = new Cache({ coverageTTL: TimeSpan.milliseconds(50) });
+    const cache = new Cache({ staleCoverageThreshold: TimeSpan.milliseconds(50) });
     const remoteReadF = vi.fn();
     const readRemote: RemoteReader = async (tr, keys) => {
       remoteReadF(tr, keys);

--- a/client/ts/src/framer/cache/reader.spec.ts
+++ b/client/ts/src/framer/cache/reader.spec.ts
@@ -97,6 +97,24 @@ describe("read", () => {
     cache.close();
   });
 
+  it("should refetch an empty range after its coverage expires", async () => {
+    const cache = new Cache({ coverageTTL: TimeSpan.milliseconds(50) });
+    const remoteReadF = vi.fn();
+    const readRemote: RemoteReader = async (tr, keys) => {
+      remoteReadF(tr, keys);
+      return new Frame([], []);
+    };
+    const reader = new Reader({ cache, readRemote });
+    const tr = new TimeRange(TimeSpan.seconds(1), TimeSpan.seconds(3));
+    await reader.read(tr, 1);
+    await reader.read(tr, 1);
+    expect(remoteReadF).toHaveBeenCalledTimes(1);
+    await new Promise((r) => setTimeout(r, 60));
+    expect(await reader.read(tr, 1)).toHaveLength(0);
+    expect(remoteReadF).toHaveBeenCalledTimes(2);
+    cache.close();
+  });
+
   it("should refetch a range whose fetch failed", async () => {
     const cache = new Cache();
     const remoteReadF = vi.fn();

--- a/client/ts/src/framer/cache/reader.spec.ts
+++ b/client/ts/src/framer/cache/reader.spec.ts
@@ -48,6 +48,38 @@ describe("read", () => {
     cache.close();
   });
 
+  it("should not refetch a range that returned no data", async () => {
+    const cache = new Cache();
+    const remoteReadF = vi.fn();
+    const readRemote: RemoteReader = async (tr, keys) => {
+      remoteReadF(tr, keys);
+      return new Frame([], []);
+    };
+    const reader = new Reader({ cache, readRemote });
+    const tr = new TimeRange(TimeSpan.seconds(1), TimeSpan.seconds(3));
+    const res = await reader.read(tr, 1);
+    expect(res).toHaveLength(0);
+    const res2 = await reader.read(tr, 1);
+    expect(res2).toHaveLength(0);
+    expect(remoteReadF).toHaveBeenCalledTimes(1);
+    cache.close();
+  });
+
+  it("should refetch a range whose fetch failed", async () => {
+    const cache = new Cache();
+    const remoteReadF = vi.fn();
+    const readRemote: RemoteReader = async (tr, keys) => {
+      remoteReadF(tr, keys);
+      throw new Error("connection lost");
+    };
+    const reader = new Reader({ cache, readRemote });
+    const tr = new TimeRange(TimeSpan.seconds(1), TimeSpan.seconds(3));
+    await expect(reader.read(tr, 1)).rejects.toThrow("connection lost");
+    await expect(reader.read(tr, 1)).rejects.toThrow("connection lost");
+    expect(remoteReadF).toHaveBeenCalledTimes(2);
+    cache.close();
+  });
+
   it("should skip a read if the value is in the cache", async () => {
     const cache = new Cache();
     const remoteReadF = vi.fn();

--- a/client/ts/src/framer/cache/reader.spec.ts
+++ b/client/ts/src/framer/cache/reader.spec.ts
@@ -8,7 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { Unreachable } from "@synnaxlabs/freighter";
-import { MultiSeries, TimeRange, TimeSpan } from "@synnaxlabs/x";
+import { id, MultiSeries, TimeRange, TimeSpan, TimeStamp } from "@synnaxlabs/x";
 import { describe, expect, it, type Mock, vi } from "vitest";
 
 import { UnexpectedError } from "@/errors";
@@ -16,6 +16,7 @@ import { Cache } from "@/framer/cache/cache";
 import { Reader, type RemoteReader } from "@/framer/cache/reader";
 import { Frame } from "@/framer/frame";
 import { Series } from "@/index";
+import { createTestClient } from "@/testutil";
 
 const basicRemoteReadFunc =
   (fn: Mock): RemoteReader =>
@@ -61,6 +62,37 @@ describe("read", () => {
     expect(res).toHaveLength(0);
     const res2 = await reader.read(tr, 1);
     expect(res2).toHaveLength(0);
+    expect(remoteReadF).toHaveBeenCalledTimes(1);
+    cache.close();
+  });
+
+  it("should cover a span the Core answers with no data after one fetch", async () => {
+    const client = createTestClient();
+    const time = await client.channels.create({
+      name: id.create(),
+      dataType: "timestamp",
+      isIndex: true,
+    });
+    const data = await client.channels.create({
+      name: id.create(),
+      dataType: "float32",
+      index: time.key,
+    });
+    const start = TimeStamp.now();
+    await client.write(start, { [time.key]: [start], [data.key]: [1] });
+    const cache = new Cache();
+    const remoteReadF = vi.fn();
+    const readRemote: RemoteReader = async (tr, keys) => {
+      remoteReadF(tr, keys);
+      return await client.read(tr, keys);
+    };
+    const reader = new Reader({ cache, readRemote });
+    const tr = new TimeRange(
+      start.add(TimeSpan.seconds(10)),
+      start.add(TimeSpan.seconds(20)),
+    );
+    expect(await reader.read(tr, data.key)).toHaveLength(0);
+    expect(await reader.read(tr, data.key)).toHaveLength(0);
     expect(remoteReadF).toHaveBeenCalledTimes(1);
     cache.close();
   });

--- a/client/ts/src/framer/cache/reader.ts
+++ b/client/ts/src/framer/cache/reader.ts
@@ -172,9 +172,11 @@ export class Reader {
           if (existing == null) grouped.set(key, [s]);
           else existing.push(s);
         });
-        channels.forEach((key) =>
-          cache.get(key).writeStatic(new MultiSeries(grouped.get(key) ?? [])),
-        );
+        channels.forEach((key) => {
+          const unary = cache.get(key);
+          unary.writeStatic(new MultiSeries(grouped.get(key) ?? []));
+          unary.markFetched(gap);
+        });
       }
     } catch (err) {
       failure = err;

--- a/client/ts/src/framer/cache/static.spec.ts
+++ b/client/ts/src/framer/cache/static.spec.ts
@@ -568,8 +568,8 @@ describe("StaticReadCache", () => {
       expect(c.dirtyRead(read).gaps).toHaveLength(0);
     });
 
-    test("should expire coverage after the coverage TTL", async () => {
-      const c = new Static({ coverageTTL: TimeSpan.milliseconds(5) });
+    test("should expire coverage after the stale coverage threshold", async () => {
+      const c = new Static({ staleCoverageThreshold: TimeSpan.milliseconds(5) });
       const tr = TimeStamp.seconds(1).spanRange(TimeSpan.seconds(1));
       c.markFetched(tr);
       expect(c.dirtyRead(tr).gaps).toHaveLength(0);
@@ -586,13 +586,13 @@ describe("StaticReadCache", () => {
       expect(c.dirtyRead(tr).gaps).toHaveLength(0);
     });
 
-    test("should pin the default coverage TTL and staleness threshold", () => {
-      expect(DEFAULT_STATIC_PROPS.coverageTTL).toEqual(TimeSpan.minutes(10));
+    test("should pin the default staleness thresholds", () => {
+      expect(DEFAULT_STATIC_PROPS.staleCoverageThreshold).toEqual(TimeSpan.minutes(10));
       expect(DEFAULT_STATIC_PROPS.staleEntryThreshold).toEqual(TimeSpan.seconds(20));
     });
 
     test("should apply expiry on read without a gc call", async () => {
-      const c = new Static({ coverageTTL: TimeSpan.milliseconds(50) });
+      const c = new Static({ staleCoverageThreshold: TimeSpan.milliseconds(50) });
       const tr = TimeStamp.seconds(1).spanRange(TimeSpan.seconds(1));
       c.markFetched(tr);
       expect(c.dirtyRead(tr).gaps).toHaveLength(0);
@@ -601,7 +601,7 @@ describe("StaticReadCache", () => {
     });
 
     test("should not extend a new mark with an expired record's bounds", async () => {
-      const c = new Static({ coverageTTL: TimeSpan.milliseconds(50) });
+      const c = new Static({ staleCoverageThreshold: TimeSpan.milliseconds(50) });
       c.markFetched(TimeStamp.seconds(1).spanRange(TimeSpan.seconds(1)));
       await sleep.sleep(TimeSpan.milliseconds(60));
       c.markFetched(TimeStamp.seconds(2).spanRange(TimeSpan.seconds(1)));
@@ -611,7 +611,7 @@ describe("StaticReadCache", () => {
     });
 
     test("should merge a bridging mark with live records only", async () => {
-      const c = new Static({ coverageTTL: TimeSpan.milliseconds(50) });
+      const c = new Static({ staleCoverageThreshold: TimeSpan.milliseconds(50) });
       c.markFetched(TimeStamp.seconds(1).spanRange(TimeSpan.seconds(1)));
       await sleep.sleep(TimeSpan.milliseconds(60));
       c.markFetched(TimeStamp.seconds(3).spanRange(TimeSpan.seconds(1)));
@@ -622,7 +622,7 @@ describe("StaticReadCache", () => {
     });
 
     test("should reopen an expired covered gap between fetched entries", async () => {
-      const c = new Static({ coverageTTL: TimeSpan.milliseconds(50) });
+      const c = new Static({ staleCoverageThreshold: TimeSpan.milliseconds(50) });
       const write = (tr: TimeRange, data: number[], alignment: bigint) =>
         c.write(
           new MultiSeries([
@@ -668,7 +668,7 @@ describe("StaticReadCache", () => {
     });
 
     test("should restart coverage on a refetch of an expired span", async () => {
-      const c = new Static({ coverageTTL: TimeSpan.milliseconds(50) });
+      const c = new Static({ staleCoverageThreshold: TimeSpan.milliseconds(50) });
       const tr = TimeStamp.seconds(1).spanRange(TimeSpan.seconds(1));
       c.markFetched(tr);
       await sleep.sleep(TimeSpan.milliseconds(60));
@@ -678,7 +678,7 @@ describe("StaticReadCache", () => {
     });
 
     test("should expire a merged span by its oldest mark", async () => {
-      const c = new Static({ coverageTTL: TimeSpan.milliseconds(200) });
+      const c = new Static({ staleCoverageThreshold: TimeSpan.milliseconds(200) });
       c.markFetched(TimeStamp.seconds(1).spanRange(TimeSpan.seconds(1)));
       await sleep.sleep(TimeSpan.milliseconds(50));
       c.markFetched(TimeStamp.seconds(2).spanRange(TimeSpan.seconds(1)));
@@ -690,7 +690,7 @@ describe("StaticReadCache", () => {
     });
 
     test("should not let a rolling read keep refreshing its own coverage", async () => {
-      const c = new Static({ coverageTTL: TimeSpan.milliseconds(200) });
+      const c = new Static({ staleCoverageThreshold: TimeSpan.milliseconds(200) });
       c.markFetched(TimeStamp.seconds(0).spanRange(TimeSpan.seconds(1)));
       for (let i = 1; i <= 4; i++) {
         await sleep.sleep(TimeSpan.milliseconds(20));
@@ -704,7 +704,7 @@ describe("StaticReadCache", () => {
     });
 
     test("should expire disjoint spans independently", async () => {
-      const c = new Static({ coverageTTL: TimeSpan.milliseconds(50) });
+      const c = new Static({ staleCoverageThreshold: TimeSpan.milliseconds(50) });
       const a = TimeStamp.seconds(1).spanRange(TimeSpan.seconds(1));
       const b = TimeStamp.seconds(10).spanRange(TimeSpan.seconds(1));
       c.markFetched(a);

--- a/client/ts/src/framer/cache/static.spec.ts
+++ b/client/ts/src/framer/cache/static.spec.ts
@@ -521,4 +521,61 @@ describe("StaticReadCache", () => {
       expect(series.length).toEqual(n);
     });
   });
+
+  describe("markFetched", () => {
+    test("should not report a gap for a covered span with no data", () => {
+      const c = new Static({});
+      const tr = TimeStamp.seconds(1).spanRange(TimeSpan.seconds(3));
+      c.markFetched(tr);
+      const { series, gaps } = c.dirtyRead(tr);
+      expect(series).toHaveLength(0);
+      expect(gaps).toHaveLength(0);
+    });
+
+    test("should subtract partial coverage from a gap", () => {
+      const c = new Static({});
+      c.markFetched(TimeStamp.seconds(1).spanRange(TimeSpan.seconds(1)));
+      const { gaps } = c.dirtyRead(TimeStamp.seconds(0).spanRange(TimeSpan.seconds(3)));
+      expect(gaps).toHaveLength(2);
+      expect(gaps[0]).toEqual(TimeStamp.seconds(0).spanRange(TimeSpan.seconds(1)));
+      expect(gaps[1]).toEqual(TimeStamp.seconds(2).spanRange(TimeSpan.seconds(1)));
+    });
+
+    test("should merge adjacent covered spans", () => {
+      const c = new Static({});
+      c.markFetched(TimeStamp.seconds(1).spanRange(TimeSpan.seconds(1)));
+      c.markFetched(TimeStamp.seconds(2).spanRange(TimeSpan.seconds(1)));
+      const { gaps } = c.dirtyRead(TimeStamp.seconds(1).spanRange(TimeSpan.seconds(2)));
+      expect(gaps).toHaveLength(0);
+    });
+
+    test("should cover the trailing gap beyond fetched data", () => {
+      const c = new Static({});
+      const dataTR = TimeStamp.seconds(1).spanRange(TimeSpan.seconds(1));
+      c.write(
+        new MultiSeries([
+          new Series({
+            data: new Float32Array([1]),
+            dataType: DataType.FLOAT32,
+            timeRange: dataTR,
+            alignment: 0n,
+          }),
+        ]),
+      );
+      const read = TimeStamp.seconds(1).spanRange(TimeSpan.seconds(4));
+      expect(c.dirtyRead(read).gaps).toHaveLength(1);
+      c.markFetched(read);
+      expect(c.dirtyRead(read).gaps).toHaveLength(0);
+    });
+
+    test("should expire coverage on gc after the staleness threshold", async () => {
+      const c = new Static({ staleEntryThreshold: TimeSpan.milliseconds(5) });
+      const tr = TimeStamp.seconds(1).spanRange(TimeSpan.seconds(1));
+      c.markFetched(tr);
+      expect(c.dirtyRead(tr).gaps).toHaveLength(0);
+      await sleep.sleep(TimeSpan.milliseconds(10));
+      c.gc();
+      expect(c.dirtyRead(tr).gaps).toHaveLength(1);
+    });
+  });
 });

--- a/client/ts/src/framer/cache/static.spec.ts
+++ b/client/ts/src/framer/cache/static.spec.ts
@@ -19,7 +19,7 @@ import {
 } from "@synnaxlabs/x";
 import { describe, expect, it, test } from "vitest";
 
-import { Static } from "@/framer/cache/static";
+import { DEFAULT_STATIC_PROPS, Static } from "@/framer/cache/static";
 
 // NOTE: Most of the insertion algorithm logic is not implemented in the static cache,
 // but inside the x/ts/src/spatial/bounds module, where there are comprehensive tests.
@@ -568,8 +568,8 @@ describe("StaticReadCache", () => {
       expect(c.dirtyRead(read).gaps).toHaveLength(0);
     });
 
-    test("should expire coverage on gc after the staleness threshold", async () => {
-      const c = new Static({ staleEntryThreshold: TimeSpan.milliseconds(5) });
+    test("should expire coverage after the coverage TTL", async () => {
+      const c = new Static({ coverageTTL: TimeSpan.milliseconds(5) });
       const tr = TimeStamp.seconds(1).spanRange(TimeSpan.seconds(1));
       c.markFetched(tr);
       expect(c.dirtyRead(tr).gaps).toHaveLength(0);
@@ -586,11 +586,103 @@ describe("StaticReadCache", () => {
       expect(c.dirtyRead(tr).gaps).toHaveLength(0);
     });
 
-    test("should expire a merged span by its oldest mark", async () => {
-      const c = new Static({ staleEntryThreshold: TimeSpan.milliseconds(5) });
+    test("should pin the default coverage TTL and staleness threshold", () => {
+      expect(DEFAULT_STATIC_PROPS.coverageTTL).toEqual(TimeSpan.minutes(10));
+      expect(DEFAULT_STATIC_PROPS.staleEntryThreshold).toEqual(TimeSpan.seconds(20));
+    });
+
+    test("should apply expiry on read without a gc call", async () => {
+      const c = new Static({ coverageTTL: TimeSpan.milliseconds(50) });
+      const tr = TimeStamp.seconds(1).spanRange(TimeSpan.seconds(1));
+      c.markFetched(tr);
+      expect(c.dirtyRead(tr).gaps).toHaveLength(0);
+      await sleep.sleep(TimeSpan.milliseconds(60));
+      expect(c.dirtyRead(tr).gaps).toHaveLength(1);
+    });
+
+    test("should not extend a new mark with an expired record's bounds", async () => {
+      const c = new Static({ coverageTTL: TimeSpan.milliseconds(50) });
       c.markFetched(TimeStamp.seconds(1).spanRange(TimeSpan.seconds(1)));
-      await sleep.sleep(TimeSpan.milliseconds(10));
+      await sleep.sleep(TimeSpan.milliseconds(60));
       c.markFetched(TimeStamp.seconds(2).spanRange(TimeSpan.seconds(1)));
+      const { gaps } = c.dirtyRead(TimeStamp.seconds(1).spanRange(TimeSpan.seconds(2)));
+      expect(gaps).toHaveLength(1);
+      expect(gaps[0]).toEqual(TimeStamp.seconds(1).spanRange(TimeSpan.seconds(1)));
+    });
+
+    test("should merge a bridging mark with live records only", async () => {
+      const c = new Static({ coverageTTL: TimeSpan.milliseconds(50) });
+      c.markFetched(TimeStamp.seconds(1).spanRange(TimeSpan.seconds(1)));
+      await sleep.sleep(TimeSpan.milliseconds(60));
+      c.markFetched(TimeStamp.seconds(3).spanRange(TimeSpan.seconds(1)));
+      c.markFetched(TimeStamp.seconds(2).spanRange(TimeSpan.seconds(1)));
+      const { gaps } = c.dirtyRead(TimeStamp.seconds(1).spanRange(TimeSpan.seconds(3)));
+      expect(gaps).toHaveLength(1);
+      expect(gaps[0]).toEqual(TimeStamp.seconds(1).spanRange(TimeSpan.seconds(1)));
+    });
+
+    test("should reopen an expired covered gap between fetched entries", async () => {
+      const c = new Static({ coverageTTL: TimeSpan.milliseconds(50) });
+      const write = (tr: TimeRange, data: number[], alignment: bigint) =>
+        c.write(
+          new MultiSeries([
+            new Series({
+              data: new Float32Array(data),
+              dataType: DataType.FLOAT32,
+              timeRange: tr,
+              alignment,
+            }),
+          ]),
+        );
+      write(TimeStamp.seconds(1).range(TimeStamp.seconds(3)), [1, 2], 1n);
+      write(TimeStamp.seconds(4).range(TimeStamp.seconds(6)), [4, 5], 4n);
+      c.markFetched(TimeStamp.seconds(3).range(TimeStamp.seconds(4)));
+      const read = () => c.dirtyRead(TimeStamp.seconds(1).range(TimeStamp.seconds(6)));
+      expect(read().gaps).toHaveLength(0);
+      await sleep.sleep(TimeSpan.milliseconds(60));
+      const { series, gaps } = read();
+      expect(series.series).toHaveLength(2);
+      expect(gaps).toHaveLength(1);
+      expect(gaps[0]).toEqual(TimeStamp.seconds(3).range(TimeStamp.seconds(4)));
+    });
+
+    test("should keep answering after gc purges the span's series", async () => {
+      const c = new Static({ staleEntryThreshold: TimeSpan.milliseconds(5) });
+      const tr = TimeStamp.seconds(1).spanRange(TimeSpan.seconds(1));
+      c.write(
+        new MultiSeries([
+          new Series({
+            data: new Float32Array([1]),
+            dataType: DataType.FLOAT32,
+            timeRange: tr,
+            alignment: 0n,
+          }),
+        ]),
+      );
+      c.markFetched(tr);
+      await sleep.sleep(TimeSpan.milliseconds(10));
+      expect(c.gc().purgedSeries).toEqual(1);
+      const { series, gaps } = c.dirtyRead(tr);
+      expect(series).toHaveLength(0);
+      expect(gaps).toHaveLength(0);
+    });
+
+    test("should restart coverage on a refetch of an expired span", async () => {
+      const c = new Static({ coverageTTL: TimeSpan.milliseconds(50) });
+      const tr = TimeStamp.seconds(1).spanRange(TimeSpan.seconds(1));
+      c.markFetched(tr);
+      await sleep.sleep(TimeSpan.milliseconds(60));
+      expect(c.dirtyRead(tr).gaps).toHaveLength(1);
+      c.markFetched(tr);
+      expect(c.dirtyRead(tr).gaps).toHaveLength(0);
+    });
+
+    test("should expire a merged span by its oldest mark", async () => {
+      const c = new Static({ coverageTTL: TimeSpan.milliseconds(200) });
+      c.markFetched(TimeStamp.seconds(1).spanRange(TimeSpan.seconds(1)));
+      await sleep.sleep(TimeSpan.milliseconds(50));
+      c.markFetched(TimeStamp.seconds(2).spanRange(TimeSpan.seconds(1)));
+      await sleep.sleep(TimeSpan.milliseconds(200));
       c.gc();
       const { gaps } = c.dirtyRead(TimeStamp.seconds(1).spanRange(TimeSpan.seconds(2)));
       expect(gaps).toHaveLength(1);
@@ -598,12 +690,13 @@ describe("StaticReadCache", () => {
     });
 
     test("should not let a rolling read keep refreshing its own coverage", async () => {
-      const c = new Static({ staleEntryThreshold: TimeSpan.milliseconds(30) });
+      const c = new Static({ coverageTTL: TimeSpan.milliseconds(200) });
       c.markFetched(TimeStamp.seconds(0).spanRange(TimeSpan.seconds(1)));
       for (let i = 1; i <= 4; i++) {
-        await sleep.sleep(TimeSpan.milliseconds(15));
+        await sleep.sleep(TimeSpan.milliseconds(20));
         c.markFetched(TimeStamp.seconds(i).spanRange(TimeSpan.seconds(1)));
       }
+      await sleep.sleep(TimeSpan.milliseconds(150));
       c.gc();
       const { gaps } = c.dirtyRead(TimeStamp.seconds(0).spanRange(TimeSpan.seconds(5)));
       expect(gaps).toHaveLength(1);
@@ -611,7 +704,7 @@ describe("StaticReadCache", () => {
     });
 
     test("should expire disjoint spans independently", async () => {
-      const c = new Static({ staleEntryThreshold: TimeSpan.milliseconds(50) });
+      const c = new Static({ coverageTTL: TimeSpan.milliseconds(50) });
       const a = TimeStamp.seconds(1).spanRange(TimeSpan.seconds(1));
       const b = TimeStamp.seconds(10).spanRange(TimeSpan.seconds(1));
       c.markFetched(a);

--- a/client/ts/src/framer/cache/static.spec.ts
+++ b/client/ts/src/framer/cache/static.spec.ts
@@ -13,7 +13,7 @@ import {
   MultiSeries,
   Series,
   sleep,
-  type TimeRange,
+  TimeRange,
   TimeSpan,
   TimeStamp,
 } from "@synnaxlabs/x";
@@ -575,6 +575,172 @@ describe("StaticReadCache", () => {
       expect(c.dirtyRead(tr).gaps).toHaveLength(0);
       await sleep.sleep(TimeSpan.milliseconds(10));
       c.gc();
+      expect(c.dirtyRead(tr).gaps).toHaveLength(1);
+    });
+
+    test("should keep fresh coverage through gc", () => {
+      const c = new Static({});
+      const tr = TimeStamp.seconds(1).spanRange(TimeSpan.seconds(1));
+      c.markFetched(tr);
+      c.gc();
+      expect(c.dirtyRead(tr).gaps).toHaveLength(0);
+    });
+
+    test("should expire a merged span by its oldest mark", async () => {
+      const c = new Static({ staleEntryThreshold: TimeSpan.milliseconds(5) });
+      c.markFetched(TimeStamp.seconds(1).spanRange(TimeSpan.seconds(1)));
+      await sleep.sleep(TimeSpan.milliseconds(10));
+      c.markFetched(TimeStamp.seconds(2).spanRange(TimeSpan.seconds(1)));
+      c.gc();
+      const { gaps } = c.dirtyRead(TimeStamp.seconds(1).spanRange(TimeSpan.seconds(2)));
+      expect(gaps).toHaveLength(1);
+      expect(gaps[0]).toEqual(TimeStamp.seconds(1).spanRange(TimeSpan.seconds(2)));
+    });
+
+    test("should not let a rolling read keep refreshing its own coverage", async () => {
+      const c = new Static({ staleEntryThreshold: TimeSpan.milliseconds(30) });
+      c.markFetched(TimeStamp.seconds(0).spanRange(TimeSpan.seconds(1)));
+      for (let i = 1; i <= 4; i++) {
+        await sleep.sleep(TimeSpan.milliseconds(15));
+        c.markFetched(TimeStamp.seconds(i).spanRange(TimeSpan.seconds(1)));
+      }
+      c.gc();
+      const { gaps } = c.dirtyRead(TimeStamp.seconds(0).spanRange(TimeSpan.seconds(5)));
+      expect(gaps).toHaveLength(1);
+      expect(gaps[0]).toEqual(TimeStamp.seconds(0).spanRange(TimeSpan.seconds(5)));
+    });
+
+    test("should expire disjoint spans independently", async () => {
+      const c = new Static({ staleEntryThreshold: TimeSpan.milliseconds(50) });
+      const a = TimeStamp.seconds(1).spanRange(TimeSpan.seconds(1));
+      const b = TimeStamp.seconds(10).spanRange(TimeSpan.seconds(1));
+      c.markFetched(a);
+      await sleep.sleep(TimeSpan.milliseconds(60));
+      c.markFetched(b);
+      c.gc();
+      expect(c.dirtyRead(a).gaps).toHaveLength(1);
+      expect(c.dirtyRead(b).gaps).toHaveLength(0);
+    });
+
+    test("should treat a fully contained mark as already covered", () => {
+      const c = new Static({});
+      c.markFetched(TimeStamp.seconds(1).spanRange(TimeSpan.seconds(3)));
+      c.markFetched(TimeStamp.seconds(2).spanRange(TimeSpan.seconds(1)));
+      const { gaps } = c.dirtyRead(TimeStamp.seconds(1).spanRange(TimeSpan.seconds(3)));
+      expect(gaps).toHaveLength(0);
+    });
+
+    test("should extend coverage on a partial overlap", () => {
+      const c = new Static({});
+      c.markFetched(TimeStamp.seconds(1).spanRange(TimeSpan.seconds(2)));
+      c.markFetched(TimeStamp.seconds(2).spanRange(TimeSpan.seconds(3)));
+      const { gaps } = c.dirtyRead(TimeStamp.seconds(1).spanRange(TimeSpan.seconds(4)));
+      expect(gaps).toHaveLength(0);
+    });
+
+    test("should merge every span a new mark bridges", () => {
+      const c = new Static({});
+      c.markFetched(TimeStamp.seconds(1).spanRange(TimeSpan.seconds(1)));
+      c.markFetched(TimeStamp.seconds(3).spanRange(TimeSpan.seconds(1)));
+      c.markFetched(TimeStamp.seconds(2).spanRange(TimeSpan.seconds(1)));
+      const { gaps } = c.dirtyRead(TimeStamp.seconds(1).spanRange(TimeSpan.seconds(3)));
+      expect(gaps).toHaveLength(0);
+    });
+
+    test("should keep a one-nanosecond hole between near-adjacent spans", () => {
+      const c = new Static({});
+      const holeStart = TimeStamp.seconds(2);
+      const holeEnd = holeStart.add(TimeSpan.nanoseconds(1));
+      c.markFetched(TimeStamp.seconds(1).range(holeStart));
+      c.markFetched(holeEnd.range(TimeStamp.seconds(3)));
+      const { gaps } = c.dirtyRead(TimeStamp.seconds(1).spanRange(TimeSpan.seconds(2)));
+      expect(gaps).toHaveLength(1);
+      expect(gaps[0]).toEqual(holeStart.range(holeEnd));
+    });
+
+    test("should subtract multiple disjoint spans from one read", () => {
+      const c = new Static({});
+      c.markFetched(TimeStamp.seconds(1).spanRange(TimeSpan.seconds(1)));
+      c.markFetched(TimeStamp.seconds(3).spanRange(TimeSpan.seconds(1)));
+      const { gaps } = c.dirtyRead(TimeStamp.seconds(0).spanRange(TimeSpan.seconds(5)));
+      expect(gaps).toHaveLength(3);
+      expect(gaps[0]).toEqual(TimeStamp.seconds(0).spanRange(TimeSpan.seconds(1)));
+      expect(gaps[1]).toEqual(TimeStamp.seconds(2).spanRange(TimeSpan.seconds(1)));
+      expect(gaps[2]).toEqual(TimeStamp.seconds(4).spanRange(TimeSpan.seconds(1)));
+    });
+
+    test("should ignore an invalid or zero-span mark", () => {
+      const c = new Static({});
+      c.markFetched(new TimeRange(TimeStamp.seconds(2), TimeStamp.seconds(2)));
+      c.markFetched(new TimeRange(TimeStamp.seconds(3), TimeStamp.seconds(1)));
+      const { gaps } = c.dirtyRead(TimeStamp.seconds(1).spanRange(TimeSpan.seconds(3)));
+      expect(gaps).toHaveLength(1);
+    });
+
+    test("should cover an internal gap between fetched entries", () => {
+      const c = new Static({});
+      const write = (tr: TimeRange, data: number[], alignment: bigint) =>
+        c.write(
+          new MultiSeries([
+            new Series({
+              data: new Float32Array(data),
+              dataType: DataType.FLOAT32,
+              timeRange: tr,
+              alignment,
+            }),
+          ]),
+        );
+      write(TimeStamp.seconds(1).range(TimeStamp.seconds(3)), [1, 2], 1n);
+      write(TimeStamp.seconds(4).range(TimeStamp.seconds(6)), [4, 5], 4n);
+      c.markFetched(TimeStamp.seconds(3).range(TimeStamp.seconds(4)));
+      const { gaps } = c.dirtyRead(TimeStamp.seconds(1).range(TimeStamp.seconds(6)));
+      expect(gaps).toHaveLength(0);
+    });
+
+    test("should still return data written into a covered span", () => {
+      const c = new Static({});
+      const tr = TimeStamp.seconds(1).spanRange(TimeSpan.seconds(3));
+      c.markFetched(tr);
+      c.write(
+        new MultiSeries([
+          new Series({
+            data: new Float32Array([1]),
+            dataType: DataType.FLOAT32,
+            timeRange: TimeStamp.seconds(2).spanRange(TimeSpan.seconds(1)),
+            alignment: 0n,
+          }),
+        ]),
+      );
+      const { series, gaps } = c.dirtyRead(tr);
+      expect(series).toHaveLength(1);
+      expect(gaps).toHaveLength(0);
+    });
+
+    test("should not report gaps for a covered span holding only streamed data", () => {
+      const c = new Static({});
+      const tr = TimeStamp.seconds(10).range(TimeStamp.seconds(20));
+      c.write(
+        new MultiSeries([
+          new Series({
+            data: new Float32Array([1]),
+            dataType: DataType.FLOAT32,
+            timeRange: tr,
+            alignment: 0n,
+          }),
+        ]),
+        true,
+      );
+      c.markFetched(tr);
+      const { series, gaps } = c.dirtyRead(tr);
+      expect(series).toHaveLength(1);
+      expect(gaps).toHaveLength(0);
+    });
+
+    test("should clear coverage on close", () => {
+      const c = new Static({});
+      const tr = TimeStamp.seconds(1).spanRange(TimeSpan.seconds(1));
+      c.markFetched(tr);
+      c.close();
       expect(c.dirtyRead(tr).gaps).toHaveLength(1);
     });
   });

--- a/client/ts/src/framer/cache/static.ts
+++ b/client/ts/src/framer/cache/static.ts
@@ -46,12 +46,19 @@ export interface StaticProps {
    * be marked as stale and subject to garbage collection.
    * @default TimeSpan.seconds(20) */
   staleEntryThreshold?: TimeSpan;
+  /**
+   * Sets how long a fetched span counts as answered before it is refetched. Bounds
+   * the refetch rate of spans that stay empty, as every refetch opens a short-lived
+   * iterator connection.
+   * @default TimeSpan.minutes(10) */
+  coverageTTL?: TimeSpan;
 }
 
 export const DEFAULT_STATIC_PROPS: Required<StaticProps> = {
   instrumentation: alamos.NOOP,
   transform: IDENTITY_TRANSFORM,
   staleEntryThreshold: TimeSpan.seconds(20),
+  coverageTTL: TimeSpan.minutes(10),
 };
 
 interface CacheEntry {
@@ -64,7 +71,7 @@ interface CacheEntry {
 interface CoveredRange {
   /** The fetched span, held even when the fetch returned no samples. */
   range: TimeRange;
-  /** When the fetch completed, for garbage collection staleness. */
+  /** When the fetch completed. Coverage answers gaps until addedAt + coverageTTL. */
   addedAt: TimeStamp;
 }
 
@@ -88,8 +95,9 @@ export class Static {
       instrumentation = DEFAULT_STATIC_PROPS.instrumentation,
       transform = DEFAULT_STATIC_PROPS.transform,
       staleEntryThreshold = DEFAULT_STATIC_PROPS.staleEntryThreshold,
+      coverageTTL = DEFAULT_STATIC_PROPS.coverageTTL,
     } = props;
-    this.props = { instrumentation, transform, staleEntryThreshold };
+    this.props = { instrumentation, transform, staleEntryThreshold, coverageTTL };
   }
 
   /**
@@ -111,25 +119,34 @@ export class Static {
   /**
    * Records tr as fetched, merging it into the covered set. Gap computation treats
    * covered spans as answered even when the fetch returned no samples, so an empty
-   * span is fetched once per staleness window instead of on every read.
+   * span is fetched once per coverage TTL instead of on every read.
    */
   markFetched(tr: TimeRange): void {
     if (!tr.isValid || tr.span.isZero) return;
     let { start, end } = tr;
-    // Keep the oldest stamp when merging. A fresh stamp would let a rolling read
-    // refresh its own coverage forever, so late backfill would never be refetched.
+    // Merging live coverage keeps the oldest stamp. A fresh stamp would let a rolling
+    // read refresh its own coverage forever, so late backfill would never be
+    // refetched. Expired records are dropped, not merged, so a refetch of their span
+    // starts a fresh TTL.
     let addedAt = TimeStamp.now();
     const keep: CoveredRange[] = [];
-    for (const c of this.covered)
+    for (const c of this.covered) {
+      if (!this.isLive(c)) continue;
       if (c.range.end.before(start) || c.range.start.after(end)) keep.push(c);
       else {
         if (c.range.start.before(start)) start = c.range.start;
         if (c.range.end.after(end)) end = c.range.end;
         if (c.addedAt.before(addedAt)) addedAt = c.addedAt;
       }
+    }
     keep.push({ range: new TimeRange(start, end), addedAt });
     keep.sort((a, b) => TimeRange.sort(a.range, b.range));
     this.covered = keep;
+  }
+
+  // Coverage answers gaps only while its TTL lasts. gc merely prunes dead records.
+  private isLive(c: CoveredRange): boolean {
+    return TimeStamp.since(c.addedAt).lessThan(this.props.coverageTTL);
   }
 
   // Containment, not overlap: a fetch stamped wider than the data it returned
@@ -176,7 +193,9 @@ export class Static {
   // Removes the covered portions of gap, returning the still-unanswered remainder.
   private subtractCovered(gap: TimeRange): TimeRange[] {
     let remaining = [gap];
-    for (const { range } of this.covered) {
+    for (const c of this.covered) {
+      if (!this.isLive(c)) continue;
+      const { range } = c;
       const next: TimeRange[] = [];
       for (const r of remaining) {
         if (!range.overlapsWith(r)) {
@@ -214,13 +233,11 @@ export class Static {
       });
     this.fetched = collect(this.fetched);
     this.streamed = collect(this.streamed);
-    // Expiring coverage re-opens the span to one fetch per staleness window, even when
-    // it keeps coming back empty. The client cannot tell "no data yet" from "no data
-    // ever" (backfill is legal), so an uncovered empty span would refetch on every
-    // read (space-heater mode). One cheap empty fetch per window is what lets late data ever appear.
-    this.covered = this.covered.filter((c) =>
-      TimeStamp.since(c.addedAt).lessThan(staleEntryThreshold),
-    );
+    // The client cannot tell "no data yet" from "no data ever" (backfill is legal).
+    // Coverage expiry re-opens an empty span to one cheap fetch per TTL instead of a
+    // refetch on every read (space-heater mode). One periodic empty fetch is what
+    // lets late data ever appear. Series purging above is not affected.
+    this.covered = this.covered.filter((c) => this.isLive(c));
     return res;
   }
 

--- a/client/ts/src/framer/cache/static.ts
+++ b/client/ts/src/framer/cache/static.ts
@@ -61,6 +61,13 @@ interface CacheEntry {
   addedAt: TimeStamp;
 }
 
+interface CoveredRange {
+  /** The fetched span, held even when the fetch returned no samples. */
+  range: TimeRange;
+  /** When the fetch completed, for garbage collection staleness. */
+  addedAt: TimeStamp;
+}
+
 /**
  * A cache for historical channel data that will not be modified after it is written.
  * Fetched and streamed entries are held apart because they measure position in
@@ -71,6 +78,9 @@ interface CacheEntry {
 export class Static {
   private fetched: CacheEntry[] = [];
   private streamed: CacheEntry[] = [];
+  // Sorted, non-overlapping spans already fetched, kept apart from the entries so a
+  // span that returned no samples still counts as answered and is not refetched.
+  private covered: CoveredRange[] = [];
   private readonly props: Required<StaticProps>;
 
   constructor(props: StaticProps) {
@@ -96,6 +106,26 @@ export class Static {
       this.writeOne(this.props.transform.convert(s), entries),
     );
     this.repairIntegrity(series, entries);
+  }
+
+  /**
+   * Records tr as fetched, merging it into the covered set. Gap computation treats
+   * covered spans as answered even when the fetch returned no samples, so an empty
+   * span is fetched once per staleness window instead of on every read.
+   */
+  markFetched(tr: TimeRange): void {
+    if (!tr.isValid || tr.span.isZero) return;
+    let { start, end } = tr;
+    const keep: CoveredRange[] = [];
+    for (const c of this.covered)
+      if (c.range.end.before(start) || c.range.start.after(end)) keep.push(c);
+      else {
+        if (c.range.start.before(start)) start = c.range.start;
+        if (c.range.end.after(end)) end = c.range.end;
+      }
+    keep.push({ range: new TimeRange(start, end), addedAt: TimeStamp.now() });
+    keep.sort((a, b) => TimeRange.sort(a.range, b.range));
+    this.covered = keep;
   }
 
   // Containment, not overlap: a fetch stamped wider than the data it returned
@@ -125,17 +155,39 @@ export class Static {
       entries.filter((e) => e.data.timeRange.overlapsWith(tr)).map((e) => e.data);
     const fetched = overlapping(this.fetched);
     const series = [...fetched, ...overlapping(this.streamed)];
-    if (fetched.length === 0) return { series: new MultiSeries(series), gaps: [tr] };
+    if (fetched.length === 0)
+      return { series: new MultiSeries(series), gaps: this.subtractCovered(tr) };
     const gaps: TimeRange[] = [];
     const pushGap = (start: TimeStamp, end: TimeStamp): void => {
       const gap = new TimeRange(start, end);
-      if (gap.isValid && !gap.span.isZero) gaps.push(gap);
+      if (gap.isValid && !gap.span.isZero) gaps.push(...this.subtractCovered(gap));
     };
     pushGap(tr.start, fetched[0].timeRange.start);
     for (let i = 1; i < fetched.length; i++)
       pushGap(fetched[i - 1].timeRange.end, fetched[i].timeRange.start);
     pushGap(fetched[fetched.length - 1].timeRange.end, tr.end);
     return { series: new MultiSeries(series), gaps };
+  }
+
+  // Removes the covered portions of gap, returning the still-unanswered remainder.
+  private subtractCovered(gap: TimeRange): TimeRange[] {
+    let remaining = [gap];
+    for (const { range } of this.covered) {
+      const next: TimeRange[] = [];
+      for (const r of remaining) {
+        if (!range.overlapsWith(r)) {
+          next.push(r);
+          continue;
+        }
+        const before = new TimeRange(r.start, range.start);
+        const after = new TimeRange(range.end, r.end);
+        if (before.isValid && !before.span.isZero) next.push(before);
+        if (after.isValid && !after.span.isZero) next.push(after);
+      }
+      remaining = next;
+      if (remaining.length === 0) break;
+    }
+    return remaining;
   }
 
   /**
@@ -158,6 +210,11 @@ export class Static {
       });
     this.fetched = collect(this.fetched);
     this.streamed = collect(this.streamed);
+    // Expiring coverage re-opens the span to one fetch per staleness window, so data
+    // committed late (backfill, an uncommitted tail) still gets picked up.
+    this.covered = this.covered.filter((c) =>
+      TimeStamp.since(c.addedAt).lessThan(staleEntryThreshold),
+    );
     return res;
   }
 
@@ -165,6 +222,7 @@ export class Static {
   close(): void {
     this.fetched = [];
     this.streamed = [];
+    this.covered = [];
   }
 
   private writeOne(series: Series, entries: CacheEntry[]): void {

--- a/client/ts/src/framer/cache/static.ts
+++ b/client/ts/src/framer/cache/static.ts
@@ -214,8 +214,10 @@ export class Static {
       });
     this.fetched = collect(this.fetched);
     this.streamed = collect(this.streamed);
-    // Expiring coverage re-opens the span to one fetch per staleness window, so data
-    // committed late (backfill, an uncommitted tail) still gets picked up.
+    // Expiring coverage re-opens the span to one fetch per staleness window, even when
+    // it keeps coming back empty. The client cannot tell "no data yet" from "no data
+    // ever" (backfill is legal), so an uncovered empty span would refetch on every
+    // read (space-heater mode). One cheap empty fetch per window is what lets late data ever appear.
     this.covered = this.covered.filter((c) =>
       TimeStamp.since(c.addedAt).lessThan(staleEntryThreshold),
     );

--- a/client/ts/src/framer/cache/static.ts
+++ b/client/ts/src/framer/cache/static.ts
@@ -116,14 +116,18 @@ export class Static {
   markFetched(tr: TimeRange): void {
     if (!tr.isValid || tr.span.isZero) return;
     let { start, end } = tr;
+    // Keep the oldest stamp when merging. A fresh stamp would let a rolling read
+    // refresh its own coverage forever, so late backfill would never be refetched.
+    let addedAt = TimeStamp.now();
     const keep: CoveredRange[] = [];
     for (const c of this.covered)
       if (c.range.end.before(start) || c.range.start.after(end)) keep.push(c);
       else {
         if (c.range.start.before(start)) start = c.range.start;
         if (c.range.end.after(end)) end = c.range.end;
+        if (c.addedAt.before(addedAt)) addedAt = c.addedAt;
       }
-    keep.push({ range: new TimeRange(start, end), addedAt: TimeStamp.now() });
+    keep.push({ range: new TimeRange(start, end), addedAt });
     keep.sort((a, b) => TimeRange.sort(a.range, b.range));
     this.covered = keep;
   }

--- a/client/ts/src/framer/cache/static.ts
+++ b/client/ts/src/framer/cache/static.ts
@@ -51,14 +51,14 @@ export interface StaticProps {
    * the refetch rate of spans that stay empty, as every refetch opens a short-lived
    * iterator connection.
    * @default TimeSpan.minutes(10) */
-  coverageTTL?: TimeSpan;
+  staleCoverageThreshold?: TimeSpan;
 }
 
 export const DEFAULT_STATIC_PROPS: Required<StaticProps> = {
   instrumentation: alamos.NOOP,
   transform: IDENTITY_TRANSFORM,
   staleEntryThreshold: TimeSpan.seconds(20),
-  coverageTTL: TimeSpan.minutes(10),
+  staleCoverageThreshold: TimeSpan.minutes(10),
 };
 
 interface CacheEntry {
@@ -71,7 +71,7 @@ interface CacheEntry {
 interface CoveredRange {
   /** The fetched span, held even when the fetch returned no samples. */
   range: TimeRange;
-  /** When the fetch completed. Coverage answers gaps until addedAt + coverageTTL. */
+  /** When the fetch completed. Coverage answers gaps until it goes stale. */
   addedAt: TimeStamp;
 }
 
@@ -95,9 +95,14 @@ export class Static {
       instrumentation = DEFAULT_STATIC_PROPS.instrumentation,
       transform = DEFAULT_STATIC_PROPS.transform,
       staleEntryThreshold = DEFAULT_STATIC_PROPS.staleEntryThreshold,
-      coverageTTL = DEFAULT_STATIC_PROPS.coverageTTL,
+      staleCoverageThreshold = DEFAULT_STATIC_PROPS.staleCoverageThreshold,
     } = props;
-    this.props = { instrumentation, transform, staleEntryThreshold, coverageTTL };
+    this.props = {
+      instrumentation,
+      transform,
+      staleEntryThreshold,
+      staleCoverageThreshold,
+    };
   }
 
   /**
@@ -117,17 +122,14 @@ export class Static {
   }
 
   /**
-   * Records tr as fetched, merging it into the covered set. Gap computation treats
-   * covered spans as answered even when the fetch returned no samples, so an empty
-   * span is fetched once per coverage TTL instead of on every read.
+   * Records tr as fetched, merging it into the covered set. A covered span counts
+   * as answered even when empty, so it is refetched once it goes stale, not per read.
    */
   markFetched(tr: TimeRange): void {
     if (!tr.isValid || tr.span.isZero) return;
     let { start, end } = tr;
-    // Merging live coverage keeps the oldest stamp. A fresh stamp would let a rolling
-    // read refresh its own coverage forever, so late backfill would never be
-    // refetched. Expired records are dropped, not merged, so a refetch of their span
-    // starts a fresh TTL.
+    // Live merges keep the oldest stamp so a rolling read cannot refresh its own
+    // coverage forever. Stale records drop, so a refetch restarts their clock.
     let addedAt = TimeStamp.now();
     const keep: CoveredRange[] = [];
     for (const c of this.covered) {
@@ -144,9 +146,9 @@ export class Static {
     this.covered = keep;
   }
 
-  // Coverage answers gaps only while its TTL lasts. gc merely prunes dead records.
+  // Coverage answers gaps only until it goes stale. gc merely prunes dead records.
   private isLive(c: CoveredRange): boolean {
-    return TimeStamp.since(c.addedAt).lessThan(this.props.coverageTTL);
+    return TimeStamp.since(c.addedAt).lessThan(this.props.staleCoverageThreshold);
   }
 
   // Containment, not overlap: a fetch stamped wider than the data it returned
@@ -233,10 +235,10 @@ export class Static {
       });
     this.fetched = collect(this.fetched);
     this.streamed = collect(this.streamed);
-    // The client cannot tell "no data yet" from "no data ever" (backfill is legal).
-    // Coverage expiry re-opens an empty span to one cheap fetch per TTL instead of a
-    // refetch on every read (space-heater mode). One periodic empty fetch is what
-    // lets late data ever appear. Series purging above is not affected.
+    // The client cannot tell "no data yet" from "no data ever" (backfill is legal),
+    // so stale coverage re-opens an empty span to one cheap fetch per staleness
+    // window instead of one per read (space-heater mode). Series purging above is not
+    // affected.
     this.covered = this.covered.filter((c) => this.isLive(c));
     return res;
   }

--- a/client/ts/src/framer/cache/unary.ts
+++ b/client/ts/src/framer/cache/unary.ts
@@ -70,6 +70,13 @@ export class Unary {
     this.static.write(series);
   }
 
+  /** Records tr as fetched so reads stop reporting it as a gap even when it holds no
+   * samples. Call after a fetch for tr completes. */
+  markFetched(tr: TimeRange): void {
+    this.checkOpen("markFetched");
+    this.static.markFetched(tr);
+  }
+
   /**
    * Reads cached data overlapping the given time range. The result includes the live
    * leading buffer when the data it actually holds overlaps the range, judged by the

--- a/client/ts/src/framer/feed.spec.ts
+++ b/client/ts/src/framer/feed.spec.ts
@@ -20,6 +20,8 @@ import { afterAll, describe, expect, it } from "vitest";
 
 import { UnexpectedError } from "@/errors";
 import { type Transform } from "@/framer/cache/transform";
+import { Feed } from "@/framer/feed";
+import { Frame } from "@/framer/frame";
 import { createTestClient } from "@/testutil";
 
 const client = createTestClient();
@@ -433,5 +435,27 @@ describe("feed", () => {
     await closable.close();
     const tr = new TimeRange(TimeStamp.now(), TimeStamp.now().add(TimeSpan.seconds(1)));
     await expect(closable.read(tr, 123)).rejects.toThrow(UnexpectedError);
+  });
+
+  it("should forward staleCoverageThreshold to the cache", async () => {
+    let calls = 0;
+    const direct = new Feed({
+      staleCoverageThreshold: TimeSpan.milliseconds(50),
+      readRemote: async () => {
+        calls++;
+        return new Frame([], []);
+      },
+      openStreamer: async () => {
+        throw new UnexpectedError("streamer unused");
+      },
+    });
+    const tr = new TimeRange(TimeSpan.seconds(1), TimeSpan.seconds(3));
+    await direct.read(tr, 1);
+    await direct.read(tr, 1);
+    expect(calls).toBe(1);
+    await sleep.sleep(TimeSpan.milliseconds(60));
+    await direct.read(tr, 1);
+    expect(calls).toBe(2);
+    await direct.close();
   });
 });

--- a/client/ts/src/framer/feed.ts
+++ b/client/ts/src/framer/feed.ts
@@ -52,6 +52,7 @@ export class Feed {
       dynamicBufferSize,
       gcInterval,
       staleEntryThreshold,
+      staleCoverageThreshold,
       removalDelay,
       breaker,
       batchDebounce,
@@ -62,6 +63,7 @@ export class Feed {
       dynamicBufferSize,
       gcInterval,
       staleEntryThreshold,
+      staleCoverageThreshold,
       instrumentation: instrumentation?.child("cache"),
     });
     this.reader = new Reader({

--- a/client/ts/src/status/status.spec.ts
+++ b/client/ts/src/status/status.spec.ts
@@ -735,6 +735,60 @@ describe("fromException", () => {
   it("should leave the description empty without a cause or message", () => {
     expect(status.fromException(new Error("boom")).description).toBe("");
   });
+
+  describe("clone safety", () => {
+    it("should keep the original error instance when it is cloneable", () => {
+      const err = new Error("boom", { cause: new Error("root") });
+      expect(status.fromException(err).details.error).toBe(err);
+    });
+
+    it("should rebuild an error whose cause cannot be cloned", () => {
+      const err = new Error("boom", { cause: () => {} });
+      err.name = "SocketError";
+      const stored = status.fromException(err).details.error;
+      expect(stored).not.toBe(err);
+      expect(stored.message).toBe("boom");
+      expect(stored.name).toBe("SocketError");
+      expect(stored.stack).toBe(err.stack);
+      expect(typeof stored.cause).toBe("string");
+      expect(() => structuredClone(stored)).not.toThrow();
+    });
+
+    it("should rebuild an error carrying an un-cloneable own field", () => {
+      const err = new Error("boom");
+      (err as unknown as { cb: () => void }).cb = () => {};
+      const stored = status.fromException(err).details.error;
+      expect(stored).not.toBe(err);
+      expect(() => structuredClone(stored)).not.toThrow();
+    });
+
+    it("should preserve error causes as errors in the rebuilt chain", () => {
+      const root = new Error("root", { cause: () => {} });
+      const err = new Error("boom", { cause: root });
+      const stored = status.fromException(err).details.error;
+      expect(stored.cause).toBeInstanceOf(Error);
+      expect((stored.cause as Error).message).toBe("root");
+      expect(() => structuredClone(stored)).not.toThrow();
+    });
+
+    it("should terminate on a cyclic cause chain", () => {
+      const err = new Error("boom");
+      err.cause = err;
+      (err as unknown as { cb: () => void }).cb = () => {};
+      const stored = status.fromException(err).details.error;
+      expect(stored.message).toBe("boom");
+      expect(() => structuredClone(stored)).not.toThrow();
+    });
+
+    it("should rebuild conservatively when the clone check budget is exhausted", () => {
+      const wide: Record<string, number> = {};
+      for (let i = 0; i < 100; i++) wide[`k${i}`] = i;
+      const err = new Error("boom", { cause: wide });
+      const stored = status.fromException(err).details.error;
+      expect(stored).not.toBe(err);
+      expect(() => structuredClone(stored)).not.toThrow();
+    });
+  });
 });
 
 describe("keepVariants", () => {

--- a/client/ts/src/status/status.spec.ts
+++ b/client/ts/src/status/status.spec.ts
@@ -780,6 +780,36 @@ describe("fromException", () => {
       expect(() => structuredClone(stored)).not.toThrow();
     });
 
+    it("should rebuild an error carrying a throwing enumerable getter", () => {
+      const err = new Error("boom");
+      Object.defineProperty(err, "trap", {
+        enumerable: true,
+        get() {
+          throw new Error("trapped");
+        },
+      });
+      const stored = status.fromException(err).details.error;
+      // Passing err to expect would trip the getter while vitest inspects it.
+      expect(stored === err).toBe(false);
+      expect(stored.message).toBe("boom");
+      expect(() => structuredClone(stored)).not.toThrow();
+    });
+
+    it("should rebuild when the cause carries a throwing enumerable getter", () => {
+      const cause: Record<string, unknown> = { ok: 1 };
+      Object.defineProperty(cause, "trap", {
+        enumerable: true,
+        get() {
+          throw new Error("trapped");
+        },
+      });
+      const err = new Error("boom", { cause });
+      const stored = status.fromException(err).details.error;
+      expect(stored).not.toBe(err);
+      expect(typeof stored.cause).toBe("string");
+      expect(() => structuredClone(stored)).not.toThrow();
+    });
+
     it("should rebuild conservatively when the clone check budget is exhausted", () => {
       const wide: Record<string, number> = {};
       for (let i = 0; i < 100; i++) wide[`k${i}`] = i;

--- a/client/ts/src/status/status.ts
+++ b/client/ts/src/status/status.ts
@@ -123,7 +123,7 @@ const isCloneable = (v: unknown): boolean => {
 /**
  * Returns err unchanged when it survives structured cloning. Otherwise rebuilds it
  * with the same name, message, and stack, stringifying any un-cloneable cause.
- * Statuses cross the worker boundary, so an un-cloneable error would kill the worker.
+ * Statuses cross the worker boundary, where an un-cloneable error kills the worker.
  */
 const cloneSafeError = (err: Error, depth: number = 8): Error => {
   if (isCloneable(err)) return err;

--- a/client/ts/src/status/status.ts
+++ b/client/ts/src/status/status.ts
@@ -80,6 +80,57 @@ export const exceptionDetailsSchema = z
   })
   .and(record.unknownZ());
 
+// Bounds the clone check so it stays cheap even when errors are created in a tight
+// loop. An exhausted budget reports un-cloneable, which safely over-rebuilds.
+const CLONE_CHECK_BUDGET = 64;
+
+const isCloneableValue = (
+  v: unknown,
+  seen: Set<object>,
+  budget: { left: number },
+): boolean => {
+  if (--budget.left < 0) return false;
+  if (v == null) return true;
+  const t = typeof v;
+  if (t === "function" || t === "symbol") return false;
+  if (t !== "object") return true;
+  const o = v;
+  if (seen.has(o)) return true;
+  seen.add(o);
+  const values = (vals: unknown[]): boolean =>
+    vals.every((e) => isCloneableValue(e, seen, budget));
+  if (o instanceof Error)
+    return isCloneableValue(o.cause, seen, budget) && values(Object.values(o));
+  if (Array.isArray(o)) return values(o);
+  const proto = Object.getPrototypeOf(o);
+  if (proto === Object.prototype || proto === null) return values(Object.values(o));
+  if (o instanceof Date || o instanceof ArrayBuffer || ArrayBuffer.isView(o))
+    return true;
+  // Host objects (an Event, a DOM node) and exotic containers land here.
+  return false;
+};
+
+const isCloneable = (v: unknown): boolean =>
+  isCloneableValue(v, new Set(), { left: CLONE_CHECK_BUDGET });
+
+/**
+ * Returns err unchanged when it survives structured cloning. Otherwise rebuilds it
+ * with the same name, message, and stack, stringifying any un-cloneable cause.
+ * Statuses cross the worker boundary, so an un-cloneable error would kill the worker.
+ */
+const cloneSafeError = (err: Error, depth: number = 8): Error => {
+  if (isCloneable(err)) return err;
+  const safe = new Error(err.message);
+  safe.name = err.name;
+  safe.stack = err.stack;
+  const { cause } = err;
+  if (cause !== undefined && depth > 0)
+    if (cause instanceof Error) safe.cause = cloneSafeError(cause, depth - 1);
+    else
+      safe.cause = isCloneable(cause) ? cause : errors.fromUnknown(cause).message;
+  return safe;
+};
+
 /** Flattens an error's cause chain into one readable line. */
 const causeChain = (err: Error): string | undefined => {
   const parts: string[] = [];
@@ -109,7 +160,7 @@ export const fromException = (
       message != null
         ? [err.message, detail].filter((part) => part != null).join(": ")
         : detail,
-    details: { stack: err.stack ?? "", error: err },
+    details: { stack: err.stack ?? "", error: cloneSafeError(err) },
   };
   // Probe the original (pre-coercion) value so a non-Error throwable with a custom
   // `toStatus()` method still contributes its status fields.

--- a/client/ts/src/status/status.ts
+++ b/client/ts/src/status/status.ts
@@ -110,8 +110,15 @@ const isCloneableValue = (
   return false;
 };
 
-const isCloneable = (v: unknown): boolean =>
-  isCloneableValue(v, new Set(), { left: CLONE_CHECK_BUDGET });
+// Object.values can trip an enumerable getter that throws. Treat a throwing value
+// as not cloneable rather than throwing while already handling an error.
+const isCloneable = (v: unknown): boolean => {
+  try {
+    return isCloneableValue(v, new Set(), { left: CLONE_CHECK_BUDGET });
+  } catch {
+    return false;
+  }
+};
 
 /**
  * Returns err unchanged when it survives structured cloning. Otherwise rebuilds it
@@ -126,8 +133,7 @@ const cloneSafeError = (err: Error, depth: number = 8): Error => {
   const { cause } = err;
   if (cause !== undefined && depth > 0)
     if (cause instanceof Error) safe.cause = cloneSafeError(cause, depth - 1);
-    else
-      safe.cause = isCloneable(cause) ? cause : errors.fromUnknown(cause).message;
+    else safe.cause = isCloneable(cause) ? cause : errors.fromUnknown(cause).message;
   return safe;
 };
 


### PR DESCRIPTION
## Summary

Discovered on line plots after the v0.58 rc deploy. Setting a rolling range that extends past the available data crashed the web Console with an Aether worker `DataCloneError`. Two independent defects combined to cause it, and both are fixed here.

## Root cause

The frame cache only recorded fetched data, never fetched spans. A span with no data stayed a permanent gap, so every render frame refetched it and opened a new iterator WebSocket until the browser refused with `Insufficient resources`. The resulting failure carried the raw WebSocket `Event` as the error `cause`. Storing that error in a status and posting it across the worker boundary failed structured cloning and killed the whole worker.

## Changes

The frame cache (`client/ts/src/framer/cache`) now records fetched-but-empty spans as covered via `markFetched` and subtracts coverage from gap computation in `dirtyRead`. Coverage expires on its own `staleCoverageThreshold` (10 minutes by default, separate from `staleEntryThreshold`), so an empty span costs at most one short-lived iterator connection per staleness window while late-committed data still gets picked up. Merging coverage keeps the oldest timestamp, so a rolling read cannot refresh its own coverage indefinitely. Failed fetches record nothing and retry as before.

`status.fromException` now stores a clone-safe error in `details.error`. Cloneable errors pass through untouched. Un-cloneable ones are rebuilt with the same `name`, `message`, and `stack`, with the offending `cause` stringified. The clone check is budget-capped so it stays cheap even when errors are created in a tight loop, and a throwing property getter counts as un-cloneable instead of throwing during error handling.

The build workflow now skips debug-symbol extraction and upload when a driver is reused from a previous run, matching the existing guard on the build steps.

## Testing

Reproduced and diagnosed with an instrumented dev Console against the deployment where the crash was found, then manually verified both fixes there. The empty span now fetches once instead of sixty times per second, the worker survives, and live plots stream normally. New unit specs cover empty-span coverage, coverage merging and subtraction, coverage expiry and restart on refetch, fetch failure retry, and clone-safe error rebuilds including cyclic `cause` chains, throwing getters, and budget exhaustion. A live-core spec verifies an empty span is fetched exactly once against a running server.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.








<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR prevents empty plot ranges from repeatedly opening iterator connections and ensures errors stored in statuses remain safe to clone across worker boundaries.

- Records successfully fetched spans independently of returned samples and expires that coverage after a configurable threshold.
- Preserves the oldest timestamp when merging coverage so rolling reads cannot postpone expiration indefinitely.
- Rebuilds uncloneable errors while preserving useful diagnostic fields.
- Forwards `staleCoverageThreshold` through `Feed` into the cache.
- Skips debug-symbol extraction and upload when reusing a previously built driver.
- Adds unit and live-core coverage for empty reads, expiration, retries, merging, and clone safety.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge; the previously reported option-forwarding defect is fixed and no new actionable failures remain.

The current implementation forwards the renamed coverage threshold through the full feed-to-cache path, retains the oldest timestamp when merging coverage, safely handles throwing getters during clone checks, and includes focused regression tests. The other previous findings were manually resolved.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| client/ts/src/framer/cache/static.ts | Adds expiring fetched-span coverage, including subtraction, merging, garbage collection, and cleanup. |
| client/ts/src/framer/cache/reader.ts | Marks each successfully fetched channel gap as covered after writing the returned frame. |
| client/ts/src/status/status.ts | Adds bounded cloneability checks and clone-safe error rebuilding for worker-bound statuses. |
| client/ts/src/framer/feed.ts | Forwards the configurable stale-coverage threshold into the cache. |
| .github/workflows/build.synnax.yaml | Guards debug-symbol extraction and upload when the driver comes from a reused build. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
  Read[Historical read] --> Cache{Range cached or covered?}
  Cache -->|Yes| Return[Return cached result]
  Cache -->|No| Fetch[Fetch gap from Core]
  Fetch -->|Success with data| Store[Store series and mark span fetched]
  Fetch -->|Success without data| Cover[Mark empty span fetched]
  Fetch -->|Failure| Retry[Leave span uncovered for retry]
  Store --> Return
  Cover --> Return
  Cover -->|Coverage expires| Cache
  Error[Transport error] --> Clone{Error cloneable?}
  Clone -->|Yes| Status[Store original error in status]
  Clone -->|No| Rebuild[Rebuild clone-safe error]
  Rebuild --> Status
  Status --> Worker[Post status across worker boundary]
```

<sub>Reviews (4): Last reviewed commit: ["Forward stale coverage threshold through..."](https://github.com/synnaxlabs/synnax/commit/dae22cb3e89604dfca10c3a227bd0d7773d221f7) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60739629)</sub>

**Context used:**

- Knowledge Base — [Client SDKs](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/client-sdks.md)
- Knowledge Base — [TypeScript and Python SDKs](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/typescript-python-sdks.md)

<!-- /greptile_comment -->