### PR TITLE
SY-4822: Add Reload Console to every context menu that lacked it

### DIFF
--- a/.github/workflows/build.synnax.yaml
+++ b/.github/workflows/build.synnax.yaml
@@ -567,6 +567,11 @@ jobs:
           # only adds time. Linux stores it on the persistent root volume. Windows uses
           # D:\pnpm-store on NVMe (same volume as node_modules, wiped on stop/start).
           cache: ${{ !endsWith(matrix.os, '-build-bot') }}
+          # A build bot hosts several runners out of one home directory, so a shared
+          # dest lets one job's store cleanup delete files another is installing.
+          dest:
+            ${{ endsWith(matrix.os, '-build-bot') && format('~/setup-pnpm-{0}',
+            runner.name) || '~/setup-pnpm' }}
 
       - name: Build Console Web Assets
         if: inputs.console && inputs.console_ref_run_id == ''
@@ -885,8 +890,15 @@ jobs:
       - name: Set up pnpm and Node.js
         uses: pnpm/setup@v2
         with:
-          # The self-hosted mac's label lacks -build-bot, so it still uses the cache.
+          # Signed builds run on macos-latest and windows-latest, which start cold and
+          # want the cache. An unsigned build takes macos-build-bot, which keeps a local
+          # store, so restoring the GitHub cache tarball only adds time.
           cache: ${{ !endsWith(matrix.os, '-build-bot') }}
+          # A build bot hosts several runners out of one home directory, so a shared
+          # dest lets one job's store cleanup delete files another is installing.
+          dest:
+            ${{ endsWith(matrix.os, '-build-bot') && format('~/setup-pnpm-{0}',
+            runner.name) || '~/setup-pnpm' }}
 
       - name: Adjust Auto Updater URL for Release Candidate
         if: inputs.sign_binaries && github.ref == 'refs/heads/rc'

--- a/console/src/app/window/Window.spec.tsx
+++ b/console/src/app/window/Window.spec.tsx
@@ -26,8 +26,8 @@ const fireFileDragOver = (target: HTMLElement): void => {
 describe("app/window/Window", () => {
   installPortalRoot();
 
-  // The window's own background carries no actions of its own, so Reload Console is
-  // the only thing standing between a right click there and a dead menu.
+  // The window's own background carries no actions of its own, so Reload Console is the
+  // only thing standing between a right click there and a dead menu.
   it("offers Reload Console from the window background", async () => {
     const { container } = await renderWithConsole(
       <Haul.Provider {...Session.Haul.PROVIDER_PROPS}>

--- a/console/src/app/window/Window.spec.tsx
+++ b/console/src/app/window/Window.spec.tsx
@@ -8,7 +8,7 @@
 // included in the file licenses/APL.txt.
 
 import { Haul } from "@synnaxlabs/pluto";
-import { createEvent, fireEvent, waitFor } from "@testing-library/react";
+import { createEvent, fireEvent, screen, waitFor } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
 
 import { Window } from "@/app/window";
@@ -25,6 +25,18 @@ const fireFileDragOver = (target: HTMLElement): void => {
 
 describe("app/window/Window", () => {
   installPortalRoot();
+
+  // The window's own background carries no actions of its own, so Reload Console is
+  // the only thing standing between a right click there and a dead menu.
+  it("offers Reload Console from the window background", async () => {
+    const { container } = await renderWithConsole(
+      <Haul.Provider {...Session.Haul.PROVIDER_PROPS}>
+        <Window.Window />
+      </Haul.Provider>,
+    );
+    fireEvent.contextMenu(getBySelector<HTMLElement>(container, ".console-main"));
+    expect(await screen.findByText("Reload Console")).toBeTruthy();
+  });
 
   // Dropping a file onto the mosaic imports it, but only while the haul carries FILE.
   // Nothing else starts that drag, so losing this makes every file drop a no-op.

--- a/console/src/feature/access/role/tree.spec.ts
+++ b/console/src/feature/access/role/tree.spec.ts
@@ -44,6 +44,16 @@ describe("role ontology service", () => {
     expect(screen.getByText("Copy properties")).toBeTruthy();
   });
 
+  it("should offer Reload Console", async () => {
+    const role = await createRole();
+    assertDefined(RoleItem.ContextMenu);
+    await renderTreeContextMenu(RoleItem.ContextMenu, {
+      client,
+      resources: [roleResource(role.key, role.name, false)],
+    });
+    expect(await screen.findByText("Reload Console")).toBeTruthy();
+  });
+
   it("should hide rename from a subject who cannot write the role", async () => {
     const role = await createRole();
     const viewer = await roles.get("Viewer");

--- a/console/src/feature/arc/editor/Text.tsx
+++ b/console/src/feature/arc/editor/Text.tsx
@@ -10,7 +10,10 @@
 import { Arc } from "@synnaxlabs/pluto";
 
 import { TaskControls } from "@/feature/arc/editor/TaskControls";
+import { ContextMenu } from "@/platform/context-menu";
 import { Session } from "@/session";
+
+const EXTRA_MENU_ITEMS = <ContextMenu.ReloadConsoleItem />;
 
 export const Text = () => {
   // Background tabs stay mounted, so an ungated autofocus would let any of them pull
@@ -18,7 +21,10 @@ export const Text = () => {
   const getTabIsFocused = Session.Panel.useGetTabIsFocused();
   return (
     <>
-      <Arc.Text.Editor autoFocus={getTabIsFocused()} />
+      <Arc.Text.Editor
+        autoFocus={getTabIsFocused()}
+        extraMenuItems={EXTRA_MENU_ITEMS}
+      />
       <TaskControls />
     </>
   );

--- a/console/src/feature/arc/tree.spec.ts
+++ b/console/src/feature/arc/tree.spec.ts
@@ -63,6 +63,13 @@ describe("arc/ontology", () => {
   });
 
   describe("context menu", () => {
+    it("should offer Reload Console", async () => {
+      const { arc, root } = await createArcInGroup();
+      await renderOntologyTree({ client, root, items: Arc.TREE_ITEMS });
+      await openTreeRowContextMenu(arc.name);
+      expect(await screen.findByText("Reload Console")).toBeTruthy();
+    });
+
     it("renames the Arc in place without a confirmation prompt", async () => {
       const { arc, root } = await createArcInGroup();
       await renderOntologyTree({ client, root, items: Arc.TREE_ITEMS });

--- a/console/src/feature/channel/tree.spec.ts
+++ b/console/src/feature/channel/tree.spec.ts
@@ -277,6 +277,18 @@ describe("channel/ontology", () => {
       expect(await screen.findByDisplayValue(calc.name)).toBeTruthy();
     });
 
+    it("should offer Reload Console", async () => {
+      const ch = await createChannel();
+      assertDefined(Item.ContextMenu);
+      await renderTreeContextMenu(Item.ContextMenu, {
+        client,
+        resources: [
+          createResource(channelClient.ontologyID(ch.key), ch.name, ch.payload),
+        ],
+      });
+      expect(await screen.findByText("Reload Console")).toBeTruthy();
+    });
+
     it("withholds rename and aliasing from an internal channel", async () => {
       const ch = await createChannel();
       const rng = await createTestRange(client);

--- a/console/src/feature/device/tree.spec.ts
+++ b/console/src/feature/device/tree.spec.ts
@@ -100,6 +100,17 @@ describe("device/ontology", () => {
 });
 
 describe("permission to write the device", () => {
+  it("should offer Reload Console", async () => {
+    const dev = await createTestDevice(client);
+    const Item = Device.TREE_ITEMS.device;
+    assertDefined(Item.ContextMenu);
+    await renderTreeContextMenu(Item.ContextMenu, {
+      client,
+      resources: [createResource(deviceClient.ontologyID(dev.key), dev.name)],
+    });
+    expect(await screen.findByText("Reload Console")).toBeTruthy();
+  });
+
   it("should withhold rename, grouping, and delete from a viewer", async () => {
     const dev = await createTestDevice(client);
     const Item = Device.TREE_ITEMS.device;

--- a/console/src/feature/group/tree.spec.ts
+++ b/console/src/feature/group/tree.spec.ts
@@ -36,6 +36,16 @@ describe("group ontology service", () => {
     expect(Item.haulItems(res)).toEqual([res.id]);
   });
 
+  it("should offer Reload Console", async () => {
+    const g = await createGroup(ontology.ROOT_ID);
+    assertDefined(Item.ContextMenu);
+    await renderTreeContextMenu(Item.ContextMenu, {
+      client,
+      resources: [groupResource(g.key, g.name)],
+    });
+    expect(await screen.findByText("Reload Console")).toBeTruthy();
+  });
+
   it("should hide rename and ungroup for a zero-depth selection", async () => {
     const g = await createGroup(ontology.ROOT_ID);
     assertDefined(Item.ContextMenu);

--- a/console/src/feature/http/task/Read.spec.ts
+++ b/console/src/feature/http/task/Read.spec.ts
@@ -131,6 +131,16 @@ describe("HTTP Read form", () => {
     await waitFor(() => expect(screen.getAllByText(/\/api\/v1/)).toHaveLength(1));
   });
 
+  it("should offer Reload Console from the endpoint context menu", async () => {
+    await renderRead();
+    await addEndpoint();
+    const path = screen.getByPlaceholderText("/api/data");
+    fireEvent.change(path, { target: { value: "/api/v1" } });
+    fireEvent.blur(path);
+    fireEvent.contextMenu(await screen.findByText(/\/api\/v1/));
+    expect(await screen.findByText("Reload Console")).toBeTruthy();
+  });
+
   it("should seed the form from the task row's config", async () => {
     const client = createTestClient();
     const config = createReadConfig("dev_1", [

--- a/console/src/feature/lineplot/LinePlot.tsx
+++ b/console/src/feature/lineplot/LinePlot.tsx
@@ -88,6 +88,8 @@ const RangeAnnotationContextMenu = ({
         <Icon.CSV />
         Download as CSV
       </Menu.Item>
+      <Menu.Divider />
+      <ContextMenu.ReloadConsoleItem />
     </ContextMenu.Menu>
   );
 };

--- a/console/src/feature/lineplot/toolbar/Annotations.spec.ts
+++ b/console/src/feature/lineplot/toolbar/Annotations.spec.ts
@@ -128,6 +128,12 @@ describe("lineplot/toolbar/Annotations", () => {
     });
   });
 
+  it("offers Reload Console from the list context menu", async () => {
+    await createRule();
+    fireEvent.contextMenu(screen.getByText("Rule 1"));
+    expect(await screen.findByText("Reload Console")).toBeTruthy();
+  });
+
   it("removes rules through the list context menu", async () => {
     const { key, store } = await createRule();
     fireEvent.contextMenu(screen.getByText("Rule 1"));

--- a/console/src/feature/lineplot/tree.spec.tsx
+++ b/console/src/feature/lineplot/tree.spec.tsx
@@ -228,6 +228,16 @@ describe("lineplot/ontology", () => {
 });
 
 describe("permission to write the line plot", () => {
+  it("should offer Reload Console", async () => {
+    const plot = await createLinePlot();
+    assertDefined(Item.ContextMenu);
+    await renderTreeContextMenu(Item.ContextMenu, {
+      client,
+      resources: [createResource(clientLineplot.ontologyID(plot.key), plot.name)],
+    });
+    expect(await screen.findByText("Reload Console")).toBeTruthy();
+  });
+
   it("should withhold rename, grouping, and delete from a viewer", async () => {
     const plot = await createLinePlot();
     assertDefined(Item.ContextMenu);

--- a/console/src/feature/log/tree.spec.ts
+++ b/console/src/feature/log/tree.spec.ts
@@ -35,6 +35,16 @@ const logResource = (key: string, name: string) =>
   createResource(log.ontologyID(key), name);
 
 describe("log ontology service", () => {
+  it("should offer Reload Console", async () => {
+    const l = await createLog();
+    assertDefined(Item.ContextMenu);
+    await renderTreeContextMenu(Item.ContextMenu, {
+      client,
+      resources: [logResource(l.key, l.name)],
+    });
+    expect(await screen.findByText("Reload Console")).toBeTruthy();
+  });
+
   it("should expose rename, group, delete, export, and link actions", async () => {
     const l = await createLog();
     assertDefined(Item.ContextMenu);

--- a/console/src/feature/pagerduty/task/Alert.spec.ts
+++ b/console/src/feature/pagerduty/task/Alert.spec.ts
@@ -78,6 +78,13 @@ describe("PagerDuty Alert form", () => {
     await screen.findByText("Disable");
   });
 
+  it("should offer Reload Console from the alert context menu", async () => {
+    await renderAlert();
+    await addAlert();
+    fireEvent.contextMenu(screen.getByText("New alert"));
+    expect(await screen.findByText("Reload Console")).toBeTruthy();
+  });
+
   it("should remove alerts through the context menu", async () => {
     await renderAlert();
     await addAlert();

--- a/console/src/feature/panel/Selector.spec.tsx
+++ b/console/src/feature/panel/Selector.spec.tsx
@@ -546,6 +546,11 @@ describe("Panel.Selector", () => {
       await screen.findByText("Delete");
     };
 
+    it("should offer Reload Console", async () => {
+      await openPillMenu();
+      expect(screen.getByText("Reload Console")).toBeTruthy();
+    });
+
     it("should offer the panel in a second window in the tauri engine", async () => {
       mocks.engine = "tauri";
       await openPillMenu();

--- a/console/src/feature/project/tree.spec.ts
+++ b/console/src/feature/project/tree.spec.ts
@@ -50,6 +50,17 @@ afterEach(() => {
 });
 
 describe("project ontology service", () => {
+  it("should offer Reload Console", async () => {
+    const p = await createProject();
+    assertDefined(Item.ContextMenu);
+    await renderTreeContextMenu(Item.ContextMenu, {
+      client,
+      resources: [projectResource(p.key, p.name)],
+      store: await createStoreWithActive(p.key),
+    });
+    expect(await screen.findByText("Reload Console")).toBeTruthy();
+  });
+
   it("should expose creation, import, export, and link actions", async () => {
     const p = await createProject();
     assertDefined(Item.ContextMenu);

--- a/console/src/feature/rack/tree.spec.ts
+++ b/console/src/feature/rack/tree.spec.ts
@@ -83,6 +83,12 @@ describe("rack ontology service", () => {
     expect(screen.getByText("Delete")).toBeTruthy();
   });
 
+  it("should offer Reload Console", async () => {
+    const r = await createRack();
+    await renderMenu([r]);
+    expect(await screen.findByText("Reload Console")).toBeTruthy();
+  });
+
   it("should hide single-selection actions for a multi-rack selection", async () => {
     const a = await createRack();
     const b = await createRack();

--- a/console/src/feature/range/Toolbar.spec.tsx
+++ b/console/src/feature/range/Toolbar.spec.tsx
@@ -180,6 +180,13 @@ describe("range/Toolbar", () => {
       );
     });
 
+    it("offers Reload Console", async () => {
+      const rng = await createTestRange(client);
+      await renderToolbar({ ranges: [toState(rng)] });
+      await openContextMenu(rng.name);
+      expect(await screen.findByText("Reload Console")).toBeTruthy();
+    });
+
     it("clears the active range", async () => {
       const rng = await createTestRange(client);
       const { store } = await renderToolbar({

--- a/console/src/feature/range/list/List.spec.tsx
+++ b/console/src/feature/range/list/List.spec.tsx
@@ -72,6 +72,17 @@ describe("range/list/List", () => {
     expect(screen.queryByText(other.name)).toBeNull();
   });
 
+  it("offers Reload Console from a range's context menu", async () => {
+    const rng = await createTestRange(client);
+    await renderList();
+    const input = await waitFor(() =>
+      getInputByNodePlaceholder(document.body, "Search Ranges..."),
+    );
+    fireEvent.change(input, { target: { value: rng.name } });
+    fireEvent.contextMenu(await screen.findByText(rng.name));
+    expect(await screen.findByText("Reload Console")).toBeTruthy();
+  });
+
   it("opens the create range modal from the add button", async () => {
     await renderList();
     await waitFor(() => getInputByNodePlaceholder(document.body, "Search Ranges..."));

--- a/console/src/feature/range/tree.spec.ts
+++ b/console/src/feature/range/tree.spec.ts
@@ -68,6 +68,13 @@ describe("range/ontology", () => {
   });
 
   describe("context menu", () => {
+    it("should offer Reload Console", async () => {
+      const { rng, root } = await createRangeInGroup();
+      await renderOntologyTree({ client, root, items: Range.TREE_ITEMS });
+      await openTreeRowContextMenu(rng.name);
+      expect(await screen.findByText("Reload Console")).toBeTruthy();
+    });
+
     it("renames the range in place and syncs the favorited copy", async () => {
       const { rng, root } = await createRangeInGroup();
       const { store } = await renderOntologyTree({

--- a/console/src/feature/schematic/toolbar/Symbols.spec.ts
+++ b/console/src/feature/schematic/toolbar/Symbols.spec.ts
@@ -149,6 +149,15 @@ describe("Schematic toolbar Symbols", () => {
     });
   });
 
+  it("offers Reload Console from a remote symbol's context menu", async () => {
+    const name = uniqueName("reload_sym");
+    const { grp } = await createRemoteSymbolGroup([name]);
+    await renderSymbolsToolbar();
+    fireEvent.click(await screen.findByText(grp.name));
+    fireEvent.contextMenu(await screen.findByText(name));
+    expect(await screen.findByText("Reload Console")).toBeTruthy();
+  });
+
   it("exports a remote symbol as JSON through its context menu", async () => {
     const downloads = captureBrowserDownloads();
     const name = uniqueName("exp_sym");

--- a/console/src/feature/schematic/tree.spec.ts
+++ b/console/src/feature/schematic/tree.spec.ts
@@ -212,6 +212,18 @@ describe("Schematic TreeContextMenu", () => {
 });
 
 describe("permission to write the schematic", () => {
+  it("should offer Reload Console", async () => {
+    const s = await createSchematic();
+    assertDefined(Item.ContextMenu);
+    await renderTreeContextMenu(Item.ContextMenu, {
+      client,
+      resources: [
+        createResource(schematic.ontologyID(s.key), s.name, { snapshot: false }),
+      ],
+    });
+    expect(await screen.findByText("Reload Console")).toBeTruthy();
+  });
+
   it("should withhold rename, grouping, copying, and delete from a viewer", async () => {
     const s = await createSchematic();
     assertDefined(Item.ContextMenu);

--- a/console/src/feature/status/list/ContextMenu.spec.tsx
+++ b/console/src/feature/status/list/ContextMenu.spec.tsx
@@ -71,6 +71,12 @@ describe("status list context menu", () => {
     expect(await screen.findByText("Unfavorite")).toBeTruthy();
   });
 
+  it("should offer Reload Console", async () => {
+    const s = await createStatus();
+    await renderMenu([s.key]);
+    expect(await screen.findByText("Reload Console")).toBeTruthy();
+  });
+
   it("should unfavorite an already-favorited status", async () => {
     const s = await createStatus();
     const store = await renderMenu([s.key], [s.key]);

--- a/console/src/feature/table/tree.spec.tsx
+++ b/console/src/feature/table/tree.spec.tsx
@@ -97,6 +97,12 @@ describe("table/ontology", () => {
       expect(screen.getByText("Copy properties")).toBeDefined();
     });
 
+    it("should offer Reload Console", async () => {
+      const t = await createTable();
+      await renderMenu({ tables: [t] });
+      expect(await screen.findByText("Reload Console")).toBeTruthy();
+    });
+
     it("hides single-selection items for multi-selections", async () => {
       const [a, b] = [await createTable(), await createTable()];
       await renderMenu({ tables: [a, b] });

--- a/console/src/feature/task/Toolbar.spec.tsx
+++ b/console/src/feature/task/Toolbar.spec.tsx
@@ -177,6 +177,13 @@ describe("task/Toolbar", () => {
       expect(await awaitTaskResourceTab(created)).toBe(t.key);
     });
 
+    it("offers Reload Console", async () => {
+      const t = await createTask();
+      await renderToolbar();
+      await openContextMenu(t.name);
+      expect(await screen.findByText("Reload Console")).toBeTruthy();
+    });
+
     it("issues a start command for a stopped task", async () => {
       const t = await createTask({ running: false });
       const streamer = await client.openStreamer(task.COMMAND_CHANNEL_NAME);

--- a/console/src/feature/task/tree.spec.tsx
+++ b/console/src/feature/task/tree.spec.tsx
@@ -233,6 +233,15 @@ describe("task ontology", () => {
 });
 
 describe("permission to write the task", () => {
+  it("should offer Reload Console", async () => {
+    const t = await createTask();
+    await renderTreeContextMenu(Menu, {
+      client,
+      resources: [createResource(t.ontologyID, t.name, { snapshot: false })],
+    });
+    expect(await screen.findByText("Reload Console")).toBeTruthy();
+  });
+
   it("should withhold rename, grouping, and delete from a viewer", async () => {
     const t = await createTask();
     await renderTreeContextMenu(Menu, {

--- a/console/src/feature/user/tree.spec.ts
+++ b/console/src/feature/user/tree.spec.ts
@@ -48,6 +48,12 @@ describe("user ontology service", () => {
     expect(screen.getByText("Copy properties")).toBeTruthy();
   });
 
+  it("should offer Reload Console", async () => {
+    const u = await createUser();
+    await renderMenu([userResource(u.key, u.username)]);
+    expect(await screen.findByText("Reload Console")).toBeTruthy();
+  });
+
   it("should not offer username or role changes for the logged-in user", async () => {
     const u = await createUser();
     await renderMenu([userResource(u.key, "synnax")]);

--- a/console/src/platform/arc/ContextMenu.spec.tsx
+++ b/console/src/platform/arc/ContextMenu.spec.tsx
@@ -55,6 +55,11 @@ describe("Arc.ContextMenu", () => {
     expect(await screen.findByText("Delete")).toBeTruthy();
   });
 
+  it("should offer Reload Console", async () => {
+    await renderMenu(await createArc());
+    expect(await screen.findByText("Reload Console")).toBeTruthy();
+  });
+
   it.each(["Viewer", "Operator"] as const)(
     "should withhold the write actions from a %s",
     async (role) => {

--- a/console/src/platform/channel/useCalculatedModal.tsx
+++ b/console/src/platform/channel/useCalculatedModal.tsx
@@ -27,6 +27,7 @@ import {
 import { primitive } from "@synnaxlabs/x";
 import { useState } from "react";
 
+import { ContextMenu } from "@/platform/context-menu";
 import { CSS } from "@/platform/css";
 import { Modals } from "@/platform/modals";
 import { Triggers } from "@/platform/triggers";
@@ -45,6 +46,8 @@ const NAME_INPUT_PROPS: Partial<Input.TextProps> = {
   variant: "text",
   placeholder: "Name",
 };
+
+const EXTRA_MENU_ITEMS = <ContextMenu.ReloadConsoleItem />;
 
 export const useCalculatedModal = Modals.create<CalculatedModalParams>(
   ({ channelKey, close }) => {
@@ -90,6 +93,7 @@ export const useCalculatedModal = Modals.create<CalculatedModalParams>(
                     initialValue={value}
                     language={Arc.NAME}
                     onValueChange={onChange}
+                    extraMenuItems={EXTRA_MENU_ITEMS}
                     isBlock
                     bordered
                     rounded

--- a/console/src/platform/context-menu/ReloadConsoleItem.spec.tsx
+++ b/console/src/platform/context-menu/ReloadConsoleItem.spec.tsx
@@ -7,25 +7,38 @@
 // License, use of this software will be governed by the Apache License, Version 2.0,
 // included in the file licenses/APL.txt.
 
+import { Drift } from "@synnaxlabs/drift";
 import { Menu } from "@synnaxlabs/pluto";
 import { fireEvent, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it } from "vitest";
 
 import { ContextMenu } from "@/platform/context-menu";
 import { Link } from "@/platform/link";
-import { renderWithConsole } from "@/testutil";
+import { renderWithConsole, type TestStore } from "@/testutil";
+
+const render = async (): Promise<TestStore> => {
+  const { store } = await renderWithConsole(
+    <Menu.Menu>
+      <ContextMenu.ReloadConsoleItem />
+    </Menu.Menu>,
+  );
+  return store;
+};
 
 describe("ContextMenu.ReloadConsoleItem", () => {
   beforeEach(() => localStorage.removeItem(Link.SHOULD_IGNORE_KEY));
 
   it("flags the next deep link as ignored before reloading", async () => {
-    await renderWithConsole(
-      <Menu.Menu>
-        <ContextMenu.ReloadConsoleItem />
-      </Menu.Menu>,
-    );
+    await render();
     expect(localStorage.getItem(Link.SHOULD_IGNORE_KEY)).toBeNull();
     fireEvent.click(screen.getByText("Reload Console"));
     expect(localStorage.getItem(Link.SHOULD_IGNORE_KEY)).toBe("true");
+  });
+
+  it("moves the window into its reloading stage", async () => {
+    const store = await render();
+    expect(Drift.selectWindow(store.getState())?.stage).not.toBe("reloading");
+    fireEvent.click(screen.getByText("Reload Console"));
+    expect(Drift.selectWindow(store.getState())?.stage).toBe("reloading");
   });
 });

--- a/console/src/platform/core/list/List.spec.tsx
+++ b/console/src/platform/core/list/List.spec.tsx
@@ -57,6 +57,15 @@ describe("Core List", () => {
     });
   });
 
+  it("should offer Reload Console from a Core's context menu", async () => {
+    await renderCoreUI(
+      <Core.List value={ALPHA.key} onChange={vi.fn()} />,
+      createCoreState([ALPHA], ALPHA.key),
+    );
+    fireEvent.contextMenu(await screen.findByText("Alpha"));
+    expect(await screen.findByText("Reload Console")).toBeTruthy();
+  });
+
   // The link names the cluster, not the record, so it opens on a machine whose own
   // record for that cluster carries a different key.
   it("should copy a link to the Core's cluster from the context menu", async () => {

--- a/pluto/src/arc/text/Editor.tsx
+++ b/pluto/src/arc/text/Editor.tsx
@@ -19,9 +19,12 @@ import { Synnax } from "@/synnax";
 
 const PLACEHOLDER = "Start typing to write your automation";
 
-export interface EditorProps extends Pick<Code.EditorProps, "autoFocus"> {}
+export interface EditorProps extends Pick<
+  Code.EditorProps,
+  "autoFocus" | "extraMenuItems"
+> {}
 
-export const Editor = ({ autoFocus = false }: EditorProps) => {
+export const Editor = ({ autoFocus = false, extraMenuItems }: EditorProps) => {
   const resourceKey = useKey();
   const client = Synnax.use();
   const dispatch = useSingleDispatch();
@@ -71,6 +74,7 @@ export const Editor = ({ autoFocus = false }: EditorProps) => {
       background={0}
       placeholder={PLACEHOLDER}
       autoFocus={autoFocus && value.length === 0}
+      extraMenuItems={extraMenuItems}
       scrollBeyondLastLine
     />
   );

--- a/pluto/src/code/Editor.spec.tsx
+++ b/pluto/src/code/Editor.spec.tsx
@@ -13,6 +13,7 @@ import { afterEach, beforeEach, describe, expect, it, type Mock, vi } from "vite
 
 import { Editor, type EditorHandle } from "@/code/Editor";
 import { BASE_THEMES, type EditorExtension, type Language } from "@/code/language";
+import { Menu } from "@/menu";
 import { Triggers } from "@/triggers";
 
 const ESCAPE: Triggers.Trigger = ["Escape"];
@@ -445,6 +446,12 @@ describe("Editor", () => {
       expect(screen.getByText("Copy")).toBeTruthy();
       expect(screen.getByText("Paste")).toBeTruthy();
       expect(screen.getByText("Format")).toBeTruthy();
+    });
+
+    it("should append the consumer's extra items to the menu", () => {
+      renderEditor({ extraMenuItems: <Menu.Item itemKey="extra">Extra</Menu.Item> });
+      openMenu(monaco.editorInstance);
+      expect(screen.getByText("Extra")).toBeTruthy();
     });
 
     it.each([

--- a/pluto/src/code/Editor.tsx
+++ b/pluto/src/code/Editor.tsx
@@ -461,6 +461,9 @@ export interface EditorProps
   extends Omit<Flex.BoxProps, "value" | "onChange" | "ref">, UseProps {
   ref?: Ref<EditorHandle>;
   loading?: ReactNode;
+  /** extraMenuItems are appended to the context menu, so a consumer can add
+   * app-specific entries (e.g. "Reload Console"). */
+  extraMenuItems?: ReactNode;
 }
 
 const MENU_EDITOR_ACTIONS: Record<string, string> = {
@@ -484,6 +487,7 @@ const EditorInternal = ({
   placeholder,
   autoFocus,
   background = 1,
+  extraMenuItems,
   ...rest
 }: Omit<EditorProps, "loading">) => {
   const { className: menuClassName, ...menuProps } = Menu.useContextMenu();
@@ -576,9 +580,10 @@ const EditorInternal = ({
           Format
         </Menu.Item>
         <Menu.Divider />
+        {extraMenuItems}
       </Menu.Menu>
     );
-  }, [createMenuAction, cursorRenameable]);
+  }, [createMenuAction, cursorRenameable, extraMenuItems]);
 
   return (
     <Flex.Box

--- a/pluto/src/log/Base.spec.tsx
+++ b/pluto/src/log/Base.spec.tsx
@@ -12,6 +12,7 @@ import { type FC, type PropsWithChildren } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Base } from "@/log/Base";
+import { Menu } from "@/menu";
 import { createSynnaxWrapper } from "@/testutil/Synnax";
 import { Triggers } from "@/triggers";
 
@@ -124,6 +125,14 @@ describe("log/Base", () => {
     it("should render custom empty content when provided", () => {
       renderLog({ emptyContent: <div data-testid="custom-empty">No data</div> });
       expect(screen.getByTestId("custom-empty")).toBeDefined();
+    });
+
+    it("should append the consumer's extra context menu items", async () => {
+      const { container } = renderLog({
+        extraContextMenuItems: <Menu.Item itemKey="extra">Extra</Menu.Item>,
+      });
+      fireEvent.contextMenu(getLogDiv(container));
+      expect(await screen.findByText("Extra")).toBeDefined();
     });
 
     it("should apply className to the container div", () => {

--- a/pluto/src/table/ContextMenu.spec.tsx
+++ b/pluto/src/table/ContextMenu.spec.tsx
@@ -14,6 +14,7 @@ import { type PropsWithChildren, type ReactElement } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Errors } from "@/errors";
+import { Menu } from "@/menu";
 import { Table } from "@/table";
 import {
   DefaultContextMenu,
@@ -85,6 +86,11 @@ describe("table DefaultContextMenu", () => {
     renderMenu({ editable: true });
     expect(await screen.findByText("Undo")).toBeDefined();
     expect(screen.getByText("Redo")).toBeDefined();
+  });
+
+  it("appends the consumer's extra items", async () => {
+    renderMenu({ extra: <Menu.Item itemKey="extra">Extra</Menu.Item> });
+    expect(await screen.findByText("Extra")).toBeDefined();
   });
 
   it("withholds undo and redo from a read-only table", async () => {


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4822](https://linear.app/synnax/issue/SY-4822)

## Description

The Arc text editor context menu had no Reload Console item. An audit of every Console
context menu found two more without it: the calculated channel expression editor and the
line plot range annotation menu.

Both editors are Pluto's `Code.Editor`, which gave consumers no way to add items. It now
takes `extraMenuItems`, matching `Schematic`, `Table`, and the Arc graph editor, and
`Arc.Text.Editor` forwards it.

The item was clicked by one spec and asserted by six. All 40 menus carry it, 35 now have
a spec that opens the menu and finds it, and the item's own spec asserts the window
reaches its reloading stage as well as the deep-link flag. Five surfaces cannot mount in
jsdom: the schematic and Arc graph canvases, the line plot, the table, and the log need
aether registries Pluto does not publish, and both Monaco editors need a Monaco mock the
Console may not install. For the table, the log, and the editors the extra-items
contract is pinned in Pluto instead.

The last commit is unrelated, and fixes this PR's own CI. A build bot hosts several
runners out of one home directory, so concurrent jobs shared `~/setup-pnpm` and
`pnpm/setup` failed with ENOTEMPTY while cleaning a store another job was installing
into. Each runner now gets its own dest. Happy to split it into its own PR.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.





<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Reload Console to the Arc text editor, calculated-channel editor, and line-plot range annotation menu. It extends Pluto's code editor context-menu API, adds broad menu coverage, verifies reload state transitions, and isolates pnpm setup directories for concurrent self-hosted runners.

- Adds consumer-provided menu items to `Code.Editor` and forwards them through `Arc.Text.Editor`.
- Adds Reload Console to the three audited context menus.
- Adds context-menu and reload-state tests across the Console and Pluto.
- Uses runner-specific pnpm setup destinations on self-hosted build bots.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge, with no actionable new defects found.

The new menu extension points are forwarded to each intended surface and covered by focused tests. The workflow uses a supported pnpm setup input and preserves the shared default only for GitHub-hosted runners.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| pluto/src/code/Editor.tsx | Adds a consumer-provided React node to the editor context menu. |
| pluto/src/arc/text/Editor.tsx | Forwards extra context-menu items to the underlying code editor. |
| console/src/feature/arc/editor/Text.tsx | Adds Reload Console to the Arc text editor menu. |
| console/src/platform/channel/useCalculatedModal.tsx | Adds Reload Console to the calculated-channel expression editor. |
| console/src/feature/lineplot/LinePlot.tsx | Adds Reload Console to the range annotation context menu. |
| .github/workflows/build.synnax.yaml | Isolates pnpm action installation directories by self-hosted runner. |


<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart LR
    Console[Console surface] --> Extra[Reload Console item]
    Extra --> Code[Pluto Code.Editor]
    Code --> Menu[Editor context menu]
    Menu --> Reload[Console reload action]
```

<sub>Reviews (2): Last reviewed commit: ["reflow"](https://github.com/synnaxlabs/synnax/commit/c4d3c465ab14e59c4b397f15e34918325350e698) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=62713116)</sub>

<!-- /greptile_comment -->