### PR TITLE
SY-4827: Fix ellipses on version update text

### DIFF
--- a/console/src/platform/version/Info.css
+++ b/console/src/platform/version/Info.css
@@ -23,6 +23,14 @@
         height: 10rem;
     }
 
+    .console-version-info__download {
+        width: 50rem;
+
+        & > .pluto-text {
+            flex-shrink: 0;
+        }
+    }
+
     .console-version-info__footer-note {
         position: absolute;
         bottom: 3rem;

--- a/console/src/platform/version/useInfoModal.spec.tsx
+++ b/console/src/platform/version/useInfoModal.spec.tsx
@@ -94,6 +94,22 @@ describe("version useInfoModal", () => {
     expect(mocks.relaunch).not.toHaveBeenCalled();
   });
 
+  it("should hold the progress bar empty until the download reports a total", async () => {
+    mocks.engine = "tauri";
+    const downloadAndInstall = vi.fn(async () => await new Promise<void>(() => {}));
+    mocks.update = { version: "9.9.9", downloadAndInstall };
+    openModal();
+    await waitFor(() =>
+      expect(screen.getByText("Version 9.9.9 available")).toBeTruthy(),
+    );
+    await act(async () => {
+      fireEvent.click(screen.getByRole("button", { name: "Update and restart" }));
+    });
+    await waitFor(() => expect(screen.getByText("Downloading update")).toBeTruthy());
+    const bar = document.querySelector<HTMLElement>(".pluto-progress-bar");
+    expect(bar?.style.width).toEqual("0%");
+  });
+
   it("should never install an update without a click", async () => {
     mocks.engine = "tauri";
     const downloadAndInstall = vi.fn(async () => {});

--- a/console/src/platform/version/useInfoModal.tsx
+++ b/console/src/platform/version/useInfoModal.tsx
@@ -113,8 +113,8 @@ export const useInfoModal = Modals.create(() => {
   const version = Session.Version.use();
   const available = useUpdateCheck();
   const { download, start } = useDownload();
-  const progressPercent =
-    (download.progress.valueOf() / download.total.valueOf()) * 100;
+  const total = download.total.valueOf();
+  const progressPercent = total === 0 ? 0 : (download.progress.valueOf() / total) * 100;
 
   let updateContent = (
     <Status.Summary level="h4" weight={350} variant="loading" gap="medium">
@@ -138,9 +138,14 @@ export const useInfoModal = Modals.create(() => {
           <Status.Summary variant="loading" level="h4" gap="medium">
             Downloading update
           </Status.Summary>
-          <Flex.Box x gap="medium" align="center" justify="center">
+          <Flex.Box
+            className={CSS.BE("version-info", "download")}
+            x
+            gap="medium"
+            align="center"
+          >
             <Progress.Progress value={progressPercent} />
-            <Text.Text color={10} overflow="ellipsis">
+            <Text.Text color={10} overflow="nowrap">
               {Math.ceil(download.progress.megabytes)} /{" "}
               {Math.ceil(download.total.megabytes)} MB
             </Text.Text>


### PR DESCRIPTION
# Issue Pull Request

## Linear Issue

[SY-4827](https://linear.app/synnax/issue/SY-4827/fix-ellipses-on-version-update-text)

## Description

The "x / y MB" label beside the update progress bar collapsed to an ellipsis. The bar is
`width: 100%`, so it claimed the whole flex row, and the label's `overflow="ellipsis"`
let it shrink to nothing. The row now has a definite width and the label cannot shrink.

Also fixes the bar rendering full for a frame before the updater reports a content
length, while the percentage was still `NaN`.

## Basic Readiness

- [x] I have performed a self-review of my code.
- [x] I have added relevant, automated tests to cover the changes.
- [x] I have updated documentation to reflect the changes.






<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes the version-update progress display by giving the download row a definite width, preventing the size label from shrinking, and rendering zero progress until a download total is available.
- Adds layout styles that preserve the progress label.
- Guards against `NaN` progress when the total is zero.
- Adds a regression test for the initial zero-total state.

<h3>Confidence Score: 5/5</h3>

The PR appears safe to merge with no outstanding findings.

The zero-total regression is covered by the added test, and the previously flagged line-length concern was correctly conceded because the line complies with the limit.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| console/src/platform/version/Info.css | Adds a fixed download-row width and prevents the progress label from shrinking. |
| console/src/platform/version/useInfoModal.tsx | Handles a zero download total and updates the progress-row layout and label overflow behavior. |
| console/src/platform/version/useInfoModal.spec.tsx | Verifies that the progress bar remains empty until the updater reports a total. |

<sub>Reviews (3): Last reviewed commit: ["Add a zero-total regression test for the..."](https://github.com/synnaxlabs/synnax/commit/29d613a924a00d4cbf2387a5ae32a35388d74f94) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=63482472)</sub>

<!-- /greptile_comment -->