### PR TITLE
[plot] Show a loading state while line plots back-fill long spans

### DIFF
--- a/console/src/feature/lineplot/LinePlot.tsx
+++ b/console/src/feature/lineplot/LinePlot.tsx
@@ -211,7 +211,7 @@ const Internal = (): ReactElement => {
           : { variant: "static", timeRange: new TimeRange(r.timeRange) },
       );
     const { custom } = ranges;
-    if (custom != null)
+    if (custom != null && rangeKeys.includes(Range.CUSTOM_KEY))
       m.set(
         Range.CUSTOM_KEY,
         custom.variant === "dynamic"
@@ -224,7 +224,7 @@ const Internal = (): ReactElement => {
             },
       );
     return m;
-  }, [resolved, ranges.custom]);
+  }, [resolved, ranges.custom, rangeKeys]);
 
   const hiddenLineKeys = Session.LinePlot.useSelectHiddenLines();
   const hiddenLines = useMemo(() => new Set(hiddenLineKeys), [hiddenLineKeys]);

--- a/pluto/src/lineplot/Frame.tsx
+++ b/pluto/src/lineplot/Frame.tsx
@@ -58,6 +58,8 @@ export interface ContextValue {
   setViewport: (viewport: Viewport.UseEvent) => void;
   addViewportHandler: (handler: Viewport.UseHandler) => destructor.Destructor;
   setHold: (hold: boolean) => void;
+  loading: boolean;
+  loadingMessage?: string;
 }
 
 const [Context, useContext] = context.create<ContextValue>({
@@ -122,6 +124,7 @@ export interface FrameProps
     Aether.ComponentProps {
   resizeDebounce?: CrudeTimeSpan;
   onHold?: (hold: boolean) => void;
+  loadingMessage?: string;
   ref?: Ref<FrameRef>;
 }
 
@@ -134,6 +137,7 @@ export const Frame = ({
   hold = false,
   onHold,
   visible,
+  loadingMessage,
   ref,
   ...rest
 }: FrameProps): ReactElement => {
@@ -141,7 +145,7 @@ export const Frame = ({
 
   const memoProps = useMemoDeepEqual({ clearOverScan, hold, visible });
 
-  const [{ path }, { grid }, setState, methods] = Aether.use({
+  const [{ path }, { grid, loading }, setState, methods] = Aether.use({
     aetherKey,
     type: lineplot.LinePlot.TYPE,
     schema: lineplot.linePlotStateZ,
@@ -252,6 +256,8 @@ export const Frame = ({
       addViewportHandler,
       setHold,
       id,
+      loading,
+      loadingMessage,
     }),
     [
       id,
@@ -263,6 +269,8 @@ export const Frame = ({
       setViewport,
       addViewportHandler,
       setHold,
+      loading,
+      loadingMessage,
     ],
   );
 

--- a/pluto/src/lineplot/LinePlot.tsx
+++ b/pluto/src/lineplot/LinePlot.tsx
@@ -501,8 +501,16 @@ export const LinePlot = ({
   useUndoRedoTriggers({ key, enabled: enableTriggers });
   const xAxisKeys = useXAxisKeys({ key });
   const viewportRef = useViewportReset({ key, hold: rest.hold });
+  const loadingMessage = useMemo(() => {
+    if (resolvedRanges == null || resolvedRanges.size === 0) return undefined;
+    const spans = [...resolvedRanges.values()].map((r) =>
+      r.variant === "dynamic" ? r.span : r.timeRange.span,
+    );
+    const longest = spans.reduce((a, b) => (b.greaterThan(a) ? b : a));
+    return `Fetching ${longest.toString()} of data`;
+  }, [resolvedRanges]);
   return (
-    <Frame ref={ref} {...rest}>
+    <Frame ref={ref} loadingMessage={loadingMessage} {...rest}>
       {xAxisKeys.map((xAxisKey) => (
         <XAxis
           key={xAxisKey}

--- a/pluto/src/lineplot/Viewport.css
+++ b/pluto/src/lineplot/Viewport.css
@@ -13,3 +13,21 @@
     position: relative;
     overflow: hidden;
 }
+
+.pluto-line-plot__loading {
+    position: absolute;
+    inset: 0;
+    pointer-events: none;
+    container-type: size;
+}
+
+/* Sits below the orbital stage, whose size is the same min() over the region. */
+.pluto-line-plot__loading-message {
+    position: absolute;
+    left: 0;
+    right: 0;
+    justify-content: center;
+    text-align: center;
+    font-size: var(--pluto-p-size);
+    top: calc(50% + min(var(--pluto-orbital-size, 18rem), 100cqw, 100cqh) / 2 + 2rem);
+}

--- a/pluto/src/lineplot/Viewport.spec.tsx
+++ b/pluto/src/lineplot/Viewport.spec.tsx
@@ -1,0 +1,57 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { act, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+
+import { lineplot } from "@/lineplot/aether";
+import { Frame } from "@/lineplot/Frame";
+import { Viewport } from "@/lineplot/Viewport";
+import { render } from "@/testutil/render";
+
+const WORKER_PATH = [
+  "alamos",
+  "status",
+  "synnax",
+  "theming",
+  "telem",
+  "staleness",
+  "render",
+  "plot",
+];
+
+describe("Viewport", () => {
+  it("should overlay the spinner and message only while loading", async () => {
+    const { container, root } = render(
+      <Frame aetherKey="plot" loadingMessage="Fetching 90d of data">
+        <Viewport />
+      </Frame>,
+      { render: true, registry: lineplot.REGISTRY },
+    );
+    let plot: lineplot.LinePlot | null = null;
+    await waitFor(() => {
+      plot = root.findChildAtPath(WORKER_PATH) as lineplot.LinePlot;
+      expect(plot).toBeInstanceOf(lineplot.LinePlot);
+    });
+    expect(container.querySelector(".pluto-line-plot__loading")).toBeNull();
+    act(() => {
+      plot?.setState((p) => ({ ...p, loading: true }));
+    });
+    await waitFor(() => {
+      expect(container.querySelector(".pluto-line-plot__loading")).not.toBeNull();
+      expect(container.textContent).toContain("Fetching 90d of data");
+    });
+    act(() => {
+      plot?.setState((p) => ({ ...p, loading: false }));
+    });
+    await waitFor(() =>
+      expect(container.querySelector(".pluto-line-plot__loading")).toBeNull(),
+    );
+  });
+});

--- a/pluto/src/lineplot/Viewport.tsx
+++ b/pluto/src/lineplot/Viewport.tsx
@@ -19,6 +19,8 @@ import {
 
 import { CSS } from "@/css";
 import { useContext } from "@/lineplot/Frame";
+import { Status } from "@/status/base";
+import { Text } from "@/text";
 import { Viewport as Base } from "@/viewport";
 
 export interface ViewportProps extends PropsWithChildren, Base.UseProps {}
@@ -33,7 +35,7 @@ export const Viewport = ({
   onChange,
   ...rest
 }: ViewportProps): ReactElement => {
-  const { setViewport } = useContext("LinePlot.Viewport");
+  const { setViewport, loading, loadingMessage } = useContext("LinePlot.Viewport");
 
   useLayoutEffect(() => {
     setViewport({ box: initial, mode: "zoom", cursor: xy.ZERO, stage: "start" });
@@ -51,6 +53,16 @@ export const Viewport = ({
 
   return (
     <Base.Mask className={CSS.BE("line-plot", "viewport")} {...maskProps}>
+      {loading && (
+        <Status.Loading className={CSS.BE("line-plot", "loading")}>
+          <Status.Orbital />
+          {loadingMessage != null && (
+            <Text.Text className={CSS.BE("line-plot", "loading-message")}>
+              {loadingMessage}
+            </Text.Text>
+          )}
+        </Status.Loading>
+      )}
       {children}
     </Base.Mask>
   );

--- a/pluto/src/lineplot/aether/LinePlot.spec.ts
+++ b/pluto/src/lineplot/aether/LinePlot.spec.ts
@@ -1,0 +1,118 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { box } from "@synnaxlabs/x";
+import { afterEach, describe, expect, it } from "vitest";
+import { z } from "zod";
+
+import { aether } from "@/aether/aether";
+import { aetherTest } from "@/aether/test";
+import { LinePlot } from "@/lineplot/aether/LinePlot";
+import { XAxis } from "@/lineplot/aether/XAxis";
+import { YAxis } from "@/lineplot/aether/YAxis";
+import { buildStack } from "@/testutil/providers";
+import { Line } from "@/vis/line/aether/line";
+import { type render } from "@/vis/render";
+import { canvasTest } from "@/vis/render/test";
+
+const stubLineStateZ = z.object({ loading: z.boolean() });
+
+// Line needs a live GL context, so a stub with its TYPE stands in for the walk.
+class StubLine extends aether.Leaf<typeof stubLineStateZ> {
+  static readonly TYPE = Line.TYPE;
+  schema = stubLineStateZ;
+
+  get loading(): boolean {
+    return this.state.loading;
+  }
+}
+
+interface LoopEntry {
+  key?: string;
+  render?: () => render.Cleanup | undefined;
+}
+
+interface Mount {
+  plot: LinePlot;
+  recorder: canvasTest.Recorder;
+  setLineLoading: (loading: boolean) => void;
+  pump: () => void;
+}
+
+describe("LinePlot", () => {
+  const teardowns: (() => void)[] = [];
+  afterEach(() => {
+    for (const teardown of teardowns) teardown();
+    teardowns.length = 0;
+  });
+
+  const mount = (lineLoading: boolean | null): Mount => {
+    const recorder = new canvasTest.Recorder();
+    const stack = buildStack({
+      registry: {
+        [LinePlot.TYPE]: LinePlot,
+        [XAxis.TYPE]: XAxis,
+        [YAxis.TYPE]: YAxis,
+        [StubLine.TYPE]: StubLine,
+      },
+      render: recorder,
+    });
+    const base = [...stack.basePath, "plot"];
+    stack.driver.update(base, LinePlot.TYPE, {
+      container: box.DECIMAL,
+      viewport: box.DECIMAL,
+      grid: {},
+    });
+    stack.driver.update([...base, "x1"], XAxis.TYPE, { location: "bottom" });
+    stack.driver.update([...base, "x1", "y1"], YAxis.TYPE, { location: "left" });
+    if (lineLoading != null)
+      stack.driver.update([...base, "x1", "y1", "l1"], StubLine.TYPE, {
+        loading: lineLoading,
+      });
+    teardowns.push(() => stack.driver.delete([aetherTest.ROOT_KEY]));
+    const pump = (): void => {
+      const entry = recorder.loopCalls
+        .map((call) => call.args[0] as LoopEntry)
+        .reverse()
+        .find((e) => e.key?.startsWith(LinePlot.TYPE) ?? false);
+      entry?.render?.();
+    };
+    return {
+      plot: stack.driver.find<LinePlot>(base),
+      recorder,
+      setLineLoading: (loading) =>
+        stack.driver.update([...base, "x1", "y1", "l1"], StubLine.TYPE, { loading }),
+      pump,
+    };
+  };
+
+  describe("loading", () => {
+    it("should suppress draws and sync state while a line back-fills", () => {
+      const m = mount(true);
+      m.pump();
+      expect(m.plot.state.loading).toBe(true);
+      expect(m.recorder.scissorCalls).toHaveLength(0);
+    });
+
+    it("should resume draws once every line settles", () => {
+      const m = mount(true);
+      m.pump();
+      m.setLineLoading(false);
+      m.pump();
+      expect(m.plot.state.loading).toBe(false);
+      expect(m.recorder.scissorCalls.length).toBeGreaterThan(0);
+    });
+
+    it("should not report loading for a plot with no lines", () => {
+      const m = mount(null);
+      m.pump();
+      expect(m.plot.state.loading).toBe(false);
+    });
+  });
+});

--- a/pluto/src/lineplot/aether/LinePlot.ts
+++ b/pluto/src/lineplot/aether/LinePlot.ts
@@ -32,6 +32,7 @@ export const linePlotStateZ = z.object({
   grid: z.record(z.string(), grid.regionZ),
   visible: z.boolean().default(true),
   clearOverScan: xy.crudeZ.default(xy.ZERO),
+  loading: z.boolean().default(false),
 });
 
 const axesBoundsZ = z.record(
@@ -125,6 +126,10 @@ export class LinePlot
     return calculateExposure(this.state.viewport, this.state.container);
   }
 
+  private get loading(): boolean {
+    return this.axes.some((a) => a.loading);
+  }
+
   private renderAxes(plot: box.Box, canvases: render.CanvasVariant[]): void {
     const p = { ...this.state, plot, canvases, exposure: this.exposure };
     this.axes.forEach((xAxis) => xAxis.render(p));
@@ -168,8 +173,12 @@ export class LinePlot
       ins.L.debug("deleted, skipping render", { key: this.key });
       return;
     }
-    if (!this.state.visible) {
-      ins.L.debug("not visible, skipping render", { key: this.key });
+    // Skips draws while loading to free the worker and avoid autoscaling partial data.
+    const loading = this.loading;
+    if (loading !== this.state.loading) this.setState((p) => ({ ...p, loading }));
+    const skip = !this.state.visible ? "not visible" : loading ? "loading" : null;
+    if (skip != null) {
+      ins.L.debug(`${skip}, skipping render`, { key: this.key });
       return ({ canvases }) =>
         renderCtx.erase(this.state.container, this.state.clearOverScan, ...canvases);
     }

--- a/pluto/src/lineplot/aether/XAxis.ts
+++ b/pluto/src/lineplot/aether/XAxis.ts
@@ -82,6 +82,10 @@ export class XAxis extends BaseAxis<typeof baseAxisStateZ, YAxis | range.Provide
     return this.childrenOfType<range.Provider>(range.Provider.TYPE);
   }
 
+  get loading(): boolean {
+    return this.yAxes.some((el) => el.loading);
+  }
+
   bounds(hold: boolean): bounds.Bounds {
     const [bound, err] = this.iBounds(hold, this.dataBounds.bind(this));
     if (err != null) throw err;

--- a/pluto/src/lineplot/aether/YAxis.ts
+++ b/pluto/src/lineplot/aether/YAxis.ts
@@ -125,6 +125,10 @@ export class YAxis extends BaseAxis<typeof baseAxisStateZ, Children> {
     }));
   }
 
+  get loading(): boolean {
+    return this.lines.some((el) => el.loading);
+  }
+
   private dataBounds(xBounds: bounds.Bounds): bounds.Bounds[] {
     return this.lines.map((el) => el.yBounds(xBounds));
   }

--- a/pluto/src/telem/aether/context.spec.ts
+++ b/pluto/src/telem/aether/context.spec.ts
@@ -1,0 +1,41 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import { describe, expect, it } from "vitest";
+
+import { Context, MemoizedSource } from "@/telem/aether/context";
+import { createFactory } from "@/telem/aether/factory";
+import { fixedNumber } from "@/telem/aether/static";
+import { type Source } from "@/telem/aether/telem";
+
+describe("MemoizedSource", () => {
+  const provider = (): Context => new Context(createFactory());
+
+  const stub = (loading?: () => boolean): Source<number> => ({
+    value: () => 1,
+    onChange: () => () => {},
+    loading,
+  });
+
+  describe("loading", () => {
+    it("should forward loading from the wrapped source", () => {
+      const source = new MemoizedSource(
+        stub(() => true),
+        provider(),
+        fixedNumber(1),
+      );
+      expect(source.loading()).toBe(true);
+    });
+
+    it("should default to false when the wrapped source lacks loading", () => {
+      const source = new MemoizedSource(stub(), provider(), fixedNumber(1));
+      expect(source.loading()).toBe(false);
+    });
+  });
+});

--- a/pluto/src/telem/aether/context.ts
+++ b/pluto/src/telem/aether/context.ts
@@ -91,6 +91,10 @@ export class MemoizedSource<V, S extends Source<V> = Source<V>> extends Memoized
     return this.wrapped.value();
   }
 
+  loading(): boolean {
+    return this.wrapped.loading?.() ?? false;
+  }
+
   cleanup(): void {
     this.wrapped.cleanup?.();
   }

--- a/pluto/src/telem/aether/remote.spec.ts
+++ b/pluto/src/telem/aether/remote.spec.ts
@@ -639,6 +639,93 @@ describe("remote", () => {
       await new Promise((resolve) => setTimeout(resolve, 5));
       expect(series.refCount).toBe(0);
     });
+
+    describe("loading", () => {
+      it("should report loading while the read is pending and clear on resolve", async () => {
+        let release = (): void => {};
+        const gate = new Promise<void>((resolve) => (release = resolve));
+        c.feed.read = async (): Promise<MultiSeries> => {
+          await gate;
+          return new MultiSeries([]);
+        };
+        const cd = new ChannelData(c, {
+          timeRange: TimeRange.MAX,
+          channel: c.channel.key,
+        });
+        const handleChange = vi.fn();
+        cd.onChange(handleChange);
+        expect(cd.loading()).toBe(true);
+        release();
+        await expect.poll(() => cd.loading()).toBe(false);
+        expect(handleChange).toHaveBeenCalled();
+        cd.cleanup();
+      });
+
+      it("should not report loading for a zero channel or empty time range", () => {
+        const zeroChannel = new ChannelData(c, {
+          timeRange: TimeRange.MAX,
+          channel: 0,
+        });
+        expect(zeroChannel.loading()).toBe(false);
+        const emptyRange = new ChannelData(c, {
+          timeRange: TimeRange.ZERO,
+          channel: c.channel.key,
+        });
+        expect(emptyRange.loading()).toBe(false);
+        expect(c.readMock).not.toHaveBeenCalled();
+        expect(c.retrieveChannelMock).not.toHaveBeenCalled();
+      });
+
+      it("should not report loading for a range within the live buffer", () => {
+        const cd = new ChannelData(c, {
+          timeRange: new TimeRange(TimeStamp.seconds(0), TimeStamp.seconds(30)),
+          channel: c.channel.key,
+        });
+        expect(cd.loading()).toBe(false);
+        expect(c.readMock).not.toHaveBeenCalled();
+      });
+
+      it("should clear loading and notify when the read fails", async () => {
+        c.feed.read = async (): Promise<MultiSeries> => {
+          throw new Error("read exploded");
+        };
+        const cd = new ChannelData(c, {
+          timeRange: TimeRange.MAX,
+          channel: c.channel.key,
+        });
+        const handleChange = vi.fn();
+        cd.onChange(handleChange);
+        expect(cd.loading()).toBe(true);
+        await expect.poll(() => cd.loading()).toBe(false);
+        expect(handleChange).toHaveBeenCalled();
+        cd.cleanup();
+      });
+
+      it("should clear loading immediately with a null client", () => {
+        const cd = new ChannelData(null, { timeRange: TimeRange.MAX, channel: 1 });
+        expect(cd.loading()).toBe(false);
+      });
+
+      it("should stay silent when cleanup precedes the read resolving", async () => {
+        let release = (): void => {};
+        const gate = new Promise<void>((resolve) => (release = resolve));
+        c.feed.read = async (): Promise<MultiSeries> => {
+          await gate;
+          return new MultiSeries([]);
+        };
+        const cd = new ChannelData(c, {
+          timeRange: TimeRange.MAX,
+          channel: c.channel.key,
+        });
+        const handleChange = vi.fn();
+        cd.onChange(handleChange);
+        expect(cd.loading()).toBe(true);
+        cd.cleanup();
+        release();
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        expect(handleChange).not.toHaveBeenCalled();
+      });
+    });
   });
 
   describe("StreamChannelData", () => {
@@ -1302,6 +1389,111 @@ describe("remote", () => {
       expect(b).toStrictEqual(bounds.INVALID);
       expect(data.series).toHaveLength(1);
       expect(data.series[0]).toBe(d);
+    });
+
+    describe("loading", () => {
+      it("should report loading until the back-fill resolves", async () => {
+        let release = (): void => {};
+        const gate = new Promise<void>((resolve) => (release = resolve));
+        c.feed.read = async (): Promise<MultiSeries> => {
+          await gate;
+          return new MultiSeries([]);
+        };
+        const cd = new StreamChannelData(c, {
+          timeSpan: TimeSpan.MAX,
+          channel: c.channel.key,
+        });
+        const handleChange = vi.fn();
+        cd.onChange(handleChange);
+        expect(cd.loading()).toBe(true);
+        await expect.poll(() => c.streamHandler != null).toBe(true);
+        // Live data delivered during the drain must not clear the loading state.
+        const live = new Series({
+          data: new Float32Array([1]),
+          timeRange: new TimeRange(TimeStamp.now(), TimeStamp.MAX),
+        });
+        c.streamHandler?.(new Map([[c.channel.key, new MultiSeries([live])]]));
+        expect(cd.loading()).toBe(true);
+        release();
+        await expect.poll(() => cd.loading()).toBe(false);
+        expect(handleChange).toHaveBeenCalled();
+        cd.cleanup();
+      });
+
+      it("should clear loading on the first failure while the retry continues", async () => {
+        let calls = 0;
+        c.feed.read = async (): Promise<MultiSeries> => {
+          calls++;
+          if (calls === 1) throw new Error("boom");
+          return new MultiSeries([]);
+        };
+        const cd = new StreamChannelData(
+          c,
+          { timeSpan: TimeSpan.MAX, channel: c.channel.key },
+          {},
+          undefined,
+          { sleepFn: async () => {} },
+        );
+        const handleChange = vi.fn();
+        cd.onChange(handleChange);
+        expect(cd.loading()).toBe(true);
+        await expect.poll(() => cd.loading()).toBe(false);
+        expect(handleChange).toHaveBeenCalled();
+        await expect.poll(() => calls >= 2).toBe(true);
+        expect(cd.loading()).toBe(false);
+        cd.cleanup();
+      });
+
+      it("should not report loading for a span within the live buffer", () => {
+        const cd = new StreamChannelData(c, {
+          timeSpan: TimeSpan.seconds(30),
+          channel: c.channel.key,
+        });
+        expect(cd.loading()).toBe(false);
+        expect(c.streamF).not.toHaveBeenCalled();
+      });
+
+      it("should not report loading for a zero channel", () => {
+        const cd = new StreamChannelData(c, { timeSpan: TimeSpan.MAX, channel: 0 });
+        expect(cd.loading()).toBe(false);
+      });
+
+      it("should clear loading immediately with a null client", () => {
+        const cd = new StreamChannelData(null, { timeSpan: TimeSpan.MAX, channel: 1 });
+        expect(cd.loading()).toBe(false);
+      });
+
+      it("should clear loading for a virtual channel without a history read", async () => {
+        c.channel = new channel.Channel({ ...c.channel, virtual: true });
+        const cd = new StreamChannelData(c, {
+          timeSpan: TimeSpan.MAX,
+          channel: c.channel.key,
+        });
+        expect(cd.loading()).toBe(true);
+        await expect.poll(() => cd.loading()).toBe(false);
+        expect(c.readMock).not.toHaveBeenCalled();
+        cd.cleanup();
+      });
+
+      it("should stay silent when cleanup precedes the back-fill resolving", async () => {
+        let release = (): void => {};
+        const gate = new Promise<void>((resolve) => (release = resolve));
+        c.feed.read = async (): Promise<MultiSeries> => {
+          await gate;
+          return new MultiSeries([]);
+        };
+        const cd = new StreamChannelData(c, {
+          timeSpan: TimeSpan.MAX,
+          channel: c.channel.key,
+        });
+        const handleChange = vi.fn();
+        cd.onChange(handleChange);
+        expect(cd.loading()).toBe(true);
+        cd.cleanup();
+        release();
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        expect(handleChange).not.toHaveBeenCalled();
+      });
     });
   });
 

--- a/pluto/src/telem/aether/remote.spec.ts
+++ b/pluto/src/telem/aether/remote.spec.ts
@@ -676,13 +676,74 @@ describe("remote", () => {
         expect(c.retrieveChannelMock).not.toHaveBeenCalled();
       });
 
-      it("should not report loading for a range within the live buffer", () => {
+      it("should report loading for a short static range until the read resolves", async () => {
+        let release = (): void => {};
+        const gate = new Promise<void>((resolve) => (release = resolve));
+        c.feed.read = async (): Promise<MultiSeries> => {
+          await gate;
+          return new MultiSeries([]);
+        };
         const cd = new ChannelData(c, {
           timeRange: new TimeRange(TimeStamp.seconds(0), TimeStamp.seconds(30)),
           channel: c.channel.key,
         });
+        const handleChange = vi.fn();
+        cd.onChange(handleChange);
+        // loading() must kick the read itself since draws are suppressed.
+        expect(cd.loading()).toBe(true);
+        expect(c.retrieveChannelMock).toHaveBeenCalled();
+        release();
+        await expect.poll(() => cd.loading()).toBe(false);
+        expect(handleChange).toHaveBeenCalled();
+        cd.cleanup();
+      });
+
+      it("should report loading for a minimal nonzero span", async () => {
+        c.feed.read = async (): Promise<MultiSeries> => new MultiSeries([]);
+        const cd = new ChannelData(c, {
+          timeRange: new TimeRange(TimeStamp.seconds(0), TimeStamp.milliseconds(1)),
+          channel: c.channel.key,
+        });
+        expect(cd.loading()).toBe(true);
+        await expect.poll(() => cd.loading()).toBe(false);
+        cd.cleanup();
+      });
+
+      it("should clear loading and notify when a short static read fails", async () => {
+        c.feed.read = async (): Promise<MultiSeries> => {
+          throw new Error("read exploded");
+        };
+        const cd = new ChannelData(c, {
+          timeRange: new TimeRange(TimeStamp.seconds(0), TimeStamp.seconds(30)),
+          channel: c.channel.key,
+        });
+        const handleChange = vi.fn();
+        cd.onChange(handleChange);
+        expect(cd.loading()).toBe(true);
+        await expect.poll(() => cd.loading()).toBe(false);
+        expect(handleChange).toHaveBeenCalled();
+        cd.cleanup();
+      });
+
+      it("should stay silent when cleanup precedes a short static read", async () => {
+        let release = (): void => {};
+        const gate = new Promise<void>((resolve) => (release = resolve));
+        c.feed.read = async (): Promise<MultiSeries> => {
+          await gate;
+          return new MultiSeries([]);
+        };
+        const cd = new ChannelData(c, {
+          timeRange: new TimeRange(TimeStamp.seconds(0), TimeStamp.seconds(30)),
+          channel: c.channel.key,
+        });
+        const handleChange = vi.fn();
+        cd.onChange(handleChange);
+        expect(cd.loading()).toBe(true);
+        cd.cleanup();
+        release();
+        await new Promise((resolve) => setTimeout(resolve, 5));
+        expect(handleChange).not.toHaveBeenCalled();
         expect(cd.loading()).toBe(false);
-        expect(c.readMock).not.toHaveBeenCalled();
       });
 
       it("should clear loading and notify when the read fails", async () => {
@@ -703,6 +764,14 @@ describe("remote", () => {
 
       it("should clear loading immediately with a null client", () => {
         const cd = new ChannelData(null, { timeRange: TimeRange.MAX, channel: 1 });
+        expect(cd.loading()).toBe(false);
+      });
+
+      it("should clear loading immediately with a null client on a short range", () => {
+        const cd = new ChannelData(null, {
+          timeRange: new TimeRange(TimeStamp.seconds(0), TimeStamp.seconds(30)),
+          channel: 1,
+        });
         expect(cd.loading()).toBe(false);
       });
 
@@ -1447,6 +1516,15 @@ describe("remote", () => {
       it("should not report loading for a span within the live buffer", () => {
         const cd = new StreamChannelData(c, {
           timeSpan: TimeSpan.seconds(30),
+          channel: c.channel.key,
+        });
+        expect(cd.loading()).toBe(false);
+        expect(c.streamF).not.toHaveBeenCalled();
+      });
+
+      it("should not report loading for a span exactly at the live buffer limit", () => {
+        const cd = new StreamChannelData(c, {
+          timeSpan: TimeSpan.minutes(1),
           channel: c.channel.key,
         });
         expect(cd.loading()).toBe(false);

--- a/pluto/src/telem/aether/remote.ts
+++ b/pluto/src/telem/aether/remote.ts
@@ -223,7 +223,7 @@ export class ChannelData
   loading(): boolean {
     if (this.skipLoading || !this.loading_) return false;
     if (!this.valid) void this.read();
-    return true;
+    return this.loading_;
   }
 
   value(): [bounds.Bounds, MultiSeries] {
@@ -334,7 +334,7 @@ export class StreamChannelData
   loading(): boolean {
     if (this.skipLoading || !this.loading_) return false;
     if (!this.valid) void this.read();
-    return true;
+    return this.loading_;
   }
 
   value(): [bounds.Bounds, MultiSeries] {

--- a/pluto/src/telem/aether/remote.ts
+++ b/pluto/src/telem/aether/remote.ts
@@ -208,7 +208,7 @@ export class ChannelData
     this.client = client;
     this.onStatusChange = options?.onStatusChange;
     const { channel, timeRange } = this.props;
-    this.skipLoading = channel === 0 || timeRange.span.valueOf() <= LOADING_MIN_SPAN;
+    this.skipLoading = channel === 0 || timeRange.span.isZero;
     this.loading_ = true;
   }
 

--- a/pluto/src/telem/aether/remote.ts
+++ b/pluto/src/telem/aether/remote.ts
@@ -177,6 +177,9 @@ const fetchChannelProperties = async (
   return { key: c.index, dataType: DataType.TIMESTAMP, virtual: false, isCalculated };
 };
 
+// Spans within the live buffer draw immediately and skip the loading state.
+const LOADING_MIN_SPAN = TimeSpan.minutes(1).valueOf();
+
 const channelDataSourcePropsZ = z.object({
   timeRange: TimeRange.z,
   channel: z.number().or(z.string()),
@@ -198,18 +201,29 @@ export class ChannelData
   private generation = 0;
   private channel: SelectedChannelProperties | null = null;
   private readonly onStatusChange?: status.Adder;
+  private readonly skipLoading: boolean;
 
   constructor(client: Client | null, props: unknown, options?: CreateOptions) {
     super(props);
     this.client = client;
     this.onStatusChange = options?.onStatusChange;
+    const { channel, timeRange } = this.props;
+    this.skipLoading = channel === 0 || timeRange.span.valueOf() <= LOADING_MIN_SPAN;
+    this.loading_ = true;
   }
 
   cleanup(): void {
     this.generation++;
     this.data.release();
     this.valid = false;
+    this.loading_ = false;
     this.channel = null;
+  }
+
+  loading(): boolean {
+    if (this.skipLoading || !this.loading_) return false;
+    if (!this.valid) void this.read();
+    return true;
   }
 
   value(): [bounds.Bounds, MultiSeries] {
@@ -234,11 +248,11 @@ export class ChannelData
     const generation = this.generation;
     this.valid = true;
     const { client } = this;
-    if (client == null) {
-      this.onStatusChange?.(DISCONNECTED_STATUS);
-      return;
-    }
     try {
+      if (client == null) {
+        this.onStatusChange?.(DISCONNECTED_STATUS);
+        return;
+      }
       const { timeRange, channel, useIndexOfChannel } = this.props;
       const ch = await fetchChannelProperties(client, channel, useIndexOfChannel);
       if (generation !== this.generation) return;
@@ -251,6 +265,8 @@ export class ChannelData
     } catch (e) {
       this.valid = false;
       this.onStatusChange?.(cstatus.fromException(e, "Failed to read channel data"));
+    } finally {
+      this.declareLoaded();
     }
   }
 }
@@ -277,6 +293,7 @@ export class StreamChannelData
   private channel: SelectedChannelProperties | null = null;
   private stopStreaming?: destructor.Destructor;
   private valid: boolean = false;
+  private readonly skipLoading: boolean;
   private generation = 0;
   private readonly breaker: breaker.Breaker;
   private readonly retryNotifier = new sync.Notifier();
@@ -294,6 +311,9 @@ export class StreamChannelData
     this.client = client;
     this.now = now;
     this.onStatusChange = options?.onStatusChange;
+    const { channel, timeSpan } = this.props;
+    this.skipLoading = channel === 0 || timeSpan.valueOf() <= LOADING_MIN_SPAN;
+    this.loading_ = true;
     this.breaker = new breaker.Breaker({
       baseInterval: TimeSpan.seconds(1),
       // A tall interval cap: live data flows independently of this loop, and a
@@ -309,6 +329,12 @@ export class StreamChannelData
       },
       ...breakerConfig,
     });
+  }
+
+  loading(): boolean {
+    if (this.skipLoading || !this.loading_) return false;
+    if (!this.valid) void this.read();
+    return true;
   }
 
   value(): [bounds.Bounds, MultiSeries] {
@@ -336,16 +362,20 @@ export class StreamChannelData
     this.valid = true;
     const { client } = this;
     if (client == null) {
+      this.declareLoaded();
       this.onStatusChange?.(DISCONNECTED_STATUS);
       return;
     }
     while (generation === this.generation)
       try {
         await this.attempt(generation, client);
+        this.declareLoaded();
         this.breaker.reset();
         this.lastFailure = undefined;
         return;
       } catch (e) {
+        // Declare loaded on the first failure so retries never hold loading forever.
+        this.declareLoaded();
         // Retrying only fixes connectivity; a definitive rejection recurs on every
         // attempt.
         if (
@@ -445,6 +475,8 @@ export class StreamChannelData
     this.stopStreaming = undefined;
     this.data.release();
     this.valid = false;
+    // No notify so a read settling after cleanup cannot wake stale observers.
+    this.loading_ = false;
   }
 }
 

--- a/pluto/src/telem/aether/telem.spec.ts
+++ b/pluto/src/telem/aether/telem.spec.ts
@@ -8,7 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { zod } from "@synnaxlabs/x";
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import { z } from "zod";
 
 import { telem } from "@/telem/aether";
@@ -44,5 +44,47 @@ describe("telem", () => {
       telem.createFactory(),
     );
     expect(await p.value()).toBe(true);
+  });
+
+  describe("AbstractSource loading", () => {
+    class LatchedSource extends telem.AbstractSource<z.ZodNumber> {
+      schema = z.number();
+
+      value(): number {
+        return this.props;
+      }
+
+      latch(): void {
+        this.loading_ = true;
+      }
+
+      settle(): void {
+        this.declareLoaded();
+      }
+    }
+
+    it("should not report loading by default", () => {
+      expect(new LatchedSource(1).loading()).toBe(false);
+    });
+
+    it("should notify exactly once when a latched source settles", () => {
+      const source = new LatchedSource(1);
+      const handleChange = vi.fn();
+      source.onChange(handleChange);
+      source.latch();
+      expect(source.loading()).toBe(true);
+      source.settle();
+      source.settle();
+      expect(source.loading()).toBe(false);
+      expect(handleChange).toHaveBeenCalledTimes(1);
+    });
+
+    it("should not notify when settling an unlatched source", () => {
+      const source = new LatchedSource(1);
+      const handleChange = vi.fn();
+      source.onChange(handleChange);
+      source.settle();
+      expect(handleChange).not.toHaveBeenCalled();
+    });
   });
 });

--- a/pluto/src/telem/aether/telem.ts
+++ b/pluto/src/telem/aether/telem.ts
@@ -67,6 +67,8 @@ export interface Telem {
 
 export interface Source<V> extends Telem, observe.Observable<void> {
   value: (props?: ValueProps) => V;
+  /** @returns true while the source's initial read is in flight. */
+  loading?: () => boolean;
 }
 
 export interface Sink<V> extends Telem {
@@ -155,7 +157,20 @@ export abstract class Base<P extends z.ZodType> extends observe.BaseObserver<voi
   cleanup(): void {}
 }
 
-export abstract class AbstractSource<P extends z.ZodType> extends Base<P> {}
+export abstract class AbstractSource<P extends z.ZodType> extends Base<P> {
+  protected loading_ = false;
+
+  loading(): boolean {
+    return this.loading_;
+  }
+
+  // Idempotent and notifies so a failure still wakes observers of the loading state.
+  protected declareLoaded(): void {
+    if (!this.loading_) return;
+    this.loading_ = false;
+    this.notify();
+  }
+}
 
 export abstract class AbstractSink<P extends z.ZodType> extends Base<P> {}
 

--- a/pluto/src/vis/line/aether/line.bench.ts
+++ b/pluto/src/vis/line/aether/line.bench.ts
@@ -1,0 +1,234 @@
+// Copyright 2026 Synnax Labs, Inc.
+//
+// Use of this software is governed by the Business Source License included in the file
+// licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with the Business Source
+// License, use of this software will be governed by the Apache License, Version 2.0,
+// included in the file licenses/APL.txt.
+
+import {
+  DataType,
+  MultiSeries,
+  Series,
+  TimeRange,
+  TimeSpan,
+  TimeStamp,
+} from "@synnaxlabs/x";
+import { afterAll, bench, type BenchOptions, describe } from "vitest";
+
+import { GL_TRANSFORM } from "@/telem/aether/convertSeries";
+import { windowBounds } from "@/vis/line/aether/bounds";
+import { buildDrawOperations, DEFAULT_OVERLAP_THRESHOLD } from "@/vis/line/aether/line";
+
+// Measures back-fill fetch speed under render-loop contention and the per-frame cost
+// the plot pays once the back-fill lands.
+
+// Samples per iterator response (client framer/iterator.ts).
+const CHUNK = 1e5;
+const FRAME_INTERVAL_MS = 1000 / 60;
+// Cells above MAX_CHUNKS are dropped since run cost grows quadratically with chunks.
+const MAX_CHUNKS = 2600;
+
+interface Spec {
+  name: string;
+  rate: number;
+  span: TimeSpan;
+  channels: number;
+  sharedIndex: boolean;
+}
+
+const RATES: [string, number][] = [
+  ["1Hz", 1],
+  ["100Hz", 100],
+  ["1kHz", 1e3],
+];
+
+const SPANS: [string, TimeSpan][] = [
+  ["1d", TimeSpan.days(1)],
+  ["7d", TimeSpan.days(7)],
+  ["30d", TimeSpan.days(30)],
+  ["1y", TimeSpan.days(365)],
+];
+
+const chunkCount = ({ rate, span }: Pick<Spec, "rate" | "span">): number =>
+  Math.ceil((rate * span.seconds) / CHUNK);
+
+const MATRIX: Spec[] = RATES.flatMap(([rateName, rate]) =>
+  SPANS.map(([spanName, span]) => ({
+    name: `${rateName} ${spanName}`,
+    rate,
+    span,
+    channels: 1,
+    sharedIndex: true,
+  })),
+).filter((s) => chunkCount(s) <= MAX_CHUNKS);
+
+// Channel scaling is measured on one small cell to keep the suite bounded.
+const CHANNEL_SPECS: Spec[] = [2, 5, 10].flatMap((channels) =>
+  [true, false].map((sharedIndex) => ({
+    name: `100Hz 1d ${channels}ch ${sharedIndex ? "shared index" : "separate indexes"}`,
+    rate: 100,
+    span: TimeSpan.days(1),
+    channels,
+    sharedIndex,
+  })),
+);
+
+const fillRamp = (x: BigInt64Array, y: Float32Array, period: bigint): void => {
+  for (let i = 0; i < x.length; i++) {
+    x[i] = BigInt(i) * period;
+    y[i] = i % 1000;
+  }
+};
+
+interface Chunks {
+  x: Series[];
+  ys: Series[][];
+}
+
+const buildChunks = ({ rate, span, channels }: Spec): Chunks => {
+  const total = Math.round(rate * span.seconds);
+  const period = BigInt(Math.round(1e9 / rate));
+  interface Template {
+    x: BigInt64Array<ArrayBuffer>;
+    y: Float32Array<ArrayBuffer>;
+  }
+  const templates = new Map<number, Template>();
+  const template = (len: number): Template => {
+    let t = templates.get(len);
+    if (t == null) {
+      const x = new BigInt64Array(new ArrayBuffer(len * 8));
+      const y = new Float32Array(new ArrayBuffer(len * 4));
+      fillRamp(x, y, period);
+      t = { x, y };
+      templates.set(len, t);
+    }
+    return t;
+  };
+  const x: Series[] = [];
+  const ys: Series[][] = Array.from({ length: channels }, () => []);
+  for (let i = 0; i < total; i += CHUNK) {
+    const len = Math.min(CHUNK, total - i);
+    const t = template(len);
+    const start = period * BigInt(i);
+    const timeRange = new TimeRange(
+      new TimeStamp(start),
+      new TimeStamp(start + period * BigInt(len)),
+    );
+    const alignment = BigInt(i);
+    x.push(
+      new Series({ data: t.x, dataType: DataType.TIMESTAMP, timeRange, alignment }),
+    );
+    for (const y of ys)
+      y.push(
+        new Series({ data: t.y, dataType: DataType.FLOAT32, timeRange, alignment }),
+      );
+  }
+  return { x, ys };
+};
+
+// One data-path frame per line, omitting GL upload, so slowdowns are a lower bound.
+const frame = (x: MultiSeries, y: MultiSeries): void => {
+  windowBounds(x, y, x.bounds, DEFAULT_OVERLAP_THRESHOLD, y.bounds);
+  buildDrawOperations(x, y, 1, 0, "decimate", DEFAULT_OVERLAP_THRESHOLD);
+};
+
+// Drain frames walk only the short live window that is on screen during back-fill.
+const buildLive = (): { x: MultiSeries; y: MultiSeries } => {
+  const len = 2000;
+  const period = BigInt(1e7);
+  const xData = new BigInt64Array(new ArrayBuffer(len * 8));
+  const yData = new Float32Array(new ArrayBuffer(len * 4));
+  fillRamp(xData, yData, period);
+  const x: Series[] = [];
+  const y: Series[] = [];
+  for (let i = 0; i < 3; i++) {
+    const start = period * BigInt(i * len);
+    const timeRange = new TimeRange(
+      new TimeStamp(start),
+      new TimeStamp(start + period * BigInt(len)),
+    );
+    const alignment = BigInt(i * len);
+    x.push(
+      GL_TRANSFORM.convert(
+        new Series({ data: xData, dataType: DataType.TIMESTAMP, timeRange, alignment }),
+      ),
+    );
+    y.push(
+      new Series({ data: yData, dataType: DataType.FLOAT32, timeRange, alignment }),
+    );
+  }
+  return { x: new MultiSeries(x), y: new MultiSeries(y) };
+};
+
+const LIVE = buildLive();
+
+interface Landed {
+  xs: MultiSeries[];
+  ys: MultiSeries[];
+}
+
+// The real reader stages the whole drain and lands it in the cache as one batch.
+const drain = (chunks: Chunks, spec: Spec, rendering: boolean): Landed => {
+  const { channels, sharedIndex } = spec;
+  const stagedX: Series[][] = Array.from({ length: channels }, () => []);
+  const stagedY: Series[][] = Array.from({ length: channels }, () => []);
+  let last = performance.now();
+  for (let i = 0; i < chunks.x.length; i++) {
+    const shared = sharedIndex ? GL_TRANSFORM.convert(chunks.x[i]) : null;
+    for (let ch = 0; ch < channels; ch++) {
+      stagedX[ch].push(shared ?? GL_TRANSFORM.convert(chunks.x[i]));
+      stagedY[ch].push(GL_TRANSFORM.convert(chunks.ys[ch][i]));
+    }
+    if (rendering && performance.now() - last >= FRAME_INTERVAL_MS) {
+      frame(LIVE.x, LIVE.y);
+      last = performance.now();
+    }
+  }
+  return {
+    xs: stagedX.map((s) => new MultiSeries(s)),
+    ys: stagedY.map((s) => new MultiSeries(s)),
+  };
+};
+
+// Weight approximates timestamp conversions, the dominant per-chunk fetch cost.
+const opts = (spec: Spec): BenchOptions | undefined => {
+  const weight = chunkCount(spec) * (spec.sharedIndex ? 1 : spec.channels);
+  if (weight > 300)
+    return { time: 0, iterations: 1, warmupTime: 0, warmupIterations: 0 };
+  if (weight > 20)
+    return { time: 0, iterations: 3, warmupTime: 0, warmupIterations: 1 };
+  return undefined;
+};
+
+for (const spec of [...MATRIX, ...CHANNEL_SPECS]) {
+  const chunks = buildChunks(spec);
+  const o = opts(spec);
+  describe(`${spec.name} (${chunkCount(spec)} chunks)`, () => {
+    // The drain benches keep their landed result so frame after load reuses it.
+    let landed: Landed | null = null;
+    afterAll(() => {
+      landed = null;
+    });
+    const exec = (rendering: boolean): void => {
+      landed = drain(chunks, spec, rendering);
+    };
+    bench("fetch only", () => exec(false), o);
+    bench("fetch during render loop", () => exec(true), o);
+    // One frame over the landed back-fill, the recurring cost the plot pays after.
+    bench(
+      "frame after load",
+      () => {
+        if (landed == null) throw new Error("no landed back-fill");
+        for (let ch = 0; ch < spec.channels; ch++) frame(landed.xs[ch], landed.ys[ch]);
+      },
+      {
+        ...o,
+        setup: () => {
+          landed ??= drain(chunks, spec, false);
+        },
+      },
+    );
+  });
+}

--- a/pluto/src/vis/line/aether/line.ts
+++ b/pluto/src/vis/line/aether/line.ts
@@ -59,7 +59,7 @@ const safelyGetDataValue = (
 export type State = z.input<typeof stateZ>;
 export type ParsedState = z.infer<typeof stateZ>;
 
-const DEFAULT_OVERLAP_THRESHOLD = TimeSpan.milliseconds(2);
+export const DEFAULT_OVERLAP_THRESHOLD = TimeSpan.milliseconds(2);
 
 export interface FindResult {
   key: string;
@@ -305,6 +305,11 @@ export class Line extends aether.Leaf<typeof stateZ, InternalState> {
     i.xTelem.cleanup?.();
     i.yTelem.cleanup?.();
     i.requestRender("layout");
+  }
+
+  get loading(): boolean {
+    const { xTelem, yTelem } = this.internal;
+    return (xTelem.loading?.() ?? false) || (yTelem.loading?.() ?? false);
   }
 
   xBounds(): bounds.Bounds {


### PR DESCRIPTION
# Issue Pull Request

## Description

Selecting a range longer than the ~60s live buffer instantly rendered just the buffered window with the x axis autoscaled to it, then silently widened once the history read landed. Line plots now blank the viewport and show the standard orbital spinner with a "Fetching 90d of data" message until every line's initial back-fill settles. Spans within the live buffer keep the instant draw, and the loading state clears on the first failed read attempt so silent retries never hold the spinner.

Also adds a benchmark harness for the back-fill pipeline (`pluto/src/vis/line/aether/line.bench.ts`).

## Benchmarks

Idle machine. "Fetch" converts and lands the back-fill, "Fetch + Render" adds a 60 fps data-path frame over the live window during the drain, "Frame after load" is one data-path frame over the landed back-fill.

| Cell      | Chunks | Fetch  | Fetch + Render | Frame after load |
| --------- | ------ | ------ | -------------- | ---------------- |
| 1Hz 1y    | 316    | 2.68 s | 2.72 s         | 131 ms           |
| 100Hz 1d  | 87     | 774 ms | 737 ms         | 10.4 ms          |
| 100Hz 7d  | 605    | 5.09 s | 5.11 s         | 500 ms           |
| 100Hz 30d | 2592   | 21.8 s | 21.8 s         | 8.77 s           |
| 1kHz 1d   | 864    | 7.31 s | 7.36 s         | 979 ms           |

| Channels | Fetch, shared index | Fetch, separate indexes | Frame after load |
| -------- | ------------------- | ----------------------- | ---------------- |
| 1        | 774 ms              | n/a                     | 10.4 ms          |
| 5        | 742 ms              | 3.63 s                  | 50 ms            |
| 10       | 739 ms              | 7.32 s                  | 101 ms           |

- Fetch is linear at ~8.4 ms per chunk; rendering during the drain costs nothing measurable, so the loading state is a UX win rather than a fetch accelerator.
- The post-load frame is quadratic in chunk count, motivating follow-up work on series coalescing for month-scale spans.
- A shared index is flat across channel counts; separate indexes add one full timestamp conversion per channel.

<img width="675" height="503" alt="image" src="https://github.com/user-attachments/assets/1441cfd0-3014-4edd-9a3e-c15082094ad3" />



## Verification

- Automated tests cover the loading latch and threshold, the aggregation chain, render suppression, and the spinner overlay.
- Manually verified in the Console. Spinner and message on long spans, instant draw on short presets, spinner clears on a failed read.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [ ] I have updated documentation to reflect the changes.



<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This revision fixes the previous finding by applying the loading state to every nonempty static range while retaining the live-buffer threshold for rolling ranges.
- Static historical plots stay blank until their initial read settles.
- Rolling ranges within the live buffer still render immediately.
- Added tests cover short static reads, minimal spans, failures, cleanup, and the live-buffer boundary.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge because the previous static-range defect is fixed and no new actionable issue remains.

The resolved loading thread is fully fixed: nonempty static ranges now initiate and report their initial read before the plot draws, while rolling ranges within the live buffer still render immediately.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| pluto/src/telem/aether/remote.ts | Static sources now load for every nonempty range, while rolling sources retain the one-minute live-buffer threshold. |
| pluto/src/telem/aether/remote.spec.ts | Tests now cover short static reads and exact live-buffer threshold behavior. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    R[Selected range] --> V{Range variant}
    V -->|Static and nonempty| L[Show loading state]
    V -->|Rolling over one minute| L
    V -->|Rolling within live buffer| D[Draw live data]
    L --> F[Start history read]
    F -->|Success or first failure| N[Clear loading state]
    N --> D
```

<sub>Reviews (2): Last reviewed commit: ["Show the loading state for all static ra..."](https://github.com/synnaxlabs/synnax/commit/81d727946cd46107fde0d7cec48d84aa12f20d71) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=60909093)</sub>

**Context used:**

- Knowledge Base — [Console data tools and visualization](https://app.greptile.com/synnax/-/custom-context/knowledge-base/synnaxlabs/synnax/-/docs/console-data-tools.md)

<!-- /greptile_comment -->